### PR TITLE
docs: the runbook asked for a signed tag nobody can cut

### DIFF
--- a/.changes/the-release-runbook-asked-for-a-key-nobody-has.md
+++ b/.changes/the-release-runbook-asked-for-a-key-nobody-has.md
@@ -1,0 +1,17 @@
+# fixed
+
+The release runbook told maintainers to cut a signed tag, and no signed tag has
+ever been cut.
+
+Both runbooks said `git tag -s`. There is no signing key on the machine that
+cuts releases, no `user.signingkey`, and no `tag.gpgsign`, so the command fails
+where it is not already impossible, and `git verify-tag` on v0.1.0 or v0.1.1
+reports no signature found. A reader who trusted the page and checked would
+find the check failing and reasonably wonder what else on the page was wishful.
+
+The runbooks now say `git tag -a`, which is what happens, and say plainly that
+the tag carries no signature and that `checksums.txt` and the bill of materials
+do. What is signed did not change: cosign keyless signing by the publish job,
+verifiable against the workflow identity, is the guarantee and always was. A
+maintainer who wants signed tags as well now has the four setup steps written
+down, stated as something they choose to do rather than something already true.

--- a/docs/src/content/docs/security/releases.md
+++ b/docs/src/content/docs/security/releases.md
@@ -207,9 +207,16 @@ of them goes red.
 3. Tag and push:
 
    ```sh
-   git tag -s v1.0.0 -m "v1.0.0"
+   git tag -a v1.0.0 -m "v1.0.0"
    git push origin v1.0.0
    ```
+
+   The tag is annotated and carries no signature. What is signed is
+   `checksums.txt` and the bill of materials, by the publish job, which is what
+   the verification steps above check. `git verify-tag` on a release tag of
+   ours answers "no signature found", and that is the honest answer rather than
+   a broken one. [Signing the tags too](#signing-the-tags-too) is what to set
+   up if you want it to answer differently.
 
 4. Watch `.github/workflows/release.yml`. It builds four platforms, packages
    each with `tools/release/build.sh`, unpacks them so the bill of materials can
@@ -245,6 +252,42 @@ Pushing the tag also publishes `ghcr.io/antifailure/control-plane:<tag>` and
 The workflow fails rather than publishing when any of those checks fail. That
 ordering is the point: every previous version of this pipeline signed and
 published first and verified never.
+
+### Signing the tags too
+
+Optional, and nobody has done it. A signed tag would say which maintainer cut
+the release. The artifact signature says something different and stronger: that
+this workflow, in this repository, at this tag produced the files. So a tag
+signature adds a second smaller claim, and its absence takes nothing away from
+the one you can already check.
+
+Setting it up is the account owner's work rather than the release pipeline's,
+because it means holding a private key. Four steps, once:
+
+1. Have a key. An SSH key you already use is enough, or make a GPG key with
+   `gpg --full-generate-key`.
+2. Tell git which key signs, and in which format:
+
+   ```sh
+   git config --global gpg.format ssh
+   git config --global user.signingkey ~/.ssh/id_ed25519.pub
+   ```
+
+   With GPG instead, leave `gpg.format` unset and give `user.signingkey` the
+   key id.
+3. Add the public half to your GitHub account as a signing key, under Settings,
+   SSH and GPG keys. Skip this and the signature is still good, and GitHub
+   still shows the tag as unverified, because it has nothing to check against.
+4. Turn it on for every tag, so a forgotten flag cannot quietly produce an
+   unsigned one:
+
+   ```sh
+   git config --global tag.gpgsign true
+   ```
+
+Step 3 of the runbook then becomes `git tag -s`, and `git verify-tag v1.0.0`
+starts answering. Until somebody does that, this page describes what the
+repository does rather than what it could do.
 
 ### If a release goes out wrong
 

--- a/docs/src/content/docs/self-hosting/releasing.md
+++ b/docs/src/content/docs/self-hosting/releasing.md
@@ -187,13 +187,17 @@ only a stale sentence.
 
 The `migrations/` half is not resolved and is read below rather than here.
 ```sh
-git tag -s v0.1.2 -m "v0.1.2"
+git tag -a v0.1.2 -m "v0.1.2"
 git push origin v0.1.2
 ```
 
-Signed, and pushed on its own. Do not push the tag in the same command as a
-branch: a tag that arrives before its commit is on `main` has no CI run for
-`cd.yml` to wait for.
+Annotated and unsigned, and pushed on its own. The signing in this pipeline is
+cosign over `checksums.txt` and the bill of materials, done by the publish job,
+and it does not depend on the tag carrying a signature. Setting up signed tags
+is optional and the steps are on the
+[releases page](/docs/security/releases#signing-the-tags-too). Do not push the
+tag in the same command as a branch: a tag that arrives before its commit is on
+`main` has no CI run for `cd.yml` to wait for.
 
 ## Watching release.yml
 


### PR DESCRIPTION
Both release runbooks told a maintainer to cut a signed tag:

```
git tag -s v1.0.0 -m "v1.0.0"
```

Nothing on the release path can run that. Verified rather than assumed:
`gpg --list-secret-keys` is empty, `user.signingkey` is unset, `gpg.format` is
unset, and neither `tag.gpgsign` nor `commit.gpgsign` is set. Both published
tags are unsigned annotated tags, so `git verify-tag v0.1.0` and
`git verify-tag v0.1.1` both answer "no signature found".

That is the shape of defect this repository keeps naming: a documented property
reality does not support, which a reader discovers only by following the
instructions.

## What changed

* `docs/src/content/docs/security/releases.md` step 3 now says `git tag -a`,
  and says the tag carries no signature while `checksums.txt` and the bill of
  materials do.
* `docs/src/content/docs/self-hosting/releasing.md` gets the same treatment,
  including the line that read "Signed, and pushed on its own."
* A new optional section, Signing the tags too, gives the four setup steps for
  a maintainer who wants them. Written as a prerequisite the reader performs,
  not as a property the project has.

Those two files were the only places. Checked with
`git grep -n -i "verify-tag\|signed tag\|tag -s" origin/main`, plus a sweep of
`www` and `console` for signing claims in the site copy.

## What did not change

The supply chain story that is real. `checksums.txt` and `sbom.spdx.json` are
signed by the publish job with cosign keyless signing, the workflow verifies
both signatures and requires a tampered copy to be rejected, and none of that
depends on a tag signature. The artifact signature is the stronger claim: it
binds the files to this workflow in this repository at this tag. A tag
signature would only say which maintainer pushed it.

No key was created, imported, or configured. That is the account owner's call.

## Gates

Run locally on the branch:

```
tagsync     every version pin names a tag that exists, or the release being prepared
prosecheck  546 files, 0 places where the punctuation gives it away
claimcheck  0 dead path claims, 318 internal links, 0 pointing nowhere
changecheck 3 changed paths
readability releases.md 16.3, releasing.md 20.6, both under the 28 threshold
```

tagsync was the one worth checking: its four patterns on the releases page each
have to match exactly once, and the edit adds no line that any of them match.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR