### PR TITLE
www: signin and signup advertised a markdown twin the build never wrote

### DIFF
--- a/.changes/two-pages-advertised-a-file-that-was-never-written.md
+++ b/.changes/two-pages-advertised-a-file-that-was-never-written.md
@@ -1,0 +1,16 @@
+# fixed
+
+The sign-in and sign-up pages advertised a markdown file that 404'd.
+
+Every page on the marketing site carried a `<link rel="alternate"
+type="text/markdown">` pointing at its own address with `.md` on the end, so an
+assistant could read 800 words of prose instead of parsing 300KB of HTML. The
+generator that writes those files does not write one for every page: it skips
+anything carrying `noindex`, because a page crawlers were asked to ignore
+should not be republished in a machine-readable form.
+
+`/signin` and `/signup` are the only two pages the site marks `noindex`, so
+they were the only two advertising a file the build never produced. Both
+addresses answered 404. The tag is now emitted only for indexable pages, which
+is the rule the generator already followed, and the SEO check asserts that
+every twin a page advertises is a file the build actually wrote.

--- a/www/lib/seo.ts
+++ b/www/lib/seo.ts
@@ -39,12 +39,25 @@ export function pageMetadata(path: string, overrides: Metadata = {}): Metadata {
     description: route.description,
     alternates: {
       canonical: url,
-      types: {
-        // The markdown twin of this page. Assistants and agent runtimes that
-        // prefer source over rendered HTML can follow this instead of parsing
-        // a 300KB document to recover 800 words.
-        "text/markdown": `${url === SITE_URL ? SITE_URL : url}.md`,
-      },
+      // The markdown twin of this page. Assistants and agent runtimes that
+      // prefer source over rendered HTML can follow this instead of parsing a
+      // 300KB document to recover 800 words.
+      //
+      // Only on indexable pages, because only indexable pages get a twin.
+      // scripts/markdown-twins.mjs deliberately skips anything carrying
+      // noindex, so /signin and /signup advertised a /signin.md and a
+      // /signup.md that the build never wrote and the host answered 404 for.
+      // Publishing the two missing files would silence the link checker and
+      // would be the wrong fix: it would put a page we asked crawlers to
+      // ignore back on the menu in a machine-readable form. The link is what
+      // was untrue, so the link is what goes.
+      ...(route.indexable
+        ? {
+            types: {
+              "text/markdown": `${url === SITE_URL ? SITE_URL : url}.md`,
+            },
+          }
+        : {}),
     },
     robots: route.indexable
       ? {

--- a/www/scripts/check-seo.mjs
+++ b/www/scripts/check-seo.mjs
@@ -379,6 +379,53 @@ for (const file of pages) {
   }
 }
 
+// Every markdown twin a page ADVERTISES has to be a file that exists.
+//
+// The per-page loop above skips noindex pages, so it only ever asked whether
+// an indexable page had a twin. It could not see the opposite failure, which
+// is the one that shipped: /signin and /signup are deliberately noindex, the
+// twin generator deliberately refuses to write a twin for a noindex page, and
+// lib/seo.ts advertised one anyway. Two <link rel="alternate"> tags pointed at
+// https://antifailure.dev/signin.md and /signup.md, the host answered 404 for
+// both, and the only thing that noticed was the external link checker, after
+// the build was green and merged.
+//
+// So this walks every built page, indexable or not, reads the address it
+// claims its markdown lives at, and asserts the build actually wrote that
+// file. It is deliberately driven by the advertised href rather than by the
+// route registry: the tag is what a crawler follows, so the tag is what has to
+// be true.
+console.log("\nAdvertised markdown twins");
+{
+  const dangling = [];
+  let advertised = 0;
+  for (const file of pages) {
+    const html = readFileSync(file, "utf8");
+    const rel = path.relative(OUT, file);
+    const tag = (html.match(/<link\b[^>]*>/gi) ?? []).find(
+      (t) => /rel="alternate"/i.test(t) && /type="text\/markdown"/i.test(t),
+    );
+    if (!tag) continue;
+    const href = tag.match(/href="([^"]*)"/i)?.[1] ?? "";
+    advertised++;
+    // Same-origin only. An absolute address on another host is somebody
+    // else's file and this check has no opinion about it.
+    if (!href.startsWith(ORIGIN + "/")) {
+      dangling.push(`${rel} advertises ${JSON.stringify(href)}, which is not on ${ORIGIN}`);
+      continue;
+    }
+    const target = href.slice(ORIGIN.length + 1);
+    if (!has(target)) dangling.push(`${rel} advertises /${target}, which the build did not write`);
+  }
+  assert(
+    advertised > 0 && dangling.length === 0,
+    `every advertised markdown twin exists (${advertised} pages advertise one)`,
+    advertised === 0
+      ? "no page advertises a markdown twin at all, which is itself the regression"
+      : dangling.join("\n         "),
+  );
+}
+
 // The skip link is in the root layout, so it is on every page, but the element
 // it points at is not: three pages do not use SiteLayout and had no id="main",
 // and one of them had no <main> at all. That made the first thing a keyboard


### PR DESCRIPTION
The `Links` workflow on main is red with two 404s and nothing else:

```
* [404] https://antifailure.dev/signin.md  (in site/signin.html, at 1:2394)
* [404] https://antifailure.dev/signup.md  (in site/signup.html, at 1:2394)
```

## What was wrong

`pageMetadata()` in `www/lib/seo.ts` gave every page a
`<link rel="alternate" type="text/markdown">` pointing at its own address with
`.md` appended. `www/scripts/markdown-twins.mjs` does not write one for every
page. It skips anything carrying `noindex`, on purpose: a page we asked
crawlers to ignore should not be republished in a machine readable form.

`/signin` and `/signup` are the only two `indexable: false` routes in
`lib/routes.ts`, so they were the only two pages advertising a file the build
never produced. The host answered 404 for both.

## The fix

The link is what was untrue, so the link is what goes. The metadata helper now
emits the markdown alternate only for indexable routes, which is the rule the
generator already follows. Publishing `signin.md` and `signup.md` would have
turned the check green faster and would have contradicted the generator's own
reason for skipping them.

The hand written 404 case is unaffected: `app/not-found.tsx` names its
alternate explicitly and `public/404.md` is a real checked in file.

## The gate

`check-seo.mjs` could not have caught this. Its per page loop `continue`s on
`noindex`, so it only ever asked whether an indexable page had a twin, never
whether a page advertised a twin it did not have.

A new pass walks every built page, indexable or not, reads the href out of the
tag a crawler would actually follow, and fails when the build did not write
that file. It is driven by the emitted tag rather than by the route registry,
because the tag is the thing that gets followed.

## Verification

Built locally with `npm run build` in `www/`:

- `out/signin.html` and `out/signup.html` contain no `.md` href at all
- `out/pricing.html` and the other indexable pages still carry theirs
- `out/404.html` still points at `404.md`, which exists
- `npm run check:seo` passes 88 of 88

Negative test, because a check that cannot say no is worse than none:
injecting the shipped `<link rel="alternate" type="text/markdown"
href="https://antifailure.dev/signin.md">` back into `out/signin.html` makes
`check:seo` exit 1 with `signin.html advertises /signin.md, which the build did
not write`. That is the exact address lychee reported.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR