### PR TITLE
insights: a rehearsal timing test that measured the runner

### DIFF
--- a/.changes/a-timing-test-that-measured-the-runner.md
+++ b/.changes/a-timing-test-that-measured-the-runner.md
@@ -1,0 +1,30 @@
+# fixed
+
+The rehearsal's per statement timing test no longer compares two real
+statements to each other.
+
+It ended by asserting that building an index over 50,000 rows takes longer
+than adding a nullable column. That is true most of the time and it was never
+the property the test exists for. It went red in CI on a pull request whose
+diff was one file mode bit and one markdown file: a contended runner spent
+84ms adding the column and 33ms building the index. A check that fails for
+reasons no diff can explain is worse than one that is missing, because it
+teaches everybody to rerun a red job without reading it, and that habit is
+what lets a real failure through.
+
+What the test is named for is per statement attribution. When the migration
+tool cannot say what it ran, a Rails or Django migration among them, the
+server's event triggers say, and each statement gets a duration of its own.
+The fixture now plants a statement whose duration is a fact rather than a
+measurement, a materialized view over pg_sleep, in the middle of three. The
+planted second has to land on the statement that slept and on neither
+neighbour, no two durations may be the same number, none may be zero, and they
+have to add up to less than the window the applier ran in. Contention can only
+make a duration longer, so a busy machine cannot push the sleeping statement
+under its floor.
+
+Between them those assertions catch one total copied onto every row, a
+duration charged to the neighbouring statement, a running total that grows
+down the list, a single statement reported for a whole file, and a duration
+read from the transaction clock rather than the wall clock. Each of the five
+was introduced in the engine on purpose, and each turned the test red.

--- a/engine/internal/insights/postgres_test.go
+++ b/engine/internal/insights/postgres_test.go
@@ -887,24 +887,80 @@ func TestRehearse_TimesEachStatementFromTheServerWhenTheApplierCannot(t *testing
 	// else ran the DDL and we did not see it go past. The server did, and the
 	// event trigger pair is how a Rails or Django migration still gets a
 	// duration per statement.
+	//
+	// The middle statement is told to sleep for a second, and that second is
+	// the only number here the machine does not get a vote on. What breaks
+	// silently in this path is not the size of a duration but where it lands:
+	// one statement's cost charged to its neighbour, one total copied onto
+	// every row, or a running total that grows down the list. Each of those
+	// moves the planted second somewhere it does not belong, and each of them
+	// survives a test that only compares two real statements to each other.
+	// That comparison is what used to be here, and it failed in CI on a pull
+	// request that changed no engine code at all: a contended runner spent
+	// 84ms adding a nullable column and 33ms building an index over 50,000
+	// rows, inverting an ordering that was never the claim.
+	const plantedSleepMS = 1000.0
 	r, err := insights.Rehearse(context.Background(), db.conn, db.watch, db.url,
 		insights.MigrationSet{Tool: insights.ToolRails},
 		&opaqueApplier{url: db.url, sql: []string{
 			"ALTER TABLE orders ADD COLUMN currency text",
+			// A statement whose duration is a fact rather than a measurement.
+			// The server cannot finish it sooner than the sleep however busy
+			// the machine is, so a floor under it is crossed only by the
+			// timing being wrong.
+			"CREATE MATERIALIZED VIEW slow_orders AS " +
+				"SELECT n FROM (SELECT 1 AS n, pg_sleep(1)) s",
 			"CREATE INDEX orders_status_idx ON orders (status)",
 		}},
 		insights.LargeTableRows)
 	require.NoError(t, err)
 	require.False(t, r.Failed, r.Error)
 
-	require.Len(t, r.Statements, 2,
+	require.Len(t, r.Statements, 3,
 		"the applier reported nothing, so every statement here came from the server")
 	require.Contains(t, r.Statements[0].SQL, "ADD COLUMN")
-	require.Contains(t, r.Statements[1].SQL, "CREATE INDEX")
-	require.Greater(t, r.Statements[1].MS, 0.0)
-	// Building an index over 50,000 rows is slower than adding a nullable
-	// column, and the ordering is the whole reason to report each separately.
-	require.Greater(t, r.Statements[1].MS, r.Statements[0].MS)
+	require.Contains(t, r.Statements[1].SQL, "MATERIALIZED VIEW")
+	require.Contains(t, r.Statements[2].SQL, "CREATE INDEX")
+
+	for i, s := range r.Statements {
+		require.Greaterf(t, s.MS, 0.0,
+			"statement %d took no time at all, which is what a duration read from the "+
+				"transaction's clock rather than the wall clock looks like", i+1)
+	}
+
+	// Timed separately means separate numbers. Two clock deltas measured to
+	// the microsecond do not land on the same value by chance, so a repeat is
+	// one number copied across rows rather than two statements that agreed.
+	require.NotEqual(t, r.Statements[0].MS, r.Statements[1].MS)
+	require.NotEqual(t, r.Statements[1].MS, r.Statements[2].MS)
+	require.NotEqual(t, r.Statements[0].MS, r.Statements[2].MS)
+
+	// The planted second landed on the statement that slept and on neither
+	// neighbour. Contention only ever makes a duration longer, so a slow
+	// machine cannot push the sleeping statement under its floor. The ceiling
+	// over the other two is half the sleep, six times the worst a catalogue
+	// only ALTER has been seen to take on the runner this test failed on.
+	require.Greater(t, r.Statements[1].MS, plantedSleepMS*0.9,
+		"the statement that slept for a second is not reported as taking about a second")
+	require.Less(t, r.Statements[0].MS, plantedSleepMS/2,
+		"adding a nullable column is catalogue work, so a duration near the sleeping "+
+			"statement's is that statement's time charged to the wrong row")
+	require.Less(t, r.Statements[2].MS, plantedSleepMS/2,
+		"building this index is not a second of work, so a duration near the sleeping "+
+			"statement's is that statement's time charged to the wrong row")
+
+	// And every duration is a slice of the one window the applier ran in
+	// rather than a copy of the whole of it. A running total, or the total
+	// repeated on every row, adds up to more than the window it happened in.
+	// The slack is for the two clocks involved, since the window is measured
+	// here and each statement is measured by the server.
+	var sum float64
+	for _, s := range r.Statements {
+		sum += s.MS
+	}
+	require.Less(t, sum, r.TotalMS+50,
+		"the statements add up to more than the whole run took, so at least one of them "+
+			"is carrying another statement's time")
 }
 
 func TestRehearse_ReportsARewriteEvenWhenTheApplierSawNothing(t *testing.T) {


### PR DESCRIPTION
`TestRehearse_TimesEachStatementFromTheServerWhenTheApplierCannot` failed in CI
today with `"33.12" is not greater than "84.532"`, on a pull request whose diff
was one file mode bit and one markdown file. Zero engine files. Its last
assertion compared two real wall clock measurements, so it was measuring the
runner.

## What the test is actually about

Its name says it times each statement FROM THE SERVER when the applier cannot
report. That is an ATTRIBUTION claim: when the migration tool cannot say what it
ran, which is every tool whose migrations are not SQL, the event trigger pair in
`capture.go` says, and each statement gets a duration of its own. Which of two
real statements happens to be slower on a contended runner is not that claim. An
index build over 50,000 rows usually beats a catalogue only ALTER and today it
did not, and nothing about the engine changed either way.

Distinctness alone is not the whole claim either. Two of the bugs that would
break this silently, a shift by one and a running total, produce three
different numbers and survive it.

So the fixture plants a statement whose duration is a fact rather than a
measurement, a `CREATE MATERIALIZED VIEW` over `pg_sleep(1)`, in the MIDDLE of
three. The assertions are then:

- every statement carries a non zero duration, which a duration read from the
  transaction clock does not
- no two are the same number, since two clock deltas measured to the microsecond
  do not agree by chance
- the planted second landed on the statement that slept and on neither
  neighbour
- the durations add up to less than the window the applier ran in

Contention only ever makes a duration longer, so a busy machine cannot push the
sleeping statement under its floor. The ceiling over its neighbours is 500ms
against a worst observed 84ms, where the assertion that broke had a margin of
about 20ms.

## Proof it can still refuse

Five deliberate breakages in `engine/internal/insights/capture.go`, each run
against the new test:

**One total copied onto every row**

```
--- FAIL: TestRehearse_TimesEachStatementFromTheServerWhenTheApplierCannot (1.48s)
    postgres_test.go:934:
        	Error:      	Should not be: 1037.167
```

**Durations rotated by one, so each statement carries its neighbour's**

```
--- FAIL: TestRehearse_TimesEachStatementFromTheServerWhenTheApplierCannot (1.30s)
    postgres_test.go:943:
        	Error:      	"20.618" is not greater than "900"
        	Messages:   	the statement that slept for a second is not reported as taking about a second
```

**A running total, each statement carrying everything before it**

```
--- FAIL: TestRehearse_TimesEachStatementFromTheServerWhenTheApplierCannot (1.32s)
    postgres_test.go:948:
        	Error:      	"1035.04" is not less than "500"
        	Messages:   	building this index is not a second of work, so a duration near the sleeping statement's is that statement's time charged to the wrong row
```

**One statement reported for the whole file**

```
--- FAIL: TestRehearse_TimesEachStatementFromTheServerWhenTheApplierCannot (1.29s)
    postgres_test.go:919:
        	Error:      	"[{ 1 ALTER TABLE orders ADD COLUMN currency text 1031.6090000000002 []}]" should have 3 item(s), but has 1
        	Messages:   	the applier reported nothing, so every statement here came from the server
```

**`clock_timestamp()` replaced by `now()`, the transaction clock**

```
--- FAIL: TestRehearse_TimesEachStatementFromTheServerWhenTheApplierCannot (1.33s)
    postgres_test.go:926:
        	Error:      	"0" is not greater than "0"
        	Messages:   	statement 1 took no time at all, which is what a duration read from the transaction's clock rather than the wall clock looks like
```

A sixth, every duration doubled, is caught only by the window sum, which is why
that assertion is there at all:

```
    postgres_test.go:961:
        	Error:      	"2066.638" is not less than "1097.135"
        	Messages:   	the statements add up to more than the whole run took, so at least one of them is carrying another statement's time
```

Then ten consecutive green runs against Postgres 17, 1.6s to 2.6s each, and
three more under `-race`. The test costs a second more than it did. That second
is the only number in it the machine does not get a vote on.

## Sibling sweep

Every `require.Greater` / `require.Less` in the engine tests near a duration,
with a judgement. Nothing else is changed here.

At risk, same defect, not fixed in this pull request:

- `engine/internal/insights/postgres_test.go:284`, `update.MS > add.MS` in
  `TestRehearse_TimesEveryStatementSeparately`. The same claim through the SQL
  applier rather than the server. Measured over five runs on a loaded
  workstation: the ADD COLUMN 3.7 to 9.4ms, the UPDATE of 50,000 rows 291 to
  466ms. Inversion needs a third of a second of stall, against the 20ms that
  broke its neighbour, so it is the same shape with a hundred times the margin.
  The fix if it ever goes red is the one in this pull request.
- `engine/cmd/af-proxy/limit_test.go:53,80,90`, upper bounds of 100 to 200ms on
  in memory token bucket work that should take microseconds. Pure CPU, no I/O,
  so only a severe stall reaches them. Wide margin, real exposure.
- `engine/internal/insights/postgres_test.go:384`,
  `found.HeldMS >= 500` after a `pg_sleep(1)`. A floor under a planted sleep,
  which contention cannot cross, EXCEPT that HeldMS comes from a sampler asking
  every 250ms, so a starved sampler could see fewer samples and report a shorter
  hold. Mostly safe, worth knowing.
- `engine/internal/load/load_test.go:194`, the P95 of `/slow` against the P95 of
  `/`. A comparison of two wall clock aggregates, but the slow route sleeps a
  planted 25ms and a P95 smooths the tail. Low risk.
- `engine/internal/scheduler/scheduler_test.go:348`, ten thousand runs planned
  in under a second, and `engine/internal/manifest/slow_test.go:64`, no corpus
  input parsing slower than 250ms. Both are deliberate performance budgets
  rather than accidental orderings. They measure the machine on purpose, the
  justfile's `gate` recipe already warns about them by name when the load
  average is high, and both log what they measured.

Safe, no change wanted:

- `engine/internal/invariant/invariant_test.go:282`. This one was already fixed
  the same way: its comment records that `< 2s` went red when another suite
  shared the server, and the fix went into the package rather than into the
  threshold.
- `engine/internal/personas/api_test.go:199` and
  `engine/internal/load/scenario_test.go:603`, floors under a planted wait and
  under a schedule. Contention only helps them pass.
- `engine/internal/personas/seed_test.go:156` (10s against a 300ms timeout),
  `engine/internal/invariant/invariant_test.go:210` (20s),
  `engine/internal/dockerutil/awaitexit_test.go:62` (30s),
  `engine/internal/load/scenario_test.go:541` and
  `engine/internal/load/load_test.go:287` (5s). Ceilings an order of magnitude
  or more above the work, guarding a hang rather than a duration.
- `engine/internal/clock/clock_test.go:233` is a fake clock and
  `engine/internal/manifest/manifest_test.go:135` compares line numbers.

## Local state worth reporting

`TestContainerApplier_LeavesNothingBehind` fails on this workstation with
`network with name af-lane6-applierclean-probe already exists`, a Docker network
another agent's run left behind yesterday with no containers attached. It fails
identically with this branch's diff stashed, so it is not mine, and I left the
network alone rather than pruning something a concurrent run might want.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR
