### PR TITLE
ci: a credential alarm that had not looked for credentials

### DIFF
--- a/.changes/a-credential-alarm-that-never-looked.internal.md
+++ b/.changes/a-credential-alarm-that-never-looked.internal.md
@@ -1,0 +1,17 @@
+# fixed
+
+The CI job named "no credentials in the tree" ran the credential scanner
+last, after eight document and claim checks. A job stops at its first
+failing step, so a single em dash failing prosecheck reported that job as
+FAILED under a name that makes a security claim, while `scanrepo` never
+executed at all. Two reviewers read the red as a credential in the tree and
+escalated, and neither could tell from the summary that the scan had not
+happened, because a step that never ran looks exactly like a step that
+failed.
+
+The scan is now its own job, with that step as its only step, so green means
+the scanner ran and found nothing rather than possibly meaning it never ran.
+The remaining eight checks keep their own job under a name that describes
+them, "the documents and the site tell the truth". A prose failure can no
+longer prevent the credential scan from happening, which is the half of the
+old arrangement that mattered.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -810,8 +810,21 @@ jobs:
         # without its prerequisites. The script is the shared part.
         run: ./tools/release/reproducible.sh
 
-  secrets:
-    name: no credentials in the tree
+  # This job is named for what it checks, not for its most important step.
+  #
+  # It used to be called "no credentials in the tree", and the credential scan
+  # was the LAST of nine steps. A job stops at its first failure, so when an em
+  # dash failed prosecheck at step eight, `scanrepo` never executed and the
+  # check reported FAILED under a name that makes a security claim. Two agents
+  # read that as a credential in the tree and escalated. Neither reading was
+  # possible to check from the summary, because the absence of a step looks
+  # exactly like its failure.
+  #
+  # A false credential alarm is expensive twice: it burns an escalation now,
+  # and it teaches the next reader to discount the one that matters. So the
+  # scan is its own job below, and this one no longer claims to be it.
+  documents:
+    name: the documents and the site tell the truth
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -881,6 +894,25 @@ jobs:
         # schemas/manifest.v1.json, so this is a claim a machine can check
         # rather than one a reviewer has to notice.
         run: go run ./tools/modecheck .
+
+  # Alone, and deliberately so.
+  #
+  # This is the only step in this job, which is what makes its result mean what
+  # its name says: green here is "the scanner ran and found nothing", never
+  # "the scanner never ran". It also means a prose failure can no longer stop
+  # the credential scan from happening at all, which is the half of the old
+  # arrangement that actually mattered.
+  credentials:
+    name: no credentials in the tree
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        with:
+          go-version-file: engine/go.mod
+          cache-dependency-path: engine/go.sum
 
       - name: Nothing in the repository looks like a live credential
         # Uses the engine's own detector, so the check and the runtime refusal


### PR DESCRIPTION
2 commits on `prep-secretsjob`, which had no pull request in any state until now.

A branch push runs no CI in this repository, so an unproposed branch is also an unverified one. Opened as a draft so CI can run against it. Found by an audit that checked every branch with `gh pr list --state all --head`, and confirmed genuinely pending with `git cherry` by patch id rather than by subject line, so nothing here is superseded work landing twice.

- ci: a credential alarm that had not looked for credentials

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR