### PR TITLE
Fix the golden flake and the goroutine leak, at their causes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ file://$PWD /tmp/fresh` is a clean machine for the length of one command.
 ```
 git clone https://github.com/antifailure/antifailure
 cd antifailure
-git config core.hooksPath .githooks   # see below
+just hooks     # turns on the commit hooks; see below
 just setup     # checks your toolchain and names what is missing
 just db        # starts the Postgres the control plane suites need
 just build     # builds the af binary into bin/af
@@ -52,7 +52,7 @@ just test      # unit and property tests
 `brew install just`, or see https://just.systems. `just` with no argument
 lists every recipe.
 
-The hooks line is worth the ten seconds. It adds the sign-off trailer for you
+`just hooks` is worth the ten seconds. It adds the sign-off trailer for you
 and refuses a commit authored by an address that is known to belong to somebody
 else's GitHub account, which is a mistake this repository has actually made.
 CI checks both, so the hooks only decide whether you find out before the push

--- a/docs/plan/QUESTIONS.md
+++ b/docs/plan/QUESTIONS.md
@@ -135,20 +135,42 @@ reports nothing, which is worse than the gap.
 Four are done and clean, in CI as well as locally: `cmd/af-proxy`,
 `conformance`, `internal/load` and `internal/subset`.
 
-`internal/insights` is the open one. It passes on a workstation and fails in
-CI, with two `net/http` `persistConn` `readLoop` and `writeLoop` pairs still in
-IO wait at exit. The stacks carry no frame from this repository; they are idle
-keep-alive connections held by an `http.Transport`. What has been audited and
-is not the cause: every `dockerutil.Client()` in the package and its tests is
-closed, including on the error paths, and the one streaming response it reads,
-`ContainerLogs` in `lastLines`, goes through `dockerutil.Discard`, which drains
-before closing. That leaves either a leak below the audited code or the known
-race where `CloseIdleConnections` returns before those goroutines unwind.
+**Answered.** `internal/insights` verifies too, and the stacks with no frame
+from this repository were this package's after all.
 
-It is left failing-open rather than silenced. `goleak.IgnoreTopFunction` on
-`net/http` would make it green and simultaneously blind it to the leak class
-most worth catching in a package that talks to the daemon, which is the same
-trade this question exists to refuse.
+They were two `net/http` `persistConn` `readLoop` and `writeLoop` pairs in IO
+wait. The audit that cleared every `dockerutil.Client()` was correct and beside
+the point: the connection was not idle, so `Client.Close` could not reclaim it,
+because `CloseIdleConnections` only touches connections that are idle.
+
+`ContainerWait` is what left it that way. It returns two channels and a
+goroutine that sends exactly one value, and the result channel is UNBUFFERED;
+the goroutine closes the response body in a defer that runs only after that
+send. Both call sites here also selected on `ctx.Done()`. When a deadline
+landed at the same moment as a result, select chose at random between two ready
+cases, and choosing the deadline parked that goroutine on the send for good:
+body never closed, connection never returned to the pool, `readLoop` and
+`writeLoop` outliving the process. Two abandoned waits, two pairs.
+
+That also explains why it only ever failed in CI. It needs the deadline and the
+container exit to coincide, which needs a loaded machine.
+
+The repair is `dockerutil.AwaitExit`, which receives from both channels and has
+no `ctx.Done()` case at all, so no caller can abandon a wait. Dropping that
+case is safe because the wait request is made with the same context: cancelling
+it fails the request the goroutine is reading, and the goroutine reports that
+on the error channel.
+`TestAwaitExit_ADeadlineEndsTheWaitAndLeavesNothingParked` holds that contract,
+because the risk of removing a `ctx.Done()` case is a hang rather than a leak.
+
+Honest about the strength of this: the parked-goroutine mechanism is proven by
+reading `ContainerWait` and is real, and the abandonment it needs is gone by
+construction rather than made less likely. What is NOT proven is a
+reproduction: the race needs two events inside the same instant and did not
+reproduce on a workstation, so a first attempt at a regression test passed
+against the unfixed code and was rewritten rather than kept. The check is back
+on in CI, which is where the failure lives and where the evidence will come
+from.
 
 ### Q9. A golden image disappears between RefreshGolden and the next Branch
 
@@ -241,6 +263,52 @@ committed image is not immediately inspectable, and `ImageRemove` with
 instrumentation inside `RefreshGolden` and `Branch` rather than more reading:
 log the image id at commit, list it back immediately, and log again at the
 `ImageInspect` that fails.
+
+**Answered, and it was the first candidate on that list.** Another test package
+was destroying this one's goldens.
+
+The evidence was in the failure text and neither earlier pass read it. The
+message names the versions that DO exist, and on 2026-08-29 at 12:37 it named
+exactly one:
+
+    Branch(gv_20260829123613_c2f585fe, env_conformance00001): AF-DB-004:
+    The golden version gv_20260829123613_c2f585fe no longer exists.
+    Available: gv_20260829123601_store-te
+
+`store-te` is not a hash. It is the first eight characters of the literal
+`store-test`, which `internal/env/goldenstore_test.go` passes as its
+`RulesHash`. So at the moment `internal/db/docker` could not find the golden it
+had committed twelve seconds earlier, the only golden on the daemon belonged to
+a different package.
+
+The cause is that package's teardown, which listed every golden on the daemon
+and destroyed all of them:
+
+    goldens, listErr := o.Goldens(c)
+    if listErr == nil {
+        for _, g := range goldens {
+            _ = o.DestroyGolden(c, g.ID)
+        }
+    }
+
+Its comment said "whatever this machine made, it takes away", which is exactly
+what it did, on a machine shared with every other package `go test ./...` runs
+in parallel. The window it hit is the one between a conformance behaviour
+refreshing a golden and branching from it, because `DestroyGolden` refuses a
+version a branch already references. That is also why its own `store-te` golden
+survived its own sweep: a branch was pinning it.
+
+The teardown now removes only the versions that orchestrator created, and
+`TestOrchestratorTeardown_LeavesGoldensItDidNotCreate` asserts both halves: a
+golden it did not create survives, and one it did create does not, so the test
+cannot pass by the teardown quietly removing nothing. Against the old teardown
+that test fails with the first assertion, which is the negative control this
+answer rests on rather than a green run.
+
+Still open underneath it, unchanged: `provider.NewGoldenVersionID` resolves to
+the second, so two refreshes inside one second still depend on their hashes
+differing. And `sweepCandidates` still removes a candidate whose `created`
+label will not parse whatever its age.
 
 ### Q10. Six call sites raise AF-DB-004 without the field its message names
 

--- a/docs/plan/QUESTIONS.md
+++ b/docs/plan/QUESTIONS.md
@@ -135,42 +135,38 @@ reports nothing, which is worse than the gap.
 Four are done and clean, in CI as well as locally: `cmd/af-proxy`,
 `conformance`, `internal/load` and `internal/subset`.
 
-**Answered.** `internal/insights` verifies too, and the stacks with no frame
-from this repository were this package's after all.
+**Answered, on the second try, and the first try is worth reading.**
+`internal/insights` verifies now. The stacks with no frame from this repository
+were this package's after all, and the audit that cleared every
+`dockerutil.Client()` was correct and beside the point: the connections were
+not idle, so `Client.Close` could not reclaim them, because
+`CloseIdleConnections` only touches connections that are idle.
 
-They were two `net/http` `persistConn` `readLoop` and `writeLoop` pairs in IO
-wait. The audit that cleared every `dockerutil.Client()` was correct and beside
-the point: the connection was not idle, so `Client.Close` could not reclaim it,
-because `CloseIdleConnections` only touches connections that are idle.
+The FIRST answer was wrong, and the wrongness was instructive. `ContainerWait`
+returns an UNBUFFERED result channel and a goroutine that closes the response
+body only after handing its result over, and both call sites here also selected
+on `ctx.Done()`, so a deadline arriving at the same moment as a result could
+park that goroutine forever. That is a real hazard, it is fixed in
+`dockerutil.AwaitExit`, and it was not this. The check went back on with that
+fix in and CI failed in exactly the same way. A mechanism that could explain
+the symptom is not evidence that it did.
 
-`ContainerWait` is what left it that way. It returns two channels and a
-goroutine that sends exactly one value, and the result channel is UNBUFFERED;
-the goroutine closes the response body in a defer that runs only after that
-send. Both call sites here also selected on `ctx.Done()`. When a deadline
-landed at the same moment as a result, select chose at random between two ready
-cases, and choosing the deadline parked that goroutine on the send for good:
-body never closed, connection never returned to the pool, `readLoop` and
-`writeLoop` outliving the process. Two abandoned waits, two pairs.
+What it actually was: `requireBranchContainer` handed back a stop function and
+the tests called it with `defer`. A deferred call in a test body runs BEFORE
+any `t.Cleanup`, so the client was closed first and `waitForBranch`'s cleanup
+then asked that same closed client to disconnect and remove a network. Those
+calls dial again, and by then nothing remains to close what they dial. One
+connection per test, outliving the process.
 
-That also explains why it only ever failed in CI. It needs the deadline and the
-container exit to coincide, which needs a loaded machine.
+Two things made this hard to see for a week. It cannot be reproduced on a
+workstation: it was chased with a full run, a `-short` run, and a run against a
+daemon with the image deliberately missing, and all three were clean. And the
+leaked goroutines carry no frame from this repository, so every stack says
+`net/http` and invites the conclusion that it is somebody else's.
 
-The repair is `dockerutil.AwaitExit`, which receives from both channels and has
-no `ctx.Done()` case at all, so no caller can abandon a wait. Dropping that
-case is safe because the wait request is made with the same context: cancelling
-it fails the request the goroutine is reading, and the goroutine reports that
-on the error channel.
-`TestAwaitExit_ADeadlineEndsTheWaitAndLeavesNothingParked` holds that contract,
-because the risk of removing a `ctx.Done()` case is a hang rather than a leak.
-
-Honest about the strength of this: the parked-goroutine mechanism is proven by
-reading `ContainerWait` and is real, and the abandonment it needs is gone by
-construction rather than made less likely. What is NOT proven is a
-reproduction: the race needs two events inside the same instant and did not
-reproduce on a workstation, so a first attempt at a regression test passed
-against the unfixed code and was rewritten rather than kept. The check is back
-on in CI, which is where the failure lives and where the evidence will come
-from.
+The evidence that closed it is the `edition boundary` job, which reproduces the
+failure in twenty four seconds and went from fail to pass across that one
+commit, with the check on and nothing else changed.
 
 ### Q9. A golden image disappears between RefreshGolden and the next Branch
 

--- a/docs/plan/STATUS.md
+++ b/docs/plan/STATUS.md
@@ -193,7 +193,7 @@ sub-phase above them read `proven`.
 | --- | --- | --- |
 | G1 | Lint: golangci-lint, biome, tsc, vale, cspell, lychee | enforced |
 | G2 | Unit and property tests | enforced |
-| G3 | Race and goroutine leak | **met**: `-race` everywhere; goleak in all 9 packages that start goroutines. The last one, `internal/insights`, cost a real leak to close: an abandoned `ContainerWait` stranded its connection, see QUESTIONS Q8 |
+| G3 | Race and goroutine leak | **met**: `-race` everywhere; goleak in all 9 packages that start goroutines. The last one, `internal/insights`, cost a real leak to close: a daemon client closed before the cleanups that still used it, see QUESTIONS Q8 |
 | G4 | Coverage thresholds per package | **measured, not yet blocking**. `just coverage`. 16 of 50 packages meet C.5 today |
 | G5 | Conformance suites | enforced |
 | G6 | Fuzz | partial: the licence, manifest and detection parsers each fuzz 60s in CI. The manifest target covers the masking rules, which are a section of it. Still unfuzzed: proxy HTTP, OpenAPI specs, APM responses, Playwright trace ingestion |

--- a/docs/plan/STATUS.md
+++ b/docs/plan/STATUS.md
@@ -193,7 +193,7 @@ sub-phase above them read `proven`.
 | --- | --- | --- |
 | G1 | Lint: golangci-lint, biome, tsc, vale, cspell, lychee | enforced |
 | G2 | Unit and property tests | enforced |
-| G3 | Race and goroutine leak | **partial**: `-race` everywhere; goleak in 8 of the 9 packages that start goroutines. `internal/insights` is open, see QUESTIONS Q8 |
+| G3 | Race and goroutine leak | **met**: `-race` everywhere; goleak in all 9 packages that start goroutines. The last one, `internal/insights`, cost a real leak to close: an abandoned `ContainerWait` stranded its connection, see QUESTIONS Q8 |
 | G4 | Coverage thresholds per package | **measured, not yet blocking**. `just coverage`. 16 of 50 packages meet C.5 today |
 | G5 | Conformance suites | enforced |
 | G6 | Fuzz | partial: the licence, manifest and detection parsers each fuzz 60s in CI. The manifest target covers the masking rules, which are a section of it. Still unfuzzed: proxy HTTP, OpenAPI specs, APM responses, Playwright trace ingestion |

--- a/engine/internal/dockerutil/awaitexit_test.go
+++ b/engine/internal/dockerutil/awaitexit_test.go
@@ -1,0 +1,71 @@
+package dockerutil_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/antifailure/antifailure/engine/internal/dockerutil"
+)
+
+// TestAwaitExit_ReturnsTheExitCode is the ordinary path: the container exits
+// before the deadline and its code comes back.
+func TestAwaitExit_ReturnsTheExitCode(t *testing.T) {
+	cli := requireDaemon(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	id := createRunning(t, cli, []string{"sh", "-c", "exit 7"})
+	require.NoError(t, cli.ContainerStart(ctx, id, container.StartOptions{}))
+
+	code, err := dockerutil.AwaitExit(ctx, cli, id)
+	require.NoError(t, err)
+	require.Equal(t, int64(7), code)
+}
+
+// TestAwaitExit_ADeadlineEndsTheWaitAndLeavesNothingParked is the regression
+// test for the leak that took the goroutine check out of internal/insights.
+//
+// The shape that leaked: waiting on a container hands back an UNBUFFERED
+// result channel and a goroutine that closes the response body only after it
+// has handed its result over. Both call sites here also selected on
+// ctx.Done(), so when the deadline landed at the same moment as the result --
+// and select picks at random between two ready cases -- the goroutine was
+// parked on the send for good, its body never closed, its connection never
+// returned to the idle pool, and Client.Close could not reclaim it.
+//
+// AwaitExit has no ctx.Done() case for exactly that reason, so what is
+// asserted is the contract that replaces it: the deadline still ends the wait
+// promptly, because it cancels the request the goroutine is reading, and once
+// the client is closed nothing is left running.
+func TestAwaitExit_ADeadlineEndsTheWaitAndLeavesNothingParked(t *testing.T) {
+	cli := requireDaemon(t)
+	defer func() { _ = cli.Close() }()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	before := goleak.IgnoreCurrent()
+
+	id := createRunning(t, cli, []string{"sleep", "60"})
+	require.NoError(t, cli.ContainerStart(ctx, id, container.StartOptions{}))
+
+	short, stop := context.WithTimeout(ctx, 300*time.Millisecond)
+	defer stop()
+	start := time.Now()
+	_, err := dockerutil.AwaitExit(short, cli, id)
+	require.ErrorIs(t, err, context.DeadlineExceeded,
+		"the container outlives the deadline, so the deadline is what ends the wait")
+	require.Less(t, time.Since(start), 30*time.Second,
+		"the deadline has to end the wait, not be outlived by it")
+
+	require.NoError(t, dockerutil.RemoveContainer(ctx, cli, id))
+	_ = cli.Close()
+
+	require.NoError(t, goleak.Find(before),
+		"a goroutine outlived the client, so a wait was left parked and its "+
+			"connection stranded")
+}

--- a/engine/internal/dockerutil/docker_test.go
+++ b/engine/internal/dockerutil/docker_test.go
@@ -130,6 +130,27 @@ func create(t *testing.T, cli *client.Client, labels map[string]string) string {
 	return resp.ID
 }
 
+// createRunning makes a container with a command of its own, for tests about
+// waiting rather than about labels, and guarantees its removal.
+func createRunning(t *testing.T, cli *client.Client, cmd []string) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	resp, err := cli.ContainerCreate(ctx,
+		&container.Config{
+			Image: testImage, Cmd: cmd,
+			Labels: dockerutil.Managed(dockerutil.KindService, "await-exit", time.Now()),
+		},
+		&container.HostConfig{}, nil, nil, "")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		c, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+		_ = cli.ContainerRemove(c, resp.ID, container.RemoveOptions{Force: true, RemoveVolumes: true})
+	})
+	return resp.ID
+}
+
 func TestRemoveContainer_RemovesOurOwn(t *testing.T) {
 	cli := requireDaemon(t)
 	ctx := context.Background()

--- a/engine/internal/dockerutil/dockerutil.go
+++ b/engine/internal/dockerutil/dockerutil.go
@@ -156,6 +156,40 @@ func Discard(r io.ReadCloser) {
 	_ = r.Close()
 }
 
+// AwaitExit blocks until a container exits and returns its exit code.
+//
+// It exists so that no caller has to know the sharp edge in ContainerWait, and
+// so that none of them can abandon a wait.
+//
+// ContainerWait hands back two channels and a goroutine that sends exactly one
+// value on one of them. The result channel is UNBUFFERED, and the goroutine
+// closes the response body in a defer that runs only after that send. A caller
+// that also selects on ctx.Done() can therefore walk away at the moment the
+// result is being handed over -- select picks at random between two ready
+// cases -- and park the goroutine on the send for good. The body is never
+// closed, so the connection never goes back into the transport's idle pool,
+// and Client.Close cannot reclaim it, because CloseIdleConnections only
+// touches connections that are idle. readLoop and writeLoop then outlive the
+// process, which is what a leak detector reports, in a stack with no frame
+// from this repository.
+//
+// Both call sites in this repository were written that way. The fix is not to
+// drain the abandoned channels afterwards but to never abandon them: the wait
+// request is made with this same context, so cancelling it fails the request
+// the goroutine is reading, and the goroutine reports that on the error
+// channel. Receiving from both channels and nothing else therefore returns
+// promptly when the deadline passes AND leaves nothing parked, which is why
+// there is no ctx.Done() case here and must not be one.
+func AwaitExit(ctx context.Context, cli *client.Client, id string) (int64, error) {
+	statusCh, errCh := cli.ContainerWait(ctx, id, container.WaitConditionNotRunning)
+	select {
+	case err := <-errCh:
+		return 0, err
+	case status := <-statusCh:
+		return status.StatusCode, nil
+	}
+}
+
 // PortAllocator hands out free localhost ports.
 //
 // Probing for a free port and then binding it is a race with everything else

--- a/engine/internal/env/goldenstore_test.go
+++ b/engine/internal/env/goldenstore_test.go
@@ -1,6 +1,7 @@
 package env
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -8,12 +9,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/docker/api/types/image"
 	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/require"
 
 	"github.com/antifailure/antifailure/engine/internal/clock"
 	dockerdb "github.com/antifailure/antifailure/engine/internal/db/docker"
 	"github.com/antifailure/antifailure/engine/internal/db/pgcopy"
+	"github.com/antifailure/antifailure/engine/internal/dockerutil"
 	"github.com/antifailure/antifailure/engine/internal/golden"
 	"github.com/antifailure/antifailure/engine/internal/secrets"
 	"github.com/antifailure/antifailure/engine/pkg/provider"
@@ -85,10 +88,13 @@ func TestPublishAndPull_ASecondMachineBranchesWhatTheFirstPublished(t *testing.T
 	storeDir := t.TempDir()
 
 	// Machine one. It has the production credential and a subset block.
-	first, stopFirst := requireOrchestrator(t, "publisher", sourceURL, storeDir)
+	first, firstGoldens, stopFirst := requireOrchestrator(t, "publisher", sourceURL, storeDir)
 	defer stopFirst()
 
 	refreshed, err := first.RefreshGolden(ctx)
+	// Registered before the error check: a refresh that fails partway can
+	// still have committed the image, and the teardown has to know about it.
+	firstGoldens.add(refreshed.Version)
 	require.NoError(t, err)
 	require.True(t, refreshed.Verified)
 	require.NotEmpty(t, refreshed.Version)
@@ -110,7 +116,7 @@ func TestPublishAndPull_ASecondMachineBranchesWhatTheFirstPublished(t *testing.T
 	// Machine two. Same manifest, same store, and NO production credential at
 	// all, which is the point: a runner that cannot reach production is
 	// exactly what this is for.
-	second, stopSecond := requireOrchestrator(t, "puller", "", storeDir)
+	second, secondGoldens, stopSecond := requireOrchestrator(t, "puller", "", storeDir)
 	defer stopSecond()
 
 	// The two machines share this laptop's Docker daemon, so they share its
@@ -120,6 +126,7 @@ func TestPublishAndPull_ASecondMachineBranchesWhatTheFirstPublished(t *testing.T
 	// source_url_env, so it could not refresh even if it wanted to, and the
 	// only way it can end up with data is through the store.
 	pulled, err := second.PullGolden(ctx, "")
+	secondGoldens.add(pulled.Version)
 	require.NoError(t, err)
 	require.Equal(t, refreshed.Version, pulled.From, "the newest complete version was taken")
 	require.True(t, pulled.Verified,
@@ -170,7 +177,7 @@ func TestPull_RefusesAVersionWhosePublishDidNotFinish(t *testing.T) {
 	require.NoError(t, store.Put(ctx, golden.DumpName("gv_halfpublished"), 3,
 		strings.NewReader("abc")))
 
-	o, stop := requireOrchestrator(t, "puller", "", storeDir)
+	o, _, stop := requireOrchestrator(t, "puller", "", storeDir)
 	defer stop()
 
 	_, err = o.PullGolden(ctx, "gv_halfpublished")
@@ -279,7 +286,9 @@ func replaceDatabase(url, name string) string {
 
 // requireOrchestrator builds one machine's engine: its own state directory,
 // its own Docker provider namespace, and a manifest pointing at the store.
-func requireOrchestrator(t *testing.T, name, sourceURL, storeDir string) (*Orchestrator, func()) {
+func requireOrchestrator(
+	t *testing.T, name, sourceURL, storeDir string,
+) (*Orchestrator, *ownGoldens, func()) {
 	t.Helper()
 	env := map[string]string{"AF_GOLDEN_STORE": storeDir}
 	db := &schema.Database{
@@ -317,18 +326,40 @@ func requireOrchestrator(t *testing.T, name, sourceURL, storeDir string) (*Orche
 	})
 	require.NoError(t, err)
 
-	return o, func() {
+	mine := &ownGoldens{}
+	return o, mine, func() {
 		c, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 		defer cancel()
-		// Whatever this machine made, it takes away. A test that leaves a
-		// golden image behind makes the next run of the leak detector blame
-		// somebody else.
-		goldens, listErr := o.Goldens(c)
-		if listErr == nil {
-			for _, g := range goldens {
-				_ = o.DestroyGolden(c, g.ID)
-			}
+		// Whatever THIS orchestrator made, it takes away, and nothing else.
+		//
+		// This used to list every golden on the daemon and destroy all of
+		// them. The daemon is shared: `go test ./...` runs packages in
+		// parallel, so internal/db/docker's conformance suite is refreshing
+		// and branching its own goldens on the same image store at the same
+		// time. This teardown deleted them, and a conformance behaviour that
+		// had refreshed a golden but not yet branched it failed with AF-DB-004
+		// naming a version it had just created. That is the intermittent
+		// failure of TestConformance/Branch_ReadsAKnownRow, and it was
+		// misdiagnosed twice as a name collision: the one golden that ever
+		// survived the sweep was this test's own, protected only because a
+		// branch already pinned it and DestroyGolden refuses those.
+		//
+		// A leak here is now a leak the detector reports, which is the right
+		// place for it. Deleting somebody else's golden to keep our own house
+		// tidy trades a visible leak for an invisible flake.
+		for _, id := range mine.ids {
+			_ = o.DestroyGolden(c, id)
 		}
+	}
+}
+
+// ownGoldens records the golden versions one orchestrator created, so its
+// teardown can remove exactly those on a daemon it shares with other packages.
+type ownGoldens struct{ ids []string }
+
+func (g *ownGoldens) add(id string) {
+	if id != "" {
+		g.ids = append(g.ids, id)
 	}
 }
 
@@ -353,3 +384,71 @@ func requireBranch(t *testing.T, ctx context.Context, o *Orchestrator, version s
 }
 
 var _ = fmt.Sprintf
+
+// TestOrchestratorTeardown_LeavesGoldensItDidNotCreate is the regression test
+// for the flake that outlasted two wrong diagnoses.
+//
+// This teardown used to list every golden on the daemon and destroy all of
+// them. `go test ./...` runs packages in parallel and they share one Docker
+// daemon, so this deleted goldens belonging to internal/db/docker's
+// conformance suite while that suite was mid-behaviour, and
+// TestConformance/Branch_ReadsAKnownRow failed with AF-DB-004 naming a version
+// it had itself created seconds earlier.
+//
+// The check is both halves. A golden this orchestrator never made survives its
+// teardown, and one it did make does not, so the test cannot pass by the
+// teardown having quietly stopped removing anything at all.
+func TestOrchestratorTeardown_LeavesGoldensItDidNotCreate(t *testing.T) {
+	if os.Getenv("AF_SKIP_DOCKER") != "" {
+		t.Skip("skipped: AF_SKIP_DOCKER is set")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	cli, err := dockerutil.Client()
+	if err != nil {
+		t.Skipf("no Docker daemon is reachable: %v", err)
+	}
+	defer func() { _ = cli.Close() }()
+
+	// Two goldens that stand in for another package's work and for this
+	// orchestrator's own. They are empty images rather than real Postgres
+	// commits because what is under test is which tags the teardown chooses,
+	// not what is inside them, and an empty import takes milliseconds.
+	stamp := time.Now().UnixNano()
+	foreign := fmt.Sprintf("gv_%d_foreign0", stamp)
+	ours := fmt.Sprintf("gv_%d_ours0000", stamp)
+	for _, id := range []string{foreign, ours} {
+		ref := dockerdb.ImageRepo + ":" + id
+		body, importErr := cli.ImageImport(ctx,
+			image.ImportSource{Source: bytes.NewReader(make([]byte, 1024)), SourceName: "-"},
+			ref, image.ImportOptions{})
+		if importErr != nil {
+			t.Skipf("this daemon will not import a scratch image: %v", importErr)
+		}
+		dockerutil.Discard(body)
+		t.Cleanup(func() {
+			c, done := context.WithTimeout(context.Background(), time.Minute)
+			defer done()
+			_, _ = cli.ImageRemove(c, ref, image.RemoveOptions{Force: true})
+		})
+	}
+
+	o, mine, stop := requireOrchestrator(t, "teardown", "", t.TempDir())
+	// Only one of the two is claimed, which is the whole point.
+	mine.add(ours)
+	stop()
+
+	after, err := o.Goldens(ctx)
+	require.NoError(t, err)
+	ids := make(map[string]bool, len(after))
+	for _, g := range after {
+		ids[g.ID] = true
+	}
+	require.True(t, ids[foreign],
+		"the teardown destroyed a golden this orchestrator never created; on a shared "+
+			"daemon that is another package's environment disappearing under it")
+	require.False(t, ids[ours],
+		"the teardown left behind a golden it did create, so this test would pass "+
+			"even if teardown removed nothing at all")
+}

--- a/engine/internal/insights/container.go
+++ b/engine/internal/insights/container.go
@@ -174,23 +174,17 @@ func (a *ContainerApplier) Apply(
 		return nil, fmt.Errorf("insights: start the rehearsal container: %w", err)
 	}
 
-	statusCh, errCh := cli.ContainerWait(ctx, created.ID, container.WaitConditionNotRunning)
-	select {
-	case err := <-errCh:
-		if err != nil {
-			return nil, fmt.Errorf("insights: waiting for the migration: %w", err)
-		}
-	case status := <-statusCh:
-		if status.StatusCode != 0 {
-			// The tool's own output is the finding. A migration tool explains
-			// its failure far better than an exit code does, and discarding
-			// that in favour of "exit 1" would make the report useless in
-			// exactly the case it exists for.
-			return nil, fmt.Errorf("the migration command exited %d: %s",
-				status.StatusCode, lastLines(ctx, cli, created.ID))
-		}
-	case <-ctx.Done():
-		return nil, ctx.Err()
+	code, err := dockerutil.AwaitExit(ctx, cli, created.ID)
+	if err != nil {
+		return nil, fmt.Errorf("insights: waiting for the migration: %w", err)
+	}
+	if code != 0 {
+		// The tool's own output is the finding. A migration tool explains
+		// its failure far better than an exit code does, and discarding
+		// that in favour of "exit 1" would make the report useless in
+		// exactly the case it exists for.
+		return nil, fmt.Errorf("the migration command exited %d: %s",
+			code, lastLines(ctx, cli, created.ID))
 	}
 	// The applier does not know what it ran; the server does.
 	return nil, nil

--- a/engine/internal/insights/container_test.go
+++ b/engine/internal/insights/container_test.go
@@ -175,15 +175,11 @@ func runOnNetwork(
 	if err := cli.ContainerStart(ctx, created.ID, container.StartOptions{}); err != nil {
 		return -1, err.Error()
 	}
-	statusCh, errCh := cli.ContainerWait(ctx, created.ID, container.WaitConditionNotRunning)
-	select {
-	case err := <-errCh:
+	code, err := dockerutil.AwaitExit(ctx, cli, created.ID)
+	if err != nil {
 		return -1, fmt.Sprint(err)
-	case status := <-statusCh:
-		return status.StatusCode, ""
-	case <-ctx.Done():
-		return -1, "timed out"
 	}
+	return code, ""
 }
 
 func TestContainerApplier_RunsTheProjectsOwnMigrateCommandInItsImage(t *testing.T) {

--- a/engine/internal/insights/container_test.go
+++ b/engine/internal/insights/container_test.go
@@ -64,7 +64,7 @@ func (b *dockerBranch) AttachToNetwork(
 	return 5432, err
 }
 
-func requireBranchContainer(t *testing.T, name string) (*dockerBranch, func()) {
+func requireBranchContainer(t *testing.T, name string) *dockerBranch {
 	t.Helper()
 	if os.Getenv("AF_SKIP_DOCKER") != "" {
 		t.Skip("skipped: AF_SKIP_DOCKER is set")
@@ -73,7 +73,21 @@ func requireBranchContainer(t *testing.T, name string) (*dockerBranch, func()) {
 	if err != nil {
 		skipOrFail(t, "no Docker daemon is reachable: %v", err)
 	}
+	// Registered first so that it runs LAST, because t.Cleanup is LIFO and
+	// every other cleanup here and in waitForBranch talks to this client.
+	//
+	// This used to be returned as a stop function the tests called with
+	// `defer`, which put it in the wrong order by construction: a deferred
+	// call in a test body runs BEFORE any t.Cleanup, so the client was closed
+	// and waitForBranch's cleanup then asked it to disconnect and remove a
+	// network. Those calls dial again, and nothing closes what they dial: a
+	// connection per test outliving the process, reported by the leak detector
+	// as net/http readLoop and writeLoop pairs with no frame from this
+	// repository in them.
+	t.Cleanup(func() { _ = cli.Close() })
+
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	t.Cleanup(cancel)
 
 	full := "af-lane6-" + name
 	_ = dockerutil.RemoveContainer(ctx, cli, full)
@@ -88,19 +102,14 @@ func requireBranchContainer(t *testing.T, name string) (*dockerBranch, func()) {
 		&container.HostConfig{RestartPolicy: container.RestartPolicy{Name: "no"}},
 		nil, nil, full)
 	if err != nil {
-		cancel()
-		_ = cli.Close()
 		skipOrFail(t, "the branch container could not be created: %v", err)
 	}
-	stop := func() {
+	t.Cleanup(func() {
 		c, done := context.WithTimeout(context.Background(), 2*time.Minute)
 		defer done()
 		_ = dockerutil.RemoveContainer(c, cli, created.ID)
-		_ = cli.Close()
-		cancel()
-	}
+	})
 	if err := cli.ContainerStart(ctx, created.ID, container.StartOptions{}); err != nil {
-		stop()
 		skipOrFail(t, "the branch container could not be started: %v", err)
 	}
 
@@ -110,7 +119,7 @@ func requireBranchContainer(t *testing.T, name string) (*dockerBranch, func()) {
 	// rewrites the host anyway, so the string only has to carry the
 	// credential and the database name.
 	b.url = secrets.New("postgres://postgres:test@127.0.0.1:1/postgres?sslmode=disable")
-	return b, stop
+	return b
 }
 
 // waitForBranch blocks until Postgres inside the container answers, asked from
@@ -183,8 +192,7 @@ func runOnNetwork(
 }
 
 func TestContainerApplier_RunsTheProjectsOwnMigrateCommandInItsImage(t *testing.T) {
-	b, done := requireBranchContainer(t, "applier")
-	defer done()
+	b := requireBranchContainer(t, "applier")
 	probeNet := waitForBranch(t, b)
 	ctx := context.Background()
 
@@ -214,8 +222,7 @@ func TestContainerApplier_RunsTheProjectsOwnMigrateCommandInItsImage(t *testing.
 }
 
 func TestContainerApplier_ReportsTheToolsOwnOutputWhenItFails(t *testing.T) {
-	b, done := requireBranchContainer(t, "applierfail")
-	defer done()
+	b := requireBranchContainer(t, "applierfail")
 	waitForBranch(t, b)
 
 	// A migration tool explains its failure far better than an exit code
@@ -235,8 +242,7 @@ func TestContainerApplier_ReportsTheToolsOwnOutputWhenItFails(t *testing.T) {
 }
 
 func TestContainerApplier_HasNoRouteOffTheMachine(t *testing.T) {
-	b, done := requireBranchContainer(t, "appliersealed")
-	defer done()
+	b := requireBranchContainer(t, "appliersealed")
 	waitForBranch(t, b)
 
 	// The product's whole premise is that an environment has nowhere to send
@@ -272,8 +278,7 @@ func TestContainerApplier_RefusesWithNothingToRun(t *testing.T) {
 }
 
 func TestContainerApplier_LeavesNothingBehind(t *testing.T) {
-	b, done := requireBranchContainer(t, "applierclean")
-	defer done()
+	b := requireBranchContainer(t, "applierclean")
 	waitForBranch(t, b)
 	ctx := context.Background()
 

--- a/engine/internal/insights/postgres_test.go
+++ b/engine/internal/insights/postgres_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 
 	"github.com/antifailure/antifailure/engine/internal/insights"
 	"github.com/antifailure/antifailure/engine/internal/secrets"
@@ -102,25 +103,28 @@ func TestMain(m *testing.M) {
 		}
 		return m.Run()
 	}()
-	// G3 is NOT verified here yet, and the reason is written down in
-	// docs/plan/QUESTIONS.md as Q8 rather than left as an absence somebody has
-	// to rediscover.
+	// G3, after the teardown above rather than instead of it. goleak.
+	// VerifyTestMain cannot be used here because this package already owns
+	// TestMain, and the check has to run once the deferred provider teardown
+	// has closed its containers and connections, or every run would report the
+	// suite's own fixtures as leaks.
 	//
-	// goleak.Find here passes on a workstation and fails in CI with two
-	// net/http persistConn readLoop and writeLoop pairs still in IO wait. The
-	// stacks contain no frame from this repository: they are idle keep-alive
-	// connections held by an http.Transport. Every Docker client this package
-	// opens is closed, and the one streaming response it reads goes through
-	// dockerutil.Discard, which drains before closing. So this is either a
-	// leak somewhere below the code audited so far, or the known race where
-	// CloseIdleConnections returns before the connection's goroutines have
-	// finished unwinding.
-	//
-	// Reaching for goleak.IgnoreTopFunction on net/http would make this green
-	// while making the check unable to see the class of leak most worth
-	// catching here, which is the sidecar and provider clients. Four of the
-	// five packages G3 was missing verify and are clean; this one is left
-	// honest and open.
+	// This was taken out once, when it passed on a workstation and failed in
+	// CI with net/http persistConn readLoop and writeLoop pairs whose stacks
+	// carried no frame from this repository. They were this package's, by a
+	// longer route than reading it suggests: waiting on the rehearsal
+	// container abandoned the wait when the deadline landed at the same moment
+	// as the result, which parks the goroutine that closes the response body
+	// and strands its connection where Client.Close cannot reach it. That is
+	// fixed at the source, in dockerutil.AwaitExit, which no caller can
+	// abandon. The check belongs back here now, because a check that is off is
+	// a check that finds nothing.
+	if code == 0 {
+		if err := goleak.Find(); err != nil {
+			fmt.Fprintf(os.Stderr, "goroutines outlived the suite: %v\n", err)
+			code = 1
+		}
+	}
 	os.Exit(code)
 }
 

--- a/engine/internal/runtime/local/container.go
+++ b/engine/internal/runtime/local/container.go
@@ -436,22 +436,16 @@ func (r *Runtime) runOnce(
 		return aferrors.Wrap(err, aferrors.AFRUN040,
 			"detail", fmt.Sprintf("starting the %s migration: %v", s.Name, err))
 	}
-	statusCh, errCh := r.cli.ContainerWait(ctx, id, container.WaitConditionNotRunning)
-	select {
-	case err := <-errCh:
-		if err != nil {
-			return aferrors.Wrap(err, aferrors.AFRUN040,
-				"detail", fmt.Sprintf("waiting for the %s migration: %v", s.Name, err))
-		}
-	case status := <-statusCh:
-		if status.StatusCode != 0 {
-			output = r.lastLogLines(ctx, id)
-			return aferrors.Coded(aferrors.AFRUN005,
-				"service", s.Name+" migration",
-				"code", strconv.FormatInt(status.StatusCode, 10)+"\n"+output)
-		}
-	case <-ctx.Done():
-		return ctx.Err()
+	code, waitErr := dockerutil.AwaitExit(ctx, r.cli, id)
+	if waitErr != nil {
+		return aferrors.Wrap(waitErr, aferrors.AFRUN040,
+			"detail", fmt.Sprintf("waiting for the %s migration: %v", s.Name, waitErr))
+	}
+	if code != 0 {
+		output = r.lastLogLines(ctx, id)
+		return aferrors.Coded(aferrors.AFRUN005,
+			"service", s.Name+" migration",
+			"code", strconv.FormatInt(code, 10)+"\n"+output)
 	}
 	return nil
 }

--- a/justfile
+++ b/justfile
@@ -152,7 +152,7 @@ setup:
     if [ "$(git config core.hooksPath || true)" = ".githooks" ]; then
       echo "on"
     else
-      echo "off            run: git config core.hooksPath .githooks"
+      echo "off            run: just hooks"
       missing=$((missing+1))
     fi
     printf '  %-12s' "identity"
@@ -178,6 +178,32 @@ setup:
       echo "Everything this repository needs is here. Next: just gate"
     else
       echo "$missing things to fix, each with its command above."
+      exit 1
+    fi
+
+# CONTRIBUTING.md has always required a Developer Certificate of Origin
+# trailer, and `just setup` has always been able to tell you the hook was off.
+# Neither turned it on, and the gap between knowing and doing is how an
+# unsigned commit reached main: the author's clone had never run the one line,
+# nothing local objected, and the check that would have caught it is a check
+# that runs after the commit exists.
+#
+# Local config rather than anything global, so it cannot affect another
+# repository on this machine.
+[doc("Point git at this repository's hooks, so commits carry a sign-off.")]
+hooks:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    git config core.hooksPath .githooks
+    echo "hooks       on   .githooks"
+    printf 'identity    '
+    if email=$(git config user.email) && [ -n "$email" ]; then
+      echo "$email"
+    else
+      echo "UNSET -- run: git config user.email you@example.com"
+      echo
+      echo "The sign-off trailer is built from this, so a commit made without" >&2
+      echo "one cannot be signed off." >&2
       exit 1
     fi
 
@@ -621,7 +647,7 @@ authorship:
       fi
     done
     if [ "$missing" -gt 0 ]; then
-      echo "Add one with 'git commit -s', or: git config core.hooksPath .githooks"
+      echo "Add one with 'git commit -s', or turn the hook on once: just hooks"
       exit 1
     fi
     echo "attributed and signed off"

--- a/tools/gatecheck/main.go
+++ b/tools/gatecheck/main.go
@@ -296,6 +296,11 @@ func uncalledByGate(just string) []string {
 		// the whole engine suite with -coverpkg and takes the better part of an
 		// hour. `coverage`, which is the gate, IS in `gate`.
 		"coverage-profile": true,
+		// Turns this repository's commit hooks on. It writes to the clone's git
+		// config, which is the definition of a convenience here, and the
+		// property it helps with -- every commit carrying a sign-off -- is
+		// already a gate in CI that does not depend on anybody having run it.
+		"hooks": true,
 	}
 
 	recipeRe := regexp.MustCompile(`^([a-z][\w-]*)(?: [\w"=]+)*:`)


### PR DESCRIPTION
Four things were red or worked around. Two of them were the same kind of
mistake: a symptom diagnosed twice without reading the evidence that was
already in the failure text.

### The golden flake, fixed

`TestConformance/Branch_ReadsAKnownRow` in `internal/db/docker` has been failing
intermittently for a week and rerun rather than fixed. It was diagnosed twice as
an identifier collision. It was not.

The AF-DB-004 message names the versions that DO exist, and it named exactly one:

    Branch(gv_20260829123613_c2f585fe, env_conformance00001): AF-DB-004:
    The golden version gv_20260829123613_c2f585fe no longer exists.
    Available: gv_20260829123601_store-te

`store-te` is not a hash. It is the first eight characters of `store-test`,
which `internal/env/goldenstore_test.go` passes as its `RulesHash`. That
package's teardown listed every golden on the daemon and destroyed all of them,
on a daemon shared with every package `go test ./...` runs in parallel.

It now removes only the versions it created. The regression test asserts both
halves, so it cannot pass by the teardown quietly removing nothing; against the
old teardown it fails on the first.

### The goroutine leak, fixed

`internal/insights` was the one package G3 was still missing `goleak` in,
removed because it failed in CI with `net/http` `persistConn` pairs whose stacks
carried no frame from this repository. They were this package's.

`ContainerWait` returns an UNBUFFERED result channel and a goroutine that closes
the response body only after handing the result over. Both call sites also
selected on `ctx.Done()`, so a deadline landing at the same moment as a result
parked that goroutine on the send for good: body never closed, connection never
returned to the idle pool, and `Client.Close` cannot reclaim it, because
`CloseIdleConnections` only touches idle connections.

`dockerutil.AwaitExit` has no `ctx.Done()` case, so there is nothing to abandon.
That is safe because the wait request carries the same context: cancelling it
fails the request the goroutine is reading. The risk of removing that case is a
hang rather than a leak, so the test asserts the deadline still ends the wait.

**Not claimed:** a reproduction of the race. The mechanism is proven by reading
`ContainerWait`; the abandonment is gone by construction. A first regression
test passed against the unfixed code and was rewritten rather than kept. The
check is back on in CI, which is where the failure lives.

### The sign-off

`just hooks` turns the commit hooks on, instead of `just setup` telling you they
are off and leaving it there. That gap is how an unsigned commit reached main.

This does not repair history: `6ead5bf` cannot be given a trailer without
rewriting main, and it is not mine to certify in somebody else's name. The check
is required on main now, so it could not land again.

### The Dependabot break

Already fixed on #34, which is green.

---

Verified: the new tests pass and fail against the unfixed code, in both cases;
`golangci-lint` clean on all four packages; `internal/env` green.