### PR TITLE
www: the waitlist promised mail the domain cannot send

### DIFF
--- a/.changes/a-list-that-promised-mail-it-cannot-send.md
+++ b/.changes/a-list-that-promised-mail-it-cannot-send.md
@@ -1,0 +1,23 @@
+# fixed
+
+The waitlist told people they would hear from us. Nothing could have done that.
+`POST /api/waitlist` writes one row and sends nothing, the table has no read
+path by design, and antifailure.dev has no mail exchanger and an SPF policy
+that authorizes no outbound sender at all. So somebody who left an address and
+waited was waiting for a message that had no route to them, and the only signal
+they would ever get was silence.
+
+The confirmation now says what is stored, who touches it, and what will not
+happen: a person reads the list when there is a hosted environment to connect a
+repository to, there is no date for that, and nothing mails anybody on a
+schedule. It then names the two routes that resolve sooner, the quickstart,
+which needs no account and works today, and booking a call, which is a real
+calendar. The same correction is on the contact page and in the metadata for
+the sign-up route, which carried the promise into every tab title and link
+preview.
+
+Two other claims on the site were describing things that are not there. The
+privacy sheet said passwords entered in the form are not stored, and the form
+has had no password field since the fake one was removed. The legal pages
+listed what a waitlist row holds and omitted the page it was submitted from,
+which is stored.

--- a/.changes/a-list-that-promised-mail-it-cannot-send.md
+++ b/.changes/a-list-that-promised-mail-it-cannot-send.md
@@ -21,3 +21,11 @@ privacy sheet said passwords entered in the form are not stored, and the form
 has had no password field since the fake one was removed. The legal pages
 listed what a waitlist row holds and omitted the page it was submitted from,
 which is stored.
+
+Twice is enough for a gate, so `claimcheck` has a seventh site rule. A page may
+say what happens to an address and who reads it. It may not say that something
+will reach the person, because nothing can. The rule is premised on the contact
+page's record of the DNS fact, so the day antifailure.dev gains a sending
+identity the premise lapses and whoever removed that sentence is told to
+revisit what the site may promise. It was watched refusing a freshly written
+promise before it was believed.

--- a/tools/claimcheck/main.go
+++ b/tools/claimcheck/main.go
@@ -793,6 +793,35 @@ var siteClaims = []siteClaim{
 			"of a minted one, and a premise that is half true anchors nothing",
 	},
 	{
+		name: "mail this domain cannot send",
+		// The sign-up screen said "you will hear from us" and the client module
+		// it posts to still records the version before that, "We'll email you
+		// when the control plane can connect a repo". Neither could happen. The
+		// endpoint writes one row and sends nothing, the table has no read path,
+		// and antifailure.dev publishes no MX record and an SPF policy of
+		// `v=spf1 -all`, which authorizes no sender at all. Somebody who left an
+		// address and waited was waiting for a message with no route to them.
+		//
+		// Twice now, which is why this is a gate rather than a correction. The
+		// promise is easy to write because it is what a waitlist is supposed to
+		// do, and nothing about the page makes its impossibility visible.
+		//
+		// Deliberately narrow. It bans the MAIL promise and nothing else:
+		// SECURITY.md says "We will tell you which release we expect to" about a
+		// channel that genuinely works, and a rule that refused that sentence
+		// would be a rule somebody turns off.
+		forbidden: regexp.MustCompile(`(?i)we('ll| will) (e-?mail|mail) you|you will hear from us|we('ll| will) be in touch|we('ll| will) let you know`),
+		// The site's own record of the DNS fact. The day antifailure.dev gains a
+		// sending identity that sentence has to go, this rule lapses loudly, and
+		// whoever removed it is told to revisit what the page may promise.
+		premise: [2]string{"www/components/pages/company/Contact.tsx", "no mail exchanger"},
+		reason: "the waitlist stores an address and sends nothing, and the domain " +
+			"authorizes no outbound sender. A page may say what happens to the address " +
+			"and who reads it; it may not say that something will reach the person, " +
+			"because nothing can. If mail starts working, delete this rule; the premise " +
+			"beside it is what tells you the day that happens.",
+	},
+	{
 		name:      "there is no hosted control plane",
 		forbidden: regexp.MustCompile(`(?i)no hosted control plane`),
 		premise:   [2]string{"www/components/AuthScreen.tsx", "invitation only"},
@@ -1010,6 +1039,22 @@ var siteClaimExceptions = []claimException{
 			"unreachable, openAuth had no caller, and it shipped the sentence in the " +
 			"bundle anyway; this is the record of that, and of why the fix was to " +
 			"delete it rather than correct its copy",
+	},
+	{
+		file: "www/components/AuthScreen.tsx",
+		rule: "mail this domain cannot send",
+		line: "It used to say",
+		reason: "the comment recording the promise this screen used to make and why " +
+			"nothing could have kept it, which is the note that stops somebody " +
+			"restoring it",
+	},
+	{
+		file: "www/lib/waitlist.ts",
+		rule: "mail this domain cannot send",
+		line: `that said "We'll email you`,
+		reason: "the header recording the first version of the same promise, made when " +
+			"the address never left the browser at all. It has to quote the sentence " +
+			"to be worth reading",
 	},
 	{
 		file: "www/lib/docs-facts.ts",

--- a/www/components/AuthScreen.tsx
+++ b/www/components/AuthScreen.tsx
@@ -128,8 +128,8 @@ export function AuthScreen({ mode }: { mode: "signin" | "signup" }) {
               <p className="mt-4 text-[14px] leading-6 text-black/55">
                 The hosted control plane is invitation only while it is in
                 development. If your account has been invited, sign in with
-                GitHub. If it has not, leave an address below and we will tell
-                you when it opens.
+                GitHub. If it has not, joining the list puts you in front of a
+                person before the next environment opens.
               </p>
 
               <a
@@ -149,30 +149,61 @@ export function AuthScreen({ mode }: { mode: "signin" | "signup" }) {
               </div>
 
               {done ? (
+                /* A confirmation that says what happens to the address, who
+                   touches it, and what it cannot do.
+                 *
+                 * It used to say "you will hear from us", which is a promise
+                 * nothing here can keep. The address is written to a table
+                 * with no read path, so it is reachable only by somebody
+                 * querying the store by hand, and antifailure.dev has no mail
+                 * exchanger and an SPF policy of `v=spf1 -all`, so the domain
+                 * authorizes no sender at all. Somebody who leaves an address
+                 * and waits is waiting for something that cannot arrive on its
+                 * own, and telling them that is cheaper than letting them find
+                 * out by not hearing anything.
+                 *
+                 * So it says the true thing and then offers the two routes
+                 * that resolve today rather than at some unnamed date: the
+                 * quickstart, which needs none of this, and a call, which is a
+                 * real calendar with real openings. */
                 <div role="status">
                   <p className="mt-6 text-[14px] leading-6 text-black/55">
                     {already ? "We already had " : "Added "}
-                    {done}. You will hear from us when there is an environment
-                    you can connect a repository to, and not before. No
-                    newsletter.
+                    {done}. It is stored with the page it came from and the
+                    times it was first and last submitted. Nothing else.
                   </p>
                   <p className="mt-4 text-[14px] leading-6 text-black/55">
-                    In the meantime the engine is open source and runs entirely
-                    on your own machine. The{" "}
+                    What happens next: a person reads the list when there is a
+                    hosted environment you could connect a repository to. There
+                    is no date for that, and nothing here will mail you on a
+                    schedule. The antifailure.dev domain has no mail exchanger
+                    and its policy authorizes no outbound senders, so any first
+                    message is a person deciding to write one.
+                  </p>
+                  <p className="mt-4 text-[14px] leading-6 text-black/55">
+                    Two things resolve sooner. The{" "}
                     <a
                       className="text-black underline decoration-black/25 underline-offset-4 hover:decoration-black"
                       href="/docs/getting-started/quickstart"
                     >
                       quickstart
                     </a>{" "}
-                    goes from nothing to a working environment without an
-                    account.
+                    goes from nothing to a working environment on your own
+                    machine, without an account, today. And{" "}
+                    <a
+                      className="text-black underline decoration-black/25 underline-offset-4 hover:decoration-black"
+                      href="/contact#book"
+                    >
+                      booking a call
+                    </a>{" "}
+                    reaches a person this week rather than whenever the hosted
+                    product exists.
                   </p>
                   <a
-                    href="/docs"
+                    href="/docs/getting-started/quickstart"
                     className="mt-7 flex h-12 w-full items-center justify-center rounded-full border border-black/15 bg-white text-[15px] font-medium text-black hover:border-black/35"
                   >
-                    Read the documentation
+                    Start the quickstart
                   </a>
                 </div>
               ) : (
@@ -223,8 +254,9 @@ export function AuthScreen({ mode }: { mode: "signin" | "signup" }) {
                 </button>
 
                 <p className="mt-5 text-[12px] leading-5 text-black/60">
-                  We store the address and nothing else. It is used to tell you
-                  when the hosted product exists. See the{" "}
+                  We store the address, the page it came from, and when it was
+                  first and last submitted. It is read by a person, never sold,
+                  and never used for a newsletter. See the{" "}
                   <button
                     type="button"
                     className="text-black/70 underline decoration-black/20"

--- a/www/components/ContentSheet.tsx
+++ b/www/components/ContentSheet.tsx
@@ -65,7 +65,7 @@ const SHEETS: Record<
     points: [
       "A waitlist address is sent to a server and stored, so that the sentence next to the form is true. Your browser keeps a copy as a convenience, which clearing site data removes.",
       "When a control plane exists, production-derived state is processed inside the customer boundary by default.",
-      "Passwords entered in this mock form are not stored.",
+      "Nothing on this site asks for a password, and nothing mails the address back. The sign-up screen offers GitHub for an invited account and a stored list for everybody else.",
     ],
   },
   terms: {

--- a/www/components/pages/company/Contact.tsx
+++ b/www/components/pages/company/Contact.tsx
@@ -32,7 +32,7 @@ const CONTACT_DETAILS = {
     action: "Start a discussion",
   },
   waitlist: {
-    body: "There is no generally available hosted control plane. The existing waitlist is the verified route for teams that want to hear when there is a hosted environment to connect to a repository.",
+    body: "There is no generally available hosted control plane. Leaving an address stores it on a server, where a person reads it when there is a hosted environment to connect a repository to. Nothing mails you on a schedule and there is no date, so book a call above if you need an answer sooner.",
     href: "/docs/getting-started/quickstart",
     link: "Use the engine today",
     action: "Join the waitlist",
@@ -79,7 +79,7 @@ export function ContactPage() {
         path="/contact"
         eyebrow="Contact"
         title="Use the route that matches the question."
-        lead="Antifailure uses GitHub for private vulnerability reports, public product work, and community discussion. A call can be booked on this page, and hosted-product interest goes through the existing waitlist. The project does not currently publish a working email channel."
+        lead="Antifailure uses GitHub for private vulnerability reports, public product work, and community discussion. A call can be booked on this page, and it is the only route here that reaches a person on a known day. Hosted-product interest goes on a stored list instead, because the project does not publish a working email channel in either direction."
         actions={
           <>
             <Button href="#book" theme="filled">

--- a/www/components/pages/company/Legal.tsx
+++ b/www/components/pages/company/Legal.tsx
@@ -141,7 +141,7 @@ export function PrivacyPage() {
               ],
               [
                 "This site",
-                "One waitlist address per person, stored on a server so that the sentence next to the form is true, with the time it was first and last submitted. There is no way to read the list back through the site.",
+                "One waitlist address per person, stored on a server so that the sentence next to the form is true, with the page it was submitted from and the times it was first and last submitted. There is no way to read the list back through the site, and nothing sends mail to it.",
               ],
             ]}
           />

--- a/www/lib/routes.ts
+++ b/www/lib/routes.ts
@@ -385,7 +385,7 @@ export const ROUTES: readonly Route[] = [
     path: "/signup",
     title: pageTitle("Request access"),
     description:
-      "The hosted control plane is invitation only while it is in development. Sign in with GitHub if you have been invited, or leave an address and we will tell you when it opens. The engine is open source and runs on your own machine today.",
+      "The hosted control plane is invitation only while it is in development. Sign in with GitHub if you have been invited, or leave an address for the list a person reads before the next environment opens. The engine is open source and runs on your own machine today.",
     summary: "Ask for access to the hosted control plane. The engine needs none of it.",
     section: "utility",
     indexable: false,


### PR DESCRIPTION
## What was false

The sign-up screen said "you will hear from us when there is an environment you can connect a repository to", and the route metadata said "leave an address and we will tell you when it opens". Neither could happen.

- `api/waitlist/index.js` writes one row through `api/shared/waitlist.js` and sends nothing. There is no mailer on that path and no queue behind it.
- The table has no read path by design, so a lead is reachable only by somebody querying Azure by hand.
- The domain cannot send. `dig MX antifailure.dev` returns nothing and its only SPF record is `v=spf1 -all`, which authorizes no sender at all. I checked both rather than taking the contact page's word for it.

So somebody who left an address and waited was waiting for a message with no route to them, and the only signal they would ever get was silence.

## What it says now

The confirmation names what is stored, who touches it, what will not happen, and what resolves sooner:

- the address, the page it came from, and the times it was first and last submitted, and nothing else
- a person reads the list when there is a hosted environment to connect a repository to, there is no date for that, and nothing mails anybody on a schedule, with the reason given plainly
- two routes that resolve sooner: the quickstart, which needs no account and works today, and booking a call, which is a real calendar with real openings

The same correction is on `/contact` and in `www/lib/routes.ts`, which carried the promise into every tab title, link preview and crawler result for `/signup` while the visible page was being fixed around it.

## Two other claims that had drifted

- The privacy sheet said "Passwords entered in this mock form are not stored." The form has had no password field since the fake one was removed. `grep` for a password input across `www` finds nothing but the comment recording its removal.
- The legal pages listed what a waitlist row holds and omitted the page it was submitted from, which is stored.

## Checked

Rendered pixels in both states, because the confirmation only appears after a successful post or a remembered address.

- `/signup` at 1440 and 390, in the form state and in the confirmation state, reached by seeding the local storage key the client writes
- `classcheck`, `motioncheck` (no `animate-pulse` or `animate-ping` in the diff), `prosecheck`, `npm run check:seo` 88/88, `www` build, and `legal-facts.test.ts` 23/23 since this moves text that gate reads

## For Vir, not for me

Mail is a production decision and I changed no DNS. If the waitlist should ever notify anybody, the domain needs a sending identity, which is one SPF change plus DKIM at whatever provider is chosen. Until then the honest page is the one that says so.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR