### PR TITLE
links: an API endpoint answering 401 is not a dead page

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -61,6 +61,11 @@ exclude = [
   "^https?://[^/]*\\.?example\\.(com|org|net)",
   "^https?://[^/]*\\.?invalid",
   "^https?://api\\.stripe\\.com",
+  # Same case: an API endpoint the documentation shows a request going to. It
+  # answers 401 without a key, which is correct behaviour and not a dead page,
+  # and it turned the scheduled external check red where a reader would never
+  # have clicked it.
+  "^https?://api\\.resend\\.com",
   "^https?://telemetry\\.",
   # A repository address that only exists once a user has made one.
   "^https?://github\\.com/your-",


### PR DESCRIPTION
The scheduled external link check has been red on `https://api.resend.com/emails`, which the CLI reference cites as the address a captured email would have gone to. It answers 401 without a key — correct behaviour, not a broken page, and nobody reading that reference was going to click it.

`api.stripe.com` is already excluded for exactly this reason, and the comment beside it says so. This is the same case and simply was not on the list.

Checked the class rather than the instance: the docs cite three `api.*` hosts. Stripe was already excluded, Resend is added here, and `api.github.com` stays in the check because it answers 200 and is a real address a reader might follow.

Verified with lychee over a fixture holding both: one excluded, one checked, zero errors.