### PR TITLE
github: the fork comment described two halves of a three part protection

### DIFF
--- a/web/apps/api/src/github/lifecycle.ts
+++ b/web/apps/api/src/github/lifecycle.ts
@@ -1384,6 +1384,14 @@ export function hashCallback(token: string): Buffer {
  * entirely. Both are real and neither is sufficient alone: GitHub's covers the
  * repository's own secrets, and this covers the credential this control plane
  * would otherwise hand out.
+ *
+ * Neither covers the third thing, and this comment used to read as though there
+ * were only two. Both halves above are about what GitHub hands a job. Neither
+ * says anything about what is already sitting on the machine the job runs on: on
+ * a self hosted runner the Docker daemon, an existing registry login and the
+ * network are ambient, and GitHub withholds none of them from a fork's code. The
+ * engine's own fork gate is what covers that, and it has to, because this control
+ * plane never sees that machine.
  */
 export async function issueCallback(
   deps: LifecycleDeps,


### PR DESCRIPTION
Found while clearing stale branches: this commit has sat on `w-github-lifecycle` since 2026-09-01 with no pull request, and its content is nowhere in main.

`issueCallback` said a fork stays secretless for two reasons. GitHub withholds secrets and the workflow identity token from a fork's pull request job, and this control plane refuses a credential for a commit no maintainer approved. Both are true, and both are about what GitHub hands a job.

Neither is about what is already on the machine. On a self hosted runner, which is the common shape for this product because it needs Docker and a golden, the daemon, an existing registry login and the network are ambient, and GitHub withholds none of them from a fork's code. The comment read as a complete account of the protection and was an account of two thirds of it.

Comment only. No behaviour changes. The engine's own fork gate is what covers the third part, and this now says so.

## Verified

The comment it amends still exists in main at `web/apps/api/src/github/lifecycle.ts`, and the branch merges into main with no conflict.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR
