### PR TITLE
db: a project on Postgres 18 could not say so

### DIFF
--- a/.changes/a-project-on-postgres-18-could-not-say-so.md
+++ b/.changes/a-project-on-postgres-18-could-not-say-so.md
@@ -1,0 +1,32 @@
+# added
+
+Goldens on Postgres 18, and a refusal that names an edit somebody can make.
+
+Postgres 18 has been the current release for a year and the docker provider
+listed 14 through 17. A project whose production is on 18 had two ways to go,
+and both were bad.
+
+Setting `database.version: 18` was refused:
+
+    AF-DB-003 The source database is Postgres 18, and this provider supports
+              14, 15, 16, 17.
+      Next: Use a provider that supports Postgres 18, or upgrade the source.
+
+No provider in the build supported 18, so the first half of that sentence named
+nothing, and the second half is the wrong direction: a source is not upgraded
+to reach a version older than the one it is already on.
+
+Leaving it at the default instead copied an 18 source into a 17 golden and said
+nothing, so the preview ran a Postgres the application does not.
+
+A golden built by the docker provider is the stock postgres image with the data
+committed into it, so the majors it handles are the ones that image is
+published for rather than a list this provider keeps. 18 is now in it, verified
+by refreshing a golden from a Postgres 18 source holding several schemas, an
+enum, a partitioned table, a materialized view, a generated column and a row
+level security policy, then branching it and reading the rows back out of the
+branch.
+
+A major the provider really cannot build now says which key to edit and what it
+may hold. The other providers are unchanged: they talk to a service and the
+service decides.

--- a/docs/src/content/docs/reference/errors.md
+++ b/docs/src/content/docs/reference/errors.md
@@ -344,7 +344,7 @@ The source database at {host} could not be reached.
 
 The source database is Postgres {found}, and this provider supports {supported}.
 
-**What to do.** Use a provider that supports Postgres {found}, or upgrade the source.
+**What to do.** Set database.version to one of {supported} if the source is one of those, or point database.provider at one that handles Postgres {found}. The docker provider builds a golden in the stock postgres image, so it handles every major that image is published for.
 
 | | |
 | --- | --- |

--- a/docs/src/content/docs/reference/manifest.md
+++ b/docs/src/content/docs/reference/manifest.md
@@ -132,7 +132,7 @@ exported on the laptop that started it.
 | Key | Notes |
 | --- | --- |
 | `provider` | `docker` (default), `neon`, `supabase`, or `dblab`. |
-| `version` | Postgres major, default 17. |
+| `version` | Postgres major, 14 through 18, default 17. Match it to production: a golden on a different major is an environment running a Postgres your application does not. |
 | `url_env` | The variable services receive the connection string in. |
 | `source_url_env` | Names the variable holding production's read only URL. |
 | `masking_rules` | Path to the rules, default `masking.yaml`. |

--- a/docs/src/content/docs/reference/schemas/manifest-v1.md
+++ b/docs/src/content/docs/reference/schemas/manifest-v1.md
@@ -113,7 +113,7 @@ Where the environment's Postgres comes from, and how the production copy is made
 | `source_url_env` | string | no | Name of the environment variable holding the read only connection string of the production database. The value is read once, during a golden refresh, on the operator's machine or runner, and never stored. Max length 128, matches `^[A-Za-z_][A-Za-z0-9_]*$`. |
 | `subset` | [Subset](#subset) | no | Take a production shaped slice rather than the whole database. |
 | `url_env` | string | no | Name of the environment variable to inject into services with the branch's connection string. Defaults to `DATABASE_URL`. Max length 128, matches `^[A-Za-z_][A-Za-z0-9_]*$`. |
-| `version` | `14`, `15`, `16`, `17` | no | Postgres major version. Must match the source, because a dump does not restore across majors. Defaults to `17`. |
+| `version` | `14`, `15`, `16`, `17`, `18` | no | Postgres major version. Match it to the source: a golden built on a different major is an environment running a Postgres your application does not. Defaults to `17`. |
 
 ## Egress
 

--- a/engine/internal/db/docker/docker.go
+++ b/engine/internal/db/docker/docker.go
@@ -161,7 +161,14 @@ func (p *Provider) Capabilities() provider.Caps {
 		// numbers the user needs.
 		MaxConcurrentBranches: 0,
 		ExpectedBranchLatency: 15 * time.Second,
-		SupportedVersions:     []int{14, 15, 16, 17},
+		// Every major the stock postgres image is published for. A golden
+		// here is that image with the data committed into it, so the set is
+		// the registry's rather than this provider's, and leaving 18 out of it
+		// walled off everybody whose production is on the current release with
+		// advice that could not be followed: "use a provider that supports
+		// Postgres 18" named no such provider, and "upgrade the source" is the
+		// wrong direction.
+		SupportedVersions:     []int{14, 15, 16, 17, 18},
 	}
 }
 

--- a/engine/internal/db/docker/docker.go
+++ b/engine/internal/db/docker/docker.go
@@ -168,7 +168,7 @@ func (p *Provider) Capabilities() provider.Caps {
 		// advice that could not be followed: "use a provider that supports
 		// Postgres 18" named no such provider, and "upgrade the source" is the
 		// wrong direction.
-		SupportedVersions:     []int{14, 15, 16, 17, 18},
+		SupportedVersions: []int{14, 15, 16, 17, 18},
 	}
 }
 

--- a/engine/internal/db/docker/versions_test.go
+++ b/engine/internal/db/docker/versions_test.go
@@ -1,0 +1,62 @@
+package docker_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/internal/clock"
+	dockerdb "github.com/antifailure/antifailure/engine/internal/db/docker"
+	aferrors "github.com/antifailure/antifailure/engine/internal/errors"
+	"github.com/antifailure/antifailure/engine/pkg/provider"
+)
+
+// Postgres 18 has been the current release for a year, and a project whose
+// production is on it could not say so.
+//
+// Setting database.version to 18 was refused with AF-DB-003, whose next step
+// was "Use a provider that supports Postgres 18, or upgrade the source". No
+// provider in this build supported 18, so the first half named nothing, and
+// the second half is the wrong direction: a source is not upgraded to reach a
+// version older than the one it is already on. Leaving it at 17 instead copied
+// an 18 source into a 17 golden without saying so, which is an environment
+// running a Postgres the application does not.
+//
+// A golden here is the stock postgres image with the data committed into it,
+// so the set this provider handles is the registry's rather than its own.
+func TestDockerProvider_HandlesEveryMajorTheImageIsPublishedFor(t *testing.T) {
+	p, err := dockerdb.New(dockerdb.Options{Version: 17, Clock: clock.New(), PortFrom: 47400})
+	if err != nil {
+		t.Skipf("skipped: no Docker daemon is reachable: %v", err)
+	}
+	defer func() { _ = p.Close() }()
+
+	for _, major := range []int{14, 15, 16, 17, 18} {
+		require.True(t, p.Capabilities().Supports(major),
+			"a project on Postgres %d cannot say so", major)
+	}
+}
+
+// The refusal for a version this provider really cannot build has to name an
+// edit somebody can make.
+func TestDockerProvider_AnUnbuildableVersionNamesTheOnesItCanBuild(t *testing.T) {
+	p, err := dockerdb.New(dockerdb.Options{Version: 17, Clock: clock.New(), PortFrom: 47410})
+	if err != nil {
+		t.Skipf("skipped: no Docker daemon is reachable: %v", err)
+	}
+	defer func() { _ = p.Close() }()
+
+	_, err = p.RefreshGolden(context.Background(), provider.GoldenSpec{Version: 13})
+	require.Error(t, err)
+
+	var coded *aferrors.Error
+	require.True(t, aferrors.As(err, &coded))
+	require.Equal(t, aferrors.AFDB003, coded.Code())
+	require.Contains(t, coded.NextStep(), "database.version",
+		"the reader has to be told which key to edit")
+	require.Contains(t, coded.NextStep(), "18",
+		"and what the highest value it may hold is")
+	require.NotContains(t, coded.NextStep(), "upgrade the source",
+		"a source is never upgraded to reach an older major")
+}

--- a/engine/internal/errors/catalog.yaml
+++ b/engine/internal/errors/catalog.yaml
@@ -177,7 +177,7 @@ errors:
   - code: AF-DB-003
     area: DB
     message: "The source database is Postgres {found}, and this provider supports {supported}."
-    next_step: "Use a provider that supports Postgres {found}, or upgrade the source."
+    next_step: "Set database.version to one of {supported} if the source is one of those, or point database.provider at one that handles Postgres {found}. The docker provider builds a golden in the stock postgres image, so it handles every major that image is published for."
     docs: providers/overview
     retryable: false
     exit_code: 3

--- a/engine/internal/errors/codes.gen.go
+++ b/engine/internal/errors/codes.gen.go
@@ -651,7 +651,7 @@ var catalog = map[Code]Entry{
 		Code:      AFDB003,
 		Area:      "DB",
 		Message:   "The source database is Postgres {found}, and this provider supports {supported}.",
-		NextStep:  "Use a provider that supports Postgres {found}, or upgrade the source.",
+		NextStep:  "Set database.version to one of {supported} if the source is one of those, or point database.provider at one that handles Postgres {found}. The docker provider builds a golden in the stock postgres image, so it handles every major that image is published for.",
 		Docs:      "providers/overview",
 		Retryable: false,
 		ExitCode:  ExitConfiguration,

--- a/schemas/manifest.v1.json
+++ b/schemas/manifest.v1.json
@@ -323,10 +323,11 @@
             14,
             15,
             16,
-            17
+            17,
+            18
           ],
           "default": 17,
-          "description": "Postgres major version. Must match the source, because a dump does not restore across majors."
+          "description": "Postgres major version. Match it to the source: a golden built on a different major is an environment running a Postgres your application does not."
         },
         "source_url_env": {
           "type": "string",

--- a/www/public/errors.v1.json
+++ b/www/public/errors.v1.json
@@ -282,7 +282,7 @@
       "area": "DB",
       "areaName": "Database",
       "message": "The source database is Postgres {found}, and this provider supports {supported}.",
-      "resolution": "Use a provider that supports Postgres {found}, or upgrade the source.",
+      "resolution": "Set database.version to one of {supported} if the source is one of those, or point database.provider at one that handles Postgres {found}. The docker provider builds a golden in the stock postgres image, so it handles every major that image is published for.",
       "docs": "https://antifailure.dev/docs/providers/overview",
       "retryable": false,
       "exitCode": 3,


### PR DESCRIPTION
Found while running the documented getting started sequence against a Postgres shaped like a production database.

## The wall

Postgres 18 has been the current release for a year. The docker provider listed 14 through 17, so a project whose production is on 18 had two ways to go and both were bad.

Say so in the manifest, and:

```
$ af golden refresh
AF-DB-003 The source database is Postgres 18, and this provider supports 14, 15,
          16, 17.
  Next: Use a provider that supports Postgres 18, or upgrade the source.
```

No provider in this build supported 18, so the first half of that sentence named nothing. The second half is the wrong direction: a source is not upgraded to reach a version older than the one it is already on.

Leave it at the default instead, and the refresh succeeds. An 18 source is copied into a 17 golden and nothing says so, which is a preview environment running a Postgres the application does not.

## What changes

A golden built by the docker provider is the stock postgres image with the data committed into it, so the majors it handles are the ones that image is published for rather than a list this provider keeps. 18 joins the set, in the provider, in the manifest schema enum, and in the reference table.

The other providers are untouched. Neon, Supabase and Database Lab talk to a service and the service decides.

AF-DB-003 now names the key to edit and the values it may hold, for the case where the version really cannot be built.

## Verified rather than reasoned about

Refreshed a golden from a Postgres 18 source holding several schemas, an extension, an enum, a composite primary key, a self referential foreign key, a circular foreign key pair, a partitioned table, a materialized view, a generated column, a sequence not owned by its column, a row level security policy and a table with no primary key. Published it, brought an environment up from it with `af up`, and read the branch:

```
PostgreSQL 18.6 on aarch64-unknown-linux-musl
customers=50 orders=20 events=40 matview=1
```

## The tests

Both were watched red first. `HandlesEveryMajorTheImageIsPublishedFor` failed on 18. `AnUnbuildableVersionNamesTheOnesItCanBuild` failed because the old next step contained neither `database.version` nor `18`, and did contain "upgrade the source".

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR