### PR TITLE
admin: correct why BYPASSRLS was chosen, without touching the migration

### DIFF
--- a/.changes/an-operator-who-can-see-every-tenant.md
+++ b/.changes/an-operator-who-can-see-every-tenant.md
@@ -7,11 +7,14 @@ Answering "why did this account's run fail" has needed somebody who can look at
 another organization's rows. Nothing in the schema allowed that, so in practice
 it would have happened through a shared password at a psql prompt, where
 nothing is recorded. `antifailure_admin` is that access made explicit: a
-separate role with BYPASSRLS, which is the only mechanism that reads two
-tenants at once now that every table carries FORCE ROW LEVEL SECURITY. It reads
-widely and writes narrowly, to exactly the actions the portal offers, and it
-gets INSERT and SELECT on the audit log and never UPDATE, so an operator cannot
-rewrite the record of what operators did.
+separate role with BYPASSRLS. It reads widely and writes narrowly, to exactly
+the actions the portal offers, and it gets INSERT and SELECT on the audit log
+and never UPDATE, so an operator cannot rewrite the record of what operators
+did.
+
+A role rather than a policy because the cost of a policy scales with the number
+of tables, so it is a boundary somebody eventually forgets to extend, and the
+forgotten table is silently invisible rather than loudly broken.
 
 It is a role rather than a privilege on purpose. The application cannot be
 granted its way into it, because reaching it means opening a connection with a

--- a/web/packages/db/test/tenancy.test.ts
+++ b/web/packages/db/test/tenancy.test.ts
@@ -398,6 +398,22 @@ describe('cross-tenant isolation', { skip: hasDatabase ? false : 'no Postgres at
    * member of that role or opening a second connection with a password this
    * process is not given.
    *
+   * A correction, recorded here because the migration that carries it has
+   * already been applied and a migration's text cannot change afterwards: that
+   * file's own comment says BYPASSRLS is the only mechanism that reads two
+   * tenants at once. It is not. Policies are OR'd, so a permissive policy
+   * keyed on a credential the caller already holds widens just as effectively
+   * with no role privilege at all, and that alternative was built and shown to
+   * work before this one was chosen over it.
+   *
+   * BYPASSRLS was still the right choice, for two reasons that are not the one
+   * the file gives. A policy per table is a cost that scales with the number of
+   * tables, so it is a boundary somebody eventually forgets to extend, and the
+   * table they forget is silently invisible to the portal rather than loudly
+   * broken. And a role attribute is a credential rather than a privilege: the
+   * application cannot be granted its way into this one, where a policy keyed
+   * on a session hash is reachable by whoever can present that hash.
+   *
    * SET ROLE is the specific attack. It needs no password and no new
    * connection, so if antifailure_admin were ever granted to antifailure_app,
    * which is one careless GRANT away and would look tidy in a migration, then


### PR DESCRIPTION
PR #87 landed a claim that is false, and this corrects it. No behaviour changes; no migration is touched.

## The false claim

#87's migration comment and its changelog fragment both said BYPASSRLS is the only mechanism that reads two tenants at once now that every table carries `FORCE ROW LEVEL SECURITY`.

`admin-portal` disproved it with a passing test in which the ordinary `antifailure_app` pool, holding a live operator session, reads two tenants with FORCE RLS on and `row_security` untouched. Policies are OR'd, so a permissive policy keyed on a credential the caller already holds widens just as effectively, with no role privilege at all. That alternative was built and shown to work before BYPASSRLS was chosen over it.

## The conclusion survives, the reason did not

BYPASSRLS was still right, for two reasons that are not the one #87 gave:

- A policy per table is a cost that scales with the number of tables, so it is a boundary somebody eventually forgets to extend, and the table they forget is **silently invisible** to the portal rather than loudly broken.
- A role attribute is a **credential** rather than a privilege. The application cannot be granted its way into it, whereas a policy keyed on a session hash is reachable by whoever can present that hash.

## Why the migration file is not edited

This is the shape of the change and it is deliberate. `web/packages/db/src/migrate.ts` digests every migration file and **refuses outright** when an applied migration's text has changed:

> A migration that already ran cannot be edited: databases that ran the old text will never receive the new text. Add a new migration instead.

That refusal is correct, and it applies to a comment exactly as it applies to DDL, because the digest is over the whole body. #87 is merged, so editing `0023_the_operator_who_can_see_every_tenant.sql` would throw on every database that has already applied it, including CI's. I made that edit first, found the digest check, and reverted it.

So the correction goes where it can actually live:

- **The changelog fragment** is edited directly. It is still in `.changes/` and has not been rolled into a release, and it is the customer-facing text that carried the claim.
- **The migration's own text** is corrected in the doc comment of `the application role cannot become the admin role`, the test that enforces the property and the natural place a reviewer checks "is this really the only way". It says plainly that the migration overstates it and why that file cannot be changed.

## Verification

`web/packages/db`, full suite against a fresh native Postgres 17 cluster: **71 passing, 0 failing, exit 0**, `migration-order` included and green because main is contiguous at 0023. `tsc --noEmit` exit 0.

## Note on numbering, since three of us got it wrong

#87 merged carrying 0023 and main is contiguous 0001 to 0023. In flight I was told 0023, then 0028, then 0029, and I had actually renumbered to 0029 and pushed before discovering #87 had already merged. That commit is abandoned rather than merged forward: renumbering now would put a gap in main, which fails the contiguity gate exactly as hard as a collision. Branches still holding a 0023 need to move to 0024 and up, not this one.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR