### PR TITLE
console: light only is a decision, and now it says so where it is noticed

### DIFF
--- a/console/app/globals.css
+++ b/console/app/globals.css
@@ -6,6 +6,17 @@
  * like a different company. What is deliberately NOT shared is the density:
  * a landing page is read once and a console is read every day, so the type is
  * smaller, the rows are tighter, and nothing is centred.
+ *
+ * LIGHT ONLY, AND THAT IS A DECISION RATHER THAN AN UNFINISHED THEME. There is
+ * no dark palette here, no `prefers-color-scheme` rule and no `dark:` class,
+ * and the same is true of every file in www. The decision is written down in
+ * docs/astro.config.mjs, next to the theme toggle it disables: one theme, not a
+ * light and dark pair, because the site commits to a single light appearance.
+ *
+ * This note exists because the absence looks exactly like an oversight from a
+ * dark viewport, and somebody notices roughly once per person. Before changing
+ * it, read that config and change the decision there first, because a dark
+ * console beside a light site is the one thing the paragraph above rules out.
  */
 @theme {
   --color-ink: #101010;


### PR DESCRIPTION
## What changed

One comment at the top of the console's stylesheet, saying that the missing dark theme is a kept decision and where the decision lives.

The console has no dark palette, no `prefers-color-scheme` rule and no `dark:` class, and neither does any file in `www`. That is deliberate. `docs/astro.config.mjs` says it beside the theme toggle it disables: one theme, not a light and dark pair, because the site commits to a single light appearance. The stylesheet already explains that it shares the marketing palette so a person signing in does not arrive somewhere that looks like a different company, which is the same decision seen from the other end.

What was missing is the pointer at the place somebody meets the absence. From a dark system the console renders light and reads as unfinished. Establishing otherwise costs a full re-derivation: grep `www` for `dark:` and `prefers-color-scheme`, count the palette tokens, count the raw colour literals, then find the astro config. I did that today and the answer was that there is nothing wrong. The next person should stop at the comment instead.

The note also records the scope if it is ever revisited, because the cheap-looking part is not the expensive part. The console is token driven, so the palette is about eleven tokens, but 66 raw colour literals across 19 files and 20 more in the stylesheet would stay light, and the real work is authoring a dark palette rather than inverting one and measuring every pair, which is what the contrast ratios recorded further down that file commit us to.

## Failure paths covered

| Failure path | Test |
| --- | --- |
| somebody reads the missing theme as an oversight and funds it | none automatable; the comment is the fix, and it names the file that holds the decision |

No code changed, so there is no test. The claim the comment makes was verified rather than assumed: zero matches for `prefers-color-scheme` and `dark:` across every css and tsx file in `www`, and the decision quoted from `docs/astro.config.mjs`.

## Security considerations

- Secrets, masked data, the proxy, the journal: none.
- New outbound connection or stored data class: none.
- What an untrusted repository or pull request can reach: unchanged. A CSS comment.
- Dependencies: none added.

## Exit criteria evidence

```
$ go run ./tools/prosecheck .
prosecheck: 552 files, 0 places where the punctuation gives it away

$ go run ./tools/changecheck .
changecheck: 1 change a user could notice, and cc68798c says why there is no fragment
```

## Checklist

- [x] Commits are signed off
- [x] A commit carries a `Changelog-None:` trailer saying why there is no fragment
- [x] Documentation is updated for anything user visible (nothing user visible changed)
- [x] Every new error code has a catalog entry (none added)
- [x] No secret, real customer record, or unredacted screenshot is included

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR