### PR TITLE
notes: two release note entries described a repository that does not exist

### DIFF
--- a/.changes/release-notes-claimed-two-things-main-does-not-do.md
+++ b/.changes/release-notes-claimed-two-things-main-does-not-do.md
@@ -1,0 +1,38 @@
+# fixed
+
+Two entries in the v1.0.0 release notes described a repository that does not
+exist. `tools/relnotes` publishes that section verbatim as the GitHub release
+body, so both would have shipped as the product's own account of itself.
+
+The first told an operator that the documentation runs the control plane image
+as `latest`. No page does, and no page can: `tools/claimcheck` refuses any pin
+that is not a `main-<sha>` or `cd-<sha>` tag, because a tag that names no commit
+tells the gate nothing it can check without a network. Both self hosting
+procedures pin `main-b53906a`. An operator following the sentence would have
+pulled an image nothing had proved could complete the procedure beside it.
+
+The second said the dispatch workflow template calls `af workload run` rather
+than assembling flags in a shell case statement, and that a knob with no flag
+behind it is now refused by name. True of the workload kinds and not of
+`scenario` or `explore`, which are the two verbs the same entry singles out as
+needing the new file. `examples/github-workflow.yml` still answers both with
+steps of their own, so a duration or a scale sent to either is still dropped in
+silence. The entry now says which half holds.
+
+Reading the template for the second one turned up a defect of its own, fixed
+here. `examples/github-workflow.yml` declared `down)` twice in one `case`, and
+bash takes the first match, so the second arm was unreachable. It carried the
+comment explaining that teardown exits 10 when something could not be removed
+and that this has to fail the job, which is a justification attached to an arm
+that never runs: it tells the next reader a behaviour is handled when nothing
+there handles it. The reasoning is true of the arm that does run, because
+`af workload teardown` returns `AF-RUN-030` when resources are still pending and
+that code carries exit 10, so the comment moves onto the live arm and the dead
+one is gone.
+
+Neither release note was caught by anything, and the reason is one sentence:
+`CHANGELOG.md` is in no gate's document list. `tools/claimcheck` reads
+`README.md`, `CONTRIBUTING.md` and `SECURITY.md` for path claims and a fixed set
+of site trees for sentence claims, and the file the release body is cut from is
+in neither. Its sentence rules are a hand curated list of claims that had
+already shipped false, so a novel one has no rule to fire.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,9 +135,13 @@ manifest or pipeline does.
   on its output, so a pull request that touches nothing any check exercises no
   longer gets an environment. It checks out with `fetch-depth: 0`, because a one
   commit deep clone has no merge base to diff against.
-- The documentation now runs the control plane image as
-  `ghcr.io/antifailure/control-plane:latest` rather than naming a version. The
-  tag is moved by the push of a `v*` tag and never by a build off `main`.
+- The documentation runs the control plane image as
+  `ghcr.io/antifailure/control-plane:main-b53906a` rather than the version tag it
+  named before. A `main-<sha>` tag names the commit the image was built from, so
+  `tools/claimcheck` can prove offline that the pinned image can complete the
+  procedure the page describes. A version tag cannot, because the only one ever
+  published was built from a different ref than the git tag of the same name,
+  and `latest` cannot either.
 - A run in which no workflow reached a verdict about the application exits `9`
   rather than `0`. A real failure still exits `8`, so a pipeline reading the
   number can tell "your change broke something" from "nothing was tested". Both
@@ -201,11 +205,15 @@ manifest or pipeline does.
   calls on your behalf; the commands a person runs are `af load run`,
   `af load scenario`, `af test` and `af explore`. Its flags are documented under
   Workloads instead.
-- The dispatch workflow template calls `af workload run` rather than assembling
-  flags in a shell case statement, and its `command` input keeps its verbs. `up`,
-  `down`, `agents` and `load` work on an older copy of the file; `scenario` and
-  `explore` need this one. An input the case statement had no flag for used to
-  be dropped without a word and is now refused by name.
+- The dispatch workflow template runs a workload through `af workload run`, and
+  its `command` input keeps its verbs. `up`, `down`, `agents` and `load` work on
+  an older copy of the file; `scenario` and `explore` need this one. A knob
+  `af workload run` has no flag for is refused by name rather than dropped
+  without a word, which is what the case statement it replaced did. That holds
+  for the workload kinds and not yet for two verbs: the template still answers
+  `scenario` and `explore` with steps of their own that call `af load scenario`
+  and `af explore` directly, so a `duration` or a `scale` sent to either is
+  still dropped in silence.
 - An exploration run through `af workload run --kind exploration` no longer
   fails the job when a goal is not reached. `docs/concepts/exploration` has
   always promised that an exploration cannot fail your build, and the promise

--- a/examples/github-workflow.yml
+++ b/examples/github-workflow.yml
@@ -273,6 +273,11 @@ jobs:
               # The real teardown, with an acknowledgement saying what was
               # removed and what is still standing. A row marked torn down
               # while the containers keep running is worse than a failure.
+              #
+              # No branch flag, for the same reason 'up' has none: the dispatch
+              # ran on the branch the environment belongs to. It exits 10 when
+              # something could not be removed, which has to fail this job
+              # rather than read as a clean teardown in the control plane.
               af workload teardown --result teardown-result.json
               ;;
             scenario)
@@ -293,13 +298,6 @@ jobs:
               done
               if [ -n "$AF_SEED" ]; then args+=(--seed "$AF_SEED"); fi
               af explore ${args[@]+"${args[@]}"}
-              ;;
-            down)
-              # No branch flag, for the same reason 'up' has none: the dispatch
-              # ran on the branch the environment belongs to. Teardown exits 10
-              # when something could not be removed, which has to fail this job
-              # rather than read as a clean teardown in the control plane.
-              af down
               ;;
             *)
               # Everything else is a workload, and one command runs all four


### PR DESCRIPTION
`tools/relnotes` publishes the v1.0.0 section of `CHANGELOG.md` verbatim as the GitHub release body. Two entries in it are not true of `main`, so both would have shipped as the product's own account of itself. This corrects the sentences and removes one unreachable case arm found while checking the second. No behaviour changes.

## The documentation does not run the image as `latest`

CHANGELOG.md said the documentation runs the control plane image as `ghcr.io/antifailure/control-plane:latest` rather than naming a version. No page does, and no page can. `tools/claimcheck` refuses any pin that is not a `main-<sha>` or `cd-<sha>` tag, because a version tag names no commit the gate can resolve without a network. Both self hosting procedures pin `main-b53906a`:

- `docs/src/content/docs/self-hosting/control-plane.md:70` and `:78`
- `docs/src/content/docs/getting-started/hosted.md:40` and `:48`

`go run ./tools/claimcheck .` reads it back the same way: `4 pin(s) of main-b53906a, built from b53906a7338a, and all 2 documented step(s) exist there`.

The entry sits under **Behaviour you may depend on that changed**, which is the section an operator reads while upgrading, so this is the worst place for it. **What moves when this tag is pushed** also discusses `latest` and is deliberately untouched here, because PR #136 is open on that paragraph.

## The dispatch template routes only some verbs through `af workload run`

CHANGELOG.md said the template calls `af workload run` rather than assembling flags in a shell case statement, and that a knob with no flag behind it is refused by name rather than dropped. That holds for the workload kinds and not for `scenario` or `explore`, which are the two verbs the same entry singles out as needing the new file.

`examples/github-workflow.yml` has its own arms for `scenario` and `explore` that call `af load scenario` and `af explore` directly. Bash takes the first matching arm, so `af workload run --kind scenario` and `--kind explore` are unreachable from this template and the promised refusal never runs on those paths. The scenario arm drops duration, scale and run_id in silence; the explore arm drops those and concurrency.

The engine side is correct, which is what makes this a template gap rather than a design one: `legacyKinds` at `engine/internal/workload/workload.go:103` resolves both verbs, and `Parse` refuses an unusable knob by name at `workload.go:221`. Nothing calls it for them.

The entry now says which half holds and names the silent drop as a known limit, rather than implying it was fixed. Whether the template should route those two verbs through `af workload run` is a code change and is deliberately not made here: the verbs-stay shape is a compatibility decision, since renaming the `command` input would answer every copy of the file already in the wild with a 422.

## A `case` arm bash never reaches

Found while reading the template for the above. `examples/github-workflow.yml` declared `down)` twice in one `case`. Bash takes the first match, so the second arm was dead, and it was the one carrying the comment explaining that teardown exits 10 when something could not be removed and that this has to fail the job. A justification attached to an arm that never runs tells the next reader a behaviour is handled when nothing there handles it.

The reasoning is true of the arm that does run: `af workload teardown` returns `AF-RUN-030` when resources are still pending (`engine/internal/cli/workload.go:473`) and that code carries `exit_code: 10` (`engine/internal/errors/catalog.yaml:555`). So the comment moves onto the live arm and the dead one is deleted.

Verified by routing every declared verb through the case statement in a shell, which also confirms the deleted arm was unreachable:

```
up -> af-up            scenario -> load-scenario
ci -> af-ci            explore  -> af-explore
down -> workload-teardown
agents, load -> workload-run
```

## How this happened, and why nothing caught it

Two `.changes` fragments were merged into one bullet. `.changes/workflow-dispatches-a-workload.md` says the template calls `af workload run` and the `command` input names a kind. `.changes/dispatch-verbs-stay-verbs.md` then reverses the second half, for the 422 reason above. The published bullet welds the first sentence of one to the conclusion of the other and is true of neither. That is a distinct failure from a fragment whose code never landed: both fragments were true when they were written.

Nothing caught either, for one reason: `CHANGELOG.md` is in no gate's document list. `tools/claimcheck` reads `README.md`, `CONTRIBUTING.md` and `SECURITY.md` for path claims (`documents`, main.go:44) and a fixed set of site trees for sentence claims (`siteTrees`, main.go:640). The file the release body is cut from is in neither. Its sentence rules are also a hand curated list of claims that had already shipped false, each with a `premise` naming the code that settles it, so a novel claim has no rule to fire against. Closing that gap is worth its own change and its own argument, and is not attempted here.

## Checked

- `go run ./tools/prosecheck .` : 552 files, 0 places where the punctuation gives it away
- `go run ./tools/claimcheck .` : 0 dead, 0 stale, 0 contradicted, pins agree
- `go run ./tools/changecheck .` : 3 changed paths, clean
- `go test ./internal/cli -run 'TestEveryCommandInTheWorkflowsExists|TestEveryCommandInTheDocsExists' -count=1` : ok
- `bash -n` over the edited case block, plus the verb routing above

A `.changes/` fragment is included under `# fixed`.

This came out of a sweep of every claim in the v1.0.0 section against `origin/main`. One further entry, the suspended organization credential under **Security**, is false because its implementation is on an unmerged branch, and is not fixable here.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR