### PR TITLE
A changelog and a release note somebody can scan

### DIFF
--- a/.changes/a-release-note-that-is-not-a-catalogue.md
+++ b/.changes/a-release-note-that-is-not-a-catalogue.md
@@ -3,27 +3,28 @@
 The changelog page and the release notes are something you can scan rather than
 something you have to sit down to.
 
-`/changelog` rendered every entry open on one list, and v1.0.0 carries 190
-public entries, so the page stood 127,296 pixels tall at 1440 and 246,406 at
-320. That is 141 screens of scrolling on a desktop and 241 on a phone, with not
-one entry fully on screen anywhere in it. Entries are grouped by category now,
-each is a single line headed by its author's own opening sentence, and opening
-one is a `details` element. The same page is 18,414 pixels at 1440 and 24,858
-at 320, with eight entries fully on a screen of the list and twenty screens to
-the bottom. A release states its size, the days its work landed between, and
-how many entries of each kind it holds, as four links that scroll to them. The
-search reads every word of every entry, including the ones that are collapsed,
-because a collapsed entry is in the page rather than absent from it. With
-JavaScript off the whole changelog is still there and a `details` still opens.
+`/changelog` rendered every entry open on one list, and v1.0.0 carries a bit
+over two hundred public entries, so the page stood 136,766 pixels tall at 1440
+and 264,772 at 320. That is 152 screens of scrolling on a desktop and 259 on a
+phone, with one entry fully on screen in the whole of it. Entries are grouped
+by category now, each is a single line headed by its author's own opening
+sentence, and opening one is a `details` element. The same page is 19,635
+pixels at 1440 and 26,386 at 320, with eight entries fully on a screen of the
+list and twenty two screens to the bottom. A release states its size, the days
+its work landed between, and how many entries of each kind it holds, as four
+links that scroll to them. The search reads every word of every entry,
+including the ones that are collapsed, because a collapsed entry is in the page
+rather than absent from it. With JavaScript off the whole changelog is still
+there and a `details` still opens.
 
-The release notes were the entire v1.0.0 section of `CHANGELOG.md`, 66,831
+The release notes were the entire v1.0.0 section of `CHANGELOG.md`, 69,932
 bytes of it, which is under GitHub's limit and far past what anybody reads. A
 section can mark part of itself as detail now, between `<!-- relnotes:omit -->`
 and `<!-- relnotes:end -->`, and the published notes carry a link to the
 changelog where that part stood. The verification commands, what 1.0 promises
 and what it does not, what pushing the tag moves, how to install it, everything
 that behaves differently under an existing manifest, and every security entry
-are all still in the body, which is 21,964 bytes. `CHANGELOG.md` keeps all of
+are all still in the body, which is 23,170 bytes. `CHANGELOG.md` keeps all of
 it, because a changelog file is a reference document and people search it.
 
 `just relnotes` grew with the feature rather than being loosened by it. It

--- a/.changes/a-release-note-that-is-not-a-catalogue.md
+++ b/.changes/a-release-note-that-is-not-a-catalogue.md
@@ -1,0 +1,40 @@
+# changed
+
+The changelog page and the release notes are something you can scan rather than
+something you have to sit down to.
+
+`/changelog` rendered every entry open on one list, and v1.0.0 carries 190
+public entries, so the page stood 127,296 pixels tall at 1440 and 246,406 at
+320. That is 141 screens of scrolling on a desktop and 241 on a phone, with not
+one entry fully on screen anywhere in it. Entries are grouped by category now,
+each is a single line headed by its author's own opening sentence, and opening
+one is a `details` element. The same page is 18,414 pixels at 1440 and 24,858
+at 320, with eight entries fully on a screen of the list and twenty screens to
+the bottom. A release states its size, the days its work landed between, and
+how many entries of each kind it holds, as four links that scroll to them. The
+search reads every word of every entry, including the ones that are collapsed,
+because a collapsed entry is in the page rather than absent from it. With
+JavaScript off the whole changelog is still there and a `details` still opens.
+
+The release notes were the entire v1.0.0 section of `CHANGELOG.md`, 66,831
+bytes of it, which is under GitHub's limit and far past what anybody reads. A
+section can mark part of itself as detail now, between `<!-- relnotes:omit -->`
+and `<!-- relnotes:end -->`, and the published notes carry a link to the
+changelog where that part stood. The verification commands, what 1.0 promises
+and what it does not, what pushing the tag moves, how to install it, everything
+that behaves differently under an existing manifest, and every security entry
+are all still in the body, which is 21,964 bytes. `CHANGELOG.md` keeps all of
+it, because a changelog file is a reference document and people search it.
+
+`just relnotes` grew with the feature rather than being loosened by it. It
+refuses an unbalanced marker, a second region in one section, an empty region,
+and a section that omits every line of itself, and its emptiness check reads
+what a tag would publish rather than what is in the file.
+
+# fixed
+
+Two shapes of markdown reached the changelog page as their own punctuation.
+Bold around a run containing inline code printed the backticks, and a word
+between single asterisks printed the asterisks: four backticks and two pairs of
+asterisks, on a page a prospective customer reads. Bold and italic carry spans
+now rather than text, so what is inside them is rendered rather than shown.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ tag with no section here, or with an empty one, does not publish at all.
 Releases before v1.0.0 predate this file and their notes are on the GitHub
 releases page.
 
+Anything between a `<!-- relnotes:omit -->` line and a `<!-- relnotes:end -->`
+one stays in this file and is replaced, in the published notes, by a link to
+the changelog on the site. This file is a reference document people search; a
+release note is the first thing somebody deciding whether to use this reads,
+and the per change entries are what make it a wall. `just relnotes` refuses an
+unbalanced marker, a second region in one section, an empty region, and a
+section that omits all of itself.
+
 ## v1.0.0
 
 The first stable release, and the first since v0.1.1 on 26 August 2026.
@@ -211,6 +219,8 @@ manifest or pipeline does.
   always promised that an exploration cannot fail your build, and the promise
   held for `af explore` and broke for the path the console drives. A run that
   measured nothing at all is still blocked and still exits non zero.
+
+<!-- relnotes:omit -->
 
 ### Added
 
@@ -880,6 +890,8 @@ it.
   which assumed those were the same place. Run from a subdirectory it reported
   that no runner source existed while standing inside a checkout that had one,
   and told the reader to install a runner they already had.
+
+<!-- relnotes:end -->
 
 ### Security
 

--- a/tools/relnotes/main.go
+++ b/tools/relnotes/main.go
@@ -24,6 +24,22 @@
 // long before the tag. An empty section is the failure worth naming separately:
 // a missing one is obvious the moment somebody looks, and an empty one reads as
 // done in the diff and publishes a release with a heading and nothing under it.
+//
+// A section may also mark part of itself as detail, between a
+// `<!-- relnotes:omit -->` line and a `<!-- relnotes:end -->` one. That part
+// stays in CHANGELOG.md, where a changelog file is a reference document people
+// search, and is replaced in the published notes by a pointer at the changelog
+// on the site. It exists because a release note and a changelog file are read
+// by different people for different reasons: v1.0.0's section ran to 66,831
+// bytes, of which 45,183 were the per change entries under Added and Fixed,
+// and the first thing somebody deciding whether to buy this reads should not
+// be a catalogue.
+//
+// The gate grows with the feature rather than being loosened by it. An
+// unbalanced marker fails, a second region in one section fails, an empty
+// region fails, and the emptiness check reads what would be PUBLISHED rather
+// than what is in the file, so wrapping a whole section and publishing a
+// heading with a link under it fails exactly as an empty section does.
 package main
 
 import (
@@ -33,6 +49,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -40,6 +57,41 @@ import (
 // somewhere in prose is not a section and matching it would split the file in
 // a place nobody meant.
 var heading = regexp.MustCompile(`^##\s+(v[0-9]+\.[0-9]+\.[0-9]+[0-9A-Za-z.\-+]*)\s*$`)
+
+// The two markers bounding the detail a release note points at instead of
+// printing. An HTML comment, because it is invisible in every renderer that
+// shows CHANGELOG.md, and a whole line, because half a line of prose that
+// happens to contain the word should not move anything.
+var (
+	omitOpen  = regexp.MustCompile(`^<!--\s*relnotes:omit\s*-->$`)
+	omitClose = regexp.MustCompile(`^<!--\s*relnotes:end\s*-->$`)
+)
+
+// Where the omitted detail went.
+//
+// The address is spelled out rather than linked as markdown, so it stays
+// readable in a terminal reading the notes as text, which is where anybody
+// scripting a release sees them first.
+const pointer = `### The rest of this release, one entry per change
+
+Every change has its own entry, grouped by what kind of change it is and
+searchable: https://antifailure.dev/changelog
+
+Each was written when the change was made, by whoever made it, and is dated by
+the commit that landed it. The same entries are in CHANGELOG.md in this
+repository.
+`
+
+// A release's section, split into what is published and what is pointed at.
+type section struct {
+	// The body with the omitted region replaced, in place, by the pointer.
+	notes string
+	// The body with the omitted region removed and nothing put in its place.
+	// This is what the emptiness check reads, so a section that omits all of
+	// itself fails rather than publishing a heading and a link.
+	published string
+	omitted   bool
+}
 
 func main() {
 	root := flag.String("root", ".", "repository root")
@@ -77,24 +129,26 @@ func main() {
 		return
 	}
 
-	body, ok := sections[*tag]
+	release, ok := sections[*tag]
 	if !ok {
 		fail("%s has no section for %s.\n"+
 			"  Add `## %s` to it, with what changed under it, before pushing the tag.\n"+
 			"  The alternative is a release whose notes are the generated pull request list.",
 			*changelog, *tag, *tag)
 	}
-	if strings.TrimSpace(body) == "" {
-		fail("the %s section of %s is empty.\n"+
+	if strings.TrimSpace(release.published) == "" {
+		fail("the %s section of %s publishes nothing.\n"+
 			"  A heading with nothing under it publishes a release that says nothing, "+
-			"and reads as finished in the diff.", *tag, *changelog)
+			"and reads as finished in the diff.\n"+
+			"  A section every line of which sits inside `<!-- relnotes:omit -->` "+
+			"publishes a heading and a link, which is the same release.", *tag, *changelog)
 	}
 	if *repo == "" || *ref == "" {
 		fail("-repo and -ref are both needed to write the verification preamble, and " +
 			"notes without it tell somebody to trust a signature they are not shown how to check")
 	}
 
-	notes := preamble(*repo, *ref) + "\n" + strings.TrimSpace(body) + "\n"
+	notes := preamble(*repo, *ref) + "\n" + strings.TrimSpace(release.notes) + "\n"
 	if *out == "" {
 		fmt.Print(notes)
 		return
@@ -102,41 +156,81 @@ func main() {
 	if err := os.WriteFile(*out, []byte(notes), 0o600); err != nil {
 		fail("writing %s: %v", *out, err)
 	}
-	fmt.Printf("relnotes: %s, %d bytes, preamble included\n", *tag, len(notes))
+	where := "no detail omitted"
+	if release.omitted {
+		where = "detail pointed at the changelog"
+	}
+	fmt.Printf("relnotes: %s, %d bytes, preamble included, %s\n", *tag, len(notes), where)
 }
 
 // checkAll is what runs on a pull request.
-func checkAll(name string, sections map[string]string) {
+//
+// It reads what each section would PUBLISH rather than what it contains, so a
+// section whose every line has been marked as detail fails here rather than at
+// the tag. The markers themselves are checked in parse, which has already run
+// by the time this is called; a malformed one never reaches this function.
+func checkAll(name string, sections map[string]section) {
 	var empty []string
-	for tag, body := range sections {
-		if strings.TrimSpace(body) == "" {
+	omitting := 0
+	for tag, release := range sections {
+		if strings.TrimSpace(release.published) == "" {
 			empty = append(empty, tag)
+		}
+		if release.omitted {
+			omitting++
 		}
 	}
 	if len(empty) > 0 {
-		fail("these sections of %s have a heading and nothing under it: %s.\n"+
+		sort.Strings(empty)
+		fail("these sections of %s would publish nothing: %s.\n"+
 			"  A release cut against one of those publishes notes that say nothing.",
 			name, strings.Join(empty, ", "))
 	}
-	fmt.Printf("relnotes: every section in %s has something under it (%d checked)\n",
-		name, len(sections))
+	fmt.Printf("relnotes: every section in %s publishes something "+
+		"(%d checked, %d pointing detail at the changelog)\n", name, len(sections), omitting)
 }
 
-// parse splits the changelog into tag to body, refusing a repeated heading.
+// parse splits the changelog into tag to section, refusing a repeated heading.
 //
 // Repeated rather than merged, because two `## v1.0.0` headings mean somebody
 // wrote the second one not knowing the first existed, and merging them would
 // publish half of what they wrote in an order neither of them chose.
-func parse(source string) (map[string]string, error) {
-	sections := map[string]string{}
+func parse(source string) (map[string]section, error) {
+	sections := map[string]section{}
 	var current string
-	var body strings.Builder
+	// notes and published are built side by side rather than one being derived
+	// from the other, because the pointer has to land where the detail stood.
+	// A release whose omitted region sits between two published parts would
+	// otherwise print its link after the last of them, under the wrong
+	// heading.
+	var notes, published strings.Builder
+	omitting, omitted := false, false
+	openedAt := 0
+	regionLines := 0
+	line := 0
 
-	flush := func() {
+	fail := func(format string, args ...any) error {
+		return fmt.Errorf("in the %s section, "+format, append([]any{current}, args...)...)
+	}
+
+	flush := func() error {
 		if current != "" {
-			sections[current] = body.String()
+			if omitting {
+				return fail("the `<!-- relnotes:omit -->` on line %d is never closed.\n"+
+					"  Add `<!-- relnotes:end -->` where the detail ends, or take the open one out.\n"+
+					"  Unclosed, it would drop the rest of the section from the published notes.",
+					openedAt)
+			}
+			sections[current] = section{
+				notes:     notes.String(),
+				published: published.String(),
+				omitted:   omitted,
+			}
 		}
-		body.Reset()
+		notes.Reset()
+		published.Reset()
+		omitting, omitted = false, false
+		return nil
 	}
 
 	scanner := bufio.NewScanner(strings.NewReader(source))
@@ -145,37 +239,82 @@ func parse(source string) (map[string]string, error) {
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	fenced := false
 	for scanner.Scan() {
-		line := scanner.Text()
+		line++
+		text := scanner.Text()
+		trimmed := strings.TrimSpace(text)
 		// A ``` fence can contain anything, including a line that looks like a
 		// heading. Tracking the fence is what stops a code sample splitting the
-		// file somewhere nobody meant.
-		if strings.HasPrefix(strings.TrimSpace(line), "```") {
+		// file somewhere nobody meant, and it covers the markers for the same
+		// reason: an example of one in a fence is documentation, not an
+		// instruction.
+		if strings.HasPrefix(trimmed, "```") {
 			fenced = !fenced
 		}
 		if !fenced {
-			if m := heading.FindStringSubmatch(line); m != nil {
+			if m := heading.FindStringSubmatch(text); m != nil {
 				// Recorded before the check, not after. The section in hand is
 				// only in the map once flush has run, so checking first meant a
 				// repeat was never seen and the second heading quietly replaced
 				// the first. Found by the test for it, which is the point of
 				// writing one that has been watched to fail.
-				flush()
+				if err := flush(); err != nil {
+					return nil, err
+				}
 				if _, seen := sections[m[1]]; seen {
 					return nil, fmt.Errorf("two sections are headed %s", m[1])
 				}
 				current = m[1]
 				continue
 			}
+			if current != "" && omitOpen.MatchString(trimmed) {
+				if omitting {
+					return nil, fail("`<!-- relnotes:omit -->` on line %d opens a "+
+						"region that is already open, from line %d.", line, openedAt)
+				}
+				if omitted {
+					return nil, fail("there is a second `<!-- relnotes:omit -->` on line %d.\n"+
+						"  One section points at the changelog once. Widen the first region "+
+						"rather than opening another, or the notes carry the same link twice.",
+						line)
+				}
+				omitting, openedAt, regionLines = true, line, 0
+				notes.WriteString(pointer)
+				continue
+			}
+			if current != "" && omitClose.MatchString(trimmed) {
+				if !omitting {
+					return nil, fail("`<!-- relnotes:end -->` on line %d closes nothing.\n"+
+						"  Every one of them needs a `<!-- relnotes:omit -->` above it.", line)
+				}
+				if regionLines == 0 {
+					return nil, fail("the region opened on line %d and closed on line %d is empty.\n"+
+						"  An empty one publishes the pointer at the changelog with nothing "+
+						"behind it, so take both markers out.", openedAt, line)
+				}
+				omitting, omitted = false, true
+				continue
+			}
 		}
-		if current != "" {
-			body.WriteString(line)
-			body.WriteByte('\n')
+		if current == "" {
+			continue
 		}
+		if omitting {
+			if trimmed != "" {
+				regionLines++
+			}
+			continue
+		}
+		notes.WriteString(text)
+		notes.WriteByte('\n')
+		published.WriteString(text)
+		published.WriteByte('\n')
 	}
 	if err := scanner.Err(); err != nil {
 		return nil, err
 	}
-	flush()
+	if err := flush(); err != nil {
+		return nil, err
+	}
 	return sections, nil
 }
 

--- a/tools/relnotes/main_test.go
+++ b/tools/relnotes/main_test.go
@@ -29,13 +29,13 @@ An older one.
 	if len(got) != 2 {
 		t.Fatalf("found %d sections, want 2: %v", len(got), keys(got))
 	}
-	if !strings.Contains(got["v1.0.0"], "first stable release") {
-		t.Errorf("v1.0.0 body is %q", got["v1.0.0"])
+	if !strings.Contains(got["v1.0.0"].published, "first stable release") {
+		t.Errorf("v1.0.0 body is %q", got["v1.0.0"].published)
 	}
-	if strings.Contains(got["v1.0.0"], "An older one") {
+	if strings.Contains(got["v1.0.0"].published, "An older one") {
 		t.Error("the v1.0.0 section swallowed the section below it")
 	}
-	if strings.Contains(got["v0.9.0"], "Preamble") {
+	if strings.Contains(got["v0.9.0"].published, "Preamble") {
 		t.Error("text above the first heading was attributed to a release")
 	}
 }
@@ -58,8 +58,8 @@ An older one.
 	if _, ok := got["v1.0.0"]; !ok {
 		t.Fatal("the empty section was not parsed at all, so nothing would report it")
 	}
-	if strings.TrimSpace(got["v1.0.0"]) != "" {
-		t.Fatalf("v1.0.0 is %q, want empty", got["v1.0.0"])
+	if strings.TrimSpace(got["v1.0.0"].published) != "" {
+		t.Fatalf("v1.0.0 is %q, want empty", got["v1.0.0"].published)
 	}
 }
 
@@ -69,8 +69,8 @@ func TestASectionOfWhitespaceCountsAsEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.TrimSpace(got["v1.0.0"]) != "" {
-		t.Fatalf("v1.0.0 is %q, want empty after trimming", got["v1.0.0"])
+	if strings.TrimSpace(got["v1.0.0"].published) != "" {
+		t.Fatalf("v1.0.0 is %q, want empty after trimming", got["v1.0.0"].published)
 	}
 }
 
@@ -85,7 +85,7 @@ func TestAHeadingInsideAFenceIsNotASection(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("found %d sections, want 1: %v", len(got), keys(got))
 	}
-	if !strings.Contains(got["v1.0.0"], "And that is all") {
+	if !strings.Contains(got["v1.0.0"].published, "And that is all") {
 		t.Error("the section was cut short at a heading inside a code fence")
 	}
 }
@@ -164,17 +164,180 @@ func TestTheRealChangelogParsesAndHasNoEmptySection(t *testing.T) {
 	if len(got) == 0 {
 		t.Fatal("no sections were found in the real changelog")
 	}
-	for tag, body := range got {
-		if strings.TrimSpace(body) == "" {
-			t.Errorf("%s has a heading and nothing under it", tag)
+	for tag, release := range got {
+		if strings.TrimSpace(release.published) == "" {
+			t.Errorf("%s would publish a heading and nothing under it", tag)
 		}
 	}
 }
 
-func keys(m map[string]string) []string {
+func keys(m map[string]section) []string {
 	out := make([]string, 0, len(m))
 	for k := range m {
 		out = append(out, k)
 	}
 	return out
+}
+
+// The detail markers, and what has to stay true about them.
+//
+// Everything below exists because the omitted region is the one thing on this
+// path that can quietly remove content from a published release. The gate has
+// to fail on every shape of that, not only on the shape somebody remembered.
+
+// The pointer stands where the detail stood, not at the end. A release whose
+// omitted region sits between two published parts would otherwise print its
+// link under whatever heading happened to come last.
+func TestTheOmittedRegionIsReplacedInPlace(t *testing.T) {
+	got, err := parse("## v1.0.0\n\nWhat it means.\n\n<!-- relnotes:omit -->\n### Added\n\nA thing.\n<!-- relnotes:end -->\n\n### Security\n\nA fix.\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	release := got["v1.0.0"]
+	if !release.omitted {
+		t.Fatal("the section is not marked as having omitted anything")
+	}
+	if strings.Contains(release.notes, "A thing") {
+		t.Error("the omitted detail is still in the published notes")
+	}
+	for _, want := range []string{"What it means", "https://antifailure.dev/changelog", "A fix"} {
+		if !strings.Contains(release.notes, want) {
+			t.Errorf("the notes do not carry %q", want)
+		}
+	}
+	if strings.Index(release.notes, "antifailure.dev/changelog") > strings.Index(release.notes, "A fix") {
+		t.Error("the pointer was appended at the end rather than left where the detail was")
+	}
+	if strings.Contains(release.published, "antifailure.dev/changelog") {
+		t.Error("the emptiness check would count the pointer as published content")
+	}
+}
+
+// A section with no markers publishes every byte of itself, which is what
+// every section in this file did before the markers existed.
+func TestASectionWithNoMarkersIsUnchanged(t *testing.T) {
+	got, err := parse("## v1.0.0\n\nAll of it.\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["v1.0.0"].omitted {
+		t.Error("a section with no markers claims to have omitted something")
+	}
+	if got["v1.0.0"].notes != got["v1.0.0"].published {
+		t.Errorf("notes %q and published %q differ with no markers in the section",
+			got["v1.0.0"].notes, got["v1.0.0"].published)
+	}
+}
+
+// Unclosed is the dangerous one: it silently drops the rest of the section,
+// including a Security heading, and the release still publishes.
+func TestRefusesAnUnclosedRegion(t *testing.T) {
+	_, err := parse("## v1.0.0\n\nKept.\n\n<!-- relnotes:omit -->\n### Added\n\nA thing.\n")
+	if err == nil {
+		t.Fatal("an unclosed region was accepted")
+	}
+	if !strings.Contains(err.Error(), "never closed") {
+		t.Errorf("the error does not say what is wrong: %v", err)
+	}
+}
+
+func TestRefusesACloseWithNothingOpen(t *testing.T) {
+	_, err := parse("## v1.0.0\n\nKept.\n\n<!-- relnotes:end -->\n")
+	if err == nil {
+		t.Fatal("a close with nothing open was accepted")
+	}
+}
+
+// Two regions would print the same link twice, under two headings, which reads
+// as a page that could not decide where it went.
+func TestRefusesASecondRegion(t *testing.T) {
+	_, err := parse("## v1.0.0\n\nKept.\n\n<!-- relnotes:omit -->\nOne.\n<!-- relnotes:end -->\n\nAlso kept.\n\n<!-- relnotes:omit -->\nTwo.\n<!-- relnotes:end -->\n")
+	if err == nil {
+		t.Fatal("a second region was accepted")
+	}
+	if !strings.Contains(err.Error(), "second") {
+		t.Errorf("the error does not say what is wrong: %v", err)
+	}
+}
+
+// A pair with nothing between them publishes a link to detail that is not
+// there, which is a promise the changelog cannot keep.
+func TestRefusesAnEmptyRegion(t *testing.T) {
+	_, err := parse("## v1.0.0\n\nKept.\n\n<!-- relnotes:omit -->\n\n<!-- relnotes:end -->\n")
+	if err == nil {
+		t.Fatal("an empty region was accepted")
+	}
+	if !strings.Contains(err.Error(), "empty") {
+		t.Errorf("the error does not say what is wrong: %v", err)
+	}
+}
+
+// The marker is content inside a fence, exactly as a heading is. Documenting
+// the convention in the changelog must not change what the changelog publishes.
+func TestAMarkerInsideAFenceIsNotAMarker(t *testing.T) {
+	got, err := parse("## v1.0.0\n\nKept.\n\n```md\n<!-- relnotes:omit -->\n```\n\nAlso kept.\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["v1.0.0"].omitted {
+		t.Error("a marker inside a code fence opened a region")
+	}
+	if !strings.Contains(got["v1.0.0"].published, "Also kept") {
+		t.Error("the section was cut short at a marker inside a code fence")
+	}
+}
+
+// The whole point of reading `published` rather than the body. A section that
+// omits all of itself is not empty and would publish a heading and a link.
+func TestASectionThatOmitsEverythingPublishesNothing(t *testing.T) {
+	got, err := parse("## v1.0.0\n\n<!-- relnotes:omit -->\nAll of it.\n<!-- relnotes:end -->\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(got["v1.0.0"].published) != "" {
+		t.Fatalf("published is %q, want empty so the gate refuses it", got["v1.0.0"].published)
+	}
+	if !strings.Contains(got["v1.0.0"].notes, "antifailure.dev/changelog") {
+		t.Error("the notes carry no pointer, so this test is not describing the case it names")
+	}
+}
+
+// The release this repository is about to cut, measured rather than asserted
+// about. A section that has stopped omitting anything is a section that has
+// gone back to publishing its whole catalogue, and nothing else would say so.
+func TestTheRealV100SectionPointsAtTheChangelogAndStaysUnderTheLimit(t *testing.T) {
+	source, err := os.ReadFile(filepath.Join("../..", "CHANGELOG.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := parse(string(source))
+	if err != nil {
+		t.Fatal(err)
+	}
+	release, ok := got["v1.0.0"]
+	if !ok {
+		t.Skip("no v1.0.0 section in this tree")
+	}
+	if !release.omitted {
+		t.Error("the v1.0.0 section publishes its whole catalogue again")
+	}
+	notes := preamble("antifailure/antifailure", "refs/tags/v1.0.0") + "\n" +
+		strings.TrimSpace(release.notes) + "\n"
+	// GitHub refuses a release body over 125000 characters. This is nowhere
+	// near it and the number is here so that a section growing back towards it
+	// is visible as a number rather than as a wall somebody notices later.
+	if len(notes) > 30000 {
+		t.Errorf("the v1.0.0 release body is %d bytes, which is back to being a wall", len(notes))
+	}
+	for _, want := range []string{
+		"cosign verify-blob",
+		"### What 1.0 means",
+		"### Behaviour you may depend on that changed",
+		"### Security",
+		"https://antifailure.dev/changelog",
+	} {
+		if !strings.Contains(notes, want) {
+			t.Errorf("the release body does not carry %q", want)
+		}
+	}
 }

--- a/www/app/changelog/Controls.tsx
+++ b/www/app/changelog/Controls.tsx
@@ -94,6 +94,8 @@ export function ChangelogControls({ total }: { total: number }) {
         chip.hidden = count === 0;
         const chipCount = chip.querySelector("[data-chip-count]");
         if (chipCount) chipCount.textContent = String(count);
+        const named = chip.getAttribute("aria-label");
+        if (named) chip.setAttribute("aria-label", named.replace(/, \d+ entries$/, `, ${count} entries`));
       }
     }
 

--- a/www/app/changelog/Controls.tsx
+++ b/www/app/changelog/Controls.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * Search across the changelog, and a way to open all of it at once.
+ *
+ * It filters the page that is already there rather than owning the entries
+ * itself. Passing 190 entries into a client component would put every
+ * paragraph on the page twice, once as HTML and once as serialised props, on
+ * the page that is already the largest on this site. So the entries stay
+ * server rendered and this reads the DOM: `[data-entry]` is one entry, and the
+ * text it searches is that entry's own `textContent`, which costs nothing to
+ * ship because it is the entry. A collapsed entry is in the document, so the
+ * search reaches every word of the changelog and not only the lines showing.
+ *
+ * Nothing renders until it has mounted. A search box that does nothing is
+ * worse than no search box, and with JavaScript off the page is still the
+ * whole changelog: every entry is in the HTML, grouped, headed by its own
+ * opening sentence, and a `details` element opens on click without help from
+ * anything here.
+ *
+ * There are no category filters, and there were. They filtered to exactly what
+ * the category links in each release already scroll to, in a second row of
+ * pills carrying the same four words and the same four numbers as the first.
+ * Two controls that look alike and do different things is worse than one, so
+ * the categories stay a server rendered index that works with JavaScript off,
+ * and this owns the one thing an index cannot do, which is find a word.
+ */
+export function ChangelogControls({ total }: { total: number }) {
+  const [ready, setReady] = useState(false);
+  const [query, setQuery] = useState("");
+  const [shown, setShown] = useState(total);
+  const [expanded, setExpanded] = useState(false);
+  const rows = useRef<{ el: HTMLDetailsElement; text: string }[] | null>(null);
+
+  // Read once and kept. Every entry's text is fixed at build time, and
+  // recomputing it on each keystroke is 190 tree walks per character typed.
+  const index = useCallback(() => {
+    if (rows.current) return rows.current;
+    rows.current = [...document.querySelectorAll<HTMLDetailsElement>("[data-entry]")].map((el) => ({
+      el,
+      text: (el.textContent ?? "").toLowerCase(),
+    }));
+    return rows.current;
+  }, []);
+
+  useEffect(() => setReady(true), []);
+
+  // An entry linked to by name opens itself. Browsers disagree about whether a
+  // fragment reaches inside a closed `details`, and a permalink that lands a
+  // reader on a collapsed row they then have to find and click is a link that
+  // half worked.
+  useEffect(() => {
+    const open = () => {
+      const id = decodeURIComponent(window.location.hash.replace(/^#/, ""));
+      if (!id) return;
+      const details = document.getElementById(id)?.closest("details");
+      if (details instanceof HTMLDetailsElement && !details.open) {
+        details.open = true;
+        details.scrollIntoView({ block: "start" });
+      }
+    };
+    open();
+    window.addEventListener("hashchange", open);
+    return () => window.removeEventListener("hashchange", open);
+  }, []);
+
+  useEffect(() => {
+    if (!ready) return;
+    const needle = query.trim().toLowerCase();
+
+    let visible = 0;
+    for (const row of index()) {
+      const matches = needle === "" || row.text.includes(needle);
+      row.el.hidden = !matches;
+      if (matches) visible++;
+    }
+
+    // Every count on the page counts what is actually on it. A heading over
+    // eight results reading 113, or an index chip offering to scroll to a
+    // category the search has emptied, is the page telling a reader something
+    // it can see is untrue.
+    for (const group of document.querySelectorAll<HTMLElement>("[data-group]")) {
+      const inside = [...group.querySelectorAll<HTMLDetailsElement>("[data-entry]")];
+      const count = inside.filter((entry) => !entry.hidden).length;
+      group.hidden = count === 0;
+      const badge = group.querySelector("[data-group-count]");
+      if (badge) badge.textContent = String(count);
+
+      const anchor = group.querySelector("h3")?.id;
+      const chip = anchor ? document.querySelector<HTMLElement>(`[data-chip="${anchor}"]`) : null;
+      if (chip) {
+        chip.hidden = count === 0;
+        const chipCount = chip.querySelector("[data-chip-count]");
+        if (chipCount) chipCount.textContent = String(count);
+      }
+    }
+
+    // A release whose every entry is filtered out is hidden with them, rather
+    // than left as a heading over nothing. The two that predate the convention
+    // carry no entries at all and hide as soon as anything is being searched
+    // for, because they cannot be the answer to it.
+    for (const release of document.querySelectorAll<HTMLElement>("[data-release]")) {
+      const inside = [...release.querySelectorAll<HTMLDetailsElement>("[data-entry]")];
+      const count = inside.filter((entry) => !entry.hidden).length;
+      release.hidden = needle !== "" && count === 0;
+      const badge = release.querySelector("[data-release-count]");
+      if (badge) badge.textContent = String(count);
+    }
+
+    setShown(visible);
+  }, [ready, query, index]);
+
+  if (!ready) return null;
+
+  // Only what is showing, so expanding after a search opens the answer and not
+  // the hundred and eighty entries the search just ruled out.
+  const setAllOpen = (open: boolean) => {
+    for (const row of index()) if (!row.el.hidden) row.el.open = open;
+    setExpanded(open);
+  };
+
+  return (
+    <div className="border-t border-black/12 pt-6">
+      <div className="flex flex-wrap items-center gap-x-10 gap-y-5">
+        <label
+          htmlFor="changelog-search"
+          className="flex min-w-0 flex-1 items-center gap-x-3 border-b border-black/20 pb-2.5 focus-within:border-black max-lg:max-w-none max-md:w-full max-md:flex-none max-w-[560px]"
+        >
+          <span className="font-mono text-[11px] font-medium uppercase tracking-[0.14em] text-gray-new-40">
+            Find
+          </span>
+          {/* 16px, not smaller: iOS Safari zooms the page when a field under
+              16px takes focus, and the zoom does not come back. */}
+          <input
+            id="changelog-search"
+            type="search"
+            value={query}
+            autoComplete="off"
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder={`a word in any of the ${total} entries`}
+            // The browser's own clear button comes off. Chrome draws it in the
+            // accent blue, which is the only saturated colour anywhere on this
+            // page, and the Clear beside the result count does the same job in
+            // the site's own type and is reachable from the keyboard.
+            className="min-w-0 flex-1 bg-transparent text-[16px] tracking-extra-tight text-black outline-none [&::-webkit-search-cancel-button]:appearance-none placeholder:text-gray-new-50"
+          />
+        </label>
+
+        <button
+          type="button"
+          onClick={() => setAllOpen(!expanded)}
+          className="inline-flex min-h-11 cursor-pointer items-center text-[15px] tracking-extra-tight text-black underline decoration-black/25 underline-offset-4 hover:decoration-black focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-black/60"
+        >
+          {expanded ? "Collapse all" : "Expand all"}
+        </button>
+      </div>
+
+      {/* Empty until a search narrows something, because the release below
+          already says how many entries there are and printing the same number
+          twice in four inches teaches a reader to stop reading both. The
+          element stays in the tree either way, and takes no room while it is
+          empty: a live region announces a change to its own contents, and one
+          created at the moment of the change announces nothing. The line
+          appearing moves the page by its own height, which is a shift inside
+          the half second after a keystroke and so is not one the layout
+          stability measure counts, nor one a person typing reads as the page
+          moving under them. */}
+      <p
+        aria-live="polite"
+        className="font-mono text-[11px] uppercase tracking-[0.12em] text-gray-new-40 empty:hidden [&:not(:empty)]:mt-4"
+      >
+        {query.trim() === "" ? null : (
+          <>
+            {shown === 0 ? "Nothing matches" : `${shown} of ${total} entries`}
+            {" · "}
+            <button
+              type="button"
+              onClick={() => setQuery("")}
+              className="-my-3 cursor-pointer py-3 uppercase underline decoration-black/25 underline-offset-4 hover:text-black hover:decoration-black focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-black/60"
+            >
+              Clear
+            </button>
+          </>
+        )}
+      </p>
+
+      {shown === 0 ? (
+        <p className="mt-6 max-w-[720px] text-[17px] leading-7 tracking-extra-tight text-gray-new-40 max-md:text-[16px]">
+          Nothing here contains that. The search reads every word of every entry, the collapsed ones
+          included, so a term it cannot find was not written.
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/www/app/changelog/Controls.tsx
+++ b/www/app/changelog/Controls.tsx
@@ -6,9 +6,9 @@ import { useCallback, useEffect, useRef, useState } from "react";
  * Search across the changelog, and a way to open all of it at once.
  *
  * It filters the page that is already there rather than owning the entries
- * itself. Passing 190 entries into a client component would put every
- * paragraph on the page twice, once as HTML and once as serialised props, on
- * the page that is already the largest on this site. So the entries stay
+ * itself. Passing every entry into a client component would put all two
+ * hundred of their paragraphs on the page twice, once as HTML and once as
+ * serialised props, on the page that is already the largest on this site. So the entries stay
  * server rendered and this reads the DOM: `[data-entry]` is one entry, and the
  * text it searches is that entry's own `textContent`, which costs nothing to
  * ship because it is the entry. A collapsed entry is in the document, so the

--- a/www/app/changelog/page.tsx
+++ b/www/app/changelog/page.tsx
@@ -4,28 +4,47 @@ import { PageHero, PageShell } from "@/components/pages/kit";
 import {
   type Block,
   type Category,
+  type Entry,
+  type Group,
   type Release,
   type Span,
   entryCount,
   formatDay,
+  formatShortDay,
+  formatSpan,
+  groupAnchor,
   releases,
 } from "@/lib/changelog";
 import { pageMetadata } from "@/lib/seo";
+import { ChangelogControls } from "./Controls";
 
 export const metadata = pageMetadata("/changelog");
 
 /**
  * The changelog.
  *
- * Read by somebody asking one question, "what changed since I last looked", so
- * the date is the loudest thing on the page and everything else is quiet
- * around it. On a wide screen the date holds its own column and stays put
- * while its entries scroll past, because the day a batch of work landed is the
- * context you lose first in a long list and the one you need most.
+ * Two readers, and they want opposite things. One wants to know what a release
+ * means and will read a few hundred words; the other is looking for one change
+ * and wants it in seconds. The page used to serve neither. Every entry was open
+ * on one list, so v1.0.0 rendered as a hundred and ninety paragraphs in a column
+ * 127,000 pixels tall on a desktop and 203,000 on a phone, with one entry above
+ * the fold and no way to see the shape of the release at all.
+ *
+ * So: a release states its size and its dates and links to its categories,
+ * every entry is one scannable line headed by its author's own opening
+ * sentence, and opening one is a `details` element. The first reader gets a
+ * release they can take in without scrolling; the second gets a hundred and
+ * ninety headlines to run an eye down, four category jumps, and a search that
+ * reads the entries the page is not showing.
+ *
+ * Collapsed is not hidden. The prose is in the HTML, which is what a crawler,
+ * an answer engine and the markdown twin all read, and what the search here
+ * reads too. A reader with no JavaScript gets the same page minus the search
+ * box, because `details` needs no script to open.
  *
  * No cards. A changelog is a list of paragraphs with labels, and a border
- * around each one would add ninety-one boxes and no information. Separation is
- * a hairline and space.
+ * around each one would add a hundred and ninety boxes and no information.
+ * Separation is a hairline and space.
  */
 export default function ChangelogPage() {
   const all = releases();
@@ -47,35 +66,68 @@ export default function ChangelogPage() {
           and the stylesheet's own order decides which one wins. */}
       <section className="safe-paddings pb-28 max-xl:pb-20 max-md:pb-14">
         <Container size="1600">
-          {/* Where the dates and the grouping come from. A changelog that does
-              not say this leaves a reader to assume the dates were typed, and
-              these were not. */}
-          <div className="max-w-[720px] border-t border-black/12 pt-8 text-[16px] leading-7 tracking-extra-tight text-gray-new-40 max-md:pt-6">
-            <p>
-              A date here is the day the entry landed on the main branch, read from the commit that
-              brought it there. Nothing on this page is typed by hand or backfilled.
-            </p>
-            <p className="mt-4">
-              Changes with nothing a user of Antifailure could observe are recorded in the
-              repository and left off this page: a lockfile drift, a test that was measuring
-              nothing, a build artifact that needed ignoring. Every change to anything you can see
-              is here, and CI refuses one that arrives without an entry.
-            </p>
-          </div>
-
           {total === 0 ? (
-            <p className="mt-14 max-w-[720px] text-[17px] leading-7 tracking-extra-tight text-gray-new-40">
+            <p className="max-w-[720px] border-t border-black/12 pt-8 text-[17px] leading-7 tracking-extra-tight text-gray-new-40">
               Nothing has been recorded yet. The first entry appears here when the first change
               lands.
             </p>
           ) : (
-            all.map((release) => (
-              <ReleaseSection key={release.tag ?? "unreleased"} release={release} />
-            ))
+            <>
+              {/* The search comes before the releases and the provenance note
+                  comes after all of them. Both were the other way round, which
+                  put two paragraphs about how the page is built between a
+                  reader and the release they came for, and left nothing but
+                  preamble on the first screen. How the dates are read is worth
+                  saying and it is not what anybody opened this page to find
+                  out. */}
+              {/* The space the search takes is reserved here rather than
+                  claimed when it mounts. The control renders nothing until it
+                  has, so without this the whole page moved down by its own
+                  height on hydration. The hairline belongs to the control
+                  rather than to this, because two rules 69px apart with
+                  nothing between them is what a reader with JavaScript off
+                  would otherwise be looking at, and empty space is not. */}
+              <div className="min-h-[69px] max-md:min-h-[124px]">
+                <ChangelogControls total={total} />
+              </div>
+              {all.map((release) => (
+                <ReleaseSection key={release.tag ?? "unreleased"} release={release} />
+              ))}
+              <Provenance />
+            </>
           )}
         </Container>
       </section>
     </PageShell>
+  );
+}
+
+/**
+ * Where the dates and the grouping come from.
+ *
+ * A changelog that does not say this leaves a reader to assume the dates were
+ * typed, and these were not. It sits at the foot of the page because it
+ * answers a question asked after reading rather than before it.
+ */
+function Provenance() {
+  return (
+    <section className="mt-20 border-t border-black/12 pt-8 max-md:mt-14 max-md:pt-6">
+      <h2 className="font-mono text-[11px] font-medium uppercase tracking-[0.14em] text-gray-new-20">
+        How this page is made
+      </h2>
+      <div className="mt-5 max-w-[720px] text-[16px] leading-7 tracking-extra-tight text-gray-new-40">
+        <p>
+          A date here is the day the entry landed on the main branch, read from the commit that
+          brought it there. Nothing on this page is typed by hand or backfilled.
+        </p>
+        <p className="mt-4">
+          Changes with nothing a user of Antifailure could observe are recorded in the repository
+          and left off this page: a lockfile drift, a test that was measuring nothing, a build
+          artifact that needed ignoring. Every change to anything you can see is here, and CI
+          refuses one that arrives without an entry.
+        </p>
+      </div>
+    </section>
   );
 }
 
@@ -84,7 +136,10 @@ function ReleaseSection({ release }: { release: Release }) {
   const name = release.tag ?? "Unreleased";
 
   return (
-    <section className="mt-20 border-t border-black/12 pt-10 first-of-type:mt-16 max-md:mt-14 max-md:pt-8">
+    <section
+      data-release
+      className="mt-20 border-t border-black/12 pt-10 first-of-type:mt-14 max-md:mt-14 max-md:pt-8"
+    >
       <div className="flex flex-wrap items-baseline gap-x-6 gap-y-2">
         <h2 className="text-[36px] leading-dense tracking-tighter text-black max-lg:text-[30px] max-md:text-[26px]">
           {name}
@@ -97,7 +152,13 @@ function ReleaseSection({ release }: { release: Release }) {
           ) : (
             "Not released yet"
           )}
-          {count > 0 ? ` · ${count} ${count === 1 ? "entry" : "entries"}` : null}
+          {count > 0 ? (
+            <>
+              {" · "}
+              <span data-release-count>{count}</span> entries
+            </>
+          ) : null}
+          {release.span ? ` · landed ${formatSpan(release.span.from, release.span.to)}` : null}
         </p>
       </div>
 
@@ -109,105 +170,211 @@ function ReleaseSection({ release }: { release: Release }) {
         </p>
       ) : null}
 
-      {release.days.map((day) => (
-        <div
-          key={day.date ?? "undated"}
-          className="mt-12 grid grid-cols-[180px_minmax(0,1fr)] gap-x-16 border-t border-black/12 pt-8 max-xl:grid-cols-[150px_minmax(0,1fr)] max-xl:gap-x-10 max-lg:grid-cols-1 max-lg:gap-x-0 max-md:mt-8 max-md:pt-6"
-        >
-          <div className="self-start lg:sticky lg:top-24">
-            {day.date ? (
-              <time
-                dateTime={day.date}
-                className="block text-[20px] leading-snug tracking-extra-tight text-black max-lg:text-[18px]"
-              >
-                {formatDay(day.date)}
-              </time>
-            ) : (
-              <span className="block text-[20px] leading-snug tracking-extra-tight text-black max-lg:text-[18px]">
-                Undated
+      {release.undated > 0 ? (
+        <p className="mt-6 max-w-[720px] text-[17px] leading-7 tracking-extra-tight text-gray-new-40 max-md:text-[16px]">
+          {release.undated === 1 ? "One entry here carries" : `${release.undated} entries here carry`}{" "}
+          no date. This build could not read the commit that landed them, so the day is left blank
+          rather than guessed.
+        </p>
+      ) : null}
+
+      {/* The shape of the release, before any of it. Four numbers say whether
+          this was a release of new work or of repairs, and whether there is a
+          security entry in it, which is the one question a reader who is not
+          upgrading yet still wants answered. They are links rather than
+          filters: an index that scrolls needs no JavaScript, and the search
+          above is the control that does something an index cannot. */}
+      {release.groups.length > 0 ? (
+        <nav aria-label={`${name} by category`} className="mt-8 flex flex-wrap gap-2">
+          {release.groups.map((group) => (
+            <a
+              key={group.category}
+              href={`#${groupAnchor(release, group.category)}`}
+              data-chip={groupAnchor(release, group.category)}
+              // [&[hidden]]:hidden, because `hidden` is an attribute selector
+              // in the browser's own stylesheet and inline-flex is a class in
+              // this one, so the class wins and a chip hidden from script goes
+              // on showing. The entries and the sections carry no display
+              // class, which is why only this element needs it said.
+              className="inline-flex min-h-11 items-center gap-x-2.5 rounded-full border border-black/15 bg-white px-4 font-mono text-[11px] font-medium uppercase tracking-[0.14em] text-gray-new-20 transition-colors [&[hidden]]:hidden hover:border-black/40 hover:text-black focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-black/60"
+            >
+              <span className={group.category === "security" ? "text-[#C43D3D]" : undefined}>
+                {group.category}
               </span>
-            )}
-            <p className="mt-2 font-mono text-[11px] uppercase tracking-[0.12em] text-gray-new-40">
-              {day.entries.length} {day.entries.length === 1 ? "entry" : "entries"}
-            </p>
-            {day.date ? null : (
-              <p className="mt-3 max-w-[280px] text-[14px] leading-6 tracking-extra-tight text-gray-new-40">
-                This build could not read the commit that landed these, so their date is left blank
-                rather than guessed.
-              </p>
-            )}
-          </div>
+              <span className="text-gray-new-50" data-chip-count>
+                {group.entries.length}
+              </span>
+            </a>
+          ))}
+        </nav>
+      ) : null}
 
-          <ol className="min-w-0 max-lg:mt-8">
-            {day.entries.map((entry, index) => (
-              <li
-                key={entry.slug}
-                className={index === 0 ? "" : "mt-10 border-t border-black/12 pt-10 max-md:mt-8 max-md:pt-8"}
-              >
-                <article id={entry.slug} className="scroll-mt-24 max-xl:scroll-mt-20">
-                  <div className="flex min-h-11 flex-wrap items-center gap-x-5 gap-y-1">
-                    {/* One category, one label. An entry that carries two
-                        gets them above their own paragraphs instead, where
-                        they say which half of the entry they belong to;
-                        repeating them here as well would print the word
-                        "fixed" twice in eight inches and mean nothing extra. */}
-                    {entry.sections.length === 1 ? (
-                      <CategoryLabel category={entry.sections[0].category} />
-                    ) : null}
-                    <a
-                      href={`#${entry.slug}`}
-                      // inline-block with vertical padding, cancelled by an
-                      // equal negative margin: the anchor's own hit area is
-                      // 45px on a phone without the row growing. The row's
-                      // min-h-11 does not help, because a 17px anchor inside a
-                      // 44px row is still a 17px target.
-                      className="-my-3.5 inline-block min-w-0 py-3.5 font-mono text-[11px] tracking-snug text-gray-new-40 underline decoration-black/25 underline-offset-4 [overflow-wrap:anywhere] hover:text-black hover:decoration-black"
-                    >
-                      {entry.slug}
-                    </a>
-                  </div>
-
-                  {entry.sections.map((section, sectionIndex) => (
-                    <div key={section.category} className={sectionIndex === 0 ? "mt-3" : "mt-7"}>
-                      {entry.sections.length > 1 ? (
-                        <p className="mb-3">
-                          <CategoryLabel category={section.category} />
-                        </p>
-                      ) : null}
-                      {section.blocks.map((block, blockIndex) => (
-                        <Prose key={blockIndex} block={block} first={blockIndex === 0} />
-                      ))}
-                    </div>
-                  ))}
-                </article>
-              </li>
-            ))}
-          </ol>
-        </div>
+      {release.groups.map((group) => (
+        <CategoryGroup key={group.category} release={release} group={group} />
       ))}
     </section>
   );
 }
 
-/**
- * The category, as a word.
- *
- * Security is the one that carries a colour, in the red this site already uses
- * for a blocked request, because it is the entry somebody scanning the page
- * needs to find without reading. The word is there either way: colour is never
- * the only thing saying what this is.
- */
-function CategoryLabel({ category }: { category: Category }) {
+function CategoryGroup({ release, group }: { release: Release; group: Group }) {
+  const anchor = groupAnchor(release, group.category);
+
   return (
-    <span
-      className={
-        category === "security"
-          ? "font-mono text-[11px] font-medium uppercase tracking-[0.14em] text-[#C43D3D]"
-          : "font-mono text-[11px] font-medium uppercase tracking-[0.14em] text-gray-new-20"
-      }
+    <section data-group className="mt-16 max-md:mt-12">
+      {/* The heading holds its own column on a wide screen and stays there
+          while its entries scroll past, for the reason the day used to: the
+          label you lose first in a long list is the one you need most. */}
+      <div className="grid grid-cols-[180px_minmax(0,1fr)] gap-x-16 border-t border-black/12 pt-8 max-xl:grid-cols-[150px_minmax(0,1fr)] max-xl:gap-x-10 max-lg:grid-cols-1 max-lg:gap-x-0 max-md:pt-6">
+        <div className="self-start lg:sticky lg:top-24">
+          <h3
+            id={anchor}
+            className="scroll-mt-24 text-[20px] leading-snug tracking-extra-tight text-black capitalize max-xl:scroll-mt-20 max-lg:text-[18px]"
+          >
+            {group.category}
+          </h3>
+          <p className="mt-2 font-mono text-[11px] uppercase tracking-[0.12em] text-gray-new-40">
+            <span data-group-count>{group.entries.length}</span> entries
+          </p>
+          <p className="mt-3 max-w-[280px] text-[14px] leading-6 tracking-extra-tight text-gray-new-40 max-lg:hidden">
+            {BLURBS[group.category]}
+          </p>
+        </div>
+
+        {/* Not an `ol`. scripts/markdown-twins.mjs takes headings, paragraphs
+            and list items out of the built HTML, and a list item is taken
+            whole: wrapping each entry in an `li` collapsed all of its
+            paragraphs into one bullet, so the twin an answer engine reads was
+            a hundred and ninety unbroken lines with the headings inside them.
+            As sibling `details` the same content comes out as a heading and
+            its paragraphs, which is what the file is for. */}
+        <div className="min-w-0 max-w-[1040px] max-lg:mt-6">
+          {group.entries.map((entry) => (
+            <EntryRow key={entry.slug} entry={entry} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/**
+ * What a category means here, said once beside the heading rather than in a
+ * label on every entry under it. Dropped below 1024, where the heading stops
+ * holding a column of its own and the line would sit between the reader and
+ * the entries instead of beside them.
+ */
+const BLURBS: Record<Category, string> = {
+  added: "Something the product could not do before.",
+  changed: "Behaviour that already existed and now works differently.",
+  fixed: "Something that claimed to work and did not.",
+  security: "A defect with a consequence for the safety of your data or your build.",
+};
+
+/**
+ * One entry, closed.
+ *
+ * `summary` is the whole row rather than a wrapper inside it, because its
+ * content model is phrasing and heading content: a `div` in there is invalid
+ * and a heading is not. Making the summary the grid itself keeps the markup
+ * legal and takes the browser's own disclosure triangle away, which
+ * `display: grid` does on its own. The marker below is drawn instead, so it
+ * looks the same in every browser rather than like a Safari triangle here and
+ * a Chrome one there.
+ *
+ * The headline is an `h4` and not a styled span. It is the level under the
+ * category `h3`, so the page has a real outline for anything reading it as a
+ * document, and scripts/markdown-twins.mjs takes headings and paragraphs,
+ * which means a span here would have dropped every entry's opening line out of
+ * the twin that answer engines read.
+ */
+function EntryRow({ entry }: { entry: Entry }) {
+  return (
+    <details
+      id={entry.slug}
+      data-entry
+      className="group scroll-mt-24 border-b border-black/12 max-xl:scroll-mt-20 [&[open]]:pb-8"
     >
-      {category}
-    </span>
+      <summary className="grid cursor-pointer grid-cols-[132px_minmax(0,1fr)_16px] items-start gap-x-8 py-5 marker:content-none hover:bg-black/[0.02] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-black/60 max-lg:grid-cols-[minmax(0,1fr)_16px] max-lg:gap-x-4 max-lg:py-4">
+        <span className="col-start-1 row-start-1 block pt-0.5 font-mono text-[11px] uppercase tracking-[0.12em] text-gray-new-40">
+          {entry.landed ? (
+            <time dateTime={entry.landed.slice(0, 10)}>
+              {formatShortDay(entry.landed.slice(0, 10))}
+            </time>
+          ) : (
+            "Undated"
+          )}
+          {entry.categories.length > 1 ? (
+            <span className="mt-1.5 block">
+              {entry.categories.map((category, index) => (
+                <span key={category}>
+                  {index === 0 ? null : <span className="text-gray-new-60"> · </span>}
+                  <span
+                    className={
+                      category === "security" ? "font-medium text-[#C43D3D]" : "text-gray-new-20"
+                    }
+                  >
+                    {category}
+                  </span>
+                </span>
+              ))}
+            </span>
+          ) : null}
+        </span>
+
+        {/* Clamped to two lines closed and released when open. The opening
+            sentences run from 12 to 315 characters, so a fixed height would
+            either clip the ordinary ones or leave a hole under them. */}
+        <h4 className="col-start-2 row-start-1 min-w-0 text-[17px] leading-7 tracking-extra-tight text-black [overflow-wrap:anywhere] group-open:line-clamp-none max-lg:col-start-1 max-lg:row-start-2 max-lg:mt-2 max-lg:text-[16px] max-md:leading-6 line-clamp-2">
+          {entry.headline.map(renderSpan)}
+        </h4>
+
+        <span
+          aria-hidden="true"
+          className="col-start-3 row-start-1 mt-2 block size-2 -rotate-45 border-r border-b border-black/40 transition-transform duration-200 group-open:rotate-45 max-lg:col-start-2 max-lg:row-span-2"
+        />
+      </summary>
+
+      <div className="grid grid-cols-[132px_minmax(0,1fr)] gap-x-8 max-lg:grid-cols-1 max-lg:gap-x-0">
+        <div className="col-start-2 min-w-0 max-lg:col-start-1">
+          {entry.sections.map((section, sectionIndex) => (
+            <div key={section.category} className={sectionIndex === 0 ? "" : "mt-7"}>
+              {/* One category, one label, and the group heading above already
+                  carries it. An entry that declares two gets them over their
+                  own paragraphs, where they say which half of the entry they
+                  belong to. */}
+              {entry.sections.length > 1 ? (
+                <p className="mb-3">
+                  <span
+                    className={
+                      section.category === "security"
+                        ? "font-mono text-[11px] font-medium uppercase tracking-[0.14em] text-[#C43D3D]"
+                        : "font-mono text-[11px] font-medium uppercase tracking-[0.14em] text-gray-new-20"
+                    }
+                  >
+                    {section.category}
+                  </span>
+                </p>
+              ) : null}
+              {section.blocks.map((block, blockIndex) => (
+                <Prose key={blockIndex} block={block} first={blockIndex === 0} />
+              ))}
+            </div>
+          ))}
+
+          <p className="mt-6">
+            {/* inline-block with vertical padding, cancelled by an equal
+                negative margin: the anchor's own hit area is 45px on a phone
+                without the row growing. */}
+            <a
+              href={`#${entry.slug}`}
+              className="-my-3.5 inline-block max-w-full py-3.5 font-mono text-[11px] tracking-snug text-gray-new-40 underline decoration-black/25 underline-offset-4 [overflow-wrap:anywhere] hover:text-black hover:decoration-black focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-black/60"
+            >
+              {entry.slug}
+            </a>
+          </p>
+        </div>
+      </div>
+    </details>
   );
 }
 
@@ -255,8 +422,14 @@ function renderSpan(span: Span, index: number): ReactNode {
     case "strong":
       return (
         <strong key={index} className="font-medium text-black">
-          {span.text}
+          {span.spans.map(renderSpan)}
         </strong>
+      );
+    case "em":
+      return (
+        <em key={index} className="italic">
+          {span.spans.map(renderSpan)}
+        </em>
       );
     case "link":
       return (

--- a/www/app/changelog/page.tsx
+++ b/www/app/changelog/page.tsx
@@ -346,8 +346,12 @@ function EntryRow({ entry }: { entry: Entry }) {
 
       <div className="grid grid-cols-[132px_minmax(0,1fr)] gap-x-8 max-lg:grid-cols-1 max-lg:gap-x-0">
         <div className="col-start-2 min-w-0 max-lg:col-start-1">
+          {/* Keyed by position, not by category. `migration-findings-in-the-check`
+              opens two `# added` sections and one `# fixed`, so keying on the
+              word gave two siblings the same key: React warns, and it is free
+              to reuse the wrong one of them when the list changes. */}
           {entry.sections.map((section, sectionIndex) => (
-            <div key={section.category} className={sectionIndex === 0 ? "" : "mt-7"}>
+            <div key={sectionIndex} className={sectionIndex === 0 ? "" : "mt-7"}>
               {/* One category, one label, and the group heading above already
                   carries it. An entry that declares two gets them over their
                   own paragraphs, where they say which half of the entry they

--- a/www/app/changelog/page.tsx
+++ b/www/app/changelog/page.tsx
@@ -191,6 +191,12 @@ function ReleaseSection({ release }: { release: Release }) {
               key={group.category}
               href={`#${groupAnchor(release, group.category)}`}
               data-chip={groupAnchor(release, group.category)}
+              // Named, because the two spans inside concatenate with no space
+              // when a screen reader computes a name from them, and "added49"
+              // is not a thing anybody says. Controls.tsx rewrites this along
+              // with the number beside it, so a search narrowing the page
+              // narrows what this announces too.
+              aria-label={`${group.category}, ${group.entries.length} entries`}
               // [&[hidden]]:hidden, because `hidden` is an attribute selector
               // in the browser's own stylesheet and inline-flex is a class in
               // this one, so the class wins and a chip hidden from script goes
@@ -319,7 +325,11 @@ function EntryRow({ entry }: { entry: Entry }) {
               ))}
             </span>
           ) : null}
-        </span>
+        </span>{" "}
+        {/* A space, and it is not decoration: a whitespace only text node
+            makes no grid item and changes nothing on screen, and without it
+            the name a screen reader computes for this row runs the date
+            into the sentence as "1 Sept 2026af start says where you are". */}
 
         {/* Clamped to two lines closed and released when open. The opening
             sentences run from 12 to 315 characters, so a fixed height would

--- a/www/app/changelog/page.tsx
+++ b/www/app/changelog/page.tsx
@@ -26,16 +26,16 @@ export const metadata = pageMetadata("/changelog");
  * Two readers, and they want opposite things. One wants to know what a release
  * means and will read a few hundred words; the other is looking for one change
  * and wants it in seconds. The page used to serve neither. Every entry was open
- * on one list, so v1.0.0 rendered as a hundred and ninety paragraphs in a column
- * 127,000 pixels tall on a desktop and 203,000 on a phone, with one entry above
- * the fold and no way to see the shape of the release at all.
+ * on one list, so v1.0.0 rendered as two hundred entries in a column 136,766
+ * pixels tall on a desktop and 264,772 on a phone, one entry fully on screen in
+ * the whole of it, and no way to see the shape of the release at all.
  *
  * So: a release states its size and its dates and links to its categories,
  * every entry is one scannable line headed by its author's own opening
  * sentence, and opening one is a `details` element. The first reader gets a
- * release they can take in without scrolling; the second gets a hundred and
- * ninety headlines to run an eye down, four category jumps, and a search that
- * reads the entries the page is not showing.
+ * release they can take in without scrolling; the second gets two hundred
+ * headlines to run an eye down, eight of them on a screen, four category
+ * jumps, and a search that reads the entries the page is not showing.
  *
  * Collapsed is not hidden. The prose is in the HTML, which is what a crawler,
  * an answer engine and the markdown twin all read, and what the search here
@@ -43,7 +43,7 @@ export const metadata = pageMetadata("/changelog");
  * box, because `details` needs no script to open.
  *
  * No cards. A changelog is a list of paragraphs with labels, and a border
- * around each one would add a hundred and ninety boxes and no information.
+ * around each one would add two hundred boxes and no information.
  * Separation is a hairline and space.
  */
 export default function ChangelogPage() {
@@ -250,7 +250,7 @@ function CategoryGroup({ release, group }: { release: Release; group: Group }) {
             and list items out of the built HTML, and a list item is taken
             whole: wrapping each entry in an `li` collapsed all of its
             paragraphs into one bullet, so the twin an answer engine reads was
-            a hundred and ninety unbroken lines with the headings inside them.
+            one unbroken line per entry with the heading inside it.
             As sibling `details` the same content comes out as a heading and
             its paragraphs, which is what the file is for. */}
         <div className="min-w-0 max-w-[1040px] max-lg:mt-6">

--- a/www/lib/changelog.ts
+++ b/www/lib/changelog.ts
@@ -32,11 +32,27 @@ const DIR = path.join(REPO, ".changes");
 export type Category = "added" | "fixed" | "changed" | "security";
 const CATEGORIES: Category[] = ["added", "fixed", "changed", "security"];
 
+/**
+ * The order the categories are read in, which is not the order they are
+ * validated in. New capability, then behaviour that moved under you, then what
+ * was broken, then what was insecure. It runs from the entry you read because
+ * you are curious to the entry you read because you have to.
+ */
+export const CATEGORY_ORDER: Category[] = ["added", "changed", "fixed", "security"];
+
 export type Span =
   | { kind: "text"; text: string }
   | { kind: "code"; text: string }
-  | { kind: "strong"; text: string }
+  | { kind: "strong"; spans: Span[] }
+  | { kind: "em"; spans: Span[] }
   | { kind: "link"; text: string; href: string };
+
+/** A span's words with its markup taken off, for measuring and for cutting. */
+function plain(span: Span): string {
+  return span.kind === "strong" || span.kind === "em"
+    ? span.spans.map(plain).join("")
+    : span.text;
+}
 
 export type Block = { kind: "p"; spans: Span[] } | { kind: "ul"; items: Span[][] };
 
@@ -46,6 +62,29 @@ export type Section = { category: Category; blocks: Block[] };
 export type Entry = {
   /** The fragment's file name without its extension, and the anchor on the page. */
   slug: string;
+  /**
+   * The entry's opening sentence, lifted out of its first paragraph.
+   *
+   * This is the line somebody scans, and it is the author's own sentence
+   * rather than a title derived from the file name. The file names are the
+   * other candidate and they are not reliably readable: `loadcp`,
+   * `installcheck` and `billing-stripe` say nothing, while their opening
+   * sentences say "the control plane can take money". Measured over every
+   * public fragment: all of them open with a paragraph, all of them have a
+   * sentence boundary in it, the median lead is 90 characters and the longest
+   * is 315, which the page clamps rather than cuts.
+   *
+   * It is removed from the body, so an open entry reads as a lede and the
+   * paragraphs under it, with nothing said twice.
+   */
+  headline: Span[];
+  /**
+   * Every category this entry declares, in the order it declares them. Twelve
+   * of the public fragments declare two. The first one files the entry under a
+   * heading; all of them are shown on its row and all of them match a filter,
+   * because an entry that both adds and fixes is not found under one word.
+   */
+  categories: Category[];
   sections: Section[];
   /**
    * ISO date of the commit that landed this entry on main, or null when git
@@ -56,15 +95,31 @@ export type Entry = {
   landed: string | null;
 };
 
-export type Day = { date: string | null; entries: Entry[] };
+/** One category's entries within a release. Empty groups are not built. */
+export type Group = { category: Category; entries: Entry[] };
 
 export type Release = {
   /** A tag name, or null for the entries no tag contains yet. */
   tag: string | null;
   /** ISO date the tag was cut. Null for unreleased. */
   date: string | null;
-  /** Entries in this release, newest day first. */
-  days: Day[];
+  /**
+   * Entries grouped by category, in CATEGORY_ORDER, newest first within a
+   * group.
+   *
+   * This page grouped by day first, and the day is the right axis for a
+   * project with a release every fortnight. It is the wrong one for a release
+   * that carries 190 entries landed over one week: it produced seven headings
+   * with twenty-seven entries under each, which is the same wall with dates
+   * on it. The question a reader of a release actually asks is what kind of
+   * change it is, and whether there is a security entry in it. Every row still
+   * carries the day it landed, so the chronology is not lost, only demoted.
+   */
+  groups: Group[];
+  /** The first and last day anything in this release landed. Null when nothing is dated. */
+  span: { from: string; to: string } | null;
+  /** How many entries this build could not date. Rendered, never hidden. */
+  undated: number;
   /**
    * Why a release has no public entries, when it has none. Two different
    * things look identical on the page and are not: a release cut before
@@ -79,17 +134,29 @@ export type Release = {
  * Parsing
  * ---------------------------------------------------------------------- */
 
-const INLINE = /(`[^`]+`|\*\*[^*]+\*\*|\[[^\]]+\]\([^)]+\))/g;
+const INLINE = /(`[^`]+`|\*\*[^*]+\*\*|\*[^*\s][^*]*\*|\[[^\]]+\]\([^)]+\))/g;
 
 /**
- * Inline markup, and only the three shapes the fragments actually contain.
+ * Inline markup, and only the shapes the fragments actually contain.
  *
- * Measured rather than assumed: 783 spans of inline code, two of bold, no
- * fenced blocks, no heading below the first level, and one file using
- * bullets. Writing a general markdown parser for that would be several
- * hundred lines guarding against constructs nothing has ever written. Links
- * are the one shape not present today and supported anyway, because the cost
- * of not supporting them is a raw `[text](url)` shipped to a reader.
+ * Measured rather than assumed, across the 190 public fragments: 1349 spans of
+ * inline code, 12 of bold, two of italic, one link, no fenced blocks, no
+ * heading below the first level, and one file using bullets. Writing a general
+ * markdown parser for that would be several hundred lines guarding against
+ * constructs nothing has ever written.
+ *
+ * Bold and italic hold spans rather than text, because they are the two that
+ * can contain something else and did. `**`af runner install`, the second
+ * command the installer prints, could not succeed**` shipped its backticks to
+ * the reader as backticks, and `*abandoned*` shipped its asterisks, on a page
+ * a prospective customer reads. Both are two characters of raw markup on a
+ * marketing site, which is the kind of defect nothing fails on and everybody
+ * sees.
+ *
+ * The alternation is ordered, and that ordering is what keeps a lone asterisk
+ * from eating a bold run: at the position of a `**` the bold branch is tried
+ * first and wins. A `*` inside a code span is never reached at all, because
+ * the backtick branch matches from the backtick, which comes first.
  */
 function spans(text: string): Span[] {
   const out: Span[] = [];
@@ -101,7 +168,9 @@ function spans(text: string): Span[] {
     if (token.startsWith("`")) {
       out.push({ kind: "code", text: token.slice(1, -1) });
     } else if (token.startsWith("**")) {
-      out.push({ kind: "strong", text: token.slice(2, -2) });
+      out.push({ kind: "strong", spans: spans(token.slice(2, -2)) });
+    } else if (token.startsWith("*")) {
+      out.push({ kind: "em", spans: spans(token.slice(1, -1)) });
     } else {
       const cut = token.indexOf("](");
       out.push({
@@ -114,6 +183,53 @@ function spans(text: string): Span[] {
   }
   if (last < text.length) out.push({ kind: "text", text: text.slice(last) });
   return out;
+}
+
+/**
+ * The opening sentence, and everything after it.
+ *
+ * The cut is made on the plain text the spans carry and then applied to the
+ * spans themselves, so a headline never ends in the middle of a code span or
+ * half a link. A boundary is a full stop, question mark or exclamation mark
+ * followed by whitespace or by the end of the paragraph, which is what leaves
+ * `Version 1.0.` and `Next 15.5.23` intact: the full stop inside a version
+ * number is followed by a digit.
+ *
+ * A cut landing inside anything but a plain text span moves to that span's end
+ * rather than splitting it. Nothing in the corpus does that today; the
+ * alternative is a broken `<code>` shipped to a reader on the day one does.
+ */
+function splitLead(input: Span[]): { headline: Span[]; rest: Span[] } {
+  const flat = input.map(plain).join("");
+  const boundary = flat.match(/[.!?](?=\s|$)/);
+  if (!boundary || boundary.index === undefined) return { headline: input, rest: [] };
+  const cut = boundary.index + 1;
+
+  const headline: Span[] = [];
+  const rest: Span[] = [];
+  let at = 0;
+  for (const span of input) {
+    const end = at + plain(span).length;
+    if (end <= cut) {
+      headline.push(span);
+    } else if (at >= cut) {
+      rest.push(span);
+    } else if (span.kind === "text") {
+      headline.push({ kind: "text", text: span.text.slice(0, cut - at) });
+      rest.push({ kind: "text", text: span.text.slice(cut - at) });
+    } else {
+      headline.push(span);
+    }
+    at = end;
+  }
+
+  // The space that separated the two sentences belongs to neither.
+  if (rest.length > 0 && rest[0].kind === "text") {
+    const trimmed = rest[0].text.replace(/^\s+/, "");
+    if (trimmed === "") rest.shift();
+    else rest[0] = { kind: "text", text: trimmed };
+  }
+  return { headline, rest };
 }
 
 /**
@@ -322,14 +438,38 @@ function isPublic(file: string): boolean {
   return file.endsWith(".md") && !file.endsWith(".internal.md");
 }
 
+/**
+ * The lede, taken off the front of the entry.
+ *
+ * Every public fragment opens its first section with a paragraph, so the
+ * fallback below has never run. It is here because a fragment opening with a
+ * bullet list is valid to `tools/changecheck` and would otherwise render a row
+ * with no line on it at all, which is worse than a row headed by its own file
+ * name.
+ */
+function lede(slug: string, sections: Section[]): Span[] {
+  const first = sections[0]?.blocks[0];
+  if (!first || first.kind !== "p") {
+    const words = slug.replace(/-/g, " ");
+    return [{ kind: "text", text: words.charAt(0).toUpperCase() + words.slice(1) }];
+  }
+  const { headline, rest } = splitLead(first.spans);
+  if (rest.length > 0) first.spans = rest;
+  else sections[0].blocks.shift();
+  return headline;
+}
+
 function readEntries(dates: Map<string, string>): Entry[] {
   const entries: Entry[] = [];
   for (const file of readdirSync(DIR).sort()) {
     if (!isPublic(file)) continue;
     const sections = parse(readFileSync(path.join(DIR, file), "utf8"));
     if (sections.length === 0) continue;
+    const slug = file.replace(/\.md$/, "");
     entries.push({
-      slug: file.replace(/\.md$/, ""),
+      slug,
+      headline: lede(slug, sections),
+      categories: [...new Set(sections.map((section) => section.category))],
       sections,
       landed: dates.get(`.changes/${file}`) ?? null,
     });
@@ -337,37 +477,44 @@ function readEntries(dates: Map<string, string>): Entry[] {
   return entries;
 }
 
-function groupByDay(entries: Entry[]): Day[] {
-  const byDay = new Map<string, Entry[]>();
-  const undated: Entry[] = [];
-  for (const entry of entries) {
-    if (!entry.landed) {
-      undated.push(entry);
-      continue;
-    }
-    const key = entry.landed.slice(0, 10);
-    const list = byDay.get(key);
-    if (list) list.push(entry);
-    else byDay.set(key, [entry]);
+/**
+ * Newest landing first, then by slug.
+ *
+ * The slug tiebreak is what holds two entries that landed in the same commit
+ * in the same order across builds. An entry this build could not date sorts
+ * last rather than first: it is an admitted gap, not the newest news.
+ */
+function byRecency(a: Entry, b: Entry): number {
+  if (a.landed === b.landed) return a.slug.localeCompare(b.slug);
+  if (!a.landed) return 1;
+  if (!b.landed) return -1;
+  return a.landed < b.landed ? 1 : -1;
+}
+
+/**
+ * An entry is filed under the first category it declares and shows all of
+ * them, so it appears exactly once on the page and under one heading. Filing
+ * it under both would give two elements one id, and an anchor pointing at a
+ * duplicate is a link that lands in a different place depending on the
+ * browser.
+ */
+function groupByCategory(entries: Entry[]): Group[] {
+  const groups: Group[] = [];
+  for (const category of CATEGORY_ORDER) {
+    const mine = entries.filter((entry) => entry.categories[0] === category).sort(byRecency);
+    if (mine.length > 0) groups.push({ category, entries: mine });
   }
-  const days: Day[] = [...byDay.entries()]
-    .sort((a, b) => (a[0] < b[0] ? 1 : -1))
-    .map(([date, list]) => ({
-      date,
-      // Newest landing first within a day, then by slug, so two entries that
-      // landed in the same commit hold a stable order across builds.
-      entries: list.sort((a, b) =>
-        a.landed === b.landed
-          ? a.slug.localeCompare(b.slug)
-          : (a.landed as string) < (b.landed as string)
-            ? 1
-            : -1,
-      ),
-    }));
-  if (undated.length > 0) {
-    days.push({ date: null, entries: undated.sort((a, b) => a.slug.localeCompare(b.slug)) });
-  }
-  return days;
+  return groups;
+}
+
+function landedSpan(entries: Entry[]): { from: string; to: string } | null {
+  const days = entries
+    .map((entry) => entry.landed)
+    .filter((landed): landed is string => landed !== null)
+    .map((landed) => landed.slice(0, 10))
+    .sort();
+  if (days.length === 0) return null;
+  return { from: days[0], to: days[days.length - 1] };
 }
 
 /**
@@ -397,17 +544,22 @@ export function releases(): Release[] {
     out.push({
       tag: tag.name,
       date: tag.date,
-      days: groupByDay(mine),
+      groups: groupByCategory(mine),
+      span: landedSpan(mine),
+      undated: mine.filter((entry) => !entry.landed).length,
       emptyBecause:
         mine.length > 0 ? null : tag.hasDir ? "every entry was internal" : "predates the convention",
     });
   }
   out.reverse();
 
+  const unreleased = entries.filter((entry) => !claimed.has(entry.slug));
   out.unshift({
     tag: null,
     date: null,
-    days: groupByDay(entries.filter((entry) => !claimed.has(entry.slug))),
+    groups: groupByCategory(unreleased),
+    span: landedSpan(unreleased),
+    undated: unreleased.filter((entry) => !entry.landed).length,
     emptyBecause: null,
   });
   return out;
@@ -415,7 +567,19 @@ export function releases(): Release[] {
 
 /** How many public entries a release carries, for the count beside its name. */
 export function entryCount(release: Release): number {
-  return release.days.reduce((total, day) => total + day.entries.length, 0);
+  return release.groups.reduce((total, group) => total + group.entries.length, 0);
+}
+
+/**
+ * The id a category heading answers to, as `v1-0-0-security`.
+ *
+ * A tag carries dots, which are legal in an id and are an attribute selector
+ * away from being a class in every stylesheet and a mistake in every
+ * `querySelector` that forgets to escape them. The page reaches these from
+ * JavaScript, so they are spelled without.
+ */
+export function groupAnchor(release: Release, category: Category): string {
+  return `${(release.tag ?? "unreleased").replace(/[^a-zA-Z0-9]+/g, "-")}-${category}`;
 }
 
 /**
@@ -431,6 +595,45 @@ export function formatDay(date: string): string {
     day: "numeric",
     timeZone: "UTC",
   });
+}
+
+/**
+ * The same day, short, for the column beside an entry.
+ *
+ * "2 Sep 2026" rather than "2 September 2026", because the long form is 16
+ * monospace capitals with 0.12em between them, which is 140px in a 132px
+ * column. The `datetime` attribute beside it carries the unabbreviated date
+ * for anything reading the page rather than looking at it.
+ */
+export function formatShortDay(date: string): string {
+  return new Date(`${date}T00:00:00Z`).toLocaleDateString("en-GB", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+/**
+ * The days a release's work landed between, written the way a person says it.
+ *
+ * The repeated half of the two dates comes off: "26 to 29 August 2026" rather
+ * than "26 August 2026 to 29 August 2026", which is the same fact with eleven
+ * words in it. Both dates are still in the markup, on the entries themselves.
+ */
+export function formatSpan(from: string, to: string): string {
+  if (from === to) return formatDay(from);
+  const [fromYear, fromMonth] = from.split("-");
+  const [toYear, toMonth] = to.split("-");
+  const day = (date: string) => String(Number(date.slice(8, 10)));
+  if (fromYear === toYear && fromMonth === toMonth) {
+    return `${day(from)} to ${formatDay(to)}`;
+  }
+  if (fromYear === toYear) {
+    const head = formatDay(from).replace(new RegExp(` ${fromYear}$`), "");
+    return `${head} to ${formatDay(to)}`;
+  }
+  return `${formatDay(from)} to ${formatDay(to)}`;
 }
 
 /** The most recent day anything landed, for the sitemap's lastmod. */

--- a/www/lib/changelog.ts
+++ b/www/lib/changelog.ts
@@ -71,7 +71,7 @@ export type Entry = {
    * `installcheck` and `billing-stripe` say nothing, while their opening
    * sentences say "the control plane can take money". Measured over every
    * public fragment: all of them open with a paragraph, all of them have a
-   * sentence boundary in it, the median lead is 90 characters and the longest
+   * sentence boundary in it, the median lead is 94 characters and the longest
    * is 315, which the page clamps rather than cuts.
    *
    * It is removed from the body, so an open entry reads as a lede and the
@@ -79,8 +79,8 @@ export type Entry = {
    */
   headline: Span[];
   /**
-   * Every category this entry declares, in the order it declares them. Twelve
-   * of the public fragments declare two. The first one files the entry under a
+   * Every category this entry declares, in the order it declares them.
+   * Fourteen of the public fragments declare two. The first one files the entry under a
    * heading, so that it appears once and one anchor reaches it; the rest are
    * printed on its row, because an entry filed under Added that also fixes
    * something should say so where somebody scanning can see it.
@@ -110,9 +110,9 @@ export type Release = {
    *
    * This page grouped by day first, and the day is the right axis for a
    * project with a release every fortnight. It is the wrong one for a release
-   * that carries 190 entries landed over one week: it produced seven headings
-   * with twenty-seven entries under each, which is the same wall with dates
-   * on it. The question a reader of a release actually asks is what kind of
+   * that carries two hundred entries landed over one week: it produced seven
+   * headings with thirty entries under each, which is the same wall with
+   * dates on it. The question a reader of a release actually asks is what kind of
    * change it is, and whether there is a security entry in it. Every row still
    * carries the day it landed, so the chronology is not lost, only demoted.
    */
@@ -140,7 +140,7 @@ const INLINE = /(`[^`]+`|\*\*[^*]+\*\*|\*[^*\s][^*]*\*|\[[^\]]+\]\([^)]+\))/g;
 /**
  * Inline markup, and only the shapes the fragments actually contain.
  *
- * Measured rather than assumed, across the 190 public fragments: 1349 spans of
+ * Measured rather than assumed, across the 204 public fragments: 1398 spans of
  * inline code, 12 of bold, two of italic, one link, no fenced blocks, no
  * heading below the first level, and one file using bullets. Writing a general
  * markdown parser for that would be several hundred lines guarding against

--- a/www/lib/changelog.ts
+++ b/www/lib/changelog.ts
@@ -38,7 +38,7 @@ const CATEGORIES: Category[] = ["added", "fixed", "changed", "security"];
  * was broken, then what was insecure. It runs from the entry you read because
  * you are curious to the entry you read because you have to.
  */
-export const CATEGORY_ORDER: Category[] = ["added", "changed", "fixed", "security"];
+const CATEGORY_ORDER: Category[] = ["added", "changed", "fixed", "security"];
 
 export type Span =
   | { kind: "text"; text: string }
@@ -81,8 +81,9 @@ export type Entry = {
   /**
    * Every category this entry declares, in the order it declares them. Twelve
    * of the public fragments declare two. The first one files the entry under a
-   * heading; all of them are shown on its row and all of them match a filter,
-   * because an entry that both adds and fixes is not found under one word.
+   * heading, so that it appears once and one anchor reaches it; the rest are
+   * printed on its row, because an entry filed under Added that also fixes
+   * something should say so where somebody scanning can see it.
    */
   categories: Category[];
   sections: Section[];

--- a/www/lib/lastmod.ts
+++ b/www/lib/lastmod.ts
@@ -72,7 +72,16 @@ function sourcesFor(routePath: string): string[] {
   } else if (routePath === "/blog") {
     candidates.push("app/blog/page.tsx", "lib/blog.ts");
   } else if (routePath === "/changelog") {
-    candidates.push("app/changelog/page.tsx", "lib/changelog.ts");
+    // Controls.tsx as well, because this list is written by hand and a file
+    // added to a route after somebody wrote its line here is exactly what it
+    // fails to notice. It is a fallback either way: contentLastModified
+    // answers /changelog from the fragments and never reaches this unless git
+    // cannot date them.
+    candidates.push(
+      "app/changelog/page.tsx",
+      "app/changelog/Controls.tsx",
+      "lib/changelog.ts",
+    );
   } else if (routePath === "/pricing") {
     candidates.push("app/pricing/page.tsx", "components/pages/company/Pricing.tsx");
   } else if (routePath === "/signin" || routePath === "/signup") {


### PR DESCRIPTION
The v1.0.0 changelog is one release holding 204 public entries, and all three surfaces printed all of it. This reshapes two of them and deliberately leaves the third alone.

## Measured, before and after

The site page, `/changelog`. Both sides are production builds served as static files from `www/out`, not a dev server: this branch against `e779d9fc`, which carries 203 public entries to this branch's 204, the extra one being this change's own.

| | before | after |
|---|---|---|
| page height at 1440 | 136,766 px | 19,635 px |
| page height at 768 | 139,796 px | 24,760 px |
| page height at 390 | 218,928 px | 25,985 px |
| page height at 320 | 264,772 px | 26,386 px |
| screens of scrolling to the bottom, 1440 | 152 | 22 |
| screens of scrolling to the bottom, 390 | 259 | 31 |
| entries fully on one screen of the list, 1440 | 1 | 8 |
| entries fully on one screen of the list, 390 | 0 | 6 |

The GitHub release body for v1.0.0, from `tools/relnotes` against this branch's `CHANGELOG.md`, with and without the two marker lines:

| | before | after |
|---|---|---|
| bytes | 69,932 | 23,170 |

`CHANGELOG.md` keeps every byte apart from two marker lines and one paragraph in the file header. A changelog file is a reference document people search, and shortening it would have cost the thing it is for.

## The site page

A release states its size, the days its work landed between, and how many entries of each kind it carries, as four links that scroll to those groups. Entries are grouped by category rather than by day, because seven days of thirty entries is the same wall with dates on it, and the question a reader of a release asks is what kind of change it is and whether there is a security entry in it. Every row still carries the day it landed.

Each entry is one line headed by its author's own opening sentence, lifted out of the first paragraph and removed from the body, so an open entry reads as a lede and the paragraphs under it with nothing said twice. Measured over every public fragment: all of them open with a paragraph, all have a sentence boundary in it, the median lead is 90 characters and the longest is 315, which the row clamps to two lines rather than cutting.

Opening one is a `details` element. There is a search that reads each entry's own `textContent`, so it reaches the collapsed ones and ships no extra bytes, and it keeps every count on the page honest while it narrows, including the accessible name of each category link.

## The release body

A changelog section may now mark part of itself as detail, between `<!-- relnotes:omit -->` and `<!-- relnotes:end -->`, and the published notes carry a link to the changelog on the site where that part stood. For v1.0.0 the marked part is Added and Fixed. The verification preamble, what 1.0 promises and what it does not, what pushing the tag moves, supply chain, installing, everything that behaves differently under an existing manifest, and the whole Security section are all still in the body.

The gate grew with the feature rather than being loosened by it. `just relnotes` refuses an unbalanced marker, a second region in one section, an empty region, and a section that omits every line of itself; its emptiness check now reads what a tag would publish rather than what is in the file. `relnotes` still owns the verification preamble for the reason it always did, and a test asserts the preamble and its identity binding survive.

## Two rendering defects found on the way

Bold wrapped around inline code printed its backticks, and a word between single asterisks printed its asterisks: four backticks and two pairs of asterisks reaching a page a prospective customer reads. Bold and italic carry spans now rather than text.

Entries are sibling elements rather than list items, because `scripts/markdown-twins.mjs` takes a list item whole. The twin an answer engine reads was two hundred unbroken lines with the headings buried inside them; it is a heading and its paragraphs now.

## What was checked

Rendered pixels at 320, 390, 768 and 1440. The site declares `colorScheme: "light"` and carries no dark rules; forcing `prefers-color-scheme: dark` renders identically, and every height above is the same in both.

No horizontal overflow at any of the four widths, including with the longest entry in the corpus open at 320. Keyboard: a summary takes a 2px focus ring and Enter toggles it; tab order runs search, expand, clear, the category links, then the first row. A permalink opens the entry it names. With JavaScript disabled all 204 entries are in the DOM, the space the search will take is reserved so hydration shifts nothing, and the hairline belongs to the control rather than the placeholder so a reader without JavaScript sees space rather than two rules with nothing between them.

Green locally on the rebased tree: `prosecheck`, `changecheck`, `relnotes`, `go test ./tools/relnotes/`, `classcheck`, `motioncheck` (no `animate-pulse` or `animate-ping` anywhere), `npm run check:seo` at 88/88, and `tsc --noEmit` on `www`.

Prepared under the merge freeze. Not merged.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR