### PR TITLE
ci: the gate on the published document was dark for the length of a queue

### DIFF
--- a/.changes/a-gate-that-was-dark-for-the-length-of-a-queue.internal.md
+++ b/.changes/a-gate-that-was-dark-for-the-length-of-a-queue.internal.md
@@ -1,0 +1,21 @@
+# fixed
+
+The check on the published OpenAPI document did not run on any branch in a
+migration chain.
+
+It is sequenced immediately after `Test` in the control plane job, and `Test`
+is red on every branch in such a chain because the numbering gate reads a gap
+until the branches ahead of it land. A step after a failed step is skipped, and
+GitHub renders a skipped step exactly like one that had nothing to do. So the
+control was dark for as long as the queue, and its darkness was invisible,
+because the job already said failure for the reason everybody expected.
+
+The cost was real. Mounting the operator router put eighteen admin routes into
+the document that antifailure.dev/openapi.json serves, each described as
+`security: []` with the sentence "Requires no permission", which is a false
+statement about the operator surface aimed at whatever generates a client from
+it. This step ran on neither the change that introduced it nor the change that
+fixed it. It was found by running the check by hand.
+
+`if: always()` on the step. A gate whose subject is a published document should
+not be silenced by an unrelated failure elsewhere in the same job.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -672,6 +672,23 @@ jobs:
         working-directory: web
 
       - name: The published OpenAPI document is the one this router serves
+        # Runs even when Test failed, which is the whole point of the line
+        # below. This step is sequenced immediately after Test, and Test is red
+        # on every branch in a migration chain because the numbering gate reads
+        # a gap until the branches ahead land. A skipped step renders exactly
+        # like one that had nothing to do, so for the length of a queue this
+        # control was dark and its darkness was invisible: the job already said
+        # failure for the reason you expected.
+        #
+        # That is not hypothetical. Mounting the operator router put eighteen
+        # admin routes into the published document described as `security: []`
+        # and "Requires no permission", and this step did not run on the change
+        # that introduced them, or on the change that fixed it. It was found by
+        # running the check by hand.
+        #
+        # A gate whose subject is a published document should not be silenced
+        # by an unrelated failure in the same job.
+        if: always()
         # www/public/openapi.json is what antifailure.dev/openapi.json serves,
         # and it is generated from the router in this job's workspace rather
         # than proxied from production at request time. The reason is in


### PR DESCRIPTION
Found by `admin-money`, confirmed by `drafts` sweeping every branch they hold. One line.

## The shape

`The published OpenAPI document is the one this router serves` is sequenced immediately after `Test` in the control plane job.

`Test` is red on **every branch in a migration chain**, because the numbering gate reads a gap until the branches ahead land. That gap is deliberate and lives as long as the queue. A step after a failed step is skipped, and **GitHub renders a skipped step exactly like one that had nothing to do**.

So this control was not dark for a few hours by accident. It was dark *structurally*, and the darkness was invisible, because the job's conclusion already said `failure` for the reason everybody expected. Reading the job told you nothing you did not already know.

```
control plane | step 8  Test: failure                                    <- the known numbering gap
control plane | step 9  The published OpenAPI document ...: SKIPPED      <- the control, silenced
```

## The cost was real

Mounting the operator router put **eighteen admin routes** into the document `antifailure.dev/openapi.json` serves, each described as `security: []` with the sentence *"Requires no permission"* — a false claim about the operator surface, aimed at whatever generates a client from it, and pointed at by `llms.txt`.

**This step ran on neither the change that introduced that nor the change that fixed it.** It was found by an agent noticing the step said `skipped` and running `openapi:check` by hand.

## The fix

`if: always()`. A gate whose subject is a published document should not be silenced by an unrelated failure elsewhere in the same job.

## Scope

Deliberately kept to the one step with a named casualty. Two other steps follow a `Test` in this file:

| step | verdict |
|---|---|
| `Build the marketing site` | skipping after a failed test is correct, the work is wasted |
| `Nothing was left behind` | a leak check, so **most** relevant precisely when a run failed |

That second one is worth a look by whoever owns it. Not changed here.

## Generalisation worth keeping

Any control sequenced after a step that is red for a *known* reason is dark, and its darkness is invisible because the job's conclusion already reads `failure` for the reason you expect. That is the third distinct instance of the early-red hazard tonight, after `#84`'s engine job hiding nineteen steps behind a doc test and `#70`'s six reds all being one compile error.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR