### PR TITLE
console: the plan page promised a change it would refuse

### DIFF
--- a/.changes/the-plan-page-promised-a-change-it-refused.md
+++ b/.changes/the-plan-page-promised-a-change-it-refused.md
@@ -1,0 +1,15 @@
+# fixed
+
+The Plan page told an organization that plan changes only change local quotas,
+on a control plane where the plan could not be changed at all.
+
+It is the sentence a page carries when it was written for one configuration and
+then a second one appeared under it. The card said "This self-hosted
+installation does not take payment. Plan changes only change local quotas."
+whenever Stripe was off, which after the plan grant fix includes every
+installation that has not set `AF_OPERATOR_SETS_PLAN`. Two cards below it, the
+same screen said the plan can only be changed by the operator. Found by
+rendering the page rather than by reading the code.
+
+The card now says where the plan comes from on this particular installation, in
+one place, and the table below it goes back to saying only what a plan allows.

--- a/console/app/(app)/plan/page.tsx
+++ b/console/app/(app)/plan/page.tsx
@@ -191,9 +191,13 @@ function Billing() {
         <div className="space-y-6">
           <Card
             title="Plan and billing"
-            note={data.billing.configured
-              ? "Stripe holds the card and computes plan changes. This control plane stores only the subscription state and card metadata."
-              : "This self-hosted installation does not take payment. Plan changes only change local quotas."}
+            note={
+              data.billing.configured
+                ? "Stripe holds the card and computes plan changes. This control plane stores only the subscription state and card metadata."
+                : data.quota.operatorSetsPlan
+                  ? "This installation takes no payment. A plan change here only changes local quotas."
+                  : "This installation takes no payment, and its plan is set by whoever runs it."
+            }
             actions={
               error ? (
                 <span
@@ -318,11 +322,7 @@ function Billing() {
 
           <Card
             title="What each plan allows"
-            note={
-              data.billing.configured || data.quota.operatorSetsPlan
-                ? "A plan that is already over its limit refuses the next environment and removes nothing that exists."
-                : "A plan that is already over its limit refuses the next environment and removes nothing that exists. This control plane takes no payment and does not grant plans by hand, so the plan is whatever its operator set."
-            }
+            note="A plan that is already over its limit refuses the next environment and removes nothing that exists."
           >
             <TableWrap>
               <Table>


### PR DESCRIPTION
## What changed

The Plan page told an organization that plan changes only change local quotas,
on a control plane where the plan could not be changed at all.

The card's note branched on Stripe alone: `configured ? ... : "This self-hosted
installation does not take payment. Plan changes only change local quotas."`
After #129 that second branch also covers every installation without
`AF_OPERATOR_SETS_PLAN`, which is exactly the hosted plane the fix was for. So
the top of the screen promised a plan change, the table two cards below said
"Ask the operator", and the sentence called a hosted control plane self hosted
while it was at it.

The note now says where the plan comes from on this particular installation and
says it once. The table below goes back to its single sentence about what a plan
allows, instead of repeating the billing fact in longer words.

## How it was found

By rendering it. I started a real control plane with the exported console, a
seeded organization and an owner session, and looked at `/plan` in both
configurations at 1440 and 390 wide. That is the only way a sentence like this
is ever found, and it was not visible in the diff, in the typecheck or in the
build, all three of which were clean on #129.

What the render also confirmed, since it is the check I owed and had not done:

- With the flag off, the Choose column reads Current, Ask the operator, Ask the
  operator, and draws no button.
- With it on, it reads Current, Move to team, Move to enterprise, and the
  buttons are the existing component at the existing size.
- No horizontal scroll at 390 wide in either state, and the table reflows to
  stacked label and value rows rather than squashing.
- No console errors in any of the eight renders.

One thing I saw and did not change: the console has no dark theme at all. There
are no `dark:` classes and no `prefers-color-scheme` rule, so a viewer with a
dark system renders the light page. That is pre-existing and outside this
change, recorded here so it is a decision rather than an oversight.

## Failure paths covered

| Failure path | Test |
| --- | --- |
| the note claims a plan change on a plane that refuses one | rendered at 1440 and 390, both configurations; the note now reads "its plan is set by whoever runs it" |
| the note and the table say different things on one screen | the table's note no longer restates the billing fact |
| a plane that does grant plans by hand still says so | rendered with `operatorSetsPlan` on: "A plan change here only changes local quotas" |

No behaviour changed, so there is no new automated test. The wiring underneath,
that `billing.get` carries `operatorSetsPlan` and that the control is drawn only
when it is true, is covered by `hosted.test.ts` from #129.

## Security considerations

- Secrets, masked data, the proxy, the journal: none.
- New outbound connection or stored data class: none.
- What an untrusted repository or pull request can reach: unchanged. Copy only.
- Dependencies: none added.

## Exit criteria evidence

```
$ go run ./tools/changecheck .
changecheck: 1 change a user could notice, described by .changes/the-plan-page-promised-a-change-it-refused.md

$ go run ./tools/prosecheck .
prosecheck: 548 files, 0 places where the punctuation gives it away

$ npm run typecheck   # console
(clean)

$ npm run build       # console
✓ prerendered as static content
```

## Checklist

- [x] Commits are signed off (`git commit -s`)
- [x] A changelog fragment exists under `.changes/`
- [x] Documentation is updated for anything user visible (no documented behaviour changed)
- [x] Every new error code has a catalog entry (none added)
- [x] No secret, real customer record, or unredacted screenshot is included

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR
