### PR TITLE
ci: test the control plane on the Node it ships on

### DIFF
--- a/.changes/a-control-plane-image-on-a-newer-node.md
+++ b/.changes/a-control-plane-image-on-a-newer-node.md
@@ -11,8 +11,13 @@ most people copy. The Next.js example builds on node:26-alpine, the Go example
 on golang:1.27-alpine over alpine:3.24, and the Django example on
 python:3.14-slim.
 
-One thing changes inside the two examples that run a migration, and it is worth
-saying because their comments used to name the old numbers. Alpine 3.24 carries
-psql 18 under the unversioned postgresql-client package, where 3.20 carried
-psql 16. A client newer than the server is the direction libpq supports, so the
-migration those examples run behaves as it did.
+One of the two examples that run a migration changes the psql it runs, and it
+is worth saying because both of their comments used to name the old numbers.
+The Go example's runtime moves from Alpine 3.20 to 3.24, which carries psql 18
+under the unversioned postgresql-client package where 3.20 carried psql 16. A
+client newer than the server is the direction libpq supports, so that migration
+behaves as it did.
+
+The Next.js example does not move. Its old base, node:22-alpine, is itself
+built on Alpine 3.24 and was already giving it psql 18, so only the comment
+there was out of date.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,6 +502,20 @@ jobs:
         run: npm run build
         working-directory: docs
 
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        # Node 26 from here down, because console/ is not only checked here, it
+        # is BUILT INTO the control plane image, whose console stage is
+        # node:26-alpine. The build step below stands in for that image build,
+        # which is what its own comment says it is for, and a stand in that
+        # compiles on a different major is not standing in for anything.
+        #
+        # A second setup-node rather than raising the job's pin, because this
+        # job also tests api/, and api/ runs on Azure Static Web Apps at
+        # node:22, measured rather than inferred in tools/site/assemble.sh.
+        # Raising the pin would have widened that mismatch to fix this one.
+        with:
+          node-version: '26'
+
       - run: npm ci --no-audit --no-fund
         working-directory: console
 
@@ -651,8 +665,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        # The same Node the runtime stage of control-plane.Dockerfile uses.
+        # web/apps/api is what that image runs, so this typecheck and these
+        # tests are the only thing standing between a type error and a running
+        # server, and they have to run on the version that will run it.
         with:
-          node-version: '24'
+          node-version: '26'
           cache: npm
           cache-dependency-path: web/package-lock.json
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,7 +264,7 @@ jobs:
           # publishes anyway, green. That is the one failure this pipeline is
           # not allowed to have: a release short an asset looks finished, and
           # nobody goes looking for a file they were never told was missing.
-          # Read out of the action's own src/main.ts at the pinned commit, where
+          # Read out of the action's own src/run.ts at the pinned commit, where
           # an unmatched pattern is a console.warn unless this is set.
           fail_on_unmatched_files: true
           # Deliberately off. The generated notes are the merged pull request

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,10 +106,13 @@ manifest or pipeline does.
   `deploy/docker/control-plane.Dockerfile` move together, the dependency
   install, the console build and the runtime, so an operator pulling the new
   tag gets one runtime rather than a mixture of two. The three examples move
-  with it, because an example is the first Dockerfile most people copy. Alpine
-  3.24 carries psql 18 under the unversioned `postgresql-client` package where
-  3.20 carried psql 16, and a client newer than the server is the direction
-  libpq supports, so the migration those examples run behaves as it did.
+  with it, because an example is the first Dockerfile most people copy. One of
+  them changes the psql its migration runs: the Go example's runtime moves from
+  Alpine 3.20 to 3.24, which carries psql 18 under the unversioned
+  `postgresql-client` package where 3.20 carried psql 16. A client newer than
+  the server is the direction libpq supports, so that migration behaves as it
+  did. The Next.js example does not move, because its Node base was already
+  built on Alpine 3.24 and was already giving it psql 18.
 - Every route to the hosted control plane says the same thing about it. The
   `/signin` and `/signup` tabs both read "Join the waitlist" and both
   descriptions said there was no hosted control plane, which a crawler, a


### PR DESCRIPTION
#113 moved `deploy/docker/control-plane.Dockerfile` to `node:26-alpine` and left CI on Node 24, so the suite gating that image now runs on a different major than the image does. Before that change they matched. `engines: node >=24` permits 26; it is not evidence that anything was ever compiled or run on 26.

Two places, and they need different shapes.

- **The control plane job** simply moves to 26. `web/apps/api` is what the runtime stage executes, and that typecheck and those tests are the only thing between a type error and a running server.
- **The console** gets a second `setup-node` inside the www job rather than a raised job pin. `console/` is built into the image's console stage, and that build step's own comment already says it exists so a type error fails the pull request rather than the image build twenty minutes later. A stand in that compiles on a different major is not standing in for anything.

The second one is a separate step because the www job also runs `npm test` in `api/`, and `api/` does not run on this Node at all. It runs on Azure Static Web Apps at `node:22`, set in one variable in `tools/site/assemble.sh` and measured against a real deployment rather than inferred. Raising the job pin would have widened that mismatch in order to close this one. `www` and `docs` stay on 24 for the same reason, being nobody's runtime.

The enterprise job stays on 24 deliberately: it installs `web` only so `ee/web` can typecheck against it, and no image copies `ee/web`, so there is no shipped runtime to match.

## Verified rather than assumed

Both suites read files outside their own directory, so both were run against the real tree on Node 26.8.1.

| suite | result |
|---|---|
| `console` tests | 72 of 72 pass |
| `console` build | clean, `out/index.html` present |
| `web` typecheck | clean |
| `web` tests | 1222 pass, 0 fail, against Postgres 17 |

## Two stale pointers fixed while reading

`release.yml` said the `fail_on_unmatched_files` behaviour was read out of the action's `src/main.ts`. #112 moved that action to v3.0.3, where the logic lives in `src/run.ts`. I read the new source at the pinned commit and the behaviour is intact, so this is a comment naming a file that no longer exists rather than a defect. It is also how a reader stops trusting comments.

The changelog said the psql move applied to both examples that run a migration. Only the Go example moved, from Alpine 3.20 which gives psql 16.14, to 3.24 which gives 18.6. The Next.js example did not move: its old base, `node:22-alpine`, is itself already built on Alpine 3.24 and was already giving it psql 18.6, so only the comment there was ever wrong. The tag publishes that section verbatim as the release body, so it is corrected in `CHANGELOG.md` and in the fragment it came from.

No changelog fragment: every path here is one `changecheck` classifies as not a surface.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR