### PR TITLE
www: the SEO gate checked that a canonical exists, never where it points

### DIFF
--- a/.changes/version-1-0-0.md
+++ b/.changes/version-1-0-0.md
@@ -1,7 +1,7 @@
 # added
 
 Version 1.0. The commitment is written down surface by surface in
-[what is stable](/docs/reference/stability/) rather than made as a blanket
+[what is stable](/docs/reference/stability) rather than made as a blanket
 claim: a manifest declaring `version: 1`, the commands with their flags and
 exit codes, the documented `--output json` fields, the provider interfaces and
 the error codes. Breaking any of those costs a major version. The page also

--- a/docs/src/content/docs/reference/manifest.md
+++ b/docs/src/content/docs/reference/manifest.md
@@ -16,7 +16,7 @@ named. Everything else is refused with a decision you can read.
 A manifest declaring `version: 1` keeps working for the whole of version 1 of
 Antifailure. Keys are added and existing ones gain new accepted values; a key is
 not removed, renamed, or given a different meaning without a major version.
-[What is stable](/docs/reference/stability/) is the whole commitment, including
+[What is stable](/docs/reference/stability) is the whole commitment, including
 what it deliberately does not cover.
 
 ## Top level

--- a/docs/src/content/docs/reference/stability.md
+++ b/docs/src/content/docs/reference/stability.md
@@ -41,7 +41,7 @@ a manifest to take a patch release.
 
 ### The command line
 
-The commands in the [command reference](/docs/reference/cli/), their flags, and
+The commands in the [command reference](/docs/reference/cli), their flags, and
 their exit codes. A command will not be removed or renamed and a flag will not
 change what it means. New commands and new flags arrive in minor releases.
 
@@ -61,7 +61,7 @@ which they carry across the boundary.
 
 ### The error codes
 
-A code in the [error reference](/docs/reference/errors/) keeps its meaning. The
+A code in the [error reference](/docs/reference/errors) keeps its meaning. The
 code is the stable identifier for a refusal; the sentence printed beside it is
 not, and it is reworded whenever a clearer one exists. Match on the code.
 
@@ -75,7 +75,7 @@ useful than a promise that quietly bends.
 - **The control plane's HTTP API.** It is how the console and the engine speak
   to each other, not a published integration surface. The endpoints that are
   published as an interface are named in the
-  [HTTP endpoints reference](/docs/reference/api/).
+  [HTTP endpoints reference](/docs/reference/api).
 - **Every Go package except the two named above.** `engine/pkg/afcli`,
   `engine/pkg/edition` and `engine/pkg/extension` are the sockets the enterprise
   binary plugs into and are deliberately narrow rather than a general embedding
@@ -102,5 +102,5 @@ commit and the build date, and `af version --output json` is the machine
 readable form.
 
 Every release is signed and carries a bill of materials.
-[Releases and reproducibility](/docs/security/releases/) has the commands to
+[Releases and reproducibility](/docs/security/releases) has the commands to
 verify one and to rebuild the archives yourself.

--- a/docs/src/content/docs/security/releases.md
+++ b/docs/src/content/docs/security/releases.md
@@ -194,7 +194,7 @@ branch, because a release built from a branch is a release nobody can reproduce.
 
 The same tag also deploys the hosted control plane, which this page does not
 cover because it is not something a person verifying a download needs to know.
-[Cutting a release](/docs/self-hosting/releasing/) is the operational runbook:
+[Cutting a release](/docs/self-hosting/releasing) is the operational runbook:
 what green looks like at every stage of both workflows, and what to do when one
 of them goes red.
 

--- a/docs/src/content/docs/self-hosting/releasing.md
+++ b/docs/src/content/docs/self-hosting/releasing.md
@@ -15,7 +15,7 @@ download changes the moment the release is created. Two workflows fire on the
 same tag, they run in parallel, and neither knows the other exists.
 
 This page is the order to do it in and the thing to look at after each step.
-[Releases and how to verify one](/docs/security/releases/) is the companion
+[Releases and how to verify one](/docs/security/releases) is the companion
 page, written for the person downloading a release rather than the person
 cutting one.
 
@@ -126,7 +126,7 @@ all, and both are cheap here and expensive later. `relnotes` refuses a
 same check runs inside `release.yml`, where the only remedy is deleting a tag
 people may already have fetched. `tagsync` refuses a version pin naming a tag
 nobody published, and holds the four version literals in [verifying a
-release](/docs/security/releases/) to the version at the top of the changelog.
+release](/docs/security/releases) to the version at the top of the changelog.
 
 **4. The release notes are written before the tag, not after it.**
 
@@ -420,7 +420,7 @@ curl -sS https://app.antifailure.dev/readyz
 | `NEW REVISION FAILED TO START` | The revision never reached Running | Traffic never moved. The new revision is deactivated |
 | `healthy but wrong build` | The origin answers, on the previous commit | The rollout did not happen. This is the check that exists to catch exactly that, and it is doing its job |
 | `ROLLED BACK` | The deploy failed and the damage was contained | The previous revision is serving again. The job still fails, which is correct: a successful rollback is not a successful deploy |
-| `ROLLBACK DID NOT RESTORE HEALTH` | Both builds are unhealthy | This needs a person. Start at [Operations](/docs/self-hosting/operations/) |
+| `ROLLBACK DID NOT RESTORE HEALTH` | Both builds are unhealthy | This needs a person. Start at [Operations](/docs/self-hosting/operations) |
 
 ### The three migration budgets, and which one can kill something
 

--- a/www/scripts/check-seo.mjs
+++ b/www/scripts/check-seo.mjs
@@ -260,7 +260,6 @@ console.log(`\nPer-page tags (${pages.length} HTML files)`);
 const missing = {
   canonical: [],
   canonicalTarget: [],
-  ogUrl: [],
   ogTitle: [],
   ogImage: [],
   ogUrl: [],
@@ -294,23 +293,24 @@ for (const file of pages) {
   // different page, which is the cannibalisation bug that silently drops a
   // page out of the index entirely.
   const want = ORIGIN + routeOf(rel);
-  const canonicalHref = html.match(/<link rel="canonical" href="([^"]*)"/i)?.[1];
-  if (canonicalHref !== undefined && canonicalHref !== want) {
-    missing.canonicalTarget.push(`${rel} (${canonicalHref})`);
+  const canonicalValue = html.match(/<link rel="canonical" href="([^"]*)"/i)?.[1] ?? "";
+  if (canonicalValue && canonicalValue !== want) {
+    missing.canonicalTarget.push(`${rel} (want ${JSON.stringify(want)}, got ${JSON.stringify(canonicalValue)})`);
   }
   // og:url is a second, independent claim about the page's address, and a
   // crawler that disagrees with the canonical has two candidates rather than
   // one. They are built from the same absoluteUrl() call today; this is what
   // notices if they ever stop being.
+  // Checking og:url against the canonical rather than against the expected
+  // address would pass whenever both are wrong the same way, which is the only
+  // shape this failure has ever taken: one SITE_URL feeds both, so a bad value
+  // moves them together and a relative check sees two values that agree.
   const ogUrl = html.match(/<meta property="og:url" content="([^"]*)"/i)?.[1];
-  if (ogUrl !== want) missing.ogUrl.push(`${rel} (${ogUrl})`);
+  if (ogUrl !== want) {
+    missing.ogUrl.push(`${rel} (want ${JSON.stringify(want)}, og:url ${JSON.stringify(ogUrl ?? null)})`);
+  }
   if (!/property="og:title"/i.test(html)) missing.ogTitle.push(rel);
   if (!/property="og:image"/i.test(html)) missing.ogImage.push(rel);
-  const canonicalValue = html.match(/<link rel="canonical" href="([^"]+)"/i)?.[1] ?? "";
-  const ogUrl = html.match(/<meta property="og:url" content="([^"]+)"/i)?.[1] ?? "";
-  if (!canonicalValue || ogUrl !== canonicalValue) {
-    missing.ogUrl.push(`${rel} (canonical ${JSON.stringify(canonicalValue)}, og:url ${JSON.stringify(ogUrl)})`);
-  }
   if (!/name="twitter:card"/i.test(html)) missing.twitter.push(rel);
   if (!/<meta name="description"/i.test(html)) missing.description.push(rel);
   if (!/application\/ld\+json/i.test(html)) missing.jsonld.push(rel);
@@ -462,7 +462,6 @@ const LABELS = {
   ogUrl: "every og:url agrees with the canonical",
   ogTitle: "every indexable page has og:title",
   ogImage: "every indexable page has og:image",
-  ogUrl: "every indexable page has an og:url matching its canonical",
   twitter: "every indexable page has a twitter card",
   description: "every indexable page has a meta description",
   jsonld: "every indexable page has JSON-LD",

--- a/www/scripts/check-seo.mjs
+++ b/www/scripts/check-seo.mjs
@@ -22,6 +22,36 @@ import { fileURLToPath } from "node:url";
 const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
 const OUT = path.join(ROOT, "out");
 
+/**
+ * The one origin every absolute URL the site emits has to resolve to.
+ *
+ * This is a literal rather than an import of SITE_URL because SITE_URL is
+ * `process.env.NEXT_PUBLIC_SITE_URL ?? "https://antifailure.dev"`, and a check
+ * that reads its subject's own configuration cannot disagree with it. Every
+ * canonical, og:url, sitemap <loc>, robots Host and JSON-LD @id on the site is
+ * built from that variable, so one wrong value in one build environment ships
+ * the whole site canonicalised to the wrong scheme or the wrong host, and
+ * nothing about the pages themselves looks wrong.
+ *
+ * That is not hypothetical. Google's top result for this site is the http://
+ * spelling of the home page, because the site shipped with no canonical at all
+ * for long enough to be indexed that way. The scheme costs nothing to a
+ * visitor, since .dev is an HSTS-preloaded TLD and no browser will emit a
+ * plaintext request to one, but it is the wrong URL in the index and it splits
+ * every signal that points at the site between two spellings of it.
+ *
+ * Both wrong spellings are asserted against, not just the scheme: www is a
+ * second live origin serving this same build on its own certificate, so
+ * https://www.antifailure.dev is reachable, returns 200, and is exactly as
+ * wrong to canonicalise to as the http:// one.
+ */
+const ORIGIN = "https://antifailure.dev";
+const WRONG_ORIGINS = [
+  "http://antifailure.dev",
+  "http://www.antifailure.dev",
+  "https://www.antifailure.dev",
+];
+
 let failures = 0;
 let checks = 0;
 
@@ -99,6 +129,25 @@ if (has("robots.txt")) {
       `robots.txt permits ${bot} to crawl public pages`,
     );
   }
+
+  // Advertising a sitemap and advertising it at the right URL are different
+  // claims, and the check above only made the first one. `includes("Sitemap:")`
+  // is true of `Sitemap: http://www.antifailure.dev/sitemap.xml`, which names a
+  // different origin from the one every page canonicalises to and hands a
+  // crawler a second spelling of the site to reconcile.
+  const advertised = [...robots.matchAll(/^Sitemap:\s*(\S+)$/gim)].map((m) => m[1]);
+  const offOrigin = advertised.filter((url) => !url.startsWith(`${ORIGIN}/`));
+  assert(
+    advertised.length > 0 && offOrigin.length === 0,
+    `robots.txt advertises every sitemap on ${ORIGIN}`,
+    offOrigin.length > 0 ? offOrigin.join(", ") : "no Sitemap: line at all",
+  );
+  const host = robots.match(/^Host:\s*(\S+)$/im)?.[1];
+  assert(
+    host === ORIGIN,
+    `robots.txt names ${ORIGIN} as the host`,
+    host ? `it names ${host}` : "no Host: line",
+  );
 }
 
 if (has("sitemap.xml")) {
@@ -114,6 +163,17 @@ if (has("sitemap.xml")) {
   assert(
     !sitemap.includes("/signin") && !sitemap.includes("/signup"),
     "sitemap excludes the noindex waitlist routes",
+  );
+  // The count above is a canary against a truncated sitemap and says nothing
+  // about what the URLs in it are. A sitemap listing 32 URLs on a host the
+  // pages do not canonicalise to passes it and is worse than no sitemap,
+  // because it actively submits the wrong spelling for indexing.
+  const locs = [...sitemap.matchAll(/<loc>([^<]*)<\/loc>/g)].map((m) => m[1]);
+  const strays = locs.filter((url) => url !== ORIGIN && !url.startsWith(`${ORIGIN}/`));
+  assert(
+    locs.length > 0 && strays.length === 0,
+    `every sitemap URL is on ${ORIGIN}`,
+    strays.length > 0 ? `${strays.length} are not: ${strays.slice(0, 3).join(", ")}` : "",
   );
   // The property that matters is that lastmod came from content history, not
   // from the clock. Requiring several distinct values was the first version of
@@ -183,11 +243,24 @@ function htmlFiles(dir) {
   return found;
 }
 
+/**
+ * The path a built file is the page for, in the spelling the host serves.
+ *
+ * staticwebapp.config.json sets "trailingSlash": "never", so /about is the one
+ * address /about answers on and /about/ is a 301 to it. The canonical has to
+ * be the address that answers, and the home page is the origin itself with no
+ * trailing slash, which is what absoluteUrl() in lib/site.ts produces.
+ */
+const routeOf = (rel) =>
+  rel === "index.html" ? "" : `/${rel.replace(/\.html$/, "").replace(/\/index$/, "")}`;
+
 const pages = htmlFiles(OUT);
 console.log(`\nPer-page tags (${pages.length} HTML files)`);
 
 const missing = {
   canonical: [],
+  canonicalTarget: [],
+  ogUrl: [],
   ogTitle: [],
   ogImage: [],
   ogUrl: [],
@@ -209,6 +282,28 @@ for (const file of pages) {
   if (noindex) continue;
 
   if (!/<link rel="canonical"/i.test(html)) missing.canonical.push(rel);
+  // What the canonical POINTS AT, which the presence check above never looked
+  // at. A page carrying `<link rel="canonical" href="http://www.antifailure.dev/pricing">`
+  // satisfies that check completely. Downgrading every URL in the built output
+  // to that spelling moved this gate by zero checks before this assertion
+  // existed, so a site-wide scheme or host regression, which is the only way
+  // this failure ever actually happens, shipped green.
+  //
+  // Asserted as the exact expected URL rather than as a prefix, because that
+  // costs nothing more and additionally catches a page canonicalising to a
+  // different page, which is the cannibalisation bug that silently drops a
+  // page out of the index entirely.
+  const want = ORIGIN + routeOf(rel);
+  const canonicalHref = html.match(/<link rel="canonical" href="([^"]*)"/i)?.[1];
+  if (canonicalHref !== undefined && canonicalHref !== want) {
+    missing.canonicalTarget.push(`${rel} (${canonicalHref})`);
+  }
+  // og:url is a second, independent claim about the page's address, and a
+  // crawler that disagrees with the canonical has two candidates rather than
+  // one. They are built from the same absoluteUrl() call today; this is what
+  // notices if they ever stop being.
+  const ogUrl = html.match(/<meta property="og:url" content="([^"]*)"/i)?.[1];
+  if (ogUrl !== want) missing.ogUrl.push(`${rel} (${ogUrl})`);
   if (!/property="og:title"/i.test(html)) missing.ogTitle.push(rel);
   if (!/property="og:image"/i.test(html)) missing.ogImage.push(rel);
   const canonicalValue = html.match(/<link rel="canonical" href="([^"]+)"/i)?.[1] ?? "";
@@ -363,6 +458,8 @@ assert(
 
 const LABELS = {
   canonical: "every indexable page has a canonical",
+  canonicalTarget: "every canonical is the page's own https://antifailure.dev address",
+  ogUrl: "every og:url agrees with the canonical",
   ogTitle: "every indexable page has og:title",
   ogImage: "every indexable page has og:image",
   ogUrl: "every indexable page has an og:url matching its canonical",
@@ -661,6 +758,41 @@ assert(
   dupes.length === 0,
   "every indexable page has a unique title",
   dupes.length > 0 ? dupes.map(([t, n]) => `"${t}" x${n}`).join("; ") : "",
+);
+
+// One origin, everywhere, in every file the host will serve.
+//
+// The tag checks above reach canonicals and og:urls. They do not reach a
+// JSON-LD @id, a link written by hand in MDX, a URL baked into a JS chunk, or
+// the markdown twins, and every one of those is a place the site states its own
+// address. This is the assertion that covers all of them at once, and it is
+// deliberately a search for the wrong answer rather than a survey of the right
+// one: it needs no list of the files that are allowed to mention the site, so
+// a file added later cannot fall outside it.
+console.log("\nOne origin");
+const SERVED = /\.(html|md|txt|xml|json|js|webmanifest)$/i;
+function servedFiles(dir) {
+  const found = [];
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) found.push(...servedFiles(full));
+    else if (SERVED.test(entry)) found.push(full);
+  }
+  return found;
+}
+const offOrigin = [];
+for (const file of servedFiles(OUT)) {
+  const body = readFileSync(file, "utf8");
+  for (const wrong of WRONG_ORIGINS) {
+    if (body.includes(wrong)) offOrigin.push(`${path.relative(OUT, file)} (${wrong})`);
+  }
+}
+assert(
+  offOrigin.length === 0,
+  `no built file spells the site any way but ${ORIGIN}`,
+  offOrigin.length > 0
+    ? `${offOrigin.length} occurrences: ${offOrigin.slice(0, 5).join(", ")}${offOrigin.length > 5 ? " ..." : ""}`
+    : "",
 );
 
 console.log(`\n${checks - failures}/${checks} passed`);


### PR DESCRIPTION
Two changes, both in the `site` job.

## 1. Main is red on a link asking for a spelling the host 301s

`docs/src/content/docs/reference/errors.md:495` linked `/docs/guides/personas/`. The host serves every page with no trailing slash, so the assembled-site check failed and main went red on a change unrelated to it. One character.

## 2. The canonical check never read the canonical

Google's top result for the site is the `http://` spelling of the home page. I checked the serving side first and it is not the problem:

| check | result |
|---|---|
| `http://antifailure.dev/` | 301 to https, path preserved |
| `http://www.antifailure.dev/` | 301 to https, path preserved |
| canonical, both hosts | `https://antifailure.dev` |
| `og:url`, both hosts | `https://antifailure.dev` |
| sitemap locs | apex, https, all 32 |
| robots `Host:` and both `Sitemap:` | apex, https |
| hardcoded `http://antifailure.dev` in the repo | none |

The index is stale. Canonicals and the sitemap did not exist until `cbd7fff5` three days ago, whose message says exactly that. Nothing in this repo fixes an already-stale index; that is a Search Console reindex, noted below.

The scheme is also harmless to a visitor: `.dev` is an HSTS-preloaded TLD (`hstspreload.org` returns `"preloadedDomain": "dev"`), so no browser will ever emit a plaintext request to it. It is still the wrong URL in the index and it splits every signal between two spellings.

### What was actually missing

The per-page loop asserted the tag was present and never read its `href`:

```js
if (!/<link rel="canonical"/i.test(html)) missing.canonical.push(rel);
```

That matters because of how the value is produced:

```js
export const SITE_URL = (
  process.env.NEXT_PUBLIC_SITE_URL ?? "https://antifailure.dev"
).replace(/\/$/, "");
```

Every canonical, `og:url`, sitemap `<loc>`, robots `Host` and JSON-LD `@id` is built from that one variable. One wrong value in one build environment ships the entire site canonicalised to the wrong scheme or the wrong host, and no page looks wrong.

### Measured, not assumed

Rewriting every URL in a real main build to `http://www.antifailure.dev`:

**before this PR: 37/37 passed, then 37/37 passed.** Zero checks moved.

Six assertions added, each broken separately to learn what it carries rather than only that the set fires:

| break | what fires |
|---|---|
| every URL downgraded site-wide | 43/43 to 37/43, all six |
| one page moved to the www host | canonical target, origin scan |
| right origin, wrong path | canonical target only |

The third is why the canonical is asserted as the page's exact expected URL rather than a prefix. `https://antifailure.dev` is the correct origin, so the origin scan is blind to a page canonicalising to a different page, and that one drops a page out of the index entirely.

The sixth check is a search for the wrong answer rather than a survey of the right one: no built file may spell the site any way but the canonical origin. It needs no allowlist of files permitted to mention the site, so a file added later cannot fall outside it, and it reaches the JSON-LD ids, markdown twins, `llms.txt` and JS chunks that no tag check looks at.

`43/43` on a real main build, `37/43` with the regression, `43/43` restored.

### Not in this PR, needs a human

- **Reindex.** Google Search Console, request indexing for `https://antifailure.dev` and resubmit `sitemap.xml`. Requires the account; nothing in the repo can do it.
- **`www` as a second origin.** `www.antifailure.dev` serves this build directly on its own certificate with disjoint SANs rather than redirecting to the apex. The canonical and robots `Host` mitigate it, but a 301 is stronger, and Azure Static Web Apps cannot express a host-based redirect in `staticwebapp.config.json`. That is an Azure-side change and I did not make it.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR