### PR TITLE
cd: a deploy reaped a concurrent deploy's live revision

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -48,6 +48,13 @@ on:
 # cancelled deploy is a half-applied one. It can be cancelled after the
 # migration and before the traffic shift, which leaves the schema ahead of the
 # running code with nothing left to finish the job.
+#
+# THE GROUP IS KEYED ON THE REF, AND A REF IS NOT A DEPLOYMENT TARGET. Two runs
+# on different refs are in different groups and both deploy to the same app. On
+# 2026-09-02 the v1.0.0 tag and the merge that produced the tagged commit were
+# in flight together and both deployed staging. The per-environment guard that
+# actually serializes a deploy is on the staging and production jobs below;
+# this group keeps a single ref's runs in order.
 concurrency:
   group: cd-${{ github.ref }}
   cancel-in-progress: false
@@ -218,6 +225,26 @@ jobs:
     needs: build
     timeout-minutes: 30
     if: github.event_name != 'workflow_dispatch' || inputs.environment == 'staging'
+    # ONE DEPLOY AT A TIME TO THIS APP, WHATEVER REF ASKED FOR IT.
+    #
+    # The workflow group above cannot do this: it is keyed on github.ref, so a
+    # tag run and a branch run are in different groups and deploy together. That
+    # happened. Both created a revision on afcp-app within a minute, and the
+    # first one to finish reaped the other one's live revision out from under it.
+    #
+    # Deliberately not keyed on anything: this is the name of the environment,
+    # and the point is that every run that deploys staging queues on it.
+    #
+    # cancel-in-progress: false, for the reason the workflow group gives. A
+    # cancelled deploy is a half-applied one, and this job migrates before it
+    # moves traffic. The cost of queueing rather than cancelling is that a third
+    # run arriving while one is queued replaces the queued one, so a commit can
+    # be skipped over. That is the right trade for staging: the run that does
+    # deploy carries the skipped commit as an ancestor, and gate has already
+    # refused anything CI did not pass.
+    concurrency:
+      group: cd-deploy-staging
+      cancel-in-progress: false
     environment:
       name: staging
       url: https://app.dev.antifailure.dev
@@ -306,6 +333,12 @@ jobs:
       && (needs.staging.result == 'success' || needs.staging.result == 'skipped')
       && (startsWith(github.ref, 'refs/tags/v')
       || (github.event_name == 'workflow_dispatch' && inputs.environment == 'production'))
+    # The same guard as staging, on its own environment. Production deploys are
+    # rare enough that this has never collided, which is not a reason to leave
+    # the one place it would matter most without it.
+    concurrency:
+      group: cd-deploy-production
+      cancel-in-progress: false
     environment:
       name: production
       url: https://app.antifailure.dev

--- a/deploy/cd/deploy.sh
+++ b/deploy/cd/deploy.sh
@@ -71,15 +71,51 @@ TOOL_CONNECTIONS=4
 # image is still in the registry and the schema has moved on.
 # ---------------------------------------------------------------------------
 reap_superseded() {
-  local keep_new="$1" keep_previous="$2" reaped=0 revision
+  local keep_new="$1" keep_previous="$2" reaped=0 revision created born
 
-  say "reaping revisions superseded by $keep_new (keeping $keep_previous to roll back onto)"
+  # WHEN THIS DEPLOY'S REVISION WAS BORN, and why a name list is not enough.
+  #
+  # "Superseded" means older than the revision this deploy just made. It does
+  # NOT mean "everything except the two names I am holding", which is what this
+  # loop used to mean, and the difference is a revision belonging to somebody
+  # else's deploy that is running at the same time as this one.
+  #
+  # That is not hypothetical. On 2026-09-02 the v1.0.0 tag and the merge to main
+  # named the same commit, and cd.yml's concurrency group is keyed on the ref,
+  # so the tag run and the branch run deployed to this app together. The branch
+  # run finished first and reaped, at 17:55:03, a revision created at 17:54:32
+  # by the tag run: a container that had pulled its image, started, and printed
+  # "control plane listening on :8080" three seconds earlier. Its own log ends
+  # "SIGTERM: draining". The tag run then spent ninety seconds asking a dead
+  # address, was told "This Container App is stopped or does not exist", and
+  # reported the release as a boot failure. Nothing had failed to boot.
+  #
+  # So the age is read and compared. A revision created at or after ours belongs
+  # to a deploy we did not supersede and is left alone, whoever started it.
+  born="$(az containerapp revision show -n "$APP" -g "$RG" --revision "$keep_new" \
+    --query "properties.createdTime" -o tsv 2>/dev/null || true)"
+  if [ -z "$born" ] || [ "$born" = "None" ]; then
+    # Said out loud rather than reaping blind. Without our own timestamp there
+    # is no way to tell a superseded revision from a concurrent one, and
+    # deactivating the wrong one kills a deploy somebody is watching.
+    say "could not read when $keep_new was created: nothing is reaped, and the connection budget below is what decides whether that is safe"
+    return 0
+  fi
+
+  say "reaping revisions superseded by $keep_new (created $born, keeping $keep_previous to roll back onto)"
   # --query on the server rather than a client-side filter, so a listing that
   # grows to the hundred revisions Container Apps retains is still one page.
-  for revision in $(az containerapp revision list -n "$APP" -g "$RG" \
-    --query "[?properties.active].name" -o tsv 2>/dev/null || true); do
+  # Name and creation time together, because the decision needs both.
+  while read -r revision created; do
+    [ -z "$revision" ] && continue
     [ "$revision" = "$keep_new" ] && continue
     [ "$revision" = "$keep_previous" ] && continue
+    # Lexicographic on the ISO 8601 the API returns, which sorts correctly
+    # because every value carries the same offset and the same field widths.
+    if [ -z "$created" ] || [[ ! "$created" < "$born" ]]; then
+      echo "leaving $revision alone: created ${created:-unknown}, not older than $keep_new"
+      continue
+    fi
     # Deliberately tolerant. A revision that cannot be deactivated is a
     # connection this deploy did not reclaim, not a reason to fail a release
     # that is already serving; assert_connection_budget below is what decides
@@ -89,7 +125,8 @@ reap_superseded() {
     else
       echo "could not deactivate $revision; it is still holding its connections"
     fi
-  done
+  done < <(az containerapp revision list -n "$APP" -g "$RG" \
+    --query "[?properties.active].[name, properties.createdTime]" -o tsv 2>/dev/null || true)
   say "deactivated $reaped superseded revision(s)"
 }
 
@@ -261,6 +298,25 @@ for _ in $(seq 1 60); do
   esac
   sleep 5
 done
+
+# The budget running out is a verdict too, and this loop used to have no way to
+# say so. It breaks on Running and exits on Failed or Degraded, and every other
+# state fell out of the bottom silently after five minutes: Activating, Unknown,
+# Deactivating, or a revision that somebody else stopped while we waited. The
+# script then smoke tested an address with nothing behind it and reported a
+# health gate failure, which reads as "the build is broken" and is a different
+# claim from "the platform never gave us a running revision".
+#
+# The migration loop above already asserts after its own budget for exactly this
+# reason. This is the same assertion in the same shape.
+if [ "${STATE:-}" != "Running" ]; then
+  say "NEW REVISION NEVER REACHED Running (last state: ${STATE:-unknown}). Traffic never moved; $PREVIOUS is still serving."
+  echo "This is the platform's answer about the revision, not the application's"
+  echo "answer about itself. Read the revision in the portal and its container"
+  echo "logs before assuming the image is at fault."
+  az containerapp revision deactivate -n "$APP" -g "$RG" --revision "$NEW" -o none 2>/dev/null || true
+  exit 1
+fi
 
 REV_FQDN="$(az containerapp revision show -n "$APP" -g "$RG" --revision "$NEW" \
   --query "properties.fqdn" -o tsv 2>/dev/null || true)"


### PR DESCRIPTION
## What happened

The v1.0.0 staging deploy (run 33663744213) was recorded as a boot failure and production was skipped behind it. Nothing failed to boot.

The revision the tag run created, `afcp-app--ce86f3775-175432`, logged its whole startup sequence and `control plane listening on :8080` at 17:55:00. Its next and last line is `SIGTERM: draining` at 17:55:05. The platform event for it is `ContainerTerminated ... reason 'ManuallyStopped'` at 17:55:04.

Two cd runs deployed staging at the same time. The v1.0.0 tag names the same commit as the merge to main, and the workflow concurrency group is keyed on `github.ref`, so `refs/tags/v1.0.0` and `refs/heads/main` were in different groups. The branch run (33661389550) created its revision at 17:53:46, promoted at 17:55:00, and then reaped, logging `deactivated 2 superseded revision(s)` at 17:55:03. The tag run's revision, created at 17:54:41, was neither the reaper's new revision nor its previous one, so it was deactivated 5 seconds after it began serving.

The tag run then asked a dead per revision address for ninety seconds, was answered `This Container App is stopped or does not exist`, and reported the deploy as unhealthy. Its own attempt to deactivate the revision returned `RevisionAlreadyInRequestedState`, which is the tell that somebody else had already done it.

Both recorded suspects were wrong, and the evidence refutes them rather than merely not supporting them. The tag run's own bootstrap execution logged `schema is up to date` at 17:54:25, so migrations 0001 to 0030 were already applied. The revision logged `plans are not set by hand: billing.set is refused (AF_OPERATOR_SETS_PLAN is not set)`, and that variable is not among the app's configured names.

## The changes, in the order each would have prevented it

**`reap_superseded` reads its own revision's creation time.** Anything created at or after it is left alone. Superseded means older than the revision this deploy made, not everything except the two names this deploy happens to be holding. This is the one that would have made the release green, and it defends against any concurrent actor, including a person in the portal, rather than only against a second workflow run.

**The staging and production jobs take a concurrency group named for the environment.** One deploy at a time reaches an app, whatever ref asked for it. The workflow group cannot express this because a ref is not a deployment target. `cancel-in-progress: false`, for the reason the workflow group already gives: this job migrates before it moves traffic, so a cancelled deploy is a half applied one. The cost is stated in the comment. A third run arriving while one is queued replaces the queued one, so a commit can be skipped over, and the run that does deploy carries it as an ancestor.

**The wait for the new revision to report Running now asserts after its budget.** It broke on Running and exited on Failed or Degraded, and every other state fell out of the bottom in silence after five minutes. That is how a revision somebody else stopped became a health gate failure that reads like a broken build. The migration loop directly above it has had that assertion all along.

## How this was checked

The reap loop was run against a table of five revisions covering older, previous, new, concurrent and same timestamp, and it reaps only the strictly older one. `bash -n` passes on the script. Against the real timestamps from the incident the branch run would have left the tag run's revision alone.

Not exercised end to end: this path only runs on a push to main, so the first real proof is the next deploy after this merges.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR