### PR TITLE
readme: point the licence badge at the file that states the carve out

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 </p>
 
 <p align="center">
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT%20except%20ee%2F-101014" alt="MIT licensed, except the ee directory" /></a>
+  <a href="LICENSING.md"><img src="https://img.shields.io/badge/license-MIT%20except%20ee%2F-101014" alt="MIT licensed, except the ee directory" /></a>
 </p>
 
 ---


### PR DESCRIPTION
The badge reads "MIT except ee/" and linked to `LICENSE`, which as of #149 is the unmodified MIT text and says nothing about `ee`. The badge made a claim and sent the reader somewhere that does not support it. `LICENSING.md` does.

`readme` flagged this and argued the repoint belonged inside #149, because `LICENSING.md` did not exist on main and a repoint before it landed would be a dead link for as long as that branch was open. That was right. #149 has since merged, so the window is closed and this is now safe as a follow-up.

## The trade, recorded because it is not free

`tools/release/build.sh` stages `LICENSE` and `README.md`, not `LICENSING.md`, so inside a release archive this relative link resolves to nothing.

That is the right way round. In the archive nobody renders the markdown, so the link is read as plain text, and the paragraph `readme` added in #163 already tells the tarball reader what they are holding and that a downloaded release is MIT throughout. In the repository, where the badge is actually rendered and clicked, it now lands on the file that states the carve out.

Not copying `LICENSING.md` into the archive stays deliberate: the archive contains no `ee/` code, so a document about `ee/` inside it would point at a directory that is not there, which is the dangling reference #149 removed.

`licensecheck` passes, and the link target exists in the repository.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR