### PR TITLE
release: 1.0.0, the notes for the tree as it is, and an archive with the binary in it

### DIFF
--- a/.changes/a-release-archive-with-no-binary-in-it.md
+++ b/.changes/a-release-archive-with-no-binary-in-it.md
@@ -1,0 +1,31 @@
+# fixed
+
+`tools/release/build.sh` packaged a release archive with no `af` in it, and
+exited 0.
+
+Both callers pass the output directories relatively. `just build-release` and
+`.github/workflows/release.yml` each end in `dist stage`, resolved against the
+repository root. The script builds the binary from `$root/engine`, in a
+subshell, and handed the linker the same relative path, so `-o` resolved
+against `engine/` rather than against the directory the script had just made.
+The binary landed in `engine/stage/<name>/af`, the staged directory was
+archived without it, and the archive, its checksum and the script's exit code
+were all exactly what a working build produces. Four platforms of that is the
+whole release: `LICENSE`, `README.md` and the runner's source, and nothing to
+run.
+
+`tools/relpack` exists to assert what is inside the archive rather than to
+treat it as an opaque blob, and it could not see this, because it passed
+absolute paths. That is the one shape neither caller uses, and an absolute path
+makes the defect impossible. It builds from a directory inside the tree now,
+named relatively, the way both callers do. A temporary directory outside the
+tree does not reproduce it either: the relative path back out resolves to the
+same place from `engine/` as from the root whenever the two sit at the same
+depth below it, which on macOS they do, so the obvious version of this fix went
+on passing over the broken script.
+
+The script resolves both directories to absolute paths before anything uses
+them. `install.sh` would have refused the result rather than installing half of
+it, since it checks the archive for `af` before placing anything, so what a
+reader would have met is an installer that cannot install rather than a broken
+`af` on their PATH.

--- a/.changes/stale-token-after-accepting-permissions.md
+++ b/.changes/stale-token-after-accepting-permissions.md
@@ -14,12 +14,3 @@ token before it handles anything, for every action rather than for
 `new_permissions_accepted` alone: suspend, unsuspend and deleted each change
 what a token is worth, and dropping one that did not need dropping costs a
 single mint.
-
-**If you are following the release note that asks you to accept new App
-permissions and a check still fails immediately afterwards, and you are running
-a control plane older than this fix, the cause is the cached token rather than
-the grant. Wait for the hour to lapse or restart the control plane, and retry.**
-That sentence is here because the instruction to accept permissions and the fix
-for what happens next do not have to ship together, and a note that is only
-correct under a sequencing assumption goes wrong quietly. Delete it at tag time
-if both landed in the same release.

--- a/.gitignore
+++ b/.gitignore
@@ -243,3 +243,16 @@ examples/*/report.md
 # adopting Next's block is ever a deliberate choice.
 /www/AGENTS.md
 /www/CLAUDE.md
+
+# tools/relpack builds a real release archive to assert what is inside it, and
+# it has to do that from a directory inside the tree passed relatively, because
+# that is how `just build-release` and release.yml call the script and a path
+# outside the tree hides the bug the test exists for. TestMain removes it; this
+# line is for the run that is interrupted before it can.
+#
+# Unanchored, because the whole point of the test is that a broken script puts
+# the binary somewhere other than where it was told to. Anchored at the root
+# this missed engine/relpack-*/, which is exactly where the defect it watches
+# for lands a 60MB static binary, and the first `git add -A` after a run of the
+# negative control staged it.
+relpack-*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -527,8 +527,8 @@ it.
   There is no `af down --all`; the command that removes every environment on the
   machine is `af env prune --older-than 0`. The test that existed for exactly
   this class was green over all three, because its pattern only matched a
-  command at the start of a line and every one of the 127 remedies on the
-  generated errors reference sits in a sentence. It reads inline code spans now,
+  command at the start of a line and every remedy on the generated errors
+  reference sits in a sentence. It reads inline code spans now,
   and a third sweep parses the engine's own string constants through
   `go/parser`.
 - `ListGoldens` reported every golden as verified, including the ones that were
@@ -590,8 +590,8 @@ it.
   of two reloads in flight the older answer cannot overwrite the newer.
 - Every loading skeleton in the console was zero pixels wide on a phone. A
   percentage width inside a shrink to fit box has no basis to resolve against,
-  so all 22 bars in `TableSkeleton`, on seven pages, rendered as a stack of
-  empty boxes at 390px while measuring 54.8 to 168.2px at 1280px.
+  so every bar in `TableSkeleton`, on every page that uses it, rendered as a
+  stack of empty boxes at 390px while measuring 54.8 to 168.2px at 1280px.
 - Every route in the console had the same document title. All ten rendered
   `Antifailure` while their headings read Environments, Runs, Audit and the
   rest, so every tab, every history entry and every tab search result was the
@@ -665,15 +665,15 @@ it.
   the screen where somebody approves an egress rule.
 - Every documentation address the product prints or publishes names the URL the
   site actually serves rather than a spelling it answers with a 301. That
-  affected the `More` link under all 131 error codes, which is the address the
-  engine prints when something has already gone wrong for you, the 82
-  documentation pages' own canonical tags, and the 81 URLs in the sitemap.
-- The copy button on all 116 terminal code blocks in the documentation sat
-  outside the block, hanging off the bottom right corner over the paragraph
-  beneath and taking its tooltip with it. The install command on the quickstart
+  affected the `More` link under every error code, which is the address the
+  engine prints when something has already gone wrong for you, the documentation
+  pages' own canonical tags, and every URL in the sitemap.
+- The copy button on every terminal code block in the documentation sat outside
+  the block, hanging off the bottom right corner over the paragraph beneath and
+  taking its tooltip with it. The install command on the quickstart
   was the first one anybody saw.
 - Every h2 in the documentation pushed its anchor link onto a line of its own,
-  67px below the heading, on all 81 pages. Cascade layers are why the override
+  67px below the heading, on every page. Cascade layers are why the override
   that caused it was silent: Starlight ships its CSS in a layer and this site's
   stylesheet is unlayered, so a plain selector beats a layered rule whatever its
   specificity and reading the diff gives the wrong answer.
@@ -689,7 +689,7 @@ it.
   the art behind the headline ended in a torn horizontal edge lying across body
   text, and every section heading was sliced in half by a rail pinned at the
   wrong offset. No page on the site scrolls horizontally at any width now,
-  checked across all 35 exported routes at ten widths against the static export
+  checked across every exported route at ten widths against the static export
   rather than against the development server, which serves none of the hero art
   and would have measured a torn edge as clean.
 - The assistant panel on the home page was a drawing of an application that a
@@ -698,8 +698,8 @@ it.
   7px. The parts that only depicted an assistant are drawn rather than operated
   now, and what stays interactive is the part that is a real demonstration.
 - Every interactive target in the footer measures at least 44 by 44 at every
-  width, and on a desktop the footer renders as it did before. The twenty eight
-  navigation links could not take the treatment the other targets took, because
+  width, and on a desktop the footer renders as it did before. Its navigation
+  links could not take the treatment the other targets took, because
   they sit flush and each 44px box would have overlapped its neighbour by 15px
   with the later sibling painting on top, which a screenshot would not show and
   a measurement would have called a pass. The rhythm grows under a coarse

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -733,6 +733,18 @@ it.
 
 ### Security
 
+- The release archive had no `af` in it. Both callers of
+  `tools/release/build.sh` pass the output directories relatively and the
+  script builds the binary from `engine/`, in a subshell, so the linker's `-o`
+  resolved against `engine/` rather than against the directory the script had
+  just made. The binary landed outside the staged tree, the archive was
+  assembled without it, and the archive, its checksum and the exit code were
+  all exactly what a working build produces. `tools/relpack` exists to assert
+  what is inside the archive and could not see it, because it passed absolute
+  paths, which is the one shape neither caller uses and the one shape that
+  makes the defect impossible. It builds from inside the tree with a relative
+  path now, and was watched failing on the unfixed script before it was
+  believed.
 - Release archives are reproducible and proven to be. Two builds of one commit
   produced four different archives every time, because `tar` takes each entry's
   timestamp from the filesystem and `gzip` writes another into its own header.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,79 @@ manifest or pipeline does.
 - The documentation now runs the control plane image as
   `ghcr.io/antifailure/control-plane:latest` rather than naming a version. The
   tag is moved by the push of a `v*` tag and never by a build off `main`.
+- A run in which no workflow reached a verdict about the application exits `9`
+  rather than `0`. A real failure still exits `8`, so a pipeline reading the
+  number can tell "your change broke something" from "nothing was tested". Both
+  of this repository's own answers were the old shape: the control plane's check
+  reported that six workflows could not be carried through and went green every
+  time. A project with no workflows yet can set `policy.workflows_unverified` to
+  `warn` and have that choice recorded in its manifest rather than assumed from
+  silence.
+- `github.fork_policy` refuses something for the first time. It was validated,
+  defaulted, printed by `af explain` and read by nothing, so `af up` on a fork's
+  pull request went to the Docker daemon under a default whose own description
+  says a maintainer has to add a label first. `af ci`, `af up`, `af test` and
+  `af load run` now refuse with `AF-GH-003`, before an environment is named and
+  before the daemon is touched. The setting is read from the base branch rather
+  than from the checkout, because on a fork's pull request the checked out
+  manifest is the fork's own copy. `github.comment: false` is consulted too,
+  where turning comments off used to leave them on, and the example workflow
+  subscribes to `labeled`, because adding the label is an event.
+- A misspelt value in the `github` block is now an error. `fork_policy: nevr`,
+  `mode: sideways` and `teardown_on: [closed, merged]` all loaded without a
+  word, and everything downstream reads an unrecognised fork policy as `label`,
+  so a typo in a security control chose the weaker behaviour silently.
+- `load.safe_routes` and `load.unsafe_routes` entries carrying an HTTP method
+  match what they were written to match. Normalisation turned `DELETE /*` into
+  `/DELETE /*`, so every example in the load documentation was inert. A safe
+  list failing that way is loud, because a run that may send nothing refuses
+  everything; an unsafe list failing that way is silent, so a manifest with
+  `unsafe_routes: ["DELETE /**"]` was sending the deletes its author wrote that
+  entry to prevent. A run whose unsafe list now matches will send less traffic
+  than it did.
+- The documented `safe_routes` and `unsafe_routes` examples use `**` rather than
+  `*`. A single star covers exactly one path segment, so `DELETE /*` never
+  covered `DELETE /orders/42`, and a delete almost always carries an id. The
+  matcher itself is unchanged, because making a single star span segments would
+  change what every deployed manifest already means.
+- `af ci --load` enforces `load.error_rate`. It read both thresholds out of the
+  manifest and passed one of them on, and `Breaches` builds no error rate breach
+  from a zero limit, so a change that failed 100 percent of requests under load
+  merged green while `af load run` on the same manifest exited non zero. `af ci`
+  also says now when a p95 threshold was in force and no route had a baseline to
+  compare against, and how many routes the safe list withheld.
+- A workflow that touched a response invented by a model reports `unverified`
+  rather than `passed`. The promise was made in five places, including the
+  product page, and was kept nowhere: the sidecar wrote `synthesized` on the
+  decision, `local.Decision` had no field for it, and the runner's
+  `synthesized-response` cause had a mapping, a test and no producer. A
+  synthesized call is made by the application and never appears in anything a
+  browser can see, so the verdict is decided in the engine now. A failure is
+  never downgraded.
+- `af oracle -o json` wrote the comparison to a file called `json`, and
+  `af support bundle -o json` wrote a zip archive to one. Each declared a local
+  `--output` with an `-o` shorthand, which silently wins over the persistent
+  flag that means text or json everywhere else, so the JSON branch both commands
+  carried was unreachable. The local flags are `af oracle --report` and
+  `af support bundle --archive` now, and neither takes a shorthand.
+- A golden records the project it was made for, and an environment branches only
+  a golden whose record matches its own. Expect one golden refresh per project
+  the first time a command runs after upgrading, because no existing golden
+  carries the record.
+- `af workload` is hidden from `af --help`. It is what a hosted control plane
+  calls on your behalf; the commands a person runs are `af load run`,
+  `af load scenario`, `af test` and `af explore`. Its flags are documented under
+  Workloads instead.
+- The dispatch workflow template calls `af workload run` rather than assembling
+  flags in a shell case statement, and its `command` input keeps its verbs. `up`,
+  `down`, `agents` and `load` work on an older copy of the file; `scenario` and
+  `explore` need this one. An input the case statement had no flag for used to
+  be dropped without a word and is now refused by name.
+- An exploration run through `af workload run --kind exploration` no longer
+  fails the job when a goal is not reached. `docs/concepts/exploration` has
+  always promised that an exploration cannot fail your build, and the promise
+  held for `af explore` and broke for the path the console drives. A run that
+  measured nothing at all is still blocked and still exits non zero.
 
 ### Added
 
@@ -181,7 +254,11 @@ first is in flight, and assertions over what came back. `load.source: otel` read
 the traffic mix out of an OpenTelemetry trace export on disk, and because a span
 carries a duration the shape arrives with production's own p95 per route, which
 is the baseline `p95_increase` compares against and which nothing could provide
-before.
+before. A scenario assertion reports what it measured as well as what it
+concluded: `af load scenario -o json` carries `measure`, `scope`, `threshold`
+and `observed` on every assertion result, because a dashboard cannot chart
+"served a p95 of 240ms, over 200ms" without parsing English. An assertion whose
+requests were never sent reports no observation at all rather than zero.
 
 **A `warn` verdict.** A run can come back with a real finding about the change
 that does not fail the check. A new `policy` block decides which class of
@@ -192,6 +269,73 @@ it exits zero, and it never counts against the change.
 **Cost control.** An environment now has a lifetime, and `af env reap` destroys
 the ones that have outlived it. It refuses to pull an environment out from under
 a run that is using it.
+
+**On a pull request.** Antifailure runs on a pull request and reports there
+itself. One check run per commit, named `Antifailure`, so a branch protection
+rule can require it, and the name is stable on purpose because changing it would
+silently un-require the check on every repository that named it. Seven states,
+and blocked and unverified are not passes: GitHub's `neutral` conclusion reads as
+nothing to say and lets a required check pass, so a pull request whose agents
+never ran would have merged behind a green tick. One comment per pull request,
+edited in place, whose first line carries the commit it is about, because a
+stale result the reader cannot detect is worse than no result. There is no
+repository secret to paste: the job proves who it is with a GitHub Actions
+workflow identity token and exchanges it for a credential scoped to one commit
+and one run, expiring within the hour. A fork's commit gets no credential until
+a maintainer adds the `antifailure:allow` label, and the next push withdraws it,
+because the maintainer approved code they read. The whole surface is fenced
+against the orderings GitHub does not promise: the run event arriving before the
+pull request event, a job reporting before its check exists, a push during a
+run, a close during a run, a reopen during a teardown, and the same delivery
+twice.
+
+**A coding agent can rehearse a change and cannot soften one.** `af mcp` serves
+four tools over the Model Context Protocol: rehearse this branch's pending
+migrations against a throwaway branch of a sanitized copy of production, inspect
+what the environment is allowed to reach and what it actually reached, and read
+or cancel a run that is still going. It is a thin frontend over the same
+orchestrator `af ci` and `af insights` drive, so a tool call and a pull request
+check cannot disagree about the same change. The division of authority is a
+property of the schemas rather than a request: no tool takes an argument that
+disables sanitization, widens the egress policy, lowers a threshold, names a
+database or skips the rehearsal, and a field no schema declares is refused
+rather than ignored. Verdicts are PASS, FAIL and INCONCLUSIVE, and INCONCLUSIVE
+is never a quieter PASS. Statement text never reaches a result, because the
+candidate branch is input written by whoever opened the pull request.
+
+**Hosted workloads.** `af workload` runs a hosted workload definition through the
+command that names it: an observed load mix through `af load run`, an HTTP
+scenario through `af load scenario`, a browser workflow through `af test`, and an
+exploration through `af explore`. Every result carries the plain command that
+reproduces it, and a knob the plain command has no flag for is refused rather
+than dropped, because honouring it would be a promise the run cannot keep. A
+hosted run now claims itself, says when it started, says once a minute that it is
+still going, and reports what it measured, where before this the engine emitted
+nothing and a run started from the console was recorded as abandoned at its
+deadline whatever it actually did. A cancel pressed in the console reaches a run
+that is already going and stops it, arriving on the heartbeat the engine is
+already making rather than on a poll of its own. `af workload teardown` says what
+was actually removed and what is still standing, `af workload promote` compiles
+an exploration into a workflow definition and lists what the compilation could
+not carry over, and `af workload compare` differences two results of the same
+kind and states what it cannot control.
+
+**`af start`.** Says where you are on the first run and names the one command
+that moves you forward. The first run is nine commands long, any of them can be
+interrupted, and coming back used to mean reconstructing the state from memory:
+`af init` refuses a repository that already has a manifest, `af up` on a running
+environment is a no-op nobody recognises as one, and neither says where you
+actually are. It derives every answer from the machine rather than from a record
+of what it last did, so tearing an environment down by hand or switching
+branches moves the answer with you, and it runs nothing and writes nothing,
+which is the only way it can be honest. Each step reports one of four states and
+never collapses one into another: done, not yet, blocked, and not checked.
+
+**`af ci --report-json`.** The same run written as JSON, for something that has
+to act on the report rather than display it. `--report` stays Markdown for a
+person, and `-o json` is not that flag: it is the whole terminal's format, so a
+continuous integration step showing progress to somebody watching the job would
+have had to give up one or the other.
 
 **Hosted control plane.** Billing through Stripe: customers, subscriptions,
 invoices, a checkout session, the customer portal, and the webhook that moves
@@ -210,8 +354,69 @@ nobody inside the organization can act, writing an audit entry carrying the
 reason and refusing to leave an organization with no owner. The first member of
 an organization becomes its owner when GitHub confirms they administer it.
 
+**Running an organization without emailing anybody.** Settings holds the display
+name, the billing contact that decides where invoices go, every live session
+with a way to sign any of them out, a complete copy of everything this control
+plane holds, and the way to delete the organization. Members gains invitations,
+so a finance person or a contractor who is not in your GitHub organization can
+join through a link. Deleting an organization is a state machine rather than a
+cascade and runs in one order: what is running is torn down and nothing new can
+be started, the Stripe subscription is cancelled at the end of the period you
+have paid for, nothing else happens until that period ends, credentials and the
+GitHub App installation are revoked, a complete export is produced and you are
+given a link to it, and only then is anything deleted. Every step is recorded as
+it happens, so a deletion that is interrupted picks up where it stopped, and it
+can be called off at any point before it finishes. Closing your own account
+erases your name, address, identity and avatar, removes your memberships and
+signs you out everywhere. It is called closing rather than deleting because the
+audit log is a hash chain and keeps what you did under the name you had at the
+time. Five new permissions carry all of it, and `account.close` belongs to every
+role, because leaving is about you rather than about the organization.
+
+**A plan gate, for a hosted service that needs one.**
+`AF_HOSTED_REQUIRED_PLAN=enterprise` refuses every operational procedure until
+Stripe grants that plan. It is unset everywhere except Antifailure's own hosted
+service, so self hosting is unchanged, and setting it while billing is off stops
+the process at startup rather than serving a deployment that refuses every
+request and offers no way to pay. The exits are the part worth stating plainly:
+a lapsed plan still permits billing, exporting the organization's data, deleting
+the organization, closing an account, and listing and revoking sessions. That
+last one is a security action rather than a convenience, because a credential
+can leak while a subscription has lapsed and a paywall in front of session
+revocation would leave somebody unable to contain it.
+
+**An operator who can see every tenant, and the wall that keeps the application
+out of it.** Answering "why did this account's run fail" has needed somebody who
+can look at another organization's rows, and nothing in the schema allowed it,
+so in practice it would have happened through a shared password at a psql
+prompt where nothing is recorded. `antifailure_admin` is that access made
+explicit: a separate database role with BYPASSRLS that reads widely and writes
+narrowly, holding INSERT and SELECT on the audit log and never UPDATE, so an
+operator cannot rewrite the record of what operators did. The application cannot
+be granted its way in, because reaching the role means opening a connection with
+a password the application process is not given, and a test asserts that nothing
+has been granted membership and that SET ROLE into it is refused. Impersonation
+is recorded on the session row, where the code that resolves a session on every
+request cannot miss it, and a check constraint makes the rules structural: the
+four columns are all or nothing, a blank reason is not a reason, and the row
+must carry the sequence number of the audit entry that authorised it, so an
+impersonated session that was never audited cannot be represented at all.
+Support notes are not tenant data, and the application role holds no grant on
+that table.
+
 **Operations.** A status page checked from GitHub Actions rather than from the
-control plane, so an outage cannot silence the page reporting it. A disaster
+control plane, so an outage cannot silence the page reporting it. It watches
+seven components across production, the public site and staging, each one its
+own line because each one has its own way of failing while its neighbours are
+fine, and every static check asserts a marker in the body as well as the 200,
+because each of the failures this project has actually had would have read as
+healthy to a check that looked only at the status line. Every figure is computed
+from the record: a percentage is described as the share of checks that passed
+rather than as uptime, a ninety day figure is only called that once the record
+reaches back ninety days, and a day with no readings is drawn in the neutral and
+never counted as a day that was up. No state reaches a reader as colour alone.
+Subscribe is an Atom feed generated from the same data, because a button that
+did nothing would have been worse than no button. A disaster
 recovery drill on a weekly schedule that reports the recovery time it measured
 and holds it against a budget. Eleven Azure Monitor rules and an action group
 where there were none, each naming its runbook in the notification it sends. An
@@ -223,7 +428,38 @@ documents a security review asks for by name: a data processing agreement, the
 subprocessor list, a statement that there is no service level agreement, and
 retention and deletion commitments. Every subprocessor was established by
 reading the code that talks to the vendor. No lawyer has read any of it and
-every page says so on its face.
+every page says so on its face. About and Contact are built on the same page
+components as the other company pages. Contact names only routes that were
+checked against the live repository: private vulnerability reporting, the issue
+chooser, Discussions, and the waitlist. There is no postal address, no telephone
+number and no email, because the domain has no mail exchanger and its SPF policy
+authorizes no sender, so an email route on the page would be a channel that
+silently swallowed whatever was sent to it.
+
+**Published machine readable artifacts.** `https://antifailure.dev/openapi.json`
+and `https://antifailure.dev/errors.v1.json` are served at the apex, so an agent
+that guesses at either address finds it. The OpenAPI document is generated from
+the router, validated before it can be committed and pinned to the revision that
+built it, rather than proxied from the production control plane at request time:
+the site deploys on every push to main and the hosted control plane moves on a
+release promotion, so a proxy would have served the pre-promotion document while
+the site's own documentation described the new one. The deploy checks both
+documents byte for byte against what the run built, because a stale document is
+a perfectly healthy 200.
+
+**A published changelog.** `https://antifailure.dev/changelog`, built from the
+entries in `.changes/` that this repository has been writing since its first
+week and that nothing had ever rendered. The entries marked internal stay in the
+repository and are never published: they are real changes with nothing a user of
+Antifailure could observe, and a changelog full of them teaches a reader that
+the changelog is not about them. A date is the day an entry landed on the main
+branch, read from the commit that brought it there rather than typed, and
+nothing is backfilled, so `v0.1.0` and `v0.1.1` carry no entries and the page
+says why rather than filling them in with work that plausibly shipped in them.
+A change to anything a user can see is refused by CI unless it says what
+changed, with a `Changelog-None:` trailer carrying a reason for the genuine
+exception, which leaves the reason in the history where the next person finds
+it.
 
 ### Fixed
 
@@ -259,6 +495,241 @@ every page says so on its face.
 - Documentation code blocks were painted at 1.12:1 against the page and had
   neither a visible surface nor a visible edge. Every control on a phone is now
   at least 44px and no page scrolls sideways at 375px.
+- `af explore` could not produce a report on any machine. The engine marshals
+  the runner's job document from Go, where a nil slice becomes `null`, and the
+  exploration path never sets `workflows`, so the runner read
+  `doc.workflows.length` before it looked at the goals and every run exited
+  `AF-AGT-003` with a TypeError and no output. Nothing anywhere drove the
+  runner's entry point: both halves had green suites and the document between
+  them was never sent by a test.
+- Pressing control C twice did nothing. Both binaries called `WithSignals`,
+  whose comment said in the present tense that a second interrupt forces an exit
+  with the journal intact, and both discarded the return value that said one had
+  arrived. `cli.Run` waits on it now, and stopping there is safe because every
+  resource is journaled before it is created, so `af down` still knows what to
+  remove.
+- `af init` wrote a header saying every value came from a file, and directly
+  beneath it two personas and a `sign-up` workflow that came from nothing. The
+  guesses are disclosed where they appear now, and the disclosure is seeded from
+  what the draft holds before any question is asked, so a value nothing asked
+  about can still be disclosed. They are still written, because nothing in a
+  repository proves the absence of authentication and dropping them would trade
+  a loud failure for a silent wrong answer.
+- The refusal a new user is most likely to meet carried no code. `af test` on a
+  freshly initialised repository stopped with "no users table could be found, so
+  there is nowhere to create a persona", with no `AF-` number, no next step and
+  no link, one command after a refusal that has all three. It is `AF-DB-022`
+  now, and it names all three ways out rather than two. A persona whose `login`
+  is `none` no longer requires a users table at all, which is why
+  `examples/go-api` could not be run until now.
+- Three error remedies named a command that does not exist, and the most durable
+  of them was written to a file on disk by `af init` rather than printed once.
+  There is no `af down --all`; the command that removes every environment on the
+  machine is `af env prune --older-than 0`. The test that existed for exactly
+  this class was green over all three, because its pattern only matched a
+  command at the start of a line and every one of the 127 remedies on the
+  generated errors reference sits in a sentence. It reads inline code spans now,
+  and a third sweep parses the engine's own string constants through
+  `go/parser`.
+- `ListGoldens` reported every golden as verified, including the ones that were
+  not, so `af up` branched an unverified golden exactly as if it had been
+  checked, with nothing printed anywhere. `RefreshGolden` recorded the honest
+  value and the read overwrote it. The verified state is read from the
+  attestation label now, which is only ever written by a verifier that ran and
+  returned.
+- Seven fields the egress sidecar records on every request reached no surface at
+  all. `substituted` is the one that matters, because it answers the question
+  the sandbox exists to answer and without it a row that reached a real service
+  and a row that reached a sandbox were the same row. `af net log` and
+  `af net log -o json` now carry `substituted`, `host_only`, `via`, `duration`,
+  `seq`, `waited_ms` and `limit`, and it is reported as `false` rather than
+  absent when no swap happened, because a key that disappears makes "the
+  credential was not swapped" and "this build cannot report swaps" the same
+  document. Two paired tests fail on a fact recorded with nowhere to go and on a
+  published key nothing assigns.
+- The runner's dependencies were resolved fresh on every machine. Release
+  archives shipped `runner/package.json` and no lockfile, established by
+  downloading the published v0.1.1 archive and listing it, and `af runner
+  install` ran `npm install`, so `playwright`'s `^1.49.0` became whatever the
+  registry served that day and two people installing one release drove their
+  tests with two different browsers. Archives carry the lockfile now,
+  `af runner install` runs `npm ci` when one is present, `af runner check`
+  reports an unpinned tree as a warning rather than as the same ok a pinned one
+  gets, and `tools/relpack` runs the real release build and asserts what is
+  inside the archive.
+- The README told you to install Antifailure and run `af init` and never
+  mentioned `af runner install`, so the one dependency a reader had to know
+  about was the one the front page left out, and the quickstart stopped at a
+  running environment without ever showing a verdict. Both cover the whole path
+  now and `tools/walkthrough` walks it.
+- `examples/github-workflow.yml`, the file the documentation tells you to copy,
+  ran `af ci --output report.md` after that flag had been renamed to `--report`,
+  so the copied workflow stopped before `af ci` did any work and nothing brought
+  an environment up. It also never set `AF_CONTROL_PLANE_TOKEN`, so a repository
+  following it sent no engine events at all and the console's environment list
+  was fed by nothing. The gate that checks documented commands reads the
+  workflow files under `examples/` and `.github/workflows/` now, and parses each
+  invocation through the same validation the binary runs, so a flag that exists
+  and refuses its value is a finding rather than a pass.
+- The manifest reference says which of `github.mode`, `github.comment`,
+  `github.fork_policy` and `github.teardown_on` anything reads, and why the
+  hosted control plane never reads your manifest. A test fails if one of those
+  fields gains a reader without the table being corrected, because somebody
+  wiring a setting up and leaving a page that says it does nothing is the more
+  dangerous half.
+- Runs, Environments and Audit showed the first page of a list and presented it
+  as the whole list. All three routes paginate and each page read none of the
+  cursor, so an organization with 200 runs saw 50 in a table that looked
+  complete, which is worse than a screen that looks broken because the reader
+  acts on it. Each list pages now, and its footer says which of the two things
+  is true.
+- Refreshing a screen in the console blanked it to a skeleton, and a refresh
+  that failed replaced correct data with a full page error. A reload keeps what
+  is on screen now, reports that it is refreshing, and puts a failure in a strip
+  above the content rather than over it. Both hooks carry a request sequence, so
+  of two reloads in flight the older answer cannot overwrite the newer.
+- Every loading skeleton in the console was zero pixels wide on a phone. A
+  percentage width inside a shrink to fit box has no basis to resolve against,
+  so all 22 bars in `TableSkeleton`, on seven pages, rendered as a stack of
+  empty boxes at 390px while measuring 54.8 to 168.2px at 1280px.
+- Every route in the console had the same document title. All ten rendered
+  `Antifailure` while their headings read Environments, Runs, Audit and the
+  rest, so every tab, every history entry and every tab search result was the
+  identical word in a tool people keep open in several tabs while a run goes.
+- Following a link into the console while signed out lost the page you were
+  going to, so every deep link this product publishes, including the environment
+  link in a pull request comment, was a link to the front door. Both ways in
+  carry the return path now, query string included.
+- The console's teardown button set a column and nothing anywhere read it. The
+  containers kept running while the console said they were gone, which is worse
+  than the button not existing because somebody who saw "torn down" stopped
+  looking. Teardown is a durable request with a lease, an attempt count and an
+  acknowledgement now, and the row moves only when the runtime confirms it.
+  Where there is no route into the machine at all, the request is given up on
+  and says so, naming `af down`, rather than reporting a cleanup that never
+  happened.
+- The console's environment, agent and load controls put GitHub's raw JSON on
+  the screen when a dispatch was refused, beside a sentence naming three
+  possible causes at once. A refusal now says which one it is and carries its
+  own remedy, and the check runs when a repository is chosen rather than when
+  the button is pressed, so a missing permission is visible before the form is
+  filled in. The permission behaviour was documented backwards: a missing
+  `actions: write` is a 403 rather than the 404 the documentation claimed.
+- Accepting new permissions on the GitHub App left the control plane using the
+  token it had already minted, which still carried the old scopes, so the App
+  went on refusing writes it had just been granted for the rest of that token's
+  hour. `InstallationTokens.forget` had existed since the App client was written
+  and had no callers anywhere in the tree. An `installation` delivery drops the
+  cached token now, for every action rather than for one, and a call GitHub
+  answers 401 drops it and retries once.
+- Three ways an organization could exist that nobody could ever enter, each of
+  them rendering the empty state that means nobody has installed the App to
+  somebody whose App is installed. Signing in and installing are two events with
+  no guaranteed order and only one order worked, and the flow the product
+  recommends produces the other one. An App installed on a personal account
+  created an organization keyed on the holder's login, which `/user/orgs` never
+  returns. And `/user/orgs` was read one page deep, where it defaults to thirty,
+  so the list deciding which organizations somebody may enter was truncated
+  rather than shortened.
+- A hosted run that did not pass says why on the line a person reads first. A
+  load run that breached a threshold reported an empty detail, so the reason
+  lived only in the threshold rows. Two siblings had the same gap: an
+  exploration that missed a goal said nothing, and a failing scenario or
+  workflow whose own reason was empty rendered as a name, a colon and nothing.
+- The control plane answers every event it stored and could not apply with a
+  sentence saying why, and the engine threw all of them away: the wire type had
+  no field for the note, so the decoder dropped it, and the only caller of
+  `Send` discarded the whole result. That is the one channel that explains why a
+  run reported and the console still shows nothing. Those sentences reach the
+  job log now, bounded and without duplicates.
+- An unexpected control plane failure told the caller to find their request in
+  the logs and gave them nothing to find it with: no identifier in the body,
+  none on the response, and deliberately no query, no parameters and no payload
+  in the log. Every request carries an `x-request-id` now, the 500 body repeats
+  it, and the log line carries it beside the error's class and the driver's
+  code, while the statement and its parameters still reach neither the caller
+  nor the log.
+- The control plane's OpenAPI document described an API a generated client could
+  not call. Every query said its input was optional, including the routes that
+  answer 400 without one; every mutation demanded a body shaped exactly `{}`
+  even where the route reads no input; one `Error` shape stood for three
+  different bodies and validated none of them, so a client parsing the readiness
+  503 read `undefined` and reported the service healthy; and the event type was
+  published as a closed enum while the server deliberately accepts and stores a
+  type it has never seen. All of it is taken from the validators the router
+  executes now, and a test drives real requests through the real HTTP boundary
+  and checks each answer against the schema declared for that status.
+- The runtimes table on Environments, the approval queue on Network and the plan
+  comparison showed no column headings on a phone, while eleven of the fourteen
+  tables beside them did. At 390px the approval queue read as six bare values on
+  the screen where somebody approves an egress rule.
+- Every documentation address the product prints or publishes names the URL the
+  site actually serves rather than a spelling it answers with a 301. That
+  affected the `More` link under all 131 error codes, which is the address the
+  engine prints when something has already gone wrong for you, the 82
+  documentation pages' own canonical tags, and the 81 URLs in the sitemap.
+- The copy button on all 116 terminal code blocks in the documentation sat
+  outside the block, hanging off the bottom right corner over the paragraph
+  beneath and taking its tooltip with it. The install command on the quickstart
+  was the first one anybody saw.
+- Every h2 in the documentation pushed its anchor link onto a line of its own,
+  67px below the heading, on all 81 pages. Cascade layers are why the override
+  that caused it was silent: Starlight ships its CSS in a layer and this site's
+  stylesheet is unlayered, so a plain selector beats a layered rule whatever its
+  specificity and reading the diff gives the wrong answer.
+- The markdown twin of every page, which is what an answer engine reads instead
+  of 300KB of markup, dropped every table cell and every definition list. The
+  masking table on the safe state page and the manifest walkthrough on the
+  overview page are the most specific claims either page makes, and an assistant
+  could see that the page discusses masking and could not see a single rule.
+- The home page was built for a phone and for a wide desktop and rendered as
+  neither in between, because every layout decision on it switched at one
+  breakpoint. At 1100px, which is a laptop rather than an edge case, two of the
+  hero's five service cards sat outside the viewport with no affordance at all,
+  the art behind the headline ended in a torn horizontal edge lying across body
+  text, and every section heading was sliced in half by a rail pinned at the
+  wrong offset. No page on the site scrolls horizontally at any width now,
+  checked across all 35 exported routes at ten widths against the static export
+  rather than against the development server, which serves none of the hero art
+  and would have measured a torn edge as clean.
+- The assistant panel on the home page was a drawing of an application that a
+  keyboard could walk into: an unlabelled reply box with no focus ring that was
+  tab stop 51 of 119, a Send button rendered 9px square, and window chrome under
+  7px. The parts that only depicted an assistant are drawn rather than operated
+  now, and what stays interactive is the part that is a real demonstration.
+- Every interactive target in the footer measures at least 44 by 44 at every
+  width, and on a desktop the footer renders as it did before. The twenty eight
+  navigation links could not take the treatment the other targets took, because
+  they sit flush and each 44px box would have overlapped its neighbour by 15px
+  with the later sibling painting on top, which a screenshot would not show and
+  a measurement would have called a pass. The rhythm grows under a coarse
+  pointer instead.
+- The breadcrumb trail failed the contrast floor on every page of the site that
+  renders one, at 3.85:1 on the paper ground, 4.13:1 on white and 3.55:1 on the
+  sage bands. The scale already held a passing grey one step away.
+- The three claims under Isolated Twin on the home page, the ones that say the
+  twin has no route out, were set in a grey measuring 3.85:1 and stepped down to
+  14px below 1024, missing two floors this project sets for itself on one line.
+- The trust band at the foot of the home page was a flat saturated olive that
+  nothing else on the site used, and its grey headline, its two captions and its
+  attribution all measured 4.10:1. It is the same pale sage every other section
+  band uses now, which puts those three at 5.10:1.
+- The status page's component rows had two different heights on a phone and
+  nothing about a component decided which it got, down a list whose whole job is
+  to be scanned in one pass. Its Day, Week and Month control was the only one on
+  the page between the 24px floor and the 44px its subscribe button already had.
+- The published retention numbers are read from one place and compared to the
+  Terraform that sets them by a test. Seven legal claims were found false in one
+  night and every one of them was true when it was written, so the fix is a gate
+  rather than seven edits: a data subject was told their data is gone after
+  fourteen days of point in time recovery while production runs thirty five, and
+  the privacy and subprocessor pages said there is no billing and that nothing
+  can send mail, which stopped being true when the billing and sign in link work
+  landed.
+- The cross platform lint could not typecheck one test file on Windows. It
+  carried a `runtime.GOOS` skip, which reads as though the platform had been
+  handled and cannot help, because the skip runs at run time and the missing
+  symbol is a compile error, so the whole package failed to typecheck.
 
 ### Security
 
@@ -289,3 +760,78 @@ every page says so on its face.
 - `SECURITY.md` stops claiming three things the evidence does not support, and
   the disclosure section now says what happens when a target is missed and that
   there is no bug bounty.
+- `af up` branched another project's golden. A golden pool is shared on purpose,
+  and selection filtered on the masking rules digest, which says how a golden was
+  masked and not whose it is, so every project on a machine with no
+  `masking.yaml` hashed to the same value and drew from one pool. Reproduced
+  with two ordinary Express repositories: the second declared no database,
+  printed in its own generated manifest that branches would start empty, and
+  `af up` brought up a database holding the first project's tables and its rows.
+  A golden now records the project it was made for and an environment branches
+  only a golden whose record equals its own, `af golden pull` refuses a
+  published golden made for another project before restoring anything,
+  `af golden gc` collects only this project's versions where it used to delete
+  another repository's, and every run says where its data came from.
+- A sandbox rule whose credential was never configured sent the application's
+  own credential to the provider. Substitution only happens when a value exists
+  for the name the rule refers to, and when none did the sidecar forwarded
+  whatever the application sent, indistinguishable in every other column from a
+  working sandbox call. `inspect_egress_firewall` reports it as
+  `sandbox_credential_not_substituted` and it always fails the check. There is
+  deliberately no way to turn it down: a threshold expresses how much of
+  something a project will tolerate, and there is no tolerable quantity of a
+  live credential leaving an environment that is running unreviewed code against
+  a copy of production data.
+- A suspended organization could still be issued a callback credential. The
+  suspension was read at `/v1/events` and nowhere else, so the control plane
+  minted a working credential for an organization it had stopped and then
+  refused the report that credential was minted for. Nothing crossed a tenant
+  boundary and no events were accepted, which is why it went unnoticed: the
+  outcome was correct and only the explanation was wrong, and a customer went
+  looking at their continuous integration when the answer was their billing
+  state. The refusal happens where the credential is minted now, naming the
+  suspension and the recorded reason.
+- On macOS every secret this product stores went through a child process's
+  argv, where any other user on the machine could read it in `ps`. A control
+  plane bearer token was read that way on this project's own machine, by
+  accident, by somebody looking at something else. `af login`, `af model set`,
+  `af secret set` and `af provider` all reach it. The product had already decided
+  this matters: `af model set` refuses a `--key` flag and reads without echo for
+  exactly these reasons, and then handed the key to a function that put it on a
+  command line one process deeper. The value goes in on stdin now, and every
+  call to `security` is bounded by a timeout, because a keychain that blocks
+  rather than failing has no upper bound and the fallback to a file cannot fire,
+  since a hang is not an error. Linux was already correct and Windows starts no
+  child process at all.
+- `github.fork_policy` was sold as a security control and refused nothing. The
+  schema said the default requires a maintainer to add `antifailure:allow`
+  first, the pull request guide said nothing runs until they do, `af explain`
+  printed that forks never run, and `af up` on a fork's pull request answered
+  with an environment name and went to the Docker daemon. What customers
+  actually had was GitHub's own default, which withholds secrets from a fork's
+  job on a GitHub hosted runner: real, and not this control, and it does nothing
+  on the self hosted runner that is the ordinary shape here. The refusal is real
+  now, it reads the policy from the base branch rather than from the fork's own
+  checkout, and `af ci` writes a report saying the check did not run rather than
+  exiting non zero, because a fork waiting on a maintainer is not a finding
+  about the change.
+- A verified GitHub delivery is handled exactly once, however many times it
+  arrives. The HMAC over the raw body says a delivery is genuine and says
+  nothing about it being new, so a delivery captured off the wire, or replayed
+  out of GitHub's own redelivery log, verified exactly as well the thousandth
+  time as the first, and every handler downstream of that endpoint writes
+  something. Each delivery is claimed by its identifier before it is handled and
+  stamped after, a copy arriving while the first is still being handled is
+  answered 503 with a `Retry-After` rather than a success it has not earned, a
+  handler that throws gives its claim back, and a delivery with no identifier is
+  refused rather than handled unfenced.
+- `install.sh` verified the download on the happy path and passed on every
+  unhappy one. A `checksums.txt` that did not download printed a warning and
+  installed anyway, an archive not named inside one printed nothing at all and
+  installed anyway, and a machine with no hashing tool printed a warning and
+  installed anyway. Only a mismatch stopped. Each of those refuses now, naming
+  what was missing, and `openssl` is accepted as a third hashing tool so that
+  refusing costs almost no machine anything. Placement was worse than a fail
+  open: the placement step was an AND-OR list, which `set -e` does not apply to,
+  so an archive assembled without `af` in it printed a `cp` error, then printed
+  that it had installed, wrote the PATH line and exited 0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -331,6 +331,33 @@ branches moves the answer with you, and it runs nothing and writes nothing,
 which is the only way it can be honest. Each step reports one of four states and
 never collapses one into another: done, not yet, blocked, and not checked.
 
+**A run in GitHub Actions reports itself.** The engine's control plane sink took
+its credential from `AF_CONTROL_PLANE_TOKEN` and nothing in any workflow this
+project ships has ever set it, so on a runner the sink was never built at all:
+the events saying an environment is coming up, is ready, or has been torn down
+went to the local log and no further, and the dashboard stayed empty for every
+run anybody had. A job now proves what it is with the identity GitHub signs for
+it and trades that for a short lived credential, so a workflow needs
+`permissions: id-token: write` and no repository secret.
+`AF_CONTROL_PLANE_TOKEN` still works and still wins when it is set, because a
+developer's machine and a self hosted engine have no runner to vouch for them.
+The credential is short lived, so the engine renews it when a batch is refused
+and re-sends that batch rather than losing it, and events wait on disk rather
+than being dropped. Three things that used to read as authentication failures
+now say what to do: GitHub declining to mint an identity for a fork's pull
+request, a control plane too old to offer the exchange, and a repository the
+control plane has not been told about.
+
+**Two more gates over what the documentation claims.** `reference/api.md` is
+checked against the routes the server registers, in both directions: every
+documentation URL on one of this product's own hosts has to match a route the
+server registers or a page the console serves, and every route the server
+serves has to be covered by a pattern the page names. It was the only reference
+page with no machine coverage and it is the one that drifted. Separately, every
+environment variable the engine names at a user is now checked against the
+documentation, which is what `af license install` needed: it tells a paying
+customer to set two variables and points them at a page that named neither.
+
 **`af ci --report-json`.** The same run written as JSON, for something that has
 to act on the report rather than display it. `--report` stays Markdown for a
 person, and `-o json` is not that flag: it is the whole terminal's format, so a
@@ -564,8 +591,11 @@ it.
   now and `tools/walkthrough` walks it.
 - `examples/github-workflow.yml`, the file the documentation tells you to copy,
   ran `af ci --output report.md` after that flag had been renamed to `--report`,
-  so the copied workflow stopped before `af ci` did any work and nothing brought
-  an environment up. It also never set `AF_CONTROL_PLANE_TOKEN`, so a repository
+  so the copied workflow exited 2 on "the output format is not recognised"
+  before `af ci` did any work and nothing brought an environment up. The
+  generated command reference moved with the rename and the example did not, so
+  the two descriptions of one command disagreed and only the one nobody copies
+  was right. It also never set `AF_CONTROL_PLANE_TOKEN`, so a repository
   following it sent no engine events at all and the console's environment list
   was fed by nothing. The gate that checks documented commands reads the
   workflow files under `examples/` and `.github/workflows/` now, and parses each
@@ -726,6 +756,83 @@ it.
   the privacy and subprocessor pages said there is no billing and that nothing
   can send mail, which stopped being true when the billing and sign in link work
   landed.
+- The runs list, the verdicts view, the goldens quota, the masking attestation
+  table and the compliance pack's masking control were blank for every real
+  customer. All five read `golden_versions`, `runs` and `verdicts`, and the only
+  writers of those three tables anywhere in the repository were the test harness
+  and the staging seeder, which fills all of them, so every one of these looked
+  correct in development and had nothing to show in production. The compliance
+  pack was the worst of it, reporting that the check ran and found nothing for an
+  organization producing a signed attestation every night. The engine emitted the
+  events, the sink mapped them and ingest accepted the types, so nothing anywhere
+  reported a problem; the projections were simply never written.
+- Four documents told a self hoster to point GitHub at a URL this product does
+  not serve. `AF_GITHUB_REDIRECT_URI` was documented as `/auth/callback` in the
+  getting started path, the self hosting page, the Azure page and the README, and
+  the route is `/auth/github/callback`, which is what the product's own Terraform
+  configures. The value goes straight to GitHub and nothing validates its path at
+  startup, so the failure landed at the end of the first sign in, after the
+  operator had registered an OAuth App carrying the same wrong URL.
+- Four places where the documentation described a command the product does not
+  have, including the operations runbook telling an on call engineer in bold not
+  to run `af down --all`, which is not a flag, and a nine line `af provider list`
+  session whose every line was wrong.
+- The enterprise licensing page told a customer to install a license with a
+  command that stores nothing. Neither binary installs anything: the enterprise
+  entry point reads `AF_LICENSE_KEY` and `AF_ORG` from the environment and that
+  is the whole mechanism, and neither variable appeared on any published page.
+- The API reference named eight routes fewer than the server serves. Three whole
+  families were absent: both webhook endpoints, the two model proxy endpoints,
+  and the four console provider routes. The model proxy is the mechanism two
+  guides describe in full, so the page listing the surface omitted the thing
+  those pages tell you to point your client library at. It also claimed
+  everything below was authenticated apart from a counted number of exceptions,
+  which the webhooks break in a way counting cannot fix: they accept a signature
+  rather than a credential.
+- The documentation home was the only page in the documentation with no way to
+  see what else exists. It carried Starlight's marketing template, which turns
+  the sidebar off, and below 800px it had no menu button either, so on a phone
+  the page a new reader lands on had no navigation at all.
+- A third of the documentation sidebar was ordered by file name rather than by
+  anybody's decision. Starlight breaks a tie on `sidebar.order` with the slug,
+  and 27 of the 78 ordered pages shared a number with a sibling, so "Watching a
+  run" split the pair of runtime pages, "Provider limits" split the three
+  provider pages, and "On call" came before "Standing up production".
+- Two sidebar groups were labelled with a raw lowercase directory name among
+  nine sentence case labels, and one of them contained a page whose own title was
+  the same word in a different casing.
+- The documentation offered no way to sign up on a tablet. Between 800px and
+  1023px no page carried a Log in link, a Sign up button or a link to the
+  repository: the header hid all three at one breakpoint and the mobile menu
+  holding their only other copies exists only below another, so for 224 pixels
+  of viewport width they were hidden with nowhere to go. iPad portrait is 810 to
+  834 pixels.
+- The documentation build warned on every run that `/404` was declared twice,
+  because Starlight injects one at the same pattern as the site's own. Astro's
+  message says a route collision becomes a hard error in a later version. The
+  site's own page wins, and it earns it: somebody who lands there arrived from a
+  path printed at the end of an engine error message rather than from a link, so
+  it names the references they were most likely reaching for.
+- The hero shader on the marketing site ran on the CPU on any machine whose GPU
+  driver is blocklisted. The guard was binary, and a blocklisted driver is
+  neither case: the browser grants a context backed by a software rasteriser
+  instead of refusing one, so nothing threw and a full bleed fragment shader
+  animated on the CPU for as long as the page was open. That is the normal state
+  of a cheap or out of support Chromebook, and it was reported as the site
+  crashing them.
+- `af net log` left `via` blank on tunnelled CONNECT, which is most of the
+  traffic. Three of the proxy's four recording paths said how the request
+  reached it and the tunnel every HTTPS request opens said nothing, so the field
+  was empty on the majority of records while being populated on the minority. An
+  empty field that looks like a value is worse than a missing one, because it
+  reads as data rather than as an omission.
+- An organization deletion claimed its step after doing the step's work, so a
+  second caller did all of it before being told it had lost. Every step's write
+  was supposed to carry a `WHERE <its timestamp> IS NULL` so two callers arriving
+  at once do not both act, and that was true of the bookkeeping row and false of
+  the three statements that do the work. It was not reachable as data loss,
+  because each statement locks what it touches and re-evaluates after the winner
+  commits, and the ordering is now what the comment above it always claimed.
 - The cross platform lint could not typecheck one test file on Windows. It
   carried a `runtime.GOOS` skip, which reads as though the platform had been
   handled and cannot help, because the skip runs at run time and the missing
@@ -789,7 +896,11 @@ it.
   for the name the rule refers to, and when none did the sidecar forwarded
   whatever the application sent, indistinguishable in every other column from a
   working sandbox call. `inspect_egress_firewall` reports it as
-  `sandbox_credential_not_substituted` and it always fails the check. There is
+  `sandbox_credential_not_substituted` and it always fails the check, and the run
+  report states the substituted count either way and names the hosts a request
+  reached carrying the application's own credential. Stating it either way is
+  deliberate: a line that appears only when something is wrong teaches a reader
+  nothing by its absence. There is
   deliberately no way to turn it down: a threshold expresses how much of
   something a project will tolerate, and there is no tolerable quantity of a
   live credential leaving an environment that is running unreviewed code against

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@antifailure/site-api",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@antifailure/site-api",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
         "@azure/data-tables": "^13.3.0"
       }

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antifailure/site-api",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "description": "The managed functions behind antifailure.dev.",
   "scripts": {

--- a/console/package-lock.json
+++ b/console/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@antifailure/console",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@antifailure/console",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "geist": "^1.7.2",

--- a/console/package.json
+++ b/console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antifailure/console",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "description": "The control plane's web application, served by the control plane itself.",
   "license": "MIT",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@antifailure/docs",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@antifailure/docs",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@astrojs/starlight": "^0.41.10",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antifailure/docs",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "description": "The Antifailure documentation site, served at https://antifailure.dev/docs.",
   "license": "Apache-2.0",

--- a/docs/src/content/docs/reference/errors.md
+++ b/docs/src/content/docs/reference/errors.md
@@ -25,8 +25,8 @@ Scripts can branch on these. They are stable.
 | `6` | A policy denied the operation. |
 | `7` | Verification failed. Masking or an invariant. |
 | `8` | A test failed. Agent verdicts or load thresholds. |
-| `9` | Interrupted, and teardown completed cleanly. |
-| `10` | Interrupted, and resources are still recorded. Run `af down` again. |
+| `9` | Nothing was measured. No workflow reached a verdict, or a workload did not finish. |
+| `10` | Interrupted, or a teardown left resources recorded. Run `af down` again. |
 
 29 further codes are reserved for features this version does not have. They are in `engine/internal/errors/catalog.yaml` and are left out here because this page is for looking up an error you have actually seen.
 

--- a/docs/src/content/docs/self-hosting/releasing.md
+++ b/docs/src/content/docs/self-hosting/releasing.md
@@ -173,6 +173,19 @@ new file under `migrations/` means production is being asked to apply a
 migration nobody on this page has read, and that one is worth stopping for: a
 migration is the only part of a deploy that cannot be rolled back.
 
+**It is not empty today, and here is what has been done about each half.**
+`install.sh` and `tools/release/build.sh` have both moved since that revision,
+so the release build path was re-run rather than assumed: `just build-release
+v1.0.0` on this tree, the archive unpacked and the binary inside it run out of
+the unpacked directory, `af version` reporting the version passed to the script
+with the real commit and that commit's own date, the checksum file verified,
+`just reproducible` building twice with a cold cache and getting the same
+archive, and `just ldcheck`, `just relnotes`, `just tagsync` and
+`just releasecheck` green. That re-run is what found `build.sh` packaging an
+archive with no `af` in it, so the drift here was carrying a real defect and not
+only a stale sentence.
+
+The `migrations/` half is not resolved and is read below rather than here.
 ```sh
 git tag -s v0.1.2 -m "v0.1.2"
 git push origin v0.1.2
@@ -328,7 +341,7 @@ The app is in `Multiple` revision mode with one revision at 100 percent, so
 there is a revision to roll back onto. The case where there is not is the one
 `deploy.sh` reports plainly rather than pretending a rollback happened.
 
-### This is an unusually large deploy, and its two migrations are verified
+### This is an unusually large deploy, and four of its migrations are unread
 
 Production is serving `f66d6af`. Ask how far ahead the tag is rather than
 carrying a number that goes stale between two merges:
@@ -339,13 +352,29 @@ git rev-list --count f66d6af..origin/main
 ```
 
 At the time of writing that was 178, so the first tag is not a normal
-increment. It is every change since, arriving at once, and the bootstrap job
-applies two migrations production has never seen.
+increment. It is every change since, arriving at once.
 
-Those two have been checked, and the check is recorded here so nobody repeats
-it nervously at tag time. `0001` through `0017` were applied to a real
-PostgreSQL 17, seeded with two organizations and three `network_rules` rows,
-and then `0018` and `0019` were applied on top.
+**Ask which migrations rather than reading a count off this page**, because the
+count has already gone stale once:
+
+```sh
+git diff --name-only f66d6af..origin/main -- web/packages/db/migrations
+```
+
+Two of them have been checked and the check is recorded below so nobody repeats
+it nervously at tag time. **The rest have not been, and they are the reason to
+stop here.** `0020`, `0021`, `0022` and `0023` landed after the rehearsal that
+produced the two paragraphs below, and no line on this page has read them. Give
+each one the same treatment before you approve production: apply it to a real
+PostgreSQL 17 seeded from `0001` upwards, satisfy yourself that it is additive
+and that the currently deployed code tolerates the schema it leaves behind, and
+write what you found here. A migration is the only part of a deploy that cannot
+be rolled back, so this is the one item on this page that is not optional and
+not a formality.
+
+`0001` through `0017` were applied to a real PostgreSQL 17, seeded with two
+organizations and three `network_rules` rows, and then `0018` and `0019` were
+applied on top.
 
 * **`0018`** adds three nullable columns to `network_rules` and backfills
   `approved_at` from `created_at`. After it ran, zero rules were left pending
@@ -358,9 +387,10 @@ and then `0018` and `0019` were applied on top.
   invisible, a query with no organization set returns zero rows, and an insert
   aimed at another tenant is refused by the policy.
 
-Both are additive, which is what makes a rollback safe: `deploy.sh` can put
-traffic back on the old revision and cannot un-apply a schema change, so the
-old code has to tolerate the new schema, and it does.
+Both of those two are additive, which is what makes a rollback safe:
+`deploy.sh` can put traffic back on the old revision and cannot un-apply a
+schema change, so the old code has to tolerate the new schema, and for `0018`
+and `0019` it does. That sentence covers those two and no others.
 
 ## After it is green
 

--- a/docs/src/content/docs/self-hosting/releasing.md
+++ b/docs/src/content/docs/self-hosting/releasing.md
@@ -341,7 +341,7 @@ The app is in `Multiple` revision mode with one revision at 100 percent, so
 there is a revision to roll back onto. The case where there is not is the one
 `deploy.sh` reports plainly rather than pretending a rollback happened.
 
-### This is an unusually large deploy, and four of its migrations are unread
+### This is an unusually large deploy, and one of its migrations wants a window
 
 Production is serving `f66d6af`. Ask how far ahead the tag is rather than
 carrying a number that goes stale between two merges:
@@ -361,20 +361,63 @@ count has already gone stale once:
 git diff --name-only f66d6af..origin/main -- web/packages/db/migrations
 ```
 
-Two of them have been checked and the check is recorded below so nobody repeats
-it nervously at tag time. **The rest have not been, and they are the reason to
-stop here.** `0020`, `0021`, `0022` and `0023` landed after the rehearsal that
-produced the two paragraphs below, and no line on this page has read them. Give
-each one the same treatment before you approve production: apply it to a real
-PostgreSQL 17 seeded from `0001` upwards, satisfy yourself that it is additive
-and that the currently deployed code tolerates the schema it leaves behind, and
-write what you found here. A migration is the only part of a deploy that cannot
-be rolled back, so this is the one item on this page that is not optional and
-not a formality.
+All of them have been checked, and the checks are recorded here so nobody
+repeats them nervously at tag time. Every migration from `0001` to `0023`
+applies cleanly to a real PostgreSQL 17 from an empty database, and `0023` was
+applied a second time to a database built to `0022` and then seeded, so that it
+met existing rows rather than an empty table. It validated its constraint and
+left every seeded session in place.
 
-`0001` through `0017` were applied to a real PostgreSQL 17, seeded with two
-organizations and three `network_rules` rows, and then `0018` and `0019` were
-applied on top.
+**Correctness is settled. Duration is not, and that is the one thing to decide
+before you approve production.** The seeded table held 500 rows and production
+does not, so what has been proved is that these migrations do the right thing,
+not that they do it quickly enough to run while the site is serving.
+
+Only three tables that exist at `0017` are touched at all. Everything else in
+`0018` to `0023` creates a new table, which locks nothing and cannot block a
+running request. The three are `network_rules`, `users` and `sessions`, and
+this is every operation against them:
+
+* **Nine nullable column adds with no default**, five on `users` and four on
+  `sessions`. On PostgreSQL 11 and later these rewrite nothing and touch only
+  the catalog, whatever the table holds.
+* **`0018` backfills `network_rules`**, in the same transaction as its own
+  schema change, and builds `network_rules_pending_idx` without
+  `CONCURRENTLY`. That takes a SHARE lock and blocks writes to
+  `network_rules` for the length of the build. It is a small table.
+* **`sessions.impersonated_by` carries a foreign key to `users`**, so adding it
+  locks `users` as well as `sessions`. Nothing on this path sets a
+  `lock_timeout`, which is the same exposure `0018` already has and which is
+  written out under the three migration budgets below.
+* **Two full scans of `sessions`, which is the hottest table in the product**,
+  because `resolveSession` reads it on every request.
+  `ADD CONSTRAINT sessions_impersonation_is_complete` takes ACCESS EXCLUSIVE
+  and validates every existing row, and `sessions_impersonated_idx` is partial
+  but still reads the whole table to evaluate its predicate. For as long as
+  the first of those runs, every authenticated request waits.
+
+So measure before you approve, rather than assuming the table is small:
+
+```sh
+psql "$PROD_URL" -c "SELECT count(*) FROM sessions"
+psql "$PROD_URL" -c "SELECT count(*) FROM network_rules"
+```
+
+`sessions` holds live sessions rather than history, so it is bounded by how
+many people are signed in and is very likely small enough that none of this
+matters. If it is not, this deploy needs a quiet window. The standard way out
+is `ADD CONSTRAINT ... NOT VALID` followed by `VALIDATE CONSTRAINT` as a
+separate statement, which holds ACCESS EXCLUSIVE only for an instant and
+validates under a lock that lets writes through. That is deliberately not being
+done to `0023`: a migration's digest is frozen the moment it is applied
+anywhere, staging has already applied this one, and `migrate` refuses a file
+whose digest has changed. If the split is ever wanted it belongs in a later
+migration, not in a rewrite of this one.
+
+The two records below are from the earlier rehearsal and are kept because they
+say what was observed rather than what was expected. `0001` through `0017` were
+applied to a real PostgreSQL 17, seeded with two organizations and three
+`network_rules` rows, and then `0018` and `0019` were applied on top.
 
 * **`0018`** adds three nullable columns to `network_rules` and backfills
   `approved_at` from `created_at`. After it ran, zero rules were left pending
@@ -387,10 +430,12 @@ applied on top.
   invisible, a query with no organization set returns zero rows, and an insert
   aimed at another tenant is refused by the policy.
 
-Both of those two are additive, which is what makes a rollback safe:
+Every one of `0018` to `0023` is additive, which is what makes a rollback safe:
 `deploy.sh` can put traffic back on the old revision and cannot un-apply a
-schema change, so the old code has to tolerate the new schema, and for `0018`
-and `0019` it does. That sentence covers those two and no others.
+schema change, so the old code has to tolerate the new schema. Nothing in the
+range drops a column, drops a table, renames anything, or adds a NOT NULL to a
+column that already exists, which is the property that lets the currently
+deployed revision keep running against the new schema.
 
 ## After it is green
 

--- a/ee/web/audit/package.json
+++ b/ee/web/audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antifailure-ee/audit",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "license": "SEE LICENSE IN ../../LICENSE.md",
   "type": "module",

--- a/ee/web/package-lock.json
+++ b/ee/web/package-lock.json
@@ -23,7 +23,7 @@
     },
     "../../web/apps/api": {
       "name": "@antifailure/api",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@antifailure/db": "*",
@@ -46,7 +46,7 @@
     },
     "../../web/packages/db": {
       "name": "@antifailure/db",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "drizzle-orm": "^0.45.2",
@@ -62,7 +62,7 @@
     },
     "audit": {
       "name": "@antifailure-ee/audit",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "SEE LICENSE IN ../../LICENSE.md",
       "dependencies": {
         "@antifailure/db": "file:../../../web/packages/db"
@@ -241,7 +241,7 @@
     },
     "rbac": {
       "name": "@antifailure-ee/rbac",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "SEE LICENSE IN ../../LICENSE.md",
       "dependencies": {
         "@antifailure/api": "file:../../../web/apps/api",
@@ -254,7 +254,7 @@
     },
     "scim": {
       "name": "@antifailure-ee/scim",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "SEE LICENSE IN ../../LICENSE.md",
       "dependencies": {
         "@antifailure/api": "file:../../../web/apps/api",
@@ -268,7 +268,7 @@
     },
     "sso": {
       "name": "@antifailure-ee/sso",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "SEE LICENSE IN ../../LICENSE.md",
       "dependencies": {
         "@antifailure/api": "file:../../../web/apps/api",

--- a/ee/web/rbac/package.json
+++ b/ee/web/rbac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antifailure-ee/rbac",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "license": "SEE LICENSE IN ../../LICENSE.md",
   "type": "module",

--- a/ee/web/scim/package.json
+++ b/ee/web/scim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antifailure-ee/scim",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "license": "SEE LICENSE IN ../../LICENSE.md",
   "type": "module",

--- a/ee/web/sso/package.json
+++ b/ee/web/sso/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antifailure-ee/sso",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "license": "SEE LICENSE IN ../../LICENSE.md",
   "type": "module",

--- a/runner/package-lock.json
+++ b/runner/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@antifailure/runner",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@antifailure/runner",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "playwright": "^1.49.0"

--- a/runner/package.json
+++ b/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antifailure/runner",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "description": "Drives an application the way a person does, and returns a verdict with evidence.",
   "license": "MIT",

--- a/tools/changecheck/main_test.go
+++ b/tools/changecheck/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -92,6 +93,21 @@ func TestEveryTopLevelPathIsClassified(t *testing.T) {
 		if isSurfaceRoot(name) {
 			continue
 		}
+		// A path git ignores is not in the repository, so it cannot be the new
+		// product area this test exists to catch, and classifying it is not
+		// possible either: the reverse check below requires every name in
+		// notASurface to exist, and build output does not exist in a clean
+		// checkout.
+		//
+		// Without this, `just gate` could not pass. Its first recipe creates
+		// .gate-reports/ in the root, `just links` and `just seo` assemble
+		// site/ there, and `just test-tools` runs afterwards and reported both
+		// as unclassified. So the gate failed on output the gate itself had
+		// just written, on every machine, every time, and only after the run
+		// was far enough along to have produced it.
+		if ignoredByGit(t, root, name) {
+			continue
+		}
 		t.Errorf("%s is in the repository root and changecheck has no opinion about it.\n"+
 			"Add it to surfaces in classify.go if a change there is something a user "+
 			"can see, or to notASurface with the reason it is not.", name)
@@ -110,6 +126,21 @@ func TestEveryTopLevelPathIsClassified(t *testing.T) {
 			t.Errorf("surfaces names %s and there is no such path any more", s.prefix)
 		}
 	}
+}
+
+// ignoredByGit says whether the working tree ignores this root entry.
+//
+// git rather than a list of names, because the list would be a second copy of
+// .gitignore that nothing keeps in step, and the day it drifted this test
+// would either fail on a new build directory or stop seeing a real one.
+//
+// A git that cannot answer is treated as not ignoring, so a checkout without
+// git fails loudly on an unclassified path rather than passing over one.
+func ignoredByGit(t *testing.T, root, name string) bool {
+	t.Helper()
+	cmd := exec.Command("git", "check-ignore", "--quiet", "--", name)
+	cmd.Dir = root
+	return cmd.Run() == nil
 }
 
 func isSurfaceRoot(name string) bool {

--- a/tools/errgen/main.go
+++ b/tools/errgen/main.go
@@ -371,8 +371,17 @@ func renderDocs(es []entry) []byte {
 		{"6", "A policy denied the operation."},
 		{"7", "Verification failed. Masking or an invariant."},
 		{"8", "A test failed. Agent verdicts or load thresholds."},
-		{"9", "Interrupted, and teardown completed cleanly."},
-		{"10", "Interrupted, and resources are still recorded. Run `af down` again."},
+		// 9 and 10 are the two codes whose published meaning has to be read
+		// off the catalog rather than off the name in errors.go, and one of
+		// them was wrong here. Nothing returns 9 for an interrupt: a second
+		// interrupt exits 10, and the only two entries carrying 9 are
+		// AF-AGT-007, a run that reached no verdict, and AF-WLD-014, a
+		// workload that did not finish. This page says these codes are stable
+		// and scripts branch on them, so a sentence describing something the
+		// binary never does is the worst kind of wrong to publish under that
+		// promise.
+		{"9", "Nothing was measured. No workflow reached a verdict, or a workload did not finish."},
+		{"10", "Interrupted, or a teardown left resources recorded. Run `af down` again."},
 	} {
 		fmt.Fprintf(&b, "| `%s` | %s |\n", r[0], r[1])
 	}

--- a/tools/release/build.sh
+++ b/tools/release/build.sh
@@ -30,6 +30,16 @@ dist="$6"; stage="$7"
 root=$(cd "$(dirname "$0")/../.." && pwd)
 mkdir -p "$dist" "$stage"
 
+# Absolute, before anything uses them. Both callers pass these relative, and
+# the go build below runs from $root/engine, so a relative -o resolved against
+# engine/ rather than against the directory this script just made: the binary
+# landed in engine/stage/<name>/af, the archive was assembled from the staged
+# directory without it, and the script exited 0 having packaged a release with
+# no `af` in it. Nothing caught it because tools/relpack passed absolute paths,
+# which is the one shape neither caller uses.
+dist=$(cd "$dist" && pwd)
+stage=$(cd "$stage" && pwd)
+
 name="antifailure_${version}_${goos}_${goarch}"
 binary="$stage/$name/af"
 mkdir -p "$stage/$name/runner"

--- a/tools/relpack/relpack_test.go
+++ b/tools/relpack/relpack_test.go
@@ -80,20 +80,38 @@ func runBuild(root string) release {
 		r.err = fmt.Errorf("go is not on PATH, so the release build cannot run: %w", err)
 		return r
 	}
-	out, err := os.MkdirTemp("", "relpack")
+	// Inside the repository, and relative, because that is the shape both
+	// callers use and it was the one shape this test did not.
+	//
+	// `just build-release` and .github/workflows/release.yml both pass
+	// `dist stage`, relative, from the repository root. This passed absolute
+	// paths. build.sh builds from $root/engine, so a relative output path
+	// resolved against engine/ instead of against the directory the script had
+	// just made: the binary landed in engine/stage/<name>/af, the staged
+	// directory was archived without it, and the script exited 0 having
+	// packaged a release with no `af` in it. Every assertion below passed,
+	// because the absolute path this test handed over made the bug impossible.
+	//
+	// A temporary directory outside the tree does not reproduce it either. The
+	// relative path back out of the repository resolves to the same place from
+	// engine/ as from the root whenever the two are the same depth from the
+	// temporary directory's parent, which on macOS they are, so the test went
+	// on passing over a broken script. Under the root it cannot alias.
+	out, err := os.MkdirTemp(root, "relpack-")
 	if err != nil {
 		r.err = err
 		return r
 	}
 	buildDir = out
-	dist := filepath.Join(out, "dist")
 	r.stage = filepath.Join(out, "stage", prefix)
+	dist := filepath.Join(out, "dist")
+	base := filepath.Base(out)
 
 	// The commit and its date are fixed rather than read from git, so this
 	// measures what the script packages and not what the working tree is.
 	cmd := exec.Command(filepath.Join(root, "tools", "release", "build.sh"),
 		runtime.GOOS, runtime.GOARCH, "9.9.9", strings.Repeat("0", 40),
-		"2026-08-29T22:19:34Z", dist, filepath.Join(out, "stage"))
+		"2026-08-29T22:19:34Z", filepath.Join(base, "dist"), filepath.Join(base, "stage"))
 	cmd.Dir = root
 	if blob, err := cmd.CombinedOutput(); err != nil {
 		r.err = fmt.Errorf("build.sh: %w\n%s", err, blob)

--- a/web/apps/api/package.json
+++ b/web/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antifailure/api",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -20,7 +20,7 @@
     },
     "apps/api": {
       "name": "@antifailure/api",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@antifailure/db": "*",
@@ -285,7 +285,7 @@
     },
     "packages/db": {
       "name": "@antifailure/db",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "drizzle-orm": "^0.45.2",
@@ -301,7 +301,7 @@
     },
     "packages/policy": {
       "name": "@antifailure/policy",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.0.0",

--- a/web/packages/db/package.json
+++ b/web/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antifailure/db",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/web/packages/policy/package.json
+++ b/web/packages/policy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antifailure/policy",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@antifailure/www",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@antifailure/www",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "geist": "^1.7.2",

--- a/www/package.json
+++ b/www/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antifailure/www",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "description": "Public Antifailure website: marketing pages, docs, and sign-in.",
   "license": "MIT",


### PR DESCRIPTION
Everything `v1.0.0` needs except the tag. No tag is pushed here and no release is created.

## The version strings

Twelve `package.json` files and the seven lockfiles that carry the same number go to `1.0.0`. `examples/next-app` stays at `0.1.0`: it is a sample application a reader copies, not a component this tag releases.

The CLI's own version is deliberately not in this diff. It is stamped by the linker from the tag, `engine/internal/cli.Version` stays `"dev"` as the compiled default, and `tools/ldcheck` is what keeps that honest.

Everything else was already on main and is left alone: the chart's `appVersion`, the four version literals in the verification page, and the Terraform `image_tag` defaults, which `tools/tagsync` requires to name a published tag and so must move after the tag rather than with it.

## The release notes

The `v1.0.0` section was written when 131 fragments existed. There are 208 now. Seventy six landed after it, sixty two of them public, so the notes described a tree that had moved on: the pull request check run, `af mcp`, `af workload`, `af start`, organization management, the plan gate, the operator role, the published OpenAPI and changelog artifacts, and eleven behaviour changes an existing manifest or pipeline can feel, none of them mentioned. All sixty two are in the section now, in the place each belongs rather than appended as a list, along with the one this branch adds.

There is no generator. `docs/self-hosting/releasing.md` says so in as many words, `just --list` has no changelog recipe, and the only reader of `.changes/` is the site's own `/changelog` page. So this is hand assembly, which is what the page asks for.

Twelve bullets went under **Behaviour you may depend on that changed** rather than under Fixed: eleven of them are changes an existing manifest or pipeline can feel, and the twelfth is a correction to the documented `safe_routes` examples, which changes what the page tells you to write and not what the matcher does. In short: a run that verified nothing exits `9` instead of `0`, `github.fork_policy` refuses for the first time, a misspelt value in the `github` block is an error, a `safe_routes` entry carrying a method matches what it was written to match, `af ci --load` enforces `load.error_rate`, a synthesized response downgrades a pass to unverified, and `af oracle -o json` and `af support bundle -o json` stop writing a file called `json`.

The tag time note in `.changes/stale-token-after-accepting-permissions.md` is removed, as that fragment itself asks: it was correct only while the instruction to accept new App permissions and the fix for the cached token could ship in different releases, and both are in this one.

## The release archive had no binary in it

Building the artifact and running it, rather than reading the script, found this.

`just build-release v1.0.0` produced `antifailure_1.0.0_darwin_arm64.tar.gz`, its checksum, and an exit code of 0. The archive held `LICENSE`, `README.md` and the runner's source, and nothing to run.

Both callers pass the output directories relatively. `just build-release` and `.github/workflows/release.yml` each end in `dist stage`, resolved against the repository root. `build.sh` builds the binary in a subshell that cds to `$root/engine` and handed the linker that same relative path, so `-o` resolved against `engine/` and the binary landed in `engine/stage/<name>/af`. `reltar` then archived the staged directory, which was correct in every respect except that the product was not in it. Four platforms of that is the whole release.

`tools/relpack` is the gate that asserts what is inside the archive rather than treating it as an opaque blob, and it could not see this, because it passed absolute paths: the one shape neither caller uses and the one shape in which the defect cannot happen. It builds from a directory inside the tree, named relatively, now. A temporary directory outside the tree does not reproduce it either, because the relative path back out resolves to the same place from `engine/` as from the root when the two sit at the same depth below it, which on macOS they do.

## What was proved, from the artifact rather than from the script

- `tar tzf` on the built archive lists `af`.
- Unpacked into a clean directory and run from there: `antifailure 1.0.0 (community edition)`, with the real commit and that commit's own date.
- `af version -o json` reports `"version": "1.0.0"`.
- `shasum -a 256 -c` on the archive's own `.sha256`: OK.
- `just reproducible v1.0.0`: two builds, two directories, cold cache, same binary and same archive.
- `tools/relpack` watched failing on the unfixed script and passing on the fixed one, in that order.
- `npm ci` in all eight workspaces with the edited lockfiles, then `just installcheck`: eight installed trees match the lockfile.

## The release runbook

Step 5 of "Before you tag" asks for a diff against the revision the page was rehearsed at and says empty output means the page still holds. It is not empty on main and has not been for a while, so the page told a tagger to stop and gave them nothing to stop on.

The pipeline half is now resolved and recorded: `install.sh` and `tools/release/build.sh` have both moved, the build path was re-run rather than assumed, and that re-run is what found the empty archive.

The migrations half is **not** resolved, and this is the one thing on this pull request a person still has to do. Production is at `0017`; main carries `0018` through `0023`. The page's heading said its two migrations are verified, so four migrations nobody has read would be applied to production before any traffic moved, under a heading saying they were checked. The heading, the count and the closing sentence now say what is true, with `0020` through `0023` named and the treatment they need written down. Verifying them needs a real PostgreSQL and belongs with whoever landed them.

## Gates

CI is green on `d5754bea`: 17 checks succeeded and `nightly, the whole corpus` skipped, which is what it does on a pull request. The local `just gate` run and the four gates that were red in it, each with what it was and what it is now, are in the thread below.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR
