### PR TITLE
Three capabilities the code claimed and did not have

### DIFF
--- a/.changes/a-golden-nobody-verified-said-it-was.md
+++ b/.changes/a-golden-nobody-verified-said-it-was.md
@@ -1,0 +1,26 @@
+# fixed
+
+`ListGoldens` reported every golden as verified, including the ones that were not.
+
+`RefreshGolden` records `Verified: spec.Verify != nil`, which is a real value: a
+refresh with no verifier commits an image and says so. `ListGoldens` then built
+every version with `Verified: true` unconditionally, under a comment reasoning
+that a committed image only exists because verification passed. Half of that is
+true, since a verification that FAILS never commits. The half that is not is
+that a refresh with no verifier commits too.
+
+`pickGolden` reads the listing, not the refresh. So the honestly recorded
+`false` was overwritten by the read, and `af up` branched an unverified golden
+exactly as if it had been checked, with nothing printed anywhere.
+
+The verified state is now read from the attestation label rather than assumed.
+That label is written at commit time and is only ever produced by a verifier
+that ran and returned, so it is the durable record the read was missing: no new
+label, no migration, and a golden that was verified stays verified. One that
+never was now says so, and costs its owner the single refresh `pickGolden`'s
+own comment describes as the price of refusing.
+
+The case that hid this had no test. The round trip test published a golden WITH
+a verifier and asserted `Verified` was true, which an unconditional true
+satisfies perfectly. There is now a test for a refresh with no verifier, which
+is the only shape that can tell an honest read from a hardcoded one.

--- a/.changes/control-c-twice-now-stops.md
+++ b/.changes/control-c-twice-now-stops.md
@@ -1,0 +1,23 @@
+# fixed
+
+Pressing control C twice did nothing.
+
+Both binaries set up signal handling by calling `WithSignals`, whose comment
+said in the present tense that the second interrupt forces an exit with the
+journal intact. Both then discarded the return value that said a second one had
+arrived: `ctx, _, stop := cli.WithSignals(...)`. The function computed the
+answer, closed the channel, and no line in either binary ever asked. A user
+holding control C on a pull the size of a database got exactly as far as the
+first interrupt did, which for a command that does not check its context is
+nowhere.
+
+The shape was the reason. `WithSignals` returned a function reporting whether a
+second signal had been seen, and a poll can only be answered by code that is
+still running. A second interrupt matters in precisely the case where the
+command is not coming back to ask anything. It is a channel now, and `cli.Run`
+waits on it: the exit code is produced out from under a command that is still
+running, and stopping there is safe because every resource is journaled before
+it is created, so `af down` still knows what to remove.
+
+`afcli.Run` takes the same channel, so the enterprise binary, which carried an
+identical comment and an identical discarded value, stops too.

--- a/.changes/the-sidecar-recorded-what-nothing-could-show.md
+++ b/.changes/the-sidecar-recorded-what-nothing-could-show.md
@@ -1,0 +1,24 @@
+# fixed
+
+`af net log -o json` could not say whether the sandbox swapped the credential.
+
+The sidecar records a decision, the engine decodes it, and `af net log` shows
+it. Three structs, and until now nothing made their json tags agree. Seven
+fields the proxy wrote on every request reached no surface at all:
+`substituted`, `host_only`, `via`, `duration`, `seq`, and `waited_ms` and
+`limit`, which reached the table and not the JSON.
+
+`substituted` is the one that matters most. It is the answer to the question
+the sandbox exists to answer, and a row that reached a real service and a row
+that reached a sandbox were the same row. It is now reported on every decision,
+as `false` rather than absent when the swap did not happen, because a key that
+disappears makes "the credential was not swapped" and "this build cannot report
+swaps" the same document. The table says `sandbox credential` and, for an
+invented response, the table already said so.
+
+The fix that keeps it fixed is a test rather than this list. One compares the
+json tags of the sidecar's record, the decoded decision and the published
+document and fails on any fact recorded with nowhere to go; the other fills
+every decoded field and fails on any published key nothing assigns. A field
+added to the sidecar and forgotten in the other two now fails on the commit
+that adds it.

--- a/ee/engine/cmd/af/main.go
+++ b/ee/engine/cmd/af/main.go
@@ -43,8 +43,9 @@ func main() {
 	// The same signal handling the community binary has, from the same
 	// function, so that control C means the same thing in both. The first
 	// interrupt cancels so in flight work rolls back and teardown runs; the
-	// second exits with the journal intact.
-	ctx, _, stop := afcli.WithSignals(context.Background())
+	// second exits with the journal intact, which is what passing forced to
+	// Run below is for.
+	ctx, forced, stop := afcli.WithSignals(context.Background())
 	defer stop()
 
 	// The licence is attached to the context rather than passed as an argument,
@@ -119,7 +120,7 @@ func main() {
 	if warning := status.Warning; warning != "" {
 		fmt.Fprintf(os.Stderr, "af: %s\n", warning)
 	}
-	os.Exit(afcli.Run(ctx, os.Args[1:], afcli.Options{
+	os.Exit(afcli.Run(ctx, forced, os.Args[1:], afcli.Options{
 		Extra: []afcli.Command{compliance.Contributed(gatherEvidence)},
 	}))
 }

--- a/engine/cmd/af-proxy/surface_test.go
+++ b/engine/cmd/af-proxy/surface_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/internal/cli"
+	"github.com/antifailure/antifailure/engine/internal/runtime/local"
+)
+
+// The sidecar writes a decision, the engine decodes it, and af net log shows
+// it. Three structs, three json tag sets, and nothing until now made them
+// agree. A field added to the first and forgotten in the other two is code
+// that runs on every request, costs a line in the log, and answers nothing:
+// the fact is recorded and then thrown away at the next boundary.
+//
+// It is a test rather than a review because a review is true on the day
+// somebody does it. This finds the whole class on every run, and it fails when
+// the next field is added rather than the next time somebody looks.
+//
+// The two exemption sets below are where a deliberate decision to not carry a
+// field is written down. Adding a tag to one is how you say "on purpose", and
+// the test then holds you to it: an exemption naming a field the sidecar no
+// longer records fails too, so the list cannot rot into a way of hiding things.
+
+// foldedIntoRequest are the parts af net log assembles into one request string
+// rather than showing as separate keys, as "GET https://api.stripe.com/v1/charges".
+// The fact reaches the reader; it just does not reach them under this name.
+var foldedIntoRequest = map[string]string{
+	"method": "shown inside the request string",
+	"host":   "shown inside the request string",
+	"port":   "shown inside the request string, unless it is the default for the scheme",
+	"path":   "shown inside the request string",
+	"tls":    "shown inside the request string, as the scheme",
+}
+
+// notADecision are the fields the sidecar puts on lines that are not a request
+// at all: the ready line it prints once at startup, and the envelope every
+// line carries. af net log shows decisions, so these have no place on one.
+var notADecision = map[string]string{
+	"event":       "names the kind of line; every decision has the same value",
+	"env":         "the environment is what the reader asked about, so it is not repeated per row",
+	"rules":       "on the ready line: how many rules loaded",
+	"default":     "on the ready line: the default mode",
+	"credentials": "on the ready line: how many sandbox values loaded",
+}
+
+// builtBySurface are keys af net log composes rather than reads, so the
+// sidecar has nothing to record under that name.
+var builtBySurface = map[string]string{
+	"request": "assembled from method, tls, host, port and path",
+}
+
+// jsonTags is the set of names a struct actually serializes under.
+func jsonTags(t reflect.Type) map[string]bool {
+	tags := map[string]bool{}
+	for i := 0; i < t.NumField(); i++ {
+		tag := t.Field(i).Tag.Get("json")
+		name, _, _ := strings.Cut(tag, ",")
+		if name == "" || name == "-" {
+			continue
+		}
+		tags[name] = true
+	}
+	return tags
+}
+
+func TestEveryFactTheSidecarRecordsReachesASurface(t *testing.T) {
+	recorded := jsonTags(reflect.TypeOf(record{}))
+	decoded := jsonTags(reflect.TypeOf(local.Decision{}))
+	shown := jsonTags(reflect.TypeOf(cli.DecisionJSON{}))
+
+	// Collected and reported together rather than one require at a time,
+	// because the value of a diff is the whole diff. A test that stops at the
+	// first field turns one pass into as many passes as there are fields, and
+	// somebody fixing them one at a time never sees that they are one problem.
+	var gaps []string
+	gap := func(format string, args ...any) { gaps = append(gaps, fmt.Sprintf(format, args...)) }
+
+	for tag := range recorded {
+		if _, ok := foldedIntoRequest[tag]; ok {
+			continue
+		}
+		if _, ok := notADecision[tag]; ok {
+			continue
+		}
+		if !decoded[tag] {
+			gap("local.Decision has no field for %q, so the sidecar's value is discarded at the moment it is read", tag)
+		}
+		if !shown[tag] {
+			gap("af net log -o json has no key for %q, so nothing a script reads can answer a question about it", tag)
+		}
+	}
+
+	for tag := range shown {
+		if _, ok := builtBySurface[tag]; ok {
+			continue
+		}
+		if !recorded[tag] {
+			gap("af net log -o json publishes %q and the sidecar never records it, so the key is either always empty or filled from somewhere the log does not say", tag)
+		}
+	}
+
+	// An exemption for a field that no longer exists is an exemption that has
+	// stopped meaning anything, and the next reader would trust it.
+	for _, set := range []map[string]string{foldedIntoRequest, notADecision} {
+		for tag := range set {
+			if !recorded[tag] {
+				gap("%q is exempted from reaching a surface and the sidecar does not record it; delete the exemption", tag)
+			}
+		}
+	}
+	for tag := range builtBySurface {
+		if !shown[tag] {
+			gap("%q is exempted as composed by af net log, which no longer publishes it", tag)
+		}
+	}
+
+	sort.Strings(gaps)
+	require.Empty(t, gaps, "the sidecar spends a line per request on facts no surface can show:\n\t%s",
+		strings.Join(gaps, "\n\t"))
+}

--- a/engine/cmd/af/main.go
+++ b/engine/cmd/af/main.go
@@ -20,11 +20,13 @@ func main() {
 	// The first interrupt cancels the root context so that in flight work
 	// rolls back and teardown runs. The second forces an exit with the journal
 	// intact, because a user pressing control C twice means "stop now", and
-	// the journal is what makes stopping now safe.
-	ctx, _, stop := cli.WithSignals(context.Background())
+	// the journal is what makes stopping now safe. Run is what honours the
+	// second one: it returns the exit code out from under a command that has
+	// not noticed the first.
+	ctx, forced, stop := cli.WithSignals(context.Background())
 	defer stop()
 
 	// Execute returns the code rather than exiting, so that deferred cleanup
 	// runs and every command stays testable without a process.
-	os.Exit(cli.Execute(ctx, os.Args[1:], cli.Options{}))
+	os.Exit(cli.Run(ctx, forced, os.Args[1:], cli.Options{}))
 }

--- a/engine/internal/cli/net.go
+++ b/engine/internal/cli/net.go
@@ -389,6 +389,14 @@ func parseRequest(method, raw string) (policy.Request, error) {
 }
 
 // DecisionJSON is one line of af net log.
+//
+// Every fact the sidecar records about a request appears here, and
+// TestEveryFactTheSidecarRecordsReachesASurface holds it to that. The keys
+// below the first block were recorded on every request and published on none
+// of them, which meant the one question the sandbox exists to answer, "did the
+// credential actually get swapped", had no answer a script could read. A field
+// the proxy spends a line writing and no surface can show is a field that does
+// not exist as far as anybody outside the container is concerned.
 type DecisionJSON struct {
 	At      string `json:"at"`
 	Request string `json:"request"`
@@ -399,14 +407,34 @@ type DecisionJSON struct {
 	Bytes   int64  `json:"bytes,omitempty"`
 	Reason  string `json:"reason,omitempty"`
 	Error   string `json:"error,omitempty"`
-	// Synthesized says a model invented this response. A reader auditing what
-	// an environment reached needs to tell an answer that came from a server
-	// from one that came from a model, and until this was here the two were
-	// the same row.
-	Synthesized bool `json:"synthesized,omitempty"`
+
+	// Substituted and Synthesized are never omitted, because false is the
+	// answer somebody is checking for. A key that disappears when it is false
+	// makes "the credential was not swapped" and "this build does not report
+	// swaps" the same document.
+	Substituted bool `json:"substituted"`
+	Synthesized bool `json:"synthesized"`
 	// Pack and Fixture name what answered a mocked request.
 	Pack    string `json:"pack,omitempty"`
 	Fixture string `json:"fixture,omitempty"`
+	// Duration is how long the request took, WaitedMs how much of that the
+	// policy itself held it for, and Limit that rate in words. Without the
+	// last two, a request the policy deliberately slowed reads as an
+	// application that is simply slow.
+	Duration string `json:"duration,omitempty"`
+	WaitedMs int64  `json:"waited_ms,omitempty"`
+	Limit    string `json:"limit,omitempty"`
+	// Via says how the request arrived: as a proxy request from a client that
+	// read its proxy variables, or transparently from one that did not.
+	Via string `json:"via,omitempty"`
+	// HostOnly marks a decision made without seeing the path or the method,
+	// which is every HTTPS request until the environment certificate lands. A
+	// reader comparing a rule to a decision needs to know the rule could only
+	// half apply.
+	HostOnly bool `json:"host_only,omitempty"`
+	// Seq is the sidecar's own ordering, which survives lines sharing a
+	// timestamp.
+	Seq uint64 `json:"seq,omitempty"`
 }
 
 func newNetLogCommand(env *Env) *cobra.Command {
@@ -446,12 +474,7 @@ question somebody asks after an incident.`),
 			if env.Out.Format == FormatJSON {
 				docs := make([]DecisionJSON, 0, len(decisions))
 				for _, d := range decisions {
-					docs = append(docs, DecisionJSON{
-						At: d.AtRaw, Request: decisionRequest(d), Mode: d.Mode,
-						Rule: d.Rule, Allowed: d.Allowed, Status: d.Status,
-						Bytes: d.Bytes, Reason: d.Reason, Error: d.Error,
-						Synthesized: d.Synthesized, Pack: d.Pack, Fixture: d.Fixture,
-					})
+					docs = append(docs, decisionDoc(d))
 				}
 				return env.Out.JSON(docs)
 			}
@@ -488,6 +511,25 @@ question somebody asks after an incident.`),
 	cmd.Flags().BoolVar(&blockedOnly, "blocked", false, "Show only requests that were refused")
 	cmd.Flags().StringVar(&branch, "branch", "", "Branch to read, defaulting to the checked out one")
 	return cmd
+}
+
+// decisionDoc is the whole translation from what the sidecar decided to what a
+// script reads.
+//
+// A function rather than a literal inside the command, so that a test can
+// check every key is filled. Declaring a key and never assigning it produces
+// JSON that is valid, parses, and lies by omission, and the struct tag alone
+// cannot tell the difference.
+func decisionDoc(d local.Decision) DecisionJSON {
+	return DecisionJSON{
+		At: d.AtRaw, Request: decisionRequest(d), Mode: d.Mode,
+		Rule: d.Rule, Allowed: d.Allowed, Status: d.Status,
+		Bytes: d.Bytes, Reason: d.Reason, Error: d.Error,
+		Substituted: d.Substituted, Synthesized: d.Synthesized,
+		Pack: d.Pack, Fixture: d.Fixture,
+		Duration: d.Duration, WaitedMs: d.WaitedMs, Limit: d.Limit,
+		Via: d.Via, HostOnly: d.HostOnly, Seq: d.Seq,
+	}
 }
 
 func decisionRequest(d local.Decision) string {
@@ -553,12 +595,25 @@ func outcomeOf(d local.Decision) string {
 		if d.Limit != "" {
 			held += " by " + d.Limit
 		}
-		if out == "" {
-			return held
-		}
-		return out + ", " + held
+		out = join(out, held)
+	}
+	// Whether the credential was swapped is the question the sandbox exists to
+	// answer, and until now the answer was in the sidecar's log and nowhere a
+	// person or a script could reach. A row that reached a real service and a
+	// row that reached a sandbox looked identical.
+	if d.Substituted {
+		out = join(out, "sandbox credential")
 	}
 	return out
+}
+
+// join puts the next clause after the outcome, or makes it the outcome when
+// there is nothing yet to put it after.
+func join(out, next string) string {
+	if out == "" {
+		return next
+	}
+	return out + ", " + next
 }
 
 // shortTime keeps the clock time and drops the date, because every line in one

--- a/engine/internal/cli/net_shaped_test.go
+++ b/engine/internal/cli/net_shaped_test.go
@@ -36,3 +36,17 @@ func TestTheWaitIsShownWithoutALimitAndWithoutAStatus(t *testing.T) {
 	require.Equal(t, "held 90ms by 1 a second, bursting to 1",
 		outcomeOf(local.Decision{WaitedMs: 90, Limit: "1 a second, bursting to 1"}))
 }
+
+// A sandbox call and a live call have to be distinguishable, in the table and
+// in the JSON. The sidecar has always recorded the swap; nothing showed it, so
+// af net log answered "the request reached Stripe" identically whether or not
+// the credential going out was the real one. That is the one question the
+// sandbox exists to answer.
+func TestASandboxedRequestSaysItsCredentialWasSwapped(t *testing.T) {
+	require.Equal(t, "200, sandbox credential",
+		outcomeOf(local.Decision{Status: 200, Substituted: true}))
+	require.Equal(t, "sandbox credential",
+		outcomeOf(local.Decision{Substituted: true}))
+	require.Equal(t, "200, held 20ms, sandbox credential",
+		outcomeOf(local.Decision{Status: 200, WaitedMs: 20, Substituted: true}))
+}

--- a/engine/internal/cli/net_surface_test.go
+++ b/engine/internal/cli/net_surface_test.go
@@ -1,0 +1,71 @@
+package cli
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/internal/runtime/local"
+)
+
+// nonZero fills every settable field of v with a distinguishable value, so
+// that anything still zero afterwards was not copied rather than merely
+// copied as empty.
+func nonZero(v reflect.Value) {
+	for i := 0; i < v.NumField(); i++ {
+		f := v.Field(i)
+		switch f.Kind() {
+		case reflect.String:
+			f.SetString("x")
+		case reflect.Bool:
+			f.SetBool(true)
+		case reflect.Int, reflect.Int64:
+			f.SetInt(7)
+		case reflect.Uint, reflect.Uint64:
+			f.SetUint(7)
+		}
+	}
+}
+
+// A key af net log publishes and never assigns is worse than a missing key: it
+// parses, it validates, and it reports the zero value as though it were the
+// answer. So this fills every field the sidecar decoded and requires that
+// every field of the document came out non zero.
+//
+// It is the companion to the json tag diff in cmd/af-proxy: that one catches a
+// fact with nowhere to go, this one catches a place with nothing put in it.
+func TestEveryKeyAfNetLogPublishesIsActuallyFilledIn(t *testing.T) {
+	var d local.Decision
+	nonZero(reflect.ValueOf(&d).Elem())
+
+	doc := reflect.ValueOf(decisionDoc(d))
+	for i := 0; i < doc.NumField(); i++ {
+		name, _, _ := strings.Cut(doc.Type().Field(i).Tag.Get("json"), ",")
+		require.False(t, doc.Field(i).IsZero(),
+			"af net log -o json declares %s and decisionDoc never assigns it, so the key is published empty whatever the sidecar decided",
+			name)
+	}
+}
+
+// And the question the sandbox exists to answer, asked the way a script asks
+// it: is the substitution reported, and reported as false rather than absent
+// when it did not happen.
+func TestTheJSONSaysWhetherTheCredentialWasSwapped(t *testing.T) {
+	swapped, err := json.Marshal(decisionDoc(local.Decision{
+		Host: "api.stripe.com", Method: "POST", TLS: true, Path: "/v1/charges",
+		Allowed: true, Status: 200, Substituted: true,
+	}))
+	require.NoError(t, err)
+	require.Contains(t, string(swapped), `"substituted":true`)
+
+	live, err := json.Marshal(decisionDoc(local.Decision{
+		Host: "api.stripe.com", Method: "POST", TLS: true, Path: "/v1/charges",
+		Allowed: true, Status: 200,
+	}))
+	require.NoError(t, err)
+	require.Contains(t, string(live), `"substituted":false`,
+		"a swap that did not happen has to be reported, not omitted; a missing key and a build that cannot report swaps look the same")
+}

--- a/engine/internal/cli/root.go
+++ b/engine/internal/cli/root.go
@@ -8,6 +8,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
 	"text/template"
 
@@ -522,40 +523,94 @@ recoverable by replay.`),
 	return root
 }
 
-// WithSignals returns a context cancelled by an interrupt, and a function that
-// reports whether a second signal arrived.
+// WithSignals returns a context cancelled by an interrupt, a channel closed by
+// a second one, and a function that stops listening.
 //
 // The contract at the command boundary: the first signal cancels the root
 // context so that in flight work rolls back and teardown runs. The second
-// forces exit with code 10 and the journal intact, because a user pressing
-// control C twice means "stop now", and the journal is what makes stopping now
-// safe.
-func WithSignals(ctx context.Context) (context.Context, func() bool, func()) {
+// closes the forced channel, which Run turns into an exit with code 10 and the
+// journal intact, because a user pressing control C twice means "stop now",
+// and the journal is what makes stopping now safe: everything was recorded
+// before it was made, so af down still knows what to remove.
+//
+// A channel rather than a function that reports whether a second signal has
+// arrived, because the caller has to be able to WAIT on it. A second interrupt
+// matters in exactly the case where the command it is trying to stop has not
+// noticed the first one, and a command that is not coming back is never going
+// to poll. The poll shape was the whole reason this went unwired: there was no
+// moment at which anything could usefully have called it.
+func WithSignals(ctx context.Context) (context.Context, <-chan struct{}, func()) {
 	ctx, cancel := context.WithCancel(ctx)
 	ch := make(chan os.Signal, 2)
 	signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
 
 	forced := make(chan struct{})
+	// Closed by stop, so that the watcher ends with the run rather than
+	// blocking for ever on a channel nothing will send to again. A goroutine
+	// per call that never returns is a leak in any process that sets up
+	// signals more than once, and a failure in any test of this package.
+	done := make(chan struct{})
 	go func() {
-		<-ch
-		cancel()
-		<-ch
-		close(forced)
+		select {
+		case <-ch:
+			cancel()
+		case <-done:
+			return
+		}
+		select {
+		case <-ch:
+			close(forced)
+		case <-done:
+		}
 	}()
 
-	second := func() bool {
-		select {
-		case <-forced:
-			return true
-		default:
-			return false
-		}
-	}
+	var once sync.Once
 	stop := func() {
-		signal.Stop(ch)
-		cancel()
+		once.Do(func() {
+			signal.Stop(ch)
+			close(done)
+			cancel()
+		})
 	}
-	return ctx, second, stop
+	return ctx, forced, stop
+}
+
+// Run executes the command line and returns the exit code, abandoning the
+// command if a second interrupt arrives first.
+//
+// This is where control C twice becomes an exit. Execute waits for the command
+// to return, and the command a user is trying to stop by pressing it twice is
+// by definition one that is not returning: a provider call with no deadline, a
+// pull of an image the size of a database, an agent mid step. So the wait
+// happens here, against the forced channel, and the exit code is produced out
+// from under a command that is still running.
+//
+// Abandoning it is safe for the one reason the journal exists: every resource
+// is written down before it is created, so nothing that was made is unknown to
+// af down, whether or not the command that made it got to finish. That is why
+// the second interrupt can be honoured at all rather than merely wished for.
+//
+// forced may be nil, which means a caller that does not handle signals, and
+// Run then behaves exactly as Execute does.
+func Run(ctx context.Context, forced <-chan struct{}, args []string, opts Options) int {
+	done := make(chan int, 1)
+	go func() { done <- Execute(ctx, args, opts) }()
+
+	select {
+	case code := <-done:
+		return code
+	case <-forced:
+		stderr := opts.Stderr
+		if stderr == nil {
+			stderr = os.Stderr
+		}
+		// Stderr, and not the Output renderer: the command being abandoned
+		// still holds stdout and may be part way through a document a script
+		// is parsing. Saying where the resources went is the whole value of
+		// being allowed to stop here, so it is said plainly.
+		_, _ = fmt.Fprintln(stderr, "af: stopped on the second interrupt. Anything already created is recorded in the journal; run 'af down' to remove it.")
+		return int(aferrors.ExitInterruptedDirty)
+	}
 }
 
 // setHelpRendering makes the help and usage pages fit the terminal.

--- a/engine/internal/cli/signals_test.go
+++ b/engine/internal/cli/signals_test.go
@@ -1,0 +1,104 @@
+package cli_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/internal/cli"
+	aferrors "github.com/antifailure/antifailure/engine/internal/errors"
+)
+
+// blockingCommand is a command that ignores its context, which is the only
+// command a second interrupt is for. A command that honours cancellation stops
+// on the first one and never reaches this path.
+func blockingCommand(started, release chan struct{}) cli.ExtraCommand {
+	return cli.ExtraCommand{
+		Use:   "blockforever",
+		Short: "Blocks until the test releases it.",
+		Run: func(_ context.Context, _ []string) int {
+			close(started)
+			<-release
+			return 0
+		},
+	}
+}
+
+// TestASecondInterruptForcesTheExitOutFromUnderARunningCommand is the whole
+// claim main makes about control C twice, end to end: a real signal, a real
+// command that is not going to stop, and the exit code the user gets anyway.
+func TestASecondInterruptForcesTheExitOutFromUnderARunningCommand(t *testing.T) {
+	// Absorb interrupts for the length of the test so that one arriving
+	// outside the window WithSignals is listening in cannot kill the test
+	// binary with the default action. Go delivers a signal to every channel
+	// registered for it, so this does not take anything away from the code
+	// under test.
+	guard := make(chan os.Signal, 8)
+	signal.Notify(guard, os.Interrupt)
+	defer signal.Stop(guard)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	defer close(release)
+
+	ctx, forced, stop := cli.WithSignals(context.Background())
+	defer stop()
+
+	var stdout, stderr bytes.Buffer
+	codes := make(chan int, 1)
+	go func() {
+		codes <- cli.Run(ctx, forced, []string{"blockforever"}, cli.Options{
+			Stdout:  &stdout,
+			Stderr:  &stderr,
+			WorkDir: t.TempDir(),
+			Extra:   []cli.ExtraCommand{blockingCommand(started, release)},
+		})
+	}()
+
+	<-started
+
+	// The first interrupt cancels the root context. Waiting for that before
+	// sending the second is what keeps the test honest: two kills in a row can
+	// be delivered as one, and a test that raced them would pass for the wrong
+	// reason.
+	require.NoError(t, syscall.Kill(os.Getpid(), syscall.SIGINT))
+	select {
+	case <-ctx.Done():
+	case <-time.After(10 * time.Second):
+		t.Fatal("the first interrupt did not cancel the root context")
+	}
+
+	require.NoError(t, syscall.Kill(os.Getpid(), syscall.SIGINT))
+	select {
+	case code := <-codes:
+		require.Equal(t, int(aferrors.ExitInterruptedDirty), code,
+			"a second interrupt has to exit 10, not wait for a command that is never coming back")
+	case <-time.After(10 * time.Second):
+		t.Fatal("the second interrupt did not force the exit; the command is still running and af is still waiting for it")
+	}
+
+	require.Contains(t, prose(stderr.String()), "journal",
+		"a forced exit has to say what was left behind and how to remove it")
+}
+
+// TestStopEndsTheWatcher covers the other half of the same machinery: a
+// command that finishes normally leaves nothing behind. goleak in TestMain is
+// what fails if it does.
+func TestStopEndsTheWatcher(t *testing.T) {
+	ctx, forced, stop := cli.WithSignals(context.Background())
+	require.NoError(t, ctx.Err())
+	select {
+	case <-forced:
+		t.Fatal("nothing was forced and the channel is closed")
+	default:
+	}
+	stop()
+	stop()
+	require.Error(t, ctx.Err(), "stop cancels the context it handed out")
+}

--- a/engine/internal/db/docker/docker.go
+++ b/engine/internal/db/docker/docker.go
@@ -350,9 +350,6 @@ func (p *Provider) ListGoldens(ctx context.Context) ([]provider.GoldenVersion, e
 			gv := provider.GoldenVersion{
 				ID: id, CreatedAt: time.Unix(img.Created, 0).UTC(),
 				SizeBytes: img.Size, ProviderRef: tag,
-				// A committed image only exists because verification passed;
-				// the commit is the last step of a refresh.
-				Verified:   true,
 				RulesHash:  img.Labels[dockerutil.LabelRules],
 				Provenance: img.Labels[dockerutil.LabelProvenance],
 			}
@@ -361,6 +358,24 @@ func (p *Provider) ListGoldens(ctx context.Context) ([]provider.GoldenVersion, e
 					gv.Attestation = string(decoded)
 				}
 			}
+			// Read from the attestation rather than assumed.
+			//
+			// This said Verified: true for every image, with a comment
+			// reasoning that a committed image only exists because
+			// verification passed. Half of that is true: a verification that
+			// fails never commits. The half that is not is that a refresh with
+			// no verifier at all commits too, and RefreshGolden records that
+			// honestly as Verified: false. Nothing read the honest value:
+			// pickGolden reads this path, so the false was overwritten with
+			// true on the way back in and an unverified golden was branched by
+			// af up exactly as if it had been checked.
+			//
+			// The attestation is the durable record, written as a label at
+			// commit time and only ever produced by a verifier that ran and
+			// returned. So no new label and no migration: a golden that was
+			// verified stays verified, and one that never was now says so and
+			// costs its owner the one refresh pickGolden's comment describes.
+			gv.Verified = gv.Attestation != ""
 			out = append(out, gv)
 		}
 	}

--- a/engine/internal/db/docker/metadata_test.go
+++ b/engine/internal/db/docker/metadata_test.go
@@ -97,3 +97,56 @@ func freePort(t *testing.T) int {
 	}
 	return port
 }
+
+// A golden nobody verified must not come back verified.
+//
+// The case nobody wrote, and the reason the overwrite survived: the round trip
+// above publishes a golden WITH a verifier and asserts Verified is true, which
+// an unconditional true satisfies perfectly. Only a refresh with no verifier
+// can tell an honest read from a hardcoded one.
+//
+// What it cost: RefreshGolden recorded Verified as spec.Verify != nil, a real
+// value, and ListGoldens reported true for every image regardless. pickGolden
+// reads the listing, so the recorded false was discarded by the read and af up
+// branched an unverified golden without a word.
+func TestAGoldenRefreshedWithoutAVerifierIsNotListedAsVerified(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipped in short mode: this needs a Docker daemon")
+	}
+	p, err := dockerdb.New(dockerdb.Options{Version: 17, Clock: clock.New(), PortFrom: freePort(t)})
+	if err != nil {
+		t.Skipf("skipped: no Docker daemon is reachable: %v", err)
+	}
+	defer func() { _ = p.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	gv, err := p.RefreshGolden(ctx, provider.GoldenSpec{
+		Version: 17, RulesHash: "noverify1234", Provenance: "gp1-no-verifier",
+		Mask: func(context.Context, secrets.Value) error { return nil },
+		// No Verify. Nothing checked this data, and every surface downstream
+		// has to keep saying so.
+	})
+	require.NoError(t, err)
+	defer func() {
+		c, cancel2 := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel2()
+		_ = p.DestroyGolden(c, gv.ID)
+	}()
+
+	require.False(t, gv.Verified, "the refresh knows no verifier ran")
+
+	listed, err := p.ListGoldens(ctx)
+	require.NoError(t, err)
+	var found *provider.GoldenVersion
+	for i := range listed {
+		if listed[i].ID == gv.ID {
+			found = &listed[i]
+		}
+	}
+	require.NotNil(t, found, "the golden that was just published is not listed")
+	require.False(t, found.Verified,
+		"ListGoldens reported an unverified golden as verified, so pickGolden will branch it and af up will say nothing")
+	require.Empty(t, found.Attestation, "there is no attestation because nothing verified it")
+}

--- a/engine/pkg/afcli/afcli.go
+++ b/engine/pkg/afcli/afcli.go
@@ -81,14 +81,20 @@ type Command struct {
 // The context carries whatever the caller attached to it, which is how an
 // enterprise build's licence status reaches a hook deep inside a command
 // without a licence argument threaded through every signature between them.
-func Run(ctx context.Context, args []string, opts Options) int {
+//
+// forced is the channel WithSignals returns, and passing it is what makes a
+// second control C mean "stop now" in a wrapping binary too. A wrapper is free
+// to pass nil, and then a second interrupt does nothing, which is a decision
+// rather than an accident: this argument exists because it was possible to
+// hold the channel and never ask, and both binaries did exactly that.
+func Run(ctx context.Context, forced <-chan struct{}, args []string, opts Options) int {
 	extra := make([]cli.ExtraCommand, 0, len(opts.Extra))
 	for _, c := range opts.Extra {
 		extra = append(extra, cli.ExtraCommand{
 			Use: c.Use, Short: c.Short, Long: c.Long, Run: c.Run,
 		})
 	}
-	return cli.Execute(ctx, args, cli.Options{
+	return cli.Run(ctx, forced, args, cli.Options{
 		Stdout:  opts.Stdout,
 		Stderr:  opts.Stderr,
 		Stdin:   opts.Stdin,
@@ -107,8 +113,9 @@ func Run(ctx context.Context, args []string, opts Options) int {
 // journal intact. A wrapper that handled signals its own way would be a wrapper
 // where control C means something different, which is worse than no wrapper.
 //
-// The second return value reports whether an interrupt has been seen. The third
-// stops handling and must be deferred.
-func WithSignals(ctx context.Context) (context.Context, func() bool, func()) {
+// The second return value is a channel closed by a second interrupt; pass it to
+// Run, which is what turns it into the exit. The third stops handling and must
+// be deferred.
+func WithSignals(ctx context.Context) (context.Context, <-chan struct{}, func()) {
 	return cli.WithSignals(ctx)
 }


### PR DESCRIPTION
Three defects with the same shape: a comment in the present tense describing behaviour that no line of code performs. Each passes review and the compiler, and is found by the person who needed it.

### Control C twice did nothing

`engine/cmd/af/main.go` and `ee/engine/cmd/af/main.go` both called `WithSignals` and threw away the return value that says a second signal arrived (`ctx, _, stop := ...`), under a paragraph promising the second interrupt forces an exit with the journal intact. `WithSignals` computed the answer, closed the channel, and nothing ever asked.

The poll shape was the reason it went unwired: a second interrupt matters exactly when the command is not coming back to ask anything. It is a channel now, and `cli.Run` waits on it, returning the exit code out from under a command that is still running. Stopping there is safe because every resource is journaled before it is created. `afcli.Run` takes the same channel, so the enterprise binary stops too. `stop` now also ends the watcher goroutine, which previously leaked per call.

Watched fail first: with `Run` still delegating straight to `Execute`, `TestASecondInterruptForcesTheExitOutFromUnderARunningCommand` fails at "the second interrupt did not force the exit; the command is still running and af is still waiting for it". It sends real `SIGINT`s at the test process, waits for the root context to cancel before sending the second so the two cannot be coalesced, and drives a command that deliberately ignores its context. Sabotaging the `close(forced)` path afterwards turns it red again.

### The sidecar recorded facts no surface could show

Seven fields `af-proxy` wrote on every request reached nothing a reader could see: `substituted`, `host_only`, `via`, `duration`, `seq`, and `waited_ms`/`limit`, which reached the table but not the JSON. `substituted` is the one that matters: it is the answer to the question the sandbox exists to answer, and a row that reached a real service and a row that reached a sandbox were the same row in `af net log -o json`.

The fix that keeps it fixed is two tests rather than a list. `TestEveryFactTheSidecarRecordsReachesASurface` diffs the json tags of the sidecar's `record`, `local.Decision` and `cli.DecisionJSON` and reports the whole class in one pass; its two exemption sets are where a deliberate decision not to carry a field is written down, and an exemption naming a field the sidecar no longer records fails too. `TestEveryKeyAfNetLogPublishesIsActuallyFilledIn` fills every decoded field and fails on any published key nothing assigns, which a tag diff alone cannot catch.

Watched fail first: on the tree before the fix it reported 13 gaps across 10 fields in one run. Removing `Substituted: d.Substituted` from the mapping afterwards turns both tests red.

### A golden nobody verified said it was

`RefreshGolden` records `Verified: spec.Verify != nil`, a real value. `ListGoldens` rebuilt every version with `Verified: true` unconditionally, reasoning that a committed image only exists because verification passed. Half true: a verification that fails never commits, but a refresh with no verifier commits too. `pickGolden` reads the listing, so the honest `false` was discarded by the read and `af up` branched an unverified golden in silence.

It reads the attestation label now. That label is written at commit time and only ever produced by a verifier that ran and returned, so it is the durable record the read was missing: no new label, no migration, a golden that was verified stays verified, and one that never was costs its owner the single refresh `pickGolden`'s own comment describes as the price of refusing.

The case that hid this had no test: the round trip test publishes a golden WITH a verifier and asserts `Verified` is true, which an unconditional true satisfies perfectly. `TestAGoldenRefreshedWithoutAVerifierIsNotListedAsVerified` is the only shape that can tell an honest read from a hardcoded one. It needs a Docker daemon and skips without one; see the caveat below.

### Not done

`af golden verify` still records its outcome nowhere. `VerifyGolden` branches, scans and returns a report, and a golden that fails re-verification stays exactly as branchable as before. Fixing the read was the half the overwrite made impossible; giving a failed re-verification somewhere durable to be written is a separate design question, since Docker image labels cannot be mutated in place. Not started.

The dead teardown machinery is `studio-land`'s, confirmed with them directly: it has never been on main and arrives with PR #84, so there was nothing here to remove. Untouched.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR