### PR TITLE
mcp: a runtime skip cannot save a compile error

### DIFF
--- a/.changes/the-windows-lint-a-runtime-skip-could-not-save.md
+++ b/.changes/the-windows-lint-a-runtime-skip-could-not-save.md
@@ -1,0 +1,11 @@
+# fixed
+
+The cross platform lint refused `internal/mcp/paths_test.go` because
+`syscall.Mkfifo` does not exist on Windows. The test carried a
+`runtime.GOOS == "windows"` skip, which reads as though the platform had been
+handled and cannot help: the skip runs at run time and the missing symbol is a
+compile error, so the whole package failed to typecheck.
+
+The fifo test moves to `paths_fifo_unix_test.go` behind `//go:build !windows`,
+matching how the package already separates `open_unix.go` from
+`open_windows.go`. It still runs on every platform that has `mkfifo`.

--- a/engine/internal/mcp/paths_fifo_unix_test.go
+++ b/engine/internal/mcp/paths_fifo_unix_test.go
@@ -1,0 +1,34 @@
+//go:build !windows
+
+// The fifo test lives here because `syscall.Mkfifo` does not exist on Windows.
+// A `runtime.GOOS` skip cannot save it: the skip runs at run time and the
+// missing symbol is a COMPILE error, so the whole package failed to typecheck
+// on Windows while the test read as if the platform had been handled. The
+// package already separates platform code this way in open_unix.go and
+// open_windows.go, and a build tag is the only guard that acts early enough.
+
+package mcp
+
+import (
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveInRoot_RejectsAFifoWithoutHanging(t *testing.T) {
+	t.Parallel()
+	root, _ := checkout(t)
+
+	// A fifo with no writer blocks a blocking open forever. If this test ever
+	// hangs rather than failing, the nonblocking flag has been dropped and
+	// the server can be stalled indefinitely by one call.
+	fifo := filepath.Join(root, "pipe")
+	require.NoError(t, syscall.Mkfifo(fifo, 0o600))
+
+	_, fault := resolveInRoot(root, "pipe")
+	require.NotNil(t, fault)
+	require.Equal(t, FaultPathRejected, fault.Code)
+	require.Contains(t, fault.Detail, "regular file")
+}

--- a/engine/internal/mcp/paths_test.go
+++ b/engine/internal/mcp/paths_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -132,25 +131,6 @@ func TestResolveInRoot_RejectsADirectory(t *testing.T) {
 	root, _ := checkout(t)
 
 	_, fault := resolveInRoot(root, "migrations")
-	require.NotNil(t, fault)
-	require.Equal(t, FaultPathRejected, fault.Code)
-	require.Contains(t, fault.Detail, "regular file")
-}
-
-func TestResolveInRoot_RejectsAFifoWithoutHanging(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("no mkfifo on Windows")
-	}
-	t.Parallel()
-	root, _ := checkout(t)
-
-	// A fifo with no writer blocks a blocking open forever. If this test ever
-	// hangs rather than failing, the nonblocking flag has been dropped and
-	// the server can be stalled indefinitely by one call.
-	fifo := filepath.Join(root, "pipe")
-	require.NoError(t, syscall.Mkfifo(fifo, 0o600))
-
-	_, fault := resolveInRoot(root, "pipe")
 	require.NotNil(t, fault)
 	require.Equal(t, FaultPathRejected, fault.Code)
 	require.Contains(t, fault.Detail, "regular file")


### PR DESCRIPTION
Main is red on **The other platforms lint**: `internal/mcp/paths_test.go:151:29: undefined: syscall.Mkfifo (typecheck)`.

## Why the existing guard could not work

The test already carried this:

```go
if runtime.GOOS == "windows" {
    t.Skip("no mkfifo on Windows")
}
```

That reads as though Windows had been handled. It cannot help. **The skip runs at run time and the missing symbol is a compile error**, so the package failed to typecheck on Windows before any test could decide to skip itself.

## The fix

The fifo test moves to `paths_fifo_unix_test.go` behind `//go:build !windows`, which is the guard that acts early enough, and which is how this package already separates `open_unix.go` from `open_windows.go`. The now unreachable `runtime.GOOS` skip goes with it rather than being kept beside a build tag that already excludes the platform.

## Verified both directions

A build tag is the easiest way to silently switch a test off, so this was checked in both directions rather than only the failing one:

| check | result |
| --- | --- |
| `go vet ./internal/mcp/` | exit 0 |
| `GOOS=windows go vet ./internal/mcp/` | exit 0 |
| `GOOS=windows go build ./internal/...` | exit 0 |
| fifo test on unix | `--- PASS`, genuinely RUNS rather than skipping |
| `gofmt` | clean |

This is the second instance of this defect class tonight. The first was `syscall.Kill` in `internal/cli/signals_test.go`, fixed in #75. Both reached main through a job that is path triggered, so **main is not red until something unrelated happens to touch the right paths**, which is why this one arrived hours after the code did.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR