### PR TITLE
legal: the pages denied a control plane the webhook creates tenants in

### DIFF
--- a/.changes/claims-that-did-not-match-the-code.md
+++ b/.changes/claims-that-did-not-match-the-code.md
@@ -1,0 +1,31 @@
+# fixed
+
+Four published claims did not match the code, and all four were true when they
+were written.
+
+The terms page said "Sign-in is for the waitlist. There is no public production
+control plane yet", and the privacy notice said "Sign-in today is for the
+waitlist". Installing the GitHub App creates an organization: the installation
+webhook inserts one and consults no allowlist, because an installation is the
+moment a tenant begins and there is no earlier point at which to ask somebody
+to sign up. The row lands on the plan the schema gives a new one.
+
+Both pages now say what happens instead, with the limit that makes it accurate:
+nothing can be run in that organization until somebody signs in, because
+creating an environment requires an actor. So an organization can exist for an
+account nobody admitted, and it can do nothing.
+
+`legal-facts` gained three assertions keyed on the mechanism rather than on the
+sentence, so the combination that was published fails: a page denying a public
+control plane while the webhook still creates organizations. The two guards the
+corrected wording leans on are held as well, because the sentence is only true
+while creating an environment requires an actor.
+
+# fixed
+
+The CI step named "The rules classify every column" claimed `af mask plan`
+refuses a column no rule names. It does not, and never did: the command exits 0
+for an unclassified column of any type, because every refusal keys on problems
+and a column with no transform cannot become one. The step is worth running and
+the comment now says what it really catches, which is a plan that cannot be
+built or cannot be run. Corrected in both workflows that carried it.

--- a/.github/workflows/antifailure.yml
+++ b/.github/workflows/antifailure.yml
@@ -167,11 +167,26 @@ jobs:
         env:
           AF_MIGRATION_DATABASE_URL: ${{ env.AF_STAGING_DATABASE_URL }}
 
-      - name: The rules classify every column
-        # Before anything is copied. `af mask plan` refuses a column no rule
-        # names and no default can decide, so this fails on a migration that
-        # added a column nobody classified, at the point where the fix is one
-        # line in masking.yaml rather than after a golden has been published.
+      - name: The masking plan is readable and every column has an answer
+        # WHAT THIS ACTUALLY CHECKS, corrected. It used to say `af mask plan`
+        # refuses a column no rule names, and it does not: the command exits 0
+        # for an unclassified column of any type. Every refusal keys on
+        # Problems, and Runnable() is len(Problems) == 0, so a column with no
+        # transform cannot make the plan unrunnable because checkFeasible
+        # returns before assigning a Problem when the transform is empty.
+        #
+        # So this step fails on a plan that cannot be BUILT or cannot be RUN:
+        # a rule naming a transform that does not exist, a transform that would
+        # break a unique constraint, nullify on a NOT NULL column, or a schema
+        # it cannot read. Those are the ones that would leave a table half
+        # masked, and catching them here is worth the step.
+        #
+        # It does NOT fail on a column nobody classified. That column is listed
+        # under "Columns no rule covers" in the output above, with what the
+        # default did to it, and the output is where somebody has to look.
+        # Making the step refuse instead would fail the next migration that
+        # adds a text column before anybody has written a rule for it, which is
+        # a deliberate product decision nobody has taken.
         run: ./bin/af -C . mask plan
 
       - name: Refresh the golden, with the attestation required

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -149,11 +149,26 @@ jobs:
         env:
           AF_MIGRATION_DATABASE_URL: ${{ env.AF_STAGING_DATABASE_URL }}
 
-      - name: The rules classify every column
-        # Before anything is copied. `af mask plan` refuses a column no rule
-        # names and no default can decide, so this fails on a migration that
-        # added a column nobody classified, at the point where the fix is one
-        # line in masking.yaml rather than after a golden has been published.
+      - name: The masking plan is readable and every column has an answer
+        # WHAT THIS ACTUALLY CHECKS, corrected. It used to say `af mask plan`
+        # refuses a column no rule names, and it does not: the command exits 0
+        # for an unclassified column of any type. Every refusal keys on
+        # Problems, and Runnable() is len(Problems) == 0, so a column with no
+        # transform cannot make the plan unrunnable because checkFeasible
+        # returns before assigning a Problem when the transform is empty.
+        #
+        # So this step fails on a plan that cannot be BUILT or cannot be RUN:
+        # a rule naming a transform that does not exist, a transform that would
+        # break a unique constraint, nullify on a NOT NULL column, or a schema
+        # it cannot read. Those are the ones that would leave a table half
+        # masked, and catching them here is worth the step.
+        #
+        # It does NOT fail on a column nobody classified. That column is listed
+        # under "Columns no rule covers" in the output above, with what the
+        # default did to it, and the output is where somebody has to look.
+        # Making the step refuse instead would fail the next migration that
+        # adds a text column before anybody has written a rule for it, which is
+        # a deliberate product decision nobody has taken.
         run: ./bin/af -C . mask plan
 
       - name: Refresh the golden, with the attestation required

--- a/web/apps/api/test/legal-facts.test.ts
+++ b/web/apps/api/test/legal-facts.test.ts
@@ -706,3 +706,86 @@ describe('the acceptable use and developer policy pages describe real mechanisms
     )
   })
 })
+
+describe('the legal pages do not deny a control plane the webhook creates tenants in', () => {
+  /**
+   * THE CLAIM THAT WAS FALSE, and how it got there.
+   *
+   * /terms said "Sign-in is for the waitlist. There is no public production
+   * control plane yet", and /privacy said "Sign-in today is for the waitlist".
+   * Both were true when written and both stopped being true when the GitHub
+   * App started creating organizations.
+   *
+   * `rememberInstallation` in github/webhook.ts inserts into `organizations`
+   * on an installation delivery, and its own comment says why: an installation
+   * IS the moment a tenant begins. It consults no allowlist. The row lands on
+   * the plan the schema defaults to, which is a real plan with real quotas.
+   *
+   * The nuance the corrected wording carries, and the reason it is not simply
+   * "there is a public control plane": nothing can be SPENT in that
+   * organization until somebody signs in, because createEnvironment is an
+   * orgProcedure and orgProcedure runs requireActor. Sign-in is where the
+   * allowlist bites. So an organization can exist for an account nobody let
+   * in, and it can do nothing.
+   *
+   * This gate is keyed on the MECHANISM rather than on the sentence. It fails
+   * if a page denies a public control plane while the webhook still creates
+   * organizations, which is the combination that was published.
+   */
+  it('reads the webhook it is reasoning about, so an empty parse cannot pass', async () => {
+    const webhook = await read('web/apps/api/src/github/webhook.ts')
+    assert.ok(webhook.length > 500, 'github/webhook.ts did not load')
+    assert.match(
+      webhook,
+      /INSERT INTO organizations/,
+      'the webhook no longer creates organizations, so this gate is reasoning about a ' +
+        'mechanism that is gone and the pages it constrains may need rereading',
+    )
+  })
+
+  it('does not deny a control plane while an installation still creates a tenant', async () => {
+    const webhook = await read('web/apps/api/src/github/webhook.ts')
+    const createsTenants = /INSERT INTO organizations/.test(webhook)
+    if (!createsTenants) return
+
+    const pages = await read('www/components/pages/company/Legal.tsx')
+    const denials: [RegExp, string][] = [
+      [
+        /no public production control plane yet/i,
+        'installing the GitHub App creates an organization, so there is one',
+      ],
+      [
+        /[Ss]ign-in (?:today )?is for the waitlist/,
+        'signing in grants membership of an organization the App created, not a place on a list',
+      ],
+    ]
+    for (const [pattern, why] of denials) {
+      assert.ok(
+        !pattern.test(pages),
+        `a legal page denies something the code does: ${why}. rememberInstallation in ` +
+          `github/webhook.ts inserts into organizations on an installation delivery and ` +
+          `consults no allowlist.`,
+      )
+    }
+  })
+
+  it('keeps the spending guard the corrected wording relies on', async () => {
+    // The page says nothing can be run until somebody signs in. That is only
+    // true while creating an environment requires an actor, so the sentence
+    // and the middleware have to move together.
+    const dispatch = await read('web/apps/api/src/routers/dispatch.ts')
+    const trpc = await read('web/apps/api/src/trpc.ts')
+    assert.match(
+      dispatch,
+      /export const createEnvironment = orgProcedure\(/,
+      'createEnvironment is no longer an orgProcedure, so the claim on /terms that nothing ' +
+        'can be run in an organization until somebody signs in may no longer hold',
+    )
+    assert.match(
+      trpc,
+      /export function orgProcedure[\s\S]{0,200}requireActor/,
+      'orgProcedure no longer requires an actor, so an organization created by an ' +
+        'installation could act with nobody signed in, and /terms says it cannot',
+    )
+  })
+})

--- a/www/components/pages/company/Legal.tsx
+++ b/www/components/pages/company/Legal.tsx
@@ -203,7 +203,8 @@ export function PrivacyPage() {
         </CounselNotice>
         <Prose className="mt-10">
           <p>
-            Sign-in today is for the waitlist. The three documents that a security review asks for
+            Signing in creates a session record and grants membership of the organization the
+            GitHub App was installed on. The three documents that a security review asks for
             by name are now drafted rather than promised: the{" "}
             <Link href="/dpa">Data Processing Agreement</Link>, the{" "}
             <Link href="/subprocessors">subprocessor list</Link>, and the{" "}
@@ -272,7 +273,7 @@ export function TermsPage() {
               ],
               [
                 "Accounts",
-                "Sign-in is for the waitlist. There is no public production control plane yet, and these terms are not a paid-service agreement.",
+                "Installing the GitHub App creates an organization in the hosted control plane, on the plan the schema gives a new one. Nothing can be run in that organization until somebody signs in to it, and sign-in can be restricted to named accounts. Nothing here is sold and no card is taken, so these terms are not a paid-service agreement.",
               ],
               [
                 "Availability",


### PR DESCRIPTION
Four published claims did not match the code. All four were true when they were written, which is the only interesting thing about them.

## The two on the site, now live since #128 merged

`/terms` said "Sign-in is for the waitlist. There is no public production control plane yet." `/privacy` said "Sign-in today is for the waitlist."

Neither is true. `rememberInstallation` in `github/webhook.ts` inserts into `organizations` on an installation delivery and consults no allowlist. Its own comment says why: an installation **is** the moment a tenant begins, and there is no earlier point at which to ask somebody to sign up. The row lands on the plan migration `0010` defaults a new one to.

The correction carries the limit that makes it accurate rather than merely less wrong. Nothing can be **spent** in that organization until somebody signs in, because `createEnvironment` is an `orgProcedure` and `orgProcedure` runs `requireActor`. So an organization can exist for an account nobody admitted, and it can do nothing. Sign-in is where an allowlist bites.

Both halves are on the page. The first without the second reads as a bigger claim than the code supports.

**Deliberately not said:** anything about what tier is offered, what it costs, or what a free plan includes. That is a commercial decision nobody has taken, and a page describing it would be inventing the product.

## The gate

`legal-facts` gained three assertions keyed on the **mechanism** rather than on the sentence, so it fails on the combination that was actually published rather than on a phrasing: a page denying a public control plane while the webhook still creates organizations.

It also holds the two guards the corrected wording leans on, because "nothing can be run until somebody signs in" is true only while `createEnvironment` requires an actor. If either moves, whoever moved it is sent to the sentence that describes it.

All three verified by breaking the thing each describes and watching it go red.

## The two in CI

The step named "The rules classify every column", in both `dogfood.yml` and `antifailure.yml`, claimed `af mask plan` refuses a column no rule names. It does not and never did. The command exits 0 for an unclassified column of any type, because every refusal keys on `Problems` and `checkFeasible` returns before assigning one when the transform is empty.

That was a false claim sitting in the one step whose stated purpose was catching exactly this. The step is still worth running, so the comment now says what it actually catches, a plan that cannot be built or cannot be run, and says out loud that an unclassified column is listed rather than refused.

Making it refuse instead would fail the next migration that adds a text column before anybody has written a rule for it. That is a deliberate product decision and it is not taken here.

## Verification

Rendered and checked at 1440px and 390px: no horizontal overflow at either, and the corrected row reads correctly in the spec table at both widths. Site build clean, 88/88 SEO checks, `prosecheck` clean over 580 files.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR