### PR TITLE
console, api: an install address nobody set hid the button next to it

### DIFF
--- a/.changes/an-install-address-nobody-set.md
+++ b/.changes/an-install-address-nobody-set.md
@@ -1,0 +1,25 @@
+# fixed
+
+The "No organization yet" screen told people to install the GitHub App and then
+recheck their membership, and on a control plane with no
+`AF_GITHUB_APP_INSTALL_URL` set it offered neither action. Both buttons were
+behind the same condition, so an unset address hid the membership recheck as
+well, even though that action is an ordinary sign-in exchange that never needed
+an installation address for anything. What was left was two paragraphs of
+instructions and a Sign out button.
+
+The recheck is now offered either way, and becomes the primary action when there
+is nothing to install from. The copy changes with the address rather than
+describing a button that is not there, because prose naming an action the page
+cannot offer is the failure and not a symptom of one.
+
+Leaving the address unset stays supported. A self-hosted control plane may grant
+membership its own way and have no App of its own to point at, so refusing to
+start over a screen it never shows would be wrong. What was missing is the
+operator being told: the startup log now names the state either way, next to the
+lines that already do this for the allowlist, the sealing key, model prices,
+Stripe and the plan gate. The variable was unset on both control planes for
+weeks precisely because nothing failed and nothing said so.
+
+A value that is not a URL at all is still refused at startup and now says which
+variable and which shape, instead of the bare `Invalid URL` that names neither.

--- a/console/components/Shell.tsx
+++ b/console/components/Shell.tsx
@@ -228,6 +228,15 @@ function SignIn({ session }: { session: Session }) {
  * installation, and until it does there is genuinely nothing here to show.
  * Saying so is the difference between a product that is waiting and one that
  * looks broken.
+ *
+ * The install address is optional, and BOTH ACTIONS USED TO BE HIDDEN WITH IT.
+ * That is how this screen became a dead end on two control planes at once: the
+ * copy told somebody to install the App and then recheck their membership, and
+ * the only button under it was Sign out. Checking membership is
+ * `/auth/github`, which never needed the install address for anything, so it is
+ * offered either way and becomes the primary action when there is nothing to
+ * install from. The copy changes with it, because prose that names an action
+ * the page cannot offer is the failure rather than a symptom of it.
  */
 function NoOrganization({ session }: { session: Session }) {
   return (
@@ -238,21 +247,25 @@ function NoOrganization({ session }: { session: Session }) {
         yet. Not an empty dashboard. Nothing.
       </Lede>
       <Lede>
-        Membership follows a GitHub App installation. Install it on the
-        organization you want to connect, then ask GitHub to check your
-        membership again.
+        {session.githubAppInstallUrl
+          ? "Membership follows a GitHub App installation. Install it on the organization you want to connect, then ask GitHub to check your membership again."
+          : "Membership follows a GitHub App installation, and this control plane has not been told where to install its App. If you already belong to a connected organization, check again below. If you do not, whoever runs this control plane has to give you the installation address."}
       </Lede>
-      {session.githubAppInstallUrl ? (
-        <div className="mt-6 space-y-3">
+      <div className="mt-6 space-y-3">
+        {session.githubAppInstallUrl ? (
           <LinkButton href={session.githubAppInstallUrl} full>
             <GitHubMark />
             Install the GitHub App
           </LinkButton>
-          <LinkButton href="/auth/github" full variant="secondary">
-            Check my GitHub membership
-          </LinkButton>
-        </div>
-      ) : null}
+        ) : null}
+        <LinkButton
+          href="/auth/github"
+          full
+          variant={session.githubAppInstallUrl ? "secondary" : "primary"}
+        >
+          Check my GitHub membership
+        </LinkButton>
+      </div>
       <div className="mt-6">
         <SignOutButton />
       </div>

--- a/docs/src/content/docs/reference/control-plane.md
+++ b/docs/src/content/docs/reference/control-plane.md
@@ -37,7 +37,7 @@ is a process that fails in production rather than at deploy time.
 | `AF_GITHUB_APP_ID` | unset | The numeric App ID from the GitHub App's settings page. Needed together with the private key and the webhook secret; setting some and not others stops the process at startup rather than producing a half-working App. |
 | `AF_GITHUB_APP_PRIVATE_KEY` | unset | The PEM GitHub generated when the App's private key was created, or that PEM base64 encoded. Literal `\n` sequences are turned back into newlines, because most ways of getting a multi-line value into a container flatten it, and the resulting key fails with a message about DECODER routines that sends you somewhere else entirely. |
 | `AF_GITHUB_APP_WEBHOOK_SECRET` | unset | The webhook secret set on the App. Every delivery is verified against it before its body is parsed. Unset means `/webhooks/github` answers 503 rather than accepting unsigned deliveries. |
-| `AF_GITHUB_APP_INSTALL_URL` | unset | The public `https://github.com/apps/<slug>/installations/new` address. When it is set, a person who signs in without an organization gets an **Install the GitHub App** action instead of a dead-end empty state. Any other origin or path stops the process at startup. |
+| `AF_GITHUB_APP_INSTALL_URL` | unset | The public `https://github.com/apps/<slug>/installations/new` address. When it is set, a person who signs in without an organization gets an **Install the GitHub App** action. When it is unset they are told the address has not been configured and are still offered **Check my GitHub membership**, which never depended on it. Either way the startup log says which. Any other origin or path, or a value that is not a URL, stops the process at startup. |
 | `AF_SIGNUP_URL` | unset | Where somebody `AF_SIGNIN_ALLOWLIST` refuses is sent instead. A refused sign-in renders a page rather than a JSON body, and when this is set that page carries one link to it. Unset is the self-hosted default and means the page offers no link: an operator running an allowlist has their own way of being asked, and pointing their users at somebody else's waitlist would be wrong. Must be an absolute `http` or `https` address, or the process stops at startup. |
 | `AF_GITHUB_API_BASE` | `https://api.github.com` | Where the GitHub API lives. For GitHub Enterprise Server, and for tests. |
 | `AF_MODEL_PRICES` | unset | What a model costs, as `model=input/output` in US dollars per million tokens, comma separated: `claude-sonnet-5=3/15,gpt-4.1=2/8`. Adds to the built-in defaults rather than replacing them. A model with no price is **refused** rather than charged nothing, because a request that spends money and adds nothing to the total is a spend cap that does not cap spending. A malformed entry stops the process at startup rather than being skipped, since a skipped entry is a model silently falling back to another price. |
@@ -93,6 +93,33 @@ the App on an organization, then choose **Check my GitHub membership**. The
 second OAuth exchange reads the installation GitHub just created and grants the
 membership. The first GitHub administrator to claim an empty organization
 becomes its owner under the rule below.
+
+When it is **unset**, that path still exists but nobody can start it from the
+console. The screen says the address has not been configured and offers **Check
+my GitHub membership** on its own, which is the right action for somebody who
+already belongs to a connected organization and the wrong one for somebody who
+does not. Unset is a supported state rather than a half configuration, because
+a self-hosted control plane may grant membership its own way and have no App to
+point at. It is not the right state for a plane with open sign-ups, and the
+startup log names it either way so an operator can tell which they have.
+
+### Getting the address
+
+It is the App's public installation page, and only a human with owner access to
+the GitHub organization that owns the App can produce it.
+
+1. Open the App's settings under the owning organization, at **Settings**, then
+   **Developer settings**, then **GitHub Apps**.
+2. If no App exists yet, create one. It needs the same App ID, private key and
+   webhook secret that `AF_GITHUB_APP_ID`, `AF_GITHUB_APP_PRIVATE_KEY` and
+   `AF_GITHUB_APP_WEBHOOK_SECRET` already document, so create it once and take
+   all four values in the same sitting.
+3. Set the App to **Any account** under Install App, not just the owning
+   account. An App only its owner can install is an App no customer can install.
+4. Read the slug out of the App's public page URL, `https://github.com/apps/<slug>`.
+   It is derived from the App name and is not always what you would guess.
+5. The value is that address with `/installations/new` on the end, and nothing
+   else. No query string and no fragment: both are refused at startup.
 
 On an enterprise-only hosted deployment that owner lands on Plan. Checkout is
 the only path that can grant the required plan; `billing.set` is refused, so an

--- a/web/apps/api/src/hosted.ts
+++ b/web/apps/api/src/hosted.ts
@@ -133,9 +133,35 @@ export const HOSTED_GATE_EXEMPT: ReadonlySet<string> = new Set([
  * read of its own, it belongs there rather than in a gated route.
  */
 
+/**
+ * Where a person with no organization is sent to install the GitHub App.
+ *
+ * UNSET IS A SUPPORTED STATE and not a half configuration, which is why this
+ * returns undefined rather than throwing on an empty value. Membership follows
+ * a GitHub App installation on the hosted plane, but a self-hosted plane may
+ * provision membership some other way and has no App of its own to point at.
+ * Refusing to start would break that installation for a screen it never shows.
+ *
+ * What unset must NOT do is leave the console telling somebody to install an
+ * App while offering no way to do it. See `NoOrganization` in
+ * `console/components/Shell.tsx`: the copy changes with this value, and the
+ * membership recheck is offered either way because it never depended on it.
+ *
+ * A malformed value IS refused, at start-up, because the alternative is a link
+ * pointing wherever an operator's typo pointed. The parse is guarded rather
+ * than left to throw: `new URL` on a string with no scheme raises `Invalid
+ * URL`, which names neither the variable nor the shape it wanted, and an
+ * operator reading that in a crash loop has to find this file to learn what
+ * was wrong.
+ */
 export function githubAppInstallUrlFrom(value: string | undefined | null): string | undefined {
   if (!value?.trim()) return undefined
-  const url = new URL(value)
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    throw new Error(INSTALL_URL_SHAPE)
+  }
   if (
     url.protocol !== 'https:' ||
     url.hostname !== 'github.com' ||
@@ -143,9 +169,11 @@ export function githubAppInstallUrlFrom(value: string | undefined | null): strin
     url.search ||
     url.hash
   ) {
-    throw new Error(
-      'AF_GITHUB_APP_INSTALL_URL must be an https://github.com/apps/<slug>/installations/new address.',
-    )
+    throw new Error(INSTALL_URL_SHAPE)
   }
   return url.toString()
 }
+
+/** One sentence, so a bad scheme and a bad shape cannot drift apart. */
+const INSTALL_URL_SHAPE =
+  'AF_GITHUB_APP_INSTALL_URL must be an https://github.com/apps/<slug>/installations/new address.'

--- a/web/apps/api/src/main.ts
+++ b/web/apps/api/src/main.ts
@@ -253,6 +253,19 @@ console.log(
     : 'plans are not set by hand: billing.set is refused (AF_OPERATOR_SETS_PLAN is not set)',
 )
 
+// Said out loud for the same reason as its neighbours, and because this one was
+// unset on both control planes for weeks without anybody noticing. Nothing
+// fails when it is missing: sign-in works, the console renders, and the only
+// symptom is on a screen the operator does not see, shown to somebody who has
+// just arrived and has no organization yet. A configuration whose absence is
+// invisible from the inside is one the startup line has to name.
+console.log(
+  githubAppInstallUrl
+    ? `people with no organization are offered the GitHub App at ${githubAppInstallUrl}`
+    : 'people with no organization are NOT offered the GitHub App: AF_GITHUB_APP_INSTALL_URL is ' +
+        'not set. They can still ask GitHub to recheck their membership.',
+)
+
 // Located once, here, and said out loud either way. A control plane running
 // without its console is a legitimate way to run this; a control plane that
 // silently answers 404 on every page because a COPY was dropped from a

--- a/web/apps/api/test/hosted.test.ts
+++ b/web/apps/api/test/hosted.test.ts
@@ -62,6 +62,26 @@ describe('the hosted plan configuration', () => {
     assert.throws(() => githubAppInstallUrlFrom('javascript:alert(1)'), /must be an https/)
     assert.throws(() => githubAppInstallUrlFrom('https://example.com/install'), /must be an https/)
   })
+
+  it('is off when unset, because a plane with no App of its own is not misconfigured', () => {
+    assert.equal(githubAppInstallUrlFrom(undefined), undefined)
+    assert.equal(githubAppInstallUrlFrom(null), undefined)
+    assert.equal(githubAppInstallUrlFrom(''), undefined)
+    assert.equal(githubAppInstallUrlFrom('   '), undefined)
+  })
+
+  it('names the variable and the shape when the value is not a URL at all', () => {
+    // The bare `new URL` throw is `Invalid URL`, which names neither. An
+    // operator meeting that in a start-up crash loop has to read the source to
+    // learn which of a dozen variables was wrong.
+    for (const bad of ['github.com/apps/af/installations/new', 'not a url', '/apps/af']) {
+      assert.throws(
+        () => githubAppInstallUrlFrom(bad),
+        /AF_GITHUB_APP_INSTALL_URL must be an https/,
+        `expected the shape message for ${JSON.stringify(bad)}`,
+      )
+    }
+  })
 })
 
 describe('starting up with the gate set', {


### PR DESCRIPTION
## What breaks today

`AF_GITHUB_APP_INSTALL_URL` is unset on both control planes and was recorded in
`PROGRESS.md` as an open question with no owner. Nothing fails when it is
missing, which is exactly why it stayed missing for weeks: the only symptom is
on a screen the operator never sees, shown to somebody who has just signed in
and has no organization yet.

I traced it defined to wired to effective before changing anything. It is read
once in `main.ts`, validated by `githubAppInstallUrlFrom`, carried through the
server options onto `/auth/session`, and rendered by `NoOrganization` in
`console/components/Shell.tsx`. It is not dead code. The defect is what that
component did with it.

**Both actions were inside the same ternary.** With the address unset the copy
told somebody to install the GitHub App and then ask GitHub to check their
membership again, and the only button underneath it was **Sign out**. Checking
membership is `/auth/github` and never depended on the install address for
anything. It was hidden along with the thing it had nothing to do with.

## The call: a documented default, not a refusal at startup

The brief asked which of three this should be. It is a documented default.

A self-hosted control plane may grant membership its own way and have no App of
its own to point at, so refusing to start would break that installation over a
screen it never shows. The docs already define `unset` as the default and this
keeps that promise.

What was actually missing is the operator being told. The startup line now names
the state either way, alongside its neighbours, which already say this for the
allowlist, the sealing key, model prices, Stripe, the plan gate and the console
build. Two control planes ran for weeks without this variable, and a
configuration whose absence is invisible from the inside is one the log has to
say out loud.

## Changes

- `console/components/Shell.tsx`. The membership recheck is offered either way
  and becomes the primary action when there is nothing to install from. The copy
  changes with the value, because prose naming an action the page cannot offer
  is the failure rather than a symptom of one.
- `web/apps/api/src/main.ts`. One startup line, both states.
- `web/apps/api/src/hosted.ts`. A malformed value is still refused at startup and
  now says so usefully. `new URL` on a string with no scheme raises `Invalid
  URL`, which names neither the variable nor the shape it wanted; the parse is
  guarded so one sentence covers a bad scheme, a bad shape, and a value that is
  not a URL at all.
- `docs/.../reference/control-plane.md`. The row described only the set case.
  It now describes both, and there are steps for producing the address, since
  only a human with owner access to the App's organization can.

## Verified rather than assumed

The new parse test **fails** with the literal `TypeError: Invalid URL` when the
guard is reverted. I checked that rather than trusting a green run.

The screen was rendered and read at three widths, not inspected in source:

| width | horizontal scroll | inner column | membership button |
|---|---|---|---|
| 320 | none | 280px | 44px high |
| 390 | none | 350px | 44px high |
| 1280 | none | 440px | 44px high |

```
console typecheck   clean          console tests   72 pass, 0 fail
api typecheck       clean          prosecheck      586 files, 0 findings
claimcheck          0 dead, 0 contradicted        constcheck   clean
```

## What this does not do

It does not create a GitHub App or a webhook, and it does not set the variable
on either control plane. Both need a human with owner access; the steps are in
the docs page this changes.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR
