### PR TITLE
golden: a refresh that read nothing published a golden

### DIFF
--- a/.changes/a-refresh-that-read-nothing-published-a-golden.md
+++ b/.changes/a-refresh-that-read-nothing-published-a-golden.md
@@ -1,0 +1,35 @@
+# fixed
+
+`af golden refresh` published an empty golden when the variable naming
+production held nothing, and exited 0.
+
+A manifest that sets `database.source_url_env` is saying where production is.
+When the variable it names was unset, the refresh read that as "no source
+configured", which is the shape a project with no production yet has. It
+started a candidate, copied nothing into it, masked nothing, verified nothing,
+and committed a golden carrying this project's own provenance. The last line it
+printed was `Bring an environment up from it with: af up`.
+
+`af up` already refuses this, with AF-DB-012, when a manifest names a source
+and no golden exists. That guard then passed, because a golden for this project
+now did exist. The environment came up, the migrations ran, and it held none of
+production's shape or volume while looking entirely correct. There was nothing
+to read that said otherwise: `af golden list` showed the empty version as
+verified and made for this project, which it was.
+
+An exported but empty variable is the same case and was equally silent, which
+is how a pull request from a fork reaches it. Forks get no secrets, so the
+variable is empty in exactly the runs nobody watches.
+
+A refresh whose named source holds nothing now stops before a candidate
+database is started:
+
+    AF-DB-016 database.source_url_env names PRODUCTION_DATABASE_URL, and
+              PRODUCTION_DATABASE_URL holds nothing in this shell.
+      Next: Export PRODUCTION_DATABASE_URL with the read only connection string
+            of the database to copy, then refresh again. To build a golden with
+            no production behind it, remove database.source_url_env and set
+            database.seed instead.
+
+A manifest with no `source_url_env` is unaffected: the empty golden it gets is
+what it asked for.

--- a/docs/src/content/docs/reference/errors.md
+++ b/docs/src/content/docs/reference/errors.md
@@ -472,6 +472,18 @@ The published golden {version} in {store} was made for a different project.
 | Retryable | No. Retrying the same operation unchanged will fail the same way. |
 | More | [concepts/goldens](/docs/concepts/goldens) |
 
+### AF-DB-016
+
+database.source_url_env names {variable}, and {variable} holds nothing in this shell.
+
+**What to do.** Export {variable} with the read only connection string of the database to copy, then refresh again. To build a golden with no production behind it, remove database.source_url_env and set database.seed instead.
+
+| | |
+| --- | --- |
+| Exit code | `3` |
+| Retryable | No. Retrying the same operation unchanged will fail the same way. |
+| More | [concepts/goldens](/docs/concepts/goldens) |
+
 ### AF-DB-020
 
 Personas cannot be provisioned because {provider} creates users only through its own API, and no sandbox tenant is configured.

--- a/engine/internal/env/golden.go
+++ b/engine/internal/env/golden.go
@@ -312,6 +312,28 @@ func (o *Orchestrator) refreshWithin(ctx context.Context, s *session) (*GoldenRe
 	started := o.opts.Clock.Now()
 	source := o.sourceURL()
 
+	// A manifest that names production and a shell that does not hold it is a
+	// refusal rather than an empty golden.
+	//
+	// This is the same defect `af up` already refuses with AF-DB-012, arriving
+	// through the other door. A refresh with the variable unset copied nothing,
+	// masked nothing, verified nothing, published a golden whose provenance is
+	// indistinguishable from a real one, exited 0 and printed "Bring an
+	// environment up from it with: af up". The next `af up` then found a golden
+	// for this project, branched an empty database, ran the migrations against
+	// it, and produced an environment that looks correct and holds none of
+	// production's shape or volume. It is the one failure a preview environment
+	// exists to prevent, and the run that caused it reported success.
+	//
+	// It is not hypothetical and it is not a typo. A pull request from a fork
+	// gets no secrets, so the variable is empty in exactly the runs nobody
+	// watches.
+	if o.opts.Manifest.Database != nil &&
+		o.opts.Manifest.Database.SourceURLEnv != "" && source.IsZero() {
+		return result, aferrors.Coded(aferrors.AFDB016,
+			"variable", o.opts.Manifest.Database.SourceURLEnv)
+	}
+
 	spec := provider.GoldenSpec{
 		Version:    databaseVersion(o.opts.Manifest),
 		RulesHash:  hash,

--- a/engine/internal/env/sourcemissing_test.go
+++ b/engine/internal/env/sourcemissing_test.go
@@ -1,0 +1,122 @@
+package env
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/internal/clock"
+	aferrors "github.com/antifailure/antifailure/engine/internal/errors"
+	"github.com/antifailure/antifailure/engine/internal/redact"
+	"github.com/antifailure/antifailure/engine/internal/testutil/fakes"
+	"github.com/antifailure/antifailure/engine/pkg/provider"
+	"github.com/antifailure/antifailure/engine/pkg/schema"
+)
+
+// A refresh whose named source holds nothing refuses rather than publishes.
+//
+// The defect: `af golden refresh` with database.source_url_env set and the
+// variable unset copied nothing, masked nothing, verified nothing, and
+// published a golden carrying this project's own provenance. It exited 0 and
+// told the reader to bring an environment up from it. The `af up` guard that
+// refuses an empty database for a manifest naming a source, AF-DB-012, then
+// passed, because by then a golden for this project existed. The environment
+// came up holding none of production's shape or volume and looking correct.
+//
+// The orderings are what these cover rather than the states. The variable
+// absent, the variable exported and empty, the variable set, and no source
+// configured at all. The last two are what keep the guard from becoming a
+// refusal for everybody and for a project that has no production yet.
+
+// countingDatabase records whether a refresh reached the provider at all.
+//
+// The assertion that matters is not only which error came back. It is that
+// nothing was built: a guard that returns the right code after a candidate
+// database has already been made and committed would still have published one.
+type countingDatabase struct {
+	*fakes.InMemoryDatabase
+	refreshes int
+}
+
+func (d *countingDatabase) RefreshGolden(
+	context.Context, provider.GoldenSpec,
+) (provider.GoldenVersion, error) {
+	d.refreshes++
+	// Refused rather than returned, so the paths after it, which need a state
+	// database this test has not opened, are never reached. What is under test
+	// is whether the call happens.
+	return provider.GoldenVersion{}, errors.New("the provider was asked to build a golden")
+}
+
+func refreshFixture(
+	t *testing.T, db *schema.Database, environ map[string]string,
+) (*Orchestrator, *session, *countingDatabase) {
+	t.Helper()
+	o, err := New(Options{
+		Root:     t.TempDir(),
+		Manifest: &schema.Manifest{Name: "app", Database: db},
+		Branch:   "main",
+		Clock:    clock.New(),
+		Redactor: redact.New(),
+		Getenv: func(k string) string {
+			if k == MaskingKeyEnv {
+				return "a-project-key-long-enough-to-be-accepted"
+			}
+			return environ[k]
+		},
+	})
+	require.NoError(t, err)
+	prov := &countingDatabase{InMemoryDatabase: fakes.NewInMemoryDatabase()}
+	return o, &session{dbProv: prov}, prov
+}
+
+func TestRefresh_ANamedSourceThatIsUnsetBuildsNothing(t *testing.T) {
+	o, s, prov := refreshFixture(t,
+		&schema.Database{SourceURLEnv: "PRODUCTION_DATABASE_URL"}, nil)
+
+	res, err := o.refreshWithin(t.Context(), s)
+	require.Error(t, err, "an unset source published a golden of nothing")
+	require.Equal(t, aferrors.AFDB016, codeOf(err))
+	require.Contains(t, err.Error(), "PRODUCTION_DATABASE_URL",
+		"the reader has to be told which variable to set")
+	require.Empty(t, res.Version, "nothing may be published from a source that was never read")
+	require.Zero(t, prov.refreshes,
+		"the refusal has to come before a candidate database is built")
+}
+
+func TestRefresh_ANamedSourceExportedEmptyBuildsNothing(t *testing.T) {
+	// The shape a missing CI secret takes. The step sets the variable from a
+	// secret that does not exist, so it is exported and holds "". A pull
+	// request from a fork gets no secrets at all, which is the run nobody
+	// watches.
+	o, s, prov := refreshFixture(t,
+		&schema.Database{SourceURLEnv: "PRODUCTION_DATABASE_URL"},
+		map[string]string{"PRODUCTION_DATABASE_URL": ""})
+
+	_, err := o.refreshWithin(t.Context(), s)
+	require.Equal(t, aferrors.AFDB016, codeOf(err))
+	require.Zero(t, prov.refreshes)
+}
+
+func TestRefresh_ANamedSourceThatIsSetStillRefreshes(t *testing.T) {
+	o, s, prov := refreshFixture(t,
+		&schema.Database{SourceURLEnv: "PRODUCTION_DATABASE_URL"},
+		map[string]string{"PRODUCTION_DATABASE_URL": "postgres://someone:secret@127.0.0.1:1/prod"})
+
+	_, err := o.refreshWithin(t.Context(), s)
+	require.NotEqual(t, aferrors.AFDB016, codeOf(err),
+		"a source that is set must not be refused as missing")
+	require.Equal(t, 1, prov.refreshes, "the ordinary case has to still reach the provider")
+}
+
+func TestRefresh_NoSourceConfiguredStillRefreshes(t *testing.T) {
+	// A project with no production behind it is a supported configuration, and
+	// the empty golden it gets is the point rather than a mistake.
+	o, s, prov := refreshFixture(t, &schema.Database{Seed: "true"}, nil)
+
+	_, err := o.refreshWithin(t.Context(), s)
+	require.NotEqual(t, aferrors.AFDB016, codeOf(err))
+	require.Equal(t, 1, prov.refreshes, "a seed only project has to still get its golden")
+}

--- a/engine/internal/errors/catalog.yaml
+++ b/engine/internal/errors/catalog.yaml
@@ -230,6 +230,13 @@ errors:
     docs: concepts/goldens
     retryable: false
     exit_code: 5
+  - code: AF-DB-016
+    area: DB
+    message: "database.source_url_env names {variable}, and {variable} holds nothing in this shell."
+    next_step: "Export {variable} with the read only connection string of the database to copy, then refresh again. To build a golden with no production behind it, remove database.source_url_env and set database.seed instead."
+    docs: concepts/goldens
+    retryable: false
+    exit_code: 3
   - code: AF-DB-007
     planned: true
     area: DB

--- a/engine/internal/errors/codes.gen.go
+++ b/engine/internal/errors/codes.gen.go
@@ -111,6 +111,9 @@ const (
 	// The published golden {version} in {store} was made for a different
 	// project.
 	AFDB015 Code = "AF-DB-015"
+	// database.source_url_env names {variable}, and {variable} holds
+	// nothing in this shell.
+	AFDB016 Code = "AF-DB-016"
 	// Personas cannot be provisioned because {provider} creates users only
 	// through its own API, and no sandbox tenant is configured.
 	AFDB020 Code = "AF-DB-020"
@@ -760,6 +763,15 @@ var catalog = map[Code]Entry{
 		Docs:      "concepts/goldens",
 		Retryable: false,
 		ExitCode:  ExitProvider,
+	},
+	AFDB016: {
+		Code:      AFDB016,
+		Area:      "DB",
+		Message:   "database.source_url_env names {variable}, and {variable} holds nothing in this shell.",
+		NextStep:  "Export {variable} with the read only connection string of the database to copy, then refresh again. To build a golden with no production behind it, remove database.source_url_env and set database.seed instead.",
+		Docs:      "concepts/goldens",
+		Retryable: false,
+		ExitCode:  ExitConfiguration,
 	},
 	AFDB020: {
 		Code:      AFDB020,

--- a/www/public/errors.v1.json
+++ b/www/public/errors.v1.json
@@ -399,6 +399,17 @@
       "planned": false
     },
     {
+      "code": "AF-DB-016",
+      "area": "DB",
+      "areaName": "Database",
+      "message": "database.source_url_env names {variable}, and {variable} holds nothing in this shell.",
+      "resolution": "Export {variable} with the read only connection string of the database to copy, then refresh again. To build a golden with no production behind it, remove database.source_url_env and set database.seed instead.",
+      "docs": "https://antifailure.dev/docs/concepts/goldens",
+      "retryable": false,
+      "exitCode": 3,
+      "planned": false
+    },
+    {
       "code": "AF-DB-020",
       "area": "DB",
       "areaName": "Database",


### PR DESCRIPTION
Found by running the documented getting started sequence against a Postgres loaded to look like a production database rather than an example.

## What happens today

A manifest sets `database.source_url_env: PRODUCTION_DATABASE_URL`. The variable is not exported. Then:

```
$ af golden refresh

Refreshing the golden

  ok    gv_20260902122216_74234e98   0 rows across 0 tables masked in 32s
  Verified 0 columns across 0 tables, 0 rows sampled.
  Bring an environment up from it with: af up
$ echo $?
0
```

Nothing was read, nothing was masked, nothing was verified, and a golden carrying this project's own provenance was committed and published. `af golden list` shows it as verified and made for this project, which it is.

`af up` already refuses an empty database for a manifest that names a source, with AF-DB-012. That guard is reached only when no golden exists, so the refresh above satisfies it. The environment then comes up, the migrations run against an empty database, and it looks correct.

An exported but empty variable behaves the same way. That is the shape a missing CI secret takes, and a pull request from a fork gets no secrets at all.

## What changes

A refresh whose named source holds nothing stops before a candidate database is started.

```
AF-DB-016 database.source_url_env names PRODUCTION_DATABASE_URL, and
          PRODUCTION_DATABASE_URL holds nothing in this shell.
  Next: Export PRODUCTION_DATABASE_URL with the read only connection string of
        the database to copy, then refresh again. To build a golden with no
        production behind it, remove database.source_url_env and set
        database.seed instead.
  More: https://antifailure.dev/docs/concepts/goldens
```

A manifest with no `source_url_env` is unaffected. The empty golden it gets is what it asked for.

## The tests

Four orderings rather than the one this was built against: the variable absent, exported and empty, set, and no source configured at all. The two refusal cases also assert the provider was never asked to build anything, because a guard that returns the right code after a candidate has been committed would still have published one. The two pass through cases assert the provider IS still reached, so the guard cannot become a refusal for everybody or break a seed only project.

Watched red before the fix and green after: the two refusal tests failed with an empty code, the two pass through tests passed.

Verified end to end against a real Postgres 17 holding multiple schemas, extensions, an enum, a composite key, a circular foreign key pair, a partitioned table, a materialized view, a generated column, row level security and a table with no primary key. Unset now exits 3 with the message above; set still refreshes and publishes.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR