### PR TITLE
license: GitHub could not detect it, and the obvious fix was a trap

### DIFF
--- a/.changes/license-github-could-not-detect-it.md
+++ b/.changes/license-github-could-not-detect-it.md
@@ -1,0 +1,29 @@
+# fixed
+
+GitHub reported this repository's license as `NOASSERTION`. No license in the
+sidebar, absent from the license filter, and to anyone scanning it, all rights
+reserved. For an MIT licensed developer tool that is a real loss, and it had
+been true for as long as the file existed.
+
+The cause was a correct paragraph in the wrong place. `LICENSE` held the MIT
+text followed by a note that `ee/` is separately licensed. GitHub identifies a
+license with Licensee, which normalizes the file and compares it against known
+texts, and appended prose is folded into that comparison, so the extra
+paragraph dropped the match below the threshold.
+
+`LICENSE` is now the unmodified MIT text and detects as MIT. The carve out
+moved to `LICENSING.md`, which states it in full and explains why it is not in
+`LICENSE`. Nothing about the boundary weakened: it is also stated in
+`ee/LICENSE.md`, in `ee/README.md`, in ADR 0002, and now in a header on every
+source file under `ee/` rather than on 55 of 76 of them.
+
+Licensee ignores HTML comments, so wrapping the old paragraph in one would have
+restored detection with the text still in `LICENSE`. That was rejected. The
+tools it would hide the carve out from are the same ones companies run before
+adopting something, so a scan would have reported the whole repository as MIT
+and missed the enterprise restriction entirely.
+
+`just licensecheck` now holds both halves: `LICENSE` is the MIT text with
+nothing appended, and the carve out is still stated outside it and in every
+`ee/` source file. Checking only the first would be satisfied by deleting the
+carve out, which is the worse of the two failures.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,19 @@ jobs:
         # release, which is about as often as anybody remembers anything.
         run: go run ./tools/tagsync .
 
+      - name: The license is detectable and the ee carve out is stated
+        # LICENSE carried the MIT text plus one paragraph naming the ee carve
+        # out. The paragraph was correct and it made the license undetectable:
+        # Licensee folds appended prose into the text it compares, so GitHub
+        # reported NOASSERTION for an MIT project. No license in the sidebar,
+        # absent from the license filter, and to anyone scanning it, all rights
+        # reserved. Nobody looks at a badge, so nothing found it.
+        #
+        # Both halves are checked together on purpose. Holding LICENSE to pure
+        # MIT alone would be satisfied by deleting the carve out, and a paid
+        # directory nobody knows is paid is the worse of the two failures.
+        run: go run ./tools/licensecheck .
+
       - name: The one command runs what this workflow runs
         # CONTRIBUTING.md promises that a green `just gate` means a green CI.
         # Nothing watched that, so a job added here would quietly stop being

--- a/.gitignore
+++ b/.gitignore
@@ -41,13 +41,96 @@ service-account*.json
 # build output is a directory and `tools/coverage` is also a command, so a
 # stray binary of that name lands here as a FILE. A directory-only rule ignored
 # the first and not the second.
+/coverage
+*.out
+*.test
+*.prof
+
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.*
+*.tfplan
+# `terraform show -json plan.tfplan` writes this, and it is NOT the human
+# readable plan in another format. The JSON carries actual values alongside a
+# separate `after_sensitive` structure that merely MARKS which of them are
+# sensitive, so what the text plan prints as (sensitive value) is present in
+# full here. A create-only plan happens to be safe because the value is not
+# known yet; the moment there is real state to compare against, this file
+# contains the generated database passwords. The cost job in CI reads it from
+# the runner's disk and it never leaves.
+plan.json
+.terraform.lock.hcl.local
+crash.log
+
+# The Azure Functions host reads api/local.settings.json when somebody runs the
+# site's API locally, and the value it needs there is the real connection
+# string for the waitlist table. Ignored before anybody writes one, because a
+# credential is only committed once.
+local.settings.json
+
+# Node
+node_modules/
+.next/
+.turbo/
+out/
+*.tsbuildinfo
+next-env.d.ts
+.astro/
+playwright-report/
+test-results/
+blob-report/
+
+# Editors and operating systems
+.DS_Store
+Thumbs.db
+.idea/
+.vscode/*
+!.vscode/extensions.json
+!.vscode/settings.recommended.json
+*.swp
+
+# Logs
+*.log
+npm-debug.log*
+pnpm-debug.log*
+
+# Local artifacts produced by test runs
+engine/**/testdata/tmp/
+runner/artifacts/
+
+# Local gate output. Generated per run, never committed.
+/.gate-reports/
+
+# Compiled binaries built in place.
+#
+# `go build ./tools/claimcheck` writes ./claimcheck into whatever directory you
+# ran it from, and `git add -A` then commits a platform specific executable that
+# is useless to everybody including the person who built it. It has happened
+# twice here: a 10MB engine/af-proxy and a 3.2MB claimcheck, both arm64 Mach-O,
+# in a repository that ships Linux binaries.
+#
+# It has now happened a third time, with a 4.2MB `dogfood`, and the third time
+# is the one that says something about the list rather than about the mistake.
+# The list named the tools that existed when it was written, eleven tools were
+# added since, and nobody thought about this file while adding them. A list
+# that has to be maintained by remembering is a list that is wrong by default.
+#
+# Named rather than globbed, because a glob wide enough to catch every future
+# one would also catch source directories that share a name with their command,
+# and `docs` is exactly that: a tool and a site, so `/docs` here would ignore
+# the whole documentation tree.
+#
+# So the completeness of this list is now checked instead of remembered.
+# tools/gatecheck's TestEveryToolsBinaryNameIsIgnored fails when a tool has no
+# line here and no reason recorded for not having one, and
+# TestNoCompiledBinaryIsTracked remains the backstop for when one lands anyway.
 /azguard
 /changecheck
 /claimcheck
 /classcheck
 /constcheck
 /cost
-/coverage
 /docscheck
 /dogfood
 /errcheck

--- a/.gitignore
+++ b/.gitignore
@@ -41,96 +41,13 @@ service-account*.json
 # build output is a directory and `tools/coverage` is also a command, so a
 # stray binary of that name lands here as a FILE. A directory-only rule ignored
 # the first and not the second.
-/coverage
-*.out
-*.test
-*.prof
-
-# Terraform
-.terraform/
-*.tfstate
-*.tfstate.*
-*.tfplan
-# `terraform show -json plan.tfplan` writes this, and it is NOT the human
-# readable plan in another format. The JSON carries actual values alongside a
-# separate `after_sensitive` structure that merely MARKS which of them are
-# sensitive, so what the text plan prints as (sensitive value) is present in
-# full here. A create-only plan happens to be safe because the value is not
-# known yet; the moment there is real state to compare against, this file
-# contains the generated database passwords. The cost job in CI reads it from
-# the runner's disk and it never leaves.
-plan.json
-.terraform.lock.hcl.local
-crash.log
-
-# The Azure Functions host reads api/local.settings.json when somebody runs the
-# site's API locally, and the value it needs there is the real connection
-# string for the waitlist table. Ignored before anybody writes one, because a
-# credential is only committed once.
-local.settings.json
-
-# Node
-node_modules/
-.next/
-.turbo/
-out/
-*.tsbuildinfo
-next-env.d.ts
-.astro/
-playwright-report/
-test-results/
-blob-report/
-
-# Editors and operating systems
-.DS_Store
-Thumbs.db
-.idea/
-.vscode/*
-!.vscode/extensions.json
-!.vscode/settings.recommended.json
-*.swp
-
-# Logs
-*.log
-npm-debug.log*
-pnpm-debug.log*
-
-# Local artifacts produced by test runs
-engine/**/testdata/tmp/
-runner/artifacts/
-
-# Local gate output. Generated per run, never committed.
-/.gate-reports/
-
-# Compiled binaries built in place.
-#
-# `go build ./tools/claimcheck` writes ./claimcheck into whatever directory you
-# ran it from, and `git add -A` then commits a platform specific executable that
-# is useless to everybody including the person who built it. It has happened
-# twice here: a 10MB engine/af-proxy and a 3.2MB claimcheck, both arm64 Mach-O,
-# in a repository that ships Linux binaries.
-#
-# It has now happened a third time, with a 4.2MB `dogfood`, and the third time
-# is the one that says something about the list rather than about the mistake.
-# The list named the tools that existed when it was written, eleven tools were
-# added since, and nobody thought about this file while adding them. A list
-# that has to be maintained by remembering is a list that is wrong by default.
-#
-# Named rather than globbed, because a glob wide enough to catch every future
-# one would also catch source directories that share a name with their command,
-# and `docs` is exactly that: a tool and a site, so `/docs` here would ignore
-# the whole documentation tree.
-#
-# So the completeness of this list is now checked instead of remembered.
-# tools/gatecheck's TestEveryToolsBinaryNameIsIgnored fails when a tool has no
-# line here and no reason recorded for not having one, and
-# TestNoCompiledBinaryIsTracked remains the backstop for when one lands anyway.
 /azguard
 /changecheck
 /claimcheck
 /classcheck
 /constcheck
 /cost
+/coverage
 /docscheck
 /dogfood
 /errcheck
@@ -140,6 +57,7 @@ runner/artifacts/
 /installcheck
 /installsh
 /ldcheck
+/licensecheck
 /licensegen
 /manifestcheck
 /modecheck

--- a/LICENSE
+++ b/LICENSE
@@ -19,9 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
----
-
-The above MIT license applies to everything in this repository except the
-"ee" directory, which is licensed separately under the Antifailure Enterprise
-License. See ee/LICENSE.md.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,56 @@
+# Licensing
+
+Two licenses, split by directory.
+
+| Where | License | What it means |
+| --- | --- | --- |
+| Everything except `ee/` | MIT, in [LICENSE](./LICENSE) | Use it, change it, sell it, run it in production, forever, with no key and no phone home. |
+| [`ee/`](./ee) | [Antifailure Enterprise License](./ee/LICENSE.md) | Source visible and modifiable. Running it in production requires a valid license key or subscription. No reselling, and no offering it to third parties as a hosted service. |
+
+The community edition is complete rather than a demo. Masking, verification,
+every database provider, the egress and mocking layer, the agent runner,
+insights, load, and the control plane are MIT and stay MIT. What is in `ee/` is
+the set of things a large company requires before a rollout and an individual
+developer never uses: single sign on, SCIM, custom roles, SIEM streaming,
+policy enforcement, customer owned runtimes, and billing.
+
+The reasoning behind the split, including the alternatives that were rejected,
+is in [ADR 0002](./docs/adr/0002-license-model.md).
+
+## Why this file exists, and why `LICENSE` no longer says it
+
+`LICENSE` used to carry the MIT text followed by a paragraph naming the `ee`
+carve out. That paragraph was correct and it made the license undetectable.
+
+GitHub identifies a license with [Licensee][], which normalizes the file and
+compares it against known license texts. Appended prose is folded into the
+comparison, so the extra paragraph dropped the match below the threshold and
+the repository reported `NOASSERTION`: no license in the sidebar, absent from
+the license filter, and to anyone scanning it, all rights reserved. For an MIT
+licensed tool that is a real loss, and it is the opposite of what the paragraph
+was trying to achieve.
+
+The fix is that `LICENSE` is now the unmodified MIT text and the carve out
+lives here. Nothing about the boundary changed. It is stated in four other
+places, each of which a reader or a scanner reaches independently:
+
+- [`ee/LICENSE.md`](./ee/LICENSE.md), the terms themselves, which also say that
+  everything outside `ee/` is MIT and carries none of the restrictions.
+- [`ee/README.md`](./ee/README.md), which opens by saying the directory is not
+  MIT licensed.
+- A header on every source file in `ee/`, naming the license and pointing at
+  `ee/LICENSE.md`.
+- [ADR 0002](./docs/adr/0002-license-model.md).
+
+A directory scoped license file is the ordinary convention for this and is what
+license scanners walk the tree to find.
+
+One thing was deliberately not done. Licensee ignores HTML comments, so
+wrapping the old paragraph in one would have restored detection while leaving
+the text in `LICENSE`. That was rejected: the tools it would hide the carve out
+from are the same ones companies run before adopting something, so a scan would
+have reported the whole repository as MIT and missed the `ee` restriction
+entirely. A green badge is not worth a boundary that automated review cannot
+see.
+
+[Licensee]: https://github.com/licensee/licensee

--- a/ee/engine/cmd/af/main_test.go
+++ b/ee/engine/cmd/af/main_test.go
@@ -1,3 +1,5 @@
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+
 package main_test
 
 // The test this binary did not have.

--- a/ee/engine/compliance/attestation_test.go
+++ b/ee/engine/compliance/attestation_test.go
@@ -1,3 +1,5 @@
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+
 package compliance
 
 // The attestation verifier, checked against attestations the engine signed.

--- a/ee/engine/compliance/audit_test.go
+++ b/ee/engine/compliance/audit_test.go
@@ -1,3 +1,5 @@
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+
 package compliance
 
 // The audit chain verifier, checked against the implementation that wrote every

--- a/ee/engine/compliance/contributed_test.go
+++ b/ee/engine/compliance/contributed_test.go
@@ -1,3 +1,5 @@
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+
 package compliance
 
 // The two sides of an allowance, kept in step.

--- a/ee/engine/compliance/license_test.go
+++ b/ee/engine/compliance/license_test.go
@@ -1,3 +1,5 @@
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+
 package compliance
 
 import (

--- a/ee/engine/feature/feature_test.go
+++ b/ee/engine/feature/feature_test.go
@@ -1,3 +1,5 @@
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+
 package feature_test
 
 import (

--- a/ee/engine/license/license_test.go
+++ b/ee/engine/license/license_test.go
@@ -1,3 +1,5 @@
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+
 package license_test
 
 import (

--- a/ee/engine/policyenforce/configure_test.go
+++ b/ee/engine/policyenforce/configure_test.go
@@ -1,3 +1,5 @@
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+
 package policyenforce_test
 
 import (

--- a/ee/engine/policyenforce/policyenforce_test.go
+++ b/ee/engine/policyenforce/policyenforce_test.go
@@ -1,3 +1,5 @@
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+
 package policyenforce_test
 
 import (

--- a/ee/engine/secrets/aws_test.go
+++ b/ee/engine/secrets/aws_test.go
@@ -1,3 +1,5 @@
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+
 package secrets
 
 // The signing, against the example AWS publishes.

--- a/ee/engine/secrets/azure_live_test.go
+++ b/ee/engine/secrets/azure_live_test.go
@@ -1,3 +1,5 @@
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+
 package secrets
 
 import (

--- a/ee/engine/secrets/cloud_test.go
+++ b/ee/engine/secrets/cloud_test.go
@@ -1,3 +1,5 @@
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+
 package secrets
 
 // Azure Key Vault and Google Secret Manager, as far as they can honestly be

--- a/ee/engine/secrets/conformance_test.go
+++ b/ee/engine/secrets/conformance_test.go
@@ -1,3 +1,5 @@
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+
 package secrets
 
 // The suite, proved able to fail.

--- a/ee/engine/secrets/vault_test.go
+++ b/ee/engine/secrets/vault_test.go
@@ -1,3 +1,5 @@
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+
 package secrets
 
 // Against a real Vault, not a fake.

--- a/ee/web/audit/src/index.ts
+++ b/ee/web/audit/src/index.ts
@@ -1,3 +1,7 @@
+// The public surface of the audit streaming package.
+//
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+
 export {
   Queue,
   PermanentError,

--- a/ee/web/audit/test/sink.test.ts
+++ b/ee/web/audit/test/sink.test.ts
@@ -1,3 +1,5 @@
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+
 // Audit forwarding, tested against the failures a log aggregator actually has.
 
 import { describe, it } from 'node:test'

--- a/ee/web/audit/test/sinks.test.ts
+++ b/ee/web/audit/test/sinks.test.ts
@@ -1,3 +1,5 @@
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+
 // The concrete sinks, tested for the two things that are easy to get wrong:
 // what goes on the wire, and which failures stop the retries.
 

--- a/ee/web/rbac/src/index.ts
+++ b/ee/web/rbac/src/index.ts
@@ -1,3 +1,7 @@
+// The public surface of the custom roles package.
+//
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+
 export {
   SCOPE_KINDS,
   validate,

--- a/ee/web/rbac/test/approvals.test.ts
+++ b/ee/web/rbac/test/approvals.test.ts
@@ -1,3 +1,5 @@
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+
 // Approval policies, tested against the ways they are defeated in practice.
 
 import { describe, it } from 'node:test'

--- a/ee/web/rbac/test/roles.test.ts
+++ b/ee/web/rbac/test/roles.test.ts
@@ -1,3 +1,5 @@
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+
 // Custom roles, and the three rules that make them predictable.
 
 import { describe, it } from 'node:test'

--- a/ee/web/sso/test/writers.test.ts
+++ b/ee/web/sso/test/writers.test.ts
@@ -1,3 +1,5 @@
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+
 // The enterprise half of "every table a screen reads is written by something
 // that is not a fixture".
 //

--- a/justfile
+++ b/justfile
@@ -70,6 +70,7 @@ gate: _reports
     run "no credential in the tree"      just scanrepo
     run "commands in the docs exist"     just docexamples
     run "documented paths exist"         just claimcheck
+    run "the license is detectable"      just licensecheck
     run "the sidebar order is chosen"    just sidebarcheck
     run "spoken variables are documented" just varcheck
     run "STATUS keeps its own rule"      just statuscheck
@@ -490,6 +491,9 @@ docexamples:
     cd engine && go test ./internal/cli -run TestEveryCommandInTheDocsExists -count=1
 
 # The punctuation this project does not use.
+licensecheck:
+    go run ./tools/licensecheck .
+
 prosecheck:
     go run ./tools/prosecheck .
 

--- a/tools/changecheck/classify.go
+++ b/tools/changecheck/classify.go
@@ -116,6 +116,7 @@ var notASurface = map[string]string{
 	"CODE_OF_CONDUCT.md":     "documentation",
 	"CONTRIBUTING.md":        "documentation",
 	"LICENSE":                "the licence text",
+	"LICENSING.md":           "the licence text, in the file LICENSE cannot hold it in",
 	"README.md":              "documentation",
 	"SECURITY.md":            "documentation",
 	"THIRD_PARTY_NOTICES.md": "generated from the dependency set",

--- a/tools/licensecheck/main.go
+++ b/tools/licensecheck/main.go
@@ -139,7 +139,20 @@ func checkLicense(root string) []string {
 // reaches, now that LICENSE cannot carry it.
 func checkCarveOut(root string) []string {
 	var problems []string
-	for _, f := range []string{"LICENSING.md", "ee/LICENSE.md", "ee/README.md"} {
+	// README.md is in this list for a reason that is not obvious, and it is
+	// about the RELEASE ARCHIVE rather than the repository.
+	//
+	// tools/release/build.sh copies exactly LICENSE and README.md into the
+	// tarball. It does not copy LICENSING.md, and it should not: the archive
+	// contains no ee/ code, so a document about ee/ inside it would point at a
+	// directory that is not there. That is the dangling reference the old
+	// LICENSE already had, naming ee/LICENSE.md in an archive with no ee/.
+	//
+	// Which leaves README.md as the only file that both states the carve out
+	// AND travels with the release. Somebody rewriting the README could drop
+	// that sentence without ever thinking about the tarball, and the carve out
+	// would silently stop shipping. So it is held here.
+	for _, f := range []string{"LICENSING.md", "README.md", "ee/LICENSE.md", "ee/README.md"} {
 		raw, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(f)))
 		if err != nil {
 			problems = append(problems, f+" is missing, and it is one of the places the "+

--- a/tools/licensecheck/main.go
+++ b/tools/licensecheck/main.go
@@ -68,22 +68,43 @@ func main() {
 	if len(os.Args) > 1 {
 		root = os.Args[1]
 	}
-	problems := check(root)
+	problems, checkedEE := check(root)
 	for _, p := range problems {
 		fmt.Fprintln(os.Stderr, "licensecheck:", p)
 	}
 	if len(problems) > 0 {
 		os.Exit(1)
 	}
-	fmt.Println("licensecheck: LICENSE is detectable MIT and the ee carve out is stated")
+	// What was actually checked, not what this usually checks. Saying "and the
+	// ee carve out is stated" on a tree where it was skipped would be a gate
+	// reporting on itself rather than on the repository, which is the failure
+	// the whole file is about.
+	if checkedEE {
+		fmt.Println("licensecheck: LICENSE is detectable MIT and the ee carve out is stated")
+		return
+	}
+	fmt.Println("licensecheck: LICENSE is detectable MIT; there is no ee/ in this tree to carve out")
 }
 
-func check(root string) []string {
-	var problems []string
+// check returns the problems found, and whether the ee/ half ran at all.
+func check(root string) (problems []string, checkedEE bool) {
 	problems = append(problems, checkLicense(root)...)
+
+	// A tree with no ee/ is a community build, which the edition boundary job
+	// makes by deleting the directory and building from what is left. There is
+	// no carve out to state when there is nothing carved out, and failing there
+	// would be a gate complaining that a deliberate tree is not the other one.
+	//
+	// Skipped LOUDLY rather than silently. A skip that prints nothing reads
+	// exactly like a pass, and the whole reason this gate exists is that
+	// nobody noticed a license going undetected for months.
+	if _, err := os.Stat(filepath.Join(root, "ee")); os.IsNotExist(err) {
+		return problems, false
+	}
+
 	problems = append(problems, checkCarveOut(root)...)
 	problems = append(problems, checkEEHeaders(root)...)
-	return problems
+	return problems, true
 }
 
 // checkLicense holds LICENSE to the MIT text with nothing appended.

--- a/tools/licensecheck/main.go
+++ b/tools/licensecheck/main.go
@@ -1,0 +1,188 @@
+// Command licensecheck proves the repository's license is still detectable and
+// that the enterprise carve out is still stated where a reader will find it.
+//
+// WHY THIS EXISTS. LICENSE held the MIT text followed by one paragraph naming
+// the `ee` carve out. The paragraph was correct, it was doing real legal work,
+// and it made the license undetectable: GitHub identifies a license with
+// Licensee, which normalizes the file and compares it to known texts, and
+// appended prose is folded into that comparison. The repository reported
+// NOASSERTION for an MIT project. No license in the sidebar, absent from the
+// license filter, and to anyone scanning it, all rights reserved.
+//
+// That is the shape of failure this whole tree keeps finding: a true statement
+// in the wrong place, with nothing watching. It was invisible because nobody
+// looks at a badge, and it would come back the first time somebody appends a
+// well meant sentence to LICENSE.
+//
+// So two properties, checked together, because either alone is a trap:
+//
+//  1. LICENSE is the MIT text and NOTHING else. Adding a line to it breaks
+//     detection, and the one line somebody would add is a pointer to the carve
+//     out, which is exactly the mistake this replaces.
+//
+//  2. The carve out is still stated outside LICENSE, and every source file
+//     under ee/ still says it is not MIT. Property 1 alone would be satisfied
+//     by deleting the carve out entirely, which is the failure that matters.
+//     A license nobody can detect is a smaller problem than a paid directory
+//     nobody knows is paid.
+//
+// The MIT text is embedded rather than fetched, because a gate that needs the
+// network is a gate that goes red on a bad morning for reasons that are not
+// about the repository.
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// mit is the canonical text, with the copyright line left out: that line is
+// the one part a project is meant to change, and Licensee ignores it when
+// matching. Everything else must be present and nothing may follow it.
+const mit = `Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.`
+
+// The header every source file under ee/ carries.
+const eeHeader = "Antifailure Enterprise License"
+
+func main() {
+	root := "."
+	if len(os.Args) > 1 {
+		root = os.Args[1]
+	}
+	problems := check(root)
+	for _, p := range problems {
+		fmt.Fprintln(os.Stderr, "licensecheck:", p)
+	}
+	if len(problems) > 0 {
+		os.Exit(1)
+	}
+	fmt.Println("licensecheck: LICENSE is detectable MIT and the ee carve out is stated")
+}
+
+func check(root string) []string {
+	var problems []string
+	problems = append(problems, checkLicense(root)...)
+	problems = append(problems, checkCarveOut(root)...)
+	problems = append(problems, checkEEHeaders(root)...)
+	return problems
+}
+
+// checkLicense holds LICENSE to the MIT text with nothing appended.
+func checkLicense(root string) []string {
+	raw, err := os.ReadFile(filepath.Join(root, "LICENSE"))
+	if err != nil {
+		return []string{"LICENSE could not be read: " + err.Error()}
+	}
+	body := string(raw)
+	if !strings.Contains(body, mit) {
+		return []string{
+			"LICENSE is not the MIT text. GitHub matches it with Licensee against known " +
+				"license texts, so a reworded license is an undetected one.",
+		}
+	}
+	// Nothing after the final line. This is the actual regression: the file
+	// stays recognisably MIT to a human and stops matching for a tool.
+	after := strings.TrimSpace(body[strings.Index(body, mit)+len(mit):])
+	if after != "" {
+		return []string{fmt.Sprintf(
+			"LICENSE has %d characters after the MIT text, beginning %q. Licensee folds "+
+				"appended prose into the text it compares, so this makes the repository "+
+				"report NOASSERTION: no license in the sidebar and none in the license "+
+				"filter. Put it in LICENSING.md, which is where the ee carve out lives "+
+				"for exactly this reason.",
+			len(after), first(after, 60))}
+	}
+	return nil
+}
+
+// checkCarveOut holds the statement that ee/ is not MIT to somewhere a reader
+// reaches, now that LICENSE cannot carry it.
+func checkCarveOut(root string) []string {
+	var problems []string
+	for _, f := range []string{"LICENSING.md", "ee/LICENSE.md", "ee/README.md"} {
+		raw, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(f)))
+		if err != nil {
+			problems = append(problems, f+" is missing, and it is one of the places the "+
+				"ee carve out is stated now that LICENSE cannot state it")
+			continue
+		}
+		if !strings.Contains(string(raw), "ee") || !mentionsEnterprise(string(raw)) {
+			problems = append(problems, f+" no longer says that ee/ is separately licensed")
+		}
+	}
+	return problems
+}
+
+func mentionsEnterprise(s string) bool {
+	return strings.Contains(s, eeHeader) || strings.Contains(s, "Enterprise License")
+}
+
+// checkEEHeaders holds every source file under ee/ to saying so itself.
+//
+// The per file header is what a license scanner walking the tree finds, and it
+// is what makes the carve out survive a file being copied out of context.
+func checkEEHeaders(root string) []string {
+	var problems []string
+	skip := regexp.MustCompile(`(^|/)(node_modules|dist|build)(/|$)`)
+	err := filepath.Walk(filepath.Join(root, "ee"), func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel := filepath.ToSlash(path)
+		if info.IsDir() {
+			if skip.MatchString(rel) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		switch filepath.Ext(path) {
+		case ".go", ".ts", ".tsx":
+		default:
+			return nil
+		}
+		raw, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		head := raw
+		if len(head) > 400 {
+			head = head[:400]
+		}
+		if !strings.Contains(string(head), eeHeader) {
+			problems = append(problems, rel+" carries no enterprise license header, so a "+
+				"reader who opens only this file is told nothing about the boundary")
+		}
+		return nil
+	})
+	if err != nil {
+		problems = append(problems, "walking ee/: "+err.Error())
+	}
+	return problems
+}
+
+func first(s string, n int) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}


### PR DESCRIPTION
**DRAFT while the merge freeze is on.** Opened as a draft so repository wide auto merge cannot land it. Convert when the freeze lifts.

## The defect

```
gh api repos/antifailure/antifailure -q .license.spdx_id
NOASSERTION
```

No license in the sidebar, absent from the license filter, and to anyone scanning it, all rights reserved. For an MIT licensed tool shipping 1.0 that is a real loss, and it had been true since the file was written.

The cause is a correct paragraph in the wrong place. `LICENSE` held the MIT text, a rule, and a note that `ee/` is separately licensed. GitHub uses Licensee, which normalizes the file and compares it against known texts, and appended prose is folded into that comparison.

I reproduced it with the real gem in a Ruby 3.3 container rather than reasoning about it. The current file returns `NOASSERTION` and the JSON shows the carve out folded into `content_normalized`.

## The obvious fix is a trap

Licensee **ignores HTML comments**. Measured, three variants:

| `LICENSE` contents | detected |
| --- | --- |
| pure MIT | MIT, exact, confidence 100 |
| MIT plus the carve out as an HTML comment | MIT, exact, confidence 100 |
| MIT plus one plain line of pointer text | `NOASSERTION` |

So the cheapest fix restores the badge with the paragraph still physically in the file, and it is the wrong answer. The tools it would hide the carve out from are the same ones companies run before adopting something. A corporate scan would report the whole repository MIT and miss the `ee` restriction entirely, and somebody would deploy `ee/` believing it was MIT. That is a weakened boundary bought with a green badge, which is the opposite of the trade worth making.

## What this does instead

`LICENSE` is now unmodified MIT. The carve out moves to `LICENSING.md`, which states it in full and records why it is not in `LICENSE`.

**Verified on the proposed tree with the real gem: SPDX `MIT`, matcher exact, confidence 100.** I also confirmed a root `LICENSING.md` does not confuse the matcher, which was a genuine risk given it globs `LICENSE` like filenames; detection matched only `LICENSE`.

## Nothing weakened, and I checked before assuming

Per ADR 0002 the boundary is enforced mechanically, by a separate Go module, a separate npm workspace and the `edition boundary` job, not by that paragraph. The carve out is additionally stated in `ee/LICENSE.md`, which also says everything outside `ee/` is MIT; in `ee/README.md`, which opens with it; in ADR 0002; and in a per file header.

That header was on **55 of 76** source files, so it was not a claim anybody could rely on. It is on all 76 now, tests included, because a test carries the same restriction as the code it exercises. Two of the gaps were non test source: `ee/web/rbac/src/index.ts` and `ee/web/audit/src/index.ts`.

## The gate

`tools/licensecheck`, wired into `just gate` and CI, holds **both** halves:

1. `LICENSE` is the MIT text with nothing appended.
2. The carve out is still stated in `LICENSING.md`, `ee/LICENSE.md` and `ee/README.md`, and every `ee/` source file still carries its header.

The pairing is the point. Checking only the first would be satisfied by deleting the carve out, and a paid directory nobody knows is paid is the worse of the two failures.

Verified by breaking each property in turn and watching it go red. The first attempt at one control stripped the wrong line and passed, which is why the sabotage gets checked as carefully as the gate.

## After merge

The API call above should return `MIT`. GitHub re-detects on push. I will confirm it rather than assume it.

## Note

`tools/licensegen` came up as a tool with zero call sites. It is unrelated to this: it issues and signs enterprise license **keys** from a private key a vault injects for one command. It is a vendor operator tool, and having no CI call site is correct by design rather than a gap.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR