### PR TITLE
ci: the deploy cancelled its own publish part way through

### DIFF
--- a/.changes/a-publish-cancelled-part-way-through.internal.md
+++ b/.changes/a-publish-cancelled-part-way-through.internal.md
@@ -1,0 +1,25 @@
+# fixed
+
+The Deploy workflow cancelled its own publish part way through.
+
+Every workflow in this repository sets `cancel-in-progress: true`, which is
+right for the ones answering "is this commit good": a superseded answer is
+worth nothing. Deploy is not answering a question. It uploads to production,
+and the steps after the upload are the ones that check the upload worked.
+
+Run 33598095533, head 8fd7fedf, is what this looks like. "Assemble one site"
+and "Check the assembled site before publishing it" both succeeded, "Publish"
+was cancelled mid flight by the next merge, and the four steps behind it were
+skipped. A partial upload reached the live site and nothing checked the
+result. "The API answers" and "The machine-readable surfaces answer, and
+describe this revision" exist precisely because a publish is not a working
+endpoint, and cancellation takes them away first.
+
+The step named "Say so when it was not published" is skipped too, so the
+failure is silent by construction: the alarm sits inside the blast radius.
+Eleven consecutive Deploy runs were cancelled this way and the last one to
+report success was three hours and eight merges earlier.
+
+Deploy now queues rather than cancels. That costs a few minutes of latency
+when merges land back to back, which is the correct trade against a half
+uploaded site nobody was told about.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,26 @@ on:
 
 concurrency:
   group: deploy-${{ github.ref }}
-  cancel-in-progress: true
+  # Queue, do not cancel. Every other workflow here cancels a superseded run
+  # because a stale answer to "is this commit good" is worth nothing. This one
+  # is not answering a question, it is uploading to production, and the steps
+  # after the upload are the ones that check the upload worked.
+  #
+  # Cancelling caught a publish in flight. Run 33598095533, head 8fd7fedf:
+  # "Assemble one site" and "Check the assembled site before publishing it"
+  # both succeeded, "Publish" was CANCELLED part way through, and the four
+  # steps after it were skipped. So a partial upload reached the live site and
+  # nothing checked the result. "The API answers" and "The machine-readable
+  # surfaces answer, and describe this revision" are exactly the checks that
+  # exist because a publish is not a working endpoint, and they are the first
+  # things cancellation takes away.
+  #
+  # The step named "Say so when it was not published" is skipped too, so this
+  # failure is silent by construction: the alarm is inside the blast radius.
+  #
+  # Queueing costs a few minutes of latency when merges land back to back. That
+  # is the correct trade against a half-uploaded site nobody was told about.
+  cancel-in-progress: false
 
 permissions:
   contents: read


### PR DESCRIPTION
## What

One line in `.github/workflows/deploy.yml`: `cancel-in-progress: false`, plus the comment explaining why this workflow is the exception, and an internal changelog fragment.

## Why

Every workflow here cancels superseded runs, which is right for the ones answering "is this commit good". Deploy is not answering a question. It uploads to production, and the steps after the upload are the ones that check the upload worked.

Run 33598095533, head 8fd7fedf:

| step | conclusion |
| --- | --- |
| Assemble one site | success |
| Check the assembled site before publishing it | success |
| Publish | **cancelled** |
| The API answers | skipped |
| The machine-readable surfaces answer, and describe this revision | skipped |
| Tell Bing what changed | skipped |
| Say so when it was not published | skipped |

A partial upload reached the live site and nothing checked the result.

The two skipped verification steps are the ones that exist because a publish is not a working endpoint. The comment on `The API answers` records two days of green deploys over a function app that refused every request. Cancellation removes them first.

The last row is the sharpest: `Say so when it was not published` is the alarm for exactly this situation, and it sits inside the blast radius, so this failure mode is silent by construction. Eleven consecutive Deploy runs were cancelled tonight; the last to report success was three hours and eight merges earlier.

## Verification

I checked production by hand rather than assuming, since CI had skipped the checks that would have:

    GET  /api                                       200
    POST /api/waitlist {"email":"not-an-address"}   400
    /openapi.json    200, 210954 bytes
    /errors.v1.json  200, 50836 bytes
    /llms.txt        200, 9069 bytes
    /sitemap.xml     200, 4712 bytes
    /robots.txt      200, 1048 bytes

The live docs sidebar also renders the ordering from #69, so that merge did reach production. The site is healthy. That is luck rather than design: an interrupted Azure Static Web Apps upload is not guaranteed to land consistently.

`prosecheck` 507 files 0 findings, `changecheck` exit 0, and the concurrency block parses with `group` and `cancel-in-progress: false` followed by `permissions`.

## Trade

Deploys queue instead of cancelling, costing a few minutes when merges land back to back. That is the right trade against a half uploaded site nobody was told about.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR