### PR TITLE
www: the hero shader accepts a context the GPU is not rendering

### DIFF
--- a/.changes/a-shader-the-gpu-was-not-rendering.md
+++ b/.changes/a-shader-the-gpu-was-not-rendering.md
@@ -1,0 +1,22 @@
+# fixed
+
+The hero shader ran on the CPU on any machine whose GPU driver is blocklisted.
+
+The component guarded against WebGL being unavailable, and that guard is
+binary: the context is refused, or it works. A blocklisted driver is neither.
+The browser grants a context backed by a software rasteriser instead of
+refusing one, so `new Renderer` succeeds, nothing throws, and a full bleed
+fragment shader animates on the CPU for as long as the page is open. That is
+the normal state of a cheap or out of support Chromebook, and it was reported
+as the site crashing them.
+
+`failIfMajorPerformanceCaveat` is the context attribute that turns that third
+case back into the refusal the component already handles well, and ogl builds
+its own attribute object without forwarding it, so the question is now asked
+separately before the real context is built. A machine with a working GPU
+answers yes and loses nothing.
+
+The loop also never stopped. Frame throttling applies to a hidden tab, not to
+an element that has scrolled out of a visible one, so a reader who scrolled
+past the hero kept paying for the shader for the rest of the visit. It now runs
+only while the canvas is on screen in a tab somebody is looking at.

--- a/www/components/SoftAurora.tsx
+++ b/www/components/SoftAurora.tsx
@@ -165,6 +165,26 @@ type SoftAuroraProps = {
   className?: string;
 };
 
+/**
+ * Whether this machine can render WebGL on its GPU rather than on its CPU.
+ *
+ * Asked on a throwaway context that is discarded immediately, because the
+ * answer decides whether to build the real one at all.
+ */
+function hasAcceleratedWebGL(): boolean {
+  try {
+    const probe = document.createElement("canvas");
+    const gl =
+      probe.getContext("webgl2", { failIfMajorPerformanceCaveat: true }) ??
+      probe.getContext("webgl", { failIfMajorPerformanceCaveat: true });
+    if (!gl) return false;
+    (gl as WebGLRenderingContext).getExtension("WEBGL_lose_context")?.loseContext();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export default function SoftAurora({
   speed = 0.6,
   scale = 1.5,
@@ -200,9 +220,31 @@ export default function SoftAurora({
     // unguarded `new Renderer` turned the entire marketing page into Next's
     // stock "a client-side exception has occurred" for those visitors. This
     // is decoration behind a headline. It degrades to nothing.
+    //
+    // The guard above is binary, and the machines this decoration actually
+    // hurts are in neither of its two cases. When a GPU driver is blocklisted,
+    // which is the normal state of a cheap or out-of-support Chromebook, the
+    // browser does not refuse a context: it grants one backed by SwiftShader
+    // and renders this full-bleed fragment shader on the CPU, every frame,
+    // forever. `new Renderer` succeeds, nothing throws, and one core sits at
+    // 100% behind a headline until the tab is killed.
+    //
+    // failIfMajorPerformanceCaveat is the flag that turns that case back into
+    // the refusal this component already handles. ogl builds its own attribute
+    // object and does not forward the flag, so the question has to be asked
+    // separately, on a throwaway canvas, before the real context is created.
+    // A machine with a working GPU answers yes and loses nothing.
+    if (!hasAcceleratedWebGL()) return;
+
     let renderer: Renderer;
     try {
-      renderer = new Renderer({ alpha: true, premultipliedAlpha: false });
+      renderer = new Renderer({
+        alpha: true,
+        premultipliedAlpha: false,
+        // Forwarded to getContext by ogl. On a laptop with two GPUs this keeps
+        // decoration off the discrete one.
+        powerPreference: "low-power",
+      });
     } catch {
       return;
     }
@@ -292,19 +334,56 @@ export default function SoftAurora({
       renderer.render({ scene: mesh });
     }
 
+    // Nothing above ever stopped this loop. A visitor who scrolled past the
+    // hero and read the rest of the page kept paying for a full-bleed shader
+    // running behind them for the whole visit, and rAF throttling does not
+    // cover it: the browser throttles a hidden TAB, not an element that has
+    // scrolled out of a visible one. Both conditions are cheap to observe, so
+    // the loop now runs only while the canvas is actually on screen in a tab
+    // somebody is looking at.
+    const update = (time: number) => {
+      animationFrameId = requestAnimationFrame(update);
+      frame(time);
+    };
+
+    let onScreen = true;
+    function running() {
+      return onScreen && document.visibilityState === "visible";
+    }
+    function sync() {
+      if (reduced) return;
+      if (running() && animationFrameId === 0) {
+        animationFrameId = requestAnimationFrame(update);
+      } else if (!running() && animationFrameId !== 0) {
+        cancelAnimationFrame(animationFrameId);
+        animationFrameId = 0;
+      }
+    }
+
+    const io = new IntersectionObserver(
+      ([entry]) => {
+        onScreen = entry.isIntersecting;
+        sync();
+      },
+      // A little margin so it is already running by the time it scrolls back in
+      // rather than starting visibly stopped.
+      { rootMargin: "200px" },
+    );
+    io.observe(root);
+    document.addEventListener("visibilitychange", sync);
+
     if (reduced) {
+      // One frame, so the art is present and still.
       frame(0);
     } else {
-      const update = (time: number) => {
-        animationFrameId = requestAnimationFrame(update);
-        frame(time);
-      };
-      animationFrameId = requestAnimationFrame(update);
+      sync();
     }
 
     return () => {
       cancelAnimationFrame(animationFrameId);
       window.removeEventListener("resize", resize);
+      document.removeEventListener("visibilitychange", sync);
+      io.disconnect();
       ro.disconnect();
       if (enableMouseInteraction && !reduced) {
         host.removeEventListener("mousemove", handleMouseMove);


### PR DESCRIPTION
Reported as the site crashing school Chromebooks.

## Memory and CPU do not explain it

Measured first, so the obvious suspects are ruled out rather than assumed:

| | home | changelog (heaviest page on the site) |
|---|---|---|
| DOM nodes | 2,108 | 4,544 |
| JS heap | 24 MB | 47 MB |
| decoded HTML | 357 KB | 1,325 KB |
| long tasks | none | **none** |

Assets are lean: 1 MB of JS, 0.1 MB of CSS, AVIF/WebP throughout. No canvas outside the hero, no video, no workers, no infinite CSS animation. All 113 `color-mix()` declarations are `@supports`-guarded with real fallbacks, so old Chrome degrades rather than breaking. None of this crashes a Chromebook.

## What is actually on the home page

A full-bleed WebGL fragment shader animating behind the headline. The component already knew this was dangerous and guarded it, and the guard is binary:

```
new Renderer throws  ->  handled, degrades to nothing
new Renderer works   ->  animate
```

**A blocklisted GPU driver is a third case, and it is the normal state of a cheap or out-of-support Chromebook.** The browser does not refuse a context there. It grants one backed by SwiftShader and runs the shader **on the CPU, every frame, for as long as the page is open**. Nothing throws, the existing guard never fires, and one core sits at 100% behind a headline.

`failIfMajorPerformanceCaveat` is the context attribute that collapses that third case back into the first one the component already handles. ogl builds its attribute object from a fixed list (`alpha, depth, stencil, antialias, premultipliedAlpha, preserveDrawingBuffer, powerPreference`) and does not forward the flag, so the question is asked separately on a throwaway context before the real one is built. A machine with a working GPU answers yes and loses nothing.

## The loop also never stopped

rAF throttling covers a hidden **tab**, not an element scrolled out of a visible one. A visitor who scrolled past the hero and read the rest of the page kept paying for the shader for the whole visit. It now runs only while the canvas is on screen in a tab somebody is looking at.

## Verified

On a real GPU: typecheck and build clean, the guard does not reject an accelerated context, the aurora renders, and it is still there after scrolling to the bottom of the page and back.

## Not verified, and worth saying plainly

- **The animation itself could not be observed running.** This harness runs its tab backgrounded, so `document.visibilityState` is permanently `"hidden"` in it. That is also why three separate attempts to count frames read zero, including against the unmodified live site as a control. The zeros were the harness, not the code.
- **I could not reproduce the Chromebook.** The crash is diagnosed from the code path, not from a failing device. If it is convenient, `chrome://gpu` on one of the affected machines will say whether WebGL is hardware-accelerated or software; if it says SwiftShader, this is the cause.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR