### PR TITLE
release: the notes claimed a tag deploys nothing, and it deploys staging

### DIFF
--- a/.changes/the-release-notes-were-wrong-about-the-release.md
+++ b/.changes/the-release-notes-were-wrong-about-the-release.md
@@ -1,0 +1,18 @@
+# fixed
+
+The v1.0.0 release notes said "Nothing else moves on its own. No deployment is
+triggered by this tag, and no existing environment is upgraded." Both halves
+were wrong, and a reader could check them faster than we could.
+
+`.github/workflows/cd.yml` triggers on `push: tags: ['v*']` as well as on a
+push to `main`. Its staging job's condition excludes only a manual dispatch
+aimed at something other than staging, so a tag push satisfies it and staging
+deploys. Its production job's condition is literally
+`startsWith(github.ref, 'refs/tags/v')`, gated behind the `production`
+environment and its required reviewers, so production is queued for a human
+rather than skipped.
+
+So the tag does deploy, it just deploys ours rather than the reader's. That
+distinction is the thing the section was trying to make and it made it by
+saying something false instead. The section now says what the tag does to our
+infrastructure and what it does to the reader's, separately.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,9 @@ Explicitly not stable, and free to change in a minor release:
 
 ### What moves when this tag is pushed
 
-Pushing `v1.0.0` publishes the control plane image as
+Pushing `v1.0.0` does three things.
+
+It publishes the control plane image as
 `ghcr.io/antifailure/control-plane:v1.0.0` and **moves
 `ghcr.io/antifailure/control-plane:latest` onto it.** `latest` resolves to the
 v0.1.1 digest until then. If you self host and pull `latest`, this tag changes
@@ -66,8 +68,18 @@ what your next pull gets, on your infrastructure, at a time we chose rather than
 one you did. Pin `v1.0.0`, or pin the digest that tag resolves to, if that
 matters to you. A tag can be moved and a digest cannot.
 
-Nothing else moves on its own. No deployment is triggered by this tag, and no
-existing environment is upgraded.
+It builds and publishes this release's archives, their checksums, the bill of
+materials and the signatures over both.
+
+And it deploys **our** hosted control plane, not yours. `cd.yml` runs on a `v*`
+tag as well as on a push to `main`: the staging job's condition excludes only a
+manual dispatch aimed elsewhere, so a tag push deploys staging without asking,
+and the production job's condition is `startsWith(github.ref, 'refs/tags/v')`
+behind the `production` environment, which carries required reviewers, so
+production moves only when a human approves it.
+
+Nothing on your infrastructure is deployed or upgraded by this tag. The only
+thing that reaches you is the image tag above, and only if you pull it.
 
 ### Supply chain
 


### PR DESCRIPTION
The v1.0.0 section of `CHANGELOG.md` said:

> Nothing else moves on its own. No deployment is triggered by this tag, and no
> existing environment is upgraded.

Both halves are false, and `tools/relnotes` publishes that section verbatim as
the GitHub release body, so the tag would have shipped the claim to the one page
a buyer reads first.

What is actually true, read off `.github/workflows/cd.yml` on `main`:

- Line 32 to 35, the trigger is `push: branches: [main], tags: ['v*']`.
- Line 220, the staging job's condition is
  `github.event_name != 'workflow_dispatch' || inputs.environment == 'staging'`.
  A tag push has `event_name == 'push'`, so the left side is true and staging
  deploys with nothing asked.
- Line 303 to 308, the production job's condition includes
  `startsWith(github.ref, 'refs/tags/v')`, and the job declares
  `environment: name: production`, which carries required reviewers. So
  production is queued for a human rather than not triggered.

The distinction the section was reaching for is real and worth keeping: nothing
on the reader's infrastructure moves. It just made that point by saying
something a reader could disprove in one click. The section now says what the
tag does to our infrastructure and what it does to theirs, separately, and keeps
the `latest` warning that was the original reason the section exists.

Checked locally against this branch: `prosecheck` 546 files clean, `changecheck`
clean, `relnotes .` clean, and `relnotes -tag v1.0.0` renders the new text into
the body at line 80.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR