### PR TITLE
security: the docker cp races need a mount, and we gate that we have none

### DIFF
--- a/docs/security/pentest-readiness.md
+++ b/docs/security/pentest-readiness.md
@@ -149,7 +149,7 @@ All four are bugs in the daemon, and for three of them that is a fact you can
 check rather than a claim to take on trust. Their Go vulnerability database
 entries are symbol-scoped, and every symbol is a method on `Daemon` in the
 `docker/docker/daemon` package: `openContainerFS`, `createIfNotExists` and
-`containerExtractToDir`. This engine imports `docker/docker/client` and five
+`containerExtractToDir`. This engine imports `docker/docker/client` and twenty
 `api/types` packages, and imports `daemon` nowhere, so none of that code is
 linked into the binary. The fourth advisory carries no symbol information at
 all, which is why it is the one govulncheck flags and the one with a written
@@ -168,6 +168,15 @@ so the copy-out direction does not exist here.
   files the create and the start are separated around the call on purpose. A
   container that has never started has no process, so the race has no second
   party.
+  Both races need a second thing as well, and it is the better of the two to
+  lean on: a volume mount to redirect. The race is in the bind mount setup the
+  daemon performs before it walks the path, so a container with nothing mounted
+  has no destination to swap. Nothing this runtime creates mounts anything, and
+  that is not a property anybody has to remember, because
+  `TestContainment_NoServiceGetsAPathToTheDaemonOrTheHost` inspects every
+  container in a live environment and fails on a bind mount or a mount. The
+  ordering argument above is a convention about two calls in two files, and
+  nothing fails when somebody reorders them. This one has a gate.
 - **CVE-2026-41567**, `PUT /containers/{id}/archive` executing a container
   binary on the host, names the API call we make rather than one we do not, so
   it gets the closest reading here. The daemon only shells out to a
@@ -186,8 +195,8 @@ so the copy-out direction does not exist here.
   it. Anything else with access to that daemon can upload a compressed archive
   to such a container even though we never do. The party at risk is whoever runs
   that daemon, it is not a path from one Antifailure user to another, and the
-  remedy is a Docker Engine upgrade by its operator, which no change here can
-  make for them.
+  remedy is a Docker Engine upgrade by its operator, to 29.5.1 or later, which
+  no change here can make for them.
 - **CVE-2026-33997**, the plugin privilege off-by-one, is accepted in
   `.govulncheck.yaml`. We install no plugin.
 


### PR DESCRIPTION
## What

Three paragraphs of the advisory section in `docs/security/pentest-readiness.md`. No code changes.

## Why

I re-ran the reachability analysis for the three container archive advisories from source rather than from the page, and the page is right on the verdict. It rests on the weaker of the two available reasons, and it has one wrong number.

### The verdict is unchanged and is not reachable

All three are symbol-scoped in the Go vulnerability database, and every symbol is a method on `Daemon` in `github.com/docker/docker/daemon`:

| advisory | Go ID | symbols |
| --- | --- | --- |
| GHSA-rg2x-37c3-w2rh, CVE-2026-42306 | GO-2026-5617 | `Daemon.openContainerFS` |
| GHSA-vp62-88p7-qqf5, CVE-2026-41568 | GO-2026-5668 | `Daemon.openContainerFS`, `Daemon.createIfNotExists` |
| GHSA-x86f-5xw2-fm2r, CVE-2026-41567 | GO-2026-5746 | `Daemon.containerExtractToDir` |

`go list -deps ./cmd/af` links 22 `docker/docker` packages, `client`, `api` and 20 under `api/types`, and no daemon package. Nothing under `ee/` imports `docker/docker` in Go source at all, so those four alerts are a module graph artifact.

**No `.govulncheck.yaml` entry is possible here, and adding one would be wrong.** govulncheck reports none of the three, because the symbols are not in the binary. An allow entry matching no finding is counted as `unused` by `tools/vulncheck` and fails the build as stale, which is the rule that keeps that file honest.

### The reason worth leaning on

The page argued the two races away with the ordering property: `copyInto` only writes into a container that has been created and not started. I verified that at every call site. `copyInto` has two callers, the sidecar policy write at `proxy.go:165` and `installCA`, and `installCA` has two of its own, `container.go:85` and `runOnce` at `container.go:514`. All three sit between a create and a `ContainerStart`, and the early-return branch that reuses a running container returns before `installCA`.

It is still the weaker reason, because nothing fails when somebody reorders those two calls.

Both upstream advisories require a **volume mount** to redirect as well as a process to do the redirecting. Moby's text for CVE-2026-42306 is explicit that the race is between mountpoint creation and the `mount()` syscall during volume bind-mount setup. This runtime mounts nothing. There is no `Binds` field anywhere in the repository, and every `HostConfig` the Docker paths build carries only `DNS`, `RestartPolicy`, `PortBindings` and `ShmSize`.

That property already has an instrument behind it, which the page did not cite: `TestContainment_NoServiceGetsAPathToTheDaemonOrTheHost` inspects every container in a live environment and fails on a bind mount or a mount.

### Two corrections

- The count of linked `api/types` packages was **five** and is **twenty**.
- The advice to upgrade the daemon now names the version, **Docker Engine 29.5.1**, which is what both advisories give as fixed. An upgrade instruction without a version is not something a reader can act on.

The CVE-2026-41567 compression argument is unchanged and I confirmed it upstream: the daemon only shells out to a decompression binary for a compressed archive, Moby says standard `docker cp` is unaffected because the CLI sends uncompressed tar, and `copyInto` writes a plain `archive/tar` stream. There is no compression import under `internal/runtime`, and the other `tar.NewWriter` call sites feed `ImageBuild`.

## Verification

```
go run ./tools/vulncheck .    2 reachable, 2 accepted, 0 unaccepted, 0 expired, 0 stale
go run ./tools/prosecheck .   517 files, 0 findings
go run ./tools/claimcheck .   0 dead, 0 stale exclusions, 0 contradicted
just spell                    91 files, 0 issues
```

## What this does not do

It does not close the eight Dependabot alerts, and nothing in a pull request can. There is no fixed version on the `github.com/docker/docker` path for any of the four. Dismissing them is a decision on the security tab, and I left it to a human.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR