### PR TITLE
cli: the token table gives up width where a shortened value still reads

### DIFF
--- a/.changes/token-list-column-widths.md
+++ b/.changes/token-list-column-widths.md
@@ -1,0 +1,8 @@
+# changed
+
+`af token list` lets STATE give up width alongside NAME when the terminal is
+too narrow for the table. PREFIX now keeps its full width in every terminal,
+because it is exactly what `af token rm` takes as an argument, and a shortened
+prefix prints something that does not work when it is pasted back. STATE reads
+`revoked 12 Mar` or `active`, so losing the date still leaves the word that
+decides anything.

--- a/engine/internal/cli/token.go
+++ b/engine/internal/cli/token.go
@@ -241,11 +241,14 @@ tells two of them apart, and it is what af token rm accepts.`),
 				}
 				rows = append(rows, []string{t.Name, t.Prefix, state, used})
 			}
-			// The name is the flex column because it is the only one a person
-			// chose the length of. A prefix, a state and a date are all short
-			// and fixed, and are the columns a reader scans down.
+			// PREFIX is deliberately not flexible. It is exactly what
+			// 'af token rm' takes as an argument, so a shortened one would
+			// print something that does not work when it is pasted back.
+			// NAME is the only unbounded column, a label somebody types, and
+			// STATE can lose its revocation date without losing the word that
+			// matters, so those two give up width to each other first.
 			e.Out.Table([]Column{
-				Flex("NAME"), Col("PREFIX"), Col("STATE"), Col("LAST USED"),
+				Flex("NAME"), Col("PREFIX"), Flex("STATE"), Col("LAST USED"),
 			}, rows)
 			return nil
 		},


### PR DESCRIPTION
Found while clearing stale branches: this commit has sat on `w-selfhost` since 2026-08-31 with no pull request, and its content is nowhere in main. It was written waiting on the `Column` signature that has since landed, so it is applicable now.

Only a column declared `Flex` is ever shortened, so declaring which ones may shorten is the whole decision. `af token list` declared one, NAME, and the comment above it gave the reason as "a prefix, a state and a date are all short and fixed."

PREFIX is not merely short. It is exactly what `af token rm` takes as an argument, which the command's own help text says: `rm <id or prefix>`. A shortened PREFIX would print something that does not work when it is pasted back, so it must never flex, and the comment now gives that as the reason rather than its width.

STATE is the opposite case. It reads `revoked 12 Mar` or `active`, and losing the date still leaves the word that decides anything. So NAME and STATE give up width to each other first, and this marks STATE flexible.

## Verified

```
go build ./...                exit 0
go vet ./internal/cli/        exit 0
go test ./internal/cli/       ok
```

The branch was rebased onto main to resolve a conflict with the comment main carries in the same place. The resolution keeps this commit's comment, which is the one that names the constraint.

This is a change a user can notice, so it carries `.changes/token-list-column-widths.md`. `changecheck` and `prosecheck` both pass against `origin/main..HEAD` locally.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR
