### PR TITLE
ci: a cancelled run is not a verdict, and main was only getting those

### DIFF
--- a/.changes/main-never-finished-a-run.internal.md
+++ b/.changes/main-never-finished-a-run.internal.md
@@ -1,0 +1,19 @@
+# fixed
+
+A run on main is never cancelled by the next merge, so every commit on main
+reaches a verdict.
+
+`ci.yml`, `security.yml`, `crosslint.yml` and `keyring.yml` all carried
+`cancel-in-progress: true` keyed on the ref, which is right for a branch and
+wrong for main. On 2026-09-02 six pull requests landed inside the length of one
+run and each cancelled the one before it. Main went from 09:07 to past 12:30
+without a single COMPLETED run.
+
+Cancelled is not red. It is also not a verdict, and the difference matters
+because `release.yml` has no CI gate of its own: a tag on an unverified commit
+publishes binaries. The only control was somebody holding merges by hand long
+enough for one run to finish, which is what actually happened, and a control
+that depends on a person noticing is not a control.
+
+Branches keep cancelling, because there the saving is real and nothing reads
+the superseded answer. Tags are excluded for the same reason main is.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,17 @@ on:
 # about the older commit stopped mattering the moment the newer one arrived.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # A run on main is the verdict a tag and a deploy are read against, so it
+  # is never cancelled. On a branch the saving is real and nothing depends
+  # on the superseded answer, so cancelling stays.
+  #
+  # Six merges landed inside one run's length on 2026-09-02 and each cancelled
+  # the one before it, so main went from 09:07 to past 12:30 with no COMPLETED
+  # run at all. Cancelled is not red, but it is not a verdict either, and
+  # `release.yml` has no gate of its own, so the only thing standing between
+  # an unverified commit and published binaries was somebody holding merges
+  # by hand. Tags are excluded for the same reason.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
 
 # Read, and only read. No job in this workflow writes anything back, and a
 # token that could is a token an action pulled from the internet could use.

--- a/.github/workflows/crosslint.yml
+++ b/.github/workflows/crosslint.yml
@@ -34,7 +34,17 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # A run on main is the verdict a tag and a deploy are read against, so it
+  # is never cancelled. On a branch the saving is real and nothing depends
+  # on the superseded answer, so cancelling stays.
+  #
+  # Six merges landed inside one run's length on 2026-09-02 and each cancelled
+  # the one before it, so main went from 09:07 to past 12:30 with no COMPLETED
+  # run at all. Cancelled is not red, but it is not a verdict either, and
+  # `release.yml` has no gate of its own, so the only thing standing between
+  # an unverified commit and published binaries was somebody holding merges
+  # by hand. Tags are excluded for the same reason.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
 
 permissions:
   contents: read

--- a/.github/workflows/keyring.yml
+++ b/.github/workflows/keyring.yml
@@ -28,7 +28,17 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # A run on main is the verdict a tag and a deploy are read against, so it
+  # is never cancelled. On a branch the saving is real and nothing depends
+  # on the superseded answer, so cancelling stays.
+  #
+  # Six merges landed inside one run's length on 2026-09-02 and each cancelled
+  # the one before it, so main went from 09:07 to past 12:30 with no COMPLETED
+  # run at all. Cancelled is not red, but it is not a verdict either, and
+  # `release.yml` has no gate of its own, so the only thing standing between
+  # an unverified commit and published binaries was somebody holding merges
+  # by hand. Tags are excluded for the same reason.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
 
 # Read, and only read. Every action is pinned to a commit rather than a tag,
 # because a tag is mutable and pinning is what makes the reviewed thing the run

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,7 +19,17 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # A run on main is the verdict a tag and a deploy are read against, so it
+  # is never cancelled. On a branch the saving is real and nothing depends
+  # on the superseded answer, so cancelling stays.
+  #
+  # Six merges landed inside one run's length on 2026-09-02 and each cancelled
+  # the one before it, so main went from 09:07 to past 12:30 with no COMPLETED
+  # run at all. Cancelled is not red, but it is not a verdict either, and
+  # `release.yml` has no gate of its own, so the only thing standing between
+  # an unverified commit and published binaries was somebody holding merges
+  # by hand. Tags are excluded for the same reason.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
 
 # Read, and only read. Same reasoning as CI: nothing here writes back, and every
 # action is pinned to a commit because a tag can be moved after it is reviewed.


### PR DESCRIPTION
Do not merge this until the v1.0.0 tag is out. It changes workflow files and I want the tag cut against a commit whose CI ran under the configuration it was tested with.

## What happened today

Six pull requests landed inside the length of one CI run. Each new commit cancelled the run for the one before it, so main went from 09:07 to past 12:30 **without a single completed run**.

```
33628079198  3cf9012d  cancelled
33629215749  70c9ae2c  cancelled
33629288032  a78f489d  cancelled
```

Nobody noticed for three hours, and the reason is that cancelled does not look like a problem. It is not red. It is also not a verdict, and the gap between those two is where this lives.

## Why it is worth fixing rather than working around

`release.yml` has no CI gate of its own. A tag on an unverified commit publishes binaries. So the only thing standing between "main has never been checked" and "four signed archives are on the releases page" was a person holding merges by hand long enough for one run to finish.

That is what actually happened today. I froze every agent and waited. It worked, and a control that depends on somebody noticing is not a control.

This is also the third time in one day that a check in this repository turned out to be structurally unable to give a verdict rather than giving a wrong one. A step skipped behind an earlier red renders the same as a step that passed. A job that hit its own `timeout-minutes` is reported as `cancelled`. And a run superseded by the next merge is reported as `cancelled` too, by the same word, for an unrelated reason.

## The change

`cancel-in-progress` becomes conditional in `ci.yml`, `security.yml`, `crosslint.yml` and `keyring.yml`:

```yaml
cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
```

Branches are unchanged, because there the saving is real and nothing reads the superseded answer. Tags are excluded for the same reason main is.

`cd.yml` already carried `false` and `control-plane-image.yml` already excluded tags, so this brings four workflows in line with two that had worked it out. `dogfood.yml` is deliberately left alone: nothing gates on it and it is long running.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR