### PR TITLE
ci: two gates that were green about a console they never opened

### DIFF
--- a/.changes/gates-that-were-green-about-the-console.md
+++ b/.changes/gates-that-were-green-about-the-console.md
@@ -1,0 +1,39 @@
+# fixed
+
+Two render gates that claimed to cover the console and never read it.
+
+`motioncheck` finds its applications on disk, and it used to include one only
+when something was found there. In CI the console was installed and built after
+both render gates ran, so an unbuilt directory was dropped from the run without
+a word and the check reported success over the marketing site alone. Measured
+on a built tree: 42 files read with the console hidden, 64 with it present,
+exit zero in both cases. The animation ban is the rule this project reaches for
+most often, and for the whole life of the gate it was enforced on one of the
+two applications.
+
+`classcheck` never claimed the console, and why it did not is the more useful
+half. It exists because `cn` is a plain join rather than tailwind-merge, and
+the console does not import `cn` anywhere, so it read as exempt. It is not. It
+composes classes in template literals, and an interpolated string that already
+carries a margin beside a margin written after it is the same defect with the
+same cause: the cascade decides, not the order of the literal.
+
+Both gates now read every Next application, find those applications by looking
+for the config file that makes one rather than by holding a list, walk for
+prerendered HTML at any depth rather than at three fixed ones, and refuse an
+application that is not built instead of skipping it. The console build moved
+above them in CI, which that refusal makes load bearing rather than incidental.
+
+`classcheck` also judges more than colour now. It began with five colour
+properties because the four defects that motivated it were colours, which was
+narrower than the rule it enforces: a height written last and beaten by a
+height written first is the same defect and just as invisible in review. The
+widening was measured before it was made rather than after. Across both
+applications, 61 files and 16661 elements, twenty one properties add exactly
+one finding.
+
+That finding is real and is fixed here. The baseline card in the hero film
+asked for 58 percent of the height and rendered at full height, because the
+component set `h-full` in its own class string and the call site passed
+`h-[58%]` beside it. Every arbitrary value is emitted before every named
+utility, so the component won and the frame it was drawing was wrong.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -521,24 +521,6 @@ jobs:
         run: npm run build
         working-directory: www
 
-      - name: No class that never applies
-        # `cn` is a plain join rather than tailwind-merge, so a className passed
-        # to a component lands beside the component's own class and the cascade
-        # picks whichever Tailwind emitted last. The site header marked the
-        # current page with text-black over a text-black/70 default, lost, and
-        # marked nothing at all for as long as the header has existed. It reads
-        # the built HTML, so it runs here, after the build above.
-        run: go run ./tools/classcheck .
-
-      - name: No animation that never stops
-        # If a piece of UI animates on an infinite loop while the user does
-        # nothing, it is wrong. Reads the built stylesheet and HTML rather than
-        # the source, because a rule existing is not an element carrying it:
-        # `.hero-scan` was read in the source twice and called harmless, and
-        # was scanning behind the front page headline the whole time. Runs
-        # here, after the build above.
-        run: go run ./tools/motioncheck .
-
       - name: The crawl surfaces the site claims to have
         # Sitemap, robots, canonicals, OpenGraph, structured data, the markdown
         # twins and the skip link. None of these break a build when they go
@@ -597,10 +579,46 @@ jobs:
         # image asserts the directory is not empty. Building it here means a
         # type error in the console fails the pull request rather than the
         # image build twenty minutes later.
+        #
+        # Two render gates now sit BELOW this step rather than above it, and
+        # that order is load bearing. Both read the render rather than the
+        # source, both cover the console, and while they ran above this step
+        # they were reading a directory that did not exist yet. motioncheck
+        # dropped the unbuilt application in silence and reported success over
+        # www alone: 42 files read where the built tree has 64, exit zero. They
+        # refuse an unbuilt application now, so moving them back up fails
+        # loudly rather than quietly.
         run: npm run build
         working-directory: console
         env:
           NEXT_TELEMETRY_DISABLED: '1'
+
+      - name: No class that never applies
+        # `cn` is a plain join rather than tailwind-merge, so a className passed
+        # to a component lands beside the component's own class and the cascade
+        # picks whichever Tailwind emitted last. The site header marked the
+        # current page with text-black over a text-black/70 default, lost, and
+        # marked nothing at all for as long as the header has existed. It reads
+        # the built HTML, so it runs here, after both builds above.
+        #
+        # It reads the console as well as www now. The console does not import
+        # `cn` at all, which made it look exempt; it composes in template
+        # literals instead, and `${inputClass} mt-0` has the same hazard for the
+        # same reason.
+        run: go run ./tools/classcheck .
+
+      - name: No animation that never stops
+        # If a piece of UI animates on an infinite loop while the user does
+        # nothing, it is wrong. Reads the built stylesheet and HTML rather than
+        # the source, because a rule existing is not an element carrying it:
+        # `.hero-scan` was read in the source twice and called harmless, and
+        # was scanning behind the front page headline the whole time. Runs
+        # here, after BOTH builds above.
+        #
+        # It has always claimed to cover the console and until now never read
+        # it once, because it ran before the console was built and skipped an
+        # application it could not find. It refuses one now instead.
+        run: go run ./tools/motioncheck .
 
       - name: The console exported the routes the control plane routes to
         # A static export writes one file per route. If a page stops exporting

--- a/justfile
+++ b/justfile
@@ -525,7 +525,8 @@ modecheck:
 # lands beside the component's own class rather than replacing it, and the
 # cascade picks whichever Tailwind emitted last. The site header marked the
 # current page with text-black over a text-black/70 default, lost, and marked
-# nothing at all. Reads the built HTML, so it needs a built www.
+# nothing at all. Reads the built HTML, so it needs a built www AND a built
+# console, and it refuses rather than skipping when either is missing.
 classcheck:
     go run ./tools/classcheck .
 
@@ -535,7 +536,10 @@ classcheck:
 # read globals.css on the same day, both saw the one infinite rule left in it,
 # and both called it harmless because nothing in that file used it. It was
 # rendered on the front page by HeroFilm.tsx. The source says which rules
-# exist; only the render says which land on an element. Needs a built www.
+# exist; only the render says which land on an element. Needs a built www AND
+# a built console, and it refuses rather than skipping when either is missing,
+# because skipping is how the console went unchecked for the whole life of
+# this gate.
 motioncheck:
     go run ./tools/motioncheck .
 

--- a/tools/classcheck/main.go
+++ b/tools/classcheck/main.go
@@ -32,10 +32,26 @@
 // lost. So the order is not something to reason about. It is something to read
 // out of the emitted stylesheet, which is what this does.
 //
-// WHAT IT READS. The built site, not the source, and that is deliberate. The
-// question is not which classes a file mentions, it is which classes land on
-// one element together, and only the renderer knows that. www prerenders to
-// static HTML, so the answer is on disk after a build with no browser needed.
+// WHAT IT READS. The built application, not the source, and that is
+// deliberate. The question is not which classes a file mentions, it is which
+// classes land on one element together, and only the renderer knows that. Both
+// www and console are `output: "export"`, so they prerender to static HTML and
+// the answer is on disk after a build with no browser needed.
+//
+// BOTH APPLICATIONS, and each against its own stylesheet. This read www alone
+// for its first life, which was a gate scoped to the smaller of the two
+// surfaces. console does not import `cn` at all, so it looked exempt; it is
+// not. It concatenates in template literals instead, and
+// `${inputClass} mt-0 w-full` has exactly the hazard `cn` has, because the
+// interpolated string can already carry a margin and the cascade, not the
+// order of the literal, decides which margin lands. An admin console of
+// twenty two pages was about to be written on that pattern with nothing
+// looking.
+//
+// The rules of one application are never compared against the HTML of the
+// other. A rule's position is only meaningful inside the sheet it came from,
+// so merging two builds into one map would compare offsets across files and
+// answer a question nobody asked.
 //
 // WHAT IT COMPARES. Only unconditional utilities: a rule whose selector is a
 // bare class, outside any @media, with no pseudo-class. A hover, focus or
@@ -54,6 +70,7 @@ package main
 import (
 	"bufio"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -77,6 +94,58 @@ type exemption struct {
 	used   bool
 }
 
+// nextApps names every Next application in the tree, by looking for the config
+// file that makes one, rather than by holding a list.
+//
+// A list would have the same shape as the bug this change closes: a claim
+// about the repository that nothing checks. The day a third application is
+// added, a list keeps the gate passing and stops it meaning anything. Reading
+// the tree cannot go stale.
+func nextApps(root string) []string {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		for _, name := range []string{"next.config.ts", "next.config.js", "next.config.mjs"} {
+			if _, err := os.Stat(filepath.Join(root, e.Name(), name)); err == nil {
+				out = append(out, e.Name())
+				break
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// prerendered returns every .html under dir, at any depth.
+//
+// This used to be three fixed globs at one, two and three path segments, which
+// was correct for the site it was written against and silently wrong for
+// anything deeper. The admin console nests four segments, as in
+// admin/customers/users/organization, so a fixed depth list would have walked
+// past the pages this gate was extended to cover and reported a clean run over
+// files it never opened. A walk cannot go out of date when somebody adds a
+// directory.
+func prerendered(dir string) []string {
+	var out []string
+	_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !d.IsDir() && strings.HasSuffix(path, ".html") {
+			out = append(out, path)
+		}
+		return nil
+	})
+	sort.Strings(out)
+	return out
+}
+
 func main() {
 	root := "."
 	if len(os.Args) > 1 {
@@ -90,32 +159,6 @@ func main() {
 func run(root string) (int, string) {
 	var b strings.Builder
 
-	cssFiles, _ := filepath.Glob(filepath.Join(root, "www", ".next", "static", "chunks", "*.css"))
-	htmlFiles, _ := filepath.Glob(filepath.Join(root, "www", ".next", "server", "app", "*.html"))
-	more, _ := filepath.Glob(filepath.Join(root, "www", ".next", "server", "app", "*", "*.html"))
-	htmlFiles = append(htmlFiles, more...)
-	more, _ = filepath.Glob(filepath.Join(root, "www", ".next", "server", "app", "*", "*", "*.html"))
-	htmlFiles = append(htmlFiles, more...)
-
-	if len(cssFiles) == 0 || len(htmlFiles) == 0 {
-		fmt.Fprintf(&b, "classcheck: no built site under www/.next. Build it first:\n\n    (cd www && npm run build)\n\n")
-		return 1, b.String()
-	}
-
-	rules := map[string]rule{}
-	for _, f := range cssFiles {
-		src, err := os.ReadFile(f)
-		if err != nil {
-			fmt.Fprintf(&b, "classcheck: %s: %v\n", f, err)
-			return 1, b.String()
-		}
-		for k, v := range parseCSS(string(src)) {
-			if _, seen := rules[k]; !seen {
-				rules[k] = v
-			}
-		}
-	}
-
 	exemptPath := filepath.Join(root, "tools", "docs", "classcheck-exemptions.tsv")
 	exempt, err := readExemptions(exemptPath)
 	if err != nil {
@@ -128,57 +171,89 @@ func run(root string) (int, string) {
 	}
 	var findings []finding
 	elements := 0
+	files := 0
 
-	for _, f := range htmlFiles {
-		src, err := os.ReadFile(f)
-		if err != nil {
-			fmt.Fprintf(&b, "classcheck: %s: %v\n", f, err)
+	found := nextApps(root)
+	if len(found) == 0 {
+		fmt.Fprintf(&b, "classcheck: no Next application found. Each one is a directory with a next.config file, and each needs `npm run build` before this gate has anything to read.\n")
+		return 1, b.String()
+	}
+
+	for _, app := range found {
+		cssFiles, _ := filepath.Glob(filepath.Join(root, app, ".next", "static", "chunks", "*.css"))
+		htmlFiles := prerendered(filepath.Join(root, app, ".next", "server", "app"))
+
+		if len(cssFiles) == 0 || len(htmlFiles) == 0 {
+			fmt.Fprintf(&b, "classcheck: no built application under %s/.next. Build it first:\n\n    (cd %s && npm run build)\n\n", app, app)
 			return 1, b.String()
 		}
-		for _, attr := range classAttrs(string(src)) {
-			elements++
-			toks := strings.Fields(attr)
-			byProp := map[string][]int{}
-			for idx, tok := range toks {
-				r, ok := rules[tok]
-				if !ok {
-					continue
-				}
-				byProp[r.prop] = append(byProp[r.prop], idx)
+		files += len(htmlFiles)
+
+		rules := map[string]rule{}
+		for _, f := range cssFiles {
+			src, err := os.ReadFile(f)
+			if err != nil {
+				fmt.Fprintf(&b, "classcheck: %s: %v\n", f, err)
+				return 1, b.String()
 			}
-			for prop, idxs := range byProp {
-				if len(idxs) < 2 {
-					continue
+			for k, v := range parseCSS(string(src)) {
+				if _, seen := rules[k]; !seen {
+					rules[k] = v
 				}
-				// `cn` joins its arguments in order and React writes the
-				// attribute verbatim, so a component's own classes come first
-				// and a call site's override comes last. The class written LAST
-				// is the one whose author meant it to apply.
-				//
-				// A default losing to an override is how overriding is supposed
-				// to look and is not reported: an earlier version of this gate
-				// flagged all 119 of those on this site and would have been
-				// muted within a day. Only the inverse is a defect, where a
-				// class written last loses to one written before it, so the
-				// author's intent is on the element and does nothing.
-				last := idxs[len(idxs)-1]
-				winner := idxs[0]
-				for _, k := range idxs[1:] {
-					if rules[toks[k]].at > rules[toks[winner]].at {
-						winner = k
+			}
+		}
+
+		for _, f := range htmlFiles {
+			src, err := os.ReadFile(f)
+			if err != nil {
+				fmt.Fprintf(&b, "classcheck: %s: %v\n", f, err)
+				return 1, b.String()
+			}
+			for _, attr := range classAttrs(string(src)) {
+				elements++
+				toks := strings.Fields(attr)
+				byProp := map[string][]int{}
+				for idx, tok := range toks {
+					r, ok := rules[tok]
+					if !ok {
+						continue
 					}
+					byProp[r.prop] = append(byProp[r.prop], idx)
 				}
-				// A strict comparison, so the same class written twice on one
-				// element is redundant rather than dead and is not reported.
-				if rules[toks[winner]].at <= rules[toks[last]].at {
-					continue
+				for prop, idxs := range byProp {
+					if len(idxs) < 2 {
+						continue
+					}
+					// `cn` joins its arguments in order and React writes the
+					// attribute verbatim, so a component's own classes come first
+					// and a call site's override comes last. The class written LAST
+					// is the one whose author meant it to apply.
+					//
+					// A default losing to an override is how overriding is supposed
+					// to look and is not reported: an earlier version of this gate
+					// flagged all 119 of those on this site and would have been
+					// muted within a day. Only the inverse is a defect, where a
+					// class written last loses to one written before it, so the
+					// author's intent is on the element and does nothing.
+					last := idxs[len(idxs)-1]
+					winner := idxs[0]
+					for _, k := range idxs[1:] {
+						if rules[toks[k]].at > rules[toks[winner]].at {
+							winner = k
+						}
+					}
+					// A strict comparison, so the same class written twice on one
+					// element is redundant rather than dead and is not reported.
+					if rules[toks[winner]].at <= rules[toks[last]].at {
+						continue
+					}
+					if markExempt(exempt, toks[last], toks[winner]) {
+						continue
+					}
+					findings = append(findings, finding{
+						file: rel(root, f), dead: toks[last], winner: toks[winner], prop: prop, sample: sample(attr),
+					})
 				}
-				if markExempt(exempt, toks[last], toks[winner]) {
-					continue
-				}
-				findings = append(findings, finding{
-					file: rel(root, f), dead: toks[last], winner: toks[winner], prop: prop, sample: sample(attr),
-				})
 			}
 		}
 	}
@@ -216,14 +291,14 @@ func run(root string) (int, string) {
 			fmt.Fprintf(&b, "%s\n    exempted but nothing matches it any more, so delete the row\n", s)
 		}
 		fmt.Fprintf(&b, "\nclasscheck: %d files, %d elements, %d classes that never apply, %d stale exemptions\n",
-			len(htmlFiles), elements, shown, len(stale))
+			files, elements, shown, len(stale))
 		fmt.Fprintf(&b, "\nA class written beside another that sets the same property does not replace it.\n")
 		fmt.Fprintf(&b, "Choose one with a ternary so only one is ever emitted, or give the component a\n")
 		fmt.Fprintf(&b, "prop for the variant. Reaching for a value that happens to win is not a fix.\n")
 		return 1, b.String()
 	}
 
-	fmt.Fprintf(&b, "classcheck: %d files, %d elements, 0 classes that never apply\n", len(htmlFiles), elements)
+	fmt.Fprintf(&b, "classcheck: %d files, %d elements, 0 classes that never apply\n", files, elements)
 	return 0, b.String()
 }
 
@@ -399,12 +474,47 @@ func plainClass(sel string) (string, bool) {
 	return name.String(), true
 }
 
+// interesting is the set of properties a conflict is judged on.
+//
+// It began as colour only, because all four defects that motivated this gate
+// were colours. That scope was narrower than the rule it enforces. Nothing
+// about a class losing to a neighbour is specific to colour: a height written
+// last and beaten by a height written first is the same defect with the same
+// cause and the same invisibility in review.
+//
+// The reason to widen it now is that the console does not import `cn` at all,
+// so it looked exempt from this whole class of bug. It is not. It composes in
+// template literals, and `${inputClass} mt-0 w-full` carries exactly the same
+// hazard, because the interpolated string can already set a margin and the
+// cascade, not the order of the literal, decides which one lands. An admin
+// console of twenty two pages was about to be written on that pattern.
+//
+// Widening it was measured before it was done rather than after. Across both
+// built applications, 61 files and 16661 elements, the whole list below adds
+// exactly one finding, and that finding is a real one. So this is not a
+// tradeoff between coverage and noise; the noise was hypothetical.
 var interesting = map[string]bool{
 	"color":            true,
 	"background-color": true,
 	"border-color":     true,
 	"fill":             true,
 	"stroke":           true,
+	"padding":          true,
+	"margin":           true,
+	"display":          true,
+	"width":            true,
+	"height":           true,
+	"text-align":       true,
+	"font-weight":      true,
+	"font-size":        true,
+	"position":         true,
+	"flex-direction":   true,
+	"justify-content":  true,
+	"align-items":      true,
+	"gap":              true,
+	"border-radius":    true,
+	"opacity":          true,
+	"overflow":         true,
 }
 
 func props(body string) []string {

--- a/tools/classcheck/main_test.go
+++ b/tools/classcheck/main_test.go
@@ -35,6 +35,11 @@ func write(t *testing.T, root, rel, body string) {
 func tree(t *testing.T, html string) string {
 	t.Helper()
 	root := t.TempDir()
+	// A fixture has to look like a repository, not just like a build output.
+	// The gate finds its applications by looking for the config file that makes
+	// one, so a tree with a .next and no next.config is not an application it
+	// has any reason to read.
+	write(t, root, "www/next.config.ts", "export default {};\n")
 	write(t, root, "www/.next/static/chunks/a.css", css)
 	write(t, root, "www/.next/server/app/index.html", html)
 	return root
@@ -151,5 +156,34 @@ func TestNoBuildSaysSo(t *testing.T) {
 	code, out := run(root)
 	if code == 0 || !strings.Contains(out, "npm run build") {
 		t.Fatalf("a missing build should say how to make one:\n%s", out)
+	}
+}
+
+// An application that exists and is NOT built must fail, naming itself.
+//
+// The regression guard for the reason this gate reads both applications. It
+// read www alone for its first life, and the console looked exempt from the
+// whole class of defect because it never imports cn. It composes in template
+// literals instead, and `${inputClass} mt-0` carries the same hazard for the
+// same reason: the interpolated string can already set a margin, and the
+// cascade rather than the order of the literal decides which one lands.
+//
+// Refusing is the point. Reading one application and reporting success reads
+// exactly like reading both.
+func TestAnApplicationThatIsNotBuiltFailsAndNamesItself(t *testing.T) {
+	root := tree(t, `<div class="text-black text-black/70"></div>`)
+	if err := os.MkdirAll(filepath.Join(root, "console"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "console", "next.config.ts"), []byte("export default {};\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	code, out := run(root)
+	if code == 0 {
+		t.Fatalf("an unbuilt application was skipped rather than refused:\n%s", out)
+	}
+	if !strings.Contains(out, "console") {
+		t.Errorf("the report does not name the application that is missing:\n%s", out)
 	}
 }

--- a/tools/motioncheck/main.go
+++ b/tools/motioncheck/main.go
@@ -46,6 +46,7 @@ package main
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -77,11 +78,22 @@ type builtSite struct {
 }
 
 func run(root string) (int, string) {
-	sites := discover(root)
-	if len(sites) == 0 {
-		return 1, "motioncheck: no built site found. Run `npm run build` in www " +
-			"(and console) first; this gate reads the render, not the source, " +
-			"and has nothing to say about an unbuilt tree.\n"
+	sites, missing := discover(root)
+	if len(sites) == 0 && missing == "" {
+		// No application at all, which is what an empty tree looks like. A gate
+		// that reads a render and finds no render has checked nothing, and
+		// reporting that as success is how a check that never ran becomes a
+		// check that always passes.
+		return 1, "motioncheck: no Next application found. Each one is a directory " +
+			"with a next.config file, and each needs `npm run build` before this " +
+			"gate has anything to read.\n"
+	}
+	if missing != "" {
+		return 1, fmt.Sprintf("motioncheck: %s is not built. Run `npm run build` in %s "+
+			"first; this gate reads the render, not the source, and has nothing to "+
+			"say about an unbuilt tree.\n\nIt names the application rather than "+
+			"skipping it, because skipping was how the console went unchecked.\n",
+			missing, missing)
 	}
 
 	var findings []string
@@ -150,20 +162,81 @@ func run(root string) (int, string) {
 // same pages twice, to .next/server/app and to out/ for a static export, so
 // only one is read: reporting a finding twice for one element reads as two
 // defects.
-func discover(root string) []builtSite {
+//
+// An application that is not built is an ERROR rather than a site to leave
+// out, and that is the whole point of this function returning a second value.
+// It used to append a site only when something was found on disk, so a missing
+// build removed the application from the run in silence. In CI the console was
+// installed and built AFTER this ran, so for as long as this check has claimed
+// to cover the console it has been reading nothing there and reporting success
+// over the files it did read. It said 42 built files instead of 64 and exited
+// zero. A gate that is green about a surface it never opened is worse than no
+// gate, because it is quoted.
+func discover(root string) ([]builtSite, string) {
 	var sites []builtSite
-	for _, app := range []string{"www", "console"} {
+	for _, app := range nextApps(root) {
 		s := builtSite{name: app}
 		s.css, _ = filepath.Glob(filepath.Join(root, app, ".next", "static", "chunks", "*.css"))
-		for _, depth := range []string{"*.html", filepath.Join("*", "*.html"), filepath.Join("*", "*", "*.html")} {
-			more, _ := filepath.Glob(filepath.Join(root, app, ".next", "server", "app", depth))
-			s.html = append(s.html, more...)
+		s.html = prerendered(filepath.Join(root, app, ".next", "server", "app"))
+		if len(s.css) == 0 && len(s.html) == 0 {
+			return nil, app
 		}
-		if len(s.css) > 0 || len(s.html) > 0 {
-			sites = append(sites, s)
+		sites = append(sites, s)
+	}
+	return sites, ""
+}
+
+// nextApps names every Next application in the tree, by looking for the config
+// file that makes one, rather than by holding a list.
+//
+// A list was the actual defect. This read `[]string{"www", "console"}` while
+// the console was not built when it ran, so the console was dropped in silence.
+// A hardcoded list has the same shape as that bug even after the silence is
+// fixed: it is a claim about the repository that nothing checks, and the day a
+// third application is added the gate keeps passing and stops meaning
+// anything. Reading the tree cannot go stale.
+func nextApps(root string) []string {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		for _, name := range []string{"next.config.ts", "next.config.js", "next.config.mjs"} {
+			if _, err := os.Stat(filepath.Join(root, e.Name(), name)); err == nil {
+				out = append(out, e.Name())
+				break
+			}
 		}
 	}
-	return sites
+	sort.Strings(out)
+	return out
+}
+
+// prerendered returns every .html under dir, at any depth.
+//
+// This was three fixed globs at one, two and three path segments, which was
+// correct for what existed when it was written and silently short by one the
+// moment a page nested deeper. The admin console nests four, as in
+// admin/customers/users/organization, so the fixed list would have walked past
+// the pages and reported a clean run over files it never opened. A walk cannot
+// go out of date when somebody adds a directory.
+func prerendered(dir string) []string {
+	var out []string
+	_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !d.IsDir() && strings.HasSuffix(path, ".html") {
+			out = append(out, path)
+		}
+		return nil
+	})
+	sort.Strings(out)
+	return out
 }
 
 var (

--- a/tools/motioncheck/main_test.go
+++ b/tools/motioncheck/main_test.go
@@ -13,6 +13,23 @@ import (
 func site(t *testing.T, files map[string]string) string {
 	t.Helper()
 	root := t.TempDir()
+	// A fixture has to look like a repository, not just like a build output.
+	// The gate finds its applications by looking for the config file that makes
+	// one, so a tree with a .next and no next.config is not an application it
+	// has any reason to read. Writing the config here is what makes these
+	// fixtures faithful; without it they were testing a shape the repository
+	// never has.
+	for name := range files {
+		if i := strings.Index(name, "/"); i > 0 {
+			cfg := filepath.Join(root, name[:i], "next.config.ts")
+			if err := os.MkdirAll(filepath.Dir(cfg), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(cfg, []byte("export default {};\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
 	for name, body := range files {
 		full := filepath.Join(root, filepath.FromSlash(name))
 		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
@@ -182,5 +199,38 @@ func TestARuleNoElementCarriesIsNotAFinding(t *testing.T) {
 	})
 	if code, out := run(root); code != 0 {
 		t.Fatalf("a rule no element carries was reported:\n%s", out)
+	}
+}
+
+// An application that exists and is NOT built must fail, naming itself.
+//
+// This is the regression guard for the defect that motivated reading both
+// applications. discover used to append a site only when something was found
+// on disk, so an unbuilt application was dropped from the run in silence. In
+// CI the console was installed and built after this gate ran, so for the whole
+// life of the gate it read www alone and reported success. It said 42 built
+// files where the built tree has 64, and exited zero.
+//
+// Skipping is the failure, not the message. A gate that is green about a
+// surface it never opened is worse than no gate, because it is quoted.
+func TestAnApplicationThatIsNotBuiltFailsAndNamesItself(t *testing.T) {
+	root := site(t, map[string]string{
+		cssPath:  ".x{color:red}",
+		htmlPath: `<div class="x"></div>`,
+	})
+	// A second application, with a config and no build. It must not be skipped.
+	if err := os.MkdirAll(filepath.Join(root, "console"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "console", "next.config.ts"), []byte("export default {};\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	code, out := run(root)
+	if code == 0 {
+		t.Fatalf("an unbuilt application was skipped rather than refused:\n%s", out)
+	}
+	if !strings.Contains(out, "console") {
+		t.Errorf("the report does not name the application that is missing:\n%s", out)
 	}
 }

--- a/www/components/home/visuals/hero/TwinFilm.tsx
+++ b/www/components/home/visuals/hero/TwinFilm.tsx
@@ -27,7 +27,8 @@ export function TwinFilm({ active }: FilmProps) {
         style={moveStyle({ opacity: 1 - page, scale: 1 + page * 0.22, y: page * 8 })}
       >
         <EnvCard
-          className="absolute inset-x-1 top-0 h-[58%]"
+          height="h-[58%]"
+          className="absolute inset-x-1 top-0"
           label="baseline"
           host="prod.internal"
           ttl="12:41"
@@ -68,6 +69,7 @@ function EnvCard({
   ttl,
   dim,
   live,
+  height = "h-full",
   className,
   style,
   children,
@@ -77,6 +79,7 @@ function EnvCard({
   ttl: string;
   dim?: boolean;
   live?: boolean;
+  height?: string;
   className?: string;
   style?: CSSProperties;
   children?: ReactNode;
@@ -84,7 +87,14 @@ function EnvCard({
   return (
     <div
       className={cn(
-        "flex h-full flex-col justify-between rounded-[10px] border border-black/[0.08] px-2.5 py-2",
+        "flex flex-col justify-between rounded-[10px] border border-black/[0.08] px-2.5 py-2",
+        // A prop rather than a class, for the same reason as the background
+        // below. h-full used to live in the string above and the baseline card
+        // passed h-[58%] through className to override it. Every arbitrary
+        // value is emitted before every named utility, so h-full won and the
+        // baseline card rendered full height. It looked correct in the diff,
+        // it read correctly in review, and the frame it was drawing was wrong.
+        height,
         // Chosen rather than layered: bg-white is emitted after this, so as
         // an additive class the dim card rendered the same white as a lit
         // one and the state the prop names never reached the screen.


### PR DESCRIPTION
`motioncheck` has claimed to cover the console since it was written, and never read it once.

Its `discover` appended an application only when something was found on disk, so an application that was not built was dropped from the run in silence. In `ci.yml` the console was installed and built AFTER both render gates ran, so every run read www alone and reported success.

Measured on the built tree:

| console | files read | elements | exit |
|---|---|---|---|
| hidden | 42 | 16561 | 0 |
| present | 64 | 16661 | 0 |

The animation ban is the tell this project rejects most often. For the whole life of the gate it was enforced on the marketing site and on nothing else.

`classcheck` never claimed the console, and why it did not is the more interesting half. It exists because `cn` is a plain join rather than tailwind-merge, and the console does not import `cn` at all, so it looked exempt. It is not. It composes in template literals, and `${inputClass} mt-0 w-full` carries the same hazard, because the interpolated string can already set a margin and the cascade, not the order of the literal, decides which one lands. An admin console of twenty two pages was about to be written on that pattern.

## What changed

* Both gates read every Next application, and both REFUSE one that is not built rather than skipping it.
* Neither holds a list of applications. They look for the directory with a next.config in it. A list is a claim about the repository that nothing checks.
* Both walk for prerendered HTML instead of globbing one, two and three path segments. The admin console nests four, as in `admin/customers/users/organization`.
* `ci.yml` builds the console before both gates rather than after, which the refusal makes load bearing.
* `classcheck` judges twenty one properties rather than five colours. Widening was measured first: across 61 files and 16661 elements it adds exactly one finding.

## The one finding, and it is real

`EnvCard` in the hero film set `h-full` in its base string, and the baseline card passed `h-[58%]` through `className`. Every arbitrary value is emitted before every named utility, so `h-full` won and the baseline card rendered full height. The file already carries a comment recording the same defect for `bg-white`, and the same fix, so this follows it.

## Verification

Both new tests were checked against the case that would fool them. With the skipping behaviour temporarily restored, `classcheck` reports `1 files, 1 elements, 0 classes that never apply` and `motioncheck` reports `2 built files, 1 elements, 0 animations that never stop`, and both new tests go red.

Locally, against a real build of both applications: classcheck 61 files 0 findings, motioncheck 64 files 0 findings, prosecheck 585 files 0, gatecheck 66 gates unchanged.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR