### PR TITLE
ci: a tag clause in four workflows that tags never reach

### DIFF
--- a/.changes/a-clause-that-could-not-be-true.internal.md
+++ b/.changes/a-clause-that-could-not-be-true.internal.md
@@ -1,0 +1,24 @@
+# fixed
+
+The concurrency expression in `ci.yml`, `security.yml`, `crosslint.yml` and
+`keyring.yml` excluded tags:
+
+    cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
+
+None of those four workflows runs on a tag. Every one of their `on:` blocks is
+a push to main plus a pull request, with a schedule or a manual dispatch on
+some of them, and no tag pattern anywhere. So the second half of that
+expression is evaluated against `refs/heads/main` or `refs/pull/N/merge` and
+never against a tag. It read as protection and was a condition that could not
+be true, with a comment above it claiming tags were excluded for a reason that
+does not apply to a workflow tags do not reach.
+
+The comment above `concurrency:` in `ci.yml` also still said, without
+qualification, that a second push cancels the first run on the same branch,
+three lines above the comment explaining that main is the exception.
+
+The behaviour is unchanged. What changes is that the file now says what it
+does, and it also now says what it does NOT do: a run that has started is
+never cancelled, and GitHub still cancels a merely pending run when a newer
+one queues behind the same in progress run. So the newest commit always
+reaches a verdict and commits in the middle of a burst still get skipped.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,9 @@ on:
     branches: [main]
   pull_request:
 
-# A second push cancels the first run on the same branch, because the answer
-# about the older commit stopped mattering the moment the newer one arrived.
+# A second push cancels the first run on a BRANCH, because the answer about the
+# older commit stopped mattering the moment the newer one arrived. On main it
+# does not, and the reason is directly below.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   # A run on main is the verdict a tag and a deploy are read against, so it
@@ -18,10 +19,24 @@ concurrency:
   # Six merges landed inside one run's length on 2026-09-02 and each cancelled
   # the one before it, so main went from 09:07 to past 12:30 with no COMPLETED
   # run at all. Cancelled is not red, but it is not a verdict either, and
-  # `release.yml` has no gate of its own, so the only thing standing between
+  # `release.yml` had no gate of its own, so the only thing standing between
   # an unverified commit and published binaries was somebody holding merges
-  # by hand. Tags are excluded for the same reason.
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
+  # by hand.
+  #
+  # There is no clause for tags here because this workflow does not run on
+  # one. The `on:` block above is a push to main and a pull request, and
+  # nothing else, so `refs/tags/` is a ref this expression is never evaluated
+  # against. The first version of this line excluded tags anyway, which read
+  # as protection and was a condition that could not be true.
+  #
+  # What this does NOT buy, so nobody reads more into it than it does: a run
+  # that has already STARTED is never cancelled, and that is the whole of it.
+  # GitHub still cancels a run that is merely PENDING when a newer one queues
+  # behind the same in progress run. So the newest commit always reaches a
+  # verdict, which is what a tag and a deploy are read against, and commits in
+  # between a burst of merges still get skipped. Every commit reaching a
+  # verdict needs a merge queue, not a bigger timeout.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 # Read, and only read. No job in this workflow writes anything back, and a
 # token that could is a token an action pulled from the internet could use.

--- a/.github/workflows/crosslint.yml
+++ b/.github/workflows/crosslint.yml
@@ -41,10 +41,24 @@ concurrency:
   # Six merges landed inside one run's length on 2026-09-02 and each cancelled
   # the one before it, so main went from 09:07 to past 12:30 with no COMPLETED
   # run at all. Cancelled is not red, but it is not a verdict either, and
-  # `release.yml` has no gate of its own, so the only thing standing between
+  # `release.yml` had no gate of its own, so the only thing standing between
   # an unverified commit and published binaries was somebody holding merges
-  # by hand. Tags are excluded for the same reason.
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
+  # by hand.
+  #
+  # There is no clause for tags here because this workflow does not run on
+  # one. The `on:` block above is a push to main and a pull request, and
+  # nothing else, so `refs/tags/` is a ref this expression is never evaluated
+  # against. The first version of this line excluded tags anyway, which read
+  # as protection and was a condition that could not be true.
+  #
+  # What this does NOT buy, so nobody reads more into it than it does: a run
+  # that has already STARTED is never cancelled, and that is the whole of it.
+  # GitHub still cancels a run that is merely PENDING when a newer one queues
+  # behind the same in progress run. So the newest commit always reaches a
+  # verdict, which is what a tag and a deploy are read against, and commits in
+  # between a burst of merges still get skipped. Every commit reaching a
+  # verdict needs a merge queue, not a bigger timeout.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/keyring.yml
+++ b/.github/workflows/keyring.yml
@@ -35,10 +35,24 @@ concurrency:
   # Six merges landed inside one run's length on 2026-09-02 and each cancelled
   # the one before it, so main went from 09:07 to past 12:30 with no COMPLETED
   # run at all. Cancelled is not red, but it is not a verdict either, and
-  # `release.yml` has no gate of its own, so the only thing standing between
+  # `release.yml` had no gate of its own, so the only thing standing between
   # an unverified commit and published binaries was somebody holding merges
-  # by hand. Tags are excluded for the same reason.
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
+  # by hand.
+  #
+  # There is no clause for tags here because this workflow does not run on
+  # one. The `on:` block above is a push to main and a pull request, and
+  # nothing else, so `refs/tags/` is a ref this expression is never evaluated
+  # against. The first version of this line excluded tags anyway, which read
+  # as protection and was a condition that could not be true.
+  #
+  # What this does NOT buy, so nobody reads more into it than it does: a run
+  # that has already STARTED is never cancelled, and that is the whole of it.
+  # GitHub still cancels a run that is merely PENDING when a newer one queues
+  # behind the same in progress run. So the newest commit always reaches a
+  # verdict, which is what a tag and a deploy are read against, and commits in
+  # between a burst of merges still get skipped. Every commit reaching a
+  # verdict needs a merge queue, not a bigger timeout.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 # Read, and only read. Every action is pinned to a commit rather than a tag,
 # because a tag is mutable and pinning is what makes the reviewed thing the run

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,10 +26,24 @@ concurrency:
   # Six merges landed inside one run's length on 2026-09-02 and each cancelled
   # the one before it, so main went from 09:07 to past 12:30 with no COMPLETED
   # run at all. Cancelled is not red, but it is not a verdict either, and
-  # `release.yml` has no gate of its own, so the only thing standing between
+  # `release.yml` had no gate of its own, so the only thing standing between
   # an unverified commit and published binaries was somebody holding merges
-  # by hand. Tags are excluded for the same reason.
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
+  # by hand.
+  #
+  # There is no clause for tags here because this workflow does not run on
+  # one. The `on:` block above is a push to main and a pull request, and
+  # nothing else, so `refs/tags/` is a ref this expression is never evaluated
+  # against. The first version of this line excluded tags anyway, which read
+  # as protection and was a condition that could not be true.
+  #
+  # What this does NOT buy, so nobody reads more into it than it does: a run
+  # that has already STARTED is never cancelled, and that is the whole of it.
+  # GitHub still cancels a run that is merely PENDING when a newer one queues
+  # behind the same in progress run. So the newest commit always reaches a
+  # verdict, which is what a tag and a deploy are read against, and commits in
+  # between a burst of merges still get skipped. Every commit reaching a
+  # verdict needs a merge queue, not a bigger timeout.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 # Read, and only read. Same reasoning as CI: nothing here writes back, and every
 # action is pinned to a commit because a tag can be moved after it is reviewed.


### PR DESCRIPTION
I wrote this clause in #127 earlier today and it is wrong.

```yaml
cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
```

None of the four workflows carrying it runs on a tag. Read off `origin/main`:

| Workflow | `on:` |
| --- | --- |
| `ci.yml` | push to main, pull_request |
| `security.yml` | push to main, pull_request, schedule, workflow_dispatch |
| `crosslint.yml` | push to main with paths, pull_request with paths, workflow_dispatch |
| `keyring.yml` | push to main with paths, pull_request with paths, workflow_dispatch |

No tag pattern anywhere. So `github.ref` is `refs/heads/main` or
`refs/pull/N/merge` when that expression is evaluated, and the second half can
never be false. It reads as protection and is a condition that cannot be true,
with a comment above it saying tags are excluded for the same reason main is.
Tags are not excluded. They do not arrive.

The comment above `concurrency:` in `ci.yml` also still said, flatly, that a
second push cancels the first run on the same branch, three lines above the
comment explaining that main is the exception to exactly that.

Behaviour is unchanged. This removes the dead half and makes the comments say
what the file does.

It also records a limit I overstated when #127 landed. I said every commit on
main would reach a verdict. It does not. `cancel-in-progress: false` protects a
run that has STARTED. GitHub still cancels a run that is merely PENDING when a
newer one queues behind the same in progress run, which is its documented
behaviour and not a bug in the fix. The timings on main after #127 landed show
it plainly:

```
d78adc8c  created 13:12:54  cancelled 13:13:57   2s after the next run appeared
37daca27  created 13:13:55  cancelled 13:14:21   2s after the next run appeared
bd5c7d6f  created 13:14:19  pending
```

What #127 genuinely buys is that the NEWEST commit always reaches a verdict,
which is what a tag and a deploy are read against, and that is the property the
release needed. Commits in the middle of a burst are still skipped. Getting
every commit to a verdict needs a merge queue, and no timeout or concurrency
setting will do it.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR