### PR TITLE
docs: the release is signed now, so the README can say so

### DIFF
--- a/.changes/the-release-is-signed-and-now-says-so.md
+++ b/.changes/the-release-is-signed-and-now-says-so.md
@@ -1,0 +1,13 @@
+# added
+
+The README says that releases carry a signed bill of materials and signed
+checksums.
+
+It did not say so before, deliberately. No published release carried either
+file until v1.0.0, and the releases page disproved the claim in under a minute
+for exactly the reader it was meant to impress. The workflow steps existed and
+had never executed.
+
+v1.0.0 ran them for the first time and published both. The sentence is
+checkable now, and it names the two filenames so a reader can settle it from
+the release page rather than taking it on trust.

--- a/README.md
+++ b/README.md
@@ -232,6 +232,13 @@ Builds are reproducible, and that is a gate rather than an aspiration: two
 builds in two directories with two caches produce identical archives on all
 four platforms, checked in CI on every pull request.
 
+Every release from v1.0.0 carries `checksums.txt.sigstore.json` and
+`sbom.spdx.json`: the checksums and a bill of materials read out of the built
+binaries, each signed with cosign keyless so there is no public key to fetch.
+The verification commands are on the release page. Neither is a claim you have
+to take on trust, because a release that ran them carries both files and
+v0.1.0 and v0.1.1 carry neither.
+
 Contributions are welcome. [CONTRIBUTING.md](CONTRIBUTING.md) covers building
 locally, running the gates and structuring commits.
 


### PR DESCRIPTION
The README deliberately carried no claim about cosign signing or an SPDX bill
of materials. The agent who wrote it left the line out on the grounds that no
published release carried either file, so the releases page disproved the claim
in under a minute for exactly the reader it was written for. The workflow steps
existed and had never executed.

v1.0.0 published at 17:55 UTC and ran both for the first time. Confirmed from
the release itself rather than from the workflow's own report:

```
checksums.txt
checksums.txt.sigstore.json
sbom.spdx.json
sbom.spdx.json.sigstore.json
antifailure_1.0.0_{darwin,linux}_{amd64,arm64}.tar.gz
```

So the sentence is checkable now. It names both filenames and states that
v0.1.0 and v0.1.1 carry neither, so a reader settles it from the release page
rather than trusting us.

`prosecheck` clean over 583 files, `claimcheck` clean at 0 contradicted.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR