### PR TITLE
conformance: the golden identifier was still colliding, across processes

### DIFF
--- a/docs/plan/QUESTIONS.md
+++ b/docs/plan/QUESTIONS.md
@@ -190,9 +190,36 @@ daemon race where a freshly committed image is not immediately inspectable; and
 `ImageRemove` with `PruneChildren: true` reaching a sibling committed from the
 same base image.
 
-**Proceeding under:** recorded, not fixed. The reproduction is a CI run, the
-window is milliseconds, and guessing at a fix for a race whose mechanism is
-unproven is how a flake becomes a flake with a plausible comment above it.
+**Answered, partly.** The identifier was still colliding, along an axis the
+first repair did not consider.
+
+The rules hash was `sha256(t.Name() + "#" + refreshCount)`. That is unique
+within one process and identical across processes: every package running this
+suite calls its entry point `TestConformance`, so `internal/db/docker`,
+`internal/db/dblab`, `internal/db/neon` and `internal/db/supabase` all produce
+the behaviour name `TestConformance/Branch_IsIsolatedFromTheGolden` and
+therefore the same eight characters, on every run. Go runs test packages in
+parallel, so "unique within one process" was never the property needed.
+
+The evidence had been in the failures the whole time and I read past it twice:
+the failure on 2026-08-29 at 03:02 and the one at 10:11 quote the SAME hash,
+`7969f160`, differing only in the timestamp. A hash that repeats across hours
+and runs is derived, not unique.
+
+It is four random bytes now, which is what `internal/masking`'s
+`uniqueRulesHash` already did for the same reason. Randomness cannot collide by
+construction, where both derivations collided along an axis nobody thought of.
+
+Not claimed as proven. The suite is green against a real daemon after the
+change, but this flake is intermittent and one green run is not evidence. What
+IS established is that the collision was real and is now impossible; if the
+failure returns, the cause is something else and the ruled-out list above still
+stands.
+
+Still open underneath it: `provider.NewGoldenVersionID` resolves to the second,
+so two refreshes in one second still depend on their hashes differing. That is
+production code, not test code, and two refreshes in a second is not something
+only a test does.
 
 ## Answered
 

--- a/engine/conformance/db.go
+++ b/engine/conformance/db.go
@@ -32,7 +32,7 @@ package conformance
 
 import (
 	"context"
-	"crypto/sha256"
+	"crypto/rand"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -276,10 +276,6 @@ type harness struct {
 	masked     int
 	verified   int
 	failVerify bool
-	// refreshes counts what this harness has asked for, so that the rules hash
-	// can differ between two refreshes inside one behaviour as well as between
-	// behaviours. See rulesHash.
-	refreshes int
 }
 
 // createdSet records the resources one run of the suite made.
@@ -381,29 +377,50 @@ func runBehavior(ctx context.Context, t *testing.T, name string, factory Factory
 	}
 }
 
-// rulesHash is different for every refresh this suite makes.
+// rulesHash is different for every refresh this suite makes, and different in
+// every process that runs it.
 //
-// It was the constant "conformance", and that made this suite intermittently
-// red in a way that pointed nowhere near itself. A golden's identifier is
-// gv_<timestamp to the second>_<first eight characters of the rules hash>, so
-// two refreshes in the same second with the same hash get the SAME identifier.
-// For a provider whose goldens are images the second commit then retags the
-// first, and one behaviour's cleanup destroys the golden another behaviour is
-// about to branch. It arrives as "the golden version no longer exists" from
-// Branch, several behaviours away from the refresh that caused it, and only on
-// machines fast enough to do two refreshes inside one second.
+// A golden's identifier is gv_<timestamp to the second>_<first eight
+// characters of the rules hash>, so two refreshes that share a second and a
+// hash get the SAME identifier. For a provider whose goldens are images the
+// second commit retags the first, and then one cleanup destroys the golden
+// something else is about to branch. It surfaces as "the golden version no
+// longer exists" from Branch, nowhere near the refresh that caused it.
 //
-// The one-second resolution is provider.NewGoldenVersionID's, and it is worth
-// fixing there as well: two refreshes in the same second is not a thing only a
-// test does. This stops the suite depending on it either way.
+// This has now been wrong twice, in the same place, for two different reasons.
+//
+// It was the constant "conformance", which collided between two refreshes in
+// one second on a fast machine. The repair derived it from the behaviour name
+// and a refresh counter, which is unique within one process and IDENTICAL
+// ACROSS PROCESSES: every package that runs this suite calls its entry point
+// TestConformance, so internal/db/docker, internal/db/dblab, internal/db/neon
+// and internal/db/supabase all produce the behaviour name
+// TestConformance/Branch_IsIsolatedFromTheGolden and therefore the same eight
+// characters, on every run for ever. The evidence was sitting in the failures:
+// two of them hours apart quoted the same hash, 7969f160, differing only in
+// the timestamp. Go runs test packages in parallel, so "unique within one
+// process" was never the property this needed.
+//
+// Four random bytes are exactly the eight hex characters that survive into an
+// identifier, which is what internal/masking's uniqueRulesHash already does
+// for the same reason. Randomness cannot collide by construction, where every
+// derivation so far has collided along an axis nobody thought about.
+//
+// The one-second resolution in provider.NewGoldenVersionID is the underlying
+// sharp edge and is still there: two refreshes in one second is not something
+// only a test does. This stops the suite depending on it either way.
 func (h *harness) rulesHash() string {
-	sum := sha256.Sum256(fmt.Appendf(nil, "%s#%d", h.t.Name(), h.refreshes))
-	return hex.EncodeToString(sum[:])[:8]
+	var b [4]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// A fallback that returned a constant would reintroduce the collision
+		// this exists to prevent, so it is loud instead.
+		h.t.Fatalf("no randomness available for a rules hash: %v", err)
+	}
+	return hex.EncodeToString(b[:])
 }
 
 // spec builds a refresh specification whose callbacks record what happened.
 func (h *harness) spec() provider.GoldenSpec {
-	h.refreshes++
 	return provider.GoldenSpec{
 		SourceURL: secrets.New("postgres://conformance@source/db"),
 		Version:   17,


### PR DESCRIPTION
`Branch_IsIsolatedFromTheGolden` has been intermittently red for months and took main down after the last merge. It is a required check now, so it blocks real pull requests.

## The bug

The rules hash was `sha256(t.Name() + "#" + refreshCount)`. That is unique within one process and **identical across processes**: every package that runs this suite calls its entry point `TestConformance`, so `internal/db/docker`, `internal/db/dblab`, `internal/db/neon` and `internal/db/supabase` all produce the behaviour name `TestConformance/Branch_IsIsolatedFromTheGolden` — and therefore the same eight characters, on every run, for ever.

Go runs test packages in parallel, so "unique within one process" was never the property this needed.

A golden's identifier is `gv_<timestamp to the second>_<hash[:8]>`. Two refreshes sharing a second and a hash share an identifier; for an image-backed provider the second commit retags the first, and a cleanup then destroys the golden something else is about to branch. It surfaces as `AF-DB-004: the golden version no longer exists` from `Branch`, nowhere near the refresh that caused it.

## The evidence was sitting in the failures

I read past it twice. The failure at 03:02 and the one at 10:11 quote the **same hash**, `7969f160`, differing only in the timestamp:

```
gv_20260829030220_7969f160
gv_20260829101128_7969f160
```

A hash that repeats across hours and across runs is derived, not unique. That was the tell.

## The fix

Four random bytes — exactly the eight hex characters that survive into an identifier, and exactly what `internal/masking`'s `uniqueRulesHash` already does for the same reason. Randomness cannot collide by construction, where both previous derivations collided along an axis nobody had thought about.

This is the **second** repair to this line. It was the constant `"conformance"` first; the fix for that derived it from the test name and collided differently. That history is in the comment so a third attempt starts informed.

The refresh counter is deleted rather than left behind — nothing read it once the hash stopped deriving from it, and a field incremented by one caller and read by none is the exact shape this repo keeps finding.

## Not claimed as proven

The full docker conformance suite is green against a real daemon after the change (375s, all behaviours), and the conformance selftest is green. **One green run of an intermittent failure is not evidence.** What is established is that this collision was real and is now impossible. If the failure returns, the cause is something else, and the ruled-out list in QUESTIONS Q9 still stands.

Still open underneath: `provider.NewGoldenVersionID` resolves to the second, so two refreshes in one second still depend on their hashes differing. That is production code, and two refreshes in a second is not something only a test does.