### PR TITLE
db.docker: say which goldens exist when the one asked for does not

### DIFF
--- a/docs/plan/QUESTIONS.md
+++ b/docs/plan/QUESTIONS.md
@@ -242,6 +242,29 @@ instrumentation inside `RefreshGolden` and `Branch` rather than more reading:
 log the image id at commit, list it back immediately, and log again at the
 `ImageInspect` that fails.
 
+### Q10. Six call sites raise AF-DB-004 without the field its message names
+
+`fill` renders a placeholder it has no value for by printing it verbatim, so an
+error raised without every field its template names reaches a reader with
+`{version}` in it.
+
+AF-DB-004's message is "The golden version {version} no longer exists." Six
+sites raise it with an `env` field and no `version`: `internal/env/insights.go`
+twice, and `internal/env/golden.go` four times. Every one of those prints the
+literal `{version}` to somebody whose environment has just failed.
+
+Found while adding the available-versions listing to the same code, which is
+why that listing is wrapped onto the error rather than added as a catalog
+field: adding `{available}` to the template would have given those six a second
+placeholder to leak.
+
+**Proceeding under:** recorded, not fixed. The repair is either passing the
+right field at each site or making `fill` refuse a template it cannot complete,
+and the second is the better one: a placeholder that reaches a user is always a
+bug, so the catalog should not be able to produce one. That is a change to how
+every error in the product renders and wants its own pass rather than being
+tacked onto this one.
+
 ## Answered
 
 *(none yet)*

--- a/engine/internal/db/docker/available_test.go
+++ b/engine/internal/db/docker/available_test.go
@@ -1,0 +1,37 @@
+package docker_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/internal/clock"
+	dockerdb "github.com/antifailure/antifailure/engine/internal/db/docker"
+	aferrors "github.com/antifailure/antifailure/engine/internal/errors"
+)
+
+// Branching a version that is not there says what IS there.
+//
+// For a person that is the difference between "gone" and knowing what they
+// could have asked for. It is also the evidence the suite's intermittent
+// "the golden version no longer exists" has never carried: a listing taken at
+// the instant it happened, so the next occurrence is a bug with data attached
+// rather than a third guess.
+func TestBranchingAMissingGoldenNamesTheOnesThatExist(t *testing.T) {
+	p, err := dockerdb.New(dockerdb.Options{Version: 17, Clock: clock.New(), PortFrom: 47300})
+	if err != nil {
+		t.Skipf("skipped: no Docker daemon is reachable: %v", err)
+	}
+	defer func() { _ = p.Close() }()
+
+	_, err = p.Branch(context.Background(), "gv_19700101000000_deadbeef", "env_missing00001")
+	require.Error(t, err)
+	require.ErrorIs(t, err, aferrors.Coded(aferrors.AFDB004),
+		"still the coded error, so callers matching on it keep working")
+	require.Contains(t, err.Error(), "Available:",
+		"and it says what exists, whether that is a list or a statement that there are none")
+	require.NotContains(t, err.Error(), "{",
+		"no unfilled placeholder reaches a reader")
+
+}

--- a/engine/internal/db/docker/docker.go
+++ b/engine/internal/db/docker/docker.go
@@ -326,6 +326,33 @@ func (p *Provider) ListGoldens(ctx context.Context) ([]provider.GoldenVersion, e
 	return out, nil
 }
 
+// describeGoldens names the versions that exist, for a message about one that
+// does not.
+//
+// Best effort and never an error: this runs on a path that has already failed,
+// and a listing that fails too must not replace the caller's problem with its
+// own.
+func (p *Provider) describeGoldens(ctx context.Context) string {
+	versions, err := p.ListGoldens(ctx)
+	if err != nil {
+		return "the available versions could not be listed: " + err.Error()
+	}
+	if len(versions) == 0 {
+		return "no golden versions exist on this daemon"
+	}
+	ids := make([]string, 0, len(versions))
+	for _, v := range versions {
+		ids = append(ids, v.ID)
+	}
+	// Newest first, and capped. A daemon holding fifty goldens should not turn
+	// one error into a page.
+	sort.Sort(sort.Reverse(sort.StringSlice(ids)))
+	if len(ids) > 5 {
+		return fmt.Sprintf("%s and %d more", strings.Join(ids[:5], ", "), len(ids)-5)
+	}
+	return strings.Join(ids, ", ")
+}
+
 // DestroyGolden removes a version, refusing one a branch still depends on.
 func (p *Provider) DestroyGolden(ctx context.Context, version string) error {
 	tag := ImageRepo + ":" + version
@@ -361,7 +388,27 @@ func (p *Provider) Branch(ctx context.Context, version, envID string) (provider.
 	tag := ImageRepo + ":" + version
 	if _, err := p.cli.ImageInspect(ctx, tag); err != nil {
 		if cerrdefs.IsNotFound(err) {
-			return provider.Branch{}, aferrors.Coded(aferrors.AFDB004, "version", version)
+			// What DOES exist, at the moment the missing one was asked for.
+			//
+			// For a person this is the difference between "that version is
+			// gone" and being told which versions they could have asked for
+			// instead, without running a second command.
+			//
+			// It is also the evidence the conformance suite's intermittent
+			// "the golden version no longer exists" has never produced. That
+			// failure has survived two repairs, and the thing nobody has is a
+			// listing taken at the instant it happened: whether the image is
+			// absent, or present under a different tag, or one of several that
+			// look alike. A flake that reappears with this attached is a bug
+			// with evidence rather than a third guess.
+			// Wrapped rather than added as a catalog field. The message
+			// template fills a missing field by printing the placeholder
+			// verbatim, and six other call sites raise this code without an
+			// "available" value, so putting it in the template would show
+			// those callers a literal {available}.
+			return provider.Branch{}, fmt.Errorf("%w Available: %s",
+				aferrors.Coded(aferrors.AFDB004, "version", version),
+				p.describeGoldens(ctx))
 		}
 		return provider.Branch{}, fmt.Errorf("db.docker: inspect the golden image: %w", err)
 	}


### PR DESCRIPTION
`The golden version gv_... no longer exists` says the version is gone and nothing about what could have been asked for instead, so the next step is always a second command.

`Branch` now names what exists at that moment, newest first, capped at five. Best effort: it runs on a path that has already failed, and a listing that fails too must not replace the caller's problem with its own.

It is also the evidence that has been missing. The conformance suite's intermittent version of this failure has survived two repairs, and nobody has a listing taken at the instant it happened. The next occurrence arrives as a bug with data rather than a third guess.

## Why wrapped, not a catalog field

`fill` prints a placeholder it has no value for verbatim. Six sites raise AF-DB-004 with an `env` field and no `version`, so a template naming `{available}` would hand those six a second placeholder to leak.

**Those six already have that bug**: each prints a literal `{version}` to somebody whose environment just failed. Recorded as Q10 rather than fixed here — the better repair is making the catalog unable to produce an unfilled placeholder at all, which changes how every error in the product renders.

## Verified

New test against a real daemon: still `errors.Is` the coded error, says `Available:`, and contains no `{`. golangci-lint 0 issues.