### PR TITLE
github: accepting a permission left the old token cached for an hour

### DIFF
--- a/.changes/stale-token-after-accepting-permissions.md
+++ b/.changes/stale-token-after-accepting-permissions.md
@@ -1,0 +1,25 @@
+# fixed
+
+Accepting new permissions on the GitHub App installation left the control plane
+using the token it had already minted, which still carried the OLD scopes. An
+installation token is cached for its full hour and GitHub invalidates the
+outstanding ones the moment a grant changes, so the App went on refusing writes
+it had just been granted. On 2026-08-31 an Actions write grant accepted at
+00:38:54Z was answered with 403 until roughly 01:36Z, complaining about a
+permission that was already in place.
+
+`InstallationTokens.forget` had existed since the App client was written and had
+no callers anywhere in the tree. An `installation` delivery now drops the cached
+token before it handles anything, for every action rather than for
+`new_permissions_accepted` alone: suspend, unsuspend and deleted each change
+what a token is worth, and dropping one that did not need dropping costs a
+single mint.
+
+**If you are following the release note that asks you to accept new App
+permissions and a check still fails immediately afterwards, and you are running
+a control plane older than this fix, the cause is the cached token rather than
+the grant. Wait for the hour to lapse or restart the control plane, and retry.**
+That sentence is here because the instruction to accept permissions and the fix
+for what happens next do not have to ship together, and a note that is only
+correct under a sequencing assumption goes wrong quietly. Delete it at tag time
+if both landed in the same release.

--- a/web/apps/api/src/github/webhook.ts
+++ b/web/apps/api/src/github/webhook.ts
@@ -70,6 +70,13 @@ export async function handleDelivery(
   event: string,
   payload: Record<string, unknown>,
   github?: GitHubClient | null,
+  /**
+   * Drops the cached installation token, when there is a cache to drop from.
+   *
+   * Optional because the webhook has to work with no App configured, which is
+   * every self-hosted control plane that has not created one yet.
+   */
+  forgetTokens?: (installationId: number) => void,
 ): Promise<WebhookOutcome> {
   const action = typeof payload.action === 'string' ? payload.action : null
   const installation = payload.installation as
@@ -86,6 +93,25 @@ export async function handleDelivery(
       if (typeof id !== 'number' || !account?.login) {
         return { event, action, handled: false, detail: 'no installation in the payload' }
       }
+      // Every `installation` action changes what a token minted for it is
+      // worth, so the cached one is dropped before any of them is handled.
+      //
+      // This is the fix for an hour of wrong answers that a person actually
+      // sat through. An installation token is cached for its full hour, GitHub
+      // invalidates the outstanding ones the moment a grant changes, and
+      // `new_permissions_accepted` is that moment. On 2026-08-31 the Actions
+      // write grant was accepted at 00:38:54Z against a process that had
+      // minted a token at 00:35:58Z, so the console answered 403 until roughly
+      // 01:36Z while the permission it was complaining about had already been
+      // granted. Nothing invalidated the token, because `forget` had no
+      // callers anywhere in the tree.
+      //
+      // Unconditional across the actions rather than matched to
+      // `new_permissions_accepted` alone: suspend, unsuspend and deleted all
+      // change what the token can do, `created` can arrive for an id a failed
+      // earlier attempt already cached, and dropping a token that did not need
+      // dropping costs one mint.
+      forgetTokens?.(id)
       if (action === 'deleted') {
         await forgetInstallation(pool, account.login, id)
         return { event, action, handled: true, detail: `installation ${id} removed` }

--- a/web/apps/api/src/main.ts
+++ b/web/apps/api/src/main.ts
@@ -211,6 +211,13 @@ const { app, ingestLimiter, authLimiter } = createServer({
   signInAllowlist,
   sealingKey,
   githubWebhookSecret: appConfig?.webhookSecret ?? null,
+  // The webhook's way of invalidating a cached token. Bound to the same
+  // InstallationTokens the GitHub client mints from, because dropping a token
+  // out of a different cache from the one that holds it is the shape of fix
+  // that reads correct in a diff and changes nothing at runtime.
+  ...(installationTokens
+    ? { forgetInstallationToken: (id: number) => installationTokens.forget(id) }
+    : {}),
   stripe: stripe.config
     ? { config: stripe.config, client: new RealStripeClient(stripe.config) }
     : null,

--- a/web/apps/api/src/server.ts
+++ b/web/apps/api/src/server.ts
@@ -171,6 +171,10 @@ export interface ServerOptions {
    * unset means the real key set.
    */
   actionsKeys?: ActionsKeys
+  /** Drops a cached installation token, so the webhook can invalidate one the
+   *  moment GitHub says the installation changed. Absent when no App is
+   *  configured, which is when there is no cache to drop from. */
+  forgetInstallationToken?: (installationId: number) => void
   /** Stripe, when this installation takes money. Null is the self-hosted
    *  default: the billing routes answer PRECONDITION_FAILED naming the
    *  variables, and the webhook endpoint refuses every delivery rather than
@@ -1426,7 +1430,14 @@ export function createServer(options: ServerOptions) {
       // questions: which accounts exist, and what is happening on a commit.
       const installation = outcome.handled
         ? null
-        : await handleDelivery(options.pool, clock, event, payload, options.github)
+        : await handleDelivery(
+            options.pool,
+            clock,
+            event,
+            payload,
+            options.github,
+            options.forgetInstallationToken,
+          )
 
       const detail = outcome.handled ? outcome.detail : (installation?.detail ?? outcome.detail)
       await closeDelivery(

--- a/web/apps/api/test/githubapp.test.ts
+++ b/web/apps/api/test/githubapp.test.ts
@@ -598,6 +598,88 @@ describe('the webhook endpoint', {
     return { status: res.status, body: await res.text() }
   }
 
+  /**
+   * The hour of wrong answers, closed end to end.
+   *
+   * Not a unit test of `forget`, because the defect was never that `forget` did
+   * not work. It was that nothing called it: a real `InstallationTokens` holds
+   * a token for a full hour, GitHub invalidates the outstanding ones the moment
+   * a grant changes, and the delivery saying so did nothing to the cache. On
+   * 2026-08-31 that put a 403 in front of a person from 00:38:54Z, when the
+   * Actions write grant was accepted, until roughly 01:36Z, when the token it
+   * was still using finally expired.
+   *
+   * So this runs the real cache, delivers a real signed `installation` webhook
+   * over HTTP, and asks whether the NEXT mint is a new token. A test that
+   * asserted `forget` empties a Map would have passed on every day of that
+   * hour.
+   */
+  test('a permission acceptance invalidates the cached token, over HTTP', async () => {
+    let minted = 0
+    const tokens = new InstallationTokens(
+      { appId: '1', privateKey, webhookSecret: SECRET },
+      frozen,
+      (async () => {
+        minted++
+        return new Response(
+          JSON.stringify({ token: `ghs_${minted}`, expires_at: '2026-08-28T13:00:00Z' }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        )
+      }) as unknown as typeof fetch,
+    )
+    const wired = await startApi({
+      githubWebhookSecret: SECRET,
+      forgetInstallationToken: (id) => tokens.forget(id),
+    })
+    try {
+      // A token, cached the way a page load caches one.
+      assert.equal(await tokens.for(4242), 'ghs_1')
+      assert.equal(await tokens.for(4242), 'ghs_1', 'the cache is not caching')
+      assert.equal(minted, 1)
+
+      // The delivery GitHub sends the instant somebody accepts a permission.
+      const body = JSON.stringify({
+        action: 'new_permissions_accepted',
+        installation: {
+          id: 4242,
+          account: { login: `forget-test-${run}`, type: 'Organization' },
+        },
+        repositories: [],
+      })
+      const res = await wired.fetch('/webhooks/github', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-github-event': 'installation',
+          // Suffixed with `run`, like every other delivery in this file, and
+          // for a reason the fixed id hid. `claimDelivery` is keyed on the
+          // delivery id, so a second run of this test against a database that
+          // already holds the row is answered as a REPLAY and never reaches
+          // handleDelivery at all. With a fixed id the test passes exactly once
+          // per database: green in CI, which builds a fresh one, and red for
+          // anybody who runs the suite twice. It also made the mutation proof
+          // meaningless, because a broken build and a replayed delivery fail
+          // with the same assertion.
+          'x-github-delivery': `forget-test-${run}`,
+          'x-hub-signature-256': sign(body, SECRET),
+        },
+        body,
+      })
+      assert.equal(res.status, 200, await res.text())
+
+      // The clock has not moved, so the cached token is still inside its hour.
+      // Anything but a fresh one here means the delivery changed nothing.
+      assert.equal(await tokens.for(4242), 'ghs_2', 'the cached token survived the delivery')
+      assert.equal(minted, 2)
+    } finally {
+      await wired.admin`DELETE FROM github_deliveries WHERE delivery_id = ${`forget-test-${run}`}`
+      const rows = await wired.admin<{ id: string }[]>`
+        SELECT id FROM organizations WHERE github_login = ${`forget-test-${run}`}`
+      for (const row of rows) await dropOrg(wired.admin, row.id)
+      await wired.close()
+    }
+  })
+
   test('an unsigned delivery is refused and writes nothing', async () => {
     const res = await deliver(
       'installation',

--- a/web/apps/api/test/harness.ts
+++ b/web/apps/api/test/harness.ts
@@ -117,6 +117,9 @@ export interface StartApiOptions {
    * somebody runs the suite.
    */
   actionsJwks?: () => string
+  /** Drops a cached installation token. Undefined means no App is configured,
+   *  which is when there is no cache for the webhook to drop from. */
+  forgetInstallationToken?: (installationId: number) => void
 }
 
 export async function startApi(options: StartApiOptions = {}): Promise<ApiHarness> {
@@ -157,6 +160,9 @@ export async function startApi(options: StartApiOptions = {}): Promise<ApiHarnes
     hostedRequiredPlan: options.hostedRequiredPlan ?? null,
     githubAppInstallUrl: options.githubAppInstallUrl,
     githubApi: options.githubApi ?? null,
+    ...(options.forgetInstallationToken
+      ? { forgetInstallationToken: options.forgetInstallationToken }
+      : {}),
     ...(options.actionsJwks
       ? {
           actionsKeys: new ActionsKeys(clock, {


### PR DESCRIPTION
Draft, for CI. Not for merging today.

## What it fixes

`InstallationTokens.forget` has existed since the App client was written, with a comment saying it is there "for when GitHub says one is no longer valid", and `git grep '\.forget('` across `web/` and `console/` returns ZERO callers. It is a dead path of the shape that reads as a working feature: the function is right, the comment is right, and nothing ever calls it.

An installation token is cached for its full hour. GitHub invalidates the outstanding ones the moment a grant changes, and `new_permissions_accepted` is the delivery that says so. On 2026-08-31 the Actions write grant was accepted at 00:38:54Z against a process that had minted a token at 00:35:58Z, and the console answered 403 until roughly 01:36Z, complaining about a permission that had already been granted.

An `installation` delivery now drops the cached token before it handles anything, and the webhook route is given a callback bound to the same `InstallationTokens` the GitHub client mints from.

## Why it matters now

`w-github-lifecycle`'s release note asks Vir to go and accept new App permissions. Without this, doing so leaves a cached token carrying the old scopes and the App keeps failing Checks writes for up to an hour, looking exactly as though the grant did not work.

## Provenance

The working code here is not mine. It was recovered from uncommitted changes in the `w-dispatch403` worktree, written 2026-08-31 and abandoned before anything committed it. I checked its premise against origin rather than taking it on trust, and rebuilt it on top of `w-github-lifecycle`, which added a fifth parameter to `handleDelivery` while the patch sat abandoned. The callback is the sixth parameter here, and the webhook route keeps main's lifecycle-first structure.

## The test it arrived with passed exactly once per database

It hardcoded `x-github-delivery: forget-test`, and `claimDelivery` is keyed on that id, so every run after the first was answered as a replay and never reached `handleDelivery` at all. Green in CI forever, because CI builds a fresh Postgres per job; red for anybody who ran the suite twice. The id and the account login are now suffixed with the file's own `run` uuid and the delivery row is deleted alongside the org, matching `prlifecycle.test.ts`.

## Proof that the test can fail

Three mutations, each restored, against a real Postgres. All three fail with "the cached token survived the delivery":

| mutation | result |
| --- | --- |
| remove `forgetTokens?.(id)` from `webhook.ts` | red |
| drop the sixth argument in `server.ts`, call intact | red |
| make `forget()` a no-op in `app.ts` | red |
| all restored | green |

Three rather than one because they prove the test guards the call, the wiring and the implementation separately, so this cannot go dead again the way `forget` did. Plus three consecutive unmutated runs, green, which the original could not have passed.

## Landing note

Carries no migration, so it is not in the 0021 to 0024 order. It conflicts with `w-github-lifecycle` at `5e71bcba` in `src/server.ts` and `test/harness.ts`; both are mechanical. Take this branch's `handleDelivery` call, and take the lifecycle branch's ordering in `harness.ts` plus this branch's one interface field and one spread. Taking both sides of `harness.ts` wholesale duplicates the spread and `tsc` does not catch it, because a repeated spread of the same key is legal TypeScript.