### PR TITLE
cd: the deploy gate called a slow queue a failed one

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -106,8 +106,26 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -uo pipefail
+          # 115 attempts at 20s is about 38 minutes, sized against this job's
+          # own timeout-minutes: 45 rather than picked. The previous 60 was 20
+          # minutes, less than half that timeout, and CI on this repository does
+          # not finish in 20 minutes when the queue is busy: the engine job alone
+          # runs about 14 minutes and control plane is similar, and they queue
+          # behind every other branch in flight.
+          #
+          # The failure that earned this: c5ae4385 merged, the marketing site
+          # deployed, and this gate gave up at 05:28 while CI was still running
+          # engine and control plane with every other job already green. CI then
+          # concluded success. Nothing was wrong with the commit and nothing
+          # reached staging, and the only way it moves after that is somebody
+          # noticing a red check and re-running the workflow by hand.
+          #
+          # Timing out and being red are different states and only one of them
+          # is a verdict about the commit. This keeps refusing a CI that
+          # concluded anything but success, which is the deliberate part, and
+          # stops calling a slow queue a failed one.
           echo "waiting for CI on $SHA"
-          for attempt in $(seq 1 60); do
+          for attempt in $(seq 1 115); do
             runs=$(gh api "repos/$REPO/actions/runs?head_sha=$SHA&per_page=50" \
               --jq '[.workflow_runs[] | select(.name=="CI")] | .[0] | "\(.status) \(.conclusion // "-") \(.html_url)"' 2>/dev/null || true)
             if [ -z "$runs" ] || [ "$runs" = "null" ]; then


### PR DESCRIPTION
## What happened

`c5ae4385` merged. The marketing site deployed fine. The `cd` gate gave up at 05:28:40 with:

> No CI conclusion for c5ae43853106d862349fc5b97b4e6edce17d976f within the budget. Nothing is deployed.

At that moment CI on that commit was still running `engine` and `control plane`, with every other job already green. It then concluded **success**. Nothing was wrong with the commit and nothing reached staging.

## The gate is right; its budget was not

Waiting for CI and refusing anything but success is deliberate and stays exactly as it is. The comment in the workflow makes the tradeoff explicit and it is the correct one.

The budget is the bug:

| | |
|---|---|
| polling budget | 60 attempts x 20s = **20 min** |
| the job's own `timeout-minutes` | **45 min** |

The wait gave up less than half way through the time the job was already allowed to take. CI on this repository does not finish in 20 minutes when the queue is busy: `engine` alone runs about 14 minutes, `control plane` is similar, and they queue behind every branch in flight. There were a dozen branches in flight tonight.

## Why it matters more than one missed deploy

**Timing out and being red are different states, and only one of them is a verdict about the commit.** Treating them the same turns a slow queue into a skipped deploy, and the control plane then sits on an older build than main with nothing saying so. The only recovery is a person noticing a red check and re-running the workflow by hand.

## The change

One line. `seq 1 60` becomes `seq 1 115`: about 38 minutes, sized against the job's own 45 minute timeout with headroom for checkout and setup, rather than picked.

```
polling budget: 115 x 20s = 2300s = 38.3 min
job timeout   : 45 min
headroom      : 6.7 min
```

The `exit 1` on a CI that concluded anything but success is untouched. The diff is 1 deletion and 19 insertions, 18 of which are the comment explaining the sizing.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR