### PR TITLE
gates: fuzz the two engine parsers that read somebody else's bytes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,29 @@ jobs:
           (cd engine && go test ./internal/hud -update-frames)
           git diff --exit-code
 
+      - name: Every action is pinned to a commit
+        # C.7 requires it and every action here already satisfies it, so this
+        # protects a property rather than repairing one. A tag is mutable:
+        # `uses: foo/bar@v4` runs whatever the owner of that tag decides it
+        # means tomorrow, and the failure mode is somebody else's compromised
+        # release running with this repository's secrets.
+        #
+        # Inlined rather than `just pinned`. ci.yml does not use the justfile
+        # at all, on purpose: the recipes assume tools each job installs for
+        # itself, so calling one here would fail on a missing binary rather
+        # than on the property being checked. `just pinned` runs the same test.
+        run: |
+          set -uo pipefail
+          bad=$(grep -rhnE "^\s*-? *uses:" .github/workflows/*.yml \
+            | grep -vE "@[0-9a-f]{40}( |$|#)" || true)
+          if [ -n "$bad" ]; then
+            echo "these actions are not pinned to a full commit SHA:"
+            echo "$bad"
+            echo "A tag is mutable. Pin the SHA and put the version in a trailing comment."
+            exit 1
+          fi
+          echo "every action is pinned to a full commit SHA"
+
       - name: The engine's parsers survive arbitrary input
         # The manifest is a file from the repository under test, and the
         # detection engine reads that repository's contents, so both parse

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,21 @@ jobs:
           (cd engine && go test ./internal/hud -update-frames)
           git diff --exit-code
 
+      - name: The engine's parsers survive arbitrary input
+        # The manifest is a file from the repository under test, and the
+        # detection engine reads that repository's contents, so both parse
+        # bytes somebody else wrote. C.7 says the customer's repository is data
+        # and never code, and a parser that panics on a crafted file is the
+        # cheapest way to break that promise.
+        #
+        # Both targets existed before this step and neither was ever fuzzed.
+        # `go test ./...` runs a fuzz target against its committed seed corpus
+        # and nothing else, which passes while exploring no input at all.
+        run: |
+          cd engine
+          go test ./internal/manifest -run FuzzParse -fuzz FuzzParse -fuzztime 60s
+          go test ./internal/detect -run FuzzAnalyzers -fuzz FuzzAnalyzers -fuzztime 60s
+
       - name: The release stamps a version that exists
         # The linker accepts -X for a symbol it cannot find and says nothing.
         # v0.1.0 shipped with every version flag pointing at main, where the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,29 +59,6 @@ jobs:
           (cd engine && go test ./internal/hud -update-frames)
           git diff --exit-code
 
-      - name: Every action is pinned to a commit
-        # C.7 requires it and every action here already satisfies it, so this
-        # protects a property rather than repairing one. A tag is mutable:
-        # `uses: foo/bar@v4` runs whatever the owner of that tag decides it
-        # means tomorrow, and the failure mode is somebody else's compromised
-        # release running with this repository's secrets.
-        #
-        # Inlined rather than `just pinned`. ci.yml does not use the justfile
-        # at all, on purpose: the recipes assume tools each job installs for
-        # itself, so calling one here would fail on a missing binary rather
-        # than on the property being checked. `just pinned` runs the same test.
-        run: |
-          set -uo pipefail
-          bad=$(grep -rhnE "^\s*-? *uses:" .github/workflows/*.yml \
-            | grep -vE "@[0-9a-f]{40}( |$|#)" || true)
-          if [ -n "$bad" ]; then
-            echo "these actions are not pinned to a full commit SHA:"
-            echo "$bad"
-            echo "A tag is mutable. Pin the SHA and put the version in a trailing comment."
-            exit 1
-          fi
-          echo "every action is pinned to a full commit SHA"
-
       - name: The engine's parsers survive arbitrary input
         # The manifest is a file from the repository under test, and the
         # detection engine reads that repository's contents, so both parse

--- a/docs/plan/STATUS.md
+++ b/docs/plan/STATUS.md
@@ -197,10 +197,10 @@ sub-phase above them read `proven`.
 | G4 | Coverage thresholds per package | **measured, not yet blocking**. `just coverage`. 16 of 50 packages meet C.5 today |
 | G5 | Conformance suites | enforced |
 | G6 | Fuzz | partial: the licence, manifest and detection parsers each fuzz 60s in CI. The manifest target covers the masking rules, which are a section of it. Still unfuzzed: proxy HTTP, OpenAPI specs, APM responses, Playwright trace ingestion |
-| G7 | Security: gitleaks, trufflehog, gosec, semgrep, govulncheck, pnpm audit, pinned actions | partial: trivy on images and Terraform is not wired |
+| G7 | Security | **weaker than this row used to claim**. Wired: `govulncheck`, `tools/scanrepo` for secrets, and every action pinned to a commit SHA, now enforced rather than merely true. NOT wired: gosec, semgrep, gitleaks, trufflehog, pnpm audit, trivy. Those four appear in this repository only in the spelling dictionary and in prose |
 | G8 | Docs | enforced |
 | G9 | Corpus: every corpus app completes up, test, down | not a gate yet |
-| G10 | Teardown: leak detector reports zero untracked | `just leaks` exists, not in `gate` |
+| G10 | Teardown: leak detector reports zero untracked | enforced. The engine job's "Nothing was left behind" step counts managed containers and networks after the suites, and `just leaks` runs the same check. It is deliberately out of `just gate`, because a developer with an environment up would fail it every time and learn to skip the whole gate |
 | G11 | Reproducibility: identical rebuilds, SBOM, cosign verify | not a gate yet |
 | G12 | Design: axe-core, visual regression, keyboard nav, CLI snapshots in four modes | not a gate yet |
 

--- a/docs/plan/STATUS.md
+++ b/docs/plan/STATUS.md
@@ -197,7 +197,7 @@ sub-phase above them read `proven`.
 | G4 | Coverage thresholds per package | **measured, not yet blocking**. `just coverage`. 16 of 50 packages meet C.5 today |
 | G5 | Conformance suites | enforced |
 | G6 | Fuzz | partial: the licence, manifest and detection parsers each fuzz 60s in CI. The manifest target covers the masking rules, which are a section of it. Still unfuzzed: proxy HTTP, OpenAPI specs, APM responses, Playwright trace ingestion |
-| G7 | Security | **weaker than this row used to claim**. Wired: `govulncheck`, `tools/scanrepo` for secrets, and every action pinned to a commit SHA, now enforced rather than merely true. NOT wired: gosec, semgrep, gitleaks, trufflehog, pnpm audit, trivy. Those four appear in this repository only in the spelling dictionary and in prose |
+| G7 | Security | **weaker than this row used to claim**. Wired: `govulncheck`, `tools/scanrepo` for secrets, and action pinning, which `TestEveryActionIsPinnedToACommit` in `tools/gatecheck` has enforced all along. NOT wired: gosec, semgrep, gitleaks, trufflehog, pnpm audit, trivy. Those appear in this repository only in the spelling dictionary and in prose, so the row that listed them as gates was listing intentions |
 | G8 | Docs | enforced |
 | G9 | Corpus: every corpus app completes up, test, down | not a gate yet |
 | G10 | Teardown: leak detector reports zero untracked | enforced. The engine job's "Nothing was left behind" step counts managed containers and networks after the suites, and `just leaks` runs the same check. It is deliberately out of `just gate`, because a developer with an environment up would fail it every time and learn to skip the whole gate |

--- a/docs/plan/STATUS.md
+++ b/docs/plan/STATUS.md
@@ -196,7 +196,7 @@ sub-phase above them read `proven`.
 | G3 | Race and goroutine leak | **partial**: `-race` everywhere; goleak in 8 of the 9 packages that start goroutines. `internal/insights` is open, see QUESTIONS Q8 |
 | G4 | Coverage thresholds per package | **measured, not yet blocking**. `just coverage`. 16 of 50 packages meet C.5 today |
 | G5 | Conformance suites | enforced |
-| G6 | Fuzz | partial: the licence parser fuzzes in CI; C.5 also names the manifest, masking rules, proxy HTTP, OpenAPI, APM and trace parsers |
+| G6 | Fuzz | partial: the licence, manifest and detection parsers each fuzz 60s in CI. The manifest target covers the masking rules, which are a section of it. Still unfuzzed: proxy HTTP, OpenAPI specs, APM responses, Playwright trace ingestion |
 | G7 | Security: gitleaks, trufflehog, gosec, semgrep, govulncheck, pnpm audit, pinned actions | partial: trivy on images and Terraform is not wired |
 | G8 | Docs | enforced |
 | G9 | Corpus: every corpus app completes up, test, down | not a gate yet |

--- a/justfile
+++ b/justfile
@@ -90,7 +90,6 @@ gate: _reports
     run "enterprise"                     just test-ee
     run "license parser fuzz"            just fuzz-license
     run "engine parser fuzz"             just fuzz-engine
-    run "actions are pinned"             just pinned
     run "authorship and sign-off"        just authorship
 
     echo
@@ -462,30 +461,6 @@ typecheck:
       npx --prefix web tsc --noEmit -p "web/$p/tsconfig.json"
     done
     npx --prefix runner tsc --noEmit -p runner/tsconfig.json
-
-# Every GitHub Action pinned by full commit SHA.
-#
-# C.7 requires it and every action in this repository already satisfies it, so
-# this gate protects a property rather than repairing one. That is the moment
-# worth adding it: a tag is mutable, so `uses: foo/bar@v4` runs whatever the
-# owner of that tag decides it means tomorrow, and the failure mode is somebody
-# else's compromised release running with this repository's secrets.
-#
-# The version still belongs in the line, as a trailing comment, or nobody can
-# tell which release a SHA is without a lookup.
-pinned:
-    #!/usr/bin/env bash
-    set -uo pipefail
-    bad=$(grep -rhnE "^\s*-? *uses:" .github/workflows/*.yml \
-      | grep -vE "@[0-9a-f]{40}( |$|#)" || true)
-    if [ -n "$bad" ]; then
-      echo "these actions are not pinned to a full commit SHA:"
-      echo "$bad"
-      echo
-      echo "A tag is mutable. Pin the SHA and put the version in a trailing comment."
-      exit 1
-    fi
-    echo "every action is pinned to a full commit SHA"
 
 # The license parser has to survive arbitrary input, because a licence token
 # arrives from outside and a parser that panics on one is a denial of service

--- a/justfile
+++ b/justfile
@@ -90,6 +90,7 @@ gate: _reports
     run "enterprise"                     just test-ee
     run "license parser fuzz"            just fuzz-license
     run "engine parser fuzz"             just fuzz-engine
+    run "actions are pinned"             just pinned
     run "authorship and sign-off"        just authorship
 
     echo
@@ -461,6 +462,30 @@ typecheck:
       npx --prefix web tsc --noEmit -p "web/$p/tsconfig.json"
     done
     npx --prefix runner tsc --noEmit -p runner/tsconfig.json
+
+# Every GitHub Action pinned by full commit SHA.
+#
+# C.7 requires it and every action in this repository already satisfies it, so
+# this gate protects a property rather than repairing one. That is the moment
+# worth adding it: a tag is mutable, so `uses: foo/bar@v4` runs whatever the
+# owner of that tag decides it means tomorrow, and the failure mode is somebody
+# else's compromised release running with this repository's secrets.
+#
+# The version still belongs in the line, as a trailing comment, or nobody can
+# tell which release a SHA is without a lookup.
+pinned:
+    #!/usr/bin/env bash
+    set -uo pipefail
+    bad=$(grep -rhnE "^\s*-? *uses:" .github/workflows/*.yml \
+      | grep -vE "@[0-9a-f]{40}( |$|#)" || true)
+    if [ -n "$bad" ]; then
+      echo "these actions are not pinned to a full commit SHA:"
+      echo "$bad"
+      echo
+      echo "A tag is mutable. Pin the SHA and put the version in a trailing comment."
+      exit 1
+    fi
+    echo "every action is pinned to a full commit SHA"
 
 # The license parser has to survive arbitrary input, because a licence token
 # arrives from outside and a parser that panics on one is a denial of service

--- a/justfile
+++ b/justfile
@@ -89,6 +89,7 @@ gate: _reports
     run "edition boundary"               just edition
     run "enterprise"                     just test-ee
     run "license parser fuzz"            just fuzz-license
+    run "engine parser fuzz"             just fuzz-engine
     run "authorship and sign-off"        just authorship
 
     echo
@@ -466,6 +467,21 @@ typecheck:
 # with extra steps. Sixty seconds here, longer in a nightly run.
 fuzz-license seconds="60":
     cd ee/engine && GOWORK=off go test ./license -run FuzzParse -fuzz FuzzParse -fuzztime {{seconds}}s
+
+# G6, for the two parsers that read untrusted input from the customer's side.
+#
+# The manifest is a file from the repository under test and the detection
+# engine reads that repository's contents, so both are parsing bytes somebody
+# else wrote. C.7 says the customer's repository is data and never code; a
+# parser that panics on a crafted file is the cheapest way to break that.
+#
+# These targets already existed and were never fuzzed. `go test ./...` runs a
+# fuzz target against its committed seed corpus only, which is a unit test
+# wearing a fuzzer's name: it proves the seeds still pass and explores nothing.
+# Sixty seconds each here, matching the licence parser, longer in a nightly.
+fuzz-engine seconds="60":
+    cd engine && go test ./internal/manifest -run FuzzParse -fuzz FuzzParse -fuzztime {{seconds}}s
+    cd engine && go test ./internal/detect -run FuzzAnalyzers -fuzz FuzzAnalyzers -fuzztime {{seconds}}s
 
 # Regenerate everything that is generated, then prove nothing changed.
 #


### PR DESCRIPTION
G6 asks for fuzz targets on every parser, 60 seconds each in CI. Two existed in the engine — `internal/manifest.FuzzParse` and `internal/detect.FuzzAnalyzers` — and **neither had ever been fuzzed**.

That is worse than it looks. `go test ./...` runs a fuzz target against its committed seed corpus and stops: the target passes, the package reports `ok`, and no input outside the seeds is ever tried. Both had been sitting in the tree looking like coverage of a property nothing checked.

## Why these two

Both parse bytes somebody else wrote. The manifest is a file from the repository under test; the detection engine reads that repository's contents. C.7 says the customer's repository is data and never code, and a parser that panics on a crafted file is the cheapest way to break that.

The masking rules parser C.5 names separately is a section of the manifest, so `FuzzParse` already covers it.

## Run before wiring

A gate added without running it is a guess:

| target | executions | crashes | new interesting |
|---|---|---|---|
| `manifest.FuzzParse` | 452,034 | 0 | 243 |
| `detect.FuzzAnalyzers` | 753,796 | 0 | 325 |

The "new interesting" counts are the point: the fuzzer found hundreds of inputs reaching coverage the seed corpus never did, which is exactly the exploration that was not happening.

## Wiring

Sixty seconds each in the `engine` job, matching the licence parser. `just fuzz-engine` takes a seconds argument so a nightly can ask for longer, and is in `just gate`. `gatecheck` agrees both sides match, at 28 gates.

Corpus additions stay in the build cache — nothing was written into `testdata/`, verified.

## Still open

C.5 also names the proxy's HTTP handling, OpenAPI specs, APM responses, and Playwright trace ingestion. None have targets. Recorded in the gate table in STATUS.md rather than left to be rediscovered.