### PR TITLE
web: a plan an owner could grant themselves

### DIFF
--- a/.changes/a-plan-an-owner-could-grant-themselves.md
+++ b/.changes/a-plan-an-owner-could-grant-themselves.md
@@ -1,0 +1,36 @@
+# security
+
+An organization owner on a control plane that takes no payment could set their
+own plan, including `enterprise`, and take the quota that goes with it.
+
+`billing.set` exists so that somebody self-hosting can change their own quota,
+and it refused the call wherever Stripe or `AF_HOSTED_REQUIRED_PLAN` was
+configured. That guard asks whether billing was set up, and the dangerous
+installation is precisely the one where it was not: a control plane serving
+people who are not its operator, whose operator has not reached Stripe yet,
+configures neither, so nothing refused. The first person into an organization
+becomes its owner and an owner holds `billing.manage`, so it was every
+signed-in tenant rather than an administrator.
+
+The question is now the one that actually decides it. `AF_OPERATOR_SETS_PLAN=1`
+is an operator saying that whoever runs this installation also decides each
+organization's plan, and without it the plan can only come from a signed Stripe
+delivery. Off is the default because the configuration at risk is the one
+nobody has configured, so a flag meaning "this is hosted" would have to be
+remembered by exactly the operator who has not thought about it yet, and
+forgetting this one closes the hole instead of opening it.
+
+Setting it alongside any Stripe variable or the hosted plan gate stops the
+process at startup rather than being refused per request, because a plan that
+can be granted by hand is not a plan anybody has to buy, and a start-up refusal
+covers whatever writes the plan next rather than the one route that carries the
+check today.
+
+# changed
+
+Self-hosted installations that change plans from the Plan page need
+`AF_OPERATOR_SETS_PLAN=1` set on the control plane. Without it the page shows
+what each plan allows and offers no control, rather than offering one that is
+always refused. Nothing else changes: the plan a control plane is already on
+stays exactly where it is, and an operator has always been able to write the
+column directly.

--- a/console/app/(app)/plan/page.tsx
+++ b/console/app/(app)/plan/page.tsx
@@ -44,6 +44,10 @@ interface PlanState {
   holding: { environments: number; goldens: number };
   takesPayment: boolean;
   hostedRequiredPlan: string | null;
+  /** Whether billing.set would do anything. False unless whoever runs this
+   *  control plane has said they set plans by hand, so the change control below
+   *  is drawn only where pressing it works. */
+  operatorSetsPlan: boolean;
 }
 
 interface SubscriptionState {
@@ -314,7 +318,11 @@ function Billing() {
 
           <Card
             title="What each plan allows"
-            note="A plan that is already over its limit refuses the next environment and removes nothing that exists."
+            note={
+              data.billing.configured || data.quota.operatorSetsPlan
+                ? "A plan that is already over its limit refuses the next environment and removes nothing that exists."
+                : "A plan that is already over its limit refuses the next environment and removes nothing that exists. This control plane takes no payment and does not grant plans by hand, so the plan is whatever its operator set."
+            }
           >
             <TableWrap>
               <Table>
@@ -360,10 +368,12 @@ function Billing() {
                           <span className="text-dim">
                             {data.billing.plans.includes(p.name) ? "Use checkout" : "Not offered here"}
                           </span>
-                        ) : (
+                        ) : data.quota.operatorSetsPlan ? (
                           <Button busy={busy === `choose-${p.name}`} onClick={() => choose(p.name)}>
                             {busy === `choose-${p.name}` ? "Changing" : `Move to ${p.name}`}
                           </Button>
+                        ) : (
+                          <span className="text-dim">Ask the operator</span>
                         )}
                       </Td>
                     </Row>

--- a/deploy/helm/antifailure-control-plane/templates/deployment.yaml
+++ b/deploy/helm/antifailure-control-plane/templates/deployment.yaml
@@ -72,6 +72,10 @@ spec:
             - name: AF_INSECURE_COOKIES
               value: "1"
             {{- end }}
+            {{- if .Values.config.operatorSetsPlan }}
+            - name: AF_OPERATOR_SETS_PLAN
+              value: "1"
+            {{- end }}
             {{- if .Values.config.eventRetentionMonths }}
             - name: AF_EVENT_RETENTION_MONTHS
               value: {{ .Values.config.eventRetentionMonths | quote }}

--- a/deploy/helm/antifailure-control-plane/values.yaml
+++ b/deploy/helm/antifailure-control-plane/values.yaml
@@ -71,6 +71,15 @@ config:
   # Only for local development over plain HTTP. Leaving this on behind a real
   # ingress sends session cookies without the Secure attribute.
   insecureCookies: false
+  # Whether whoever runs this control plane also decides each organization's
+  # plan, which is what the Plan page's change control writes.
+  #
+  # Leave it false on any installation where the people signing in are not you.
+  # The first person into an organization becomes its owner, an owner holds
+  # billing.manage, and with this on and no Stripe configured that is a
+  # signed-in stranger granting themselves the largest plan. Turning it on
+  # alongside Stripe stops the process at startup.
+  operatorSetsPlan: false
 # Keeping event partitions ahead of the writes. A range-partitioned table with
 # no partition for an incoming row does not slow down, it fails, so this is not
 # optional housekeeping.

--- a/docs/src/content/docs/reference/control-plane.md
+++ b/docs/src/content/docs/reference/control-plane.md
@@ -45,6 +45,7 @@ is a process that fails in production rather than at deploy time.
 | `AF_STRIPE_PRICE_ENTERPRISE` | unset | The Stripe price the `enterprise` plan is sold at. |
 | `AF_STRIPE_API_BASE` | `https://api.stripe.com` | Where the Stripe API lives. For tests, which point it at the engine's own Stripe mock pack, and for nothing else. |
 | `AF_HOSTED_REQUIRED_PLAN` | unset | Set to `enterprise` on a hosted control plane that is sold only to enterprise organizations. Authentication, sign-out and the exits remain reachable; browser procedures, CLI provider operations, model proxy requests and engine ingestion are refused until Stripe grants the enterprise plan. The exits are billing, exporting the organization's data, deleting the organization, closing an account, and listing and revoking sessions: a plan gate may restrict what the product does for a customer and may never restrict their ability to leave, to retrieve what is theirs, or to secure their account. Any other value stops the process. Setting this while billing is off also stops the process, because otherwise no customer could satisfy the gate. Leave it unset when self-hosting. |
+| `AF_OPERATOR_SETS_PLAN` | unset | Set to `1` on an installation where whoever runs the control plane also decides each organization's plan. Unset, `billing.set` is refused and the plan can only come from a signed Stripe delivery, which is the right answer anywhere the people signing in are not the operator: the first person into an organization becomes its owner, an owner holds `billing.manage`, and on a plane that takes no payment that would be a signed-in stranger granting themselves the largest plan. It is off by default rather than on because the dangerous configuration is the one where nothing has been configured yet, and a flag that has to be remembered would be forgotten by exactly that operator. Set it when you run the control plane for yourself; you can already write the column with `psql`, and this is the same act with an audit entry. Setting it together with any Stripe variable or with `AF_HOSTED_REQUIRED_PLAN` stops the process, because a plan that can be granted by hand is not a plan anybody has to buy. Any value other than `1`, `0`, `true`, `false` or unset stops the process. |
 | `AF_CONSOLE_DIR` | `/app/console-out` | Where the console's build is. The published image carries it at the default and nothing needs setting. Point it elsewhere only if you build `console/` yourself. A directory that is not there is not fatal: the API serves normally, the start-up log says the console is missing, and every page answers with that sentence rather than a blank 404 that reads like a routing bug. |
 
 ## Set on the engine, not here
@@ -86,6 +87,11 @@ becomes its owner under the rule below.
 On an enterprise-only hosted deployment that owner lands on Plan. Checkout is
 the only path that can grant the required plan; `billing.set` is refused, so an
 owner cannot turn a free organization into an enterprise one without Stripe.
+That refusal does not depend on Stripe being configured. `billing.set` is
+refused on every installation that has not set `AF_OPERATOR_SETS_PLAN=1`,
+including one where billing has not been set up yet, because that is the
+installation on which an owner granting themselves the largest plan would
+otherwise succeed.
 The signed subscription webhook changes the plan. **Refresh from Stripe** asks
 Stripe for every subscription belonging to that customer and repairs the same
 state when a webhook never arrives, including the case where no local

--- a/web/apps/api/src/hosted.ts
+++ b/web/apps/api/src/hosted.ts
@@ -19,6 +19,56 @@ export function hostedRequiredPlanFrom(value: string | undefined | null): Hosted
   )
 }
 
+/**
+ * Whether whoever runs this installation also decides each organization's plan.
+ *
+ * THE DEFAULT IS OFF, AND THAT IS THE WHOLE POINT. `billing.set` writes
+ * `organizations.plan`, which is the column every quota is read from, and the
+ * caller who reaches it is an org owner rather than the operator. On a plane
+ * one person runs for themselves those are the same person and the route is an
+ * administrative convenience, because that person can already write the column
+ * with psql. On a plane that serves anybody else they are not the same person,
+ * and the route is a signed-in stranger granting themselves the largest plan.
+ *
+ * Read that failure the other way round, because it decides the shape of this
+ * flag. The dangerous configuration is the one where nothing is configured:
+ * no Stripe, no plan gate, an operator who has not thought about billing yet.
+ * A flag meaning "this plane is hosted" would have to be REMEMBERED by exactly
+ * the operator who has not thought about it, so forgetting it would leave the
+ * hole open. This flag means the opposite, so forgetting it closes the hole and
+ * costs a self-hosted operator one variable they set once.
+ *
+ * It may not be combined with billing. See main.ts: a plan that can be granted
+ * by hand is not a plan anybody has to buy, and the process refuses to start
+ * rather than serving that contradiction.
+ */
+export function operatorSetsPlanFrom(value: string | undefined | null): boolean {
+  const raw = value?.trim().toLowerCase()
+  if (!raw || raw === '0' || raw === 'false') return false
+  if (raw === '1' || raw === 'true') return true
+  throw new Error(
+    `AF_OPERATOR_SETS_PLAN must be 1, 0 or unset; received ${JSON.stringify(value)}.`,
+  )
+}
+
+/**
+ * Why the plan cannot be written by hand, said to the person who asked.
+ *
+ * Two different readers and two different next steps. A customer on a plane
+ * that takes money is told where the plan comes from. An operator on a plane
+ * that takes none is told the variable that turns the route on, because they
+ * are the only person who could set it and the alternative is reading the
+ * source to find out the route exists at all.
+ */
+export function planSetRefusal(takesPayment: boolean): string {
+  return takesPayment
+    ? 'This installation derives paid plans from Stripe. Use checkout or the billing portal; ' +
+        'the plan cannot be set directly.'
+    : 'This control plane does not grant plans by hand. Set AF_OPERATOR_SETS_PLAN=1 if you run ' +
+        'it yourself and decide the plan yourself; a plane that serves anybody else should take ' +
+        'payment instead.'
+}
+
 export function hasHostedAccess(
   plan: string | null | undefined,
   required: HostedRequiredPlan | null,

--- a/web/apps/api/src/main.ts
+++ b/web/apps/api/src/main.ts
@@ -27,7 +27,11 @@ import { sweepEmailSignInTokens } from './auth/email.ts'
 import { resumeDeletions } from './enterprise/deletion.ts'
 import type { EmailSignInConfig } from './auth/email.ts'
 import { RealStripeClient, stripeConfigFrom } from './billing/index.ts'
-import { githubAppInstallUrlFrom, hostedRequiredPlanFrom } from './hosted.ts'
+import {
+  githubAppInstallUrlFrom,
+  hostedRequiredPlanFrom,
+  operatorSetsPlanFrom,
+} from './hosted.ts'
 
 function required(name: string, ...fallbacks: string[]): string {
   for (const n of [name, ...fallbacks]) {
@@ -177,9 +181,11 @@ console.log(stripe.summary)
 
 let hostedRequiredPlan
 let githubAppInstallUrl
+let operatorSetsPlan = false
 try {
   hostedRequiredPlan = hostedRequiredPlanFrom(process.env.AF_HOSTED_REQUIRED_PLAN)
   githubAppInstallUrl = githubAppInstallUrlFrom(process.env.AF_GITHUB_APP_INSTALL_URL)
+  operatorSetsPlan = operatorSetsPlanFrom(process.env.AF_OPERATOR_SETS_PLAN)
 } catch (err) {
   console.error(err instanceof Error ? err.message : String(err))
   process.exit(2)
@@ -190,10 +196,31 @@ if (hostedRequiredPlan && !stripe.config) {
   )
   process.exit(2)
 }
+// The other contradiction, refused for the same reason and in the same place.
+//
+// A route that grants any plan by hand, on a process that also sells those
+// plans, is a product nobody has to pay for. Refusing it HERE rather than only
+// inside `billing.set` is the point: a start-up refusal covers whatever writes
+// the plan next, and a check inside one procedure covers one procedure. The
+// pair of them is what makes `operatorSetsPlan` mean "this process takes no
+// money at all" wherever it is read.
+if (operatorSetsPlan && (stripe.config || hostedRequiredPlan)) {
+  console.error(
+    'AF_OPERATOR_SETS_PLAN is set on an installation that takes payment. A plan that can be ' +
+      'granted by hand is not a plan anybody has to buy: unset it, or unset the Stripe ' +
+      'variables and AF_HOSTED_REQUIRED_PLAN.',
+  )
+  process.exit(2)
+}
 console.log(
   hostedRequiredPlan
     ? `hosted access requires the ${hostedRequiredPlan} plan`
     : 'no hosted plan gate: this installation serves every plan',
+)
+console.log(
+  operatorSetsPlan
+    ? 'plans are set by hand: billing.set writes the plan on this installation'
+    : 'plans are not set by hand: billing.set is refused (AF_OPERATOR_SETS_PLAN is not set)',
 )
 
 // Located once, here, and said out loud either way. A control plane running
@@ -229,6 +256,7 @@ const { app, ingestLimiter, authLimiter } = createServer({
     : {}),
   stripe: billing,
   hostedRequiredPlan,
+  operatorSetsPlan,
   githubAppInstallUrl,
   modelPrices,
   consoleBuild,

--- a/web/apps/api/src/routers/billing.ts
+++ b/web/apps/api/src/routers/billing.ts
@@ -6,6 +6,13 @@
 // administrative act by somebody who already holds `billing.manage`, and it is
 // audited as one.
 //
+// It is also OFF unless an operator turns it on, and that is not a detail. The
+// person holding `billing.manage` is the org owner, which the first person into
+// any organization becomes, and on a plane serving anybody but its operator
+// that person setting their own plan is a stranger writing their own
+// entitlement. `AF_OPERATOR_SETS_PLAN` is the operator saying the two are the
+// same person here. See `hosted.ts`.
+//
 // The reason it is worth building on its own is that the enforcement already
 // exists and had nothing to point at. `PLAN_QUOTAS` defines free, team and
 // enterprise, `checkQuota` refuses over the limit, and `organizations.plan`
@@ -23,6 +30,7 @@ import { TRPCError } from '@trpc/server'
 import { sql } from 'drizzle-orm'
 import { router, orgProcedure, audit, type OrgContext } from '../trpc.ts'
 import { checkQuota, DEFAULT_PLAN, PLAN_QUOTAS } from '../limits.ts'
+import { planSetRefusal } from '../hosted.ts'
 
 const PLANS = Object.keys(PLAN_QUOTAS) as [string, ...string[]]
 
@@ -66,6 +74,10 @@ async function plans(c: OrgContext) {
       // renders it and somebody reading the API has to know too.
       takesPayment: c.stripe !== null,
       hostedRequiredPlan: c.hostedRequiredPlan,
+      // Whether `set` below would do anything, so the console can leave the
+      // control out rather than drawing one that always refuses. A button that
+      // is always refused reads as broken rather than as not offered.
+      operatorSetsPlan: c.operatorSetsPlan,
     }
   })
 }
@@ -84,11 +96,27 @@ export const billingRouter = router({
     .input(z.object({ plan: z.enum(PLANS), reason: z.string().max(500).optional() }))
     .mutation(async ({ ctx, input }) => {
       const c = ctx as OrgContext
-      if (c.stripe || c.hostedRequiredPlan) {
+      // DEFAULT DENY, and the inversion is the whole fix.
+      //
+      // This used to refuse only `if (c.stripe || c.hostedRequiredPlan)`, which
+      // is a guard that reads correctly and protects nobody: it asks whether
+      // billing was configured, and the dangerous plane is precisely the one
+      // where it was not. A hosted control plane whose operator has not reached
+      // Stripe yet configures neither, so both were null, so an org owner could
+      // call this with `enterprise` and grant themselves five hundred
+      // environments. The first person into any organization is its owner, and
+      // an owner holds `billing.manage`, so that was every signed-in tenant.
+      //
+      // Now the question is the one that actually decides it: has whoever runs
+      // this installation SAID they set plans by hand? Unset means no, so a
+      // plane nobody has configured refuses, and the operator who legitimately
+      // wants the route sets AF_OPERATOR_SETS_PLAN=1 once. main.ts refuses to
+      // start if that is combined with Stripe or the hosted gate, so reaching
+      // this line with the flag on means this process takes no money at all.
+      if (!c.operatorSetsPlan) {
         throw new TRPCError({
           code: 'PRECONDITION_FAILED',
-          message:
-            'This installation derives paid plans from Stripe. Use checkout or the billing portal; the plan cannot be set directly.',
+          message: planSetRefusal(c.stripe !== null || c.hostedRequiredPlan !== null),
         })
       }
       const changed = await c.pool.withTenant(c.tenant, async (db) => {

--- a/web/apps/api/src/server.ts
+++ b/web/apps/api/src/server.ts
@@ -193,6 +193,10 @@ export interface ServerOptions {
   /** Null for self-hosting. The hosted service requires this plan everywhere
    *  except authentication, billing, health, and sign-out. */
   hostedRequiredPlan?: HostedRequiredPlan | null
+  /** Whether the plan may be written by hand through `billing.set`. False by
+   *  default, deliberately: the safe answer is the one an operator who has not
+   *  thought about billing gets without doing anything. See hosted.ts. */
+  operatorSetsPlan?: boolean
   /** Public GitHub App installation address shown to a signed-in user who has
    *  no organization yet. */
   githubAppInstallUrl?: string
@@ -277,6 +281,7 @@ export function createServer(options: ServerOptions) {
   const secure = options.secureCookies ?? true
   const metrics = options.metrics ?? createMetrics(options.version ?? 'dev')
   const hostedRequiredPlan = options.hostedRequiredPlan ?? null
+  const operatorSetsPlan = options.operatorSetsPlan ?? false
   // Read once. It is the bounded set of label values, and reading it per
   // request would be the metrics endpoint doing work proportional to traffic.
   const declaredRoutes = Object.keys(ENDPOINT_LIMITS)
@@ -2102,6 +2107,7 @@ export function createServer(options: ServerOptions) {
           mailer: options.emailSignIn?.mailer ?? null,
           productName: options.emailSignIn?.productName ?? 'Antifailure',
           hostedRequiredPlan,
+          operatorSetsPlan,
           actor,
           origin: 'web',
           ip: c.req.header('x-forwarded-for') ?? undefined,

--- a/web/apps/api/src/trpc.ts
+++ b/web/apps/api/src/trpc.ts
@@ -79,6 +79,11 @@ export interface Context {
   /** Null on self-hosted installations. Hosted Antifailure sets enterprise,
    *  leaving billing reachable while operational procedures are refused. */
   hostedRequiredPlan: HostedRequiredPlan | null
+  /** Whether whoever runs this installation also decides each organization's
+   *  plan. False everywhere it is not said out loud, because the caller who
+   *  reaches the route that writes the plan is an org owner rather than the
+   *  operator. See hosted.ts. */
+  operatorSetsPlan: boolean
   /** Null for an unauthenticated request. */
   actor: Actor | null
   /** Where the request came from, recorded on every audit entry. */

--- a/web/apps/api/test/harness.ts
+++ b/web/apps/api/test/harness.ts
@@ -100,6 +100,11 @@ export interface StartApiOptions {
   stripe?: Billing | null
   /** The plan required by a hosted deployment. Null is the self-hosted default. */
   hostedRequiredPlan?: HostedRequiredPlan | null
+  /** Whether this installation's operator sets plans by hand. Undefined is the
+   *  default the server ships with, and it is the refusing one: `billing.set`
+   *  is off unless somebody says otherwise, so a suite that does not mention
+   *  this is testing the configuration production runs in. */
+  operatorSetsPlan?: boolean
   githubAppInstallUrl?: string
   /** Acting on a repository as the installation. Undefined means no App, which
    *  is a real way to run this: deliveries still record installations and
@@ -158,6 +163,7 @@ export async function startApi(options: StartApiOptions = {}): Promise<ApiHarnes
     ...(options.consoleDir ? { consoleBuild: await findConsoleBuild(options.consoleDir) } : {}),
     stripe: options.stripe ?? null,
     hostedRequiredPlan: options.hostedRequiredPlan ?? null,
+    operatorSetsPlan: options.operatorSetsPlan ?? false,
     githubAppInstallUrl: options.githubAppInstallUrl,
     githubApi: options.githubApi ?? null,
     ...(options.forgetInstallationToken

--- a/web/apps/api/test/hosted.test.ts
+++ b/web/apps/api/test/hosted.test.ts
@@ -6,7 +6,10 @@ import {
   HOSTED_GATE_EXEMPT,
   githubAppInstallUrlFrom,
   hostedRequiredPlanFrom,
+  operatorSetsPlanFrom,
 } from '../src/hosted.ts'
+import { readFile, readdir } from 'node:fs/promises'
+import path from 'node:path'
 import { hashEngineToken } from '../src/ingest.ts'
 import { fileURLToPath } from 'node:url'
 import {
@@ -37,6 +40,18 @@ describe('the hosted plan configuration', () => {
     assert.equal(hostedRequiredPlanFrom(undefined), null)
     assert.equal(hostedRequiredPlanFrom(' enterprise '), 'enterprise')
     assert.throws(() => hostedRequiredPlanFrom('team'), /must be enterprise or unset/)
+  })
+
+  it('treats plans set by hand as off unless an operator says otherwise', () => {
+    assert.equal(operatorSetsPlanFrom(undefined), false)
+    assert.equal(operatorSetsPlanFrom(''), false)
+    assert.equal(operatorSetsPlanFrom('0'), false)
+    assert.equal(operatorSetsPlanFrom('false'), false)
+    assert.equal(operatorSetsPlanFrom('1'), true)
+    assert.equal(operatorSetsPlanFrom(' TRUE '), true)
+    // Anything else is a typo, and a typo that reads as off would be a plane
+    // whose operator believes they turned the route on.
+    assert.throws(() => operatorSetsPlanFrom('yes'), /must be 1, 0 or unset/)
   })
 
   it('accepts only the public GitHub App installation address shape', () => {
@@ -102,6 +117,26 @@ describe('starting up with the gate set', {
     const { code, out } = await start({ AF_HOSTED_REQUIRED_PLAN: 'enterprise' })
     assert.equal(code, 2, `expected a refusal, got ${code}: ${out}`)
     assert.match(out, /AF_HOSTED_REQUIRED_PLAN is set but billing is off/)
+  })
+
+  it('refuses to start when plans are set by hand on a plane that takes money', async () => {
+    // The contradiction, refused where it cannot be reached around. A route
+    // that grants a plan and a checkout that sells the same plan on one
+    // process is a product nobody has to pay for, and it stops here rather
+    // than in whichever procedure happens to carry the check today.
+    const stripe = await start({
+      AF_OPERATOR_SETS_PLAN: '1',
+      AF_STRIPE_SECRET_KEY: 'sk_test_not_a_real_key',
+      AF_STRIPE_WEBHOOK_SECRET: 'whsec_not_a_real_secret',
+      AF_STRIPE_PRICE_TEAM: 'price_team',
+      AF_STRIPE_PRICE_ENTERPRISE: 'price_enterprise',
+    })
+    assert.equal(stripe.code, 2, `expected a refusal, got ${stripe.code}: ${stripe.out}`)
+    assert.match(stripe.out, /AF_OPERATOR_SETS_PLAN/)
+
+    const value = await start({ AF_OPERATOR_SETS_PLAN: 'yes' })
+    assert.equal(value.code, 2, value.out)
+    assert.match(value.out, /must be 1, 0 or unset/)
   })
 
   it('refuses a plan it does not sell and an installation address it cannot trust', async () => {
@@ -436,5 +471,226 @@ describe('a lapsed plan does not close the exits', {
       [...HOSTED_GATE_EXEMPT].sort(),
       exits.map((e) => e.permission).sort(),
     )
+  })
+})
+
+/**
+ * The plan nobody paid for.
+ *
+ * THE CONFIGURATION UNDER TEST IS THE ONE PRODUCTION BOOTS IN, and that is the
+ * only reason this suite exists. No Stripe, no plan gate, sign-in open to
+ * whoever the allowlist admits. Every other suite in this file configures
+ * something; this one configures nothing, because a hosted plane whose operator
+ * has not got to billing yet is not a hypothetical, it is the state the hosted
+ * control plane is in the day the code that can take money first reaches it.
+ *
+ * `billing.set` used to refuse only when Stripe or the gate was configured, so
+ * in exactly this configuration an org owner, which is what the first person
+ * into any organization becomes, could call it with `enterprise` and take a
+ * five hundred environment, twenty thousand env-hour plan for nothing.
+ *
+ * It has been proved able to fail: with the refusal removed from
+ * `routers/billing.ts`, the first cell below goes red reporting that the
+ * organization is on the enterprise plan.
+ */
+describe('a control plane that takes no money does not hand out its own plans', {
+  skip: hasDatabase ? false : 'no Postgres at AF_TEST_DATABASE_URL',
+}, () => {
+  let h: ApiHarness
+  let org: Org
+  let owner: SignedIn
+
+  before(async () => {
+    // Nothing configured, deliberately. This is the whole fixture.
+    h = await startApi()
+    org = await seedOrg(h.admin, 'plan-unconfigured')
+    owner = await signInAs(h, org, 'owner')
+  })
+
+  after(async () => {
+    await dropOrg(h.admin, org.orgId)
+    await h.close()
+  })
+
+  async function planOf(): Promise<string> {
+    const [row] = await h.admin<{ plan: string }[]>`
+      SELECT plan FROM organizations WHERE id = ${org.orgId}`
+    return row!.plan
+  }
+
+  it('refuses an owner who asks for the enterprise plan', async () => {
+    assert.equal(await planOf(), 'free')
+    const refused = await callProcedure(h, owner, 'billing.set', 'mutation', {
+      plan: 'enterprise',
+    })
+    assert.equal(errorCode(refused.body), 'PRECONDITION_FAILED', JSON.stringify(refused.body))
+    assert.match(JSON.stringify(refused.body), /AF_OPERATOR_SETS_PLAN/)
+    assert.equal(await planOf(), 'free', 'an owner granted themselves the enterprise plan')
+  })
+
+  it('refuses every other plan too, and writes no audit entry', async () => {
+    for (const plan of ['team', 'free']) {
+      const refused = await callProcedure(h, owner, 'billing.set', 'mutation', { plan })
+      assert.equal(errorCode(refused.body), 'PRECONDITION_FAILED', `${plan}: ${JSON.stringify(refused.body)}`)
+    }
+    const entries = await h.admin<{ n: string }[]>`
+      SELECT count(*) AS n FROM audit_entries
+      WHERE org_id = ${org.orgId} AND action = 'organization.plan_changed'`
+    assert.equal(Number(entries[0]!.n), 0, 'a refused plan change was audited as a change')
+    assert.equal(await planOf(), 'free')
+  })
+
+  it('says so in the payload the console renders, so no button is offered', async () => {
+    // The other half of the same defect. The route refusing while the console
+    // still draws "Move to enterprise" is a product that offers a control it
+    // always refuses, which reads as broken rather than as refused.
+    const { status, body } = await callProcedure(h, owner, 'billing.get', 'query', {})
+    assert.equal(status, 200, JSON.stringify(body))
+    const got = data<{ takesPayment: boolean; operatorSetsPlan: boolean }>(body)
+    assert.equal(got.takesPayment, false)
+    assert.equal(got.operatorSetsPlan, false)
+  })
+})
+
+/**
+ * The self-hosted operator, who is the reason the route exists at all.
+ *
+ * One person runs the control plane, runs the database, and decides what their
+ * own organization is on. Refusing them would be refusing somebody who can
+ * already write the column with psql, so the route stays, behind one variable
+ * they set once.
+ */
+describe('an operator who says they set plans by hand may set them', {
+  skip: hasDatabase ? false : 'no Postgres at AF_TEST_DATABASE_URL',
+}, () => {
+  let h: ApiHarness
+  let org: Org
+  let owner: SignedIn
+
+  before(async () => {
+    h = await startApi({ operatorSetsPlan: true })
+    org = await seedOrg(h.admin, 'plan-self-hosted')
+    owner = await signInAs(h, org, 'owner')
+  })
+
+  after(async () => {
+    await dropOrg(h.admin, org.orgId)
+    await h.close()
+  })
+
+  it('moves the plan and audits it', async () => {
+    const { status, body } = await callProcedure(h, owner, 'billing.set', 'mutation', {
+      plan: 'team',
+      reason: 'self-hosted, and I am the operator',
+    })
+    assert.equal(status, 200, JSON.stringify(body))
+    const got = data<{ plan: string; changed: boolean; operatorSetsPlan: boolean }>(body)
+    assert.equal(got.plan, 'team')
+    assert.equal(got.changed, true)
+    assert.equal(got.operatorSetsPlan, true)
+
+    const [row] = await h.admin<{ plan: string }[]>`
+      SELECT plan FROM organizations WHERE id = ${org.orgId}`
+    assert.equal(row!.plan, 'team')
+
+    const [entry] = await h.admin<{ detail: { plan: string; tookPayment: boolean } }[]>`
+      SELECT detail FROM audit_entries
+      WHERE org_id = ${org.orgId} AND action = 'organization.plan_changed'
+      ORDER BY seq DESC LIMIT 1`
+    assert.equal(entry!.detail.plan, 'team')
+    assert.equal(entry!.detail.tookPayment, false)
+  })
+})
+
+/**
+ * Stripe configured, no plan gate. The middle configuration, and the one this
+ * file had no cell for: the enterprise-only suite above proves the gate refuses
+ * it, and proving that only with the gate on would leave a plane that takes
+ * money but sells every plan untested.
+ */
+describe('a plane that takes money never grants a plan by hand', {
+  skip: hasDatabase ? false : 'no Postgres at AF_TEST_DATABASE_URL',
+}, () => {
+  let h: ApiHarness
+  let org: Org
+  let owner: SignedIn
+
+  before(async () => {
+    const stripe = await stripeAgainstMockPack()
+    h = await startApi({ stripe: stripe.billing })
+    org = await seedOrg(h.admin, 'plan-stripe-only')
+    owner = await signInAs(h, org, 'owner')
+  })
+
+  after(async () => {
+    await dropOrg(h.admin, org.orgId)
+    await h.close()
+  })
+
+  it('refuses and names Stripe rather than a variable', async () => {
+    const refused = await callProcedure(h, owner, 'billing.set', 'mutation', { plan: 'team' })
+    assert.equal(errorCode(refused.body), 'PRECONDITION_FAILED', JSON.stringify(refused.body))
+    assert.match(JSON.stringify(refused.body), /derives paid plans from Stripe/)
+    const [row] = await h.admin<{ plan: string }[]>`
+      SELECT plan FROM organizations WHERE id = ${org.orgId}`
+    assert.equal(row!.plan, 'free')
+  })
+})
+
+/**
+ * The guard against the next procedure, rather than against this one.
+ *
+ * A refusal inside `billing.set` protects `billing.set`. It says nothing about
+ * the route somebody adds next year that also writes the column, and a guard
+ * that covers one caller of a shared piece of state is the shape of defect this
+ * whole file exists because of. So the column's writers are enumerated from the
+ * source: two, one gated on the operator's declaration and one gated on a
+ * signed Stripe delivery. A third has to be classified deliberately, here,
+ * before the suite goes green again.
+ */
+describe('the writers of organizations.plan', () => {
+  const expected = ['routers/billing.ts', 'billing/webhook.ts'].sort()
+
+  async function sources(dir: string): Promise<string[]> {
+    const entries = await readdir(dir, { withFileTypes: true })
+    const out: string[] = []
+    for (const e of entries) {
+      const full = path.join(dir, e.name)
+      if (e.isDirectory()) out.push(...(await sources(full)))
+      else if (e.name.endsWith('.ts')) out.push(full)
+    }
+    return out
+  }
+
+  it('are the two the product intends and nothing else', async () => {
+    const root = fileURLToPath(new URL('../src', import.meta.url))
+    const found: string[] = []
+    for (const file of await sources(root)) {
+      const text = await readFile(file, 'utf8')
+      for (const m of text.matchAll(/(?:UPDATE|INSERT INTO)\s+organizations\b[\s\S]*?`/gi)) {
+        if (/\bplan\b/i.test(m[0])) {
+          found.push(path.relative(root, file))
+          break
+        }
+      }
+    }
+    assert.deepEqual(
+      [...new Set(found)].sort(),
+      expected,
+      'a route that writes organizations.plan was added or removed. A new one is a new way to ' +
+        'grant an entitlement: gate it the way billing.set is gated, then add it here.',
+    )
+  })
+
+  it('finds the known writers at all, so a broken scan cannot pass quietly', async () => {
+    // The negative control. If the pattern stops matching, the assertion above
+    // goes green having compared two empty lists.
+    const text = await readFile(
+      fileURLToPath(new URL('../src/routers/billing.ts', import.meta.url)),
+      'utf8',
+    )
+    const hits = [...text.matchAll(/(?:UPDATE|INSERT INTO)\s+organizations\b[\s\S]*?`/gi)]
+      .filter((m) => /\bplan\b/i.test(m[0]))
+    assert.equal(hits.length, 1, 'the scan no longer finds the write it was written against')
   })
 })

--- a/web/apps/api/test/verbs.test.ts
+++ b/web/apps/api/test/verbs.test.ts
@@ -562,7 +562,11 @@ describe('the control plane acts', { skip: hasDatabase ? false : 'no Postgres at
   }
 
   before(async () => {
-    h = await startApi()
+    // Self-hosted, with the operator declaring that they set plans by hand.
+    // Without it `billing.set` is refused, which is the shipped default and is
+    // proved in hosted.test.ts; this suite is about what the route does once an
+    // operator has turned it on.
+    h = await startApi({ operatorSetsPlan: true })
     org = await seedOrg(h.admin, 'verbs')
     owner = await signInAs(h, org, 'owner')
     admin = await signInAs(h, org, 'admin')


### PR DESCRIPTION
## What changed

`billing.set` writes `organizations.plan`, the column every quota is read from,
and it refused the call only `if (c.stripe || c.hostedRequiredPlan)`. That guard
asks whether billing was configured, and the installation at risk is precisely
the one where it was not. A control plane that serves people who are not its
operator, whose operator has not reached Stripe yet, sets neither variable, so
nothing refused. The first person into an organization becomes its owner and an
owner holds `billing.manage`, so this was every signed in tenant, not an
administrator: `billing.set({plan: 'enterprise'})` took 500 environments, 100
goldens and 20000 env hours a day for nothing. It is invisible in production
today only because production is 868 commits behind main and has no
`billing.set` at all, so the tag that ships main is what would ship the hole.

`AF_OPERATOR_SETS_PLAN=1` is now an operator saying that whoever runs this
installation also decides each organization's plan. Without it the plan can come
only from a signed Stripe delivery.

### Why this shape rather than the alternatives

Refusing on a hosted plane needs a way to know the plane is hosted, and the only
signal in the tree is `AF_HOSTED_REQUIRED_PLAN`, which the hosted plane does not
set. That is the whole defect, so a flag meaning "this is hosted" would have to
be remembered by exactly the operator who has not thought about billing yet, and
forgetting it would leave the hole open. This flag means the opposite. Forgetting
it closes the hole, and it costs a self hosted operator one variable set once.
Default deny is the only arrangement where the mistake is safe.

There is a start up refusal too, and it is the half that answers "a second
procedure somebody adds later". Setting `AF_OPERATOR_SETS_PLAN` beside any Stripe
variable or the hosted plan gate stops the process, matching the refusal
`main.ts` already makes for `AF_HOSTED_REQUIRED_PLAN` with billing off. A plan
that can be granted by hand is not a plan anybody has to buy. That refusal is why
`operatorSetsPlan` can be read anywhere as "this process takes no money at all".
It could not be the only guard: a plane with nothing configured is a legitimate
self hosted install and must still boot, so the plane that must be refused cannot
be identified at start up, only the contradiction can.

### Every route that can write the plan

Enumerated from the source rather than from memory, and now enumerated by a test
so a third one has to be classified deliberately:

| Writer | Reachable by | Gate |
| --- | --- | --- |
| `routers/billing.ts` `billing.set` | a signed in org owner | `operatorSetsPlan`, off unless declared |
| `billing/webhook.ts` | Stripe, over a signature verified delivery | the signature, and a price the plane recognises |
| `packages/db/src/staging.ts` | the demo data seeder, no HTTP route | not reachable by a request |
| `src/bootstrap-org.ts`, `src/backup-scratch.ts` | operator CLIs | insert only, and they do not name `plan`, so the column takes its `free` default |

`subscriptions.checkout`, `portal`, `cancel` and `reconcile` never write the
column directly; `reconcile` writes it through the Stripe client and requires
Stripe. Nothing in `ee/` writes it. The Go CLI has no plan route.

The console is the other half of the same defect and is fixed with it. The Plan
page drew a "Move to enterprise" button whenever Stripe was off. It now draws the
control only where pressing it works and says why when it does not, and
`billing.get` carries `operatorSetsPlan` so the page can tell.

## Failure paths covered

Every one below was watched RED against this branch's parent before the fix
existed, then green after. The first three failed by returning 200 and moving the
organization onto `team` or `enterprise`; the start up cell failed by the process
starting and having to be killed at the 30 second timeout.

| Failure path | Test |
| --- | --- |
| hosted, billing off, no gate: an owner grants themselves enterprise | `a control plane that takes no money does not hand out its own plans > refuses an owner who asks for the enterprise plan` |
| the same, any plan, and no audit entry claiming a change | `... > refuses every other plan too, and writes no audit entry` |
| the console is told, so no button is drawn that always refuses | `... > says so in the payload the console renders, so no button is offered` |
| self hosted, operator declared: the route still works and is audited | `an operator who says they set plans by hand may set them > moves the plan and audits it` |
| Stripe configured, no gate: refused, naming Stripe rather than a variable | `a plane that takes money never grants a plan by hand > refuses and names Stripe rather than a variable` |
| hosted with the gate on: still refused | `enterprise-only hosted access > cannot self-entitle through the administrative plan route` (pre-existing) |
| the contradictory configuration does not start | `starting up with the gate set > refuses to start when plans are set by hand on a plane that takes money` |
| a typo in the variable does not read as off | same test, and `the hosted plan configuration > treats plans set by hand as off unless an operator says otherwise` |
| a later route writing the same column is noticed | `the writers of organizations.plan > are the two the product intends and nothing else`, with a negative control so a broken scan cannot pass quietly |

## Security considerations

- Secrets, masked data, the proxy, the journal: none. No secret is read, written
  or logged, and the new variable holds no secret.
- New outbound connection or stored data class: none.
- What an untrusted repository or pull request can reach: unchanged. This is a
  browser authenticated tRPC procedure and no engine, workflow or repository path
  reaches it.
- Dependencies: none added.

One thing this does not do, recorded rather than implied. It does not configure
the hosted control plane. Production still has no Stripe variables and no
`AF_HOSTED_REQUIRED_PLAN`, which stays a founder decision with real money behind
it. What changes is that shipping main to a plane in that state no longer hands
out enterprise plans while the decision is pending.

## Exit criteria evidence

```
$ go run ./tools/changecheck .
changecheck: 8 changes a user could notice, described by .changes/a-plan-an-owner-could-grant-themselves.md

$ go run ./tools/prosecheck .
prosecheck: 514 files, 0 places where the punctuation gives it away

$ go run ./tools/varcheck .
varcheck: 7 variables named at a user, every one documented, 0 exemptions

$ go run ./tools/claimcheck .
claimcheck: 248 site files, 6 claim rules, 3 line exceptions, 0 contradicted

$ npm run typecheck --workspace apps/api
(clean)

$ npm run openapi:check --workspace apps/api
openapi: ../../../www/public/openapi.json matches the router, 72 paths

$ node --test test/hosted.test.ts
8 suites pass, including the 5 cells that were red before the fix
```

## Checklist

- [x] Commits are signed off (`git commit -s`)
- [x] A changelog fragment exists under `.changes/`
- [x] Documentation is updated for anything user visible
- [x] Every new error code has a catalog entry (no new codes; the refusal is `PRECONDITION_FAILED`, as it was)
- [x] No secret, real customer record, or unredacted screenshot is included

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR
