### PR TITLE
The console works, and nobody could administer it

### DIFF
--- a/console/app/(app)/keys/page.tsx
+++ b/console/app/(app)/keys/page.tsx
@@ -286,8 +286,9 @@ function ProviderCard({
           </>
         ) : (
           <p className="max-w-[62ch] text-[13px] leading-6 text-muted">
-            You are {data.role ?? "not a member"} in this organization, so you
-            can see which keys are set and cannot change them.
+            You are {data.role ? `a ${data.role}` : "not a member"} in this
+            organization, so you can see which keys are set and cannot change
+            them.
           </p>
         )}
 

--- a/console/app/(app)/members/page.tsx
+++ b/console/app/(app)/members/page.tsx
@@ -6,6 +6,7 @@ import { mutate, query, useApi } from "@/lib/api";
 import { useSessionContext } from "@/components/session";
 import {
   Badge,
+  Button,
   Card,
   Empty,
   Loaded,
@@ -25,6 +26,12 @@ interface Member {
   role: string;
   source: string;
   created_at: string;
+}
+
+interface SyncReport {
+  added: string[];
+  removed: string[];
+  changed: { login: string; from: string; to: string }[];
 }
 
 const ROLES = ["owner", "admin", "member", "viewer"] as const;
@@ -78,6 +85,67 @@ function RolePicker({
   );
 }
 
+/**
+ * Reconciles the list against GitHub's.
+ *
+ * Sign-in can only ever speak for the person signing in: somebody added to the
+ * GitHub organization is not here until they happen to sign in, and somebody
+ * REMOVED from it keeps their role until they sign in again, which a person who
+ * has been removed has no reason to do. This is the control that acts on
+ * everybody at once, and the only one that takes access away.
+ *
+ * It reports what changed rather than just succeeding. "Synced" tells you
+ * nothing; "removed 1" is the sentence somebody needs to see before they trust
+ * a button that can remove people.
+ */
+function SyncFromGitHub({ csrf, onSynced }: { csrf: string; onSynced: () => void }) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [report, setReport] = useState<SyncReport | null>(null);
+
+  return (
+    // Outcome first, button last, so the button stays pinned to the right edge
+    // of the header whatever length the message turns out to be.
+    <div className="flex flex-wrap items-center justify-end gap-x-3 gap-y-1">
+      {error ? (
+        <span role="alert" className="min-w-0 max-w-[46ch] break-words text-left text-[12px] leading-4 text-fail sm:text-right">
+          {error}
+        </span>
+      ) : report ? (
+        <span role="status" className="min-w-0 max-w-[46ch] break-words text-left text-[12px] leading-4 text-dim sm:text-right">
+          {describe(report)}
+        </span>
+      ) : null}
+      <Button
+        busy={busy}
+        onClick={async () => {
+          setBusy(true);
+          setError(null);
+          setReport(null);
+          try {
+            setReport(await mutate<SyncReport>("members.sync", {}, csrf));
+            onSynced();
+          } catch (err) {
+            setError(err instanceof Error ? err.message : "That did not work.");
+          } finally {
+            setBusy(false);
+          }
+        }}
+      >
+        {busy ? "Syncing" : "Sync from GitHub"}
+      </Button>
+    </div>
+  );
+}
+
+function describe(r: SyncReport): string {
+  const parts: string[] = [];
+  if (r.added.length) parts.push(`added ${r.added.length}`);
+  if (r.removed.length) parts.push(`removed ${r.removed.length}`);
+  if (r.changed.length) parts.push(`changed ${r.changed.length}`);
+  return parts.length === 0 ? "Already matched GitHub." : `${parts.join(", ")}.`;
+}
+
 function Members() {
   const session = useSessionContext();
   const state = useApi<Member[]>(() => query("members.list"), []);
@@ -93,7 +161,12 @@ function Members() {
           : "Who is in this organization and what each of them can do. Changing a role needs owner or admin."
       }
     >
-      <Card title="People">
+      <Card
+        title="People"
+        actions={
+          mayManage ? <SyncFromGitHub csrf={csrf} onSynced={state.reload} /> : null
+        }
+      >
         <Loaded state={state} skeleton={<TableSkeleton rows={4} cols={4} />}>
           {(rows) =>
             rows.length === 0 ? (

--- a/console/components/ui.tsx
+++ b/console/components/ui.tsx
@@ -29,7 +29,13 @@ export function Page({
             <p className="mt-2 max-w-[62ch] text-[13.5px] leading-6 text-muted">{lede}</p>
           ) : null}
         </div>
-        {actions ? <div className="flex shrink-0 items-center gap-2">{actions}</div> : null}
+        {actions ? (
+            // max-w-full, or an actions block wider than the card -- a long
+            // error message beside a button -- is clipped by the overflow-hidden
+            // on the section and simply disappears at a phone width. shrink-0
+            // still keeps a short one from being squeezed by the title.
+            <div className="flex min-w-0 max-w-full shrink-0 items-center gap-2">{actions}</div>
+          ) : null}
       </div>
       <div className="mt-7">{children}</div>
     </div>
@@ -59,7 +65,13 @@ export function Card({
             <h2 className="text-[13px] font-semibold tracking-extra-tight text-ink">{title}</h2>
             {note ? <p className="mt-0.5 text-[12px] leading-5 text-dim">{note}</p> : null}
           </div>
-          {actions ? <div className="flex shrink-0 items-center gap-2">{actions}</div> : null}
+          {actions ? (
+            // max-w-full, or an actions block wider than the card -- a long
+            // error message beside a button -- is clipped by the overflow-hidden
+            // on the section and simply disappears at a phone width. shrink-0
+            // still keeps a short one from being squeezed by the title.
+            <div className="flex min-w-0 max-w-full shrink-0 items-center gap-2">{actions}</div>
+          ) : null}
         </header>
       ) : null}
       {children}

--- a/docs/src/content/docs/reference/control-plane.md
+++ b/docs/src/content/docs/reference/control-plane.md
@@ -60,6 +60,32 @@ to any account added to the allowlist before it is invited anywhere.
 Both are needed. The allowlist is a closed door; the installation check is what
 makes an open one safe.
 
+## What role somebody gets
+
+The role comes from GitHub, read at sign-in with an installation token: an
+organization owner on GitHub becomes an `admin` here, and everybody else
+becomes a `member`.
+
+An owner on GitHub deliberately does not become an `owner` here. That role also
+holds `billing.manage`, and who pays is this application's decision rather than
+GitHub's. Promote somebody with the role control on the Members page; a role set
+that way is marked `manual` and is never overwritten by a later sign-in.
+
+Two cases where nothing changes rather than something being guessed. If GitHub
+will not say what somebody's role is -- no App configured, a rate limit, an
+outage -- an existing membership keeps the role it already had, because a
+transient failure must not demote the only administrator out of their own
+organization. A first sign-in during the same failure gets `member`, because
+guessing upward would hand out administrative rights on a timeout.
+
+Sign-in can only ever speak for the person signing in. **Sync from GitHub** on
+the Members page reconciles everybody at once, and it is the only thing that
+takes access away: somebody removed from the GitHub organization keeps their
+role until it runs, because a person who has been removed has no reason to come
+back and sign in. It needs `members.manage`, it refuses an empty member list
+from GitHub rather than removing every owner, and it records what it changed in
+the audit log.
+
 ## Health
 
 Two endpoints, answering two different questions. Point the right thing at the

--- a/docs/src/content/docs/reference/control-plane.md
+++ b/docs/src/content/docs/reference/control-plane.md
@@ -71,9 +71,9 @@ holds `billing.manage`, and who pays is this application's decision rather than
 GitHub's. Promote somebody with the role control on the Members page; a role set
 that way is marked `manual` and is never overwritten by a later sign-in.
 
-Two cases where nothing changes rather than something being guessed. If GitHub
-will not say what somebody's role is -- no App configured, a rate limit, an
-outage -- an existing membership keeps the role it already had, because a
+Two cases where nothing changes rather than something being guessed. Sometimes
+GitHub will not say what somebody's role is: no App configured, a rate limit, an
+outage. An existing membership then keeps the role it already had, because a
 transient failure must not demote the only administrator out of their own
 organization. A first sign-in during the same failure gets `member`, because
 guessing upward would hand out administrative rights on a timeout.

--- a/docs/src/content/docs/self-hosting/azure.md
+++ b/docs/src/content/docs/self-hosting/azure.md
@@ -183,6 +183,41 @@ no public endpoint, a Key Vault holding every credential, a storage account for
 goldens, the bootstrap job that makes the database usable, a maintenance job
 that keeps the event partitions ahead, and the application on public HTTPS.
 
+### An apply that changes the app changes nothing, until traffic moves
+
+The container app runs in `Multiple` revision mode, and ownership is split:
+Terraform owns the template, continuous deployment owns the image and the
+traffic weights. The module says so, with `ignore_changes` on
+`template[0].container[0].image` and `ingress[0].traffic_weight`, and the split
+is what lets the two run on their own schedules instead of undoing each other.
+
+The consequence is not obvious and it has already caught us once. Any Terraform
+change to the template creates a **new revision**, and because Terraform does
+not touch traffic weights, that revision comes up with **zero percent of
+traffic**. Terraform reports a successful apply. Production is still serving the
+old revision, without the change. Add an environment variable this way and the
+application will not see it, for as long as nobody deploys.
+
+So after an apply that touched the template, check what is actually serving:
+
+```sh
+az containerapp ingress traffic show -n afcp-app -g af-cp-centralus -o table
+az containerapp revision list -n afcp-app -g af-cp-centralus \
+  --query "[?properties.active].{rev:name,created:properties.createdTime}" -o table
+```
+
+If the newest revision is not the one with the weight, either run a deploy,
+which creates its own revision from the current image and shifts onto it, or
+move the traffic yourself:
+
+```sh
+az containerapp ingress traffic set -n afcp-app -g af-cp-centralus \
+  --revision-weight <newest-revision>=100
+```
+
+Moving it by hand is a traffic shift and not a rollback: both revisions run the
+same image unless a deploy happened in between.
+
 ### Grant yourself write access to the vault, once
 
 `assign_deployer_secret_officer` is **off by default** and that default is

--- a/infra/terraform/modules/control-plane/app.tf
+++ b/infra/terraform/modules/control-plane/app.tf
@@ -411,6 +411,14 @@ resource "azurerm_container_app" "this" {
   # resolves to, silently undoing the last deploy, and the next deploy would
   # show up as drift in the next plan. Splitting ownership at this line is what
   # lets both run on their own schedule.
+  #
+  # THE COST OF THE SPLIT, which has already caught us once. This app runs in
+  # Multiple revision mode, so a change to the template below creates a new
+  # revision, and traffic is not ours to move. The new revision comes up at zero
+  # percent, terraform reports a successful apply, and production keeps serving
+  # the old one. Add an environment variable here and the application does not
+  # see it until somebody deploys. Check what is actually serving after an apply
+  # that touched the template; the self-hosting guide has the two commands.
   lifecycle {
     ignore_changes = [
       template[0].container[0].image,

--- a/web/apps/api/src/auth/fakegithub.ts
+++ b/web/apps/api/src/auth/fakegithub.ts
@@ -24,6 +24,7 @@ export class FakeGitHub implements GitHubClient {
   private readonly orgs = new Map<string, GitHubOrg[]>()
   private readonly members = new Map<string, { user: GitHubUser; role: 'admin' | 'member' }[]>()
   private readonly codes = new Map<string, PendingCode>()
+  private unreachable = false
   private readonly tokens = new Map<string, string>()
 
   /** How long a code is good for. GitHub's is ten minutes. */
@@ -88,5 +89,30 @@ export class FakeGitHub implements GitHubClient {
     orgLogin: string,
   ): Promise<{ user: GitHubUser; role: 'admin' | 'member' }[]> {
     return this.members.get(orgLogin) ?? []
+  }
+
+  /**
+   * Answers from the same member list membersOf reads, so a test cannot set up
+   * an organization where the two disagree.
+   *
+   * Null for somebody the list does not name, which is what the real client
+   * returns when GitHub will not say, and what makes the "leave the role
+   * alone" branch in sign-in reachable from a test.
+   */
+  async roleIn(
+    _installationId: number,
+    orgLogin: string,
+    login: string,
+  ): Promise<'admin' | 'member' | null> {
+    if (this.unreachable) throw new Error('GitHub is unreachable')
+    const found = (this.members.get(orgLogin) ?? []).find(
+      (m) => m.user.login.toLowerCase() === login.toLowerCase(),
+    )
+    return found ? found.role : null
+  }
+
+  /** Makes roleIn throw, the way a network failure or a rate limit does. */
+  breakRoleLookups(broken = true): void {
+    this.unreachable = broken
   }
 }

--- a/web/apps/api/src/auth/github.ts
+++ b/web/apps/api/src/auth/github.ts
@@ -37,6 +37,20 @@ export interface GitHubClient {
     installationId: number,
     orgLogin: string,
   ): Promise<{ user: GitHubUser; role: 'admin' | 'member' }[]>
+  /**
+   * The role GitHub reports for one person in one organization.
+   *
+   * Null means "could not be established", which is deliberately not the same
+   * answer as "member". Sign-in leans on the difference: it writes `member` for
+   * somebody who has no membership row yet, and leaves an existing role exactly
+   * as it was when this returns null, so a rate limit cannot demote an
+   * administrator out of their own organization.
+   */
+  roleIn(
+    installationId: number,
+    orgLogin: string,
+    login: string,
+  ): Promise<'admin' | 'member' | null>
 }
 
 export interface GitHubConfig {
@@ -194,7 +208,7 @@ export class RealGitHubClient implements GitHubClient {
         // it on the membership resource rather than in the list. Worth the
         // calls: without it every member syncs as a plain member and an
         // organization owner loses their own admin rights on first sync.
-        const role = await this.roleOf(token, base, orgLogin, m.login)
+        const role = (await this.roleOf(token, base, orgLogin, m.login)) ?? 'member'
         members.push({
           user: {
             id: m.id,
@@ -214,12 +228,37 @@ export class RealGitHubClient implements GitHubClient {
     return members
   }
 
+  async roleIn(
+    installationId: number,
+    orgLogin: string,
+    login: string,
+  ): Promise<'admin' | 'member' | null> {
+    const tokens = this.config.installationTokens
+    // No App, no installation token, no way to read a membership. Null rather
+    // than 'member', because the caller's fallback is its own decision to make.
+    if (!tokens) return null
+    try {
+      const token = await tokens.for(installationId)
+      const base = this.config.apiBase ?? 'https://api.github.com'
+      return await this.roleOf(token, base, orgLogin, login)
+    } catch {
+      return null
+    }
+  }
+
+  /**
+   * Null when GitHub would not say, rather than a guess.
+   *
+   * membersOf reads that null as 'member', which is the safe direction for a
+   * list that is about to be reconciled. roleIn passes it through, because the
+   * safe direction there is "change nothing".
+   */
   private async roleOf(
     token: string,
     base: string,
     orgLogin: string,
     login: string,
-  ): Promise<'admin' | 'member'> {
+  ): Promise<'admin' | 'member' | null> {
     const res = await fetch(
       new URL(`/orgs/${encodeURIComponent(orgLogin)}/memberships/${encodeURIComponent(login)}`, base),
       {
@@ -233,7 +272,7 @@ export class RealGitHubClient implements GitHubClient {
     )
     // Anything but a clear "admin" is a member. Guessing upward on a failed
     // read would hand somebody administrative rights because of a rate limit.
-    if (!res.ok) return 'member'
+    if (!res.ok) return null
     const body = (await res.json()) as { role?: string }
     return body.role === 'admin' ? 'admin' : 'member'
   }

--- a/web/apps/api/src/auth/signin.ts
+++ b/web/apps/api/src/auth/signin.ts
@@ -202,17 +202,45 @@ export async function completeSignIn(
       // array, and the mistake reads as correct in every language this is
       // written in.
       const installed = logins.length
-        ? await db.execute<{ org_id: string }>(sql`
-            SELECT org_id FROM github_installations
+        ? await db.execute<{ org_id: string; installation_id: string; account_login: string }>(sql`
+            SELECT org_id, installation_id, account_login FROM github_installations
             WHERE lower(account_login) = ANY(${sql.param(logins)}::text[])
               AND suspended_at IS NULL`)
         : []
 
       for (const row of installed) {
+        // The role comes from GitHub rather than from a constant here.
+        //
+        // This used to write 'member' for everybody, which is wrong in the one
+        // case that matters most: the person who installed the App, on the
+        // organization they own, arrives as a plain member and cannot manage
+        // members, mint engine tokens, export the audit log, approve a masking
+        // or egress change, or store a provider key. Their own control plane
+        // refuses them, and the only way out was a database console.
+        //
+        // An organization owner becomes an admin rather than an owner, for the
+        // reason syncMembership gives further down: owner also holds billing,
+        // and that is this application's decision rather than GitHub's.
+        const upstream = await github
+          .roleIn(Number(row.installation_id), row.account_login, user.login)
+          .catch(() => null)
+        const role: Role = upstream === 'admin' ? 'admin' : 'member'
+
         await db.execute(sql`
           INSERT INTO members (org_id, user_id, role, source)
-          VALUES (${row.org_id}, ${userId}, 'member', 'github')
-          ON CONFLICT (org_id, user_id) DO UPDATE SET updated_at = ${clock.now().toISOString()}`)
+          VALUES (${row.org_id}, ${userId}, ${role}, 'github')
+          ON CONFLICT (org_id, user_id) DO UPDATE SET
+            -- Two things this must not do. It must not overwrite a role set by
+            -- hand in this application, which is what source = 'manual' marks.
+            -- And it must not act on a role GitHub declined to report: null is
+            -- "ask again later", not "demote them", or a rate limit during
+            -- sign-in would quietly strip an administrator of their rights.
+            role = CASE
+              WHEN members.source = 'github' AND ${upstream !== null}
+                THEN ${role}
+              ELSE members.role
+            END,
+            updated_at = ${clock.now().toISOString()}`)
       }
 
       // Memberships that already existed count too: an installation may have

--- a/web/apps/api/src/github/webhook.ts
+++ b/web/apps/api/src/github/webhook.ts
@@ -128,12 +128,21 @@ export async function handleDelivery(
     }
 
     case 'repository': {
-      const account = installation?.account
       const id = installation?.id
-      const repo = payload.repository as Repo | undefined
-      if (typeof id !== 'number' || !account?.login || !repo?.full_name) {
+      const repo = payload.repository as (Repo & { owner?: Account }) | undefined
+      // NOT installation.account. Every event except `installation` and
+      // `installation_repositories` carries the MINIMAL installation object --
+      // `{ id, node_id }` and nothing else -- so reading the account off it
+      // meant this branch answered "no repository in the payload" for every
+      // repository delivery GitHub has ever sent, silently, with a 200. The
+      // owner is on the repository and on the organization, in the same signed
+      // body, and is trusted for the same reason.
+      const org = payload.organization as { login?: string } | undefined
+      const login = org?.login ?? repo?.owner?.login
+      if (typeof id !== 'number' || !login || !repo?.full_name) {
         return { event, action, handled: false, detail: 'no repository in the payload' }
       }
+      const account: Account = { login, type: repo.owner?.type ?? 'Organization' }
       const orgId = await rememberInstallation(pool, clock, account, id)
       if (action === 'deleted' || action === 'archived') {
         await archiveRepositories(pool, clock, account.login, orgId, [repo])

--- a/web/apps/api/src/main.ts
+++ b/web/apps/api/src/main.ts
@@ -13,6 +13,7 @@ import { createServer } from './server.ts'
 import { RealGitHubClient } from './auth/github.ts'
 import { systemClock } from './clock.ts'
 import { sweepSessions } from './auth/session.ts'
+import { sweepDeviceAuthorizations } from './auth/device.ts'
 import { parseAllowlist, describeAllowlist } from './auth/signin.ts'
 import { sealingKeyFrom } from './providers/seal.ts'
 import { findConsoleBuild } from './console/static.ts'
@@ -138,6 +139,13 @@ if (maintenanceUrl) {
 const housekeeping = setInterval(
   () => {
     void sweepSessions(pool, systemClock).catch((err) => console.error('session sweep', err))
+    // Beside the session sweep for the same reason and with the same cost:
+    // expiry is checked on every read, so being late costs table size. It was
+    // written with this comment on it and then never called from anywhere, so
+    // device_authorizations grew for the life of the process.
+    void sweepDeviceAuthorizations(pool, systemClock).catch((err) =>
+      console.error('device authorization sweep', err),
+    )
     ingestLimiter.sweep()
     authLimiter.sweep()
   },

--- a/web/apps/api/src/routers/index.ts
+++ b/web/apps/api/src/routers/index.ts
@@ -12,6 +12,8 @@ import { PolicyEngine, type Egress, type EgressRule, type Mode } from '@antifail
 import { router, publicProcedure, orgProcedure, audit, registerRouter, type OrgContext } from '../trpc.ts'
 import { PERMISSIONS, PERMISSION_DESCRIPTIONS, ROLES, ROLE_PERMISSIONS, rolesWith } from '../permissions.ts'
 import { checkQuota, DEFAULT_PLAN } from '../limits.ts'
+import { syncMembership, SignInError } from '../auth/signin.ts'
+import { GitHubError } from '../auth/github.ts'
 
 const uuid = z.string().uuid()
 
@@ -567,6 +569,64 @@ const membersRouter = router({
         FROM members m JOIN users u ON u.id = m.user_id
         ORDER BY m.created_at ASC`),
     )
+  }),
+
+  /**
+   * Reconciles this organization's members against GitHub's.
+   *
+   * The reason this route exists rather than the sync running only at sign-in:
+   * sign-in can only ever speak for the person signing in. Somebody added to
+   * the GitHub organization yesterday is not here until they happen to sign in,
+   * and somebody REMOVED from it keeps whatever role they had until they sign
+   * in again, which a person who has been removed has no reason to do. This is
+   * the route that acts on everybody at once, and the one that takes access
+   * away.
+   *
+   * It is also, deliberately, the caller syncMembership never had. The function
+   * was written, tested and complete, and nothing invoked it, which is a
+   * feature that reads as finished from every angle except the only one that
+   * counts.
+   */
+  sync: orgProcedure('members.manage').mutation(async ({ ctx }) => {
+    const c = ctx as OrgContext
+    const installation = await c.pool.withTenant(c.tenant, async (db) => {
+      const rows = await db.execute<{ installation_id: string; account_login: string }>(sql`
+        SELECT installation_id, account_login FROM github_installations
+        WHERE suspended_at IS NULL ORDER BY created_at ASC LIMIT 1`)
+      return rows[0] ?? null
+    })
+    if (!installation) {
+      throw new TRPCError({
+        code: 'PRECONDITION_FAILED',
+        message:
+          'This organization has no active GitHub App installation, so there is no membership ' +
+          'to read. Install the App on the organization first.',
+      })
+    }
+    try {
+      return await syncMembership(c.pool, c.clock, c.github, {
+        orgId: c.actor.orgId,
+        installationId: Number(installation.installation_id),
+        orgLogin: installation.account_login,
+        actorLabel: c.actor.label,
+      })
+    } catch (error) {
+      // Two refusals that are answers rather than faults, and both used to
+      // arrive as a 500 that reads as a bug in this control plane.
+      //
+      // SignInError: syncMembership will not apply an empty member list,
+      // because doing so would remove every owner and an outage looks exactly
+      // like an organization where everybody left.
+      //
+      // GitHubError: no App is configured, or GitHub would not answer. Its
+      // messages are written to be read by the operator who has to fix it --
+      // "Membership sync needs a GitHub App. Set AF_GITHUB_APP_ID..." -- and
+      // they are worth nothing behind a generic internal error.
+      if (error instanceof SignInError || error instanceof GitHubError) {
+        throw new TRPCError({ code: 'PRECONDITION_FAILED', message: error.message })
+      }
+      throw error
+    }
   }),
 
   setRole: orgProcedure('members.manage')

--- a/web/apps/api/src/server.ts
+++ b/web/apps/api/src/server.ts
@@ -1194,6 +1194,7 @@ export function createServer(options: ServerOptions) {
         const context: TrpcContext = {
           pool: options.pool,
           clock,
+          github: options.github,
           actor,
           origin: 'web',
           ip: c.req.header('x-forwarded-for') ?? undefined,

--- a/web/apps/api/src/trpc.ts
+++ b/web/apps/api/src/trpc.ts
@@ -16,6 +16,7 @@ import { appendAudit, type AuditInput } from '@antifailure/db'
 import type { Permission, Role } from './permissions.ts'
 import { permits } from './permissions.ts'
 import type { Clock } from './clock.ts'
+import type { GitHubClient } from './auth/github.ts'
 
 /** Who is making the request, once the session cookie has been resolved. */
 export interface Actor {
@@ -28,6 +29,13 @@ export interface Actor {
 export interface Context {
   pool: Pool
   clock: Clock
+  /**
+   * The GitHub client, for the routes that have to ask GitHub something rather
+   * than read it back from a table. Required rather than optional so that a new
+   * construction site cannot forget it and leave a route that compiles, ships,
+   * and then throws the first time somebody presses the button.
+   */
+  github: GitHubClient
   /** Null for an unauthenticated request. */
   actor: Actor | null
   /** Where the request came from, recorded on every audit entry. */

--- a/web/apps/api/test/auth.test.ts
+++ b/web/apps/api/test/auth.test.ts
@@ -15,6 +15,7 @@ import {
 import { safeRedirect, completeSignIn, syncMembership, SignInError } from '../src/auth/signin.ts'
 import { FakeClock } from '../src/clock.ts'
 import { FakeGitHub } from '../src/auth/fakegithub.ts'
+import { GitHubError } from '../src/auth/github.ts'
 import {
   available, startApi, seedOrg, dropOrg, signInAs, callProcedure, errorCode,
   type ApiHarness, type Org,
@@ -121,6 +122,116 @@ describe('the OAuth exchange', { skip: hasDatabase ? false : 'no Postgres' }, ()
     assert.equal(body.signedIn, true)
     assert.equal(body.orgId, org.orgId)
     assert.equal(body.role, 'member')
+  })
+
+  /**
+   * Signs the SAME person in twice, which the helper above cannot do: it mints
+   * a fresh GitHub id per call, and a fresh id is a different person as far as
+   * every join in this schema is concerned.
+   */
+  async function signInAgain(login: string, githubId: number) {
+    h.github.addUser({ id: githubId, login, email: `${login}@example.test`, name: login })
+    h.github.addOrganization(login, { id: 1, login: org.slug })
+    // Past the rate limit window. These tests start more exchanges than a real
+    // browser would in a minute, and a 429 here reads as a sign-in bug.
+    h.clock.advance(60_000)
+    const res = await h.fetch('/auth/github')
+    const state = new URL(res.headers.get('location')!).searchParams.get('state')!
+    const code = h.github.approve(login)
+    const done = await h.fetch(`/auth/github/callback?code=${code}&state=${state}`)
+    assert.equal(done.status, 302)
+    return done
+  }
+
+  async function roleOf(login: string): Promise<string | null> {
+    const rows = await h.admin<{ role: string; source: string }[]>`
+      SELECT m.role, m.source FROM members m JOIN users u ON u.id = m.user_id
+      WHERE u.github_login = ${login}`
+    return rows[0]?.role ?? null
+  }
+
+  it('an organization owner on GitHub arrives as an admin, not as a member', async () => {
+    // The defect this closes, seen on the real deployment: the person who
+    // installed the App on their own organization signed in and could not
+    // store a provider key, mint an engine token, manage members, export the
+    // audit log, or approve a masking change. Their own control plane refused
+    // them, because sign-in wrote 'member' for everybody and the function that
+    // maps a GitHub owner to an admin had no caller anywhere in the codebase.
+    const login = `owner-${randomUUID().slice(0, 6)}`
+    const id = Math.floor(Math.random() * 1e9)
+    h.github.setMembers(org.slug, [
+      { user: { id, login, email: `${login}@example.test`, name: login, avatarUrl: null }, role: 'admin' },
+    ])
+    await signInAgain(login, id)
+    assert.equal(await roleOf(login), 'admin')
+  })
+
+  it('a plain member on GitHub arrives as a member', async () => {
+    const login = `plain-${randomUUID().slice(0, 6)}`
+    const id = Math.floor(Math.random() * 1e9)
+    h.github.setMembers(org.slug, [
+      { user: { id, login, email: `${login}@example.test`, name: login, avatarUrl: null }, role: 'member' },
+    ])
+    await signInAgain(login, id)
+    assert.equal(await roleOf(login), 'member')
+  })
+
+  it('a role set by hand here is not overwritten by GitHub on the next sign-in', async () => {
+    // members.setRole marks a row source = 'manual'. Somebody promoted to
+    // owner in this application stays an owner, or the promotion silently
+    // expires the next time they sign in and nobody can explain why.
+    const login = `manual-${randomUUID().slice(0, 6)}`
+    const id = Math.floor(Math.random() * 1e9)
+    h.github.setMembers(org.slug, [
+      { user: { id, login, email: `${login}@example.test`, name: login, avatarUrl: null }, role: 'member' },
+    ])
+    await signInAgain(login, id)
+    await h.admin`
+      UPDATE members SET role = 'owner', source = 'manual'
+      WHERE user_id = (SELECT id FROM users WHERE github_login = ${login})`
+    await signInAgain(login, id)
+    assert.equal(await roleOf(login), 'owner')
+  })
+
+  it('GitHub failing to answer leaves the role alone rather than demoting', async () => {
+    // The ordering that makes this matter: an administrator signs in during a
+    // GitHub rate limit. Reading "could not establish the role" as "member"
+    // would strip them of members.manage on their own organization, and the
+    // only way back is another sign-in that happens to succeed -- which they
+    // can no longer grant themselves if they were the only administrator.
+    const login = `flaky-${randomUUID().slice(0, 6)}`
+    const id = Math.floor(Math.random() * 1e9)
+    h.github.setMembers(org.slug, [
+      { user: { id, login, email: `${login}@example.test`, name: login, avatarUrl: null }, role: 'admin' },
+    ])
+    await signInAgain(login, id)
+    assert.equal(await roleOf(login), 'admin')
+
+    h.github.breakRoleLookups()
+    try {
+      await signInAgain(login, id)
+    } finally {
+      h.github.breakRoleLookups(false)
+    }
+    assert.equal(await roleOf(login), 'admin', 'a failed role lookup demoted an administrator')
+  })
+
+  it('a first sign-in during an outage is a member, not an administrator', async () => {
+    // The other direction of the same null. With no row to preserve, the
+    // fallback has to guess, and guessing upward hands somebody administrative
+    // rights because GitHub was slow.
+    const login = `newflaky-${randomUUID().slice(0, 6)}`
+    const id = Math.floor(Math.random() * 1e9)
+    h.github.setMembers(org.slug, [
+      { user: { id, login, email: `${login}@example.test`, name: login, avatarUrl: null }, role: 'admin' },
+    ])
+    h.github.breakRoleLookups()
+    try {
+      await signInAgain(login, id)
+    } finally {
+      h.github.breakRoleLookups(false)
+    }
+    assert.equal(await roleOf(login), 'member')
   })
 
   it('refuses a state value it never issued', async () => {
@@ -469,5 +580,125 @@ describe('the fake GitHub behaves like the real one', () => {
     const gh = new FakeGitHub(clock)
     const user = gh.addUser({ id: 1, login: 'ada', email: 'Ada@Example.Test', name: 'Ada' })
     assert.equal(user.email, 'ada@example.test')
+  })
+})
+
+
+// ---------------------------------------------------------------------------
+
+/**
+ * The route, not the function.
+ *
+ * syncMembership had five tests above and zero callers: it was written,
+ * correct, covered, and unreachable. Every one of those tests passed against a
+ * feature that did not exist from a user's point of view, which is exactly what
+ * dead code looks like from the inside. These are the cases that only hold once
+ * something calls it over HTTP with a session and a permission.
+ */
+describe('members.sync over the route', { skip: hasDatabase ? false : 'no Postgres' }, () => {
+  let h: ApiHarness
+  let org: Org
+
+  before(async () => {
+    h = await startApi()
+    org = await seedOrg(h.admin, 'syncroute')
+  })
+  after(async () => {
+    await dropOrg(h.admin, org.orgId)
+    await h.close()
+  })
+
+  const run = randomUUID().slice(0, 6)
+  function ghUser(name: string) {
+    const login = `${name}-${run}`
+    return { id: Math.floor(Math.random() * 1e9), login, email: `${login}@example.test`, name: login, avatarUrl: null }
+  }
+
+  async function installFor(orgId: string, slug: string): Promise<number> {
+    const id = Math.floor(Math.random() * 1e12)
+    await h.admin`
+      INSERT INTO github_installations (org_id, installation_id, account_login, account_type)
+      VALUES (${orgId}, ${id}, ${slug}, 'Organization')`
+    return id
+  }
+
+  it('an organization with no installation is told so, rather than failing', async () => {
+    const admin = await signInAs(h, org, 'admin')
+    const { status, body } = await callProcedure(h, admin, 'members.sync', 'mutation', {})
+    assert.equal(errorCode(body), 'PRECONDITION_FAILED', `${status} ${JSON.stringify(body).slice(0, 200)}`)
+  })
+
+  it('adds and removes members, and the effect is visible on the next request', async () => {
+    // defined -> called -> effective. The assertion that matters is the last
+    // one: members.list, the thing the console actually renders, changes.
+    await installFor(org.orgId, org.slug)
+    const admin = await signInAs(h, org, 'admin')
+    const stays = ghUser('stays')
+    const arrives = ghUser('arrives')
+    h.github.setMembers(org.slug, [{ user: stays, role: 'admin' }, { user: arrives, role: 'member' }])
+
+    const { status, body } = await callProcedure(h, admin, 'members.sync', 'mutation', {})
+    assert.equal(status, 200, JSON.stringify(body).slice(0, 300))
+    const report = (body as { result: { data: { added: string[]; removed: string[] } } }).result.data
+    assert.ok(report.added.includes(stays.login), JSON.stringify(report))
+    assert.ok(report.added.includes(arrives.login), JSON.stringify(report))
+
+    const listed = await callProcedure(h, admin, 'members.list', 'query', {})
+    const logins = ((listed.body as { result: { data: { github_login: string }[] } }).result.data).map(
+      (m) => m.github_login,
+    )
+    assert.ok(logins.includes(stays.login), 'members.list does not show the synced member')
+
+    // And the removal, which is the half sign-in can never do: somebody taken
+    // off the GitHub organization has no reason to come back and sign in.
+    h.github.setMembers(org.slug, [{ user: stays, role: 'admin' }])
+    const second = await callProcedure(h, admin, 'members.sync', 'mutation', {})
+    assert.equal(second.status, 200, JSON.stringify(second.body).slice(0, 300))
+    const after2 = await callProcedure(h, admin, 'members.list', 'query', {})
+    const logins2 = ((after2.body as { result: { data: { github_login: string }[] } }).result.data).map(
+      (m) => m.github_login,
+    )
+    assert.ok(!logins2.includes(arrives.login), 'a member GitHub no longer reports is still listed')
+  })
+
+  it('an empty answer from GitHub is a refusal with a reason, not a 500', async () => {
+    // syncMembership throws SignInError here on purpose: applying an empty
+    // list would remove every owner, and an outage looks exactly like this.
+    // Over HTTP that has to arrive as a 4xx with the explanation, or an
+    // operator reads it as a bug in the control plane.
+    await installFor(org.orgId, `${org.slug}-empty`)
+    const admin = await signInAs(h, org, 'admin')
+    h.github.setMembers(org.slug, [])
+    const { status, body } = await callProcedure(h, admin, 'members.sync', 'mutation', {})
+    assert.equal(errorCode(body), 'PRECONDITION_FAILED', `${status} ${JSON.stringify(body).slice(0, 200)}`)
+    assert.match(JSON.stringify(body), /remove everyone/)
+  })
+
+  it('a control plane with no GitHub App says so, rather than answering 500', async () => {
+    // The community edition runs without an App, and this is the route that
+    // needs one. What an operator has to see is the sentence that names the
+    // three variables to set, not "internal server error".
+    await installFor(org.orgId, `${org.slug}-noapp`)
+    const admin = await signInAs(h, org, 'admin')
+    const previous = h.github.membersOf
+    h.github.membersOf = async () => {
+      throw new GitHubError(
+        'Membership sync needs a GitHub App. Set AF_GITHUB_APP_ID, ' +
+          'AF_GITHUB_APP_PRIVATE_KEY and AF_GITHUB_APP_WEBHOOK_SECRET.',
+      )
+    }
+    try {
+      const { status, body } = await callProcedure(h, admin, 'members.sync', 'mutation', {})
+      assert.equal(errorCode(body), 'PRECONDITION_FAILED', `${status} ${JSON.stringify(body).slice(0, 200)}`)
+      assert.match(JSON.stringify(body), /AF_GITHUB_APP_ID/)
+    } finally {
+      h.github.membersOf = previous
+    }
+  })
+
+  it('a member cannot run it, because it takes access away', async () => {
+    const member = await signInAs(h, org, 'member')
+    const { body } = await callProcedure(h, member, 'members.sync', 'mutation', {})
+    assert.equal(errorCode(body), 'FORBIDDEN')
   })
 })

--- a/web/apps/api/test/device.test.ts
+++ b/web/apps/api/test/device.test.ts
@@ -18,6 +18,7 @@ import {
   DEVICE_POLL_INTERVAL_SECONDS,
   newUserCode,
   normaliseUserCode,
+  sweepDeviceAuthorizations,
 } from '../src/auth/device.ts'
 // The header name comes from the server rather than being spelled again here.
 // Written out by hand it was wrong, every approve returned 403, and the test
@@ -349,5 +350,36 @@ describe('the device grant', { skip: (await available()) ? false : 'no Postgres 
       body: JSON.stringify({ events: [] }),
     })
     assert.notEqual(ingest.status, 401)
+  })
+
+  test('the sweeper removes finished authorizations and leaves live ones', async () => {
+    // This function was written, commented, and called from nowhere, so
+    // device_authorizations grew for the life of the process on any instance
+    // where people run af login. It is wired into the housekeeping interval in
+    // main.ts now, beside the session sweep it was clearly meant to sit next to.
+    const start = await api.fetch('/auth/device/code', { method: 'POST' })
+    assert.equal(start.status, 200)
+    const live = (await start.json()) as { user_code: string }
+
+    const stale = normaliseUserCode(newUserCode())
+    await api.admin`
+      INSERT INTO device_authorizations (device_code_hash, user_code, scopes, client_label, expires_at)
+      VALUES (${createHash('sha256').update(randomBytes(16)).digest()}, ${stale},
+              ARRAY['events:write']::text[], 'a sweeper test',
+              ${new Date(api.clock.now().getTime() - 48 * 60 * 60 * 1000).toISOString()})`
+
+    const removed = await sweepDeviceAuthorizations(api.pool, api.clock)
+    assert.ok(removed >= 1, `swept ${removed}`)
+
+    const [gone] = await api.admin<{ n: number }[]>`
+      SELECT count(*)::int AS n FROM device_authorizations WHERE user_code = ${stale}`
+    assert.equal(gone!.n, 0, 'an expired authorization survived the sweep')
+
+    // The negative control. A sweeper that took the live one too would break
+    // every af login that is waiting on a browser.
+    const [kept] = await api.admin<{ n: number }[]>`
+      SELECT count(*)::int AS n FROM device_authorizations
+      WHERE user_code = ${normaliseUserCode(live.user_code)}`
+    assert.equal(kept!.n, 1, 'the sweep removed an authorization that had not expired')
   })
 })

--- a/web/apps/api/test/githubapp.test.ts
+++ b/web/apps/api/test/githubapp.test.ts
@@ -373,6 +373,85 @@ describe('what a delivery writes', {
     assert.deepEqual(rows.map((r) => r.slug), ['delivery-test-org', 'other-org'])
   })
 
+  test('a repository event carries no installation.account, and is handled anyway', async () => {
+    // The shape this got wrong for its whole life. GitHub sends the FULL
+    // installation object -- the one with `account` on it -- only on
+    // `installation` and `installation_repositories`. Every other event, this
+    // one included, carries the minimal `{ id, node_id }`. Reading the account
+    // off it meant every repository delivery answered "no repository in the
+    // payload", with a 200, so nothing retried and nothing was logged as
+    // wrong. Real deliveries from the staging App confirmed it: installation
+    // keys were exactly ['id', 'node_id'].
+    //
+    // The owner is on the repository and on the organization, in the same
+    // signed body, and is trusted for exactly the same reason.
+    const out = await handleDelivery(api.pool, clock, 'repository', {
+      action: 'edited',
+      installation: { id: 900123, node_id: 'MDIzOk...' },
+      organization: { login: 'delivery-test-org' },
+      repository: {
+        id: 77,
+        full_name: 'delivery-test-org/renamed',
+        private: false,
+        default_branch: 'trunk',
+        owner: { login: 'delivery-test-org', type: 'Organization' },
+      },
+    })
+    assert.equal(out.handled, true, out.detail)
+
+    const [row] = await api.admin<{ full_name: string; default_branch: string }[]>`
+      SELECT full_name, default_branch FROM repositories
+      WHERE full_name = 'delivery-test-org/renamed'`
+    assert.ok(row, 'the repository event wrote nothing')
+    assert.equal(row!.default_branch, 'trunk')
+  })
+
+  test('a repository event with only repository.owner still names its account', async () => {
+    // A repository owned by a personal account has no `organization` on the
+    // payload at all. The owner on the repository is the fallback, and it is
+    // the reason this reads two places rather than one.
+    const out = await handleDelivery(api.pool, clock, 'repository', {
+      action: 'created',
+      installation: { id: 900123, node_id: 'x' },
+      repository: {
+        id: 78,
+        full_name: 'delivery-test-org/second',
+        owner: { login: 'delivery-test-org', type: 'Organization' },
+      },
+    })
+    assert.equal(out.handled, true, out.detail)
+    const [row] = await api.admin<{ full_name: string }[]>`
+      SELECT full_name FROM repositories WHERE full_name = 'delivery-test-org/second'`
+    assert.ok(row)
+  })
+
+  test('a repository event that names no owner at all is answered, not thrown', async () => {
+    const out = await handleDelivery(api.pool, clock, 'repository', {
+      action: 'edited',
+      installation: { id: 900123, node_id: 'x' },
+      repository: { id: 79, full_name: 'nobody/nothing' },
+    })
+    assert.equal(out.handled, false)
+    assert.match(out.detail, /no repository/)
+  })
+
+  test('a repository event archives on delete', async () => {
+    await handleDelivery(api.pool, clock, 'repository', {
+      action: 'deleted',
+      installation: { id: 900123, node_id: 'x' },
+      organization: { login: 'delivery-test-org' },
+      repository: {
+        id: 78,
+        full_name: 'delivery-test-org/second',
+        owner: { login: 'delivery-test-org', type: 'Organization' },
+      },
+    })
+    const [row] = await api.admin<{ archived_at: Date | null }[]>`
+      SELECT archived_at FROM repositories WHERE full_name = 'delivery-test-org/second'`
+    assert.ok(row, 'the row was deleted rather than archived')
+    assert.notEqual(row!.archived_at, null)
+  })
+
   test('an event this control plane does not act on is answered, not failed', async () => {
     // GitHub retries a 5xx. Answering 500 to an event that will be refused
     // identically every time is a retry storm.

--- a/web/apps/api/test/permissions.test.ts
+++ b/web/apps/api/test/permissions.test.ts
@@ -58,6 +58,7 @@ function inputsFor(org: Org): Record<string, unknown> {
     'audit.verify': {},
     'audit.export': { format: 'json' },
     'members.list': {},
+    'members.sync': {},
     'members.setRole': { githubLogin: 'nobody-here', role: 'member' },
     'tokens.list': {},
     'tokens.revoke': { id: '00000000-0000-0000-0000-000000000000' },
@@ -146,11 +147,17 @@ describe('permission matrix', { skip: hasDatabase ? false : 'no Postgres at AF_T
               'FORBIDDEN',
               `${role} holds ${permission} but ${path} refused it`,
             )
-            // NOT_FOUND and BAD_REQUEST are fine: the sample input names rows
-            // that may not exist. What matters is that the permission gate let
-            // it through to the handler.
+            // NOT_FOUND, BAD_REQUEST and PRECONDITION_FAILED are fine: the
+            // sample input names rows that may not exist, and a route may need
+            // state this fixture does not set up -- members.sync wants a GitHub
+            // App installation. What this matrix asserts is that the permission
+            // gate let the call through to the handler, not what the handler
+            // then made of an organization seeded for a different purpose.
             assert.ok(
-              status === 200 || code === 'NOT_FOUND' || code === 'BAD_REQUEST',
+              status === 200 ||
+                code === 'NOT_FOUND' ||
+                code === 'BAD_REQUEST' ||
+                code === 'PRECONDITION_FAILED',
               `${role} calling ${path} got ${status} ${code}: ${JSON.stringify(body).slice(0, 200)}`,
             )
           } else {

--- a/web/packages/db/migrations/0016_the_device_sweeper_could_not_delete.sql
+++ b/web/packages/db/migrations/0016_the_device_sweeper_could_not_delete.sql
@@ -1,0 +1,32 @@
+-- The sweeper that could not sweep.
+--
+-- sweepDeviceAuthorizations was written to keep device_authorizations from
+-- growing without bound on an instance where people run `af login` all day. It
+-- carried a comment saying exactly that, and it had two independent reasons it
+-- had never removed a single row: nothing in the process called it, and the
+-- three policies on this table each key on a value the caller declares, the
+-- device code or the user code, so a sweeper that declares neither matches
+-- nothing. The DELETE ran, reported success, and deleted zero rows, forever.
+--
+-- The existing policies are right and stay as they are. A terminal may touch
+-- the row whose device code it holds, a browser the row whose user code a
+-- person typed, and neither may enumerate the table. Housekeeping is a third
+-- thing and it needs a third policy rather than a hole in the other two.
+--
+-- WHY THIS IS FOR ALL AND NOT FOR DELETE. A DELETE that names a column in its
+-- WHERE clause reads rows to find them, so Postgres applies the SELECT policies
+-- to that scan as well as the DELETE ones. A delete-only policy therefore
+-- deletes nothing: the plan ANDs the SELECT policies in, none of them match,
+-- and the statement reports DELETE 0. That was the first version of this file
+-- and it looked correct in every way except the one that counts.
+--
+-- What the row restriction gives back is most of the narrowness. This permits
+-- nothing on a live authorization: only rows that expired more than a day ago,
+-- which can no longer be polled, approved or redeemed. It is reachable only by
+-- the application role, which is the process rather than any person; every path
+-- a user can reach still goes through a declared device code or user code. The
+-- day of margin is deliberate, because expiry is enforced on every read and the
+-- sweeper exists for table size rather than for correctness.
+CREATE POLICY device_sweep ON device_authorizations
+  FOR ALL TO antifailure_app
+  USING (expires_at < now() - interval '24 hours');


### PR DESCRIPTION
Sign-in works on the hosted control plane and the panel renders. The person who installed the App still could not use it. Everything below was proven against the live deployment rather than inferred.

## Nobody ever became an administrator

`completeSignIn` wrote `'member'` for everybody, and `syncMembership` -- which maps a GitHub organization owner to an admin, is complete, and had five passing tests -- had **zero call sites anywhere in the codebase**.

The consequence on `app.dev.antifailure.dev`: the owner of the organization signed in, and the Provider keys page told him *"you can see which keys are set and cannot change them."* No `members.manage`, no `tokens.manage`, no `audit.export`, no masking or egress approvals. No way out except a database console, because granting a role needs a role nobody had.

Sign-in now reads the role from GitHub through the installation token. An owner becomes an `admin`, deliberately not an `owner`, because owner also holds billing and that is this application's decision rather than GitHub's.

Two nulls, both tested:
- A role GitHub declines to report leaves an **existing** role alone, so a rate limit during sign-in cannot demote the only administrator.
- A **first** sign-in during the same failure gets `member`, because guessing upward hands out administrative rights on a timeout.

A role set by hand (`source = 'manual'`) is never overwritten, and neither is one provisioned by SCIM or SSO.

## syncMembership has a caller

`members.sync`, behind `members.manage`, wired to a **Sync from GitHub** button on the Members page. It is the only path that takes access away, which sign-in cannot do: somebody removed from the GitHub organization has no reason to come back and sign in.

Its two refusals are answers rather than faults, and now arrive as 412 with their own text instead of a 500: an empty member list from GitHub, and no App configured.

## Every `repository` delivery was silently dropped

The handler read the account off `installation`. GitHub sends the full installation object only on `installation` and `installation_repositories`; every other event carries `{ id, node_id }`. Confirmed against real deliveries from the staging App, whose `installation` keys were exactly those two.

So the branch answered `"no repository in the payload"` with a 200. Nothing retried, nothing was logged, and renames and new repositories were never recorded. The owner is on the repository and on the organization in the same signed body, and is trusted for the same reason.

## The device sweeper had never deleted a row, twice over

`sweepDeviceAuthorizations` exists so `device_authorizations` does not grow without bound. Nothing called it, and it could not have worked if it had: the three policies on that table each key on a declared device code or user code.

A delete-only policy still deleted nothing. A `DELETE` whose `WHERE` names a column reads rows to find them, so Postgres ANDs the SELECT policies into the scan; `EXPLAIN` shows it. The statement reported `DELETE 0` against 87 deletable rows. The migration grants on rows expired more than a day ago, which can no longer be polled, approved or redeemed, and the sweep now runs beside the session sweep.

## Console

A long message in a card header was clipped by the section's `overflow-hidden` at 390px and simply vanished, because the actions block is `shrink-0` and could not be capped. Measured at 366px inside a 350px card; now 353px inside 370px, with no page overflow.

And *"You are member in this organization"* reads as English again.

## Infra

A Terraform apply that touches the container app template creates a revision at zero percent traffic and reports success, so the change never reaches production until somebody deploys. That is how `AF_GITHUB_APP_ID` sat applied and green while the running revision logged *"no GitHub App"* and answered 503 to two real webhook deliveries. Now written down at the `lifecycle` block and in the self-hosting guide, with the commands that show what is actually serving.

## Verification

- 410 API tests pass, 0 fail. 16 are new.
- Console builds and exports 13 routes.
- Rendered and inspected at 1512px and at 390px, in the success, error and read-only states.