### PR TITLE
auth: a suspended organization could still mint a callback credential

### DIFF
--- a/.changes/a-suspended-organization-could-still-mint.md
+++ b/.changes/a-suspended-organization-could-still-mint.md
@@ -1,0 +1,15 @@
+# security
+
+A suspended organization could still be issued a callback credential.
+
+The suspension was read at `/v1/events` and nowhere else, so the control plane
+issued a working credential to an organization it had stopped and then refused
+the report that credential was minted for. Nothing crossed a tenant boundary
+and no events were accepted, which is why this went unnoticed: the outcome was
+correct and only the explanation was wrong. A customer saw the credential
+succeed and ingestion fail, and went looking at their continuous integration
+when the answer was their billing state.
+
+The refusal now happens where the credential is minted, and it names the
+suspension and the recorded reason. Checks that are already running are
+untouched, which is the same promise the kill switch makes everywhere else.

--- a/web/apps/api/src/github/lifecycle.ts
+++ b/web/apps/api/src/github/lifecycle.ts
@@ -31,6 +31,7 @@ import { randomBytes, createHash } from 'node:crypto'
 import { sql } from 'drizzle-orm'
 import type { Db, Pool } from '@antifailure/db'
 import type { Clock } from '../clock.ts'
+import { suspensionReason } from '../ingest.ts'
 import { GitHubApiError, GitHubPermissionError, type RepositoryApi } from './api.ts'
 import {
   CHECK_NAME,
@@ -1403,6 +1404,38 @@ export async function issueCallback(
   const token = randomBytes(32).toString('base64url')
   const hash = hashCallback(token)
   const now = deps.clock.now()
+
+  // A suspended organization is refused here, where the credential is minted,
+  // rather than only at /v1/events where it was already refused. A customer
+  // whose organization is stopped used to watch this call succeed and then
+  // watch ingestion fail, which points them at the reporting path instead of at
+  // their billing state.
+  //
+  // Its own read rather than a clause in the transaction below. That
+  // transaction is scoped to the GitHub account, and from that scope the
+  // organizations table is reachable only through the policy matching
+  // organizations.github_login against the account, so an organization whose
+  // installation sits on any other login reads back as zero rows: silence that
+  // is indistinguishable from "not suspended", on the one question being asked.
+  // suspensionReason runs under the tenant, where the ordinary policy covers it,
+  // and it is the same function /v1/events calls, so the two paths cannot drift
+  // apart on what counts as suspended.
+  //
+  // Missing repository is left to the transaction, which owns that sentence.
+  const owner = await deps.pool.withGitHubAccount(login, (db) =>
+    repositoryByName(db, claim.repository),
+  )
+  if (owner) {
+    const suspended = await suspensionReason(deps.pool, owner.org_id)
+    if (suspended !== null) {
+      return {
+        refused:
+          `This organization is suspended, so no credential is issued for ` +
+          `${shortSha(claim.headSha)}: ${suspended}. Checks that are already running are ` +
+          `untouched.`,
+      }
+    }
+  }
 
   const result: { refused: string } | { generationId: string } = await deps.pool.withGitHubAccount(
     login,

--- a/web/apps/api/test/prlifecycle.test.ts
+++ b/web/apps/api/test/prlifecycle.test.ts
@@ -1048,6 +1048,127 @@ describe(
       assert.equal(res.status, 409)
     })
 
+    // -----------------------------------------------------------------------
+    // A suspended organization
+    //
+    // The suspension was read at /v1/events and nowhere else, so a stopped
+    // organization was issued a working credential and refused only when it
+    // tried to use it. Nothing crossed a tenant boundary and nothing could be
+    // ingested, so this is noise rather than a breach, but it is the expensive
+    // kind of noise: the customer is shown a failure on the reporting path when
+    // the answer is their billing state, and that is where they go looking.
+    // -----------------------------------------------------------------------
+
+    it('a suspended organization is refused the credential rather than the report', async () => {
+      const head = sha('suspended-org')
+      await deliver('pull_request', pullRequestPayload('opened', 33, head))
+
+      await h.admin`
+        UPDATE organizations
+        SET suspended_at = now(), suspended_reason = 'unpaid invoice'
+        WHERE id = ${org.orgId}`
+      try {
+        const res = await h.fetch('/v1/pr/callback-token', {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            authorization: `Bearer ${identityToken({ repository, runId: 5021 }, h.clock.now())}`,
+          },
+          body: JSON.stringify({ head_sha: head }),
+        })
+        assert.equal(res.status, 409)
+        const body = (await res.json()) as { error: string }
+        // The message names the suspension AND its reason. "409" on its own
+        // sends the reader back to the check, which is where this defect used
+        // to send them.
+        assert.match(body.error, /suspended/i)
+        assert.match(body.error, /unpaid invoice/)
+        assert.doesNotMatch(body.error, /no check is waiting/)
+
+        // Nothing was minted. The refusal has to happen BEFORE the write, not
+        // beside it: a row carrying a callback hash is a credential that exists.
+        const [row] = await h.admin<{ callback_hash: Buffer | null; state: string }[]>`
+          SELECT g.callback_hash, g.state::text AS state
+          FROM pr_generations g JOIN pull_requests p ON p.id = g.pull_request_id
+          WHERE p.repository_id = ${org.repoId}::uuid AND g.head_sha = ${head}`
+        assert.ok(row, 'the generation the delivery created is missing')
+        assert.equal(row!.callback_hash, null)
+        assert.equal(row!.state, 'queued')
+      } finally {
+        await h.admin`
+          UPDATE organizations SET suspended_at = NULL, suspended_reason = NULL
+          WHERE id = ${org.orgId}`
+      }
+
+      // And the same call succeeds once the suspension lifts, which is what
+      // separates this from a check that refuses everybody.
+      const res = await h.fetch('/v1/pr/callback-token', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${identityToken({ repository, runId: 5022 }, h.clock.now())}`,
+        },
+        body: JSON.stringify({ head_sha: head }),
+      })
+      assert.equal(res.status, 200)
+      const issued = (await res.json()) as { token: string }
+      assert.ok(issued.token)
+    })
+
+    it('the suspension is read where the tenant is known, not where the account is', async () => {
+      // The same organization, reached through a SECOND installation whose
+      // account login is not the one on the organization row. An organization
+      // can hold more than one installation, which is why installationFor looks
+      // an installation up by owner rather than taking the organization's
+      // first.
+      //
+      // This is the case that separates a suspension read under the tenant from
+      // one read on the GitHub account connection. On that connection the
+      // organizations table is reachable only through the policy matching
+      // organizations.github_login against the account, so from here the row is
+      // invisible, and a check written there reads zero rows and lets the mint
+      // through. The refusal below is the correct scope working; a mint, or a
+      // refusal that talks about a missing check, is the wrong one.
+      const second = `second-${randomUUID().slice(0, 8)}`
+      const full = `${second}/app`
+      await h.admin`
+        INSERT INTO github_installations (org_id, installation_id, account_login, account_type)
+        VALUES (${org.orgId}, ${installationId + 1}, ${second}, 'Organization')`
+      await h.admin`INSERT INTO repositories (org_id, full_name) VALUES (${org.orgId}, ${full})`
+      await h.admin`
+        UPDATE organizations
+        SET suspended_at = now(), suspended_reason = 'an incident'
+        WHERE id = ${org.orgId}`
+      try {
+        const res = await h.fetch('/v1/pr/callback-token', {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            authorization: `Bearer ${identityToken(
+              { repository: full, runId: 5023 },
+              h.clock.now(),
+            )}`,
+          },
+          body: JSON.stringify({ head_sha: sha('second-account') }),
+        })
+        assert.equal(res.status, 409)
+        const body = (await res.json()) as { error: string }
+        assert.match(body.error, /suspended/i)
+        assert.match(body.error, /an incident/)
+        // The tell of the wrong scope. With no generation on this commit, an
+        // implementation whose suspension read came back empty falls straight
+        // through to the generation lookup and answers with this instead.
+        assert.doesNotMatch(body.error, /no check is waiting/)
+      } finally {
+        await h.admin`
+          UPDATE organizations SET suspended_at = NULL, suspended_reason = NULL
+          WHERE id = ${org.orgId}`
+        await h.admin`DELETE FROM repositories WHERE full_name = ${full}`
+        await h.admin`
+          DELETE FROM github_installations WHERE installation_id = ${installationId + 1}`
+      }
+    })
+
     function lifecycle() {
       return {
         pool: h.pool,


### PR DESCRIPTION
## The defect

`issueCallback` reads the generation, the fork approval and the repository, and never reads `organizations.suspended_at`. A suspended organization is issued a working callback credential and then refused at `/v1/events`, which is the one place the suspension IS checked.

Nothing crosses a tenant boundary and the organization cannot ingest, so this is noise rather than a breach. It is the expensive kind of noise: the customer watches the credential issue, watches ingestion fail with an unrelated error, and goes looking at the reporting path when the answer is their billing state.

## Where the read lives, which is the whole of the fix

The minting transaction runs on a connection scoped to the GitHub account. From that scope `organizations` is reachable only through `github_delivery_writes_org`, which matches `organizations.github_login` against the account. An organization holding an installation on any other login reads back as zero rows there, and zero rows is indistinguishable from "not suspended" on the one question being asked. `installationFor` already documents that an organization can hold more than one installation, so this is a shape the schema allows rather than a hypothetical.

So the read runs under the tenant, through `suspensionReason`, the same function `/v1/events` calls. The two paths cannot drift on what counts as suspended.

## The tests, and the breaks that were watched fail

Two, and the second is the one that earns its place.

- `a suspended organization is refused the credential rather than the report`
- `the suspension is read where the tenant is known, not where the account is`

**Break one**, removing ONLY the suspension read and leaving everything else: both new tests red, all 29 pre-existing tests green. The first reported `200 !== 409`, which is the credential being minted for a suspended organization. The second reported `no check is waiting on 003c888`.

**Break two**, moving the read onto the account connection and changing nothing else: 30 pass, 1 fail. The first test PASSES, because the fixture organization has `github_login` equal to its installation's `account_login` and cannot tell the two scopes apart. Only the second fails. That is why it exists: it reaches the same organization through a second installation on a different account login, where the wrong scope reads nothing and lets the mint through.

Each test lifts the suspension and retries, so neither passes for an implementation that refuses everybody.

## What was run

Against a native Postgres 17 on 55432. Docker is down on this machine (`docker info` exit 1), so the container recipe was unusable and a native server was used instead.

- `npx tsc --noEmit -p apps/api/tsconfig.json`: exit 0
- `test/prlifecycle.test.ts`: exit 0, 31 tests, 31 pass, 0 skipped
- full `apps/api` suite: exit 0, 970 tests, 959 pass, 0 fail, 11 skipped

All 11 skips are the backup and restore drill suites, each skipping with "no Docker daemon, so there is nowhere to stand up a database to restore into". None of them touches this change, and CI has a daemon.

## One thing found on the way, not fixed here

`deletion.test.ts` `two resumers arriving at once do not both do the same step` is flaky on this branch AND on unmodified `main`. Measured on a loaded machine: 5 runs of main's own code failed once, 3 runs with this change failed twice and passed once. Same assertion each time, `2 !== 1`, both resumers moving. It is schedule-sensitive rather than caused by anything here, and PR #95 is already aimed at it.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR
