### PR TITLE
infra: the image pins name v1.0.0, now that v1.0.0 exists

### DIFF
--- a/.changes/the-image-pins-name-the-release-now.md
+++ b/.changes/the-image-pins-name-the-release-now.md
@@ -1,0 +1,13 @@
+# changed
+
+The control plane stack and module now default `image_tag` to `v1.0.0`.
+
+They were pinned to `v0.1.1`, deliberately, until the tag existed.
+`tools/tagsync` classifies both as `live` pins, meaning they are read by an
+apply from `main` rather than from a released tree, and
+`azurerm_container_app_job.maintenance` reads the value with no
+`ignore_changes`. So pointing them at a tag before that tag published would not
+have produced a stale deployment, it would have produced a failed apply on the
+stack that runs the product.
+
+v1.0.0 published at 17:55 UTC, so they can name it now.

--- a/infra/terraform/modules/control-plane/variables.tf
+++ b/infra/terraform/modules/control-plane/variables.tf
@@ -154,7 +154,7 @@ variable "image_repository" {
 }
 variable "image_tag" {
   type    = string
-  default = "v0.1.1"
+  default = "v1.0.0"
 }
 variable "image_digest" {
   type        = string

--- a/infra/terraform/stacks/control-plane/variables.tf
+++ b/infra/terraform/stacks/control-plane/variables.tf
@@ -89,7 +89,7 @@ variable "image_repository" {
 
 variable "image_tag" {
   type    = string
-  default = "v0.1.1"
+  default = "v1.0.0"
 }
 
 variable "image_digest" {


### PR DESCRIPTION
The control plane stack and module defaulted `image_tag` to `v0.1.1` and stayed
there through the entire release, deliberately.

`tools/tagsync` classifies both as **live** pins: read by an apply from `main`
rather than from a released tree. `azurerm_container_app_job.maintenance` reads
the value with no `ignore_changes`, so an apply takes whatever they say.
Pointing them at a tag that had not published yet would not have produced a
stale deployment, it would have produced a failed apply on the stack that runs
the product. That is why the release runbook makes this step 6, separate and
after, and why `tagsync` is a gate rather than a comment.

v1.0.0 published at 17:55 UTC on `e86f3775`, with all six assets including the
signed checksums and the signed bill of materials, neither of which any
previous release carried. `tagsync` accepts this bump now and would have
refused it an hour ago.

Verified from outside the repository rather than from the workflow's own report:

```
antifailure 1.0.0 (community edition)
  commit    e86f377501b5384ba200e19d5625851041a1ab62
  go        go1.26.8
  platform  darwin/arm64
```

The recorded commit is the tagged commit. GitHub reports v1.0.0 as latest, the
installer resolves `latest` through the API, the checksum verifies, and
`runner/package-lock.json` travels in the archive, which v0.1.1 did not.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR