### PR TITLE
www: the primary action was a door most visitors cannot open

### DIFF
--- a/.changes/every-button-pointed-at-a-locked-door.md
+++ b/.changes/every-button-pointed-at-a-locked-door.md
@@ -1,0 +1,23 @@
+# changed
+
+The primary action on antifailure.dev is the free path now, everywhere the
+product is pitched. It was "Request access", which leads to an invitation wall
+that only a handful of GitHub accounts can pass, so the site described an
+open-source engine and then pointed every visitor at a door they cannot open.
+The engine is MIT licensed and installs with one command, so that is what the
+filled button does: the home hero, the closing panel on every page, the default
+hero on every inner page, the solutions heroes and the header now lead with the
+quickstart and offer hosted access beside it. The hero also carries the install
+command itself, which the closing panel already did.
+
+The hero's two sentences swapped order for the same reason. It opened with the
+restriction and closed with what a visitor can have; it now says what they can
+have first.
+
+The `Docs` link in the header of every page was a `next/link`. The
+documentation is built by Astro and merged into the published site afterwards,
+so the app router does not own `/docs`: it prefetched a payload that does not
+exist and answered the click with a client side navigation to nothing. The
+header already had the helper that makes this distinction and this one link was
+not using it, which is the third time this exact defect has been found on this
+site.

--- a/www/components/home/Cta.tsx
+++ b/www/components/home/Cta.tsx
@@ -42,14 +42,18 @@ export function Cta() {
               it sits quietly beneath rather than competing with the buttons for
               the remaining width. Sized to its content: the shared white
               variant is a fixed percentage of the viewport, which truncated a
-              fifty character command down to "curl -fsS…". */}
+              fifty character command down to eleven.
+
+              The filled action is the quickstart rather than the invitation
+              wall. The quickstart is the one a visitor can finish today, and
+              the install line beneath it is its first command. */}
           <div className="flex shrink-0 flex-col items-end gap-y-4 max-lg:w-full max-lg:items-stretch">
             <div className="flex items-center gap-4 max-md:flex-col max-md:items-stretch max-md:gap-y-3 max-md:[&_a]:w-full">
-              <Button href="/signup" theme="white">
-                Request access
+              <Button href="/docs/getting-started/quickstart" theme="white">
+                Start the quickstart
               </Button>
-              <Button href="/docs" theme="outlined-inverse">
-                Read the docs
+              <Button href="/signup" theme="outlined-inverse">
+                Request hosted access
               </Button>
             </div>
             <CopyCodeButton variant="terminal" className="max-lg:w-full" />

--- a/www/components/home/Hero.tsx
+++ b/www/components/home/Hero.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/layout/Button";
 import { Container } from "@/components/layout/Container";
 import { SectionLabel } from "@/components/layout/SectionLabel";
+import { CopyCodeButton } from "./media/CopyCodeButton";
 import { HeroFilm } from "./media/HeroFilm";
 import { HeroServices } from "./HeroServices";
 
@@ -16,28 +17,42 @@ export function Hero() {
           <br className="max-xl:hidden" />{" "}
           on a disposable production twin.
         </h1>
+        {/* The free path first, because it is the only one a visitor can take
+            today without somebody else's permission. The primary button used
+            to be "Request access", which leads to an invitation wall, so the
+            page pitched a product and then pointed at a locked door. The
+            engine is MIT licensed and the quickstart needs no account, so that
+            is the action, and the install line under it is the first command
+            of it rather than a third call to action. */}
         <div className="mt-8 flex gap-x-5 max-lg:mt-7 max-lg:gap-x-4 max-md:flex-col max-md:gap-y-3 max-md:[&_a]:w-full">
-          <Button href="/signup" theme="filled">
-            Request access
+          <Button href="/docs/getting-started/quickstart" theme="filled">
+            Start the quickstart
           </Button>
-          <Button href="/docs" theme="outlined">
-            Read the docs
+          <Button href="/signup" theme="outlined">
+            Request hosted access
           </Button>
         </div>
+        <CopyCodeButton
+          variant="white"
+          className="mt-5 w-auto max-w-full border border-black/12 bg-white px-4 hover:bg-[#f7f7f5] max-xl:w-auto max-lg:w-full"
+        />
         {/* The state of the product, on the page that sends the most people to
             /signup. This button said "Get started" and led to an invitation
             wall, and the only page that admitted it was /pricing, which most
             visitors never open. Worded to match that page rather than beside
             it: two descriptions of one product state is how the first of them
-            goes stale. */}
+            goes stale.
+
+            The two sentences are now in the order a visitor needs them: what
+            they can have, then what they cannot have yet. */}
         <p className="mt-6 max-w-[760px] text-[15px] leading-6 tracking-extra-tight text-gray-new-40 max-lg:mt-5 max-lg:max-w-[520px] max-md:text-[14px]">
-          The hosted control plane is invitation only while it is in development.
+          The engine is open source and runs in your own continuous integration
+          today, with no account.
           {/* Broken at the sentence, the same way the h1 above is, rather than
               left to text-balance, which put the first sentence's "The" alone
               at the end of a line. */}
           <br className="max-lg:hidden" />{" "}
-          The engine is open source and runs in your own continuous integration
-          today.
+          The hosted control plane is invitation only while it is in development.
         </p>
         <div className="relative mt-36 max-md:mt-24 max-sm:mt-16">
           <HeroServices />

--- a/www/components/layout/SiteHeader.tsx
+++ b/www/components/layout/SiteHeader.tsx
@@ -219,20 +219,33 @@ export function SiteHeader({ overlay = true }: { overlay?: boolean }) {
               {/* There is no Discord. The link that used to sit here was
                   labelled Discord and went to the waitlist form, which is a
                   broken promise in the header of every page. */}
-              <Link
+              {/* HeaderLink rather than next/link. The documentation is built
+                  by Astro and merged into the published site afterwards, so
+                  the app router does not own /docs: it prefetched an RSC
+                  payload that does not exist and answered the click with a
+                  client side navigation to nothing. The helper above this file
+                  makes exactly that distinction and this one link, in the
+                  header of every page, was not using it. */}
+              <HeaderLink
                 href="/docs"
                 className="flex items-center gap-1.5 text-black transition-colors hover:text-gray-new-40"
               >
                 <BookIcon className="h-[18px] w-[18px] text-gray-new-20" />
                 <span className="text-sm leading-none tracking-extra-tight">Docs</span>
-              </Link>
+              </HeaderLink>
             </div>
+            {/* The filled action in the header of every page used to be
+                "Request access", which is an invitation wall. The engine is
+                MIT licensed and installs with one command, so the action a
+                visitor can actually take is the one that leads. Somebody who
+                has been invited signs in beside it, and /signin carries the
+                waitlist form for somebody who has not. */}
             <div className="flex gap-x-3.5">
               <Button href="/signin" theme="outlined" size="xxs">
                 Sign in
               </Button>
-              <Button href="/signup" theme="filled" size="xxs">
-                Request access
+              <Button href="/docs/getting-started/quickstart" theme="filled" size="xxs">
+                Install the engine
               </Button>
             </div>
           </div>
@@ -461,8 +474,12 @@ export function SiteHeader({ overlay = true }: { overlay?: boolean }) {
               <Button href="/signin" theme="outlined" className="flex-1">
                 Sign in
               </Button>
-              <Button href="/signup" theme="filled" className="flex-1">
-                Request access
+              <Button
+                href="/docs/getting-started/quickstart"
+                theme="filled"
+                className="flex-1"
+              >
+                Install the engine
               </Button>
             </div>
           </div>

--- a/www/components/pages/kit.tsx
+++ b/www/components/pages/kit.tsx
@@ -66,11 +66,11 @@ function PagesClose() {
           </div>
           <div className="flex min-w-0 flex-col items-start gap-4 max-lg:w-full">
             <div className="flex gap-x-5 max-sm:w-full max-sm:flex-col max-sm:gap-y-3 max-sm:[&_a]:w-full max-sm:[&_button]:w-full">
-              <Button href="/signup" theme="filled">
-                Request access
+              <Button href="/docs/getting-started/quickstart" theme="filled">
+                Start the quickstart
               </Button>
-              <Button href="/docs" theme="outlined">
-                Read the docs
+              <Button href="/signup" theme="outlined">
+                Request hosted access
               </Button>
             </div>
             <CopyCodeButton
@@ -136,11 +136,11 @@ export function PageHero({
         <div className="mt-8 flex gap-x-5 max-lg:mt-7 max-sm:flex-col max-sm:gap-y-3 max-sm:[&_a]:w-full max-sm:[&_button]:w-full">
           {actions ?? (
             <>
-              <Button href="/signup" theme="filled">
-                Request access
+              <Button href="/docs/getting-started/quickstart" theme="filled">
+                Start the quickstart
               </Button>
-              <Button href="/docs" theme="outlined">
-                Read the docs
+              <Button href="/signup" theme="outlined">
+                Request hosted access
               </Button>
             </>
           )}

--- a/www/components/pages/solutions/well.tsx
+++ b/www/components/pages/solutions/well.tsx
@@ -149,9 +149,15 @@ function HeroCopy({
           </p>
         ))}
       </div>
-      <div className="mt-8">
-        <Button href="/signup" theme="filled">
-          Request access
+      {/* The same pair as every other hero on the site, in the same order.
+          This one offered only the invitation wall, so a solutions page pitched
+          the product and then gave a visitor nothing they could do today. */}
+      <div className="mt-8 flex gap-x-5 max-sm:flex-col max-sm:gap-y-3 max-sm:[&_a]:w-full">
+        <Button href="/docs/getting-started/quickstart" theme="filled">
+          Start the quickstart
+        </Button>
+        <Button href="/signup" theme="outlined">
+          Request hosted access
         </Button>
       </div>
     </>


### PR DESCRIPTION
Every call to action on antifailure.dev led with **Request access**, which goes to `/signup` and an invitation wall gated by `AF_SIGNIN_ALLOWLIST` to a handful of GitHub accounts. The site pitched an MIT licensed engine that installs with one command and then pointed every visitor at a door they cannot open.

The free path leads now, and hosted access is the secondary action beside it:

- the home hero, which also carries the install command itself
- the closing panel on the home page and the closing band on every other page
- the default hero used by every inner page
- the solutions verticals hero, which offered only the invitation wall
- the header of every page, desktop and mobile drawer

The hero's two sentences also swapped order. It opened with the restriction and closed with what a visitor can have; it says what they can have first now.

## The header's Docs link was broken

`www/components/layout/SiteHeader.tsx` linked `/docs` with `next/link`. The documentation is built by Astro and merged into the published site afterwards, so the app router does not own that route: it prefetches a payload that does not exist and answers the click with a client side navigation to nothing. The file already had `HeaderLink`, the helper that makes exactly this distinction, and this one link was not using it. Same defect as the two `Contact.tsx` already documents.

## Checked

Built the site and looked at the rendered pixels rather than the source.

- home page at 1440, 1280 and 390: header fits with the longer label, buttons and install pill do not clip, `document.scrollWidth` equals the viewport at 390 so there is no horizontal scroll
- the dark closing panel at 390: white primary, outlined secondary, install line, all full width and legible
- gates run locally green: `classcheck` (0 classes that never apply), `motioncheck` (0 animations that never stop, and no `animate-pulse` or `animate-ping` in the diff), `prosecheck`, `readability`, `www` build, `npm run check:seo` 88/88

No new colour, component, radius or spacing value. Every control is the existing `Button` and `CopyCodeButton` with themes the design system already defines.

## Not touched

No Azure setting, no `AF_SIGNIN_ALLOWLIST`, no DNS, no Stripe. Opening the hosted control plane is a separate decision and this changes nothing about who can sign in.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR