### PR TITLE
legal: warranty, liability and acceptable use, with the engine claims held to the engine

### DIFF
--- a/.changes/legal-warranty-liability-and-acceptable-use.md
+++ b/.changes/legal-warranty-liability-and-acceptable-use.md
@@ -1,0 +1,32 @@
+# added
+
+The terms of use now carry the three sections they were missing: what the
+software is allowed to touch, a warranty disclaimer, and the shape of a
+limitation of liability. Two new pages join them, an acceptable use policy at
+`/acceptable-use` and a developer policy at `/developer-policy` covering the
+control plane API and the engine's Model Context Protocol surface.
+
+The liability section publishes no cap. The contracting entity, the registered
+address, the governing law and the figure itself are rendered as visible blanks,
+because a cap written before a lawyer has chosen the jurisdiction it will be
+read in is a number rather than a protection. The page says which exclusions no
+contract can make, and says plainly that whether any of it is enforceable
+depends on the jurisdiction, on whether the customer is a business or a
+consumer, and on whether the harm was caused by our own negligence.
+
+What the terms claim about the engine is now held to the engine. `legal-facts`
+gained seven assertions: that the customer's source database is opened in a
+transaction Postgres has marked read only, that teardown refuses a container
+Antifailure did not label, that `NewRuleSet` still appends the default masking
+rules so an unconfigured project is not an unmasked one, and that a golden
+failing verification is still never published. Each one was checked by breaking
+the guard on purpose and watching the assertion go red.
+
+The eighth pins the list of column types the verification scan reads. The terms
+describe that scan as a check that a masking rule missed a column rather than a
+proof that no personal data survives, and that wording is exact on purpose:
+the scan's type list and the masking default's type list are the same six
+entries, so a column outside them is read by neither. Changing either list now
+sends whoever changed it to the sentence describing it.
+
+No lawyer has read any of it, and every page says so on its face.

--- a/web/apps/api/test/legal-facts.test.ts
+++ b/web/apps/api/test/legal-facts.test.ts
@@ -449,3 +449,203 @@ describe('the subprocessor page describes the code that exists', () => {
     )
   })
 })
+
+describe('the terms describe guards that are really in the engine', () => {
+  /**
+   * The terms page now makes four claims about what the software can touch,
+   * and each one is a claim about a mechanism rather than an intention. That
+   * is the only reason they are publishable: an intention drifts silently and
+   * a mechanism fails a test when somebody removes it.
+   *
+   * These are deliberately keyed on the CONSTRUCT rather than on a sentence.
+   * Asserting the page contains a phrase would check that two files were
+   * edited together, which is what a reviewer already does. Asserting the
+   * engine still opens a read only transaction checks the thing the customer
+   * is actually relying on.
+   */
+  const engineRoot = path.join(repoRoot, 'engine')
+  const engine = (p: string) => readFile(path.join(engineRoot, p), 'utf8')
+
+  it('reads the engine sources it is reasoning about, so an empty parse cannot pass', async () => {
+    // Same negative control as the retention block above. Every assertion that
+    // follows is a substring search, and a substring search over a file that
+    // failed to load is a quiet pass.
+    for (const file of [
+      'internal/subset/execute.go',
+      'internal/dockerutil/dockerutil.go',
+      'internal/masking/rules.go',
+      'internal/verify/scan.go',
+      'internal/env/golden.go',
+    ]) {
+      const source = await engine(file).catch(() => '')
+      assert.ok(source.length > 500, `${file} did not load, so the assertions over it prove nothing`)
+    }
+  })
+
+  it('opens the customer source database in a read only transaction', async () => {
+    // The terms say a connection string with more rights than it needs still
+    // cannot be written through. That sentence is only true because Postgres
+    // is enforcing it, not because the code declines to write.
+    const source = await engine('internal/subset/execute.go')
+    assert.match(
+      source,
+      /BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY/,
+      'the terms page tells customers their production database is opened read only and that a ' +
+        'over-privileged connection string still cannot be written through. Nothing in the ' +
+        'subset path sets a read only transaction any more, so that sentence is now a promise ' +
+        'rather than a mechanism.',
+    )
+  })
+
+  it('refuses to remove a container Antifailure did not label', async () => {
+    // The terms say teardown removes only resources carrying our own labels
+    // and refuses anything else. The refusal is the claim; selecting by label
+    // would not be enough, because a selection can be widened by a caller.
+    const source = await engine('internal/dockerutil/dockerutil.go')
+    assert.match(
+      source,
+      /ErrNotOurs/,
+      'the terms page tells customers teardown refuses anything Antifailure did not create. ' +
+        'The ownership refusal is gone, so teardown now removes whatever it was handed.',
+    )
+    assert.match(
+      source,
+      /func RemoveContainer[\s\S]{0,600}IsOurs\(insp\.Config\.Labels\)/,
+      'RemoveContainer no longer checks ownership before removing, so the published claim that ' +
+        'it refuses a container it does not own is false.',
+    )
+  })
+
+  it('keeps masking on by default, with no way to switch it off', async () => {
+    // The terms say there is no setting that disables masking and a project
+    // with no rules file still gets the built-in set. Both halves come from
+    // NewRuleSet appending the defaults underneath whatever was declared.
+    const source = await engine('internal/masking/rules.go')
+    // The APPEND, not a mention of DefaultRules anywhere in the function. The
+    // first version of this matched the capacity hint on NewRuleSet's first
+    // line, `make([]Rule, 0, len(rules)+len(DefaultRules()))`, so deleting the
+    // loop that actually appends the defaults left the assertion passing. It
+    // was an instrument that could not say no, found by breaking the code on
+    // purpose and watching this stay green.
+    assert.match(
+      source,
+      /for _, r := range DefaultRules\(\) \{/,
+      'the terms page says a project with no rules file still gets the built-in rule set. ' +
+        'NewRuleSet no longer appends DefaultRules, so an unconfigured project now masks nothing.',
+    )
+  })
+
+  it('never publishes a golden whose verification found real data', async () => {
+    const source = await engine('internal/env/golden.go')
+    assert.match(
+      source,
+      /if !report\.Clean\(\)/,
+      'the terms page says a golden whose verification scan finds real data is never published. ' +
+        'The refusal is gone.',
+    )
+  })
+
+  /**
+   * THE ONE THAT IS A LIMIT RATHER THAN A GUARANTEE, and the reason it is here.
+   *
+   * The terms deliberately say the verification scan reads "the column types
+   * that can hold a sentence" and samples rows, rather than saying it reads
+   * every column. That wording is exact, and it is exact because it is
+   * currently generous: the scan's type list and the masking default's type
+   * list are the same six entries, so a citext or text[] column is masked by
+   * neither and read by neither.
+   *
+   * Writing the stronger sentence would have been a lie. Writing this weaker
+   * one and leaving it unguarded would let somebody later widen the scan,
+   * making the page understate the product, or narrow it, making the page
+   * overstate it. So the list itself is pinned. Changing it sends whoever
+   * changed it to the sentence on the terms page that describes it.
+   */
+  it('pins the column types the verification scan can see, which the terms describe as a limit', async () => {
+    const source = await engine('internal/verify/scan.go')
+    assert.match(
+      source,
+      /c\.data_type IN \('text', 'character varying', 'character', 'json', 'jsonb', 'xml'\)/,
+      'the set of column types the verification scan reads has changed. The terms page describes ' +
+        'this scan as covering "the column types that can hold a sentence" and as a check that a ' +
+        'rule missed a column rather than a proof that no personal data survives. If the list ' +
+        'grew, that sentence now understates the product. If it shrank, it overstates it. Either ' +
+        'way the page needs rereading, and so does the matching list in ' +
+        'internal/masking/rules.go looksSensitive, which is the same six types and is what ' +
+        'decides whether an unclassified column is emptied.',
+    )
+  })
+
+  it('keeps the scan and the masking default agreeing about which types matter', async () => {
+    // The two lists are the reason the sentence on the terms page is worded as
+    // a limit. If they ever disagree, one layer is covering something the
+    // other is not, and the honest description of the pair changes.
+    const rules = await engine('internal/masking/rules.go')
+    assert.match(
+      rules,
+      /func looksSensitive[\s\S]{0,400}case "text", "character varying", "character", "json", "jsonb", "xml":/,
+      'looksSensitive no longer covers the same types as the verification scan. The masking ' +
+        'default and the scan that backstops it are supposed to be described together on the ' +
+        'terms page, and they can no longer be.',
+    )
+  })
+})
+
+describe('the acceptable use and developer policy pages describe real mechanisms', () => {
+  it('reads the pages it is checking, so an empty parse cannot pass', async () => {
+    const legal = await read('www/components/pages/company/Legal.tsx')
+    assert.ok(
+      /export function AcceptableUsePage/.test(legal) &&
+        /export function DeveloperPolicyPage/.test(legal),
+      'the two new legal pages are not in Legal.tsx, so every assertion below is vacuous',
+    )
+  })
+
+  it('does not claim a suspension mechanism that the control plane lacks', async () => {
+    // The acceptable use page says an organization can be suspended, that this
+    // stops new work, and that it leaves the data in place. That is a specific
+    // capability and it is the only enforcement action the page claims.
+    const legal = await read('www/components/pages/company/Legal.tsx')
+    if (!/can be suspended/.test(legal)) return
+
+    const schema = await read('web/packages/db/src/schema.ts')
+    assert.match(
+      schema,
+      /suspended/,
+      'the acceptable use page says an organization can be suspended and that suspension leaves ' +
+        'the data in place. Nothing in the schema records suspension any more, so the page ' +
+        'describes an enforcement action that does not exist.',
+    )
+  })
+
+  it('does not claim every endpoint is rate limited unless the registry is real', async () => {
+    // The developer policy says every public endpoint has a limit declared in
+    // one registry that the middleware reads. The registry is the claim.
+    const legal = await read('www/components/pages/company/Legal.tsx')
+    if (!/declared in a single registry/.test(legal)) return
+
+    const limits = await read('web/apps/api/src/limits.ts')
+    assert.match(
+      limits,
+      /export const ENDPOINT_LIMITS/,
+      'the developer policy says every public endpoint has a rate limit declared in one ' +
+        'registry. ENDPOINT_LIMITS is gone, so the limits are wherever somebody remembered to ' +
+        'put them, which is the thing the page says is not the case.',
+    )
+  })
+
+  it('does not claim a Model Context Protocol surface that is not shipped', async () => {
+    // The whole second half of the developer policy is about a model driving
+    // the engine. A page describing a surface that was removed would be
+    // telling somebody to be careful about nothing.
+    const legal = await read('www/components/pages/company/Legal.tsx')
+    if (!/Model Context Protocol/.test(legal)) return
+
+    const { access } = await import('node:fs/promises')
+    await assert.doesNotReject(
+      access(path.join(repoRoot, 'engine/internal/mcp/engine.go')),
+      'the developer policy devotes a section to the engine Model Context Protocol ' +
+        'surface, and engine/internal/mcp is gone',
+    )
+  })
+})

--- a/www/app/acceptable-use/page.tsx
+++ b/www/app/acceptable-use/page.tsx
@@ -1,0 +1,8 @@
+import { AcceptableUsePage } from "@/components/pages/company/Legal";
+import { pageMetadata } from "@/lib/seo";
+
+export const metadata = pageMetadata("/acceptable-use");
+
+export default function Page() {
+  return <AcceptableUsePage />;
+}

--- a/www/app/developer-policy/page.tsx
+++ b/www/app/developer-policy/page.tsx
@@ -1,0 +1,8 @@
+import { DeveloperPolicyPage } from "@/components/pages/company/Legal";
+import { pageMetadata } from "@/lib/seo";
+
+export const metadata = pageMetadata("/developer-policy");
+
+export default function Page() {
+  return <DeveloperPolicyPage />;
+}

--- a/www/components/pages/company/Legal.tsx
+++ b/www/components/pages/company/Legal.tsx
@@ -12,6 +12,7 @@ import {
   RelatedGrid,
   SpecTable,
 } from "@/components/pages/kit";
+import { cn } from "@/lib/cn";
 import { BACKUP_RECOVERY, LOG_RETENTION } from "@/lib/legal-facts";
 import {
   NOT_ENGAGED,
@@ -32,10 +33,24 @@ const NOT_CLAIMED = [
  *
  * The terms page had this inline. Four pages want it now, and four copies of a
  * border rule is how two of them end up a pixel apart from the other two.
+ *
+ * `measure` is opt in rather than the default, and the reason is the two
+ * different jobs this list does. The original rows are fragments, four or five
+ * words each, and a rule that stopped at 720px beside them would read as a
+ * short line rather than a considered measure. The acceptable use and developer
+ * policy rows are whole sentences, and at the 1600px container they set a line
+ * roughly 190 characters long, which is unreadable and looked it. 720px is the
+ * width `Prose` and the counsel notice already use, so this is the system's own
+ * measure rather than a third one invented here.
  */
-function Ledger({ items }: { items: string[] }) {
+function Ledger({ items, measure }: { items: string[]; measure?: boolean }) {
   return (
-    <ul className="mt-12 flex flex-col border-t border-black/10 max-md:mt-8">
+    <ul
+      className={cn(
+        "mt-12 flex flex-col border-t border-black/10 max-md:mt-8",
+        measure && "max-w-[720px]",
+      )}
+    >
       {items.map((item) => (
         <li
           key={item}
@@ -271,6 +286,108 @@ export function TermsPage() {
         <PageHeading title="<strong>What these terms do not say.</strong>" />
         <Ledger items={NOT_CLAIMED} />
       </PageSection>
+      <PageSection tone="ruled">
+        <PageHeading
+          kicker="Your side"
+          title="<strong>What the software is allowed to touch,</strong> and what decides that."
+        />
+        <Prose className="mt-10">
+          <p>
+            The honest version of a liability section starts here rather than at a cap, because
+            what the software can reach is a fact about the code and a cap is a guess about a
+            court. Each row below is a limit the engine enforces, not a promise it intends to keep.
+          </p>
+        </Prose>
+        <div className="mt-14 max-md:mt-10">
+          <SpecTable
+            rows={[
+              [
+                "Your production database",
+                "Named by the variable in source_url_env and read, never written. The golden refresh reaches it only through pg_dump, and the subsetting path opens it inside a transaction Postgres has marked read only, so a connection string with more rights than it needs still cannot be written through.",
+              ],
+              [
+                "Your cloud permissions",
+                "You remain responsible for the credentials you give the agent and for everything those credentials can reach. Nothing here can narrow a permission you granted.",
+              ],
+              [
+                "Containers and branches",
+                "Teardown removes only resources carrying Antifailure's own labels, and refuses anything else by name. A database branch is created and destroyed through the provider's API under a reserved prefix.",
+              ],
+              [
+                "Masking",
+                "Runs on every golden. There is no setting that disables it, and a project with no rules file still gets the built-in set. A golden whose verification scan finds real data is never published, so it can never be branched.",
+              ],
+            ]}
+          />
+        </div>
+        <Prose className="mt-10">
+          <p>
+            The limit worth stating next to that last row, because a reader would otherwise assume
+            more than is true: the verification scan reads the column types that can hold a
+            sentence, and samples rows rather than reading every row. It is a check that a masking
+            rule missed a column entirely, which is the failure it is built for. It is not a proof
+            that no personal data survives anywhere in a schema, and it is not offered as one.
+          </p>
+        </Prose>
+      </PageSection>
+      <PageSection>
+        <PageHeading
+          kicker="Warranty"
+          title="<strong>The software is provided as it is.</strong> A pass is evidence, not insurance."
+        />
+        <Prose className="mt-10">
+          <p>
+            To the extent the law allows, the software is provided without warranty of any kind,
+            express or implied, including any implied warranty of merchantability, fitness for a
+            particular purpose, or non infringement. A run reports what it could observe and
+            reproduce under the conditions it created. It does not certify that a deployment is
+            correct, and a passing report is not a representation that production will not fail.
+          </p>
+          <p className="mt-5">
+            Some of that exclusion is unenforceable in some places, and against consumers it is
+            unenforceable in most. Which parts survive where is a question for counsel and is
+            marked as such below rather than asserted here.
+          </p>
+        </Prose>
+      </PageSection>
+      <PageSection tone="panel">
+        <PageHeading
+          kicker="Liability"
+          title="<strong>The shape of the cap, with the numbers left out.</strong>"
+        />
+        <Prose className="mt-10">
+          <p>
+            Four values decide this section and none of them exists yet, so they are left visibly
+            blank rather than filled with something that reads as settled: the contracting entity{" "}
+            <Blank>entity name</Blank>, its registered address <Blank>registered address</Blank>,
+            the governing law and venue <Blank>jurisdiction</Blank>, and the figure the cap is set
+            at <Blank>liability cap</Blank>. A cap written before a lawyer has chosen the
+            jurisdiction it will be read in is a number, not a protection.
+          </p>
+        </Prose>
+        <div className="mt-14 max-md:mt-10">
+          <SpecTable
+            rows={[
+              [
+                "Excluded, intended",
+                "Indirect, incidental, special and consequential loss, and loss of profit, revenue, goodwill or data, to the extent the law allows.",
+              ],
+              [
+                "Capped, intended",
+                "Everything else, at a figure tied to what was paid over a stated period. Both the figure and the period are unset.",
+              ],
+              [
+                "Never excluded",
+                "Death or personal injury caused by negligence, fraud and fraudulent misrepresentation, and anything else a governing law refuses to let a contract exclude. This carve out is not a courtesy and cannot be drafted away.",
+              ],
+              [
+                "Not addressed here",
+                "Whether any of the above is enforceable against a given customer in a given place, which depends on the jurisdiction, on whether the customer is a business or a consumer, and on whether the harm was caused by our own negligence.",
+              ],
+            ]}
+          />
+        </div>
+      </PageSection>
       <PageSection>
         <CounselNotice>
           This page states product limits so that waitlist visitors are not sold a zero-failure
@@ -280,19 +397,236 @@ export function TermsPage() {
         <Prose className="mt-10">
           <p>
             When a hosted control plane is generally available, these pages will be replaced with
-            dated legal documents that name a contracting entity, governing law, and acceptable
-            use. Until then, treat every safety report as evidence about the conditions the run
-            actually reproduced, a pass or a fail, not as insurance.
+            dated legal documents that name a contracting entity and a governing law. The{" "}
+            <Link href="/acceptable-use">acceptable use policy</Link> and the{" "}
+            <Link href="/developer-policy">developer policy</Link> are drafted already, because
+            both describe what the software does rather than what a company has decided. Until
+            then, treat every safety report as evidence about the conditions the run actually
+            reproduced, a pass or a fail, not as insurance.
           </p>
         </Prose>
       </PageSection>
       <RelatedGrid
         items={[
-          { href: "/privacy", title: "Privacy Notice", description: "What we collect and never take." },
           {
-            href: "/dpa",
-            title: "Data Processing Agreement",
-            description: "The terms for data we process on your behalf.",
+            href: "/acceptable-use",
+            title: "Acceptable use",
+            description: "What the product may not be pointed at.",
+          },
+          {
+            href: "/developer-policy",
+            title: "Developer policy",
+            description: "The API, the MCP surface, and the tokens that reach them.",
+          },
+          { href: "/sla", title: "Service levels", description: "There is no SLA. Here is what there is." },
+        ]}
+      />
+    </PageShell>
+  );
+}
+
+/**
+ * The two lists this page is built from.
+ *
+ * Kept as data rather than prose because an acceptable use policy is read by
+ * somebody checking whether one specific thing is allowed, and a paragraph is
+ * the wrong shape for that. The first list is what the product may not be
+ * pointed at. The second is the half most acceptable use policies leave out:
+ * what we will not do to a customer, which is the only part of the document
+ * that costs us anything to write.
+ */
+const NOT_PERMITTED = [
+  "Pointing the agent at a system you are not authorised to test. The product exists to exercise an application until it breaks, and doing that to somebody else's is an attack however it is labelled.",
+  "Naming a production database in source_url_env that you do not have the right to copy, including one holding another company's data under a contract that does not allow it.",
+  "Using a golden as a way to move production data somewhere it is not allowed to go. A masked copy is still derived from the original, and masking is a reduction of risk rather than a change of jurisdiction.",
+  "Running the load generator against a third party you do not control. Containment holds inside the environment; a host you allow through it is a host you are sending real traffic to.",
+  "Feeding the product data you are prohibited from processing, including special category personal data, payment card data, and anything under an export control you have not cleared.",
+  "Reselling access, or running the hosted control plane as a service for others, without a written agreement that says you may.",
+];
+
+const WE_WILL_NOT = [
+  "Read your production database. The engine reaches a source only through pg_dump and a read only transaction, and no part of the hosted control plane holds a source connection string.",
+  "Use your data to train a model. Nothing in this product sends customer data to a model provider for training, and there is no path that would.",
+  "Take a snapshot of production into the hosted control plane. It is not a backup target, and the trust boundary is drawn so that it cannot become one.",
+  "Enforce this policy by reading your environments. Enforcement is a conversation, because the alternative is a surveillance capability nobody asked for.",
+];
+
+export function AcceptableUsePage() {
+  return (
+    <PageShell>
+      <PageHero
+        path="/acceptable-use"
+        eyebrow="Acceptable Use"
+        title="It rehearses failure. Point it only at systems you are allowed to break."
+        lead="A short policy, because a long one is a policy nobody reads before doing the thing it prohibits. The product's whole purpose is to drive an application into its worst conditions, which makes where you aim it the only question that matters."
+        actions={
+          <>
+            <Button href="/terms" theme="outlined">
+              Terms of Use
+            </Button>
+            <Button href="/developer-policy" theme="outlined">
+              Developer policy
+            </Button>
+          </>
+        }
+      />
+      <PageSection>
+        <PageHeading
+          kicker="Prohibited"
+          title="<strong>What the product may not be pointed at.</strong>"
+        />
+        <Ledger items={NOT_PERMITTED} measure />
+      </PageSection>
+      <PageSection tone="panel">
+        <PageHeading
+          kicker="The other direction"
+          title="<strong>What we will not do,</strong> which is the half worth writing down."
+        />
+        <Ledger items={WE_WILL_NOT} measure />
+      </PageSection>
+      <PageSection tone="ruled">
+        <PageHeading kicker="Enforcement" title="<strong>What happens if this is broken.</strong>" />
+        <div className="mt-14 max-md:mt-10">
+          <SpecTable
+            rows={[
+              [
+                "How we would find out",
+                "A report, a bill, or a provider telling us. There is no monitoring of what an environment contains, and building one to enforce this policy would cost more privacy than the policy protects.",
+              ],
+              [
+                "What we would do",
+                "Ask first. An organization can be suspended, which stops new work and leaves the data in place, and that mechanism exists in the control plane today.",
+              ],
+              [
+                "Immediate suspension",
+                "Reserved for an active attack on somebody else, or a legal demand we have to act on. Everything else gets a conversation before anything stops.",
+              ],
+              [
+                "Appeal",
+                "Write to the contact on this site. There is no formal appeal process yet and pretending otherwise would be worse than saying so.",
+              ],
+            ]}
+          />
+        </div>
+      </PageSection>
+      <PageSection>
+        <CounselNotice>
+          No lawyer has read this. It describes what the software does and what we intend, and it
+          has not been checked for whether it is enforceable or complete. It must be reviewed
+          before the product takes money.
+        </CounselNotice>
+      </PageSection>
+      <RelatedGrid
+        items={[
+          { href: "/terms", title: "Terms of Use", description: "Scope, warranty, and liability." },
+          {
+            href: "/developer-policy",
+            title: "Developer policy",
+            description: "The API, the MCP surface, and the tokens that reach them.",
+          },
+          {
+            href: "/privacy",
+            title: "Privacy Notice",
+            description: "What we collect and never take.",
+          },
+        ]}
+      />
+    </PageShell>
+  );
+}
+
+export function DeveloperPolicyPage() {
+  return (
+    <PageShell>
+      <PageHero
+        path="/developer-policy"
+        eyebrow="Developer Policy"
+        title="Two programmable surfaces, and what each one is allowed to do."
+        lead="The control plane has an HTTP API, and the engine serves its tools to a model over the Model Context Protocol. They have different threat models, so they get different rules rather than one paragraph covering both."
+        actions={
+          <>
+            <Button href="/terms" theme="outlined">
+              Terms of Use
+            </Button>
+            <Button href="/acceptable-use" theme="outlined">
+              Acceptable use
+            </Button>
+          </>
+        }
+      />
+      <PageSection>
+        <PageHeading kicker="The API" title="<strong>Tokens, limits, and what a token can reach.</strong>" />
+        <div className="mt-14 max-md:mt-10">
+          <SpecTable
+            rows={[
+              [
+                "Authentication",
+                "A token belongs to one organization and carries a role. Nothing in the API is reachable without one, and a token is stored as a hash, so a leaked database does not yield a working credential.",
+              ],
+              [
+                "Rate limits",
+                "Every public endpoint has one, declared in a single registry that the middleware reads. An endpoint added without a limit is a build failure rather than an endpoint with no limit, which is the usual way this goes wrong.",
+              ],
+              [
+                "Scope",
+                "A token reaches its own organization and no other. This is enforced by row level policy in the database rather than only by a check in the application.",
+              ],
+              [
+                "If a token leaks",
+                "Revoke it. Revocation is immediate for the API. A token already inside a running engine keeps working until that run finishes, and this is stated because the opposite would be assumed.",
+              ],
+            ]}
+          />
+        </div>
+      </PageSection>
+      <PageSection tone="panel">
+        <PageHeading
+          kicker="The MCP surface"
+          title="<strong>A model driving the engine is still you,</strong> for every purpose in these terms."
+        />
+        <Prose className="mt-10">
+          <p>
+            The engine can serve its tools to a model over the Model Context Protocol, which means
+            a model can create environments, run workloads and tear them down. The rule that
+            follows is the one worth stating plainly: an action a model takes through your engine
+            is your action. The acceptable use policy applies to it unchanged, and a model
+            misreading an instruction is not a defence any more than a script with a bug would be.
+          </p>
+          <p className="mt-5">
+            The MCP server runs on your machine and speaks over a local transport rather than a
+            network port. It has whatever access your shell has. Granting a model that surface is a
+            decision with the same weight as giving it your terminal, and it should be made the
+            same way.
+          </p>
+        </Prose>
+      </PageSection>
+      <PageSection tone="ruled">
+        <PageHeading kicker="Building on it" title="<strong>What you may do with the interfaces.</strong>" />
+        <Ledger
+          measure
+          items={[
+            "Build whatever you like against the API for your own organization, including things we did not anticipate. That is what an API is.",
+            "Automate the CLI in your own pipelines. The exit codes and the report format are the contract, and the report is versioned so that a parser does not break silently.",
+            "Do not use the API to work around a limit on your plan, including by spreading one workload across organizations.",
+            "Do not present output from this product as a certification, an audit, or a guarantee of correctness to a third party. It is evidence about one run under conditions that run created.",
+            "Interfaces marked internal or undocumented may change without notice. The documented API and the report schema will not change incompatibly without a version.",
+          ]}
+        />
+      </PageSection>
+      <PageSection>
+        <CounselNotice>
+          No lawyer has read this. It is drafted from the code, so it is accurate about what the
+          interfaces do and silent on whether it is enforceable. It must be reviewed before the
+          product takes money.
+        </CounselNotice>
+      </PageSection>
+      <RelatedGrid
+        items={[
+          { href: "/terms", title: "Terms of Use", description: "Scope, warranty, and liability." },
+          {
+            href: "/acceptable-use",
+            title: "Acceptable use",
+            description: "What the product may not be pointed at.",
           },
           { href: "/sla", title: "Service levels", description: "There is no SLA. Here is what there is." },
         ]}

--- a/www/lib/routes.ts
+++ b/www/lib/routes.ts
@@ -294,6 +294,28 @@ export const ROUTES: readonly Route[] = [
     parent: "/privacy",
   },
   {
+    path: "/acceptable-use",
+    title: pageTitle("Acceptable Use"),
+    description:
+      "Where the product may and may not be pointed, and what we will not do to a customer.",
+    summary: "The acceptable use policy, and the enforcement that exists rather than the kind that does not.",
+    section: "legal",
+    indexable: true,
+    priority: 0.3,
+    parent: "/terms",
+  },
+  {
+    path: "/developer-policy",
+    title: pageTitle("Developer Policy"),
+    description:
+      "The rules for the control plane API and for the engine's Model Context Protocol surface.",
+    summary: "What a token may reach, what a model driving the engine is responsible for, and what may change without notice.",
+    section: "legal",
+    indexable: true,
+    priority: 0.3,
+    parent: "/terms",
+  },
+  {
     path: "/sla",
     title: pageTitle("Service levels"),
     description:


### PR DESCRIPTION
## Read this before anything else

**These documents require review by a qualified lawyer before this product takes money.** I am not one and neither is anyone who reviewed this. Enforceability of a limitation of liability clause varies by jurisdiction, by whether the customer is a business or a consumer, and by whether the harm was caused by the vendor's own negligence. Nothing in this pull request changes that, and nothing in it should be read as protection. It is a structured, honest draft plus a precise list of what a human has to decide.

Do not merge this to publish. Publishing terms is the founder's decision.

## What already existed, which is more than the brief assumed

Main already publishes `/terms`, `/privacy`, `/dpa`, `/subprocessors`, `/data-retention` and `/sla`, all rendered from `Legal.tsx`, plus `legal-facts.test.ts`, which holds published retention numbers to the Terraform that sets them and published capabilities to the modules that provide them. That gate is good and this branch feeds it rather than working around it.

The actual gap was narrower and sharper than "there are no terms". Grepping `Legal.tsx` for liability, warranty, indemnity and "as is" returned zero hits. The site stated product limits honestly and had no warranty disclaimer, no limitation of liability, and no acceptable use policy anywhere.

## What this adds

Three sections on `/terms`: what the software is allowed to touch, a warranty disclaimer, and the shape of a limitation of liability. Two new pages, `/acceptable-use` and `/developer-policy`, the second covering the control plane API and the engine's Model Context Protocol surface.

The liability section publishes no number. Entity, registered address, governing law and the cap figure render through the `Blank` component the DPA already uses, so the page is visibly unfinished rather than looking settled. It names the exclusions no contract can make and states which questions it is not answering.

## The part that is not prose

Four of the terms' claims are about mechanisms in the engine, and a claim about a mechanism is publishable where a claim about an intention is not, because a mechanism fails a test when somebody removes it. `legal-facts` gained assertions that the customer's source database is opened in a Postgres level `READ ONLY` transaction, that `RemoveContainer` still refuses a container without an Antifailure label, that `NewRuleSet` still appends `DefaultRules` so an unconfigured project is not an unmasked one, and that `golden.go` still refuses to publish an unclean scan.

Each was verified by breaking the guard on purpose and watching the assertion go red. That found a real defect in my own work: the masking assertion first matched the capacity hint on `NewRuleSet`'s opening line, so deleting the loop that actually appends the defaults left it green. It matches the loop now.

One assertion pins a list rather than a guard, and it is the one worth reading. See below.

## A finding this branch does not fix

The verification scan reads six column types. `looksSensitive`, which decides whether an unclassified column is emptied, names the same six. They are not independent layers. A `citext` or `text[]` column is masked by neither and read by neither, and it does not appear in the unclassified report either, so `af mask plan` is silent about it. Confirmed against a real PostgreSQL 17: `citext` reports `USER-DEFINED` and `text[]` reports `ARRAY`, and neither is in the list.

That is why the terms describe the scan as a check that a masking rule missed a column rather than as a proof that no personal data survives. The wording is exact rather than modest. The eighth assertion pins the type list so that changing either half sends whoever changed it to the sentence describing it.

I have not fixed the underlying gap here, deliberately. Widening the masking default is not additive: a `citext` column currently copied would start being emptied, which changes `rules_digest`, invalidates existing goldens and can break an environment that needs the column populated. That is not a release day change for an agent to make alone. Full write up, with the reproduction and the suggested fix, is at `/private/tmp/af-liability-findings.md`.

## Design

Ledger rows set a line roughly 190 characters long at the 1600px container, which is unreadable and looked it, so the two new pages opt into the 720px measure `Prose` and the counsel notice already use. The original short rows keep full width, so `/terms` is unchanged where it was already fine.

Checked at 1440px and 390px on the real rendered build: no horizontal overflow at either width, the spec tables stack correctly on mobile, and the `Blank` placeholders wrap without escaping the container. The site is light only by declaration, `colorScheme: "light"` in `layout.tsx` with no `dark:` class anywhere, and it renders identically under a dark OS preference, so there is no dark rendering to check and I am not claiming to have checked one.

## Gates

- `legal-facts.test.ts`: 23 pass, and the 5 new engine assertions each proven to fail when their guard is removed
- `prosecheck`: 514 files, clean
- `changecheck`: satisfied by the fragment
- API `typecheck`: clean
- `www` build: clean, both new routes prerendered
- `check:seo`: 87/87, both routes in the sitemap and reachable from the home page

## What only a lawyer or the founder can decide

1. The legal entity name and its registered address.
2. The governing law and the venue.
3. The contact address for legal notices, and the privacy contact the retention page has been leaving blank.
4. The liability cap figure and the period it is tied to.
5. Whether the warranty disclaimer survives in the jurisdictions being sold into, and whether a separate consumer facing set is needed.
6. Whether the intended exclusions are enforceable where the customer sits, and how the non excludable carve outs should be worded for that jurisdiction.
7. Whether an indemnity is wanted at all. I drafted none, in either direction.
8. Whether the acceptable use policy's enforcement section commits to more process than the company wants to be held to.
9. Whether `/sla` saying there is no service level agreement is still the position once money changes hands.
10. **The enterprise license already points at `/terms`, and `/terms` currently disclaims being the kind of document it is pointed at.** Found after this branch was opened, and it is the sharpest item on this list. `ee/LICENSE.md` permits production use of the enterprise directory only if you "have agreed to, and are in compliance with, the Antifailure Terms of Service, available at https://antifailure.dev/terms, or a substantially similar written agreement". The page at that URL says "Sign-in is for the waitlist. There is no public production control plane yet, and these terms are not a paid-service agreement." So on the day somebody buys an enterprise license, the condition they must satisfy resolves to a page saying it is not that kind of document. The signed agreement clause is a real escape hatch for a negotiated enterprise deal, so this is not fatal, but the self serve route named first in the license does not currently work. Deciding whether `/terms` becomes an actual agreement is the single largest change of legal posture on the site and is not a change an agent should make.

## One more thing the founder should know before publishing any of this

The control plane has a plan named `free` that is the default for any organization with no plan recorded (`DEFAULT_PLAN` in `limits.ts`), carrying real quotas and cost caps of 24 environment hours per run and 72 per rolling day. `costs.ts` says in its own comment that "free is where a runaway costs the vendor rather than the customer".

The site describes no hosted free tier at all. Its only zero dollar tier is Community, "local engine, forever", whose bullet reads "No hosted compute. Your cloud, your credentials", which is a true statement about a self hosted engine and says nothing about the hosted one.

That matters for these drafts specifically: if organizations can land on a hosted plan by default, then item 10 above is not hypothetical, and the sentence on `/terms` about the waitlist is already wrong. This is reported rather than fixed, because what is actually being offered is a commercial decision.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR
