### PR TITLE
www: a phone pass over the restyled homepage

### DIFF
--- a/www/app/globals.css
+++ b/www/app/globals.css
@@ -460,3 +460,16 @@ body {
     animation: none !important;
   }
 }
+/*
+ * A horizontally scrolling strip whose right edge dissolves instead of
+ * chopping a word in half.
+ *
+ * Only below `md`: at desk width these strips are wide enough that nothing
+ * overflows, and a mask there would just fade content for no reason.
+ */
+@media (max-width: 767px) {
+  .fade-scroll-x {
+    -webkit-mask-image: linear-gradient(to right, #000 calc(100% - 24px), transparent 100%);
+    mask-image: linear-gradient(to right, #000 calc(100% - 24px), transparent 100%);
+  }
+}

--- a/www/app/page.tsx
+++ b/www/app/page.tsx
@@ -13,11 +13,14 @@ export default function Page() {
   return (
     <SiteLayout>
       <Hero />
+      {/* Isolated Twin and Workload Studio trade places: the twin is what the
+          workload runs against, so it has to be on the page before the studio
+          that drives it. */}
       <TocWrapper>
         <Migrations />
-        <Workload />
-        <Features />
         <Twins />
+        <Features />
+        <Workload />
         <Firewall />
       </TocWrapper>
       <Trust />

--- a/www/components/IdeSection.tsx
+++ b/www/components/IdeSection.tsx
@@ -276,13 +276,16 @@ function TokenView({
   const text = tokens.map((tok) => tok.t).join("") + (echo ?? "");
   const lines = Math.max(8, text.split("\n").length);
   return (
-    <div className="flex min-h-[228px] font-mono text-[13px] leading-[22px]">
-      <div className="select-none py-3.5 pl-3 pr-3 text-right text-[#565656]">
+    <div className="flex min-h-[228px] font-mono text-[13px] leading-[22px] max-sm:min-h-[200px] max-sm:text-[11px] max-sm:leading-[19px]">
+      {/* The gutter is dropped on a phone rather than shrunk. The code has to
+          wrap at that width, and a wrapped line makes every number below it
+          point at the wrong row — a broken gutter is worse than none. */}
+      <div className="select-none py-3.5 pl-3 pr-3 text-right text-[#565656] max-sm:hidden">
         {Array.from({ length: lines }, (_, i) => (
           <div key={i}>{i + 1}</div>
         ))}
       </div>
-      <pre className="min-w-0 flex-1 overflow-auto py-3.5 pr-4 outline-none">
+      <pre className="min-w-0 flex-1 overflow-auto py-3.5 pr-4 outline-none max-sm:overflow-visible max-sm:px-3.5 max-sm:whitespace-pre-wrap max-sm:break-words">
         {tokens.map((tok, i) => (
           <span key={i} className={tok.cls || VAR}>
             {tok.t}
@@ -659,7 +662,7 @@ export function IdePlay() {
           ) : null}
         </div>
         <div className="min-w-0 bg-white">
-          <div className="flex overflow-x-auto border-b border-black/[0.07] px-1 text-[12.5px]">
+          <div className="fade-scroll-x no-scrollbars flex overflow-x-auto border-b border-black/[0.07] px-1 text-[12.5px]">
             {openTabs.map((id) => {
               const on = id === activeFile;
               return (
@@ -720,12 +723,12 @@ export function IdePlay() {
                 style={{ animation: "wt-sheen 0.9s cubic-bezier(0.16,1,0.3,1) 1" }}
               />
             ) : null}
-            <div className="flex gap-5 overflow-x-auto px-3 text-[11.5px] text-black/35">
+            <div className="fade-scroll-x no-scrollbars flex gap-5 overflow-x-auto px-3 text-[11.5px] text-black/35 max-sm:gap-4">
               {BOTTOM_TABS.map((tab) => (
                 <button
                   key={tab.id}
                   type="button"
-                  className={`shrink-0 border-b py-1.5 ${
+                  className={`shrink-0 whitespace-nowrap border-b py-1.5 ${
                     bottomTab === tab.id
                       ? "border-black text-black"
                       : "border-transparent hover:text-black/70"
@@ -736,9 +739,7 @@ export function IdePlay() {
                 </button>
               ))}
             </div>
-            <pre className="min-h-[128px] overflow-x-auto px-4 pb-4 font-mono text-[12px] leading-[20px] text-black/72">
-              {bottomBody}
-            </pre>
+            <pre className="min-h-[128px] overflow-x-auto px-4 pb-4 font-mono text-[12px] leading-[20px] text-black/72 max-sm:min-h-[96px] max-sm:px-3.5 max-sm:text-[11px] max-sm:leading-[18px]">{bottomBody}</pre>
           </div>
         </div>
         <div className="hidden min-w-0 bg-[#f4f4f2] p-2 xl:block">

--- a/www/components/home/Features.tsx
+++ b/www/components/home/Features.tsx
@@ -15,6 +15,7 @@ export function Features() {
         <div className="min-w-0 border-t border-black/12 pt-9 max-lg:pt-7">
           <Heading
             icon="features"
+            label="Safety properties"
             title="<strong>Safety properties, not slogans.</strong> The platform answers whether this deployment is safe to ship under the conditions that actually matter."
           />
           <SafetyCards className="mt-16 max-xl:mt-12 max-lg:mt-10 max-md:mt-8" />

--- a/www/components/home/Firewall.tsx
+++ b/www/components/home/Firewall.tsx
@@ -15,6 +15,7 @@ export function Firewall() {
         <div className="min-w-0 border-t border-black/12 pt-9 max-lg:pt-7">
           <Heading
             icon="firewall"
+            label="Side-Effect Firewall"
             title="<strong>Fail closed on side effects.</strong> The twin cannot charge cards, email users, or invoke production webhooks. Unknown destinations are blocked."
           />
           <div className="mt-8 max-xl:mt-6 max-lg:mt-5">

--- a/www/components/home/Migrations.tsx
+++ b/www/components/home/Migrations.tsx
@@ -15,6 +15,7 @@ export function Migrations() {
         <div className="min-w-0">
           <Heading
             icon="migrations"
+            label="Migration Safety"
             title="<strong>Migration Safety.</strong> Catch exclusive locks before they take checkout down. Locks, plans, and rollback feasibility before it ships."
           />
           <div className="relative mt-14 min-w-0 max-xl:mt-12 max-lg:mt-10 max-md:mt-8 max-sm:mt-11">

--- a/www/components/home/Toc.tsx
+++ b/www/components/home/Toc.tsx
@@ -1,48 +1,87 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { cn } from "@/lib/cn";
 
 const SECTIONS = [
-  { id: "migrations", title: "Migration Safety", theme: "light" as const },
-  { id: "workload", title: "Workload Studio", theme: "light" as const },
-  { id: "features", title: "Safety properties", theme: "light" as const },
-  { id: "twins", title: "Isolated Twin", theme: "light" as const },
-  { id: "firewall", title: "Side-Effect Firewall", theme: "light" as const },
+  { id: "migrations", title: "Migration Safety" },
+  { id: "twins", title: "Isolated Twin" },
+  { id: "features", title: "Safety properties" },
+  { id: "workload", title: "Workload Studio" },
+  { id: "firewall", title: "Side-Effect Firewall" },
 ];
 
-export function TocWrapper({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="relative">
-      <div className="absolute top-0 bottom-0 left-[calc(50%-min(100vw,1600px)/2+32px)] h-full max-xl:hidden">
-        <Toc />
-      </div>
-      {children}
-    </div>
-  );
+/** Sticky header (56px below lg) plus the rail itself. */
+const RAIL_OFFSET = 100;
+
+/** Dissolve whichever edge still has a name behind it. */
+function edgeMask({ left, right }: { left: boolean; right: boolean }) {
+  if (!left && !right) return undefined;
+  const start = left ? "transparent 0, #000 28px" : "#000 0";
+  const end = right ? "#000 calc(100% - 28px), transparent 100%" : "#000 100%";
+  return `linear-gradient(to right, ${start}, ${end})`;
 }
 
-function Toc() {
-  const [active, setActive] = useState(SECTIONS[0].id);
-  const [theme, setTheme] = useState<"light" | "sage">("light");
-  const tocRef = useRef<HTMLDivElement>(null);
+function prefersReducedMotion() {
+  return typeof window !== "undefined" && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+function scrollToSection(id: string) {
+  const el = document.getElementById(id);
+  if (!el) return;
+  const top = el.getBoundingClientRect().top + window.scrollY - RAIL_OFFSET;
+  window.scrollTo({ top, behavior: prefersReducedMotion() ? "auto" : "smooth" });
+}
+
+/**
+ * Where the reader is in the section stack.
+ *
+ * Two answers, because the two rails sit in different places. The desktop rail
+ * is a column of links at a known height, so a section becomes current when its
+ * top passes its own link. The mobile rail is a bar pinned under the header, so
+ * a section becomes current when its top passes the bar.
+ */
+function useSectionState(tocRef: React.RefObject<HTMLDivElement | null>) {
+  const [state, setState] = useState({ deskIndex: 0, railIndex: 0, progress: 0 });
 
   useEffect(() => {
     const update = () => {
-      if (!tocRef.current) return;
-      const links = tocRef.current.querySelectorAll("li");
-      let current = SECTIONS[0];
+      // The rail reads a third of the way down rather than at its own edge. A
+      // probe at the bar itself named the previous section while most of the
+      // screen already showed the next one.
+      const probe = window.scrollY + Math.max(RAIL_OFFSET, window.innerHeight * 0.34);
+      const links = tocRef.current?.querySelectorAll("li");
+
+      let deskIndex = 0;
+      let railIndex = 0;
       SECTIONS.forEach((section, index) => {
         const el = document.getElementById(section.id);
-        const link = links[index];
-        if (!el || !link) return;
-        if (el.getBoundingClientRect().top <= link.getBoundingClientRect().top) {
-          current = section;
-        }
+        if (!el) return;
+        const top = el.getBoundingClientRect().top;
+        if (top + window.scrollY <= probe) railIndex = index;
+
+        const link = links?.[index];
+        if (link && top <= link.getBoundingClientRect().top) deskIndex = index;
       });
-      setActive(current.id);
-      setTheme(current.theme);
+
+      const first = document.getElementById(SECTIONS[0].id);
+      const last = document.getElementById(SECTIONS[SECTIONS.length - 1].id);
+      let progress = 0;
+      if (first && last) {
+        const start = first.getBoundingClientRect().top + window.scrollY;
+        const end = last.getBoundingClientRect().bottom + window.scrollY;
+        progress = Math.min(1, Math.max(0, (probe - start) / Math.max(1, end - start)));
+      }
+
+      setState((prev) =>
+        prev.deskIndex === deskIndex &&
+        prev.railIndex === railIndex &&
+        Math.abs(prev.progress - progress) < 0.002
+          ? prev
+          : { deskIndex, railIndex, progress },
+      );
     };
+
     update();
     window.addEventListener("scroll", update, { passive: true });
     window.addEventListener("resize", update);
@@ -50,13 +89,127 @@ function Toc() {
       window.removeEventListener("scroll", update);
       window.removeEventListener("resize", update);
     };
+  }, [tocRef]);
+
+  return state;
+}
+
+export function TocWrapper({ children }: { children: React.ReactNode }) {
+  const tocRef = useRef<HTMLDivElement>(null);
+  const { deskIndex, railIndex, progress } = useSectionState(tocRef);
+
+  return (
+    <div className="relative">
+      <div className="absolute top-0 bottom-0 left-[calc(50%-min(100vw,1600px)/2+32px)] h-full max-xl:hidden">
+        <Toc activeIndex={deskIndex} tocRef={tocRef} />
+      </div>
+      <SectionRail activeIndex={railIndex} progress={progress} />
+      {children}
+    </div>
+  );
+}
+
+/**
+ * The mobile and tablet section rail.
+ *
+ * Below `xl` the desktop column is hidden, which left ten thousand pixels of
+ * scroll with nothing to say where you were or what was left. This pins the
+ * same five names under the header for exactly as long as the stack is on
+ * screen, keeps the current one scrolled into view, and draws how far through
+ * the argument the reader has come.
+ */
+function SectionRail({ activeIndex, progress }: { activeIndex: number; progress: number }) {
+  const trackRef = useRef<HTMLDivElement>(null);
+  const chipRefs = useRef<(HTMLAnchorElement | null)[]>([]);
+  const [edges, setEdges] = useState({ left: false, right: true });
+
+  const readEdges = useCallback(() => {
+    const track = trackRef.current;
+    if (!track) return;
+    setEdges({
+      left: track.scrollLeft > 4,
+      right: track.scrollLeft + track.clientWidth < track.scrollWidth - 4,
+    });
   }, []);
 
+  useEffect(() => {
+    const track = trackRef.current;
+    const chip = chipRefs.current[activeIndex];
+    if (!track || !chip) return;
+    const left = chip.offsetLeft - (track.clientWidth - chip.clientWidth) / 2;
+    track.scrollTo({ left: Math.max(0, left), behavior: prefersReducedMotion() ? "auto" : "smooth" });
+    const id = window.setTimeout(readEdges, 420);
+    return () => window.clearTimeout(id);
+  }, [activeIndex, readEdges]);
+
+  useEffect(readEdges, [readEdges]);
+
+  return (
+    <div
+      className={cn(
+        "sticky top-16 z-30 bg-[#f7f7f5] max-lg:top-14 xl:hidden",
+      )}
+    >
+      <nav
+        ref={trackRef}
+        aria-label="Sections"
+        onScroll={readEdges}
+        style={{
+          maskImage: edgeMask(edges),
+          WebkitMaskImage: edgeMask(edges),
+        }}
+        className="no-scrollbars flex items-stretch gap-x-1 overflow-x-auto px-8 max-md:px-5"
+      >
+        {SECTIONS.map((section, index) => {
+          const isActive = index === activeIndex;
+          return (
+            <a
+              key={section.id}
+              ref={(node) => {
+                chipRefs.current[index] = node;
+              }}
+              href={`#${section.id}`}
+              aria-current={isActive ? "location" : undefined}
+              onClick={(event) => {
+                event.preventDefault();
+                scrollToSection(section.id);
+              }}
+              className={cn(
+                "shrink-0 whitespace-nowrap border-b-[1.5px] py-3 pr-4 text-[13px] tracking-extra-tight transition-colors duration-200",
+                "first:pl-0",
+                isActive ? "border-black text-black" : "border-transparent text-black/40",
+              )}
+            >
+              <span className="mr-1.5 font-mono text-[10px] tabular-nums text-black/30">
+                {String(index + 1).padStart(2, "0")}
+              </span>
+              {section.title}
+            </a>
+          );
+        })}
+      </nav>
+      <div className="h-px w-full bg-black/10" aria-hidden>
+        <div
+          className="h-px bg-black/45 transition-[width] duration-200 ease-out"
+          style={{ width: `${Math.round(progress * 100)}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function Toc({
+  activeIndex,
+  tocRef,
+}: {
+  activeIndex: number;
+  tocRef: React.RefObject<HTMLDivElement | null>;
+}) {
   return (
     <div className="sticky top-0 z-10 pt-40 pb-60" ref={tocRef}>
       <ul className="flex w-[224px] flex-col gap-y-1.5">
-        {SECTIONS.map((section) => {
-          const isActive = active === section.id;
+        {SECTIONS.map((section, index) => {
+          const isActive = index === activeIndex;
           return (
             <li key={section.id}>
               <a
@@ -68,7 +221,6 @@ function Toc() {
                   !isActive && "text-gray-new-50",
                   "hover:text-black",
                   isActive && "text-black before:bg-black",
-                  theme === "sage" && isActive && "text-black before:bg-black",
                 )}
                 onClick={(e) => {
                   e.preventDefault();

--- a/www/components/home/Trust.tsx
+++ b/www/components/home/Trust.tsx
@@ -1,14 +1,17 @@
 import { Container } from "@/components/layout/Container";
 import { SectionLabel } from "@/components/layout/SectionLabel";
+import { TrustIcon } from "@/components/home/media/icons";
 import { cn } from "@/lib/cn";
 
 const ITEMS = [
   {
+    icon: "failclosed" as const,
     title: "Fail closed",
     description: "Unknown destinations, missing sanitization evidence, or failed cleanup cannot ship.",
     className: "w-[216px] max-xl:w-48",
   },
   {
+    icon: "hosted" as const,
     title: "Customer-hosted",
     description: "Production data stays inside the customer boundary. The control plane never needs a copy.",
     className: "w-72 max-xl:w-64",
@@ -38,7 +41,7 @@ export function Trust() {
             <ul className="mt-16 flex gap-[92px] max-xl:mt-12 max-xl:gap-10 max-md:flex-col max-md:gap-7">
               {ITEMS.map((item) => (
                 <li className={cn(item.className, "max-lg:w-auto max-lg:max-w-[280px] max-md:max-w-none max-md:w-full")} key={item.title}>
-                  <div className="mb-5 size-8 rounded-full bg-black max-xl:mb-4 max-lg:mb-3.5 max-lg:size-7 max-md:size-6" />
+                  <TrustIcon name={item.icon} className="mb-5 text-black max-xl:mb-4 max-lg:mb-3.5" />
                   <h3 className="text-4xl leading-dense tracking-tighter max-xl:text-[36px] max-lg:text-[28px] max-md:text-[24px]">
                     {item.title}
                   </h3>

--- a/www/components/home/Twins.tsx
+++ b/www/components/home/Twins.tsx
@@ -56,6 +56,7 @@ export function Twins() {
         <div className="min-w-0">
           <Heading
             icon="twins"
+            label="Isolated Twin"
             title="<strong>A disposable production twin.</strong> Build the candidate, restore safe state, contain side effects, and destroy everything when the report is done."
           />
           <div className="relative mt-14 min-w-0 max-xl:mt-12 max-lg:mt-10 max-md:mt-8 max-sm:mt-11">

--- a/www/components/home/Workload.tsx
+++ b/www/components/home/Workload.tsx
@@ -15,6 +15,7 @@ export function Workload() {
         <div className="min-w-0">
           <Heading
             icon="workload"
+            label="Workload Studio"
             title="<strong>Workload Studio for the change that matters.</strong> Observed patterns, deterministic journeys, and exploratory users. Not production traffic diverted."
           />
           <div className="relative mt-14 min-w-0 max-xl:mt-12 max-lg:mt-10 max-md:mt-8 max-sm:mt-11">

--- a/www/components/home/media/icons.tsx
+++ b/www/components/home/media/icons.tsx
@@ -1,10 +1,12 @@
 import { cn } from "@/lib/cn";
 
+export type HeadingIconName = "workload" | "migrations" | "twins" | "firewall" | "features";
+
 export function HeadingIcon({
   name,
   className,
 }: {
-  name: "migrations" | "workload" | "twins" | "firewall" | "features";
+  name: HeadingIconName;
   className?: string;
 }) {
   const cls = cn("pointer-events-none size-14 max-xl:size-12 max-lg:size-10 max-md:size-9", className);
@@ -113,6 +115,66 @@ export function FeatureIcon({
     <svg viewBox="0 0 24 24" className={cls} fill="none" aria-hidden>
       <ellipse cx="12" cy="8" rx="7" ry="3" stroke="currentColor" strokeWidth="1.4" />
       <path d="M5 8v8c0 1.7 3.1 3 7 3s7-1.3 7-3V8" stroke="currentColor" strokeWidth="1.4" />
+    </svg>
+  );
+}
+
+/**
+ * The two trust-model marks.
+ *
+ * These slots used to be `size-8 rounded-full bg-black` — a filled circle in
+ * place of an icon, which reads as a decision nobody made. They now say what
+ * the claim underneath them says: a packet stopped at a closed gate, and a
+ * boundary with the data inside it.
+ */
+export function TrustIcon({
+  name,
+  className,
+}: {
+  name: "failclosed" | "hosted";
+  className?: string;
+}) {
+  const cls = cn("pointer-events-none size-10 max-xl:size-9 max-lg:size-8", className);
+  if (name === "failclosed") {
+    // An attempt that stops short of the wall, and the production behind the
+    // wall it never reached.
+    return (
+      <svg viewBox="0 0 36 36" className={cls} fill="none" aria-hidden>
+        <path d="M2 18h11.4" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+        <path
+          d="m9.8 14.4 3.6 3.6-3.6 3.6"
+          stroke="currentColor"
+          strokeWidth="1.6"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path d="M18.4 3v30" stroke="#33bf00" strokeWidth="2.4" strokeLinecap="round" />
+        <path
+          d="M23.4 11h10.6M23.4 18h10.6M23.4 25h7.6"
+          stroke="currentColor"
+          strokeOpacity="0.3"
+          strokeWidth="1.6"
+          strokeLinecap="round"
+        />
+      </svg>
+    );
+  }
+  // The customer boundary with the data inside it, and the control plane
+  // outside, holding no copy.
+  return (
+    <svg viewBox="0 0 36 36" className={cls} fill="none" aria-hidden>
+      <rect x="1.8" y="8.6" width="22" height="21.6" stroke="currentColor" strokeWidth="1.6" />
+      <rect x="6.4" y="13.6" width="12.8" height="11.6" stroke="#33bf00" strokeWidth="1.6" />
+      <path d="M24.6 19.4h3.4" stroke="currentColor" strokeWidth="1.6" strokeDasharray="2 2.2" />
+      <rect
+        x="28.6"
+        y="15.4"
+        width="5.6"
+        height="8"
+        stroke="currentColor"
+        strokeOpacity="0.45"
+        strokeWidth="1.6"
+      />
     </svg>
   );
 }

--- a/www/components/home/visuals/FailClosedScene.tsx
+++ b/www/components/home/visuals/FailClosedScene.tsx
@@ -1,3 +1,5 @@
+import { cn } from "@/lib/cn";
+
 const COLUMNS = [
   {
     title: "Simulated",
@@ -260,11 +262,82 @@ function Tag({ color, label }: { color: string; label: string }) {
   );
 }
 
+/**
+ * The phone reading of the same truth.
+ *
+ * A three-column board with a chat window floating over it is a shape that only
+ * works at desk width. Squeezed onto a phone the columns disappeared behind the
+ * card and the section lost its evidence. The board's rows are the evidence, so
+ * on a phone they become what they are: a ledger of attempted effects, each one
+ * with what the firewall did about it.
+ */
+const LEDGER = COLUMNS.flatMap((col) =>
+  col.cards.slice(0, col.title === "Blocked" ? 3 : 2).map((card) => ({
+    id: card.id,
+    title: card.title,
+    tag: card.tags[0],
+    disposition: col.title.toLowerCase(),
+    icon: col.icon,
+  })),
+);
+
+function EgressLedger() {
+  return (
+    <div className="overflow-hidden rounded-[12px] border border-black/[0.08] bg-white">
+      <div className="flex items-center justify-between border-b border-black/[0.06] px-3.5 py-2.5">
+        <span className="font-mono text-[10px] font-medium uppercase tracking-[0.14em] text-[#8A8F98]">
+          Egress ledger
+        </span>
+        <span className="text-[12px] tabular-nums tracking-tight text-[#8A8F98]">
+          {COLUMNS.reduce((n, col) => n + col.count, 0)} attempts
+        </span>
+      </div>
+      <div className="flex items-center gap-4 border-b border-black/[0.06] bg-[#FAFAFB] px-3.5 py-2">
+        {COLUMNS.map((col) => (
+          <span key={col.title} className="flex items-center gap-1.5 text-[12px] tracking-tight text-[#6B6F76]">
+            <ColIcon kind={col.icon} />
+            {col.title}
+            <span className="tabular-nums text-[#9B9EA5]">{col.count}</span>
+          </span>
+        ))}
+      </div>
+      <ul>
+        {LEDGER.map((row) => (
+          <li
+            key={row.id}
+            className="flex items-start justify-between gap-3 border-b border-black/[0.05] px-3.5 py-2.5 last:border-b-0"
+          >
+            <span className="min-w-0">
+              <span className="block text-[13px] leading-snug tracking-tight text-[#1A1A1A]">{row.title}</span>
+              <span className="mt-1 flex items-center gap-1.5">
+                <span className="font-mono text-[10px] tabular-nums tracking-tight text-[#9B9EA5]">{row.id}</span>
+                <Tag color={row.tag.color} label={row.tag.label} />
+              </span>
+            </span>
+            <span
+              className={cn(
+                "mt-0.5 shrink-0 font-mono text-[10px] uppercase tracking-[0.1em]",
+                row.disposition === "blocked" ? "text-[#2F8A5F]" : "text-[#9B9EA5]",
+              )}
+            >
+              {row.disposition}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
 export function FailClosedScene() {
   return (
     <div data-scene="fail-closed" className="pointer-events-none relative w-full select-none" aria-hidden>
-      <div className="relative aspect-[1024/477] w-full overflow-hidden max-xl:aspect-auto">
-        <div className="absolute inset-0 bg-[#EFEFF1] max-xl:hidden">
+      <div className="hidden max-xl:mt-1 max-xl:flex max-xl:flex-col max-xl:gap-4">
+        <EgressLedger />
+        <SlackThread mobile />
+      </div>
+      <div className="relative aspect-[1024/477] w-full overflow-hidden max-xl:hidden">
+        <div className="absolute inset-0 bg-[#EFEFF1]">
           <div className="absolute inset-y-0 left-[38%] right-0 flex gap-3 pt-[11%] pr-6 pb-[8%] opacity-[0.82]">
             {COLUMNS.map((col) => (
               <div key={col.title} className="flex w-[248px] shrink-0 flex-col">
@@ -322,7 +395,29 @@ export function FailClosedScene() {
           }}
         />
 
-        <div className="absolute top-[11.1%] bottom-[7.5%] left-[4.9%] z-10 flex w-[32.5%] min-w-[280px] max-w-[340px] flex-col overflow-hidden rounded-[12px] border border-black/[0.08] bg-white shadow-[0_16px_48px_rgba(0,0,0,0.10)] max-xl:relative max-xl:inset-auto max-xl:h-auto max-xl:w-full max-xl:min-w-0 max-xl:max-w-none max-xl:shadow-[0_1px_0_rgba(0,0,0,0.04),0_24px_48px_rgba(0,0,0,0.08)]">
+        <SlackThread />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The thread that reads the ledger back in human words.
+ *
+ * On a wide screen it floats over the board. On a phone it sits under the
+ * ledger as its own block, at content height, because a card pinned to 78% of
+ * a fixed-height stage cut its own last message in half.
+ */
+function SlackThread({ mobile }: { mobile?: boolean }) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col overflow-hidden rounded-[12px] border border-black/[0.08] bg-white",
+        mobile
+          ? "w-full"
+          : "absolute top-[11.1%] bottom-[7.5%] left-[4.9%] z-10 w-[32.5%] min-w-[280px] max-w-[340px] shadow-[0_16px_48px_rgba(0,0,0,0.10)]",
+      )}
+    >
           <div className="flex h-11 shrink-0 items-center justify-between border-b border-black/[0.06] px-3.5">
             <div className="flex items-center gap-2">
               <SlackHash />
@@ -400,8 +495,6 @@ export function FailClosedScene() {
               </div>
             </div>
           </div>
-        </div>
-      </div>
     </div>
   );
 }

--- a/www/components/home/visuals/MigrationScene.tsx
+++ b/www/components/home/visuals/MigrationScene.tsx
@@ -47,6 +47,7 @@ const HOLD = 14.4;
 const LOCK_LIMIT = 2;
 
 const TABS = ["Catch exclusive locks", "Safer expand-and-contract"] as const;
+const TABS_SHORT = ["Exclusive lock", "Expand-and-contract"] as const;
 
 const SQL_RISKY =
   "ALTER TABLE subscriptions ADD COLUMN access_tier text NOT NULL DEFAULT 'free';";
@@ -410,6 +411,7 @@ function Film({
       />
       <InnerPills
         items={TABS}
+        short={TABS_SHORT}
         active={tab}
         onSelect={onTab ? (index) => onTab(index === 0 ? 0 : 1) : undefined}
         action={

--- a/www/components/home/visuals/StudioWindow.tsx
+++ b/www/components/home/visuals/StudioWindow.tsx
@@ -75,26 +75,44 @@ export function InnerHeader({
   );
 }
 
+/**
+ * The tab row inside a run window.
+ *
+ * `short` carries the same tabs written for a phone. Two twenty-character
+ * labels and a verdict chip do not fit in 290 points, and the alternative was
+ * a tab whose name ended mid-word.
+ */
 export function InnerPills({
   items,
+  short,
   active,
   onSelect,
   action,
 }: {
   items: readonly string[];
+  short?: readonly string[];
   active: number;
   onSelect?: (index: number) => void;
   action?: ReactNode;
 }) {
   return (
-    <div className="flex h-10 shrink-0 items-center justify-between gap-3 border-y border-black/[0.08] px-3 max-md:px-2">
-      <div className="flex min-w-0 items-center gap-0.5 overflow-x-auto no-scrollbars">
+    <div className="flex h-10 shrink-0 items-center justify-between gap-3 border-y border-black/[0.08] px-3 max-md:gap-2 max-md:px-2">
+      <div className="fade-scroll-x flex min-w-0 items-center gap-0.5 overflow-x-auto no-scrollbars">
         {items.map((item, index) => {
           const selected = index === active;
           const className = cn(
-            "shrink-0 rounded-[8px] px-2.5 py-1 text-[12px] tracking-extra-tight",
+            "shrink-0 rounded-[8px] px-2.5 py-1 text-[12px] tracking-extra-tight max-md:px-2 max-md:text-[11px]",
             selected ? "bg-[#F4F4F6] text-[#1A1A1A]" : "text-[#6B6F76]",
           );
+          const label =
+            short && short[index] && short[index] !== item ? (
+              <>
+                <span className="max-md:hidden">{item}</span>
+                <span className="hidden max-md:inline">{short[index]}</span>
+              </>
+            ) : (
+              item
+            );
           if (onSelect) {
             return (
               <button
@@ -103,19 +121,19 @@ export function InnerPills({
                 className={cn(className, "pointer-events-auto hover:text-[#1A1A1A]")}
                 onClick={() => onSelect(index)}
               >
-                {item}
+                {label}
               </button>
             );
           }
           return (
             <span key={item} className={className}>
-              {item}
+              {label}
             </span>
           );
         })}
       </div>
       {action ? (
-        <span className="shrink-0 rounded-[8px] px-2.5 py-1 text-[12px] tracking-extra-tight text-[#6B6F76] ring-1 ring-black/[0.08]">
+        <span className="shrink-0 rounded-[8px] px-2.5 py-1 text-[12px] tracking-extra-tight text-[#6B6F76] ring-1 ring-black/[0.08] max-md:px-2 max-md:text-[11px]">
           {action}
         </span>
       ) : null}

--- a/www/components/home/visuals/headerMinis.tsx
+++ b/www/components/home/visuals/headerMinis.tsx
@@ -18,6 +18,10 @@ const MINI_CSS = `
   letter-spacing: -0.02em;
   color: ${GREEN};
   white-space: nowrap;
+  /* The masked address is longer than the cell. Dissolve it rather than
+     letting it run into the frame edge. */
+  -webkit-mask-image: linear-gradient(to right, #000 60%, transparent 100%);
+  mask-image: linear-gradient(to right, #000 60%, transparent 100%);
 }
 .mini-scramble::after { content: "m***@twin"; }
 .mini-packet { transform: translate(28px, 0); }

--- a/www/components/layout/Heading.tsx
+++ b/www/components/layout/Heading.tsx
@@ -1,15 +1,26 @@
 import { cn } from "@/lib/cn";
-import { HeadingIcon } from "@/components/home/media/icons";
+import { HeadingIcon, type HeadingIconName } from "@/components/home/media/icons";
 
+/**
+ * A section head.
+ *
+ * On a wide screen the sticky table of contents names the section, so the head
+ * is just the mark and the sentence. Below `xl` that rail is gone, and the mark
+ * on its own left a lone glyph floating above a wall of text with nothing to
+ * say what part of the argument you had reached. The `label` rides beside the
+ * mark at those widths and carries the name the rail would have carried.
+ */
 export function Heading({
   title,
+  label,
   theme = "light",
   icon,
   className,
 }: {
   title: string;
+  label?: string;
   theme?: "light" | "dark";
-  icon?: "migrations" | "workload" | "twins" | "firewall" | "features";
+  icon?: HeadingIconName;
   className?: string;
 }) {
   return (
@@ -17,16 +28,31 @@ export function Heading({
       className={cn(
         "flex max-w-[960px] flex-col gap-y-14",
         "max-xl:max-w-[800px] max-xl:gap-y-12",
-        "max-lg:max-w-xl max-lg:gap-y-7",
-        "max-md:max-w-full",
+        "max-lg:max-w-xl max-lg:gap-y-6",
+        "max-md:max-w-full max-md:gap-y-5",
         className,
       )}
     >
-      {icon ? <HeadingIcon name={icon} /> : null}
+      {icon ? (
+        <div className="flex items-center gap-x-3.5 max-md:gap-x-3">
+          <HeadingIcon name={icon} />
+          {label ? (
+            <span
+              className={cn(
+                "hidden font-mono text-[11px] font-medium uppercase leading-none tracking-[0.14em]",
+                "max-xl:inline-block max-md:text-[10px]",
+                theme === "light" ? "text-black/45" : "text-black/50",
+              )}
+            >
+              {label}
+            </span>
+          ) : null}
+        </div>
+      ) : null}
       <h2
         className={cn(
           "indent-24 text-[48px] font-normal leading-dense tracking-tighter text-pretty [&>strong]:font-normal",
-          "max-xl:text-[40px] max-lg:indent-16 max-lg:text-[28px] max-lg:text-wrap max-md:indent-0 max-md:text-[24px]",
+          "max-xl:text-[40px] max-lg:indent-16 max-lg:text-[28px] max-lg:text-wrap max-md:indent-0 max-md:text-[26px]",
           theme === "light" && "text-gray-new-40 [&>strong]:text-black-pure",
           theme === "dark" && "text-gray-new-50 [&>strong]:text-black",
         )}

--- a/www/components/layout/SiteHeader.tsx
+++ b/www/components/layout/SiteHeader.tsx
@@ -8,7 +8,7 @@ import { Container } from "./Container";
 import { Logo } from "./Logo";
 import { cn } from "@/lib/cn";
 import { FOOTER_MENUS, GITHUB_URL, HEADER_MENUS } from "@/lib/nav";
-import { MenuCardArt, ProductMiniStyles } from "@/components/home/visuals/headerMinis";
+import { HeaderMini, MenuCardArt, ProductMiniStyles } from "@/components/home/visuals/headerMinis";
 import { Chevron, DiscordIcon, GitHubIcon } from "../icons";
 
 function HeaderLink({
@@ -126,8 +126,9 @@ export function SiteHeader({ overlay = true }: { overlay?: boolean }) {
           "after:absolute after:right-0 after:bottom-0 after:left-0 after:h-px after:bg-gray-new-90",
         )}
       >
-        <Container className="static z-10 flex w-full items-center justify-between max-md:px-8 max-sm:px-5" size="1920">
-          <div className="flex items-center gap-x-[92px] xl:gap-x-10">
+        <Container className="static z-10 flex w-full items-center justify-between gap-x-6 max-md:px-8 max-sm:px-5" size="1920">
+          {/* The gap used to be 92px below `xl` and 40px above it, which is backwards: the narrow end is where the row runs out of room, and at 1024 it pushed the sign-up button past the right edge of the page. */}
+            <div className="flex items-center gap-x-6 xl:gap-x-10">
             <Logo />
             <nav className="group/main-nav max-xl:hidden" aria-label="Main">
               <ul className="flex items-center">
@@ -145,8 +146,8 @@ export function SiteHeader({ overlay = true }: { overlay?: boolean }) {
                         <HeaderLink
                           href={menu.href}
                           className={cn(
-                            "relative flex h-16 items-center gap-x-1 rounded-sm px-3.5 text-[15px] font-normal leading-normal tracking-snug whitespace-pre text-black/70 transition-colors duration-200 hover:text-black xl:px-2.5",
-                            index === 0 && "-ml-3.5 xl:-ml-2.5",
+                            "relative flex h-16 items-center gap-x-1 rounded-sm px-2.5 text-[15px] font-normal leading-normal tracking-snug whitespace-pre text-black/70 transition-colors duration-200 hover:text-black",
+                            index === 0 && "-ml-2.5",
                             pathname === menu.href && "text-black",
                           )}
                         >
@@ -156,7 +157,7 @@ export function SiteHeader({ overlay = true }: { overlay?: boolean }) {
                         <button
                           type="button"
                           className={cn(
-                            "group/main-nav-trigger relative flex h-16 items-center gap-x-1 rounded-sm px-3.5 text-[15px] font-normal leading-normal tracking-snug whitespace-pre text-black/70 transition-colors duration-200 hover:text-black xl:px-2.5",
+                            "group/main-nav-trigger relative flex h-16 items-center gap-x-1 rounded-sm px-2.5 text-[15px] font-normal leading-normal tracking-snug whitespace-pre text-black/70 transition-colors duration-200 hover:text-black",
                             isActive && "text-black",
                             open !== null && !isActive && "text-gray-new-50",
                           )}
@@ -346,16 +347,25 @@ export function SiteHeader({ overlay = true }: { overlay?: boolean }) {
                           <div className="mb-3 text-[10px] font-medium uppercase tracking-snug text-gray-new-50">
                             {section.title}
                           </div>
-                          <div className="flex flex-col gap-3">
+                          {/* The same thumbnails the desktop dropdown gets. The
+                              phone menu is the first thing most visitors open,
+                              and eleven identical text rows told them nothing
+                              about what any of these pages contain. */}
+                          <div className="flex flex-col gap-3.5">
                             {section.items.map((item) => (
                               <HeaderLink
                                 key={item.href}
                                 href={item.href}
-                                className="text-[16px] tracking-extra-tight"
+                                className="group flex items-center gap-3 text-[16px] tracking-extra-tight"
                                 onClick={closeNow}
                               >
-                                {item.title}
-                                <span className="mt-0.5 block text-[13px] text-gray-new-50">{item.description}</span>
+                                <HeaderMini title={item.title} />
+                                <span className="min-w-0">
+                                  {item.title}
+                                  <span className="mt-0.5 block text-[13px] leading-snug text-gray-new-50">
+                                    {item.description}
+                                  </span>
+                                </span>
                               </HeaderLink>
                             ))}
                           </div>


### PR DESCRIPTION
## Summary

A phone pass over the homepage restyle that landed in #42, rebased on top of
it now that it is on main.

Where the two passes touched the same thing, #42 wins: its Workload Studio
mark, its Migration Safety copy, its mint Trust block, its retuned section
spacing, its `Checkout` thread label, and its `xl` breakpoints for the run
windows, the safety report and the editor stage — all of which are wider than
the ones this pass had used. Where one pass had a mark and the other had
nothing, the mark ships.

### What this adds

- **A section rail below `xl`.** The sticky table of contents is desktop-only,
  which left ten thousand pixels of scroll with nothing to say where the
  reader was. The rail pins the five section names under the header for as
  long as the stack is on screen, keeps the current one in view, and draws
  progress through it. Section heads carry the same name beside their mark at
  those widths.
- **Isolated Twin and Workload Studio trade places.** The twin is what the
  workload runs against, so it belongs on the page before the studio that
  drives it.
- **The two icon slots that were not icons.** The trust model drew a filled
  black circle above each of its claims; they are now a packet stopped at a
  closed gate, and a boundary with the data inside and the control plane
  outside.
- **Sideways-scrolling strips dissolve at the edge** instead of chopping a
  word in half: the editor tab rows, its bottom panel, and the run window pill
  rows. Editor code wraps rather than running off the screen, and the gutter
  steps aside there, because a wrapped line makes every number under it point
  at the wrong row.
- **The side-effect firewall had no evidence on a phone.** Its board is hidden
  below `xl`; the board's rows are the evidence, so they become a ledger of
  attempted effects and what the firewall did about each one.
- **The header ran past the right edge of the page at exactly 1024px**,
  because the gap between the logo and the nav was 92px below `xl` and 40px
  above it.
- **The phone menu shows the same thumbnails the desktop dropdown has**,
  instead of eleven identical rows of text.

## Test plan

Verified against the built static export, not just the source.

- [x] No horizontal overflow at 320 / 360 / 390 / 430 / 768 / 1024 / 1280
- [x] Homepage read end to end at 390, 768 and 1512
- [x] `/product`, `/product/report`, `/product/migrations`, `/product/firewall`,
      `/product/twins`, `/solutions`, `/pricing` clean at 390 / 768 / 1512
- [x] All five section marks render, Workload Studio being #42's
- [x] `tsc --noEmit` and `next build` clean

https://claude.ai/code/session_018j89Ty7azxwWpoSeDLn4sP
