### PR TITLE
docs: the README never mentioned the MCP server, and neither does anything else

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,11 +131,41 @@ are `examples/go-api` and `examples/django-api`, and
 `examples/github-workflow.yml` is the same run inside GitHub Actions, which
 leaves one comment on the pull request and edits it in place.
 
+## Your coding agent can run it
+
+`af mcp` serves the rehearsal tools to an agent over the Model Context
+Protocol. It is started by an MCP client rather than typed, in the checkout it
+should serve, and it speaks the protocol on standard input and output, so
+running it in a terminal looks like it has hung. It needs no account, no
+control plane and no model key of its own.
+
+The part worth reading twice is what an agent cannot do with it. The agent
+chooses the hypothesis and Antifailure chooses the safety controls, and that is
+a property of the schemas rather than a convention the tools ask an agent to
+respect. There is no argument on any tool that can disable sanitization, widen
+the egress policy, lower a threshold, name a database or skip the rehearsal,
+and unknown fields are refused rather than ignored. So an agent cannot weaken
+an experiment in order to make its own change pass. Thresholds come from the
+`policy` block of your manifest, and the verdict comes from the same evaluator
+`af ci` uses, so a tool call and a pull request check cannot disagree about the
+same change.
+
+| Tool | What it does |
+| --- | --- |
+| `rehearse_migration_safety` | Applies the branch's pending migrations to a throwaway branch of a masked copy of production and reports the slow statements, the tables Postgres rewrote, the locks and their durations, and what the schema linter objected to at production's table sizes. Returns a `run_id`. |
+| `inspect_egress_firewall` | What the environment may reach, what it reached, and whether containment held. Read only. Reports whether a sandbox credential was really swapped on the way out, which is the case that otherwise looks identical to a working one. |
+| `get_rehearsal_run` | Status, and the verdict once it has finished. Evidence is paginated. |
+| `cancel_rehearsal_run` | Asks a run to stop at the next point it can tear down safely, rather than killing it and leaking the environment. |
+
+A run answers `PASS`, `FAIL` or `INCONCLUSIVE`. `INCONCLUSIVE` is not a weaker
+`PASS`: an experiment that did not finish says nothing about the change. The
+[MCP reference](https://antifailure.dev/docs/reference/mcp) has the rest.
+
 ## What is in here
 
 | Path | What it is |
 | --- | --- |
-| `engine` | The Go engine and the `af` command. Orchestration, masking, verification, egress policy, insights, the journal. |
+| `engine` | The Go engine and the `af` command. Orchestration, masking, verification, egress policy, insights, the journal, and the MCP server. |
 | `runner` | The agent runner. TypeScript, because it drives Chromium, and installed beside `af` rather than downloaded. |
 | `schemas` | The JSON Schemas that are the source of truth. The Go types mirror `schemas/manifest.v1.json` and a test fails when they drift. |
 | `examples` | Three applications that run: a Next.js app, a Go API, a Django API. |
@@ -197,6 +227,10 @@ commands with their flags and exit codes, the JSON each command documents
 under `--output json`, the provider interfaces, and the error codes. That page
 also names what is deliberately not covered, which is the half worth reading
 first.
+
+Builds are reproducible, and that is a gate rather than an aspiration: two
+builds in two directories with two caches produce identical archives on all
+four platforms, checked in CI on every pull request.
 
 Contributions are welcome. [CONTRIBUTING.md](CONTRIBUTING.md) covers building
 locally, running the gates and structuring commits.


### PR DESCRIPTION
**Draft on purpose.** There is a merge freeze on main and auto merge is enabled repository wide, so this is a draft so that it cannot land by itself. Un-draft it when the freeze lifts and you have looked at it.

Grepping `www/components`, `www/app` and `www/lib` for MCP returns one hit and it is a comment inside a route. The README had none. The product ships a finished MCP server that nothing a developer reads ever names.

## What I verified myself, rather than relaying

- `newMCPCommand` is registered at `engine/internal/cli/root.go:515`. A real call site, not another declared-and-uncalled surface.
- Free by construction on three counts. It lives under `engine/internal`, which is MIT, so the community binary carries it; grepping the package for a licence, plan, entitlement, bearer or control plane dependency returns nothing functional; and none of its four tools is the agent runner, so it needs no model key.
- The four tools are the four the package registers, read off the source rather than the docs page.

The claim I was most careful with is the one about authority, because it is the one a security reviewer would try to falsify. I checked it at the schema, not at the prose asserting it. Every input property across all four tools is `project_id`, `idempotency_key`, `repository_file`, `hypothesis`, `probe`, `observed_limit`, `evidence_cursor` and `reason`. None carries a threshold, a policy, a credential or a database. `repository_file` resolves inside the checkout and explicitly does not select which migrations run. `hypothesis` is recorded and never executed. Thresholds reach the evaluator through `Project.Gate`, read from the manifest, which no call can address.

The mechanism is stronger than the audit described and the section says so, because it is the part worth trusting: the schemas are **closed objects**, so a weakening argument is inexpressible rather than refused by name. `TestValidate_RejectsTheSafetyWeakeningFieldsThatDoNotExist` makes that a test rather than a comment, and its own note explains why there is deliberately no list of forbidden words for a new spelling to slip past.

Also here: one line about reproducible builds beside the stability promise, because that one is gated rather than aspirational and the CI job runs on every pull request.

## Two things I left out, and why

**The free tier numbers.** They are real, three environments, two goldens and one gigabyte at `web/apps/api/src/limits.ts:483`. They do not belong in this file. `checkQuota` has exactly one non-test caller, `routers/dispatch.ts:327`, so those numbers bound environments the **hosted control plane dispatches**. Nothing under `engine` enforces a quota at all. Putting them in a README whose install section says "no account, no control plane, nothing calls home" would tell a reader the local tool stops at three environments, which is the opposite of true. They belong on a pricing page, and the audit's own Q7 argues that tier should be renamed or retired before it is advertised anywhere.

**Cosign signing and the SPDX bill of materials.** Not claimed, because no published release carries either. v0.1.0 and v0.1.1 each ship four archives, `checksums.txt` and the notices file and nothing else. The releases page is exactly where a reviewer would check and it would disprove the sentence in under a minute. STATUS 1.5 already records that v1.0.0 is the first tag whose workflow runs them. Once that tag exists and carries `checksums.txt.sigstore.json` and `sbom.spdx.json`, the claim becomes checkable and I will add it.

## Gates

`prosecheck`, `claimcheck`, `modecheck`, `constcheck`, `forbidden`, `spell`, `vale` and `authorship` all pass locally, and `lychee` reports 12 of 12 links resolving, including the MCP reference page.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR