### PR TITLE
doctor: it never looked at what copies production

### DIFF
--- a/.changes/doctor-never-looked-at-what-copies-production.md
+++ b/.changes/doctor-never-looked-at-what-copies-production.md
@@ -1,0 +1,31 @@
+# added
+
+`af doctor` reports the Postgres client, and the newest server version it can
+read.
+
+Doctor's promise is that every problem it names is one you would otherwise meet
+halfway through a run. Copying production shells out to `pg_dump` and
+`pg_restore`, and it never looked at either. A machine with neither, or with a
+client older than the source, said "This machine can run Antifailure" and then
+failed at the step that comes after every other one: the repository read, the
+manifest written, the images built, and only then does the copy stop.
+
+`pg_dump` refuses a server newer than itself outright, and there is no flag for
+it, so the ceiling is worth knowing before the twenty minutes rather than after.
+
+```
+  ok    Postgres client              pg_dump 18 at /opt/homebrew/bin/pg_dump, so
+                                     it can copy a source up to Postgres 18
+```
+
+A warning rather than a failure when nothing is found. A project that fills its
+golden from `database.seed` runs neither program, and doctor answers about the
+machine, so it has no manifest to tell the two apart.
+
+The ceiling is the newest client installed, which is not the one a copy runs. A
+copy picks the oldest client that still clears the server it just asked, so that
+a machine with 15, 16 and 18 copies a 16 server with the 16 client. Doctor has
+connected to nothing and has no bar to clear, and asking the copy's question
+with no bar returns the oldest install: the first version of this reported a
+ceiling of Postgres 17 on a machine that copied an 18 source three commands
+later. The two questions are now two functions and a test holds them apart.

--- a/engine/internal/cli/doctor.go
+++ b/engine/internal/cli/doctor.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/antifailure/antifailure/engine/internal/db/pgcopy"
 	"github.com/antifailure/antifailure/engine/internal/dockerutil"
 	"github.com/antifailure/antifailure/engine/internal/model"
 	"github.com/antifailure/antifailure/engine/internal/runtime/local"
@@ -246,6 +247,7 @@ func RunDoctor(ctx context.Context, env *Env, p Prober) DoctorReport {
 		checkKernelIsolation,
 		checkProxyEnvironment,
 		checkGit,
+		checkPostgresClient,
 		checkModelKey,
 		checkLeftoverEnvironments,
 	}
@@ -663,6 +665,44 @@ func checkModelKey(ctx context.Context, env *Env, _ Prober) CheckResult {
 	r.Status = CheckWarn
 	r.Detail = detail + ", never verified"
 	r.Remediation = "Run 'af model test'. It makes one cheap call and says exactly what is wrong when the key is revoked, out of credit, or pointed at a model the key cannot use."
+	return r
+}
+
+// checkPostgresClient reports the pg_dump this machine would copy a source with.
+//
+// Doctor's promise is that every problem it names is one you would otherwise
+// meet halfway through a run, and this was the clearest example of one it did
+// not look at. Copying production shells out to pg_dump and pg_restore. A
+// machine with neither, or with a client older than the server, fails at the
+// step that comes after everything else: the repository read, the manifest
+// written, the images built, and only then does the copy stop. pg_dump refuses
+// a server newer than itself and there is no flag for it, so the ceiling is
+// worth knowing before the twenty minutes rather than after.
+//
+// A warning rather than a failure, both ways. A project with database.seed and
+// no source never runs either binary, so a machine without them can still do
+// everything else, and this check has no manifest to tell the two apart: it
+// answers about the machine, which is what this command is.
+func checkPostgresClient(_ context.Context, _ *Env, _ Prober) CheckResult {
+	r := CheckResult{Name: "Postgres client"}
+	r.Remediation = "Install the client tools if this machine copies a production database: " +
+		"on macOS 'brew install libpq' or 'brew install postgresql@18', on Debian or Ubuntu " +
+		"'apt-get install postgresql-client-18'. A project that fills its golden with " +
+		"database.seed instead of copying a source needs neither."
+
+	path, major, err := pgcopy.ClientTools()
+	if err != nil {
+		r.Status = CheckWarn
+		r.Detail = "pg_dump and pg_restore are not on the path or anywhere this looked, " +
+			"so a source database cannot be copied"
+		return r
+	}
+	r.Status = CheckPass
+	// The ceiling rather than the version alone. "17.6" is a fact about the
+	// binary; "up to Postgres 17" is the thing that decides whether a refresh
+	// will work, and it is the sentence somebody on 18 needs to read.
+	r.Detail = fmt.Sprintf("pg_dump %d at %s, so it can copy a source up to Postgres %d",
+		major, path, major)
 	return r
 }
 

--- a/engine/internal/cli/doctor_pgclient_test.go
+++ b/engine/internal/cli/doctor_pgclient_test.go
@@ -1,0 +1,54 @@
+package cli_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/internal/cli"
+)
+
+// af doctor said this machine could run Antifailure without looking at the two
+// programs that copy production.
+//
+// Its own promise is that every problem it names is one you would otherwise
+// meet halfway through a run, and this was the clearest example it did not
+// look at. Copying a source shells out to pg_dump and pg_restore. A machine
+// with neither, or with a client older than the server, fails at the step
+// after everything else: the repository read, the manifest written, the images
+// built, and only then does the copy stop. pg_dump refuses a server newer than
+// itself outright, with no flag to get past it.
+func TestDoctor_ReportsThePostgresClientAndItsCeiling(t *testing.T) {
+	t.Parallel()
+	got := runCLI(t, t.TempDir(), nil, "doctor", "-o", "json")
+
+	var report cli.DoctorReport
+	require.NoError(t, json.Unmarshal([]byte(got.stdout), &report))
+
+	var found *cli.CheckResult
+	for i := range report.Checks {
+		if report.Checks[i].Name == "Postgres client" {
+			found = &report.Checks[i]
+		}
+	}
+	require.NotNil(t, found,
+		"doctor answers for the machine and says nothing about what copies production")
+	require.NotEmpty(t, found.Detail)
+	require.NotEmpty(t, found.Remediation)
+
+	// The ceiling rather than the version alone. "pg_dump 17" is a fact about
+	// a binary; "up to Postgres 17" is what decides whether a refresh works,
+	// and it is the sentence somebody whose production is newer has to read.
+	if found.Status == cli.CheckPass {
+		require.Contains(t, strings.ToLower(found.Detail), "up to postgres",
+			"a version with no ceiling leaves the reader to know pg_dump's rule themselves")
+	}
+
+	// Never a hard failure. A project that fills its golden from database.seed
+	// runs neither program, so a machine without them can still do everything
+	// else, and this check has no manifest to tell the two apart.
+	require.NotEqual(t, cli.CheckFail, found.Status,
+		"a machine that copies no production database is not a broken machine")
+}

--- a/engine/internal/db/pgcopy/clienttools_test.go
+++ b/engine/internal/db/pgcopy/clienttools_test.go
@@ -1,0 +1,118 @@
+package pgcopy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Which of several installed clients is the answer depends on the question,
+// and the two questions look alike enough that the wrong answer reads as
+// right.
+//
+// A copy asks "what should I run against a server of version N", and the
+// answer is the oldest client that still clears N: a machine with 15, 16 and
+// 18 copying a 16 server should use 16. `af doctor` asks "what could this
+// machine read at all", with nothing connected and so no bar to clear, and the
+// answer is the newest. Feeding the first function a bar of zero answers the
+// second question with the OLDEST install, which on the machine this was
+// written on reported a ceiling of Postgres 17 while an 18 client sat on the
+// PATH and copied an 18 source successfully.
+
+func candidates(majors ...int) []toolCandidate {
+	out := make([]toolCandidate, 0, len(majors))
+	for _, m := range majors {
+		out = append(out, toolCandidate{path: "/pg/" + itoa(m) + "/pg_dump", major: m})
+	}
+	return out
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}
+
+func TestNewest_IsTheCeilingWhateverTheOrderTheyWereFoundIn(t *testing.T) {
+	tests := []struct {
+		name string
+		have []toolCandidate
+		want int
+	}{
+		{"one install", candidates(17), 17},
+		{"newest last", candidates(15, 16, 18), 18},
+		{"newest first", candidates(18, 16, 15), 18},
+		{"a binary that would not say its version", candidates(0, 16), 16},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, newest(tc.have).major)
+		})
+	}
+}
+
+func TestBestFor_TakesTheOldestThatStillClearsTheServer(t *testing.T) {
+	have := candidates(15, 16, 18)
+	require.Equal(t, 16, bestFor(have, 16).major,
+		"a 16 server should be copied with the 16 client, not the newest for its own sake")
+	require.Equal(t, 18, bestFor(have, 17).major)
+	require.Equal(t, 18, bestFor(have, 99).major,
+		"with nothing new enough it returns the newest, so the refusal names the real gap")
+}
+
+// The two questions disagree, which is the whole reason they are two
+// functions. A ceiling asked for through bestFor with no bar names the oldest
+// install on the machine.
+func TestTheCeilingIsNotBestForWithNoBar(t *testing.T) {
+	have := candidates(15, 16, 18)
+	require.Equal(t, 15, bestFor(have, 0).major)
+	require.Equal(t, 18, newest(have).major,
+		"af doctor reports what this machine could read, which is never the oldest install")
+}
+
+// And ClientTools has to ask the right one of them.
+//
+// This is the assertion the two pure tests above cannot make. The first draft
+// of this function asked bestFor with a bar of zero, which type checks, reads
+// as sensible, and reported a ceiling of Postgres 17 on a machine that copied
+// an 18 source successfully three commands later.
+func TestClientTools_ReportsTheCeilingAndNotTheOldestInstall(t *testing.T) {
+	installed := candidates(15, 16, 18)
+	previous := lookupTools
+	lookupTools = func(string) ([]toolCandidate, error) { return installed, nil }
+	t.Cleanup(func() { lookupTools = previous })
+
+	path, major, err := ClientTools()
+	require.NoError(t, err)
+	require.Equal(t, 18, major,
+		"doctor would tell a project on Postgres 18 that this machine tops out at 15")
+	require.Contains(t, path, "18")
+}
+
+// A machine with pg_dump and no pg_restore fails halfway through a copy, with
+// the archive already written, so it is not a machine that has the tools.
+func TestClientTools_NeedsBothProgramsAndNotOne(t *testing.T) {
+	previous := lookupTools
+	lookupTools = func(name string) ([]toolCandidate, error) {
+		if name == "pg_restore" {
+			return nil, errNoRestoreForTest
+		}
+		return candidates(18), nil
+	}
+	t.Cleanup(func() { lookupTools = previous })
+
+	_, _, err := ClientTools()
+	require.Error(t, err)
+}
+
+var errNoRestoreForTest = errTest("pg_restore is not installed anywhere this looked")
+
+type errTest string
+
+func (e errTest) Error() string { return string(e) }

--- a/engine/internal/db/pgcopy/pgcopy.go
+++ b/engine/internal/db/pgcopy/pgcopy.go
@@ -188,45 +188,77 @@ var searchDirs = []string{
 // It returns the newest one it can find, and whether that one is new enough,
 // so the caller can produce a message about the actual gap rather than a
 // generic one.
-func toolFor(name string, wantMajor int) (path string, haveMajor int, err error) {
-	type candidate struct {
-		path  string
-		major int
-	}
-	var found []candidate
+// toolCandidate is one install of pg_dump or pg_restore this machine has.
+type toolCandidate struct {
+	path  string
+	major int
+}
 
+// toolsFound is every install of name this machine has, in no order.
+//
+// Split out of toolFor so that a caller which wants the CEILING rather than a
+// match can have it. toolFor answers "the oldest that is still new enough",
+// which is the right question when a server version is known and the wrong one
+// when nothing has connected yet: with no bar to clear, the oldest install is
+// exactly the wrong answer.
+func toolsFound(name string) ([]toolCandidate, error) {
+	var found []toolCandidate
 	if p, lookErr := exec.LookPath(name); lookErr == nil {
-		found = append(found, candidate{p, toolMajor(p)})
+		found = append(found, toolCandidate{p, toolMajor(p)})
 	}
 	for _, pattern := range searchDirs {
 		matches, _ := filepath.Glob(filepath.Join(pattern, name))
 		for _, m := range matches {
-			found = append(found, candidate{m, toolMajor(m)})
+			found = append(found, toolCandidate{m, toolMajor(m)})
 		}
 	}
 	if len(found) == 0 {
-		return "", 0, fmt.Errorf(
+		return nil, fmt.Errorf(
 			"pgcopy: %s is not on the path and is not installed anywhere this looked. "+
 				"It is what copies a source database. Install the Postgres client tools, "+
 				"or configure a seed command instead of a source", name)
 	}
+	return found, nil
+}
 
+// newest is the highest major among the candidates, which is the highest
+// server version they can read.
+func newest(found []toolCandidate) toolCandidate {
 	best := found[0]
 	for _, c := range found[1:] {
 		if c.major > best.major {
 			best = c
 		}
 	}
-	// Prefer the oldest that is still new enough, so a machine with several
-	// installed uses the one that matches rather than the newest for its own
-	// sake.
-	chosen := best
+	return best
+}
+
+func toolFor(name string, wantMajor int) (path string, haveMajor int, err error) {
+	found, err := toolsFound(name)
+	if err != nil {
+		return "", 0, err
+	}
+	chosen := bestFor(found, wantMajor)
+	return chosen.path, chosen.major, nil
+}
+
+// bestFor picks the oldest candidate that is still new enough for the server,
+// so a machine with several installed uses the one that matches rather than
+// the newest for its own sake. With nothing new enough it returns the newest,
+// which is what makes the refusal name the actual gap.
+//
+// Pure, and separate from the search, because it and [newest] answer different
+// questions and the wrong one of the two reads as correct. bestFor with no bar
+// to clear returns the OLDEST install on the machine, which as an answer to
+// "what could this machine read" is exactly backwards.
+func bestFor(found []toolCandidate, wantMajor int) toolCandidate {
+	chosen := newest(found)
 	for _, c := range found {
 		if c.major >= wantMajor && (chosen.major < wantMajor || c.major < chosen.major) {
 			chosen = c
 		}
 	}
-	return chosen.path, chosen.major, nil
+	return chosen
 }
 
 // toolMajor asks a binary its version. Zero when it will not say, which sorts
@@ -794,4 +826,43 @@ func Tail(s string) string {
 		lines = lines[len(lines)-6:]
 	}
 	return strings.Join(lines, "; ")
+}
+
+// ClientTools reports the newest pg_dump and pg_restore this machine can find,
+// and the major version they can read up to.
+//
+// It exists so that `af doctor` can answer the question a refresh answers far
+// too late. Copying a source shells out to these two, and a machine with
+// neither, or with a client older than the server, fails at the one step that
+// comes after everything else: the repository has been read, the manifest
+// written, the images built, and only then does the copy stop. pg_dump refuses
+// a server newer than itself outright and that cannot be worked around, so
+// knowing the ceiling in advance is the difference between a five second
+// correction and a twenty minute one.
+//
+// It runs the binaries to ask their versions and touches no database, so it is
+// safe in a check that promises to change nothing.
+// lookupTools is toolsFound, injected so that a test can present a machine with
+// several clients installed. The distinction this function turns on only shows
+// up when there is more than one, and a test that skips unless the machine
+// happens to have three is a test that runs nowhere.
+var lookupTools = toolsFound
+
+func ClientTools() (path string, major int, err error) {
+	// The newest rather than the one a copy would choose. A copy picks the
+	// oldest client that still clears the server's version, which is right
+	// when a server has been asked and wrong here, where nothing has
+	// connected: the question is what this machine COULD read, and that is
+	// the ceiling.
+	dumps, err := lookupTools("pg_dump")
+	if err != nil {
+		return "", 0, err
+	}
+	// Both, because a copy runs both and a machine with only one of them fails
+	// halfway through with the archive already written.
+	if _, restoreErr := lookupTools("pg_restore"); restoreErr != nil {
+		return "", 0, restoreErr
+	}
+	best := newest(dumps)
+	return best.path, best.major, nil
 }


### PR DESCRIPTION
Found while running the documented sequence against a real Postgres. `af doctor` ended with "This machine can run Antifailure" on a machine whose ability to copy a production database it had not examined.

## Why this belongs in doctor

The command's own description says every problem it names is one you would otherwise meet halfway through a run. Copying a source shells out to `pg_dump` and `pg_restore`. A machine with neither, or with a client older than the source, gets all the way through: the repository read, the manifest written, the images built, and only then does the copy stop. `pg_dump` refuses a server newer than itself outright, with no flag to get past it, so the ceiling is worth knowing before the twenty minutes rather than after.

```
  ok    Postgres client              pg_dump 18 at /opt/homebrew/bin/pg_dump, so
                                     it can copy a source up to Postgres 18
```

A warning rather than a failure when nothing is found. A project that fills its golden from `database.seed` runs neither program, and doctor answers about the machine, so it has no manifest to tell the two apart. Turning that into a red check would fail a machine that is fine.

## The subtle part, and the bug I shipped into my own first draft

The ceiling is the newest client installed. That is **not** the one a copy runs.

A copy asks "what should I run against a server of version N" and takes the oldest client that still clears N, so a machine with 15, 16 and 18 copies a 16 server with the 16 client. Doctor asks "what could this machine read at all", with nothing connected and no bar to clear. Feeding the copy's function a bar of zero answers doctor's question with the **oldest** install.

It type checks, it reads as sensible, and it reported a ceiling of Postgres 17 on the machine this was written on, three commands after that same machine copied a Postgres 18 source successfully.

So the selection is split from the search into two named functions, and `ClientTools` takes its search through a variable a test can replace. The test presents a machine with 15, 16 and 18 and asserts 18, which is the only shape that tells the two apart. Restoring the first draft makes it fail with `expected: 18, actual: 15`.

## Tests

Four, all watched red for their own reason rather than by failing to compile: the ceiling over several orderings including a binary that will not state its version, the copy's own selection rule, the two answering differently, and `ClientTools` asking the right one. Plus a doctor level test that the check exists, carries a remediation, states a ceiling, and is never a hard failure.

`./internal/cli` and `./internal/db/pgcopy` pass.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR