### PR TITLE
security: the archive we upload never reaches CVE-2026-41567's branch

### DIFF
--- a/docs/security/pentest-readiness.md
+++ b/docs/security/pentest-readiness.md
@@ -169,15 +169,25 @@ so the copy-out direction does not exist here.
   container that has never started has no process, so the race has no second
   party.
 - **CVE-2026-41567**, `PUT /containers/{id}/archive` executing a container
-  binary on the host, is the one worth a tester's attention, because it names
-  the API call we make rather than one we do not. The residual exposure, stated
-  rather than argued away: a service container's image is built from the
-  repository under test, and the daemon belongs to the developer or the CI
-  runner. On a runner building a pull request from a fork, that image is
-  influenced by whoever opened it, and the party at risk is whoever runs that
-  daemon. It is not a path from one Antifailure user to another. The remedy is a
-  Docker Engine upgrade by the daemon's operator, which no change here can make
-  for them.
+  binary on the host, names the API call we make rather than one we do not, so
+  it gets the closest reading here. The daemon only shells out to a
+  decompression binary when the uploaded archive is compressed. The advisory
+  says so itself, and says ordinary `docker cp` is unaffected for exactly that
+  reason. Every archive this engine uploads to that endpoint is built by
+  `copyInto`, which writes an `archive/tar` stream and wraps it in nothing:
+  there is no gzip, zstd or xz under `internal/runtime` at all, and the other
+  `tar.NewWriter` call sites in the repository build image contexts for
+  `ImageBuild`, which is a different endpoint. Our request does not reach the
+  vulnerable branch.
+  That is an argument about the archives we send and it does not make the daemon
+  safe, so the exposure worth naming is still the daemon's. A service
+  container's image is built from the repository under test, and on a runner
+  building a pull request from a fork that image is influenced by whoever opened
+  it. Anything else with access to that daemon can upload a compressed archive
+  to such a container even though we never do. The party at risk is whoever runs
+  that daemon, it is not a path from one Antifailure user to another, and the
+  remedy is a Docker Engine upgrade by its operator, which no change here can
+  make for them.
 - **CVE-2026-33997**, the plugin privilege off-by-one, is accepted in
   `.govulncheck.yaml`. We install no plugin.
 


### PR DESCRIPTION
## What

One paragraph of `docs/security/pentest-readiness.md`. No code changes.

## Why

I audited the eight Dependabot alerts independently before touching anything. The repository's existing analysis in `SECURITY.md`, `docs/security/pentest-readiness.md` and `.govulncheck.yaml` is correct on every material point, and I confirmed each one from source rather than from the page:

- All eight are one dependency counted twice. `engine/go.mod` and `ee/engine/go.mod` both require `github.com/docker/docker` v28.5.1.
- There is no version to move to. Verified against proxy.golang.org: `github.com/docker/docker` and `github.com/moby/moby` both stop at v28.5.2. Docker 29.x exists upstream but is tagged `docker-v29.7.2`, which is not a resolvable Go module version, so the module path is frozen. The fixes are on `github.com/moby/moby/v2`, at a beta.
- Three of the four are symbol scoped in the Go vulnerability database, and every symbol is a method on `Daemon` in `docker/docker/daemon`. `go list -deps ./cmd/af` links `client`, the `api` package and twenty `api/types` packages, and no daemon package, so that code is not in the binary. The same holds for `ee`.
- The fourth carries no symbol information, which is why govulncheck flags it and why it has a written entry in `.govulncheck.yaml`. `just vuln` reports 2 reachable, 2 accepted, 0 unaccepted, 0 expired, 0 stale.

The one thing I found that the page did not use is a checkable precondition on the highest severity item, the one it singles out as worth a tester's attention.

## The finding

CVE-2026-41567 needs a **compressed** archive: the daemon only shells out to an external decompression binary in that case, and the advisory itself notes ordinary `docker cp` is unaffected for that reason. Every archive this engine sends to `PUT /containers/{id}/archive` is built by `copyInto`, which writes a plain `archive/tar` stream and wraps it in nothing. There is no gzip, zstd or xz under `internal/runtime`, and the other `tar.NewWriter` call sites build image contexts for `ImageBuild`, a different endpoint.

So our request does not reach the vulnerable branch. That is an argument about the archives we send and not about the daemon, so the residual exposure the page already named is kept rather than replaced.

## Verification

- `go run ./tools/prosecheck .` exit 0, 487 files, 0 findings
- `just spell` exit 0, 91 files, 0 issues
- `go run ./tools/vulncheck .` exit 0, 2 reachable, 2 accepted, 0 unaccepted, 0 expired, 0 stale

## What this does not do

It does not close the eight alerts. Nothing in a pull request can: Dependabot asks whether a vulnerable version is in the module graph, and it is, with no fixed version published for the path we import. Closing them is a dismissal decision on the security tab, not a code change, and I left that to a human.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR
