### PR TITLE
engine: the runner install looked one level up and the checkout was two

### DIFF
--- a/.changes/the-runner-was-two-levels-up-and-nobody-looked.md
+++ b/.changes/the-runner-was-two-levels-up-and-nobody-looked.md
@@ -1,0 +1,19 @@
+# fixed
+
+`af runner install` now finds the runner from anywhere inside a checkout,
+rather than only from its root.
+
+It searched the working directory and its parent, which assumed the working
+directory was the root of the checkout. That is usually true, so it held until
+something ran from a subdirectory. Run from `examples/go-api`, it searched
+`examples/go-api/runner` and `examples/runner`, found neither, and reported
+that no runner source existed while standing two levels below a checkout that
+had one. The remedy it printed told the reader to install a runner they
+already had.
+
+The search now climbs to the directory holding `.git` and stops there. It
+stops at the checkout rather than the filesystem root because a runner outside
+it belongs to something else, and copying that one would succeed, which is the
+worse failure: the wrong runner stays invisible until a test will not run.
+Outside a checkout the two nearest directories are searched, which is the pair
+this looked in before, so nothing that already worked has changed.

--- a/engine/internal/cli/runner.go
+++ b/engine/internal/cli/runner.go
@@ -571,10 +571,8 @@ func runnerSource(e *Env, from string) (string, error) {
 	candidates := []string{from}
 	if from == "" {
 		candidates = nil
-		// Beside the working directory, for a checkout.
-		candidates = append(candidates,
-			filepath.Join(e.WorkDir, "runner"),
-			filepath.Join(e.WorkDir, "..", "runner"))
+		// At and above the working directory, for a checkout.
+		candidates = append(candidates, checkoutRunners(e.WorkDir)...)
 		// Beside the binary, for an installed release, which ships the runner
 		// next to it rather than fetching it.
 		if self, err := os.Executable(); err == nil {
@@ -594,6 +592,50 @@ func runnerSource(e *Env, from string) (string, error) {
 	}
 	return "", aferrors.Coded(aferrors.AFAGT004,
 		"detail", "no runner source was found; looked in "+strings.Join(candidates, ", "))
+}
+
+// checkoutRunners lists the runner directories at and above dir, stopping at
+// the checkout dir sits in.
+//
+// This ascends because the working directory is not reliably the root of the
+// checkout, and looking exactly one level up quietly assumed it was. Running
+// `af runner install` from examples/go-api searched examples/go-api/runner and
+// examples/runner, then reported that no runner source existed, while the
+// runner it wanted sat at the top of the very checkout it was running inside.
+// Anyone who keeps a project in a subdirectory met the same wall, and the
+// error told them to install a runner they already had.
+//
+// The ascent stops at the directory holding .git rather than walking to the
+// filesystem root. A walk to the root would eventually find an unrelated
+// ~/runner belonging to something else and copy that, which is a worse failure
+// than the one this fixes: it succeeds, and the wrong runner is only visible
+// later as a test that will not run.
+//
+// Outside any checkout there is no root to stop at, so only the two nearest
+// directories are offered. That is exactly the pair this searched before, so
+// the case that already worked still works, and the error message does not
+// list every directory up to / and bury the two that matter.
+func checkoutRunners(dir string) []string {
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		abs = dir
+	}
+	var found []string
+	for d := abs; ; {
+		found = append(found, filepath.Join(d, "runner"))
+		if _, err := os.Stat(filepath.Join(d, ".git")); err == nil {
+			return found
+		}
+		parent := filepath.Dir(d)
+		if parent == d {
+			break
+		}
+		d = parent
+	}
+	if len(found) > 2 {
+		found = found[:2]
+	}
+	return found
 }
 
 // copyTree copies the runner's source, and nothing it can rebuild.

--- a/engine/internal/cli/runner_source_test.go
+++ b/engine/internal/cli/runner_source_test.go
@@ -1,0 +1,127 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A checkout with a runner at its root, and a project some levels down inside
+// it, which is the shape that made `af runner install` claim no runner source
+// existed while standing inside a checkout that had one. The walkthrough runs
+// from examples/<name>, two levels below the root, so one level of ascent was
+// not enough and the number of levels was never the real rule.
+func writeCheckout(t *testing.T, depth int) (root, work string) {
+	t.Helper()
+	root = t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	src := filepath.Join(root, "runner", "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte("//\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	work = root
+	for i := 0; i < depth; i++ {
+		work = filepath.Join(work, "d")
+	}
+	if err := os.MkdirAll(work, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return root, work
+}
+
+func TestRunnerSourceFindsTheCheckoutRunnerFromASubdirectory(t *testing.T) {
+	for _, depth := range []int{0, 1, 2, 4} {
+		root, work := writeCheckout(t, depth)
+		got, err := runnerSource(&Env{WorkDir: work}, "")
+		if err != nil {
+			t.Fatalf("depth %d: %v", depth, err)
+		}
+		want := filepath.Join(root, "runner")
+		if got != want {
+			t.Errorf("depth %d: got %q, want %q", depth, got, want)
+		}
+	}
+}
+
+// The ascent has to stop somewhere, and the check is that it stops at the
+// checkout rather than at the filesystem root. A runner outside the checkout
+// belongs to something else, and copying it would succeed, which is worse than
+// failing: the wrong runner only shows up later as a test that will not run.
+func TestRunnerSourceDoesNotClimbOutOfTheCheckout(t *testing.T) {
+	outside := t.TempDir()
+	src := filepath.Join(outside, "runner", "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte("//\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	root := filepath.Join(outside, "checkout")
+	if err := os.MkdirAll(filepath.Join(root, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	work := filepath.Join(root, "examples", "go-api")
+	if err := os.MkdirAll(work, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := runnerSource(&Env{WorkDir: work}, "")
+	if err == nil {
+		t.Fatalf("found %q outside the checkout, and should have found nothing", got)
+	}
+	if strings.Contains(err.Error(), filepath.Join(outside, "runner")) {
+		t.Errorf("the runner outside the checkout was searched: %v", err)
+	}
+}
+
+// An explicit --from still wins, and is still the only thing searched, so the
+// ascent cannot quietly substitute a different runner for the one asked for.
+func TestRunnerSourceHonoursAnExplicitFrom(t *testing.T) {
+	root, work := writeCheckout(t, 2)
+	other := t.TempDir()
+	src := filepath.Join(other, "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte("//\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := runnerSource(&Env{WorkDir: work}, other)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != other {
+		t.Errorf("got %q, want the explicit %q, not the checkout at %q", got, other, root)
+	}
+}
+
+// Outside a checkout the search is the pair it always was, so the error names
+// the two directories that could plausibly hold a runner rather than every
+// directory between here and the filesystem root.
+func TestCheckoutRunnersStopsAtTwoWithoutACheckout(t *testing.T) {
+	work := filepath.Join(t.TempDir(), "a", "b", "c")
+	if err := os.MkdirAll(work, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	got := checkoutRunners(work)
+	want := []string{
+		filepath.Join(work, "runner"),
+		filepath.Join(filepath.Dir(work), "runner"),
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("got %v, want %v", got, want)
+			break
+		}
+	}
+}


### PR DESCRIPTION
This is the one red check standing between main and the v1.0.0 tag.

## What was wrong

`af runner install` searched the working directory and its parent for the runner. That assumes the working directory is the root of the checkout. It usually is, so nothing noticed.

The walkthrough now runs `af runner install` from `examples/<name>`, which is two levels down. It searched `examples/go-api/runner` and `examples/runner`, found neither, and reported `AF-AGT-004 no runner source was found` while standing inside a checkout whose runner sat at the top. The remedy it printed told the reader to install a runner they already had.

The error message prints the paths it searched, and that is what identified this:

```
looked in /home/runner/work/antifailure/antifailure/examples/go-api/runner,
          /home/runner/work/antifailure/antifailure/examples/runner,
          /tmp/runner, /share/antifailure/runner
```

Three examples failed identically. This is not the version bump in #109; nothing in the search is version dependent.

It is also a real defect for anyone keeping a project in a subdirectory of a checkout, not only for the walkthrough.

## What changed

The search ascends to the directory holding `.git` and stops there.

It stops at the checkout rather than the filesystem root on purpose. A walk to the root would eventually find an unrelated `~/runner` and copy it, and that failure succeeds, so the wrong runner stays invisible until a test will not run. Failing loudly is the better of the two.

Outside any checkout there is no root to stop at, so the ascent offers the two nearest directories, which is exactly the pair searched before. The case that already worked still works, and the error does not list every directory up to `/`.

## Verification

The new test fails against the old two level search with the same message CI produced, and passes against the ascent, at depths zero through four. It also asserts that a runner outside the checkout is never searched, and that an explicit `--from` still wins alone.

Resolution was confirmed against the real repository layout from `examples/go-api`, which returns the checkout root runner. That path ran through a git worktree, where `.git` is a file rather than a directory, so both shapes work.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR