### PR TITLE
docs, gate: the flag rename survived in the one form neither gate could see

### DIFF
--- a/docs/src/content/docs/getting-started/pull-requests.md
+++ b/docs/src/content/docs/getting-started/pull-requests.md
@@ -27,8 +27,12 @@ and a step that leaves the report:
 
 - name: Run the check
   if: steps.change.outputs.environment == 'true'
-  run: af ci --output report.md
+  run: af ci --report report.md
 ```
+
+Both steps write `report.md`, on purpose. `af change` writes it so that a change
+needing no environment still leaves a comment saying why, and `af ci` overwrites
+the file when it runs.
 
 Two steps rather than one because the installer writes its bin directory to
 `GITHUB_PATH`, which is how a step extends the PATH of the steps after it. That

--- a/engine/internal/cli/docexamples_test.go
+++ b/engine/internal/cli/docexamples_test.go
@@ -29,7 +29,19 @@ import (
 var (
 	// A command line inside a fenced block: a line beginning with af, before
 	// any shell operator that would make the rest something else.
-	afLine = regexp.MustCompile(`(?m)^\s*(?:[a-z_]+=\$\()?af\s+([^\n|>&;#]*)`)
+	//
+	// The optional `run:` is not decoration. Without it this pattern requires
+	// af to be the first word on the line, and a GitHub Actions step that runs
+	// one command writes it as `run: af ci ...` on a single line. Six such
+	// invocations were invisible to both this gate and the workflow one next
+	// door, across examples/github-workflow.yml and three documentation pages,
+	// and one of them was `af ci --output report.md` on the page that teaches
+	// the pull request integration. That is the SAME defect this gate's
+	// neighbour was written to catch, surviving in the one form neither
+	// pattern could see. A `- ` is allowed only in front of `run:`, so a
+	// markdown list item that merely mentions af in prose is still not read as
+	// an invocation.
+	afLine = regexp.MustCompile(`(?m)^\s*(?:(?:-\s+)?run:\s+)?(?:[a-z_]+=\$\()?af\s+([^\n|>&;#]*)`)
 	// A long flag, with or without a value.
 	longFlag = regexp.MustCompile(`--[a-zA-Z][a-zA-Z0-9-]*`)
 )


### PR DESCRIPTION
1 commits on `prep-workflows`, which had no pull request in any state until now.

A branch push runs no CI in this repository, so an unproposed branch is also an unverified one. Opened as a draft so CI can run against it. Found by an audit that checked every branch with `gh pr list --state all --head`, and confirmed genuinely pending with `git cherry` by patch id rather than by subject line, so nothing here is superseded work landing twice.

- docs, gate: the flag rename survived in the one form neither gate could see

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR