### PR TITLE
docs: the README is the only carve out statement that travels with a release

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,9 @@ four platforms, checked in CI on every pull request.
 Contributions are welcome. [CONTRIBUTING.md](CONTRIBUTING.md) covers building
 locally, running the gates and structuring commits.
 
-MIT, except `ee`, which is under the Antifailure Enterprise License. The
-boundary is proved rather than asserted: a CI job deletes `ee`, builds and
-tests the engine from what is left, and then inspects the binary it shipped for
-enterprise package paths.
+MIT, except the `ee` directory of this repository, which is under the
+Antifailure Enterprise License. Nothing under `engine` imports it and a release
+archive carries no enterprise source, so a release you download is MIT
+throughout. The boundary is proved rather than asserted: a CI job deletes `ee`,
+builds and tests the engine from what is left, and then inspects the binary it
+shipped for enterprise package paths.


### PR DESCRIPTION
Follow-on to #145, which was merged while this commit was still in flight. One paragraph in README.md.

`tools/release/build.sh:76` copies exactly `LICENSE` and `README.md` into the release archive. Once #149 makes `LICENSE` the pure MIT text, so GitHub stops reporting this repository as NOASSERTION, README.md becomes the only file in a downloaded release that says the `ee` directory is licensed separately at all.

The sentence was already there and it stays, which is what `tools/licensecheck` in #149 will require. What it gains is the half a tarball reader needs and a repository reader does not, which is what they are holding:

- No file under `engine` imports the `ee` module, and `engine/go.mod` does not require it. Checked, not assumed.
- The archive stages the binary, the runner source, `LICENSE` and `README.md`, and nothing else.

So a downloaded release is MIT throughout, and now says so.

**The badge is deliberately untouched.** It still points at `LICENSE`. `LICENSING.md` does not exist on main yet, so repointing it here would be a dead link for as long as #149 is open, and in either merge order the two files would briefly disagree. That change belongs inside #149, where the commit that creates `LICENSING.md` is the commit that points at it. Flagged to `legal` directly.

Gates run locally: `prosecheck`, `claimcheck`, `modecheck`, `constcheck`, `forbidden`, `spell`, `vale` all pass, and `lychee` reports 12 of 12 links resolving.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR