### PR TITLE
golden: a shared store does not make one project's golden everybody's

### DIFF
--- a/.changes/a-golden-belongs-to-one-project.md
+++ b/.changes/a-golden-belongs-to-one-project.md
@@ -1,0 +1,33 @@
+# security
+
+`af up` branched another project's golden.
+
+A golden pool is shared: the Docker provider keeps goldens as images on a
+machine wide daemon, and a published store is shared by a fleet on purpose.
+Selection filtered on the masking rules digest, which says how a golden was
+masked and not whose it is. A project with no `masking.yaml` declares no rules,
+so every project on a machine without one hashed to the same value and drew
+from one pool.
+
+Reproduced with two ordinary Express repositories. One declared a production
+database and refreshed a golden from it. The other declared none, printed in
+its own generated manifest that "branches will start empty", and `af up`
+brought up a database holding the first project's tables and its rows.
+
+A golden now records the project it was made for, along with the variable
+naming production, the seed command, the masking digest, the subset and the
+Postgres major, and an environment branches only a golden whose record equals
+its own. `af golden pull` refuses a published golden made for another project,
+checking the claim in the signed attestation before restoring anything.
+`af golden gc` collects only this project's versions, where running it in one
+repository used to delete another repository's goldens. `af golden list` says
+which project each version belongs to.
+
+Every run now says where its data came from, rather than printing a version
+identifier alone:
+
+    branching the database from gv_20260901033741_74234e98, made for
+    acme-billing from the database named by PRODUCTION_DATABASE_URL
+
+Expect one golden refresh per project the first time a command runs after this
+change, because no existing golden carries the record.

--- a/.changes/an-empty-golden-is-reusable.internal.md
+++ b/.changes/an-empty-golden-is-reusable.internal.md
@@ -1,0 +1,10 @@
+# fixed
+
+A project with no production database refreshed a golden on every `af up`.
+
+The path that creates an empty golden stamped `seedRulesHash(seed)`, which for
+a project with no seed command is the literal string `empty`, while selection
+asked for the digest of an empty rule set. Those two never matched, so the
+golden made by one run was refused by the next and a new one was built each
+time. Both paths now record the same project identity, so the second run
+branches what the first one made.

--- a/docs/plan/STATUS.md
+++ b/docs/plan/STATUS.md
@@ -530,6 +530,21 @@ branched whichever verified golden was newest regardless of which manifest made
 it, so a preview of one project could come up holding a masked copy of another
 project's database.
 
+That last one was fixed twice, and the first fix is worth recording because it
+looked right. Selection was narrowed to the masking rules digest, which is a
+statement about how a golden was masked and not about whose it is: a project
+with no `masking.yaml` declares no rules, and every project on a machine
+without one therefore hashed to the same value and shared one pool. Reproduced
+on 2026-09-01 with the released binary and two ordinary Express repositories:
+one declared a production database and refreshed a golden from it, the other
+declared none, printed in its own generated manifest that "branches will start
+empty", and came up holding the first project's tables and rows. A golden now
+records the project it was made for along with the source variable, the seed,
+the rules, the subset and the Postgres major (`engine/internal/env/provenance.go`),
+selection is exact equality on that, `af golden pull` refuses a published
+golden made for another project, `af golden gc` no longer collects other
+projects' goldens, and every branch line says where its data came from.
+
 ## Phase 14. Scaling
 
 | Sub-phase | State | Notes |

--- a/docs/src/content/docs/concepts/goldens.md
+++ b/docs/src/content/docs/concepts/goldens.md
@@ -35,6 +35,58 @@ af golden gc            # remove versions nothing came from
 af golden pull [ver]    # bring a published one onto this machine
 ```
 
+## Which golden an environment branches
+
+A golden pool is shared. With the Docker provider a golden is an image on the
+daemon, and a daemon is machine wide, so every repository on your laptop draws
+from one pool. A published store is shared by a whole fleet on purpose.
+
+So `af up` does not take the newest verified golden. It takes the newest
+verified golden **made for this project**, and a golden records what made it:
+
+| Recorded | Why it separates two projects |
+| --- | --- |
+| `name` | The project the manifest names. |
+| `source_url_env` | The variable naming production, or nothing. |
+| `seed` | The command that fills a golden when there is no production. |
+| masking rules | The digest of `masking.yaml`, or of no rules at all. |
+| `subset` | A slice and the whole database are different content. |
+| `version` | The Postgres major the golden holds. |
+
+The variable's **name** is recorded, never the connection string it resolves
+to. The machine that pulls a published golden has no production credential,
+which is the entire point of publishing, so an identity built from the resolved
+host would differ between the machine that made a golden and every machine
+entitled to use it.
+
+The repository's path on disk is deliberately not part of it either. CI checks
+out somewhere new on every run and a worktree per branch is a different
+directory, so keying on the path would refuse the golden every time and cost a
+full copy of production.
+
+Nothing changes for the ordinary case: one project, many branches, one golden.
+What changes is that a golden belonging to a different project, or made under
+masking rules you have since edited, or taken as a subset when this manifest
+asks for the whole database, is refused rather than branched:
+
+```
+AF-DB-012 No golden here was made for this project, and 3 were made for
+something else.
+  Next: Run 'af golden refresh' to make one from the source this manifest names.
+```
+
+Every run says where its data came from, so the choice can be checked rather
+than assumed:
+
+```
+branching the database from gv_20260901033741_74234e98, made for acme-billing
+from the database named by PRODUCTION_DATABASE_URL, under masking rules a91f0c
+```
+
+`af golden list` marks each version with the project it belongs to, and
+`af golden gc` only collects this project's, so running it in one repository
+never removes another repository's goldens.
+
 ## Refreshing
 
 ```yaml
@@ -151,6 +203,21 @@ A pulled golden is **not** trusted because it came from the store. The
 verification scan runs again, on the machine that pulled it, against the
 database that actually arrived. Skipping that would make the store a way to get
 an unverified database branched, which is the one thing the product refuses.
+
+Nor is it trusted to be yours. The attestation carries the project the golden
+was made for, signed along with everything else, and a version made for another
+project is refused before any of it is restored:
+
+```
+AF-DB-015 The published golden gv_20260901033741_74234e98 in the local store at
+/srv/goldens was made for a different project.
+  Next: Name a version this project published with 'af golden pull <version>',
+  or run 'af golden refresh' on a machine that can reach the source.
+```
+
+That matters most for `af golden pull` with no version named, which takes the
+newest complete object in the store. In a bucket several projects publish to,
+the newest object is not necessarily yours.
 
 The local copy gets a new version identifier, because an identifier carries when
 the version was made and this copy was made now. `af golden pull` prints both.

--- a/docs/src/content/docs/concepts/goldens.md
+++ b/docs/src/content/docs/concepts/goldens.md
@@ -60,7 +60,7 @@ host would differ between the machine that made a golden and every machine
 entitled to use it.
 
 The repository's path on disk is deliberately not part of it either. CI checks
-out somewhere new on every run and a worktree per branch is a different
+out somewhere new on every run and a separate checkout per branch is a different
 directory, so keying on the path would refuse the golden every time and cost a
 full copy of production.
 

--- a/docs/src/content/docs/reference/errors.md
+++ b/docs/src/content/docs/reference/errors.md
@@ -422,6 +422,18 @@ No database branch exists for {env}.
 | Retryable | No. Retrying the same operation unchanged will fail the same way. |
 | More | [concepts/goldens](/docs/concepts/goldens/) |
 
+### AF-DB-015
+
+The published golden {version} in {store} was made for a different project.
+
+**What to do.** Name a version this project published with 'af golden pull <version>', or run 'af golden refresh' on a machine that can reach the source. A store is shared, so the newest object in it is not necessarily yours.
+
+| | |
+| --- | --- |
+| Exit code | `5` |
+| Retryable | No. Retrying the same operation unchanged will fail the same way. |
+| More | [concepts/goldens](/docs/concepts/goldens/) |
+
 ### AF-DB-020
 
 Personas cannot be provisioned because {provider} creates users only through its own API, and no sandbox tenant is configured.

--- a/docs/src/content/docs/reference/errors.md
+++ b/docs/src/content/docs/reference/errors.md
@@ -388,9 +388,9 @@ The subset could not be taken: {detail}
 
 ### AF-DB-012
 
-No golden matches this manifest's masking rules, and {count} were made under different ones.
+No golden here was made for this project, and {count} were made for something else.
 
-**What to do.** Run 'af golden refresh' to make one from the source this manifest names.
+**What to do.** Run 'af golden refresh' to make one from the source this manifest names. A golden is chosen by the project it was made for, the database it was copied from, the masking rules, the subset and the Postgres version, so one belonging to another project on this machine is never branched here.
 
 | | |
 | --- | --- |

--- a/engine/conformance/db.go
+++ b/engine/conformance/db.go
@@ -119,6 +119,7 @@ var databaseBehaviors = []Behavior{
 	{"Refresh_CallsMaskThenVerify", "A refresh applies the masking rules before it verifies, and does both.", ""},
 	{"Refresh_RefusesToPublishWhenVerificationFails", "A refresh whose verification fails publishes nothing.", ""},
 	{"List_ReturnsWhatWasCreated", "A published version appears in the listing.", ""},
+	{"List_ReturnsTheProvenanceThatWasRecorded", "A published version carries back the project it was made for, so selection can refuse another project's golden.", ""},
 	{"Branch_ReadsAKnownRow", "A branch holds the golden's data.", ""},
 	{"Branch_IsIdempotentByEnvironment", "Branching twice for one environment returns one branch, not two.", ""},
 	{"Branch_RefusesAnUnverifiedGolden", "Branching an unverified version fails with AF-MSK-001.", ""},
@@ -336,6 +337,8 @@ func runBehavior(ctx context.Context, t *testing.T, name string, factory Factory
 		h.refreshRefusesWhenVerificationFails(ctx)
 	case "List_ReturnsWhatWasCreated":
 		h.listReturnsWhatWasCreated(ctx)
+	case "List_ReturnsTheProvenanceThatWasRecorded":
+		h.listReturnsTheProvenance(ctx)
 	case "Branch_ReadsAKnownRow":
 		h.branchReadsAKnownRow(ctx)
 	case "Branch_IsIdempotentByEnvironment":
@@ -425,6 +428,10 @@ func (h *harness) spec() provider.GoldenSpec {
 		SourceURL: secrets.New("postgres://conformance@source/db"),
 		Version:   17,
 		RulesHash: h.rulesHash(),
+		// Distinct per refresh for the same reason the rules hash is: this
+		// suite runs against shared daemons and shared accounts, so a fixed
+		// value would let one run's assertion pass on another run's golden.
+		Provenance: "gp1-conformance-" + h.rulesHash(),
 		Mask: func(_ context.Context, _ secrets.Value) error {
 			h.masked++
 			return nil
@@ -589,6 +596,45 @@ func (h *harness) listReturnsWhatWasCreated(ctx context.Context) {
 		}
 	}
 	h.t.Fatalf("version %s was published and does not appear in the listing of %d", gv.ID, len(goldens))
+}
+
+// listReturnsTheProvenance is the check that keeps golden selection working
+// for every provider rather than only for the one it was written against.
+//
+// The engine refuses to branch a version whose recorded provenance is not this
+// project's, so a provider that accepts the field on a refresh and drops it
+// before the listing turns every one of its goldens into an unbranchable one,
+// and the symptom is a full refresh on every command rather than an error.
+// That failure is invisible from inside the engine, which is why it is
+// asserted here, once, against all four providers.
+func (h *harness) listReturnsTheProvenance(ctx context.Context) {
+	spec := h.spec()
+	gv, err := h.p.RefreshGolden(ctx, spec)
+	h.trackGolden(gv.ID)
+	if err != nil {
+		h.t.Fatalf("RefreshGolden: %v", err)
+	}
+	if gv.Provenance != spec.Provenance {
+		h.t.Errorf("the refresh returned provenance %q for a version made with %q",
+			gv.Provenance, spec.Provenance)
+	}
+	goldens, err := h.p.ListGoldens(ctx)
+	if err != nil {
+		h.t.Fatalf("ListGoldens: %v", err)
+	}
+	for _, g := range goldens {
+		if g.ID != gv.ID {
+			continue
+		}
+		if g.Provenance != spec.Provenance {
+			h.t.Fatalf("version %s was published for %q and lists as %q, so the engine "+
+				"cannot tell whose golden it is and will refuse to branch it",
+				g.ID, spec.Provenance, g.Provenance)
+		}
+		return
+	}
+	h.t.Fatalf("version %s was published and does not appear in the listing of %d",
+		gv.ID, len(goldens))
 }
 
 func (h *harness) branchReadsAKnownRow(ctx context.Context) {

--- a/engine/internal/cli/golden.go
+++ b/engine/internal/cli/golden.go
@@ -195,10 +195,10 @@ func newGoldenListCommand(env *Env) *cobra.Command {
 				// machine's worth of other projects' goldens as though `af up`
 				// could use any of them, and for a long time it could.
 				owner := env.Out.S(StyleWarn, "another project")
-				switch {
-				case g.Provenance == mine:
+				switch g.Provenance {
+				case mine:
 					owner = env.Out.S(StyleGood, "this project")
-				case g.Provenance == "":
+				case "":
 					owner = env.Out.S(StyleWarn, "not recorded")
 				}
 				rows = append(rows, []string{

--- a/engine/internal/cli/golden.go
+++ b/engine/internal/cli/golden.go
@@ -26,6 +26,12 @@ type GoldenJSON struct {
 	CreatedAt string `json:"created_at"`
 	SizeBytes int64  `json:"size_bytes,omitempty"`
 	RulesHash string `json:"rules_hash,omitempty"`
+	// Provenance is the project the version was made for, and Mine says
+	// whether that is this one. Both, because a caller scripting against this
+	// wants the answer without having to know how the identity is built, and
+	// an operator reading it wants to see that two rows differ.
+	Provenance string `json:"provenance,omitempty"`
+	Mine       bool   `json:"mine"`
 }
 
 // RefreshJSON is the result of a refresh.
@@ -143,6 +149,15 @@ func newGoldenListCommand(env *Env) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			// What this project may branch, so the listing can say which rows
+			// are available here. A golden pool is shared: on Docker it is
+			// every project on the machine, and a listing that shows all of
+			// them without saying whose they are is what made an unbranchable
+			// golden look like a usable one.
+			mine, err := o.GoldenIdentity()
+			if err != nil {
+				return err
+			}
 			if env.Out.Format == FormatJSON {
 				docs := make([]GoldenJSON, 0, len(goldens))
 				for _, g := range goldens {
@@ -150,6 +165,7 @@ func newGoldenListCommand(env *Env) *cobra.Command {
 						Version: g.ID, Verified: g.Verified,
 						CreatedAt: g.CreatedAt.UTC().Format(time.RFC3339),
 						SizeBytes: g.SizeBytes, RulesHash: g.RulesHash,
+						Provenance: g.Provenance, Mine: g.Provenance == mine,
 					})
 				}
 				return env.Out.JSON(docs)
@@ -174,13 +190,25 @@ func newGoldenListCommand(env *Env) *cobra.Command {
 				if rules == "" {
 					rules = "not recorded"
 				}
+				// Whose golden this is, said on every row. The pool is
+				// shared, so a listing that does not say this presents a
+				// machine's worth of other projects' goldens as though `af up`
+				// could use any of them, and for a long time it could.
+				owner := env.Out.S(StyleWarn, "another project")
+				switch {
+				case g.Provenance == mine:
+					owner = env.Out.S(StyleGood, "this project")
+				case g.Provenance == "":
+					owner = env.Out.S(StyleWarn, "not recorded")
+				}
 				rows = append(rows, []string{
 					g.ID, state, g.CreatedAt.Local().Format("2006-01-02 15:04"),
-					humanBytes(uint64(g.SizeBytes)), rules,
+					humanBytes(uint64(g.SizeBytes)), rules, owner,
 				})
 			}
 			env.Out.Table([]Column{
-				Col("VERSION"), Col("STATE"), Col("CREATED"), Num("SIZE"), Flex("RULES"),
+				Col("VERSION"), Col("STATE"), Col("CREATED"), Num("SIZE"),
+				Flex("RULES"), Flex("FOR"),
 			}, rows)
 
 			// What this project publishes, and when it refreshes next. Both
@@ -257,8 +285,25 @@ bring an environment up at all, which is worse than the disk it saved.`),
 			if err != nil {
 				return err
 			}
+			mine, err := o.GoldenIdentity()
+			if err != nil {
+				return err
+			}
+			// Only this project's, which is a correctness rule and not a
+			// courtesy. The Docker provider keeps goldens as images on a
+			// machine wide daemon, so this used to sweep every project on the
+			// laptop: running `af golden gc` in one repository destroyed
+			// another repository's goldens, and the retention count it
+			// enforced was a count across all of them. The same shared pool
+			// that let `af up` branch somebody else's golden let this delete
+			// it. Left alone is counted so the outcome is not silent.
+			skipped := 0
 			versions := make([]golden.Version, 0, len(goldens))
 			for _, g := range goldens {
+				if g.Provenance != mine {
+					skipped++
+					continue
+				}
 				versions = append(versions, golden.Version{
 					ID: g.ID, CreatedAt: g.CreatedAt, Verified: g.Verified,
 				})
@@ -286,10 +331,15 @@ bring an environment up at all, which is worse than the disk it saved.`),
 				return env.Out.JSON(map[string]any{
 					"removed": removed, "kept": kept, "keep": effective,
 					"keep_from": source, "refused": refused,
+					"other_projects": skipped,
 				})
 			}
 			env.Out.Printf("Removed %d, kept %d, keeping %d from %s.\n",
 				removed, kept, effective, source)
+			if skipped > 0 {
+				env.Out.Printf("  %d belong to other projects on this machine and were left alone.\n",
+					skipped)
+			}
 			for _, d := range decisions {
 				if !d.Remove {
 					env.Out.Printf("  %s %s: %s\n",

--- a/engine/internal/cli/init.go
+++ b/engine/internal/cli/init.go
@@ -439,9 +439,9 @@ func renderManifest(m *schema.Manifest) ([]byte, error) {
 		b.WriteString(strings.TrimSpace(`
 # Detection found no production database to build a golden from, so branches
 # start from an empty database this project makes for itself. A golden another
-# project on this machine made is never branched here, whatever the two have in
-# common. To copy production instead, add the name of the variable holding its
-# read only connection string:
+# project on this machine made is never branched into an environment here,
+# whatever the two have in common. To copy production instead, add the name of
+# the variable holding its read only connection string:
 #
 #   database:
 #     source_url_env: PRODUCTION_DATABASE_URL

--- a/engine/internal/cli/init.go
+++ b/engine/internal/cli/init.go
@@ -438,8 +438,10 @@ func renderManifest(m *schema.Manifest) ([]byte, error) {
 		b.WriteString("\n")
 		b.WriteString(strings.TrimSpace(`
 # Detection found no production database to build a golden from, so branches
-# will start empty. To copy production instead, add the name of the variable
-# holding its read only connection string:
+# start from an empty database this project makes for itself. A golden another
+# project on this machine made is never branched here, whatever the two have in
+# common. To copy production instead, add the name of the variable holding its
+# read only connection string:
 #
 #   database:
 #     source_url_env: PRODUCTION_DATABASE_URL

--- a/engine/internal/db/dblab/dblab.go
+++ b/engine/internal/db/dblab/dblab.go
@@ -349,6 +349,7 @@ func (p *Provider) RefreshGolden(ctx context.Context, spec provider.GoldenSpec) 
 	message := encodeMeta(meta{
 		Version:           version,
 		RulesHash:         spec.RulesHash,
+		Provenance:        spec.Provenance,
 		CreatedAt:         created.Format(time.RFC3339),
 		Verified:          spec.Verify != nil,
 		AttestationSHA256: sha256Hex(attestation),
@@ -374,7 +375,8 @@ func (p *Provider) RefreshGolden(ctx context.Context, spec provider.GoldenSpec) 
 
 	gv := provider.GoldenVersion{
 		ID: version, CreatedAt: created, RulesHash: spec.RulesHash,
-		Verified: spec.Verify != nil, Attestation: attestation, ProviderRef: snapshotID,
+		Provenance: spec.Provenance,
+		Verified:   spec.Verify != nil, Attestation: attestation, ProviderRef: snapshotID,
 	}
 	if fresh, err := p.client.GetSnapshot(ctx, snapshotID); err == nil {
 		gv.SizeBytes = fresh.LogicalSize
@@ -446,6 +448,7 @@ func (p *Provider) ListGoldens(ctx context.Context) ([]provider.GoldenVersion, e
 			CreatedAt:   m.createdAt(s.CreatedAt.Time),
 			SizeBytes:   s.LogicalSize,
 			RulesHash:   m.RulesHash,
+			Provenance:  m.Provenance,
 			Verified:    m.Verified,
 			ProviderRef: s.ID,
 		})

--- a/engine/internal/db/dblab/meta.go
+++ b/engine/internal/db/dblab/meta.go
@@ -37,7 +37,11 @@ type meta struct {
 	Antifailure int    `json:"antifailure"`
 	Version     string `json:"version"`
 	RulesHash   string `json:"rules_hash"`
-	CreatedAt   string `json:"created_at"`
+	// Provenance is the project the golden was made for. A snapshot written
+	// before this field existed leaves it empty, and the engine refuses to
+	// branch such a snapshot rather than guessing whose it is.
+	Provenance string `json:"provenance,omitempty"`
+	CreatedAt  string `json:"created_at"`
 	// Verified is written true and never false. A refresh that fails
 	// verification never reaches the snapshot at all, so an unverified golden
 	// cannot be created by this provider. The field is here because reading it

--- a/engine/internal/db/docker/docker.go
+++ b/engine/internal/db/docker/docker.go
@@ -266,6 +266,9 @@ func (p *Provider) RefreshGolden(ctx context.Context, spec provider.GoldenSpec) 
 	if spec.RulesHash != "" {
 		changes = append(changes, `LABEL `+dockerutil.LabelRules+`=`+spec.RulesHash)
 	}
+	if spec.Provenance != "" {
+		changes = append(changes, `LABEL `+dockerutil.LabelProvenance+`=`+spec.Provenance)
+	}
 	if attestation != "" {
 		changes = append(changes, `LABEL `+dockerutil.LabelAttestation+`=`+
 			base64.StdEncoding.EncodeToString([]byte(attestation)))
@@ -280,7 +283,8 @@ func (p *Provider) RefreshGolden(ctx context.Context, spec provider.GoldenSpec) 
 
 	gv := provider.GoldenVersion{
 		ID: version, CreatedAt: p.clock.Now().UTC(), RulesHash: spec.RulesHash,
-		Verified: spec.Verify != nil, Attestation: attestation, ProviderRef: tag,
+		Provenance: spec.Provenance,
+		Verified:   spec.Verify != nil, Attestation: attestation, ProviderRef: tag,
 	}
 	if info, err := p.cli.ImageInspect(ctx, tag); err == nil {
 		gv.SizeBytes = info.Size
@@ -348,8 +352,9 @@ func (p *Provider) ListGoldens(ctx context.Context) ([]provider.GoldenVersion, e
 				SizeBytes: img.Size, ProviderRef: tag,
 				// A committed image only exists because verification passed;
 				// the commit is the last step of a refresh.
-				Verified:  true,
-				RulesHash: img.Labels[dockerutil.LabelRules],
+				Verified:   true,
+				RulesHash:  img.Labels[dockerutil.LabelRules],
+				Provenance: img.Labels[dockerutil.LabelProvenance],
 			}
 			if raw := img.Labels[dockerutil.LabelAttestation]; raw != "" {
 				if decoded, decErr := base64.StdEncoding.DecodeString(raw); decErr == nil {

--- a/engine/internal/db/docker/metadata_test.go
+++ b/engine/internal/db/docker/metadata_test.go
@@ -41,10 +41,11 @@ func TestGoldenMetadata_SurvivesARoundTrip(t *testing.T) {
 	defer cancel()
 
 	const rules = "abc123def456"
+	const prov = "gp1-metadata-round-trip"
 	const attestation = `{"report":{"columns":84},"golden":"x","signature":"sig"}`
 
 	gv, err := p.RefreshGolden(ctx, provider.GoldenSpec{
-		Version: 17, RulesHash: rules,
+		Version: 17, RulesHash: rules, Provenance: prov,
 		Mask: func(context.Context, secrets.Value) error { return nil },
 		Verify: func(context.Context, secrets.Value) (string, error) {
 			return attestation, nil
@@ -58,6 +59,7 @@ func TestGoldenMetadata_SurvivesARoundTrip(t *testing.T) {
 	}()
 
 	require.Equal(t, rules, gv.RulesHash, "the refresh itself has to report it")
+	require.Equal(t, prov, gv.Provenance, "and the project it was made for")
 
 	// The part that was broken: a different process, asking the provider what
 	// exists, rather than the struct the refresh happened to return.
@@ -73,6 +75,9 @@ func TestGoldenMetadata_SurvivesARoundTrip(t *testing.T) {
 	require.NotNil(t, found, "the golden that was just published is not listed")
 	require.Equal(t, rules, found.RulesHash,
 		"the rules digest did not survive, so golden selection cannot use it")
+	require.Equal(t, prov, found.Provenance,
+		"the project the golden was made for did not survive, so `af up` cannot tell "+
+			"this project's golden from another project's and will refuse both")
 	require.Equal(t, attestation, found.Attestation,
 		"the attestation did not survive, so the comment cannot report the masking")
 	require.True(t, found.Verified)

--- a/engine/internal/db/neon/client.go
+++ b/engine/internal/db/neon/client.go
@@ -43,6 +43,7 @@ const (
 	AnnVersion     = "antifailure-version" // the golden version identifier
 	AnnFrom        = "antifailure-from"    // the golden a branch came from
 	AnnRulesHash   = "antifailure-rules"   // the masking rules that produced a golden
+	AnnProvenance  = "antifailure-project" // the project a golden was made for, and out of what
 	AnnVerified    = "antifailure-verified"
 	AnnAttestation = "antifailure-attestation"
 	AnnCreatedAt   = "antifailure-created"

--- a/engine/internal/db/neon/neon.go
+++ b/engine/internal/db/neon/neon.go
@@ -187,10 +187,11 @@ func (p *Provider) RefreshGolden(ctx context.Context, spec provider.GoldenSpec) 
 		ParentID:     parent.ID,
 		WithEndpoint: true,
 		Annotation: map[string]string{
-			AnnKind:      "golden",
-			AnnVersion:   version,
-			AnnRulesHash: spec.RulesHash,
-			AnnCreatedAt: created.Format(time.RFC3339),
+			AnnKind:       "golden",
+			AnnVersion:    version,
+			AnnRulesHash:  spec.RulesHash,
+			AnnProvenance: spec.Provenance,
+			AnnCreatedAt:  created.Format(time.RFC3339),
 		},
 	})
 	if err != nil {
@@ -247,7 +248,8 @@ func (p *Provider) RefreshGolden(ctx context.Context, spec provider.GoldenSpec) 
 
 	gv := provider.GoldenVersion{
 		ID: version, CreatedAt: created, RulesHash: spec.RulesHash,
-		Verified: spec.Verify != nil, Attestation: attestation, ProviderRef: candidate.ID,
+		Provenance: spec.Provenance,
+		Verified:   spec.Verify != nil, Attestation: attestation, ProviderRef: candidate.ID,
 	}
 	if fresh, err := p.client.GetBranch(ctx, candidate.ID); err == nil {
 		gv.SizeBytes = fresh.LogicalSize
@@ -276,6 +278,7 @@ func (p *Provider) goldenFrom(b Branch) provider.GoldenVersion {
 	gv := provider.GoldenVersion{
 		ID:          b.Annotation[AnnVersion],
 		RulesHash:   b.Annotation[AnnRulesHash],
+		Provenance:  b.Annotation[AnnProvenance],
 		SizeBytes:   b.LogicalSize,
 		ProviderRef: b.ID,
 		// A branch carries the golden prefix only because a refresh renamed it

--- a/engine/internal/db/supabase/supabase.go
+++ b/engine/internal/db/supabase/supabase.go
@@ -213,7 +213,9 @@ func (p *Provider) RefreshGolden(ctx context.Context, spec provider.GoldenSpec) 
 		// branch exists, and an annotation that has to be added afterwards is
 		// one more call that can fail between verifying a golden and being able
 		// to say which rules produced it.
-		Annotation: annotation{Rules: spec.RulesHash, CreatedAt: created},
+		Annotation: annotation{
+			Rules: spec.RulesHash, Provenance: spec.Provenance, CreatedAt: created,
+		},
 	})
 	if err != nil {
 		return provider.GoldenVersion{}, err
@@ -273,6 +275,7 @@ func (p *Provider) RefreshGolden(ctx context.Context, spec provider.GoldenSpec) 
 		ID:          version,
 		CreatedAt:   created,
 		RulesHash:   spec.RulesHash,
+		Provenance:  spec.Provenance,
 		Verified:    spec.Verify != nil,
 		Attestation: attestation,
 		ProviderRef: candidate.ID,
@@ -304,6 +307,7 @@ func (p *Provider) ListGoldens(ctx context.Context) ([]provider.GoldenVersion, e
 		gv := provider.GoldenVersion{
 			ID:          strings.TrimPrefix(b.Name, PrefixGolden),
 			RulesHash:   ann.Rules,
+			Provenance:  ann.Provenance,
 			ProviderRef: b.ID,
 			// A branch carries the golden prefix only because a refresh renamed
 			// it after verification returned without an error. The attestation
@@ -823,10 +827,11 @@ func joinInts(vs []int) string {
 
 // annotation is the metadata a branch carries in its git_branch field.
 type annotation struct {
-	From      string
-	EnvID     string
-	Rules     string
-	CreatedAt time.Time
+	From       string
+	EnvID      string
+	Rules      string
+	Provenance string
+	CreatedAt  time.Time
 }
 
 // String encodes an annotation as one line of key=value pairs.
@@ -836,7 +841,7 @@ type annotation struct {
 // survive naive concatenation; the encoding is here because the next value
 // somebody adds might not.
 func (a annotation) String() string {
-	parts := make([]string, 0, 4)
+	parts := make([]string, 0, 5)
 	add := func(k, v string) {
 		if v != "" {
 			parts = append(parts, k+"="+url.QueryEscape(v))
@@ -845,6 +850,7 @@ func (a annotation) String() string {
 	add("from", a.From)
 	add("env", a.EnvID)
 	add("rules", a.Rules)
+	add("project", a.Provenance)
 	if !a.CreatedAt.IsZero() {
 		add("created", a.CreatedAt.UTC().Format(time.RFC3339))
 	}
@@ -878,6 +884,8 @@ func parseAnnotation(s string) annotation {
 			a.EnvID = value
 		case "rules":
 			a.Rules = value
+		case "project":
+			a.Provenance = value
 		case "created":
 			if at, err := time.Parse(time.RFC3339, value); err == nil {
 				a.CreatedAt = at

--- a/engine/internal/dockerutil/dockerutil.go
+++ b/engine/internal/dockerutil/dockerutil.go
@@ -58,6 +58,14 @@ const (
 	// separate checks read those fields, and both were silently inert.
 	LabelRules       = "dev.antifailure.rules"
 	LabelAttestation = "dev.antifailure.attestation"
+	// LabelProvenance is which project a golden was made for, and out of what.
+	//
+	// Separate from LabelRules because the two answer different questions and
+	// the daemon is shared. The rules digest says how a golden was masked; two
+	// unrelated projects with no masking.yaml were masked identically and
+	// share it, which is how `af up` in one project branched another project's
+	// production data. This says whose it is.
+	LabelProvenance = "dev.antifailure.provenance"
 	// LabelService is the manifest service name a container runs.
 	LabelService = "dev.antifailure.service"
 	// LabelServiceKind is web, worker, or cron.

--- a/engine/internal/env/env.go
+++ b/engine/internal/env/env.go
@@ -953,32 +953,50 @@ func (o *Orchestrator) newDatabaseProvider(ctx context.Context) (provider.Databa
 
 // pickGolden chooses the version a branch is made from.
 //
-// Verified, and made under the rules this manifest declares. It returns how
-// many verified versions were refused for the second reason so that the
-// caller can say something better than "no golden": a store with six goldens
-// in it and none of them usable here is a different situation from an empty
-// one, and telling them apart is the difference between "run af golden
-// refresh" and "something is wrong".
+// Verified, and made for this project. It returns how many verified versions
+// were refused for the second reason so that the caller can say something
+// better than "no golden": a store with six goldens in it and none of them
+// usable here is a different situation from an empty one, and telling them
+// apart is the difference between "run af golden refresh" and "something is
+// wrong".
 //
-// A version that records no rules at all is refused too, and that is the part
-// worth arguing about. The first version of this accepted one, reasoning that
-// a missing record should not break a machine that had goldens on it already.
-// That reasoning is wrong: a golden whose provenance is unknown cannot be shown
-// to match this manifest, and branching it is exactly the cross contamination
+// A version that records no provenance at all is refused too, and that is the
+// part worth arguing about. The first version of this accepted one, reasoning
+// that a missing record should not break a machine that had goldens on it
+// already. That reasoning is wrong: a golden whose origin is unknown cannot be
+// shown to belong here, and branching it is exactly the cross contamination
 // this exists to stop. It is not hypothetical. With the lenient rule in place,
-// bringing the control plane up branched an empty golden the masking test suite
-// had published minutes earlier, and the environment came up with a schema and
-// no data in it.
+// bringing the control plane up branched an empty golden the masking test
+// suite had published minutes earlier, and the environment came up with a
+// schema and no data in it.
+//
+// That is the half the previous author closed. This is the other half, and it
+// was the common case rather than the corner one. The predicate used to be the
+// masking rules digest, which answers "were these masked the same way" and not
+// "may this environment branch that". Two unrelated projects with no
+// masking.yaml declare the same rules, namely none, so they hashed to the same
+// eight bytes and shared one pool. Reproduced with the released binary and two
+// ordinary Express repositories: acme-billing refreshed a golden from its
+// production database; nova-shop declared no database at all, printed in its
+// own manifest that "branches will start empty", and came up holding
+// acme-billing's customers and regions tables with acme-billing's rows in
+// them. See internal/env/provenance.go for what the identity is made of and
+// why each part of it survives the reuse that has to keep working.
 //
 // Refusing costs a refresh, and the error says to run one. Accepting costs
 // somebody a preview built on another project's data, and says nothing.
-func pickGolden(goldens []provider.GoldenVersion, wantRules string) (string, int) {
+func pickGolden(goldens []provider.GoldenVersion, want string) (string, int) {
 	refused := 0
 	for _, g := range goldens {
 		if !g.Verified {
 			continue
 		}
-		if g.RulesHash != wantRules {
+		// Compared against the empty string as well as against want, because
+		// want is never empty: provenance always carries at least the manifest
+		// name and the major version. A version recording nothing would
+		// otherwise match a caller that could not compute its own identity,
+		// which is the lenient rule this comment exists to refuse.
+		if g.Provenance == "" || g.Provenance != want {
 			refused++
 			continue
 		}
@@ -1471,29 +1489,29 @@ func (o *Orchestrator) database(ctx context.Context, s *session) (string, provid
 		return "", zero, secrets.Value{}, secrets.Value{}, err
 	}
 
-	// Which rules produced it, not merely that something produced it.
+	// Whose golden it is, not merely that something produced it.
 	//
-	// The store is per repository and a repository holds more than one
-	// manifest. Selecting the newest verified golden and nothing else means a
-	// preview of one project branches a masked copy of another project's
-	// database, which is what actually happened here: bringing the control
-	// plane up branched a golden an example had refreshed thirty seconds
-	// earlier, and the environment came up with the wrong schema entirely.
-	// Copying one project's data into another project's preview is the failure
-	// this product is sold to prevent.
+	// The pool is shared. The Docker provider keeps goldens as images on a
+	// machine wide daemon, and a configured store is shared by a fleet on
+	// purpose, so selecting the newest verified golden and nothing else means
+	// a preview of one project branches a masked copy of another project's
+	// database. That happened twice. First with no filter at all: bringing the
+	// control plane up branched a golden an example had refreshed thirty
+	// seconds earlier. Then again with a filter on the masking rules digest,
+	// which looks like a project key and is not one, because two projects with
+	// no masking.yaml declare identical rules and hash to the same value.
 	//
-	// The rules digest is the right key and it was already recorded for this,
-	// unread: GoldenVersion.RulesHash says it "identifies the masking rules
-	// that produced it, so that a rules change can be detected without
-	// re-reading the data". Matching on it is stronger than matching on a
-	// name, because it also refuses a golden of the right database masked
-	// under rules somebody has since changed, which is a golden whose
-	// attestation is about a different question than the one being asked.
-	_, wantRules, rulesErr := o.rules()
-	if rulesErr != nil {
-		return "", zero, secrets.Value{}, secrets.Value{}, rulesErr
+	// The identity that does separate projects is built in provenance.go, out
+	// of the manifest name, the variable naming production, the seed command,
+	// the masking digest, the subset and the major version. It is exact
+	// equality rather than a prefix or a subset match: a golden either was
+	// made for this work or it was not.
+	prov, provErr := o.provenanceOf()
+	if provErr != nil {
+		return "", zero, secrets.Value{}, secrets.Value{}, provErr
 	}
-	version, refused := pickGolden(goldens, wantRules)
+	want := prov.digest()
+	version, refused := pickGolden(goldens, want)
 	// A configured source and nothing to branch is a refusal rather than an
 	// empty database.
 	//
@@ -1517,7 +1535,13 @@ func (o *Orchestrator) database(ctx context.Context, s *session) (string, provid
 	if pinned := o.opts.PinGolden; pinned != "" {
 		version = ""
 		for _, g := range goldens {
-			if g.ID == pinned && g.Verified {
+			// The provenance is checked on this path too. A pin says which of
+			// this project's goldens to use, not that the check is waived, and
+			// the only thing standing between a pin and another project's data
+			// is that today's only caller happens to pass a version it made
+			// itself. That is a property of the caller and not of this code,
+			// and the next caller will not know it was load bearing.
+			if g.ID == pinned && g.Verified && g.Provenance == want {
 				version = g.ID
 				break
 			}
@@ -1526,8 +1550,8 @@ func (o *Orchestrator) database(ctx context.Context, s *session) (string, provid
 			return "", zero, secrets.Value{}, secrets.Value{}, aferrors.Coded(
 				aferrors.AFORC009, "version", pinned)
 		}
-		o.progress("branching the database from " + version + ", pinned by the caller")
-		return o.branchFrom(ctx, s, version)
+		return o.branchFrom(ctx, s, version,
+			"pinned by the caller, "+prov.describe())
 	}
 
 	// A cron expression on a laptop has nothing to fire it, so the next
@@ -1571,6 +1595,16 @@ func (o *Orchestrator) database(ctx context.Context, s *session) (string, provid
 		gv, refreshErr := s.dbProv.RefreshGolden(ctx, provider.GoldenSpec{
 			Version:   databaseVersion(o.opts.Manifest),
 			RulesHash: seedRulesHash(seed),
+			// Recorded here as well as on the refresh path, and it is what
+			// makes this golden reusable at all. Before provenance existed
+			// this branch stamped seedRulesHash(seed), which for a project
+			// with no seed is the literal string "empty", while selection
+			// asked for the digest of an empty rule set. Those two never
+			// matched, so a project with no production database built a fresh
+			// golden on every single `af up` and branched it once. The fix for
+			// the leak is also the fix for that: one identity, written by
+			// every path that publishes and read by the path that selects.
+			Provenance: want,
 			// No source database is configured, so the golden is built from
 			// nothing. Where the manifest names a seed command, that command
 			// is what puts data in it; otherwise the schema arrives with the
@@ -1598,7 +1632,7 @@ func (o *Orchestrator) database(ctx context.Context, s *session) (string, provid
 			events.F("phase", "golden"), events.F("version", version),
 			events.F("verified", true))
 	}
-	return o.branchFrom(ctx, s, version)
+	return o.branchFrom(ctx, s, version, prov.describe())
 }
 
 // branchFrom creates this environment's branch of a chosen golden.
@@ -1607,13 +1641,21 @@ func (o *Orchestrator) database(ctx context.Context, s *session) (string, provid
 // as a chosen one. Two copies of the journal, branch and connection string
 // sequence would be two places to forget to record an intent, and a branch
 // created before its journal entry is a branch teardown cannot find.
+//
+// origin says where the golden came from, in a clause a person can check. The
+// line used to be "branching the database from gv_20260901033741_74234e98" and
+// nothing else, which reads exactly the same when the choice is right as when
+// it is wrong: the run that branched an unrelated project's production data
+// printed that sentence and looked correct. A decision nobody can check is one
+// refactor away from an incorrect one nobody notices.
 func (o *Orchestrator) branchFrom(
-	ctx context.Context, s *session, version string,
+	ctx context.Context, s *session, version, origin string,
 ) (string, provider.Branch, secrets.Value, secrets.Value, error) {
 	var zero provider.Branch
-	o.progress("branching the database from " + version)
+	o.progress("branching the database from " + version + ", " + origin)
 	o.event(s, events.DBBranching, "branching from "+version,
-		events.F("phase", "branching"), events.F("version", version))
+		events.F("phase", "branching"), events.F("version", version),
+		events.F("origin", origin))
 
 	// Recorded against the provider that is about to create it, not against
 	// "docker". The provider name is the first half of the key the compensating

--- a/engine/internal/env/export_test.go
+++ b/engine/internal/env/export_test.go
@@ -52,8 +52,37 @@ func (o *Orchestrator) BaselineTreeForTest(ctx context.Context, rev string) (str
 // needs to be able to reach directly. Reaching it through Up would need a
 // provider, a runtime, a journal and a lock, and the property being asserted
 // is a property of one loop.
-func PickGoldenForTest(goldens []provider.GoldenVersion, wantRules string) (string, int) {
-	return pickGolden(goldens, wantRules)
+func PickGoldenForTest(goldens []provider.GoldenVersion, want string) (string, int) {
+	return pickGolden(goldens, want)
+}
+
+// GoldenProvenanceForTest is the identity an orchestrator computes for its own
+// project, as the digest a golden records.
+//
+// Exported because the property this file's tests exist for is a property of
+// two orchestrators taken together: that two projects compute different
+// identities, and that one project computes the same one on every branch. A
+// test of the selection loop alone cannot see either, and the selection loop
+// was never the part that was wrong.
+func (o *Orchestrator) GoldenProvenanceForTest() (string, error) {
+	return o.GoldenIdentity()
+}
+
+// RulesDigestForTest is the masking rules digest, which used to be the whole
+// of golden selection.
+//
+// Exported so a test can state the defect as a property rather than describe
+// it: two unrelated projects with no masking.yaml compute the SAME rules
+// digest, which is why that value could never have been a project key.
+func (o *Orchestrator) RulesDigestForTest() (string, error) {
+	_, hash, err := o.rules()
+	return hash, err
+}
+
+// AttestedProvenanceForTest exposes attestedProvenance, which is the check a
+// machine pulling from a shared store makes before it restores anything.
+func AttestedProvenanceForTest(attestation string) string {
+	return attestedProvenance(attestation)
 }
 
 // RunSeedForTest exposes runSeed to the package's external tests.

--- a/engine/internal/env/golden.go
+++ b/engine/internal/env/golden.go
@@ -303,22 +303,27 @@ func (o *Orchestrator) refreshWithin(ctx context.Context, s *session) (*GoldenRe
 	if err != nil {
 		return nil, err
 	}
+	prov, err := o.provenanceOf()
+	if err != nil {
+		return nil, err
+	}
 
 	result := &GoldenResult{}
 	started := o.opts.Clock.Now()
 	source := o.sourceURL()
 
 	spec := provider.GoldenSpec{
-		Version:   databaseVersion(o.opts.Manifest),
-		RulesHash: hash,
-		SourceURL: source,
+		Version:    databaseVersion(o.opts.Manifest),
+		RulesHash:  hash,
+		Provenance: prov.digest(),
+		SourceURL:  source,
 		Mask: func(ctx context.Context, url secrets.Value) error {
 			rows, tables, maskErr := o.maskDatabase(ctx, s, url, key, rules, hash)
 			result.Rows, result.Tables = rows, tables
 			return maskErr
 		},
 		Verify: func(ctx context.Context, url secrets.Value) (string, error) {
-			report, att, verifyErr := o.verifyDatabase(ctx, s, url, hash)
+			report, att, verifyErr := o.verifyDatabase(ctx, s, url, hash, prov.digest())
 			result.Report = report
 			result.Attestation = att
 			if verifyErr != nil {
@@ -610,8 +615,14 @@ func (o *Orchestrator) maskDatabase(
 }
 
 // verifyDatabase reads a database back and signs what it found.
+//
+// The provenance is signed alongside the report rather than only stamped on
+// the provider's own copy, because a published golden is read by a machine
+// that has only the store: an annotation on a Docker image never leaves the
+// daemon that holds it, and a claim about whose data a dump is has to be one
+// the puller can check.
 func (o *Orchestrator) verifyDatabase(
-	ctx context.Context, s *session, url secrets.Value, hash string,
+	ctx context.Context, s *session, url secrets.Value, hash, prov string,
 ) (verify.Report, string, error) {
 	conn, err := pgx.Connect(ctx, url.Reveal())
 	if err != nil {
@@ -635,7 +646,7 @@ func (o *Orchestrator) verifyDatabase(
 	if err != nil {
 		return report, "", err
 	}
-	att, err := verify.Sign(report, "", hash, priv)
+	att, err := verify.Sign(report, "", hash, prov, priv)
 	if err != nil {
 		return report, "", err
 	}

--- a/engine/internal/env/golden_selection_test.go
+++ b/engine/internal/env/golden_selection_test.go
@@ -1,83 +1,407 @@
 package env_test
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/antifailure/antifailure/engine/internal/clock"
 	"github.com/antifailure/antifailure/engine/internal/env"
 	"github.com/antifailure/antifailure/engine/pkg/provider"
+	"github.com/antifailure/antifailure/engine/pkg/schema"
 )
 
-// A repository holds more than one manifest, and they share one golden store.
+// One machine holds every project's goldens, so selection is a security
+// boundary rather than a convenience.
 //
-// The regression: `af up` took the newest verified golden and nothing else, so
-// bringing the control plane up branched a golden an example had refreshed
-// thirty seconds earlier. The environment came up with another project's
-// schema and another project's masked data in it. Copying one project's data
-// into another project's preview is the failure this product exists to
-// prevent, and it took one line of selection logic to cause.
-func TestPickGolden_RefusesAGoldenMadeUnderOtherRules(t *testing.T) {
-	goldens := []provider.GoldenVersion{
-		{ID: "gv_2_store", Verified: true, RulesHash: "store111"},
-		{ID: "gv_1_control", Verified: true, RulesHash: "ctrl2222"},
+// The Docker provider keeps goldens as images and a daemon is machine wide; a
+// configured golden store is shared by a fleet on purpose. Whether an
+// environment may branch a given golden is therefore a question that gets
+// asked on every `af up`, and it has been answered wrongly twice.
+//
+// The first answer was "the newest verified one", and bringing the control
+// plane up branched a golden an example had refreshed thirty seconds earlier.
+// The second answer was "the newest verified one made under the same masking
+// rules", which looks like a project key and is not one: a project with no
+// masking.yaml declares no rules, and every project on a machine with no
+// masking.yaml therefore declared the SAME rules and shared one pool.
+//
+// Reproduced with the released binary before any of this was written, in two
+// ordinary Express repositories with a Dockerfile each and neither declaring a
+// masking rule. acme-billing declared a production database and refreshed a
+// golden from it. nova-shop declared none, said in its own generated manifest
+// that "branches will start empty", and `af up` printed "branching the
+// database from gv_20260901033741_74234e98" and brought up a database holding
+// acme-billing's customers and regions tables with acme-billing's rows in them.
+//
+// These tests are about the identity, not about the loop. The loop was never
+// the part that was wrong.
+
+// project builds an orchestrator the way a repository on disk would, with an
+// optional masking.yaml, so that the identity under test is computed from the
+// same inputs the real command computes it from.
+func project(t *testing.T, name string, mutate func(*schema.Manifest, string)) *env.Orchestrator {
+	t.Helper()
+	root := t.TempDir()
+	m := &schema.Manifest{
+		Name: name,
+		Database: &schema.Database{
+			Provider:     schema.DBDocker,
+			Version:      17,
+			URLEnv:       "DATABASE_URL",
+			MaskingRules: "masking.yaml",
+		},
 	}
-	got, refused := env.PickGoldenForTest(goldens, "ctrl2222")
-	require.Equal(t, "gv_1_control", got,
-		"the newest golden belongs to another manifest and must not be branched here")
+	if mutate != nil {
+		mutate(m, root)
+	}
+	o, err := env.New(env.Options{
+		Root: root, Manifest: m, Branch: "main", Clock: clock.New(),
+	})
+	require.NoError(t, err)
+	return o
+}
+
+func identity(t *testing.T, o *env.Orchestrator) string {
+	t.Helper()
+	got, err := o.GoldenProvenanceForTest()
+	require.NoError(t, err)
+	require.NotEmpty(t, got, "an identity is never empty; the empty string is what a golden "+
+		"that recorded nothing carries, and the two must never be equal")
+	return got
+}
+
+func writeRules(t *testing.T, root, body string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "masking.yaml"), []byte(body), 0o600))
+}
+
+// The reproduced defect, as a property.
+//
+// Two unrelated projects, neither with a masking.yaml, which is the ordinary
+// state of a repository somebody ran `af init` in five minutes ago. Under the
+// rules digest both hashed to 74234e98afe7498f and shared one pool. This is
+// the assertion the old code could not have passed.
+func TestGoldenIdentity_TwoProjectsWithNoMaskingRulesDoNotShareAGolden(t *testing.T) {
+	acmeProject := project(t, "acme-billing", func(m *schema.Manifest, _ string) {
+		m.Database.SourceURLEnv = "PROD_DATABASE_URL"
+	})
+	novaProject := project(t, "nova-shop", nil)
+	acme, nova := identity(t, acmeProject), identity(t, novaProject)
+
+	// The defect stated as a property, rather than described. The two projects
+	// agree on the masking rules digest, because neither declares a rule and
+	// the digest of no rules is one fixed value, and that is precisely why
+	// that digest could never have been the key. They must not agree on the
+	// identity that decides what may be branched.
+	acmeRules, err := acmeProject.RulesDigestForTest()
+	require.NoError(t, err)
+	novaRules, err := novaProject.RulesDigestForTest()
+	require.NoError(t, err)
+	require.Equal(t, acmeRules, novaRules,
+		"two projects with no masking.yaml were masked identically; if this ever "+
+			"stops being true, the reason this fix exists has changed")
+	require.NotEqual(t, acme, nova,
+		"a project that declares no production database must not be able to branch "+
+			"a golden another project copied out of one")
+
+	// Selection agrees, which is the half that reaches a user. A golden made
+	// for acme is refused for nova and counted as a refusal, which is what
+	// lets the error say "there are goldens here and none of them are yours"
+	// rather than "there are no goldens".
+	got, refused := env.PickGoldenForTest([]provider.GoldenVersion{
+		{ID: "gv_20260901033741_74234e98", Verified: true, Provenance: acme, RulesHash: acmeRules},
+	}, nova)
+	require.Empty(t, got)
 	require.Equal(t, 1, refused)
 }
 
-// An unverified version is never branched, whatever its rules say. That rule
+// Two projects that differ in nothing except their name.
+//
+// Separated from the reproduced pair deliberately. In that pair one project
+// declares a production database and the other does not, so the source alone
+// separates them and the test would still pass with the project name taken out
+// of the identity entirely. This one has no other difference to fall back on.
+func TestGoldenIdentity_TwoProjectsAlikeInEverythingButTheirNameDoNotShare(t *testing.T) {
+	one := identity(t, project(t, "checkout", nil))
+	two := identity(t, project(t, "storefront", nil))
+	require.NotEqual(t, one, two,
+		"two fresh repositories with no production database and no masking rules "+
+			"differ in nothing a golden records except whose they are")
+
+	got, refused := env.PickGoldenForTest([]provider.GoldenVersion{
+		{ID: "gv_1", Verified: true, Provenance: one},
+	}, two)
+	require.Empty(t, got)
+	require.Equal(t, 1, refused)
+}
+
+// Identical masking rules are not identity either, and this is the case the
+// previous fix would have looked correct against.
+//
+// Two projects that both mask email the same way are still two projects. The
+// rules digest is equal by construction here, so nothing about masking can
+// separate them and only the project can.
+func TestGoldenIdentity_TwoProjectsWithIdenticalMaskingRulesDoNotShareAGolden(t *testing.T) {
+	rules := "rules:\n  - table: public.users\n    column: email\n    transform: email\n"
+	one := project(t, "acme-billing", func(_ *schema.Manifest, root string) {
+		writeRules(t, root, rules)
+	})
+	two := project(t, "nova-shop", func(_ *schema.Manifest, root string) {
+		writeRules(t, root, rules)
+	})
+	require.NotEqual(t, identity(t, one), identity(t, two),
+		"two projects masking the same way are still two projects")
+}
+
+// The reuse that has to keep working, or the whole store is pointless.
+//
+// One project, two branches, and the identity is the same, so the second
+// branch costs a branch rather than a full refresh of production. A fix that
+// made every environment refresh would be routed around within a day.
+func TestGoldenIdentity_OneProjectAcrossBranchesSharesOneGolden(t *testing.T) {
+	root := t.TempDir()
+	writeRules(t, root, "rules:\n  - table: public.users\n    column: email\n    transform: email\n")
+	m := &schema.Manifest{
+		Name: "acme-billing",
+		Database: &schema.Database{
+			Provider: schema.DBDocker, Version: 17,
+			URLEnv: "DATABASE_URL", MaskingRules: "masking.yaml",
+			SourceURLEnv: "PROD_DATABASE_URL",
+		},
+	}
+	main, err := env.New(env.Options{Root: root, Manifest: m, Branch: "main", Clock: clock.New()})
+	require.NoError(t, err)
+	feature, err := env.New(env.Options{
+		Root: root, Manifest: m, Branch: "feature/add-billing", Clock: clock.New(),
+	})
+	require.NoError(t, err)
+
+	shared := identity(t, main)
+	require.Equal(t, shared, identity(t, feature),
+		"a second branch of one project must branch the golden the first one made")
+
+	got, refused := env.PickGoldenForTest([]provider.GoldenVersion{
+		{ID: "gv_1", Verified: true, Provenance: shared},
+	}, identity(t, feature))
+	require.Equal(t, "gv_1", got)
+	require.Zero(t, refused)
+}
+
+// The identity does not depend on where the repository is checked out.
+//
+// This is the reason the repository root is not part of it, and it is the
+// difference between a pool that matches and a pool that never does. CI checks
+// out somewhere new on every run, a git worktree per branch is a different
+// directory, and the machine that pulls a published golden has never seen the
+// publisher's disk at all. Keying on the path would refuse the golden in every
+// one of those cases and cost a full copy of production each time.
+func TestGoldenIdentity_DoesNotDependOnTheCheckoutDirectory(t *testing.T) {
+	rules := "rules:\n  - table: public.users\n    column: email\n    transform: email\n"
+	laptop := project(t, "acme-billing", func(m *schema.Manifest, root string) {
+		m.Database.SourceURLEnv = "PROD_DATABASE_URL"
+		writeRules(t, root, rules)
+	})
+	runner := project(t, "acme-billing", func(m *schema.Manifest, root string) {
+		m.Database.SourceURLEnv = "PROD_DATABASE_URL"
+		writeRules(t, root, rules)
+	})
+	require.NotEqual(t, laptop, runner, "the two orchestrators are in different directories")
+	require.Equal(t, identity(t, laptop), identity(t, runner),
+		"a CI runner with a fresh checkout must be able to branch what the laptop published")
+}
+
+// A golden a test suite published is never selectable by a real project.
+//
+// This is not a hypothetical: the golden the released binary branched into an
+// unrelated project came from this repository's own goldenstore fixture, whose
+// manifest is named app-publisher and whose schema is two tables called
+// customers and regions. The fixture and the project differ in the name and in
+// whether a production database is declared at all, and either one alone is
+// enough to refuse it.
+func TestGoldenIdentity_ATestSuitesGoldenIsNotSelectableByARealProject(t *testing.T) {
+	fixture := identity(t, project(t, "app-publisher", func(m *schema.Manifest, _ string) {
+		m.Database.SourceURLEnv = "PROD_URL"
+		follow := 1
+		m.Database.Subset = &schema.Subset{
+			Enabled: true, SeedTable: "regions", SeedWhere: "code = 'eu'",
+			MaxRows: 1000, FollowDependents: &follow,
+		}
+	}))
+	real := identity(t, project(t, "nova-shop", nil))
+
+	got, refused := env.PickGoldenForTest([]provider.GoldenVersion{
+		{ID: "gv_20260901033708_74234e98", Verified: true, Provenance: fixture},
+	}, real)
+	require.Empty(t, got, "a fixture's golden reached a real project's environment once already")
+	require.Equal(t, 1, refused)
+}
+
+// Every part of the identity is load bearing, one mutation at a time.
+//
+// Written as a table because the failure this guards against is a component
+// silently dropping out of the digest: a refactor that stops feeding the seed
+// command in changes nothing visible, and quietly widens the pool by one axis.
+// Each row is a manifest that differs from the base in exactly one way and
+// must not share the base's golden.
+func TestGoldenIdentity_EveryComponentSeparatesTwoProjects(t *testing.T) {
+	base := func(m *schema.Manifest, _ string) {
+		m.Database.SourceURLEnv = "PROD_DATABASE_URL"
+		m.Database.Seed = "psql -f seed.sql"
+		follow := 2
+		m.Database.Subset = &schema.Subset{
+			Enabled: true, SeedTable: "accounts", MaxRows: 500, FollowDependents: &follow,
+		}
+	}
+	baseline := identity(t, project(t, "acme-billing", base))
+
+	cases := map[string]func(*schema.Manifest, string){
+		"a different project name": func(m *schema.Manifest, root string) {
+			base(m, root)
+			m.Name = "acme-invoicing"
+		},
+		"a different production variable": func(m *schema.Manifest, root string) {
+			base(m, root)
+			m.Database.SourceURLEnv = "OTHER_DATABASE_URL"
+		},
+		"no production variable at all": func(m *schema.Manifest, root string) {
+			base(m, root)
+			m.Database.SourceURLEnv = ""
+		},
+		"a different seed command": func(m *schema.Manifest, root string) {
+			base(m, root)
+			m.Database.Seed = "psql -f other.sql"
+		},
+		"masking rules where there were none": func(m *schema.Manifest, root string) {
+			base(m, root)
+			writeRules(t, root, "rules:\n  - table: public.users\n    column: email\n    transform: email\n")
+		},
+		"a different subset": func(m *schema.Manifest, root string) {
+			base(m, root)
+			m.Database.Subset.SeedTable = "organizations"
+		},
+		"no subset": func(m *schema.Manifest, root string) {
+			base(m, root)
+			m.Database.Subset.Enabled = false
+		},
+		"a different Postgres major": func(m *schema.Manifest, root string) {
+			base(m, root)
+			m.Database.Version = 16
+		},
+	}
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			require.NotEqual(t, baseline, identity(t, project(t, "acme-billing", mutate)),
+				"this difference produces a different golden and must produce a different identity")
+		})
+	}
+}
+
+// Two manifests that describe the same work agree, so nothing forces a refresh
+// for a change that is not one. A subset listing the same two virtual
+// relationships in the other order asks for the same slice.
+func TestGoldenIdentity_IsNotDisturbedByOrderingOrByADisabledBlock(t *testing.T) {
+	follow := 1
+	withVirtual := func(order []schema.VirtualRelationship) *env.Orchestrator {
+		return project(t, "acme-billing", func(m *schema.Manifest, _ string) {
+			m.Database.Subset = &schema.Subset{
+				Enabled: true, SeedTable: "accounts", MaxRows: 10,
+				FollowDependents: &follow, VirtualRelationships: order,
+			}
+		})
+	}
+	a := schema.VirtualRelationship{From: "public.a.id", To: "public.b.a_id"}
+	b := schema.VirtualRelationship{From: "public.c.id", To: "public.d.c_id"}
+	require.Equal(t,
+		identity(t, withVirtual([]schema.VirtualRelationship{a, b})),
+		identity(t, withVirtual([]schema.VirtualRelationship{b, a})),
+		"reordering two lines of a manifest is not a change to what a golden holds")
+
+	require.Equal(t,
+		identity(t, project(t, "acme-billing", nil)),
+		identity(t, project(t, "acme-billing", func(m *schema.Manifest, _ string) {
+			m.Database.Subset = &schema.Subset{Enabled: false, SeedTable: "accounts"}
+		})),
+		"a subset block that is switched off produces the same golden as no block at all")
+}
+
+// An unverified version is never branched, whatever else it records. That rule
 // predates this one and is the product's central promise.
 func TestPickGolden_NeverBranchesAnUnverifiedVersion(t *testing.T) {
 	goldens := []provider.GoldenVersion{
-		{ID: "gv_new", Verified: false, RulesHash: "ctrl2222"},
-		{ID: "gv_old", Verified: true, RulesHash: "ctrl2222"},
+		{ID: "gv_new", Verified: false, Provenance: "gp1-mine"},
+		{ID: "gv_old", Verified: true, Provenance: "gp1-mine"},
 	}
-	got, _ := env.PickGoldenForTest(goldens, "ctrl2222")
+	got, _ := env.PickGoldenForTest(goldens, "gp1-mine")
 	require.Equal(t, "gv_old", got)
 }
 
 // Nothing usable, and the count says why.
 //
 // Six goldens in the store and none of them usable here is a different
-// situation from an empty store, and the caller says something different
-// about each.
+// situation from an empty store, and the caller says something different about
+// each. An unverified version is not a refusal about ownership and must not be
+// counted as one, or the message tells somebody to go looking for a project
+// that does not exist.
 func TestPickGolden_SaysHowManyItRefused(t *testing.T) {
 	goldens := []provider.GoldenVersion{
-		{ID: "a", Verified: true, RulesHash: "other111"},
-		{ID: "b", Verified: true, RulesHash: "other222"},
-		{ID: "c", Verified: false, RulesHash: "ctrl2222"},
+		{ID: "a", Verified: true, Provenance: "gp1-other1"},
+		{ID: "b", Verified: true, Provenance: "gp1-other2"},
+		{ID: "c", Verified: false, Provenance: "gp1-mine"},
 	}
-	got, refused := env.PickGoldenForTest(goldens, "ctrl2222")
+	got, refused := env.PickGoldenForTest(goldens, "gp1-mine")
 	require.Empty(t, got)
-	require.Equal(t, 2, refused, "an unverified version is not a refusal about rules")
+	require.Equal(t, 2, refused, "an unverified version is not a refusal about ownership")
 }
 
-// A version that records no rules at all is refused.
+// A version that records nothing is refused.
 //
 // The first version of this accepted one, reasoning that a missing record
 // should not break a machine that already had goldens on it. That reasoning
 // was wrong and it cost a run: with the lenient rule in place, bringing the
 // control plane up branched an empty golden the masking test suite had
-// published minutes earlier, and the environment came up with a schema and no
-// data in it. A golden whose provenance is unknown cannot be shown to match
-// this manifest, and refusing costs a refresh where accepting costs somebody a
-// preview built on the wrong data.
-func TestPickGolden_RefusesAVersionThatRecordsNoRules(t *testing.T) {
+// published minutes earlier. Every golden this engine publishes records its
+// project, so one that records nothing came from somewhere else.
+func TestPickGolden_RefusesAVersionThatRecordsNothing(t *testing.T) {
 	got, refused := env.PickGoldenForTest(
-		[]provider.GoldenVersion{{ID: "gv_unknown", Verified: true}}, "ctrl2222")
+		[]provider.GoldenVersion{{ID: "gv_unknown", Verified: true}}, "gp1-mine")
+	require.Empty(t, got)
+	require.Equal(t, 1, refused)
+
+	// And it is refused even when the caller could not compute an identity of
+	// its own, which is the shape a lenient comparison degrades into.
+	got, refused = env.PickGoldenForTest(
+		[]provider.GoldenVersion{{ID: "gv_unknown", Verified: true}}, "")
 	require.Empty(t, got)
 	require.Equal(t, 1, refused)
 }
 
-// The observed case, exactly: a newer golden from another suite, with nothing
-// recorded about what made it.
-func TestPickGolden_PrefersTheMatchOverANewerUnknown(t *testing.T) {
-	got, _ := env.PickGoldenForTest([]provider.GoldenVersion{
-		{ID: "gv_20260829173008_278879ab", Verified: true},
-		{ID: "gv_20260829163911_710c39a7", Verified: true, RulesHash: "ctrl2222"},
-	}, "ctrl2222")
+// The observed case, exactly: a newer golden from another project, and this
+// project's own older one behind it.
+func TestPickGolden_PrefersTheMatchOverANewerStranger(t *testing.T) {
+	got, refused := env.PickGoldenForTest([]provider.GoldenVersion{
+		{ID: "gv_20260901033741_74234e98", Verified: true, Provenance: "gp1-acme"},
+		{ID: "gv_20260829163911_710c39a7", Verified: true, Provenance: "gp1-nova"},
+	}, "gp1-nova")
 	require.Equal(t, "gv_20260829163911_710c39a7", got)
+	require.Equal(t, 1, refused)
+}
+
+// A published golden is checked before a byte of it is restored.
+//
+// A store is shared on purpose and `af golden pull` with no version named
+// takes the newest object in it, so the attestation is where the claim about
+// whose data this is has to live. An attestation carrying none reads as the
+// empty string, which is never equal to a real identity.
+func TestAttestedProvenance_ReadsTheClaimAndRefusesAnAbsentOne(t *testing.T) {
+	require.Equal(t, "gp1-acme",
+		env.AttestedProvenanceForTest(`{"rules_hash":"abc","provenance":"gp1-acme"}`))
+	require.Empty(t, env.AttestedProvenanceForTest(`{"rules_hash":"abc"}`))
+	require.Empty(t, env.AttestedProvenanceForTest(`not json at all`))
+
+	mine := identity(t, project(t, "nova-shop", nil))
+	require.NotEqual(t, mine, env.AttestedProvenanceForTest(`{"rules_hash":"abc"}`),
+		"a golden published before this field existed is refused rather than assumed to be ours")
 }

--- a/engine/internal/env/goldenstore.go
+++ b/engine/internal/env/goldenstore.go
@@ -174,6 +174,11 @@ func (o *Orchestrator) pullWithin(ctx context.Context, s *session, version strin
 				"an empty database, so a published dump has nowhere to go", s.dbProv.Name()))
 	}
 
+	prov, err := o.provenanceOf()
+	if err != nil {
+		return nil, err
+	}
+
 	if version == "" {
 		available, listErr := golden.VersionsIn(ctx, store)
 		if listErr != nil {
@@ -197,6 +202,27 @@ func (o *Orchestrator) pullWithin(ctx context.Context, s *session, version strin
 		return nil, aferrors.Coded(aferrors.AFDB011, "detail", err.Error())
 	}
 
+	// Whose golden this is, before a byte of it is restored.
+	//
+	// A store is shared on purpose, which is the whole point of publishing,
+	// and with no version named this takes the newest object in it. Without
+	// this check that is the same defect as the local one one layer out: the
+	// newest thing in a bucket several projects publish to is not necessarily
+	// this project's, and restoring it would put another project's masked
+	// production into this project's golden pool, where every later `af up`
+	// would branch it as its own.
+	//
+	// The attestation is where the claim lives because it is the only part of
+	// a published golden that travels with it and is signed. An older
+	// attestation carries none, and one is refused rather than assumed to be
+	// ours: this refusal costs a refresh and naming the version explicitly
+	// still works, where the other way round costs somebody a preview built on
+	// data that was never theirs.
+	if attested := attestedProvenance(attestation); attested != prov.digest() {
+		return nil, aferrors.Coded(aferrors.AFDB015,
+			"version", version, "store", store.Name())
+	}
+
 	result := &PullResult{From: version}
 	rulesHash := attestedRulesHash(attestation)
 
@@ -206,6 +232,12 @@ func (o *Orchestrator) pullWithin(ctx context.Context, s *session, version strin
 		// comparable with one refreshed here under the same rules and shows up
 		// as a different one under different rules.
 		RulesHash: rulesHash,
+		// This project's own identity, not the one read out of the store. The
+		// two are equal, because a mismatch was refused above, and computing
+		// it here rather than copying it is what keeps that true: a pulled
+		// golden that recorded a foreign identity would be unbranchable, and
+		// one that recorded a copied identity would launder a stolen one.
+		Provenance: prov.digest(),
 		// Non-zero so the provider takes the Load path rather than its seed.
 		SourceURL: secrets.New("published://" + version),
 		Load: func(ctx context.Context, _, candidate secrets.Value) error {
@@ -227,7 +259,7 @@ func (o *Orchestrator) pullWithin(ctx context.Context, s *session, version strin
 		// attestation describe a database that no longer exists.
 		Mask: func(context.Context, secrets.Value) error { return nil },
 		Verify: func(ctx context.Context, url secrets.Value) (string, error) {
-			report, att, verifyErr := o.verifyDatabase(ctx, s, url, rulesHash)
+			report, att, verifyErr := o.verifyDatabase(ctx, s, url, rulesHash, prov.digest())
 			result.Report = report
 			if verifyErr != nil {
 				return "", verifyErr
@@ -271,6 +303,23 @@ func readObject(ctx context.Context, store golden.Store, name string) (string, e
 		return "", err
 	}
 	return string(body), nil
+}
+
+// attestedProvenance reads the identity of the project an attestation was
+// signed for, and returns the empty string when it carries none.
+//
+// Empty is never equal to a real identity, because a real one always carries
+// at least the manifest name and the major version, so an attestation written
+// before this field existed is refused by the comparison rather than by a
+// separate branch that somebody could later invert.
+func attestedProvenance(attestation string) string {
+	var doc struct {
+		Provenance string `json:"provenance"`
+	}
+	if err := json.Unmarshal([]byte(attestation), &doc); err != nil {
+		return ""
+	}
+	return doc.Provenance
 }
 
 // attestedRulesHash reads the rules hash out of an attestation, and returns a

--- a/engine/internal/env/goldenstore_test.go
+++ b/engine/internal/env/goldenstore_test.go
@@ -88,7 +88,8 @@ func TestPublishAndPull_ASecondMachineBranchesWhatTheFirstPublished(t *testing.T
 	storeDir := t.TempDir()
 
 	// Machine one. It has the production credential and a subset block.
-	first, firstGoldens, stopFirst := requireOrchestrator(t, "publisher", sourceURL, storeDir)
+	first, firstGoldens, stopFirst := requireOrchestrator(
+		t, storeProject, "publisher", sourceURL, storeDir)
 	defer stopFirst()
 
 	refreshed, err := first.RefreshGolden(ctx)
@@ -116,15 +117,16 @@ func TestPublishAndPull_ASecondMachineBranchesWhatTheFirstPublished(t *testing.T
 	// Machine two. Same manifest, same store, and NO production credential at
 	// all, which is the point: a runner that cannot reach production is
 	// exactly what this is for.
-	second, secondGoldens, stopSecond := requireOrchestrator(t, "puller", "", storeDir)
+	second, secondGoldens, stopSecond := requireOrchestrator(
+		t, storeProject, "puller", "", storeDir)
 	defer stopSecond()
 
 	// The two machines share this laptop's Docker daemon, so they share its
 	// image store, and pretending otherwise would be a fiction the assertion
 	// then has to work around. What is real and is asserted below is that the
-	// second machine has NO production credential: its manifest has no
-	// source_url_env, so it could not refresh even if it wanted to, and the
-	// only way it can end up with data is through the store.
+	// second machine has NO production credential: PROD_URL is unset in its
+	// environment, so it could not refresh even if it wanted to, and the only
+	// way it can end up with data is through the store.
 	pulled, err := second.PullGolden(ctx, "")
 	secondGoldens.add(pulled.Version)
 	require.NoError(t, err)
@@ -161,6 +163,75 @@ func TestPublishAndPull_ASecondMachineBranchesWhatTheFirstPublished(t *testing.T
 	require.Equal(t, int64(0), americans, "and it is still a slice rather than everything")
 }
 
+// A shared store does not make one project's golden everybody's.
+//
+// `af golden pull` with no version named takes the newest complete object in
+// the store, and a store is shared by a fleet on purpose. Without a check on
+// whose golden it is, the newest object in a bucket several projects publish
+// to would be restored into whichever project asked, and every later `af up`
+// there would branch it as its own: the same defect as the local one, one
+// layer further out and with the data crossing a machine boundary on the way.
+//
+// The refusal is by name so somebody can act on it, and naming a version
+// explicitly does not get around it, because the check is on the attestation
+// rather than on which version was chosen.
+func TestPull_RefusesAGoldenPublishedByAnotherProject(t *testing.T) {
+	if os.Getenv("AF_SKIP_DOCKER") != "" {
+		t.Skip("skipped: AF_SKIP_DOCKER is set")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+	defer cancel()
+
+	sourceURL, stopSource := requireSourceDatabase(t, ctx)
+	defer stopSource()
+	storeDir := t.TempDir()
+
+	publisher, publisherGoldens, stopPublisher := requireOrchestrator(
+		t, storeProject, "publisher", sourceURL, storeDir)
+	defer stopPublisher()
+
+	refreshed, err := publisher.RefreshGolden(ctx)
+	publisherGoldens.add(refreshed.Version)
+	require.NoError(t, err)
+	require.NotEmpty(t, refreshed.Published, "the golden reached the store")
+
+	// A different project, everything else identical: the same store, the same
+	// provider, the same Postgres version, the same declared source variable
+	// and the same subset. Only the manifest name differs, which is the thing
+	// that says whose work this is.
+	stranger, strangerGoldens, stopStranger := requireOrchestrator(
+		t, "some-other-app", "puller", "", storeDir)
+	defer stopStranger()
+
+	pulled, err := stranger.PullGolden(ctx, "")
+	if pulled != nil {
+		strangerGoldens.add(pulled.Version)
+	}
+	require.Error(t, err, "another project's published golden was restored into this one")
+	require.Contains(t, err.Error(), "AF-DB-015")
+
+	// And naming it explicitly is refused for the same reason, so the refusal
+	// is not merely a property of how the newest version is chosen.
+	pulled, err = stranger.PullGolden(ctx, refreshed.Version)
+	if pulled != nil {
+		strangerGoldens.add(pulled.Version)
+	}
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "AF-DB-015")
+
+	// The counter check, so this test cannot pass by the pull being broken for
+	// everybody: the project that published it can still pull it.
+	owner, ownerGoldens, stopOwner := requireOrchestrator(
+		t, storeProject, "puller", "", storeDir)
+	defer stopOwner()
+	ok, err := owner.PullGolden(ctx, "")
+	if ok != nil {
+		ownerGoldens.add(ok.Version)
+	}
+	require.NoError(t, err, "the project that published this golden must still be able to pull it")
+	require.True(t, ok.Verified)
+}
+
 func TestPull_RefusesAVersionWhosePublishDidNotFinish(t *testing.T) {
 	if os.Getenv("AF_SKIP_DOCKER") != "" {
 		t.Skip("skipped: AF_SKIP_DOCKER is set")
@@ -177,7 +248,7 @@ func TestPull_RefusesAVersionWhosePublishDidNotFinish(t *testing.T) {
 	require.NoError(t, store.Put(ctx, golden.DumpName("gv_halfpublished"), 3,
 		strings.NewReader("abc")))
 
-	o, _, stop := requireOrchestrator(t, "puller", "", storeDir)
+	o, _, stop := requireOrchestrator(t, storeProject, "puller", "", storeDir)
 	defer stop()
 
 	_, err = o.PullGolden(ctx, "gv_halfpublished")
@@ -284,16 +355,46 @@ func replaceDatabase(url, name string) string {
 	return url[:at+1] + rest[:slash+1] + name + suffix
 }
 
+// storeProject is the manifest name both machines in the store test declare.
+//
+// One name, because they are one project: a runner pulling what a laptop
+// published is the same repository checked out somewhere else, and a golden is
+// selected by the project it was made for. The fixture used to give them two
+// names, app-publisher and app-puller, while its own comment said "same
+// manifest", and nothing noticed because selection did not look at the name.
+const storeProject = "app-goldenstore"
+
 // requireOrchestrator builds one machine's engine: its own state directory,
 // its own Docker provider namespace, and a manifest pointing at the store.
+//
+// project and branch are separate parameters because they are separate
+// properties and the difference is the point of the fixture. Two machines of
+// ONE project differ by branch, which a golden's identity ignores, so what one
+// publishes the other may branch. A different project differs by name, which
+// the identity includes, so it may not.
+//
+// sourceURL is the CREDENTIAL and not the declaration. Both machines declare
+// source_url_env: PROD_URL, because both are the same manifest; only the
+// publisher has a value for it. That asymmetry is the whole reason a golden's
+// identity records the variable's NAME rather than the resolved host: a runner
+// that could resolve production would not need the store.
 func requireOrchestrator(
-	t *testing.T, name, sourceURL, storeDir string,
+	t *testing.T, project, branch, sourceURL, storeDir string,
 ) (*Orchestrator, *ownGoldens, func()) {
 	t.Helper()
+	one := 1
 	env := map[string]string{"AF_GOLDEN_STORE": storeDir}
 	db := &schema.Database{
-		Provider: schema.DBDocker,
-		Version:  testPostgresMajor,
+		Provider:     schema.DBDocker,
+		Version:      testPostgresMajor,
+		SourceURLEnv: "PROD_URL",
+		Subset: &schema.Subset{
+			Enabled:          true,
+			SeedTable:        "regions",
+			SeedWhere:        "code = 'eu'",
+			MaxRows:          1000,
+			FollowDependents: &one,
+		},
 		Golden: &schema.Golden{
 			Retain:     3,
 			Storage:    schema.StorageLocal,
@@ -302,21 +403,12 @@ func requireOrchestrator(
 	}
 	if sourceURL != "" {
 		env["PROD_URL"] = sourceURL
-		db.SourceURLEnv = "PROD_URL"
-		one := 1
-		db.Subset = &schema.Subset{
-			Enabled:          true,
-			SeedTable:        "regions",
-			SeedWhere:        "code = 'eu'",
-			MaxRows:          1000,
-			FollowDependents: &one,
-		}
 	}
 
 	o, err := New(Options{
 		Root:     t.TempDir(),
-		Manifest: &schema.Manifest{Name: "app-" + name, Database: db},
-		Branch:   "main",
+		Manifest: &schema.Manifest{Name: project, Database: db},
+		Branch:   branch,
 		Clock:    clock.New(),
 		Getenv:   func(k string) string { return env[k] },
 		Secrets: secrets.NewChain(secrets.NewCISource(func(k string) (string, bool) {
@@ -434,7 +526,7 @@ func TestOrchestratorTeardown_LeavesGoldensItDidNotCreate(t *testing.T) {
 		})
 	}
 
-	o, mine, stop := requireOrchestrator(t, "teardown", "", t.TempDir())
+	o, mine, stop := requireOrchestrator(t, storeProject, "teardown", "", t.TempDir())
 	// Only one of the two is claimed, which is the whole point.
 	mine.add(ours)
 	stop()

--- a/engine/internal/env/maskevents_test.go
+++ b/engine/internal/env/maskevents_test.go
@@ -210,7 +210,7 @@ func TestVerifyDatabase_SaysVerifiedOnTheStream(t *testing.T) {
 	_, _, err := o.maskDatabase(t.Context(), s, url, maskEventsKey(t), maskEventsRules(t), "h1")
 	require.NoError(t, err)
 
-	report, attestation, err := o.verifyDatabase(t.Context(), s, url, "h1")
+	report, attestation, err := o.verifyDatabase(t.Context(), s, url, "h1", "gp1-test")
 	require.NoError(t, err)
 	require.NotEmpty(t, attestation)
 	require.NoError(t, bus.Close())
@@ -241,7 +241,7 @@ func TestVerifyDatabase_ReportsEveryFindingAtErrorLevel(t *testing.T) {
 	sink := events.NewMemorySink(256)
 	bus.AddSink(sink)
 
-	report, _, err := o.verifyDatabase(t.Context(), &session{bus: bus}, url, "h1")
+	report, _, err := o.verifyDatabase(t.Context(), &session{bus: bus}, url, "h1", "gp1-test")
 	require.Error(t, err, "an unmasked database must not verify clean")
 	require.NoError(t, bus.Close())
 

--- a/engine/internal/env/provenance.go
+++ b/engine/internal/env/provenance.go
@@ -140,8 +140,9 @@ func (p provenance) digest() string {
 //
 // It describes THIS project's inputs, and it is only ever printed about a
 // golden whose recorded identity is equal to this project's, so the two
-// descriptions are the same description. The pinned path does not get to use
-// it for that reason.
+// descriptions are the same description. The pinned path prints it too. It
+// may, because a pin now requires that same equality: naming a version says
+// which of this project's goldens to use, not that the check is waived.
 func (p provenance) describe() string {
 	parts := make([]string, 0, 3)
 	parts = append(parts, "made for "+p.Project)

--- a/engine/internal/env/provenance.go
+++ b/engine/internal/env/provenance.go
@@ -1,0 +1,241 @@
+package env
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/antifailure/antifailure/engine/pkg/schema"
+)
+
+// Which project a golden was made for, and out of what.
+//
+// A golden pool is shared. The Docker provider keeps goldens as images on the
+// daemon, and a daemon is machine wide, so every project on a laptop draws
+// from one pool; a configured golden store is shared on purpose, by a fleet.
+// Selection therefore has to answer "may this environment branch that golden",
+// and until this file existed it answered a different question.
+//
+// What it answered was "were the two masked under the same rules". That is a
+// real question and the answer is still needed, but it is not the same
+// question, and the gap between them is the whole defect: a project with no
+// masking.yaml declares no rules, json.Marshal of a nil slice is the four
+// bytes `null`, and every project on the machine without a masking.yaml
+// therefore hashed to 74234e98afe7498f and shared one pool. The discriminator
+// separated masking configurations. It did not separate projects, and the
+// common configuration is no configuration.
+//
+// Reproduced before it was fixed, with the released binary and two ordinary
+// Express repositories: acme-billing declared a production database and ran
+// `af golden refresh`; nova-shop declared none, said in its own manifest that
+// "branches will start empty", and came up holding acme-billing's customers
+// and regions tables with acme-billing's rows in them. Copying one project's
+// data into another project's preview is the failure this product is sold to
+// prevent.
+//
+// So a golden now records the identity of the work that produced it, and
+// selection is equality on that identity. The parts, and why each one is
+// stable across the reuse that has to keep working:
+//
+//   - project, the manifest name. It travels with the repository, so it is the
+//     same on a laptop, on every branch, on a CI runner with a fresh checkout,
+//     and on a second machine that pulls from the store. The repository root
+//     path has none of those properties: CI checks out somewhere new every
+//     run, a git worktree per branch is a different root, and the machine that
+//     pulls a published golden has never seen the publisher's disk at all.
+//     Keying on the path would cost a full refresh on every one of those,
+//     which is a pool that never matches, which people route around.
+//   - source, the NAME of the variable holding production's connection string,
+//     never the string. The resolved host and database would discriminate
+//     harder, and it is exactly the wrong choice: the runner that pulls a
+//     published golden has no production credential, which is the entire point
+//     of publishing, so it cannot resolve the variable and would compute a
+//     different identity from the machine that made the golden. The declared
+//     name is in the manifest, so both sides read the same thing. It also
+//     keeps a production hostname out of a label and out of a shared bucket.
+//   - seed, the command that fills a golden when there is no production to
+//     copy. Change the command and the next run refuses the golden the old one
+//     made rather than branching stale data.
+//   - rules, the masking digest that used to be the whole of this. Still here,
+//     still doing its own job: a golden of the right database masked under
+//     rules somebody has since changed is a golden whose attestation answers a
+//     different question from the one being asked.
+//   - subset, because a slice of a database and the whole of it are different
+//     content, and a manifest that turns subsetting on has changed what a
+//     golden IS rather than how it was made.
+//   - postgres, the major version. Branching a 16 golden into a project that
+//     asks for 17 is a preview of a server the project does not run.
+//
+// The schema of the golden itself is deliberately not part of this. It is
+// tempting, and it cannot work as an acceptance test: the golden holds
+// production's schema, the project's own migrations have not run yet, and
+// there is nothing on this side to compare it against without running them
+// first. A fingerprint is good provenance to display and a bad key to match
+// on, and matching on it would make every pool empty for one migration.
+//
+// What this deliberately does NOT separate: two projects that declare the same
+// name, the same source variable, the same seed, the same rules, the same
+// subset and the same major version. Those two goldens were made from the same
+// inputs, and there is nothing observable that tells them apart. Separating
+// them needs an identifier a person assigns, and the manifest has no field for
+// one today. It is recorded here rather than left to be rediscovered.
+type provenance struct {
+	// Project is the manifest name.
+	Project string
+	// Source is the variable naming production, or the empty string.
+	Source string
+	// Seed is the manifest's seed command, or the empty string.
+	Seed string
+	// Rules is the masking rules digest, the same value GoldenVersion.RulesHash
+	// carries.
+	Rules string
+	// Subset describes the slice the manifest asks for, or the empty string.
+	Subset string
+	// Postgres is the major version the golden holds.
+	Postgres int
+}
+
+// provenanceScheme prefixes every digest.
+//
+// A version rather than a bare hash, so that changing what goes into the
+// recipe is a visible refusal of every older golden rather than a silent one.
+// Anybody who bumps it should expect one refresh per project and should say so
+// in the changelog.
+const provenanceScheme = "gp1"
+
+// digest is the value a golden records and selection compares.
+//
+// The canonical form names every field rather than relying on the order of a
+// struct or of a JSON encoder. Reordering the fields of a Go struct is a
+// refactor, and a refactor that silently invalidates every golden on every
+// machine is the kind of change nobody connects to the refresh it causes.
+func (p provenance) digest() string {
+	var b strings.Builder
+	write := func(k, v string) {
+		b.WriteString(k)
+		b.WriteByte('=')
+		b.WriteString(v)
+		b.WriteByte('\n')
+	}
+	write("project", p.Project)
+	write("source", orNone(p.Source))
+	write("seed", orNone(shortHash("seed", p.Seed)))
+	write("rules", orNone(p.Rules))
+	write("subset", orNone(p.Subset))
+	write("postgres", strconv.Itoa(p.Postgres))
+	sum := sha256.Sum256([]byte(b.String()))
+	return provenanceScheme + "-" + hex.EncodeToString(sum[:10])
+}
+
+// describe says in one clause where a golden came from.
+//
+// It exists because the run used to print only "branching the database from
+// gv_20260901033741_74234e98", an opaque identifier and nothing else, which is
+// exactly as convincing when the choice is right as when it is wrong. A
+// correct decision nobody can check is one refactor away from an incorrect one
+// nobody notices.
+//
+// It describes THIS project's inputs, and it is only ever printed about a
+// golden whose recorded identity is equal to this project's, so the two
+// descriptions are the same description. The pinned path does not get to use
+// it for that reason.
+func (p provenance) describe() string {
+	parts := make([]string, 0, 3)
+	parts = append(parts, "made for "+p.Project)
+	switch {
+	case p.Source != "":
+		parts = append(parts, "from the database named by "+p.Source)
+	case p.Seed != "":
+		parts = append(parts, "from this project's seed command")
+	default:
+		parts = append(parts, "from no production database, so it holds no rows")
+	}
+	if p.Rules != "" {
+		parts = append(parts, "under masking rules "+p.Rules)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// provenanceOf is the identity of the golden this project may branch.
+func (o *Orchestrator) provenanceOf() (provenance, error) {
+	_, rules, err := o.rules()
+	if err != nil {
+		return provenance{}, err
+	}
+	p := provenance{
+		Project:  o.opts.Manifest.Name,
+		Rules:    rules,
+		Postgres: databaseVersion(o.opts.Manifest),
+	}
+	if db := o.opts.Manifest.Database; db != nil {
+		p.Source = db.SourceURLEnv
+		p.Seed = db.Seed
+		p.Subset = subsetIdentity(db.Subset)
+	}
+	return p, nil
+}
+
+// subsetIdentity describes the slice a manifest asks for, and is empty when it
+// asks for none.
+//
+// A disabled subset block and an absent one produce the same golden, so they
+// produce the same identity. The relationships are sorted because a manifest
+// listing the same two in the other order asks for the same slice, and a
+// refresh forced by moving a line is a refresh nobody can explain.
+func subsetIdentity(s *schema.Subset) string {
+	if s == nil || !s.Enabled {
+		return ""
+	}
+	follow := "default"
+	if s.FollowDependents != nil {
+		follow = strconv.Itoa(*s.FollowDependents)
+	}
+	virtual := make([]string, 0, len(s.VirtualRelationships))
+	for _, r := range s.VirtualRelationships {
+		virtual = append(virtual, r.From+">"+r.To)
+	}
+	sort.Strings(virtual)
+	return shortHash("subset", fmt.Sprintf("%s|%s|%d|%s|%s",
+		s.SeedTable, s.SeedWhere, s.MaxRows, follow, strings.Join(virtual, ",")))
+}
+
+// shortHash digests one component under its own domain separator, so that a
+// seed command and a subset description can never collide with each other.
+func shortHash(domain, body string) string {
+	if body == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(domain + "\x00" + body))
+	return hex.EncodeToString(sum[:8])
+}
+
+// orNone spells an absent component rather than leaving it blank, so that
+// "declares no source" and "declares a source named the empty string" cannot
+// hash to the same thing.
+func orNone(s string) string {
+	if s == "" {
+		return "none"
+	}
+	return s
+}
+
+// GoldenIdentity is the value a golden has to record for this project to be
+// allowed to branch it.
+//
+// Exported for the commands that have to reason about the same pool the
+// selector does. `af golden gc` is the sharp one: it used to sweep every
+// golden the daemon held, so running it in one project deleted another
+// project's goldens, which is the same shared pool defect pointing the other
+// way. `af golden list` uses it to say which rows are this project's rather
+// than presenting a machine's worth of goldens as though they were all
+// available here.
+func (o *Orchestrator) GoldenIdentity() (string, error) {
+	p, err := o.provenanceOf()
+	if err != nil {
+		return "", err
+	}
+	return p.digest(), nil
+}

--- a/engine/internal/errors/catalog.yaml
+++ b/engine/internal/errors/catalog.yaml
@@ -218,8 +218,8 @@ errors:
     exit_code: 5
   - code: AF-DB-012
     area: DB
-    message: "No golden matches this manifest's masking rules, and {count} were made under different ones."
-    next_step: "Run 'af golden refresh' to make one from the source this manifest names."
+    message: "No golden here was made for this project, and {count} were made for something else."
+    next_step: "Run 'af golden refresh' to make one from the source this manifest names. A golden is chosen by the project it was made for, the database it was copied from, the masking rules, the subset and the Postgres version, so one belonging to another project on this machine is never branched here."
     docs: concepts/goldens
     retryable: false
     exit_code: 5

--- a/engine/internal/errors/catalog.yaml
+++ b/engine/internal/errors/catalog.yaml
@@ -223,6 +223,13 @@ errors:
     docs: concepts/goldens
     retryable: false
     exit_code: 5
+  - code: AF-DB-015
+    area: DB
+    message: "The published golden {version} in {store} was made for a different project."
+    next_step: "Name a version this project published with 'af golden pull <version>', or run 'af golden refresh' on a machine that can reach the source. A store is shared, so the newest object in it is not necessarily yours."
+    docs: concepts/goldens
+    retryable: false
+    exit_code: 5
   - code: AF-DB-007
     planned: true
     area: DB

--- a/engine/internal/errors/codes.gen.go
+++ b/engine/internal/errors/codes.gen.go
@@ -93,8 +93,8 @@ const (
 	AFDB010 Code = "AF-DB-010"
 	// The subset could not be taken: {detail}
 	AFDB011 Code = "AF-DB-011"
-	// No golden matches this manifest's masking rules, and {count} were
-	// made under different ones.
+	// No golden here was made for this project, and {count} were made for
+	// something else.
 	AFDB012 Code = "AF-DB-012"
 	// The database seed command failed: {detail}
 	AFDB013 Code = "AF-DB-013"
@@ -664,8 +664,8 @@ var catalog = map[Code]Entry{
 	AFDB012: {
 		Code:      AFDB012,
 		Area:      "DB",
-		Message:   "No golden matches this manifest's masking rules, and {count} were made under different ones.",
-		NextStep:  "Run 'af golden refresh' to make one from the source this manifest names.",
+		Message:   "No golden here was made for this project, and {count} were made for something else.",
+		NextStep:  "Run 'af golden refresh' to make one from the source this manifest names. A golden is chosen by the project it was made for, the database it was copied from, the masking rules, the subset and the Postgres version, so one belonging to another project on this machine is never branched here.",
 		Docs:      "concepts/goldens",
 		Retryable: false,
 		ExitCode:  ExitProvider,

--- a/engine/internal/errors/codes.gen.go
+++ b/engine/internal/errors/codes.gen.go
@@ -100,6 +100,9 @@ const (
 	AFDB013 Code = "AF-DB-013"
 	// No database branch exists for {env}.
 	AFDB014 Code = "AF-DB-014"
+	// The published golden {version} in {store} was made for a different
+	// project.
+	AFDB015 Code = "AF-DB-015"
 	// Personas cannot be provisioned because {provider} creates users only
 	// through its own API, and no sandbox tenant is configured.
 	AFDB020 Code = "AF-DB-020"
@@ -684,6 +687,15 @@ var catalog = map[Code]Entry{
 		Area:      "DB",
 		Message:   "No database branch exists for {env}.",
 		NextStep:  "Run 'af up' to create one. This is not a missing golden: nothing has been branched for this environment yet.",
+		Docs:      "concepts/goldens",
+		Retryable: false,
+		ExitCode:  ExitProvider,
+	},
+	AFDB015: {
+		Code:      AFDB015,
+		Area:      "DB",
+		Message:   "The published golden {version} in {store} was made for a different project.",
+		NextStep:  "Name a version this project published with 'af golden pull <version>', or run 'af golden refresh' on a machine that can reach the source. A store is shared, so the newest object in it is not necessarily yours.",
 		Docs:      "concepts/goldens",
 		Retryable: false,
 		ExitCode:  ExitProvider,

--- a/engine/internal/manifest/explain.go
+++ b/engine/internal/manifest/explain.go
@@ -121,7 +121,8 @@ func Explain(m *schema.Manifest, width int) string {
 		fmt.Fprintf(&b, "  seeded by    %s\n", value(d.Seed, 15, width))
 	} else {
 		fmt.Fprintf(&b, "  source       %s\n",
-			value("none declared, so branches start from an empty database", 15, width))
+			value("none declared, so branches start from an empty database this "+
+				"project makes for itself, never another project's golden", 15, width))
 	}
 	fmt.Fprintf(&b, "  masking      %s\n", value(d.MaskingRules, 15, width))
 	fmt.Fprintf(&b, "  golden       %s\n", value(fmt.Sprintf("refresh %s, keep %d, storage %s",

--- a/engine/internal/testutil/fakes/inmemory.go
+++ b/engine/internal/testutil/fakes/inmemory.go
@@ -77,6 +77,7 @@ func (d *InMemoryDatabase) RefreshGolden(ctx context.Context, spec provider.Gold
 		ID:          fmt.Sprintf("gv_inmemory_%04d", d.seq),
 		CreatedAt:   time.Date(2026, 1, 1, 0, 0, d.seq, 0, time.UTC),
 		RulesHash:   spec.RulesHash,
+		Provenance:  spec.Provenance,
 		Verified:    true,
 		Attestation: att,
 	}

--- a/engine/internal/verify/attest_test.go
+++ b/engine/internal/verify/attest_test.go
@@ -24,7 +24,7 @@ func TestSign_ProducesSomethingThatVerifies(t *testing.T) {
 	_, priv, err := verify.GenerateKey()
 	require.NoError(t, err)
 
-	a, err := verify.Sign(sampleReport(), "gv_1", "rules-abc", priv)
+	a, err := verify.Sign(sampleReport(), "gv_1", "rules-abc", "gp1-abc", priv)
 	require.NoError(t, err)
 	require.True(t, a.Verify())
 	require.NotEmpty(t, a.Signature)
@@ -39,7 +39,7 @@ func TestVerify_RejectsAChangedReport(t *testing.T) {
 	_, priv, err := verify.GenerateKey()
 	require.NoError(t, err)
 
-	a, err := verify.Sign(sampleReport(), "gv_1", "rules-abc", priv)
+	a, err := verify.Sign(sampleReport(), "gv_1", "rules-abc", "gp1-abc", priv)
 	require.NoError(t, err)
 
 	tampered := a
@@ -59,6 +59,22 @@ func TestVerify_RejectsAChangedReport(t *testing.T) {
 	tampered.RulesHash = "other-rules"
 	require.False(t, tampered.Verify(),
 		"a golden verified under one set of rules is not one verified under another")
+
+	// The claim a machine pulling from a shared store acts on. A golden store
+	// is shared by a fleet on purpose, and the only thing stopping a runner
+	// restoring another project's masked production is that this field says
+	// whose it is. Rewriting it must not survive.
+	tampered = a
+	tampered.Provenance = "gp1-somebody-else"
+	require.False(t, tampered.Verify(),
+		"an attestation must not be transferable to another project")
+
+	// And the direction that matters more, because it looks like an old
+	// document rather than an edited one: taking the claim out entirely.
+	tampered = a
+	tampered.Provenance = ""
+	require.False(t, tampered.Verify(),
+		"a signed claim about whose golden this is cannot be dropped to make it anybody's")
 }
 
 func TestVerify_RejectsAFindingRemovedFromAReport(t *testing.T) {
@@ -73,7 +89,7 @@ func TestVerify_RejectsAFindingRemovedFromAReport(t *testing.T) {
 		Schema: "public", Table: "customers", Column: "email",
 		Detector: "email", Example: "ad****om", Rows: 200,
 	}}
-	a, err := verify.Sign(report, "gv_1", "rules-abc", priv)
+	a, err := verify.Sign(report, "gv_1", "rules-abc", "gp1-abc", priv)
 	require.NoError(t, err)
 	require.False(t, a.Report.Clean())
 	require.True(t, a.Verify())
@@ -91,7 +107,7 @@ func TestVerify_RejectsAnotherKeysSignature(t *testing.T) {
 	otherPub, otherPriv, err := verify.GenerateKey()
 	require.NoError(t, err)
 
-	a, err := verify.Sign(sampleReport(), "gv_1", "rules-abc", priv)
+	a, err := verify.Sign(sampleReport(), "gv_1", "rules-abc", "gp1-abc", priv)
 	require.NoError(t, err)
 
 	// Swapping in another key's public half, which is what somebody who wanted
@@ -101,7 +117,7 @@ func TestVerify_RejectsAnotherKeysSignature(t *testing.T) {
 	require.False(t, forged.Verify())
 
 	// And a signature from another key over the same document.
-	resigned, err := verify.Sign(sampleReport(), "gv_1", "rules-abc", otherPriv)
+	resigned, err := verify.Sign(sampleReport(), "gv_1", "rules-abc", "gp1-abc", otherPriv)
 	require.NoError(t, err)
 	mixed := a
 	mixed.Signature = resigned.Signature
@@ -112,7 +128,7 @@ func TestVerify_RejectsMalformedFields(t *testing.T) {
 	t.Parallel()
 	_, priv, err := verify.GenerateKey()
 	require.NoError(t, err)
-	a, err := verify.Sign(sampleReport(), "gv_1", "rules-abc", priv)
+	a, err := verify.Sign(sampleReport(), "gv_1", "rules-abc", "gp1-abc", priv)
 	require.NoError(t, err)
 
 	for name, mutate := range map[string]func(*verify.Attestation){

--- a/engine/internal/verify/scan.go
+++ b/engine/internal/verify/scan.go
@@ -274,6 +274,16 @@ type Attestation struct {
 	// verified under one set of rules is not mistaken for one verified under
 	// another.
 	RulesHash string `json:"rules_hash"`
+	// Provenance identifies the project the golden was made for and the inputs
+	// that produced it, so that a machine pulling a published golden can tell
+	// whether it is looking at its own project's work or somebody else's.
+	//
+	// Signed along with everything else, which is the point of putting it
+	// here rather than only in a provider annotation: a store is shared, and a
+	// claim about whose data this is has to be one the reader can check.
+	// Omitted when empty so that an attestation written before this field
+	// existed still verifies against its own signature.
+	Provenance string `json:"provenance,omitempty"`
 	// PublicKey is the verifying key, base64.
 	PublicKey string `json:"public_key"`
 	// Signature covers the canonical form of everything above.
@@ -281,9 +291,9 @@ type Attestation struct {
 }
 
 // Sign produces a signed attestation.
-func Sign(report Report, golden, rulesHash string, key ed25519.PrivateKey) (Attestation, error) {
+func Sign(report Report, golden, rulesHash, provenance string, key ed25519.PrivateKey) (Attestation, error) {
 	a := Attestation{
-		Report: report, Golden: golden, RulesHash: rulesHash,
+		Report: report, Golden: golden, RulesHash: rulesHash, Provenance: provenance,
 		PublicKey: base64.StdEncoding.EncodeToString(key.Public().(ed25519.PublicKey)),
 	}
 	payload, err := a.payload()

--- a/engine/pkg/provider/db.go
+++ b/engine/pkg/provider/db.go
@@ -33,6 +33,18 @@ type GoldenVersion struct {
 	// RulesHash identifies the masking rules that produced it, so that a rules
 	// change can be detected without re-reading the data.
 	RulesHash string
+	// Provenance identifies the project this version was made for and the
+	// inputs that produced it, so that selection can refuse a golden belonging
+	// to somebody else.
+	//
+	// A golden pool is shared: the Docker provider keeps versions as images on
+	// a machine wide daemon, and a configured store is shared by a fleet on
+	// purpose. RulesHash alone cannot answer whether a version may be branched
+	// here, because two unrelated projects that declare no masking rules
+	// declare the SAME rules and hash to the same value. Empty means the
+	// version predates this field or arrived some other way, and the engine
+	// refuses to branch it rather than guessing.
+	Provenance string
 	// Verified reports whether the verification scanner passed. Branch refuses
 	// an unverified version; that rule is the product's central promise and it
 	// is enforced here rather than in a checklist.
@@ -136,6 +148,10 @@ type GoldenSpec struct {
 	Version int
 	// RulesHash identifies the masking rules being applied.
 	RulesHash string
+	// Provenance identifies the project the golden is being made for. A
+	// provider records it alongside the version and returns it from
+	// ListGoldens; it is opaque to the provider and is never parsed by one.
+	Provenance string
 	// Load fills the candidate from the source, and REPLACES the provider's
 	// own copy when it is set.
 	//


### PR DESCRIPTION
The P0. `af up` in one repository branched another project's database, and it
was reproduced verbatim on 2026-09-01 with the released binary and two ordinary
Express repositories: one declared a production database and refreshed a golden
from it; the other declared none, printed in its own generated manifest that
"branches will start empty", and came up holding the first project's tables and
rows. Two unrelated repositories both received Antifailure's own test fixture.

The first fix was narrowed to the masking rules digest, which is a statement
about how a golden was masked and not about whose it is. A project with no
`masking.yaml` declares no rules, so every project on a machine without one
hashed to the same value and shared one pool.

What lands here: a golden records the project it was made for alongside the
source variable, the seed, the rules, the subset and the Postgres major
(`engine/internal/env/provenance.go`); selection is exact equality on that;
`af golden pull` refuses a published golden made for another project; `af golden
gc` no longer collects other projects' goldens; and every branch line says where
its data came from.

No migration, so this takes no position in the migration chain.

Merged onto main `c3902294` with no conflicts. `go build ./...` in `engine` is
green on the merge result. Draft, so its first CI run is not on main: pushing a
branch in this repository runs nothing.