### PR TITLE
www: the free plan's limits were enforced and published nowhere

### DIFF
--- a/.changes/free-limits-that-only-a-refusal-would-tell-you.md
+++ b/.changes/free-limits-that-only-a-refusal-would-tell-you.md
@@ -1,0 +1,29 @@
+# added
+
+The pricing page publishes what the free plan actually allows, and the numbers
+come from the code that enforces them. Three environments live at once, twenty
+four environment-hours committed by one run, and seventy two environment-hours
+in any rolling day. All three were enforced in the control plane and printed
+nowhere a customer could read, so the only way to learn the shape of the free
+plan was to reach a limit and read the refusal.
+
+They live in `www/lib/plan-facts.ts` and the page renders them from there.
+`web/apps/api/test/plan-facts.test.ts` fails the build if that file and
+`PLAN_QUOTAS` or `PLAN_COST_CAPS` stop agreeing, which is the same gate
+`legal-facts.test.ts` puts over the legal pages and for the same reason: every
+one of the seven published claims that test was written for was true when it
+was written.
+
+Two quotas are deliberately not published. `PLAN_QUOTAS` also declares
+`goldens` and `artifactGigabytes` for every plan, and neither is enforced
+anywhere: both are counted for display and no path refuses a creation over
+either. Publishing a limit that nothing applies is the same defect pointing the
+other way, so the test refuses those two by name until somebody wires them.
+
+The page also answers the questions a visitor arrives with, including whether
+the MCP server is free. It is. `af mcp` is a command of the engine, the engine
+is MIT licensed, it runs on your own machine over standard input and output,
+and the enterprise directory contains no MCP code at all.
+
+The free tier is the page's primary action now rather than an outlined
+afterthought beside an invitation wall.

--- a/web/apps/api/test/plan-facts.test.ts
+++ b/web/apps/api/test/plan-facts.test.ts
@@ -1,0 +1,101 @@
+// The free plan numbers the site publishes, against the code that enforces them.
+//
+// THE CLASS THIS EXISTS FOR. `PLAN_QUOTAS` and `PLAN_COST_CAPS` decide whether
+// an organization's next environment is created. Both were enforced and
+// published nowhere a customer could read, so the only way to learn the free
+// plan's shape was to hit it. Publishing them fixes that once; nothing stops
+// them drifting afterwards, and a pricing page that is wrong about a number is
+// worse than one that never named it, because somebody plans around it.
+//
+// legal-facts.test.ts is the same gate over the legal pages and it was written
+// after seven published claims were found false in one night. Every one of them
+// was true when it was written. This is that lesson applied to the one page
+// where a wrong number costs money.
+//
+// WHAT IT CANNOT SEE. It holds numbers. It cannot hold the sentence beside a
+// number: "three environments at once" and "three environments a month" carry
+// the same integer and mean different things, and the words around them stay a
+// judgement. It also cannot see a limit nobody thought to publish. What it does
+// do is fail at the moment the code moves, which is the moment the page becomes
+// wrong.
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { PLAN_QUOTAS, DEFAULT_PLAN } from '../src/limits.ts'
+import { PLAN_COST_CAPS } from '../src/costs.ts'
+
+/**
+ * The published file is READ AS TEXT rather than imported, for the reason
+ * legal-facts.test.ts gives: www is a separate npm project with its own module
+ * resolution, and importing across the boundary compiles here and fails there.
+ *
+ * The cost of parsing is that a file which stops matching reads as an empty set
+ * and every assertion over it passes vacuously. The first test is the negative
+ * control on exactly that.
+ */
+const here = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.join(here, '..', '..', '..', '..')
+const facts = await readFile(path.join(repoRoot, 'www/lib/plan-facts.ts'), 'utf8')
+
+/** The `value:` of one entry in FREE_PLAN, by its key. */
+function published(key: string): number | null {
+  const block = facts.match(new RegExp(`\\n  ${key}: \\{[\\s\\S]*?\\n  \\},`, 'm'))
+  if (!block) return null
+  const found = block[0].match(/value:\s*(\d+(?:\.\d+)?)\s*,/)
+  return found ? Number(found[1]) : null
+}
+
+describe('the free plan numbers the site publishes', () => {
+  it('parses at all, so the assertions below are about the file', () => {
+    // Without this every test that follows would pass against a file that had
+    // been renamed, reformatted or deleted, which is the failure mode of every
+    // gate that reads prose.
+    for (const key of ['environments', 'perRunHours', 'perDayHours']) {
+      assert.notEqual(
+        published(key),
+        null,
+        `www/lib/plan-facts.ts no longer parses for ${key}. Either the shape changed ` +
+          'or the file moved. Fix the parser here rather than deleting the assertion.',
+      )
+    }
+    assert.equal(published('noSuchKey'), null, 'the parser matches anything, so it proves nothing')
+  })
+
+  it('names the plan an organization has when it is paying nothing', () => {
+    // Every number below is about `free` specifically, and `free` matters only
+    // because it is what an organization with no live subscription gets.
+    assert.equal(DEFAULT_PLAN, 'free')
+  })
+
+  it('publishes the environment quota the control plane enforces', () => {
+    // dispatch.ts refuses a creation over this, counting environments whose
+    // state is not torn_down.
+    assert.equal(published('environments'), PLAN_QUOTAS[DEFAULT_PLAN]!.environments)
+  })
+
+  it('publishes both cost caps the control plane enforces', () => {
+    const caps = PLAN_COST_CAPS[DEFAULT_PLAN]!
+    assert.equal(published('perRunHours'), caps.perRunHours)
+    assert.equal(published('perDayHours'), caps.perDayHours)
+  })
+
+  it('does not publish a quota nothing enforces', () => {
+    // `goldens` and `artifactGigabytes` are declared in PLAN_QUOTAS and are
+    // counted for display only: no path refuses a creation over either. If
+    // somebody wires enforcement, this test is the note that the page may now
+    // say so. Until then, publishing them would be the same defect the rest of
+    // this file exists to prevent, pointing the other way.
+    for (const unenforced of ['goldens', 'artifactGigabytes']) {
+      assert.equal(
+        published(unenforced),
+        null,
+        `www/lib/plan-facts.ts publishes ${unenforced}, which nothing enforces. Either ` +
+          'wire the quota into a path that can refuse, or take the number off the page.',
+      )
+    }
+  })
+})

--- a/www/components/pages/company/Pricing.tsx
+++ b/www/components/pages/company/Pricing.tsx
@@ -2,11 +2,15 @@ import { Button } from "@/components/layout/Button";
 import { Chevron } from "@/components/icons";
 import { cn } from "@/lib/cn";
 import {
+  Faq,
   PageHeading,
   PageHero,
   PageSection,
   PageShell,
+  Prose,
+  type FaqItem,
 } from "@/components/pages/kit";
+import { FREE_PLAN } from "@/lib/plan-facts";
 
 type PlanCta = {
   href: string;
@@ -31,14 +35,19 @@ const PLANS: Plan[] = [
     name: "Community",
     price: "$0",
     period: "local engine, forever",
-    tagline: "Open-source proving ground on your machine and your cloud.",
-    cta: { href: "/docs", label: "Inspect the surface", theme: "outlined" },
+    tagline: "The whole engine, on your machine and your cloud, with no account.",
+    // The filled action on this page, because it is the only plan on it a
+    // visitor can start without somebody else's permission. It used to be an
+    // outlined "Inspect the surface" while the invitation wall carried the
+    // filled button in the hero above.
+    cta: { href: "/docs/getting-started/quickstart", label: "Start the quickstart", theme: "filled" },
     includes: [
+      "MIT licensed, installed with one command",
       "Docker Compose and basic Postgres support",
+      "The MCP server, af mcp, for a coding agent",
       "Bring-your-own infrastructure and model keys",
-      "Community simulators and local reports",
       "Inspectable agent, sanitization, egress, and cleanup",
-      "No hosted compute. Your cloud, your credentials",
+      "No account and no key. Your cloud, your credentials",
     ],
   },
   {
@@ -135,6 +144,78 @@ function PlanCard({ plan }: { plan: Plan }) {
   );
 }
 
+/**
+ * What free actually gives you, from the code that enforces it.
+ *
+ * These three numbers decide whether an organization's next environment is
+ * created and they were published nowhere a customer could read. The only way
+ * to learn the shape of the free plan was to reach a limit and read the
+ * refusal, which is a support ticket that a sentence prevents.
+ *
+ * The values come from lib/plan-facts.ts rather than from this file, and
+ * web/apps/api/test/plan-facts.test.ts fails the build if that file and the
+ * enforcement stop agreeing.
+ */
+function FreePlanFacts() {
+  return (
+    <ul className="mt-14 grid grid-cols-3 gap-x-12 max-xl:grid-cols-1 max-xl:gap-y-10 max-md:mt-10">
+      {Object.entries(FREE_PLAN).map(([key, fact]) => (
+        <li key={key} className="min-w-0 border-t border-black/15 pt-6">
+          <div className="text-[14px] tracking-extra-tight text-gray-new-40">{fact.label}</div>
+          <div className="mt-4 font-title text-[36px] leading-none tracking-tighter text-black max-xl:text-[32px]">
+            {fact.value}
+          </div>
+          <div className="mt-2 text-[14px] tracking-extra-tight text-gray-new-40">{fact.unit}</div>
+          <p className="mt-5 text-[15px] leading-6 tracking-extra-tight text-black/80">
+            {fact.body}
+          </p>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/**
+ * The questions a visitor actually arrives with, and the MCP one nobody had
+ * answered anywhere a customer looks.
+ *
+ * Answered here rather than in a paragraph because Faq carries the FAQPage
+ * markup from the same array, so each pair is individually quotable by an
+ * answer engine and the markup cannot disagree with the rendering.
+ */
+const PRICING_FAQ: FaqItem[] = [
+  {
+    question: "Is the MCP server free?",
+    answer:
+      "Yes, and it needs no account. The MCP server is part of the engine, which is MIT licensed, and your client starts it on your own machine with one command. It serves the rehearsal tools to a coding agent over standard input and output, so there is no hosted component behind it, no key, and no plan attached to it. The enterprise directory carries no MCP code at all.",
+  },
+  {
+    question: "Do I need an account to use Antifailure?",
+    answer:
+      "No. The quickstart goes from an empty machine to a running environment with no account and no sign-up. An account exists only for the hosted control plane, which coordinates environments across a team and is invitation only while it is in development.",
+  },
+  {
+    question: "Is the engine really open source?",
+    answer:
+      "Yes, under the MIT license. Everything outside the ee directory is MIT, which is the engine, the command line interface, the masking, the egress gateway, the reports and the MCP server. The ee directory is public source under a separate enterprise license and running it needs a license key.",
+  },
+  {
+    question: "What happens when a free limit is reached?",
+    answer:
+      "The next environment is refused, with a message naming the limit, what the organization is currently holding, and who can change it. Nothing that already exists is torn down. Taking somebody's running environment away because a number moved is not a behaviour this product has.",
+  },
+  {
+    question: "Can I run the control plane myself?",
+    answer:
+      "Yes. The control plane is in the same repository and the self-hosting documentation covers it. The three numbers above are the defaults it ships with, so an installation you run yourself enforces the same free plan unless its operator moves an organization to another plan or edits the numbers.",
+  },
+  {
+    question: "What is an environment-hour?",
+    answer:
+      "One environment, held for one hour. It is the unit the control plane can actually measure: every environment holds a database branch, a network and a container per service for as long as it exists, so the cost is close to linear in it. A cap in dollars would need a price list per runtime, per region and per service size, none of which a control plane has.",
+  },
+];
+
 export function PricingPage() {
   return (
     <PageShell>
@@ -142,22 +223,23 @@ export function PricingPage() {
         path="/pricing"
         eyebrow="Pricing"
         title="Operational value, not AI personalities."
-        lead="Community is the local engine and it works today. Team is a platform fee plus run usage. Growth and Enterprise add volume, policy, and governance. These bands are illustrative, not a quote."
+        lead="Community is the local engine. It is free, it is MIT licensed, and it works today with no account. Team is a platform fee plus run usage. Growth and Enterprise add volume, policy, and governance. Those bands are illustrative, not a quote."
         actions={
           <>
-            <Button href="/signup">Request access</Button>
-            <Button href="/docs" theme="outlined">
-              Read the docs
+            <Button href="/docs/getting-started/quickstart">Start the quickstart</Button>
+            <Button href="/signup" theme="outlined">
+              Request hosted access
             </Button>
           </>
         }
       />
       <PageSection className="pt-0">
         <p className="mb-14 max-w-[720px] border-l border-black/15 pl-6 text-[16px] leading-7 tracking-extra-tight text-gray-new-40 max-md:mb-10 max-md:pl-4">
-          The hosted control plane is deployed and invitation only while it is in development.
-          Today the engine runs in your own continuous integration, on your own compute, and the
-          access button leads to a waitlist unless you have been invited. Team and Enterprise are
-          open for design partners, and those two buttons book a call rather than take an address.
+          Community needs nothing from us. The engine is MIT licensed, it installs with one
+          command, and the quickstart runs on your own compute without an account. The hosted
+          control plane is deployed and invitation only while it is in development, so the access
+          button leads to a waitlist unless you have been invited. Team and Enterprise are open
+          for design partners, and those two buttons book a call rather than take an address.
         </p>
         <ul className="grid grid-cols-3 items-stretch gap-x-12 max-xl:grid-cols-1 max-xl:gap-y-12">
           {PLANS.map((plan) => (
@@ -166,6 +248,26 @@ export function PricingPage() {
             </li>
           ))}
         </ul>
+      </PageSection>
+      <PageSection tone="ruled">
+        <PageHeading
+          kicker="Free plan"
+          title="<strong>Three numbers decide what free gives you.</strong> These are the ones a control plane enforces, not a summary of them."
+        />
+        <Prose className="mt-8">
+          <p>
+            The engine itself has no quota. It is MIT licensed, it runs on your machine and in
+            your own continuous integration, and nothing in it counts environments or hours. The
+            three below are what a control plane enforces for an organization with no live
+            subscription, and they apply the same way whether that control plane is the hosted
+            one or one you run yourself.
+          </p>
+          <p className="mt-6">
+            Reaching any of them refuses the next environment and says so, naming the number and
+            what you are holding. Nothing that is already running is ever torn down.
+          </p>
+        </Prose>
+        <FreePlanFacts />
       </PageSection>
       <PageSection tone="ruled">
         <PageHeading
@@ -188,6 +290,13 @@ export function PricingPage() {
             </details>
           ))}
         </div>
+      </PageSection>
+      <PageSection tone="plain">
+        <PageHeading
+          kicker="Questions"
+          title="<strong>What free covers, in the words people ask it in.</strong> Including the one about MCP."
+        />
+        <Faq path="/pricing" items={PRICING_FAQ} />
       </PageSection>
     </PageShell>
   );

--- a/www/lib/plan-facts.ts
+++ b/www/lib/plan-facts.ts
@@ -1,0 +1,59 @@
+/**
+ * What the free plan actually allows, in the numbers the code enforces.
+ *
+ * These were enforced and published nowhere. `PLAN_QUOTAS` and
+ * `PLAN_COST_CAPS` in the control plane decide whether an organization's next
+ * environment is created, and a person deciding whether this product fits
+ * their team had no way to read either one without cloning the repository. A
+ * limit a customer discovers by hitting it is a support ticket that a sentence
+ * would have prevented.
+ *
+ * So the numbers live here, the pricing page renders them from here, and
+ * `web/apps/api/test/plan-facts.test.ts` fails the build if this file and the
+ * enforcement stop agreeing. That test is the point of the file. Writing the
+ * numbers into JSX would have been shorter and would have drifted the first
+ * time somebody changed a plan, which is exactly how the seven false legal
+ * claims that `legal-facts.test.ts` exists for were made.
+ *
+ * WHAT THESE ARE NOT. They are not limits on the engine. The engine is MIT
+ * licensed, runs on your machine and in your own continuous integration, and
+ * has no quota of any kind: nothing in it counts environments or hours. These
+ * are what a CONTROL PLANE enforces for an organization that has no live
+ * subscription, and they apply the same way whether that control plane is the
+ * hosted one or one you run yourself.
+ *
+ * WHAT IS DELIBERATELY ABSENT. `PLAN_QUOTAS` also declares `goldens` and
+ * `artifactGigabytes` for every plan. Neither is enforced anywhere: both are
+ * counted for display and nothing refuses a creation over either number. They
+ * are not published here because publishing a limit nothing applies would be
+ * the same defect in the other direction.
+ */
+
+/** One published number, and the words that make it mean something. */
+export interface PlanFact {
+  value: number;
+  unit: string;
+  label: string;
+  body: string;
+}
+
+export const FREE_PLAN: Record<"environments" | "perRunHours" | "perDayHours", PlanFact> = {
+  environments: {
+    value: 3,
+    unit: "at once",
+    label: "Live environments",
+    body: "Environments that exist and have not been torn down. The fourth is refused until one of the three is gone, and nothing that is already running is ever taken away.",
+  },
+  perRunHours: {
+    value: 24,
+    unit: "environment-hours",
+    label: "One run may commit to",
+    body: "The lifetime a single dispatch may ask for. A day is the default runtime.ttl, so one environment for one branch is never refused, and a thirty day lifetime asked for in one call is.",
+  },
+  perDayHours: {
+    value: 72,
+    unit: "environment-hours",
+    label: "Any rolling day may accrue",
+    body: "The total across a moving twenty four hours, not a calendar day. It is what stops a workflow that creates an environment per push from running up a month of environment time in an afternoon.",
+  },
+};


### PR DESCRIPTION
## The numbers, and where they were read from

`web/apps/api/src/limits.ts` and `web/apps/api/src/costs.ts` decide whether an organization's next environment is created. Nothing published them, so the only way to learn the shape of the free plan was to reach a limit and read the refusal.

| What | Free | Enforced by |
| --- | --- | --- |
| Live environments at once | 3 | `PLAN_QUOTAS.free.environments`, refused in `routers/dispatch.ts` counting environments whose state is not `torn_down` |
| Environment-hours one run may commit to | 24 | `PLAN_COST_CAPS.free.perRunHours`, checked against the lifetime before anything is created |
| Environment-hours in any rolling day | 72 | `PLAN_COST_CAPS.free.perDayHours`, over a moving twenty four hours |

The page and the code agree because they cannot disagree: `www/lib/plan-facts.ts` holds the published values and `web/apps/api/test/plan-facts.test.ts` fails the build when they drift from `PLAN_QUOTAS` or `PLAN_COST_CAPS`. Same gate as `legal-facts.test.ts`, for the same reason. I watched it go red before believing it: changing the published 3 to a 5 fails one assertion and leaves the other four green.

## Two quotas I did not publish, and this is the one thing worth a second look

`PLAN_QUOTAS` also declares `goldens` and `artifactGigabytes` for every plan. **Neither is enforced anywhere.** Both are counted for display in `routers/billing.ts` and `routers/index.ts`, and no path refuses a creation over either number. Golden versions are written by `ingest.ts` from an engine event, so refusing there would mean dropping a fact the engine has already reported, which is a product decision rather than a mechanical fix. `artifactGigabytes` has no reader at all outside the type.

So the page says nothing about them, and the test refuses them by name until somebody wires enforcement. Publishing a limit that nothing applies is the same defect as hiding one that does, pointing the other way.

## MCP

The pricing page now answers it, because nothing in the product surface did. **The MCP server is free and needs no account.** `engine/internal/cli/mcp.go` registers `af mcp` on the community root command, `engine/internal/mcp` is 24 files under the repository's MIT `LICENSE`, it speaks the protocol on standard input and output against the local checkout, and it consults no license or feature gate. `grep -rniE mcp ee/` returns nothing, so the enterprise directory carries no MCP code at all.

Answered as an FAQ block so the FAQPage markup and the visible answer come from one array, alongside the questions about accounts, the license, what a refusal does, and self-hosting.

## Checked

- built the site and looked at the rendered pixels: `/pricing` full page at 1440, and at 390 for the free plan band and the FAQ
- no horizontal scroll at 390, and no element extends past the viewport
- `classcheck`, `motioncheck` (no `animate-pulse` or `animate-ping` in the diff), `prosecheck`, `npm run check:seo` 88/88, `www` build, `web` typecheck across workspaces, and the new test
- no new colour, radius, spacing or component. The facts band reuses the plan card's own type and hairline vocabulary and the FAQ is the existing kit component

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR