### PR TITLE
build: two builds of one commit produced different binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
             -ldflags "-s -w \
               -X github.com/antifailure/antifailure/engine/internal/cli.Version=$version \
               -X github.com/antifailure/antifailure/engine/internal/cli.Commit=$GITHUB_SHA \
-              -X github.com/antifailure/antifailure/engine/internal/cli.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+              -X github.com/antifailure/antifailure/engine/internal/cli.BuildDate=$(git show -s --format=%cI HEAD)" \
             -o "../dist/af" ./cmd/af
 
       - name: Package

--- a/docs/plan/STATUS.md
+++ b/docs/plan/STATUS.md
@@ -201,7 +201,7 @@ sub-phase above them read `proven`.
 | G8 | Docs | enforced |
 | G9 | Corpus: every corpus app completes up, test, down | not a gate yet |
 | G10 | Teardown: leak detector reports zero untracked | enforced. The engine job's "Nothing was left behind" step counts managed containers and networks after the suites, and `just leaks` runs the same check. It is deliberately out of `just gate`, because a developer with an environment up would fail it every time and learn to skip the whole gate |
-| G11 | Reproducibility: identical rebuilds, SBOM, cosign verify | not a gate yet |
+| G11 | Reproducibility: identical rebuilds, SBOM, cosign verify | **rebuilds are reproducible now, and were not**. Both `build-release` and release.yml stamped BuildDate with `$(date -u)`, so every build of one commit differed and the shipping path was non-reproducible. The date comes from the commit. `just reproducible` builds twice and compares; it is in `just gate` and not yet a CI job. SBOM and cosign verification are still unwired |
 | G12 | Design: axe-core, visual regression, keyboard nav, CLI snapshots in four modes | not a gate yet |
 
 G4 is measured rather than blocking on purpose. Thirty four of fifty packages

--- a/justfile
+++ b/justfile
@@ -88,6 +88,7 @@ gate: _reports
     run "runner"                         just test-runner
     run "edition boundary"               just edition
     run "enterprise"                     just test-ee
+    run "builds are reproducible"        just reproducible
     run "license parser fuzz"            just fuzz-license
     run "engine parser fuzz"             just fuzz-engine
     run "authorship and sign-off"        just authorship
@@ -238,7 +239,7 @@ build-release version="dev":
     cd engine && go build -trimpath -ldflags "-s -w \
       -X github.com/antifailure/antifailure/engine/internal/cli.Version={{version}} \
       -X github.com/antifailure/antifailure/engine/internal/cli.Commit=$(git rev-parse HEAD) \
-      -X github.com/antifailure/antifailure/engine/internal/cli.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+      -X github.com/antifailure/antifailure/engine/internal/cli.BuildDate=$(git show -s --format=%cI HEAD)" \
       -o ../bin/af ./cmd/af
     @./bin/af version
 
@@ -461,6 +462,34 @@ typecheck:
       npx --prefix web tsc --noEmit -p "web/$p/tsconfig.json"
     done
     npx --prefix runner tsc --noEmit -p runner/tsconfig.json
+
+# G11. Two builds of one commit produce the same binary.
+#
+# It did not. The release recipe stamped BuildDate with $(date -u), so every
+# build of the same commit differed, and release.yml carried the identical
+# line: the shipping path was non-reproducible, not just the local one. The
+# date comes from the commit now, which is deterministic and still means
+# something to whoever reads `af version`.
+#
+# A gate rather than a note, because this is the kind of property that is true
+# until somebody adds one more -X flag.
+reproducible version="v0.0.0-gate":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    just build-release {{version}} > /dev/null
+    a=$(shasum -a 256 bin/af | cut -d' ' -f1)
+    just build-release {{version}} > /dev/null
+    b=$(shasum -a 256 bin/af | cut -d' ' -f1)
+    if [ "$a" != "$b" ]; then
+      echo "two builds of this commit differ:"
+      echo "  $a"
+      echo "  $b"
+      echo
+      echo "Something in the build embeds the moment it ran. The usual cause is a"
+      echo "timestamp in an -X flag; derive it from the commit instead."
+      exit 1
+    fi
+    echo "two builds of this commit are identical: $a"
 
 # The license parser has to survive arbitrary input, because a licence token
 # arrives from outside and a parser that panics on one is a denial of service


### PR DESCRIPTION
G11 asks that release builds be reproducible. They were not — and the shipping path was no better than the local one. Both `just build-release` and `release.yml` stamped:

```
-X ...cli.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)
```

so every build of the same commit embedded the moment it ran.

## Measured, not reasoned about

Two builds of `c85678f`, seconds apart:

| build | sha256 (first 16) |
|---|---|
| 1 | `5dbcbc2f3824307f` |
| 2 | `102c2353fccf550f` |

The same two builds after this change: **identical**, `b37f7404219c5984`.

## The fix

The date comes from the commit, `git show -s --format=%cI HEAD` — deterministic per commit, and still meaningful to whoever reads `af version`. That output is unchanged in shape; it shows the commit's date rather than the build's.

`just reproducible` builds twice and compares, and is in `just gate`. It needs no negative control written for it: **the failure above is the control**, produced by this exact check against the code as it stood.

## Scope

Not a CI job yet, and the STATUS row says so rather than implying otherwise — two full release builds per run belongs in the release workflow, not on every branch, and that is its own pass. SBOM generation and `cosign verify-blob` are the other two halves of G11 and remain unwired.