### PR TITLE
masking: two layers keyed off one list were never two layers

### DIFF
--- a/.changes/masking-a-type-nobody-classified.md
+++ b/.changes/masking-a-type-nobody-classified.md
@@ -1,0 +1,41 @@
+# fixed
+
+The masking default and the verification scan that backstops it were keyed off
+the same six element list of column types, so they were never two layers. A
+column of any other type was not masked, was not listed among the columns no
+rule covers, and was not read by the scan. It shipped into every preview
+environment and the golden's attestation said it had been verified.
+
+The types are not exotic. `information_schema` reports `citext` as
+`USER-DEFINED` and `text[]` as `ARRAY`, checked against a real PostgreSQL 17,
+and `citext` is what an application uses for an email column precisely because a
+person types into it. A column called `email` was saved by the name based rule,
+which ignores type. A column called `handle` on `citext` was not.
+
+`looksSensitive` was a known-yes list with no known-no list beside it, so an
+unrecognised type was silently treated as structural, as though somebody had
+decided it was safe. There is now a `knownStructural` list of the types whose
+text form cannot carry a sentence, and a type in neither list is reported as a
+question. Nothing new is masked: masking a column that is copied today would
+change what existing goldens hold and blank a column an environment may need,
+which is a decision for whoever owns the product rather than a bug fix.
+
+`af mask plan` also no longer tells you that every column it lists ships
+unchanged. Some are emptied by the default and some genuinely ship, and a person
+reading the list could not tell which of their columns had leaked.
+
+# fixed
+
+A verification scan that could not read a column reported itself clean. The
+sentence "a column nobody could read is not a column that passed" was written
+twice in `scan.go` and implemented nowhere, so `Clean()` counted findings and
+ignored skips, and the golden was published on the strength of it. That was the
+one way a golden could pass verification without having been verified.
+
+Fixing it exposed a second defect immediately. The refusal path read
+`report.Findings[0]` with no length check, which was safe only because every
+path into it had a finding. A report whose only problem was an unreadable column
+now reaches that line, so the fix for a silent pass would have shipped as a
+panic on the golden refresh. Findings are reported first, and a skip now returns
+`AF-MSK-011`, which says the column could not be read rather than claiming a
+detector found something in it.

--- a/docs/src/content/docs/reference/errors.md
+++ b/docs/src/content/docs/reference/errors.md
@@ -896,6 +896,18 @@ Masking could not run: {detail}
 | Retryable | No. Retrying the same operation unchanged will fail the same way. |
 | More | [concepts/masking](/docs/concepts/masking) |
 
+### AF-MSK-011
+
+Verification could not read {table}.{column}, so the golden was not verified: {detail}
+
+**What to do.** Grant the scanner read access to {table}.{column} and refresh the golden. A column the scan could not read is not a column that passed.
+
+| | |
+| --- | --- |
+| Exit code | `7` |
+| Retryable | No. Retrying the same operation unchanged will fail the same way. |
+| More | [concepts/verification](/docs/concepts/verification) |
+
 ## Egress
 
 ### AF-NET-001

--- a/engine/internal/cli/mask.go
+++ b/engine/internal/cli/mask.go
@@ -135,12 +135,24 @@ func newMaskPlanCommand(env *Env) *cobra.Command {
 
 			if len(plan.Unclassified) > 0 {
 				env.Out.Section("Columns no rule covers")
+				// Which of these actually shipped, per row.
+				//
+				// This said "so they ship as they are" about the whole list, and
+				// most of the list is emptied by the default rather than shipped.
+				// The two are genuinely different outcomes and a person reading
+				// their own schema could not tell which had happened to which
+				// column, which is the one thing the list is for.
 				env.Out.Println(env.Out.Wrap(
-					"These hold text and nothing decided what happens to them, so they ship as they "+
-						"are. Add a rule for each, or decide that shipping it is fine.", 0))
+					"Nothing decided what happens to these. Each one says what the default did "+
+						"with it. Add a rule for each, or decide that what happened is fine.", 0))
 				env.Out.Println("")
 				for _, a := range plan.Unclassified {
-					env.Out.Printf("  %s.%s  (%s)\n", a.Table, a.Column.Name, a.Column.Type)
+					did := "COPIED UNCHANGED"
+					if a.Transform != "" {
+						did = "emptied by default (" + a.Transform + ")"
+					}
+					env.Out.Printf("  %s.%s  (%s)  %s\n",
+						a.Table, a.Column.Name, a.Column.Type, did)
 				}
 				env.Out.Println("")
 			}

--- a/engine/internal/env/export_test.go
+++ b/engine/internal/env/export_test.go
@@ -154,3 +154,6 @@ func (o *Orchestrator) InvokeRunnerCapturingDocument(
 	out, err := o.invokeRunner(ctx, runnerPath, job)
 	return captured, out, err
 }
+
+// DescribeSkipForTest exposes the split of one verify.Scan skipped line.
+func DescribeSkipForTest(line string) (string, string, string) { return describeSkip(line) }

--- a/engine/internal/env/golden.go
+++ b/engine/internal/env/golden.go
@@ -703,16 +703,52 @@ func (o *Orchestrator) verifyDatabase(
 				events.F("detector", f.Detector),
 				events.F("table", f.Schema+"."+f.Table), events.F("column", f.Column))
 		}
-		first := report.Findings[0]
-		return report, string(body), aferrors.Coded(aferrors.AFMSK002,
-			"detector", first.Detector, "table", first.Schema+"."+first.Table,
-			"column", first.Column)
+		// A skip with no findings reaches here now, and it did not before, so
+		// this index was safe and is not. Clean() used to ignore Skipped, which
+		// meant every path into this branch had at least one finding;
+		// report.Findings[0] on a report whose only problem is an unreadable
+		// column is an index out of range, and the fix for a silent pass would
+		// have been a panic. Findings first, because a column the scan READ and
+		// disliked is the more specific answer.
+		if len(report.Findings) > 0 {
+			first := report.Findings[0]
+			return report, string(body), aferrors.Coded(aferrors.AFMSK002,
+				"detector", first.Detector, "table", first.Schema+"."+first.Table,
+				"column", first.Column)
+		}
+		for _, skipped := range report.Skipped {
+			o.eventErr(s, events.MaskFinding,
+				"verification could not read "+skipped,
+				events.F("skipped", skipped))
+		}
+		// Safe because !Clean() with no findings means Skipped is non empty,
+		// which is Clean()'s definition and not an assumption about the caller.
+		table, column, detail := describeSkip(report.Skipped[0])
+		return report, string(body), aferrors.Coded(aferrors.AFMSK011,
+			"table", table, "column", column, "detail", detail)
 	}
 	o.event(s, events.MaskVerified,
 		fmt.Sprintf("verified %d columns across %d tables", report.Columns, report.Tables),
 		events.F("tables", report.Tables), events.F("columns", report.Columns),
 		events.F("rows_sampled", report.RowsSampled), events.F("verified", true))
 	return report, string(body), nil
+}
+
+// describeSkip splits one of verify.Scan's skipped lines into the fields the
+// error catalogue names.
+//
+// The line is "schema.table.column: reason", so the column is what follows the
+// LAST dot rather than the first: a schema qualified name has two, and cutting
+// on the first turns public.customers.notes into table "public" and column
+// "customers.notes". Written as its own function because that off by one is
+// invisible in an error nobody has triggered yet.
+func describeSkip(line string) (table, column, detail string) {
+	where, detail, _ := strings.Cut(line, ": ")
+	table, column = where, ""
+	if i := strings.LastIndex(where, "."); i >= 0 {
+		table, column = where[:i], where[i+1:]
+	}
+	return table, column, detail
 }
 
 // PlanResult is what af mask plan produced.

--- a/engine/internal/env/skip_test.go
+++ b/engine/internal/env/skip_test.go
@@ -1,0 +1,39 @@
+package env_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/internal/env"
+)
+
+// The column is what follows the LAST dot, not the first.
+//
+// verify.Scan writes "schema.table.column: reason". Cutting on the first dot
+// reports table "public" and column "customers.notes", which names a column
+// that does not exist in an error telling somebody to grant access to it.
+func TestDescribeSkip(t *testing.T) {
+	t.Parallel()
+
+	for _, c := range []struct{ line, table, column, detail string }{
+		{
+			"public.customers.notes: permission denied for table customers",
+			"public.customers", "notes", "permission denied for table customers",
+		},
+		{
+			// A reason carrying its own colon, which the detail must keep whole.
+			"app.orders.note: ERROR: canceling statement due to statement timeout",
+			"app.orders", "note", "ERROR: canceling statement due to statement timeout",
+		},
+		{
+			// Degenerate, so the split cannot panic on something unexpected.
+			"weird", "weird", "", "",
+		},
+	} {
+		table, column, detail := env.DescribeSkipForTest(c.line)
+		require.Equal(t, c.table, table, c.line)
+		require.Equal(t, c.column, column, c.line)
+		require.Equal(t, c.detail, detail, c.line)
+	}
+}

--- a/engine/internal/errors/catalog.yaml
+++ b/engine/internal/errors/catalog.yaml
@@ -562,6 +562,13 @@ errors:
     docs: concepts/masking
     retryable: false
     exit_code: 3
+  - code: AF-MSK-011
+    area: MSK
+    message: "Verification could not read {table}.{column}, so the golden was not verified: {detail}"
+    next_step: "Grant the scanner read access to {table}.{column} and refresh the golden. A column the scan could not read is not a column that passed."
+    docs: concepts/verification
+    retryable: false
+    exit_code: 7
   - code: AF-NET-001
     area: NET
     message: "The request to {host} was blocked by rule {rule}."

--- a/engine/internal/errors/codes.gen.go
+++ b/engine/internal/errors/codes.gen.go
@@ -244,6 +244,9 @@ const (
 	AFMSK008 Code = "AF-MSK-008"
 	// Masking could not run: {detail}
 	AFMSK010 Code = "AF-MSK-010"
+	// Verification could not read {table}.{column}, so the golden was not
+	// verified: {detail}
+	AFMSK011 Code = "AF-MSK-011"
 
 	// Egress
 	// The request to {host} was blocked by rule {rule}.
@@ -1204,6 +1207,15 @@ var catalog = map[Code]Entry{
 		Docs:      "concepts/masking",
 		Retryable: false,
 		ExitCode:  ExitConfiguration,
+	},
+	AFMSK011: {
+		Code:      AFMSK011,
+		Area:      "MSK",
+		Message:   "Verification could not read {table}.{column}, so the golden was not verified: {detail}",
+		NextStep:  "Grant the scanner read access to {table}.{column} and refresh the golden. A column the scan could not read is not a column that passed.",
+		Docs:      "concepts/verification",
+		Retryable: false,
+		ExitCode:  ExitVerification,
 	},
 	AFNET001: {
 		Code:      AFNET001,

--- a/engine/internal/masking/default_test.go
+++ b/engine/internal/masking/default_test.go
@@ -159,3 +159,70 @@ func TestUnclassified_ListsWhatWasEmptiedByDefaultAsWellAsWhatCouldNotBe(t *test
 		"the questions a plan asks are wrong: a masked-by-default column must still be asked "+
 			"about, and a structural column must not be")
 }
+
+// A type the classifier has never heard of is a question, not a silence.
+//
+// THE GAP THIS CLOSES. looksSensitive answered "can this hold a sentence?" with
+// a known-yes list of six types, and everything else fell through with no
+// transform and, crucially, with Unmatched unset. So a citext column was not
+// masked AND not reported: absent from `af mask plan` entirely, which is worse
+// than the not-null case, because that one at least prints a line telling
+// somebody what shipped.
+//
+// The types are not exotic. information_schema reports citext as USER-DEFINED
+// and text[] as ARRAY, checked against a real PostgreSQL 17 rather than
+// remembered, and citext is what an application uses for an email column
+// precisely because a person types into it.
+//
+// This does NOT mask them. Masking them by default would change what an
+// existing golden contains, invalidate every rules_digest, and empty a column
+// some environment needs populated. It makes the plan say "I do not know about
+// this column" where it used to say nothing at all, which is the only half that
+// is safe to change without a decision from somebody who owns the product.
+func TestAssign_AsksAboutATypeItDoesNotRecognise(t *testing.T) {
+	assignments := assign(t,
+		masking.ColumnInfo{Name: "id", Type: "uuid", Nullable: true},
+		// citext, as information_schema reports it.
+		masking.ColumnInfo{Name: "handle", Type: "USER-DEFINED", Nullable: true},
+		// text[], as information_schema reports it.
+		masking.ColumnInfo{Name: "tags", Type: "ARRAY", Nullable: true},
+		masking.ColumnInfo{Name: "passport_scan", Type: "bytea", Nullable: true},
+	)
+
+	for _, column := range []string{"handle", "tags", "passport_scan"} {
+		a := find(t, assignments, "orders", column)
+		require.True(t, a.Unmatched,
+			"%s is of a type nothing classifies, so it is copied into every preview "+
+				"environment and does not appear in the plan that is supposed to list "+
+				"what nobody looked at", column)
+		require.Empty(t, a.Transform,
+			"%s must not be masked by this change: masking it would empty a column an "+
+				"environment may need and invalidate every existing golden", column)
+		require.Empty(t, a.Problem, "%s must not make the plan unrunnable", column)
+		require.Contains(t, a.Why, "does not recognise")
+	}
+}
+
+func TestAssign_StillSaysNothingAboutAStructuralType(t *testing.T) {
+	// The other half, and the reason this is a third category rather than
+	// "report everything unmatched". A list containing every bigint and every
+	// timestamp in the schema is a list nobody reads, which is the same as no
+	// list at all.
+	assignments := assign(t,
+		masking.ColumnInfo{Name: "id", Type: "uuid", Nullable: true},
+		masking.ColumnInfo{Name: "quantity", Type: "bigint", Nullable: true},
+		masking.ColumnInfo{Name: "ratio", Type: "double precision", Nullable: true},
+		masking.ColumnInfo{Name: "placed_at", Type: "timestamp with time zone", Nullable: true},
+		masking.ColumnInfo{Name: "due", Type: "date", Nullable: true},
+		masking.ColumnInfo{Name: "shipped", Type: "boolean", Nullable: true},
+		masking.ColumnInfo{Name: "amount", Type: "numeric", Nullable: true},
+	)
+
+	for _, column := range []string{
+		"id", "quantity", "ratio", "placed_at", "due", "shipped", "amount",
+	} {
+		a := find(t, assignments, "orders", column)
+		require.False(t, a.Unmatched, "%s is not a question anybody has to answer", column)
+		require.Empty(t, a.Transform, "%s holds nothing about a person", column)
+	}
+}

--- a/engine/internal/masking/rules.go
+++ b/engine/internal/masking/rules.go
@@ -271,9 +271,29 @@ func (rs *RuleSet) Assign(tables []Table) []Assignment {
 			// Only the types that can hold a sentence. A bigint called quantity
 			// needs no rule and emptying it would break every environment for
 			// nothing, which is how a fail-closed default gets turned off.
-			if a.Transform == "" && looksSensitive(c) {
+			if a.Transform == "" && !knownStructural(c) {
 				a.Unmatched = true
 				switch {
+				case !looksSensitive(c):
+					// A THIRD ANSWER, and the reason it exists.
+					//
+					// looksSensitive is a known-yes list of six types and there
+					// was no known-no list, so everything else fell through with
+					// no transform AND no Unmatched, which meant a citext column
+					// was neither masked nor reported. Not in the plan at all.
+					// That is worse than the not-null case below, which at least
+					// prints a line saying what shipped.
+					//
+					// information_schema reports citext as USER-DEFINED and
+					// text[] as ARRAY, so neither is exotic and neither was
+					// visible. Reported and NOT masked: emptying it by default
+					// would change what an existing golden holds, move every
+					// rules_digest, and blank a column some environment needs.
+					// Saying so is the half that costs nobody anything.
+					a.Why = "This classifier does not recognise the type " + c.Type +
+						", so nothing decided what happens to this column and it is " +
+						"copied unchanged. The verification scan does not read this " +
+						"type either. Give it a transform, or a rule saying it is fine."
 				case isJSON(c):
 					// A JSON column is emptied whether or not it can hold
 					// null, because `empty_json` writes a value rather than
@@ -410,6 +430,35 @@ func isJSON(c ColumnInfo) bool {
 func looksSensitive(c ColumnInfo) bool {
 	switch strings.ToLower(c.Type) {
 	case "text", "character varying", "character", "json", "jsonb", "xml":
+		return true
+	}
+	return false
+}
+
+// knownStructural reports the types worth saying nothing about.
+//
+// The counterpart to looksSensitive, and the pair is the point: one is a
+// known-yes list, this is a known-no list, and a type in NEITHER is one nobody
+// has classified. Before this existed the absence of a known-no list meant
+// every unrecognised type was silently treated as structural, so citext and
+// text[] were passed over as though somebody had decided they were safe.
+//
+// A bigint called quantity genuinely needs no rule and asking about it would
+// produce a list nobody reads, which is the same as producing no list. These
+// are the types whose text form cannot carry a sentence somebody typed:
+// numbers, times, booleans, and identifiers the database generates.
+//
+// Deliberately NOT here: bytea, inet, cidr, macaddr, hstore, tsvector, ARRAY
+// and USER-DEFINED. A bytea holds whatever was uploaded, an inet locates
+// somebody, and the last two are how information_schema reports every array
+// and every extension or enum type, citext among them.
+func knownStructural(c ColumnInfo) bool {
+	switch strings.ToLower(c.Type) {
+	case "smallint", "integer", "bigint", "decimal", "numeric", "real",
+		"double precision", "money", "smallserial", "serial", "bigserial",
+		"boolean", "uuid", "date", "time", "time without time zone",
+		"time with time zone", "timestamp", "timestamp without time zone",
+		"timestamp with time zone", "interval", "oid", "bit", "bit varying":
 		return true
 	}
 	return false

--- a/engine/internal/verify/detect_test.go
+++ b/engine/internal/verify/detect_test.go
@@ -278,3 +278,39 @@ func BenchmarkDetectors_OnOrdinaryValue(b *testing.B) {
 		}
 	}
 }
+
+// A column nobody could read is not a column that passed.
+//
+// That sentence was written twice in scan.go, once above the Skipped field and
+// once above the append that fills it, and it was implemented nowhere: Clean()
+// read only Findings, so a scan that failed to read a column reported itself
+// clean and the golden was published. It is the same shape as a function with
+// no callers. The guarantee was stated, believed, and absent.
+//
+// The consequence is specific rather than theoretical. env/golden.go refuses to
+// publish on !report.Clean(), so an unreadable column was the one way a golden
+// could pass verification without anybody having verified it, and the
+// attestation it carries says how many columns were read.
+func TestReport_AColumnThatCouldNotBeReadIsNotClean(t *testing.T) {
+	t.Parallel()
+
+	// No findings at all. Under the old Clean() this was indistinguishable
+	// from a scan that read everything and found nothing.
+	report := verify.Report{
+		Columns: 2,
+		Skipped: []string{"public.customers.notes: permission denied"},
+	}
+	require.False(t, report.Clean(),
+		"a scan that could not read a column reported itself clean, so a golden holding "+
+			"that column would be published as verified")
+}
+
+func TestReport_CleanStillMeansCleanWhenNothingWasSkipped(t *testing.T) {
+	t.Parallel()
+
+	// The other half, so the fix cannot be "always return false".
+	require.True(t, verify.Report{Columns: 2, RowsSampled: 40}.Clean())
+	require.False(t, verify.Report{
+		Findings: []verify.Finding{{Detector: "email", Table: "customers", Column: "email"}},
+	}.Clean())
+}

--- a/engine/internal/verify/scan.go
+++ b/engine/internal/verify/scan.go
@@ -77,7 +77,22 @@ type Report struct {
 }
 
 // Clean reports whether the golden may be branched.
-func (r Report) Clean() bool { return len(r.Findings) == 0 }
+//
+// Skipped counts, and it did not. The sentence above the field says a column
+// nobody could read is not a column that passed, and the comment above the
+// append that fills it says ignoring one would let an unreadable column count
+// as a clean one. Both were true statements about a rule nothing enforced:
+// this read only Findings, so a scan that failed on a column returned clean and
+// env/golden.go published the golden on the strength of it.
+//
+// Which is the one way a golden could pass verification without having been
+// verified, and it is worse than a finding, because a finding is a column the
+// scan READ and disliked while a skip is a column it never saw at all.
+//
+// Reading it as unclean is deliberately the strict direction. A scan that
+// cannot read a column is a scan whose answer is "I do not know", and the whole
+// design of this package is that not knowing fails rather than passes.
+func (r Report) Clean() bool { return len(r.Findings) == 0 && len(r.Skipped) == 0 }
 
 // DefaultSampleSize is how many rows per column are read.
 //

--- a/www/public/errors.v1.json
+++ b/www/public/errors.v1.json
@@ -773,6 +773,17 @@
       "planned": false
     },
     {
+      "code": "AF-MSK-011",
+      "area": "MSK",
+      "areaName": "Masking and verification",
+      "message": "Verification could not read {table}.{column}, so the golden was not verified: {detail}",
+      "resolution": "Grant the scanner read access to {table}.{column} and refresh the golden. A column the scan could not read is not a column that passed.",
+      "docs": "https://antifailure.dev/docs/concepts/verification",
+      "retryable": false,
+      "exitCode": 7,
+      "planned": false
+    },
+    {
       "code": "AF-NET-001",
       "area": "NET",
       "areaName": "Egress",


### PR DESCRIPTION
**DRAFT while the merge freeze is on.** Opened as a draft deliberately, so repository wide auto merge cannot land it. Ready for review now; convert when the freeze lifts.

## The finding

The masking fail closed default and the verification scan that backstops it both ask `information_schema` for `data_type` and both compare it against the same six entries. They were never two layers.

A column of any other type is not masked, is not listed among the columns no rule covers, and is not read by the scan. It ships into every preview environment and the golden's attestation says it was verified clean.

Confirmed against a real PostgreSQL 17 rather than remembered:

| column type | `data_type` | masked | reported | scanned |
| --- | --- | --- | --- | --- |
| `text` | `text` | yes | yes | yes |
| domain over `text` | `text` | yes | yes | yes |
| `citext` | `USER-DEFINED` | no | no | no |
| `text[]` | `ARRAY` | no | no | no |
| `bytea` | `bytea` | no | no | no |

`citext` is what an application uses for an email column precisely because a person types into it. A column named `email` survived on the name based rule, which ignores type. A column named `handle` did not.

## What this changes, and what it deliberately does not

`looksSensitive` was a known-yes list with nothing beside it, so an unrecognised type fell through as though somebody had decided it was safe. `knownStructural` is the missing half. A type in neither list is now reported as a question.

**Nothing new is masked.** Emptying a column that is copied today would move every `rules_digest`, invalidate existing goldens, and blank a column an environment may need. That is a product decision, not a bug fix, and it is not mine to make.

The reporting half is safe because `Unmatched` is read by exactly one function, `Unclassified`, whose output is printed and never enforced. `Runnable()` is `len(Problems) == 0`, and an unclassified column can never become a `Problem`, because `checkFeasible` returns before assigning one when the transform is empty. Traced every reader in Go and TypeScript; the only external consumers are two CI steps that depend on the exit code, which cannot change.

## The second fix, and the defect it exposed

A verification scan that could not read a column reported itself clean. "A column nobody could read is not a column that passed" was written twice in `scan.go` and implemented nowhere, so `Clean()` counted findings and ignored skips.

Fixing that immediately exposed something louder. The refusal path read `report.Findings[0]` with no length check. That index was safe **only because** `Clean()` ignored `Skipped`, so every path into the branch had a finding. Counting skips makes a skip only report reach that line, so the fix for a silent pass would have shipped as a panic on the golden refresh path.

Findings are answered first now, and a skip returns a new `AF-MSK-011`, exit code 7, because `AF-MSK-002` says "Verification found data matching {detector}" which is false for a column nothing could read. `describeSkip` is its own tested function because the line is `schema.table.column` and cutting on the first dot names a column that does not exist.

## Also

`af mask plan` stopped telling you that every column it lists ships unchanged. Most are emptied by the default, some genuinely ship, and a person reading their own schema could not tell which had happened to which column.

## Verification

Every new assertion was checked by breaking the thing it describes and watching it go red. One of those controls stripped the wrong line and passed, which is why the sabotage gets checked as carefully as the gate.

The full masking suite timed out at 600s at one point and that was **not** this change: the container backed `TestPlan_ClassifiesAndRefusesWhatItCannotDo` passes in 28s with these changes stashed and 37s with them applied, and sixteen containers from other agents were running at the time.

## Not fixed here

The `dogfood` and `antifailure` workflows have a step named "The rules classify every column" whose comment claims `af mask plan` refuses an unclassified column. It does not; that step exits 0 today. Making it true is the breaking change described above and needs a product decision.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR