### PR TITLE
admin: the developer platform, and a cross-site guard that never ran

### DIFF
--- a/.changes/operator-cross-site-token.internal.md
+++ b/.changes/operator-cross-site-token.internal.md
@@ -1,0 +1,17 @@
+# security
+
+The cross-site guard on operator mutations did not run on any deployment where
+the session cookie is Secure.
+
+The operator cookie is written as `__Host-af_admin_session` when Secure and
+under the bare name when not. The tRPC context read it with a reader that knows
+both names; the guard in front of it read only the bare name, found nothing, and
+skipped the origin check and the token check entirely. The request then reached
+the mutation fully authenticated. Every deployment that serves the portal over
+HTTPS was affected, and no deployment that serves it over plain HTTP was, which
+is why the existing suite passed: it builds the bare name by hand against a test
+server that speaks plain HTTP.
+
+The guard now uses the reader that knows both names, and the suite asks its four
+questions again with the name a browser actually sends. The console sends the
+token it was already able to fetch.

--- a/.changes/operator-developer-platform.md
+++ b/.changes/operator-developer-platform.md
@@ -1,0 +1,26 @@
+# added
+
+The operator portal can see the repositories, credentials and deliveries on an
+installation, and revoke a credential that has leaked.
+
+Four sections. **Repositories & Pull Requests** lists every repository connected
+to the installation and, for one of them, its pull requests with the newest
+check generation on each, so a customer reporting that a check never appeared is
+answered from the row rather than from a log. A fork approval that no longer
+covers the head is reported as a stale approval rather than as an approval.
+
+**API Keys** lists every credential that can act as a customer, with its prefix,
+what created it, what it acts as and when it was last used. An operator holding
+`admin.keys.revoke` can revoke one, and revoking a GitHub workflow identity
+binding also revokes every token that binding has minted. There is no rotate:
+only a hash is stored, so nothing in this product can produce a replacement, and
+the page says so rather than offering a button that could not work.
+
+**Integrations & Webhooks** shows the GitHub App installations and every
+delivery that arrived from GitHub or Stripe, including the ones that resolved to
+no organization and the ones nothing handled. It is inbound only, because that
+is what this product records.
+
+**MCP Management** reports that this control plane holds no MCP record, because
+`af mcp` runs on the developer's machine and never speaks to it, and lists the
+four tools the engine serves with the file and symbol each claim comes from.

--- a/console/app/admin/platform/api-keys/page.tsx
+++ b/console/app/admin/platform/api-keys/page.tsx
@@ -1,18 +1,557 @@
 "use client";
 
-import { PlannedSection } from "@/components/admin/primitives";
+import { useState } from "react";
+import {
+  Badge,
+  Button,
+  Card,
+  Confirm,
+  Field,
+  Loaded,
+  TableSkeleton,
+  When,
+  inputClass,
+} from "@/components/ui";
+import {
+  AdminPage,
+  DataTable,
+  EmptyList,
+  FilterBar,
+  StatusChip,
+  type Column,
+} from "@/components/admin/primitives";
+import { More } from "@/components/pagination";
+import { operatorMay, useAdminContext } from "@/lib/admin";
+import {
+  revokeBinding,
+  revokeCredential,
+  standingTone,
+  useBindings,
+  useCredentials,
+  type AdminBinding,
+  type AdminCredential,
+  type ApiError,
+} from "@/lib/admin-platform";
 
 /**
- * API Keys
+ * Every credential that can act as a customer, and the one thing to do about
+ * one.
  *
- * Not written yet. The route exists from the first commit because a navigation
- * entry that 404s teaches the reader to distrust the rail, and they cannot tell
- * a section that is coming from one that is broken.
+ * WHAT THIS SCREEN IS FOR. Somebody reports a key in a public repository, or an
+ * account is being closed, or a pipeline stopped and nobody knows whether the
+ * credential behind it is still alive. All three are answered here, and the
+ * third is why revoked and expired credentials are listed rather than hidden:
+ * the reader is usually checking that the one they killed is the one that
+ * stopped working.
  *
- * TO BUILD THIS SECTION: replace the body below with the real page, and add its
- * routes to web/apps/api/src/admin/platform.ts. Nothing else in the portal
- * has to change. See console/app/admin/README.md.
+ * WHY THERE IS NO ROTATE BUTTON, said on the page rather than left as an
+ * absence for somebody to file a bug about. Rotation means minting a
+ * replacement, a replacement is a secret, and a route that minted one would
+ * have to return it through this portal. Only the hash of a credential is
+ * stored, so nothing in this product can show one after the moment it is
+ * created, and the operator portal must not become the exception. Revoke is the
+ * honest action; the customer creates the replacement.
+ *
+ * THE VALUE IS NOT HERE AND CANNOT BE. Every row carries a prefix, which is the
+ * first twelve characters and exactly what the customer sees in their own
+ * console, so an operator and a customer can agree which credential they are
+ * discussing without either of them holding one.
  */
+
+const KIND_WORDS: Record<string, string> = {
+  engine: "engine",
+  cli: "person",
+  oidc: "workflow",
+};
+
+const KIND_HINTS: Record<string, string> = {
+  engine:
+    "Belongs to the organization rather than to whoever made it, so it keeps working after that person leaves.",
+  cli: "Minted by af login for one person's machine, and it acts as them.",
+  oidc: "Minted per workflow job by trading a GitHub identity. Short lived, and tied to a binding.",
+};
+
 export default function PlatformApiKeysPage() {
-  return <PlannedSection href="/admin/platform/api-keys" />;
+  return (
+    <AdminPage
+      href="/admin/platform/api-keys"
+      lede="Every credential that can act as a customer, across every organization. Values are stored only as hashes and are never shown here."
+    >
+      <div className="space-y-5">
+        <Credentials />
+        <Bindings />
+      </div>
+    </AdminPage>
+  );
+}
+
+/* -------------------------------------------------------------------------
+ * Credentials
+ * ---------------------------------------------------------------------- */
+
+function Credentials() {
+  const { me } = useAdminContext();
+  const [search, setSearch] = useState("");
+  const [kind, setKind] = useState("");
+  const [live, setLive] = useState("");
+  const state = useCredentials(search, kind, live === "live");
+  const [revoking, setRevoking] = useState<AdminCredential | null>(null);
+
+  const mayRevoke = operatorMay(me, "admin.keys.revoke");
+
+  const columns: Column<AdminCredential>[] = [
+    {
+      key: "name",
+      header: "Credential",
+      cell: (r) => (
+        <>
+          <span className="block truncate font-medium text-ink">{r.name}</span>
+          <span className="block truncate font-mono text-[12px] text-muted">{r.prefix}</span>
+        </>
+      ),
+    },
+    {
+      key: "org",
+      header: "Organization",
+      cell: (r) => <span className="font-mono text-[12px]">{r.orgSlug}</span>,
+    },
+    {
+      key: "kind",
+      header: "Kind",
+      cell: (r) => (
+        <>
+          <Badge tone="neutral">{KIND_WORDS[r.kind] ?? r.kind}</Badge>
+          {r.bindingRepository ? (
+            <span className="mt-1 block truncate font-mono text-[12px] text-muted">
+              {r.bindingRepository}
+            </span>
+          ) : null}
+        </>
+      ),
+    },
+    {
+      key: "standing",
+      header: "Standing",
+      cell: (r) => (
+        <>
+          <StatusChip value={r.standing} tone={standingTone(r.standing)} />
+          {r.standing === "expired" && r.expiresAt ? (
+            <span className="mt-1 block text-[12px] text-muted">
+              <When value={r.expiresAt} />
+            </span>
+          ) : null}
+        </>
+      ),
+    },
+    {
+      key: "lastUsed",
+      header: "Last used",
+      cell: (r) =>
+        // Never used and used a year ago are different facts, and a blank cell
+        // reads as a value that failed to load rather than as either of them.
+        r.lastUsedAt === null ? (
+          <span className="text-dim">Never used</span>
+        ) : (
+          <When value={r.lastUsedAt} />
+        ),
+    },
+    {
+      key: "actor",
+      header: "Acts as",
+      cell: (r) =>
+        r.actsAs ? (
+          <span className="truncate">{r.actsAs}</span>
+        ) : (
+          // Null on a machine token on purpose. Saying "a machine" rather than
+          // leaving it empty is the difference between a stated fact and a
+          // field somebody thinks is broken.
+          <span className="text-dim">A machine</span>
+        ),
+    },
+  ];
+
+  if (mayRevoke) {
+    columns.push({
+      key: "revoke",
+      header: "Action",
+      cell: (r) =>
+        // A button only where pressing it changes something observable.
+        //
+        // An expired credential is ALREADY refused: authenticateEngine compares
+        // expires_at against the clock on every request before it does anything
+        // else, so revoking one would move a column and stop nothing. A control
+        // whose effect cannot be observed is the shape of a feature that looks
+        // built and is not, and this list is not a queue of rows to tidy.
+        r.standing === "revoked" ? (
+          <span className="text-dim">Revoked</span>
+        ) : r.standing === "expired" ? (
+          <span className="text-dim">Expired, already refused</span>
+        ) : (
+          <Button variant="danger" onClick={() => setRevoking(r)}>
+            Revoke
+            {/* The row's own credential inside the button's accessible name.
+                Six buttons all announced as "Revoke" are six buttons a screen
+                reader user cannot tell apart, and this is the list where
+                pressing the wrong one stops the wrong customer working. A span
+                rather than an aria-label because Button takes children and not
+                arbitrary attributes, and an aria-label passed to it would be
+                dropped silently. */}
+            <span className="sr-only">
+              {" "}
+              {r.name}, {r.prefix}, in {r.orgSlug}
+            </span>
+          </Button>
+        ),
+    });
+  }
+
+  return (
+    <Card
+      title="Credentials"
+      note={
+        mayRevoke
+          ? "Revoking is immediate and cannot be undone. There is no rotate: only the hash is stored, so nothing here can produce a replacement. The customer makes one with af token create."
+          : "Your role can read this list and not change it."
+      }
+    >
+      <FilterBar
+        search={{
+          value: search,
+          onChange: setSearch,
+          label: "Search credentials by organization, name or prefix",
+          placeholder: "Organization, name or prefix",
+        }}
+        filters={[
+          {
+            label: "Kind",
+            value: kind,
+            onChange: setKind,
+            options: [
+              { value: "", label: "Every kind" },
+              { value: "engine", label: "Engine" },
+              { value: "cli", label: "Person" },
+              { value: "oidc", label: "Workflow" },
+            ],
+          },
+          {
+            label: "Standing",
+            value: live,
+            onChange: setLive,
+            options: [
+              { value: "", label: "Including revoked and expired" },
+              { value: "live", label: "Live only" },
+            ],
+          },
+        ]}
+      />
+      <Loaded state={state} skeleton={<TableSkeleton rows={6} cols={6} />}>
+        {(rows) => (
+          <DataTable
+            columns={columns}
+            rows={rows}
+            keyOf={(r) => r.id}
+            empty={
+              <EmptyList
+                title={
+                  search || kind || live
+                    ? "No credential matches that"
+                    : "No credentials have been created"
+                }
+              >
+                {search || kind || live
+                  ? "Nothing on this installation matches those filters. Clearing them shows every credential, including revoked and expired ones."
+                  : "Nobody has created an engine token, signed in with af login, or connected a workflow identity yet. The first one appears here as soon as they do."}
+              </EmptyList>
+            }
+            footer={
+              <More
+                shown={rows.length}
+                noun={{ one: "credential", many: "credentials" }}
+                hasMore={state.hasMore}
+                busy={state.busy}
+                error={state.moreError}
+                onMore={state.more}
+              />
+            }
+          />
+        )}
+      </Loaded>
+
+      <RevokeCredential
+        credential={revoking}
+        onClose={() => setRevoking(null)}
+        onDone={state.reload}
+      />
+    </Card>
+  );
+}
+
+/* -------------------------------------------------------------------------
+ * The confirmation
+ * ---------------------------------------------------------------------- */
+
+/** The shortest reason the route will take. Checked here as well so the button
+ *  says why it is disabled rather than the server refusing after the press. */
+const MIN_REASON = 8;
+
+function RevokeCredential({
+  credential,
+  onClose,
+  onDone,
+}: {
+  credential: AdminCredential | null;
+  onClose: () => void;
+  onDone: () => void;
+}) {
+  const [reason, setReason] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function run() {
+    if (!credential) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await revokeCredential(credential.id, reason.trim());
+      setReason("");
+      onClose();
+      onDone();
+    } catch (err) {
+      setError((err as ApiError).message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Confirm
+      open={credential !== null}
+      title={credential ? `Revoke ${credential.name}?` : "Revoke"}
+      // The credential's own prefix, not the word "delete". Typing the thing's
+      // name is what makes somebody read the row they are about to act on, and
+      // in a list of six similar credentials that is the whole safeguard.
+      phrase={credential?.prefix}
+      confirmLabel="Revoke"
+      busy={busy}
+      error={error ?? (reason.trim().length > 0 && reason.trim().length < MIN_REASON ? `The reason needs at least ${MIN_REASON} characters.` : null)}
+      onCancel={() => {
+        setReason("");
+        setError(null);
+        onClose();
+      }}
+      onConfirm={() => void run()}
+    >
+      <p>
+        <strong className="font-medium text-ink">What this does:</strong> the next request
+        presenting this credential is refused. Anything already running keeps running until it next
+        calls the control plane.
+      </p>
+      <p>
+        There is no way back. Only a hash of the value is stored, so nobody, including us, can
+        recover it. {credential ? <span className="font-mono">{credential.orgSlug}</span> : null}{" "}
+        creates a replacement themselves with <span className="font-mono">af token create</span>.
+      </p>
+      {credential ? (
+        <p className="text-[12.5px] text-dim">{KIND_HINTS[credential.kind] ?? ""}</p>
+      ) : null}
+      <Field
+        label="Reason"
+        hint="Recorded in the platform audit chain and in the customer's own audit log, where they will read it. Required."
+      >
+        <input
+          className={inputClass}
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          maxLength={500}
+          required
+        />
+      </Field>
+    </Confirm>
+  );
+}
+
+/* -------------------------------------------------------------------------
+ * OIDC bindings
+ * ---------------------------------------------------------------------- */
+
+function Bindings() {
+  const { me } = useAdminContext();
+  const [search, setSearch] = useState("");
+  const state = useBindings(search);
+  const [revoking, setRevoking] = useState<AdminBinding | null>(null);
+  const [reason, setReason] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<string | null>(null);
+
+  const mayRevoke = operatorMay(me, "admin.keys.revoke");
+
+  async function run() {
+    if (!revoking) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const done = await revokeBinding(revoking.id, reason.trim());
+      // The route's own words, including the count it actually revoked, rather
+      // than this page guessing from the number it rendered a moment ago.
+      setResult(
+        done.alreadyRevoked
+          ? done.effect
+          : `${done.repository} can no longer trade a workflow identity for a token. ${done.tokensRevoked} live token${done.tokensRevoked === 1 ? "" : "s"} stopped working.`,
+      );
+      setReason("");
+      setRevoking(null);
+      state.reload();
+    } catch (err) {
+      setError((err as ApiError).message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const columns: Column<AdminBinding>[] = [
+    {
+      key: "repository",
+      header: "Repository",
+      cell: (r) => <span className="block truncate font-mono text-[12px] text-ink">{r.repository}</span>,
+    },
+    {
+      key: "org",
+      header: "Organization",
+      cell: (r) => <span className="font-mono text-[12px]">{r.orgSlug}</span>,
+    },
+    {
+      key: "standing",
+      header: "Standing",
+      cell: (r) =>
+        r.revokedAt === null ? (
+          <Badge tone="pass">live</Badge>
+        ) : (
+          <Badge tone="neutral">revoked</Badge>
+        ),
+    },
+    {
+      key: "tokens",
+      header: "Live tokens",
+      numeric: true,
+      cell: (r) => r.liveTokens.toLocaleString(),
+    },
+    {
+      key: "lastUsed",
+      header: "Last minted",
+      cell: (r) =>
+        r.lastUsedAt === null ? (
+          <span className="text-dim">Never</span>
+        ) : (
+          <When value={r.lastUsedAt} />
+        ),
+    },
+  ];
+
+  if (mayRevoke) {
+    columns.push({
+      key: "revoke",
+      header: "Action",
+      cell: (r) =>
+        r.revokedAt !== null ? (
+          <span className="text-dim">Revoked</span>
+        ) : (
+          <Button variant="danger" onClick={() => setRevoking(r)}>
+            Revoke
+            <span className="sr-only">
+              {" "}
+              the binding for {r.repository} in {r.orgSlug}
+            </span>
+          </Button>
+        ),
+    });
+  }
+
+  return (
+    <Card
+      title="GitHub workflow identities"
+      note="A binding lets workflows in one repository trade their own GitHub identity for a short lived token. Revoking one also revokes every token it has already minted."
+    >
+      <FilterBar
+        search={{
+          value: search,
+          onChange: setSearch,
+          label: "Search bindings by repository or organization",
+          placeholder: "Repository or organization",
+        }}
+      />
+      {result ? (
+        <p role="status" className="border-b border-rule px-4 py-3 text-[12.5px] leading-5 text-ink">
+          {result}
+        </p>
+      ) : null}
+      <Loaded state={state} skeleton={<TableSkeleton rows={4} cols={5} />}>
+        {(rows) => (
+          <DataTable
+            columns={columns}
+            rows={rows}
+            keyOf={(r) => r.id}
+            empty={
+              <EmptyList
+                title={search ? "No binding matches that" : "No workflow identities are bound"}
+              >
+                {search
+                  ? "No repository or organization on this installation matches that. Clear the search to see every binding."
+                  : "No customer has connected a GitHub workflow identity yet. Until one does, their workflows authenticate with a static engine token instead, which is in the list above."}
+              </EmptyList>
+            }
+            footer={
+              <More
+                shown={rows.length}
+                noun={{ one: "binding", many: "bindings" }}
+                hasMore={state.hasMore}
+                busy={state.busy}
+                error={state.moreError}
+                onMore={state.more}
+              />
+            }
+          />
+        )}
+      </Loaded>
+
+      <Confirm
+        open={revoking !== null}
+        title={revoking ? `Revoke the binding for ${revoking.repository}?` : "Revoke"}
+        phrase={revoking?.repository}
+        confirmLabel="Revoke"
+        busy={busy}
+        error={error}
+        onCancel={() => {
+          setRevoking(null);
+          setReason("");
+          setError(null);
+        }}
+        onConfirm={() => void run()}
+      >
+        <p>
+          <strong className="font-medium text-ink">What this does:</strong> no workflow in that
+          repository can trade its identity for a token again, and the{" "}
+          {revoking?.liveTokens ?? 0} token
+          {(revoking?.liveTokens ?? 0) === 1 ? "" : "s"} it has already minted stop working on their
+          next request.
+        </p>
+        <p>
+          A revocation that left the issued tokens alive would not be a revocation, which is why
+          both happen together.
+        </p>
+        <Field
+          label="Reason"
+          hint="Recorded in the platform audit chain and in the customer's own audit log. Required."
+        >
+          <input
+            className={inputClass}
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            maxLength={500}
+            required
+          />
+        </Field>
+      </Confirm>
+    </Card>
+  );
 }

--- a/console/app/admin/platform/integrations/page.tsx
+++ b/console/app/admin/platform/integrations/page.tsx
@@ -1,18 +1,288 @@
 "use client";
 
-import { PlannedSection } from "@/components/admin/primitives";
+import { useState } from "react";
+import { Badge, Card, Loaded, TableSkeleton, When } from "@/components/ui";
+import {
+  AdminPage,
+  DataTable,
+  EmptyList,
+  FilterBar,
+  StatusChip,
+  type Column,
+} from "@/components/admin/primitives";
+import { More } from "@/components/pagination";
+import {
+  deliveryStanding,
+  useDeliveries,
+  useInstallations,
+  type AdminDelivery,
+  type AdminInstallation,
+} from "@/lib/admin-platform";
 
 /**
- * Integrations & Webhooks
+ * What arrives here from GitHub and from Stripe, and whether it was handled.
  *
- * Not written yet. The route exists from the first commit because a navigation
- * entry that 404s teaches the reader to distrust the rail, and they cannot tell
- * a section that is coming from one that is broken.
+ * INBOUND ONLY, AND SAID SO ON THE PAGE. This product has no outbound webhook
+ * subscription table, no delivery attempt table for one and no signing secret
+ * store. What it has is two inbound ledgers. A screen titled "Webhooks" that
+ * drew an outbound delivery log over an inbound table would answer the wrong
+ * question confidently, which on an incident call is worse than answering none.
  *
- * TO BUILD THIS SECTION: replace the body below with the real page, and add its
- * routes to web/apps/api/src/admin/platform.ts. Nothing else in the portal
- * has to change. See console/app/admin/README.md.
+ * WHAT AN OPERATOR OPENS THIS FOR: a customer says their pull request check
+ * never appeared, or their plan did not change after they paid. Both are
+ * usually a delivery that never arrived or one that arrived and was not
+ * handled, and the difference between those two is the first thing to
+ * establish.
  */
 export default function PlatformIntegrationsPage() {
-  return <PlannedSection href="/admin/platform/integrations" />;
+  return (
+    <AdminPage
+      href="/admin/platform/integrations"
+      lede="The GitHub App installations on this instance, and every delivery that arrived from GitHub or Stripe."
+    >
+      <div className="space-y-5">
+        <Installations />
+        <Deliveries />
+      </div>
+    </AdminPage>
+  );
+}
+
+/* -------------------------------------------------------------------------
+ * Installations
+ * ---------------------------------------------------------------------- */
+
+function Installations() {
+  const [search, setSearch] = useState("");
+  const state = useInstallations(search);
+
+  const columns: Column<AdminInstallation>[] = [
+    {
+      key: "account",
+      header: "GitHub account",
+      cell: (r) => (
+        <>
+          <span className="block truncate font-medium text-ink">{r.accountLogin}</span>
+          <span className="block truncate text-[12px] text-muted">{r.accountType}</span>
+        </>
+      ),
+    },
+    {
+      key: "org",
+      header: "Organization",
+      cell: (r) => <span className="font-mono text-[12px]">{r.orgSlug}</span>,
+    },
+    {
+      key: "repositories",
+      header: "Repositories",
+      numeric: true,
+      cell: (r) => r.repositories.toLocaleString(),
+    },
+    {
+      key: "lastDelivery",
+      header: "Last delivery",
+      cell: (r) =>
+        r.lastDeliveryAt === null ? (
+          // The single most useful cell on this card. An installation that has
+          // never delivered anything is an installation whose events are not
+          // reaching us at all, which is a different problem from one whose
+          // deliveries arrive and fail.
+          <span className="text-warn">Nothing has ever arrived</span>
+        ) : (
+          <When value={r.lastDeliveryAt} />
+        ),
+    },
+    {
+      key: "standing",
+      header: "Standing",
+      cell: (r) =>
+        r.suspended ? <Badge tone="fail">suspended</Badge> : <Badge tone="pass">installed</Badge>,
+    },
+  ];
+
+  return (
+    <Card
+      title="GitHub App installations"
+      note="An organization with no installation receives nothing, whatever else is configured."
+    >
+      <FilterBar
+        search={{
+          value: search,
+          onChange: setSearch,
+          label: "Search installations by GitHub account or organization",
+          placeholder: "Account or organization",
+        }}
+      />
+      <Loaded state={state} skeleton={<TableSkeleton rows={4} cols={5} />}>
+        {(rows) => (
+          <DataTable
+            columns={columns}
+            rows={rows}
+            keyOf={(r) => r.id}
+            empty={
+              <EmptyList
+                title={search ? "No installation matches that" : "The app is not installed anywhere"}
+              >
+                {search
+                  ? "No GitHub account or organization on this installation matches that. Clear the search to see every one."
+                  : "No customer has installed the GitHub App yet, so no pull request event can reach this control plane. Installing it is the customer's action, taken from their own console."}
+              </EmptyList>
+            }
+            footer={
+              <More
+                shown={rows.length}
+                noun={{ one: "installation", many: "installations" }}
+                hasMore={state.hasMore}
+                busy={state.busy}
+                error={state.moreError}
+                onMore={state.more}
+              />
+            }
+          />
+        )}
+      </Loaded>
+    </Card>
+  );
+}
+
+/* -------------------------------------------------------------------------
+ * Deliveries
+ * ---------------------------------------------------------------------- */
+
+function Deliveries() {
+  const [source, setSource] = useState("github");
+  const [unhandled, setUnhandled] = useState("");
+  const [search, setSearch] = useState("");
+  const state = useDeliveries(source, unhandled === "unhandled", search);
+
+  const columns: Column<AdminDelivery>[] = [
+    {
+      key: "event",
+      header: "Event",
+      cell: (r) => (
+        <>
+          <span className="block truncate font-medium text-ink">{r.event}</span>
+          {r.action ? (
+            <span className="block truncate text-[12px] text-muted">{r.action}</span>
+          ) : null}
+        </>
+      ),
+    },
+    {
+      key: "org",
+      header: "Organization",
+      cell: (r) =>
+        r.orgSlug === null ? (
+          // Deliberately kept and deliberately worded. The column is nullable
+          // because a delivery about an account this installation has never
+          // seen resolves to nobody, and those are exactly the rows worth
+          // reading when a customer says their events go nowhere.
+          <span className="text-warn">Matched no organization</span>
+        ) : (
+          <span className="font-mono text-[12px]">{r.orgSlug}</span>
+        ),
+    },
+    {
+      key: "account",
+      header: source === "github" ? "Account" : "Stripe customer",
+      mono: true,
+      cell: (r) => (r.account ? <span className="truncate">{r.account}</span> : <span className="text-dim">Not recorded</span>),
+    },
+    {
+      key: "received",
+      header: "Received",
+      cell: (r) => <When value={r.receivedAt} />,
+    },
+    {
+      key: "standing",
+      header: "Outcome",
+      cell: (r) => {
+        const standing = deliveryStanding(r);
+        return <StatusChip value={standing.label} tone={standing.tone} />;
+      },
+    },
+  ];
+
+  return (
+    <Card
+      title="Deliveries"
+      note="Inbound only. This product registers no outbound webhooks, so there is no outbound delivery log to show and none is drawn here."
+    >
+      <FilterBar
+        search={{
+          value: search,
+          onChange: setSearch,
+          label: "Search deliveries by event type, account or organization",
+          placeholder: "Event, account or organization",
+        }}
+        filters={[
+          {
+            label: "Sender",
+            value: source,
+            onChange: (next) => {
+              setSource(next);
+              // The two ledgers use different words for an outcome, so a filter
+              // set for one is a filter that means something else against the
+              // other. Cleared rather than carried across.
+              setUnhandled("");
+            },
+            options: [
+              { value: "github", label: "GitHub" },
+              { value: "stripe", label: "Stripe" },
+            ],
+          },
+          {
+            label: "Showing",
+            value: unhandled,
+            onChange: setUnhandled,
+            options: [
+              { value: "", label: "Every delivery" },
+              {
+                value: "unhandled",
+                label: source === "github" ? "Never handled" : "Unresolved",
+              },
+            ],
+          },
+        ]}
+      />
+      <Loaded state={state} skeleton={<TableSkeleton rows={8} cols={5} />}>
+        {(rows) => (
+          <DataTable
+            columns={columns}
+            rows={rows}
+            keyOf={(r) => r.id}
+            empty={
+              <EmptyList
+                title={
+                  unhandled
+                    ? "Everything that arrived was handled"
+                    : search
+                      ? "No delivery matches that"
+                      : "Nothing has arrived yet"
+                }
+              >
+                {unhandled
+                  ? "Nothing in this ledger is waiting. That is an answer rather than an empty screen: every delivery that reached this control plane was decided."
+                  : search
+                    ? "No delivery in this ledger matches that. Clear the search to see every one."
+                    : source === "github"
+                      ? "No GitHub delivery has reached this control plane. If a customer expects one, check that the app is installed for their account in the card above."
+                      : "No Stripe event has reached this control plane. On an installation with no Stripe configuration that is the correct state."}
+              </EmptyList>
+            }
+            footer={
+              <More
+                shown={rows.length}
+                noun={{ one: "delivery", many: "deliveries" }}
+                hasMore={state.hasMore}
+                busy={state.busy}
+                error={state.moreError}
+                onMore={state.more}
+              />
+            }
+          />
+        )}
+      </Loaded>
+    </Card>
+  );
 }

--- a/console/app/admin/platform/mcp/page.tsx
+++ b/console/app/admin/platform/mcp/page.tsx
@@ -1,18 +1,151 @@
 "use client";
 
-import { PlannedSection } from "@/components/admin/primitives";
+import { Card, CardSkeleton, Loaded } from "@/components/ui";
+import { AdminPage } from "@/components/admin/primitives";
+import { useMcpSurface } from "@/lib/admin-platform";
 
 /**
- * MCP Management
+ * MCP Management, and the honest answer to what there is to manage: nothing
+ * here.
  *
- * Not written yet. The route exists from the first commit because a navigation
- * entry that 404s teaches the reader to distrust the rail, and they cannot tell
- * a section that is coming from one that is broken.
+ * WHY THIS PAGE IS NOT A FLEET OF SERVERS. `af mcp` is a real, shipped engine
+ * feature, and it runs entirely on the developer's machine. It binds one
+ * checkout, speaks the protocol on standard input and output, and keeps its
+ * runs in that project's own state directory. It opens no connection to this
+ * control plane, presents no credential and sends no event. So there is no
+ * server list, no connection count, no last seen time and no adoption figure,
+ * and a page showing one would be showing numbers nobody measured. This
+ * repository has a check called figurecheck because an invented number shipped
+ * once already.
  *
- * TO BUILD THIS SECTION: replace the body below with the real page, and add its
- * routes to web/apps/api/src/admin/platform.ts. Nothing else in the portal
- * has to change. See console/app/admin/README.md.
+ * WHAT THE PAGE IS FOR INSTEAD. One question an operator is actually asked,
+ * usually by a customer's security reviewer: can an agent use this to make a
+ * check easier on itself. The answer is no, and it is provable rather than a
+ * promise, because the refusal is a property of the tool schemas rather than a
+ * rule the tools ask a model to respect. Every claim below carries the engine
+ * file and symbol it came from, and admin-platform.test.ts opens each file and
+ * looks for each symbol, so a tool renamed or unregistered fails the suite
+ * rather than leaving this page describing a product that moved.
+ *
+ * THE ABSENCE IS SENT BY THE SERVER, not assumed here. `recordsAnything` is a
+ * field on the route, so the day a write path exists this page changes because
+ * the server changed rather than because somebody remembered to edit it.
  */
 export default function PlatformMcpPage() {
-  return <PlannedSection href="/admin/platform/mcp" />;
+  const state = useMcpSurface();
+
+  return (
+    <AdminPage
+      href="/admin/platform/mcp"
+      lede="What this control plane knows about the MCP server, and where the answers actually live."
+    >
+      <Loaded state={state} framed skeleton={<CardSkeleton count={3} />}>
+        {(surface) => (
+          <div className="space-y-5">
+            <Card title="This console holds no MCP record">
+              <div className="max-w-[72ch] space-y-3 px-4 py-4 text-[13px] leading-6 text-muted">
+                {surface.recordsAnything ? (
+                  // Unreachable today and deliberately written anyway. If a
+                  // write path is ever added, this page must stop claiming an
+                  // absence rather than keep asserting one that has ended.
+                  <p className="text-ink">
+                    This control plane now records something about MCP. This page has not been
+                    rebuilt for it, so read the routes rather than trusting this text.
+                  </p>
+                ) : (
+                  <>
+                    <p>{surface.why}</p>
+                    <p>
+                      Nothing on this page is a measurement, because there is nothing here to
+                      measure. What follows is the tool surface the engine serves, which is checked
+                      in and can be read from the source.
+                    </p>
+                  </>
+                )}
+              </div>
+            </Card>
+
+            <Card
+              title="The tools an agent can call"
+              note="Served by the engine on the developer's machine, not by this control plane."
+            >
+              <ul className="divide-y divide-rule">
+                {surface.tools.map((tool) => (
+                  <li key={tool.name} className="px-4 py-4">
+                    <p className="font-mono text-[13px] font-medium text-ink">{tool.name}</p>
+                    <p className="mt-1.5 max-w-[72ch] text-[13px] leading-6 text-muted">
+                      {tool.does}
+                    </p>
+                    <p className="mt-2 max-w-[72ch] text-[13px] leading-6 text-ink">
+                      <span className="font-medium">What it refuses:</span> {tool.refuses}
+                    </p>
+                    {/* The provenance, in the smallest type on the card and
+                        never hidden. It is what makes the two paragraphs above
+                        checkable rather than a claim, and a reader who wants to
+                        verify one should not have to ask where to look. */}
+                    <p className="mt-2 text-[11.5px] leading-5 text-dim">
+                      Served by <span className="break-all font-mono">{tool.servedBy}</span>
+                    </p>
+                  </li>
+                ))}
+              </ul>
+            </Card>
+
+            <Card title="Why an agent cannot weaken a check">
+              <div className="max-w-[72ch] space-y-3 px-4 py-4 text-[13px] leading-6 text-muted">
+                <p>
+                  There is no argument on any tool that disables sanitization, widens the egress
+                  policy, lowers a threshold, names a database or skips the rehearsal. That is a
+                  property of the schemas rather than a convention the tools ask an agent to
+                  respect, and it holds because an argument the server does not know is refused
+                  rather than ignored.
+                </p>
+                <p className="text-[11.5px] leading-5 text-dim">
+                  The refusal is at{" "}
+                  <span className="break-all font-mono">{surface.unknownFieldRefusal}</span>
+                </p>
+                <p>
+                  Thresholds come from the policy block of the project&apos;s manifest, and the
+                  verdict is decided by the same evaluator the pull request check uses, so a tool
+                  call and a check cannot disagree about the same change.
+                </p>
+                <p className="text-[11.5px] leading-5 text-dim">
+                  The four tools above are the four registered in{" "}
+                  <span className="break-all font-mono">{surface.registeredIn}</span>, which is the
+                  whole set an agent can reach.
+                </p>
+              </div>
+            </Card>
+
+            <Card title="Where MCP is actually managed">
+              <div className="max-w-[72ch] space-y-3 px-4 py-4 text-[13px] leading-6 text-muted">
+                <p>
+                  On the developer&apos;s machine, by their MCP client. The server is started by the
+                  client rather than typed by a person, with{" "}
+                  <span className="font-mono text-[12.5px] text-ink">{surface.command}</span> in the
+                  repository it is to serve.
+                </p>
+                <p>
+                  Running it in a terminal looks like it has hung. That is the protocol waiting for
+                  a client, and it is the first thing to say to somebody who reports it as broken.
+                </p>
+                <p>
+                  {/* An ordinary link to the docs site, which is served from the
+                      same installation. The one thing this page can usefully do
+                      is send the reader somewhere that has the answer. */}
+                  <a
+                    className="font-medium text-ink underline underline-offset-2"
+                    href={surface.documentation}
+                  >
+                    The MCP server reference
+                  </a>{" "}
+                  documents every tool, the three verdicts, and what makes a result inconclusive.
+                </p>
+              </div>
+            </Card>
+          </div>
+        )}
+      </Loaded>
+    </AdminPage>
+  );
 }

--- a/console/app/admin/platform/repositories/page.tsx
+++ b/console/app/admin/platform/repositories/page.tsx
@@ -1,18 +1,494 @@
 "use client";
 
-import { PlannedSection } from "@/components/admin/primitives";
+import { Suspense, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import {
+  Badge,
+  Card,
+  CardSkeleton,
+  CellLink,
+  Loaded,
+  TableSkeleton,
+  When,
+} from "@/components/ui";
+import {
+  AdminPage,
+  DataTable,
+  Drawer,
+  EmptyList,
+  Facts,
+  FilterBar,
+  StatusChip,
+  type Column,
+} from "@/components/admin/primitives";
+import { More } from "@/components/pagination";
+import {
+  approvalWording,
+  shortSha,
+  useGenerations,
+  usePullRequests,
+  useRepositories,
+  useRepository,
+  type AdminGeneration,
+  type AdminPullRequest,
+  type AdminRepository,
+} from "@/lib/admin-platform";
 
 /**
- * Repositories & Pull Requests
+ * The repositories this installation answers on, and the pull requests it is
+ * answering.
  *
- * Not written yet. The route exists from the first commit because a navigation
- * entry that 404s teaches the reader to distrust the rail, and they cannot tell
- * a section that is coming from one that is broken.
+ * THE QUESTION THIS SCREEN ANSWERS: a customer says the check on one pull
+ * request never appeared. Support has a repository name and a number, and the
+ * answer is in the generation behind that pull request, where `state` and
+ * `detail` together say what happened in one sentence. So the path is
+ * repository, then pull requests, then that pull request's generations, and
+ * each step is one query rather than a page that pretends to know everything.
  *
- * TO BUILD THIS SECTION: replace the body below with the real page, and add its
- * routes to web/apps/api/src/admin/platform.ts. Nothing else in the portal
- * has to change. See console/app/admin/README.md.
+ * A QUERY STRING RATHER THAN A DYNAMIC SEGMENT. The console is a static export,
+ * so a detail view is /admin/platform/repositories?id=<uuid> and never
+ * /admin/platform/repositories/[id], which cannot be exported without knowing
+ * every id at build time. next.config.ts says so and the rest of the console
+ * already follows it.
  */
 export default function PlatformRepositoriesPage() {
-  return <PlannedSection href="/admin/platform/repositories" />;
+  return (
+    <Suspense
+      fallback={
+        <AdminPage href="/admin/platform/repositories">
+          <Card>
+            <TableSkeleton rows={6} cols={5} />
+          </Card>
+        </AdminPage>
+      }
+    >
+      <Screen />
+    </Suspense>
+  );
+}
+
+function Screen() {
+  const params = useSearchParams();
+  const id = params.get("id");
+  return id ? <Detail repositoryId={id} /> : <RepositoryList />;
+}
+
+/* -------------------------------------------------------------------------
+ * The list
+ * ---------------------------------------------------------------------- */
+
+function RepositoryList() {
+  const [search, setSearch] = useState("");
+  const state = useRepositories(search);
+
+  const columns: Column<AdminRepository>[] = [
+    {
+      key: "repository",
+      header: "Repository",
+      cell: (r) => (
+        <>
+          {/* A link on the name rather than a clickable row: a row that
+              navigates on click has no keyboard equivalent and no address to
+              copy, and CellLink is already 44px tall under a thumb. */}
+          <CellLink href={`/admin/platform/repositories?id=${encodeURIComponent(r.id)}`}>
+            <span className="block truncate font-mono text-[12.5px] font-medium text-ink">
+              {r.fullName}
+            </span>
+          </CellLink>
+          <span className="block truncate font-mono text-[12px] text-muted">{r.orgSlug}</span>
+        </>
+      ),
+    },
+    {
+      key: "branch",
+      header: "Default branch",
+      mono: true,
+      cell: (r) => r.defaultBranch,
+    },
+    {
+      key: "open",
+      header: "Open PRs",
+      numeric: true,
+      cell: (r) => r.openPullRequests.toLocaleString(),
+    },
+    {
+      key: "activity",
+      header: "Last pull request",
+      cell: (r) =>
+        // Never and zero open are different facts. A repository that has never
+        // had a pull request recorded has never exercised this product at all,
+        // which is worth telling apart from one whose pull requests are closed.
+        r.lastPullRequestAt === null ? (
+          <span className="text-dim">None recorded</span>
+        ) : (
+          <When value={r.lastPullRequestAt} />
+        ),
+    },
+    {
+      key: "standing",
+      header: "Standing",
+      cell: (r) => (
+        <>
+          {r.archived ? <Badge tone="neutral">archived</Badge> : <Badge tone="pass">active</Badge>}
+          {r.private ? null : (
+            <span className="mt-1 block text-[12px] text-muted">Public repository</span>
+          )}
+        </>
+      ),
+    },
+  ];
+
+  return (
+    <AdminPage href="/admin/platform/repositories">
+      <Card>
+        <FilterBar
+          search={{
+            value: search,
+            onChange: setSearch,
+            label: "Search repositories by name or organization",
+            placeholder: "owner/name or organization",
+          }}
+        />
+        <Loaded state={state} skeleton={<TableSkeleton rows={6} cols={5} />}>
+          {(rows) => (
+            <DataTable
+              columns={columns}
+              rows={rows}
+              keyOf={(r) => r.id}
+              empty={
+                <EmptyList
+                  title={search ? "No repository matches that" : "No repositories are connected"}
+                >
+                  {search
+                    ? "Nothing on this installation has that name, and no organization has that slug. Clear the search to see every repository."
+                    : "No customer has connected a repository yet. A repository appears here the first time the GitHub App delivers an event about it."}
+                </EmptyList>
+              }
+              footer={
+                <More
+                  shown={rows.length}
+                  noun={{ one: "repository", many: "repositories" }}
+                  hasMore={state.hasMore}
+                  busy={state.busy}
+                  error={state.moreError}
+                  onMore={state.more}
+                />
+              }
+            />
+          )}
+        </Loaded>
+      </Card>
+    </AdminPage>
+  );
+}
+
+/* -------------------------------------------------------------------------
+ * One repository
+ * ---------------------------------------------------------------------- */
+
+function Detail({ repositoryId }: { repositoryId: string }) {
+  const repository = useRepository(repositoryId);
+  const [state, setState] = useState("open");
+  const pulls = usePullRequests(repositoryId, state);
+  const [open, setOpen] = useState<AdminPullRequest | null>(null);
+
+  return (
+    <Loaded
+      state={repository}
+      framed
+      skeleton={
+        <AdminPage title="Repository">
+          <CardSkeleton count={2} />
+        </AdminPage>
+      }
+    >
+      {(repo) => (
+        <AdminPage
+          title={repo.fullName}
+          lede={
+            <>
+              In <span className="font-mono">{repo.orgSlug}</span>, tracked since{" "}
+              <When value={repo.createdAt} />
+            </>
+          }
+          actions={
+            <CellLink href="/admin/platform/repositories">Back to every repository</CellLink>
+          }
+        >
+          <div className="space-y-5">
+            <Card title="Repository">
+              <Facts
+                facts={[
+                  { label: "Organization", value: repo.orgName },
+                  { label: "Slug", value: repo.orgSlug, mono: true },
+                  { label: "Default branch", value: repo.defaultBranch, mono: true },
+                  { label: "Visibility", value: repo.private ? "Private" : "Public" },
+                  { label: "GitHub id", value: repo.githubId, mono: true },
+                  {
+                    label: "Standing",
+                    value: repo.archived ? "Archived on GitHub" : "Active",
+                  },
+                  {
+                    label: "App installation",
+                    value:
+                      repo.installations.length === 0 ? (
+                        // The first thing to check when a customer reports that
+                        // nothing arrives. A repository row survives the
+                        // installation being removed, so this really can be
+                        // empty on a repository that used to work.
+                        <span className="text-warn">
+                          None. No event about this repository can reach the control plane.
+                        </span>
+                      ) : (
+                        repo.installations
+                          .map(
+                            (i) => `${i.accountLogin}${i.suspended ? " (suspended)" : ""}`,
+                          )
+                          .join(", ")
+                      ),
+                  },
+                ]}
+              />
+            </Card>
+
+            <Card
+              title="Pull requests"
+              note="The newest generation for each, which is where a check that never appeared is explained."
+            >
+              <FilterBar
+                filters={[
+                  {
+                    label: "State",
+                    value: state,
+                    onChange: setState,
+                    options: [
+                      { value: "open", label: "Open" },
+                      { value: "merged", label: "Merged" },
+                      { value: "closed", label: "Closed" },
+                      { value: "", label: "Every state" },
+                    ],
+                  },
+                ]}
+              />
+              <Loaded state={pulls} skeleton={<TableSkeleton rows={5} cols={4} />}>
+                {(rows) => (
+                  <DataTable
+                    columns={pullRequestColumns(setOpen)}
+                    rows={rows}
+                    keyOf={(r) => r.id}
+                    empty={
+                      <EmptyList
+                        title={
+                          state === "open"
+                            ? "No open pull requests"
+                            : state === ""
+                              ? "No pull requests recorded"
+                              : `No ${state} pull requests`
+                        }
+                      >
+                        {state === ""
+                          ? "This control plane has never recorded a pull request on this repository. Either none has been opened since the app was installed, or its deliveries are not arriving. The Integrations section shows which."
+                          : "Change the state filter above to see the ones in other states."}
+                      </EmptyList>
+                    }
+                    footer={
+                      <More
+                        shown={rows.length}
+                        noun={{ one: "pull request", many: "pull requests" }}
+                        hasMore={pulls.hasMore}
+                        busy={pulls.busy}
+                        error={pulls.moreError}
+                        onMore={pulls.more}
+                      />
+                    }
+                  />
+                )}
+              </Loaded>
+            </Card>
+          </div>
+
+          <Generations pullRequest={open} onClose={() => setOpen(null)} />
+        </AdminPage>
+      )}
+    </Loaded>
+  );
+}
+
+function pullRequestColumns(
+  onOpen: (pr: AdminPullRequest) => void,
+): Column<AdminPullRequest>[] {
+  return [
+    {
+      key: "number",
+      header: "Pull request",
+      cell: (r) => (
+        <>
+          <button
+            type="button"
+            onClick={() => onOpen(r)}
+            // A real button, so it is in the tab order, activates on Enter and
+            // Space, and is announced as a control. A div with an onClick here
+            // would be invisible to a keyboard.
+            className="block max-w-full truncate text-left font-medium text-ink underline decoration-rule-strong underline-offset-2"
+          >
+            #{r.number} {r.title ?? "Untitled"}
+          </button>
+          <span className="block truncate font-mono text-[12px] text-muted">
+            {r.headRef} into {r.baseRef}
+          </span>
+        </>
+      ),
+    },
+    {
+      key: "state",
+      header: "State",
+      cell: (r) => (
+        <>
+          <StatusChip value={r.state} />
+          {r.draft ? <span className="mt-1 block text-[12px] text-muted">Draft</span> : null}
+        </>
+      ),
+    },
+    {
+      key: "origin",
+      header: "Approval",
+      cell: (r) => {
+        const approval = approvalWording(r);
+        return (
+          <>
+            <Badge tone={approval.tone}>{approval.label}</Badge>
+            {r.fromFork ? (
+              <span className="mt-1 block truncate font-mono text-[12px] text-muted">
+                fork: {r.headRepository}
+              </span>
+            ) : null}
+          </>
+        );
+      },
+    },
+    {
+      key: "generation",
+      header: "Newest check",
+      cell: (r) =>
+        r.latestGeneration === null ? (
+          // The answer to "the check never appeared", stated rather than left
+          // as a blank cell for the reader to interpret.
+          <span className="text-warn">No check has ever been created</span>
+        ) : (
+          <>
+            <StatusChip value={r.latestGeneration.state} />
+            <span className="mt-1 block font-mono text-[12px] text-muted">
+              {shortSha(r.latestGeneration.headSha)} attempt {r.latestGeneration.attempt}
+            </span>
+          </>
+        ),
+    },
+  ];
+}
+
+/* -------------------------------------------------------------------------
+ * One pull request's generations
+ * ---------------------------------------------------------------------- */
+
+function Generations({
+  pullRequest,
+  onClose,
+}: {
+  pullRequest: AdminPullRequest | null;
+  onClose: () => void;
+}) {
+  const state = useGenerations(pullRequest?.id ?? "");
+
+  return (
+    <Drawer
+      open={pullRequest !== null}
+      title={pullRequest ? `#${pullRequest.number} check history` : "Check history"}
+      onClose={onClose}
+    >
+      <Loaded state={state} skeleton={<CardSkeleton count={2} />}>
+        {(rows) =>
+          rows.length === 0 ? (
+            <EmptyList title="No check has been created for this pull request">
+              Nothing was ever queued against it. That usually means the delivery that would have
+              started one did not arrive, or the head is from a fork nobody has approved.
+            </EmptyList>
+          ) : (
+            <ul className="divide-y divide-rule">
+              {rows.map((g) => (
+                <li key={g.id} className="px-4 py-4">
+                  <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                    <StatusChip value={g.state} />
+                    <span className="font-mono text-[12px] text-muted">
+                      {shortSha(g.headSha)} attempt {g.attempt}
+                    </span>
+                  </div>
+                  {g.detail ? (
+                    // The one sentence the generation carries. 0021 keeps it to
+                    // a sentence on purpose, so it is shown whole rather than
+                    // truncated into something that reads like a different one.
+                    <p className="mt-2 break-words text-[13px] leading-6 text-ink">{g.detail}</p>
+                  ) : null}
+                  <dl className="mt-2 grid grid-cols-[minmax(0,110px)_minmax(0,1fr)] gap-x-4 gap-y-1 text-[12px] leading-5">
+                    <GenerationFact label="Queued" value={<When value={g.queuedAt} />} />
+                    {g.startedAt ? (
+                      <GenerationFact label="Started" value={<When value={g.startedAt} />} />
+                    ) : null}
+                    {g.finishedAt ? (
+                      <GenerationFact label="Finished" value={<When value={g.finishedAt} />} />
+                    ) : null}
+                    {g.finishedAt === null && g.deadlineAt ? (
+                      <GenerationFact label="Gives up" value={<When value={g.deadlineAt} />} />
+                    ) : null}
+                    {g.envId ? (
+                      <GenerationFact
+                        label="Environment"
+                        value={<span className="font-mono">{g.envId}</span>}
+                      />
+                    ) : null}
+                    {g.reportedBy ? (
+                      <GenerationFact label="Reported by" value={g.reportedBy} />
+                    ) : null}
+                    {g.checkRunId === null ? (
+                      // Null while the installation does not hold checks:write.
+                      // Saying which permission is missing is the whole value of
+                      // showing this at all.
+                      <GenerationFact
+                        label="Check run"
+                        value={
+                          <span className="text-warn">
+                            None. The installation does not hold checks: write, so only the comment
+                            was posted.
+                          </span>
+                        }
+                      />
+                    ) : (
+                      <GenerationFact
+                        label="Check run"
+                        value={<span className="font-mono">{g.checkRunId}</span>}
+                      />
+                    )}
+                    {g.supersededBy ? (
+                      <GenerationFact
+                        label="Superseded"
+                        value="A newer generation replaced this one."
+                      />
+                    ) : null}
+                  </dl>
+                </li>
+              ))}
+            </ul>
+          )
+        }
+      </Loaded>
+    </Drawer>
+  );
+}
+
+function GenerationFact({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <>
+      <dt className="text-dim">{label}</dt>
+      <dd className="min-w-0 break-words text-muted">{value}</dd>
+    </>
+  );
 }

--- a/console/lib/admin-nav.ts
+++ b/console/lib/admin-nav.ts
@@ -192,7 +192,7 @@ export const ADMIN_NAV: AdminNavGroup[] = [
         label: "Repositories & Pull Requests",
         href: "/admin/platform/repositories",
         Icon: IconRepositories,
-        permission: "admin.tenants.read",
+        permission: "admin.repos.read",
         summary:
           "The repositories this installation is connected to and the pull requests it is answering on.",
       },
@@ -200,22 +200,37 @@ export const ADMIN_NAV: AdminNavGroup[] = [
         label: "MCP Management",
         href: "/admin/platform/mcp",
         Icon: IconMcp,
-        permission: "admin.tenants.read",
-        summary: "The MCP servers customers have connected, and what each one is allowed to reach.",
+        permission: "admin.mcp.read",
+        // Rewritten by the lane that built the section, and the change is the
+        // point rather than a wording preference. The MCP server runs on the
+        // developer's machine and never speaks to this control plane, so there
+        // are no connected servers to list and nothing this console could say
+        // one is allowed to reach. The summary is read on the overview
+        // directory, where a sentence promising a fleet is the same invented
+        // dashboard the page itself refuses to draw.
+        summary:
+          "What this control plane records about MCP, which is nothing, and the tools the engine serves.",
       },
       {
         label: "API Keys",
         href: "/admin/platform/api-keys",
         Icon: IconKeys,
-        permission: "admin.tenants.read",
+        permission: "admin.keys.read",
         summary: "Keys issued across the platform, when each was last used, and how to revoke one.",
       },
       {
         label: "Integrations & Webhooks",
         href: "/admin/platform/integrations",
         Icon: IconIntegrations,
-        permission: "admin.tenants.read",
-        summary: "Outbound deliveries, what failed, and the endpoints that keep refusing them.",
+        permission: "admin.webhooks.read",
+        // Also rewritten, for the same reason. This product registers no
+        // outbound webhooks: there is no subscription table, no delivery
+        // attempt table and no signing secret store. What exists is two INBOUND
+        // ledgers, github_deliveries and billing_events. A summary promising
+        // outbound deliveries and refusing endpoints describes a feature the
+        // schema does not have.
+        summary:
+          "The GitHub App installations here, and every delivery that arrived from GitHub or Stripe.",
       },
     ],
   },

--- a/console/lib/admin-platform.ts
+++ b/console/lib/admin-platform.ts
@@ -1,0 +1,371 @@
+"use client";
+
+/**
+ * The Developer Platform lane's client.
+ *
+ * A third module beside admin.ts rather than additions to it, for the reason
+ * admin.ts is a second module beside api.ts: the transport is REUSED and
+ * nothing else is. Every hook here goes through `query`, `usePages` and
+ * `adminMutate`, so there is no second fetch wrapper for the error shape, the
+ * credentials mode or the CSRF header to drift in.
+ *
+ * EVERY PAGED LIST USES usePages, without exception. Three screens in this
+ * console already read one page of a cursor paged route and told the reader the
+ * list was complete when it was showing a third of it. On this lane that would
+ * be an operator concluding a credential does not exist because it sorted past
+ * the cut, which is a confident wrong answer about a security surface.
+ */
+
+import { query, useApi, usePages, type ApiError } from "@/lib/api";
+import { adminMutate, type AdminPage } from "@/lib/admin";
+
+export type { ApiError };
+
+/* -------------------------------------------------------------------------
+ * Repositories and pull requests
+ * ---------------------------------------------------------------------- */
+
+export interface AdminRepository {
+  id: string;
+  orgId: string;
+  orgSlug: string;
+  fullName: string;
+  defaultBranch: string;
+  private: boolean;
+  archived: boolean;
+  createdAt: string;
+  openPullRequests: number;
+  /** Null when no pull request has ever been recorded for it, which is not the
+   *  same as zero open ones and is rendered differently. */
+  lastPullRequestAt: string | null;
+}
+
+export interface AdminRepositoryDetail {
+  id: string;
+  orgId: string;
+  orgSlug: string;
+  orgName: string;
+  fullName: string;
+  defaultBranch: string;
+  private: boolean;
+  githubId: string | null;
+  archived: boolean;
+  createdAt: string;
+  installations: { accountLogin: string; accountType: string; suspended: boolean }[];
+}
+
+export interface AdminGenerationSummary {
+  state: string;
+  detail: string | null;
+  attempt: number;
+  headSha: string | null;
+  verdict: unknown;
+  updatedAt: string | null;
+}
+
+export interface AdminPullRequest {
+  id: string;
+  number: number;
+  title: string | null;
+  state: string;
+  draft: boolean;
+  fromFork: boolean;
+  headRef: string;
+  baseRef: string;
+  headRepository: string;
+  headSha: string;
+  approvedSha: string | null;
+  approvedBy: string | null;
+  approvedAt: string | null;
+  /** Whether the approval is for the commit that is currently at the head. A
+   *  fork approval that outlived a push is an approval of code nobody looked
+   *  at, so the two are reported apart rather than as one boolean. */
+  approvalCoversHead: boolean;
+  openedAt: string | null;
+  updatedAt: string;
+  latestGeneration: AdminGenerationSummary | null;
+}
+
+export interface AdminGeneration {
+  id: string;
+  headSha: string;
+  attempt: number;
+  state: string;
+  detail: string | null;
+  checkRunId: string | null;
+  workflowRunId: string | null;
+  reportedBy: string | null;
+  envId: string | null;
+  verdict: unknown;
+  supersededBy: string | null;
+  queuedAt: string | null;
+  startedAt: string | null;
+  finishedAt: string | null;
+  deadlineAt: string | null;
+  updatedAt: string;
+}
+
+export function useRepositories(search: string) {
+  return usePages<AdminRepository>(
+    async (cursor) => {
+      const page = await query<AdminPage<AdminRepository>>("admin.platform.repositories.list", {
+        limit: 50,
+        ...(search ? { query: search } : {}),
+        ...(cursor === null ? {} : { cursor }),
+      });
+      return { rows: page.rows, next: page.nextCursor };
+    },
+    [search],
+  );
+}
+
+export function usePullRequests(repositoryId: string, state: string) {
+  return usePages<AdminPullRequest>(
+    async (cursor) => {
+      const page = await query<AdminPage<AdminPullRequest>>(
+        "admin.platform.repositories.pullRequests",
+        {
+          repositoryId,
+          limit: 50,
+          ...(state ? { state } : {}),
+          ...(cursor === null ? {} : { cursor }),
+        },
+      );
+      return { rows: page.rows, next: page.nextCursor };
+    },
+    [repositoryId, state],
+  );
+}
+
+export function useRepository(repositoryId: string) {
+  return useApi<AdminRepositoryDetail>(
+    () => query("admin.platform.repositories.get", { repositoryId }),
+    [repositoryId],
+  );
+}
+
+/**
+ * Every generation for one pull request.
+ *
+ * useApi rather than usePages because the route is bounded at fifty rather than
+ * paged, and it is bounded because the schema carries a UNIQUE on
+ * (pull_request_id, head_sha): fifty rows means fifty distinct heads. A `More`
+ * footer here would offer a page that does not exist.
+ *
+ * The empty string is a real argument. A hook cannot be called conditionally,
+ * so the panel that is closed asks for nothing and the route is never called,
+ * which is what the guard in the caller is for.
+ */
+export function useGenerations(pullRequestId: string) {
+  return useApi<AdminGeneration[]>(
+    () =>
+      pullRequestId === ""
+        ? Promise.resolve([])
+        : query("admin.platform.repositories.generations", { pullRequestId }),
+    [pullRequestId],
+  );
+}
+
+/* -------------------------------------------------------------------------
+ * Credentials
+ * ---------------------------------------------------------------------- */
+
+/** live, expired or revoked, decided by the server so this file and the route
+ *  cannot disagree about which of expired and revoked wins. */
+export type { CredentialStanding } from "@/lib/platform-format";
+import type { CredentialStanding } from "@/lib/platform-format";
+
+export interface AdminCredential {
+  id: string;
+  orgId: string;
+  orgSlug: string;
+  name: string;
+  /** The first twelve characters, which is what the customer's own console
+   *  shows them. There is no field on this type that holds the value, because
+   *  only the hash is stored and no route in this product can return one. */
+  prefix: string;
+  kind: string;
+  scopes: string[];
+  createdAt: string;
+  lastUsedAt: string | null;
+  expiresAt: string | null;
+  revokedAt: string | null;
+  expired: boolean;
+  standing: CredentialStanding;
+  createdBy: string | null;
+  /** Who the credential acts AS, which is null for a machine token on purpose:
+   *  a machine is not a person, and putting its actions in somebody's audit
+   *  trail is what the null prevents. */
+  actsAs: string | null;
+  bindingRepository: string | null;
+}
+
+export interface AdminBinding {
+  id: string;
+  orgId: string;
+  orgSlug: string;
+  repository: string;
+  createdAt: string;
+  lastUsedAt: string | null;
+  revokedAt: string | null;
+  createdBy: string | null;
+  liveTokens: number;
+}
+
+export function useCredentials(search: string, kind: string, liveOnly: boolean) {
+  return usePages<AdminCredential>(
+    async (cursor) => {
+      const page = await query<AdminPage<AdminCredential>>("admin.platform.keys.list", {
+        limit: 50,
+        liveOnly,
+        ...(search ? { query: search } : {}),
+        ...(kind ? { kind } : {}),
+        ...(cursor === null ? {} : { cursor }),
+      });
+      return { rows: page.rows, next: page.nextCursor };
+    },
+    [search, kind, liveOnly],
+  );
+}
+
+export function useBindings(search: string) {
+  return usePages<AdminBinding>(
+    async (cursor) => {
+      const page = await query<AdminPage<AdminBinding>>("admin.platform.keys.bindings", {
+        limit: 50,
+        ...(search ? { query: search } : {}),
+        ...(cursor === null ? {} : { cursor }),
+      });
+      return { rows: page.rows, next: page.nextCursor };
+    },
+    [search],
+  );
+}
+
+export interface RevokeResult {
+  revoked: boolean;
+  alreadyRevoked: boolean;
+  /** Said by the route rather than written here. Two sentences that mean the
+   *  same thing today are two sentences that disagree after somebody edits
+   *  one, and this is the sentence an operator repeats to the customer. */
+  effect: string;
+}
+
+export async function revokeCredential(tokenId: string, reason: string) {
+  return adminMutate<RevokeResult & { prefix: string }>("admin.platform.keys.revoke", {
+    tokenId,
+    reason,
+  });
+}
+
+export async function revokeBinding(bindingId: string, reason: string) {
+  return adminMutate<RevokeResult & { repository: string; tokensRevoked: number }>(
+    "admin.platform.keys.revokeBinding",
+    { bindingId, reason },
+  );
+}
+
+/* -------------------------------------------------------------------------
+ * Integrations
+ * ---------------------------------------------------------------------- */
+
+export interface AdminInstallation {
+  id: string;
+  orgId: string;
+  orgSlug: string;
+  installationId: string;
+  accountLogin: string;
+  accountType: string;
+  suspended: boolean;
+  createdAt: string;
+  repositories: number;
+  lastDeliveryAt: string | null;
+}
+
+export interface AdminDelivery {
+  id: string;
+  /** Null for a delivery about an account this installation has never seen.
+   *  Kept rather than filtered out: those are the rows worth reading when
+   *  somebody reports that their events go nowhere. */
+  orgSlug: string | null;
+  account: string | null;
+  event: string;
+  action: string | null;
+  receivedAt: string;
+  handledAt: string | null;
+  outcome: string | null;
+}
+
+export function useInstallations(search: string) {
+  return usePages<AdminInstallation>(
+    async (cursor) => {
+      const page = await query<AdminPage<AdminInstallation>>(
+        "admin.platform.integrations.installations",
+        {
+          limit: 50,
+          ...(search ? { query: search } : {}),
+          ...(cursor === null ? {} : { cursor }),
+        },
+      );
+      return { rows: page.rows, next: page.nextCursor };
+    },
+    [search],
+  );
+}
+
+export function useDeliveries(source: string, unhandledOnly: boolean, search: string) {
+  return usePages<AdminDelivery>(
+    async (cursor) => {
+      const page = await query<AdminPage<AdminDelivery>>("admin.platform.integrations.deliveries", {
+        source,
+        unhandledOnly,
+        limit: 50,
+        ...(search ? { query: search } : {}),
+        ...(cursor === null ? {} : { cursor }),
+      });
+      return { rows: page.rows, next: page.nextCursor };
+    },
+    [source, unhandledOnly, search],
+  );
+}
+
+/* -------------------------------------------------------------------------
+ * MCP
+ * ---------------------------------------------------------------------- */
+
+export interface McpSurface {
+  /** Whether this control plane records anything about MCP at all. Sent by the
+   *  server rather than assumed here, so the day a write path exists the page
+   *  changes because the server changed. */
+  recordsAnything: boolean;
+  why: string;
+  tools: { name: string; does: string; refuses: string; servedBy: string }[];
+  registeredIn: string;
+  unknownFieldRefusal: string;
+  command: string;
+  documentation: string;
+}
+
+export function useMcpSurface() {
+  return useApi<McpSurface>(() => query("admin.platform.mcp.surface"), []);
+}
+
+/* -------------------------------------------------------------------------
+ * Re-exported so a page imports one module
+ * ---------------------------------------------------------------------- */
+
+/**
+ * The pure helpers live in lib/platform-format.ts and are re-exported here.
+ *
+ * Split for one reason and it is not tidiness: console unit tests are literally
+ * `node --test lib/*.test.ts`, so a test can only reach a module that loads
+ * outside a browser. This file imports React hooks; that one imports nothing at
+ * all, which is what makes the three decisions in it testable. Everything a
+ * page needs still arrives from one import.
+ */
+export {
+  standingTone,
+  approvalWording,
+  shortSha,
+  deliveryStanding,
+} from "@/lib/platform-format";

--- a/console/lib/admin.ts
+++ b/console/lib/admin.ts
@@ -163,17 +163,65 @@ export function useAdminAudit(severity: string) {
 }
 
 /**
+ * The operator session's cross-site token, fetched once and kept.
+ *
+ * A module level cache rather than state on a component, because every screen
+ * in the portal mutates through one function and refetching the token before
+ * each write would be a second round trip on every button.
+ *
+ * A PROMISE rather than a string, so two buttons pressed at once share one
+ * request instead of racing to fill the same slot.
+ */
+let operatorCsrf: Promise<string> | null = null;
+
+async function csrfToken(): Promise<string> {
+  operatorCsrf ??= rest<{ signedIn: boolean; csrfToken: string }>("/v1/admin/session").then(
+    (s) => s.csrfToken,
+    (err) => {
+      // Never cache a failure. A token fetch that failed because the network
+      // dropped would otherwise poison every mutation for the life of the tab.
+      operatorCsrf = null;
+      throw err;
+    },
+  );
+  return operatorCsrf;
+}
+
+/**
  * A tRPC mutation on the operator router.
  *
- * NO CSRF TOKEN, and that is a decision rather than an omission. The product's
- * console sends one because its session cookie is SameSite=Lax, which a
- * cross-site top-level POST still carries. The operator cookie is
- * SameSite=Strict, so a browser sends it on NO cross-site request of any kind
- * and there is nothing for a token to add. If that cookie's SameSite is ever
- * loosened, this is the line that has to grow a token.
+ * THE COMMENT HERE USED TO SAY NO TOKEN WAS NEEDED, and it was wrong in a way
+ * worth recording. Its argument was that the operator cookie is
+ * SameSite=Strict, so a browser sends it on no cross-site request at all and a
+ * token adds nothing. SameSite is SITE scoped rather than origin scoped, so a
+ * subdomain an attacker controls is inside it, which is exactly the case the
+ * token is for. The server agrees: it refuses every non GET request that
+ * carries a live operator cookie without a matching x-antifailure-admin-csrf.
+ *
+ * Retried ONCE on the refusal that names the header, and only that one. A token
+ * is derived from the session, so signing out and back in in another tab makes
+ * the cached one stale, and an operator who has to reload the portal to press a
+ * button twice will conclude the button is broken. Once rather than in a loop,
+ * because a second refusal is a real one and retrying it forever would turn a
+ * configuration problem into a page that hangs.
  */
 export async function adminMutate<T>(path: string, input: unknown): Promise<T> {
-  return rest<T>(`/trpc/${path}`, { method: "POST", body: input });
+  try {
+    return await rest<T>(`/trpc/${path}`, {
+      method: "POST",
+      body: input,
+      adminCsrf: await csrfToken(),
+    });
+  } catch (err) {
+    const failure = err as ApiError;
+    if (failure.status !== 403 || !/admin-csrf/i.test(failure.message)) throw failure;
+    operatorCsrf = null;
+    return rest<T>(`/trpc/${path}`, {
+      method: "POST",
+      body: input,
+      adminCsrf: await csrfToken(),
+    });
+  }
 }
 
 export async function suspendTenant(orgId: string, reason: string) {

--- a/console/lib/api.ts
+++ b/console/lib/api.ts
@@ -19,6 +19,11 @@ const BASE = process.env.NEXT_PUBLIC_AF_API ?? "";
 /** Sent on every mutation. Read from GET /auth/session, which derives it from
  *  the session secret without revealing it. */
 const CSRF_HEADER = "x-antifailure-csrf";
+/** The operator portal's own header. A SECOND name rather than the same one,
+ *  because the two cookies are independent credentials in independent tables
+ *  and a request can legitimately carry both. The server checks each against
+ *  its own cookie, so sending the tenant token here would present nothing. */
+const ADMIN_CSRF_HEADER = "x-antifailure-admin-csrf";
 
 export interface Session {
   signedIn: boolean;
@@ -93,12 +98,13 @@ export async function mutate<T>(path: string, input: unknown, csrf: string): Pro
  *  tRPC: the session, sign-out, device approval, and provider keys. */
 export async function rest<T>(
   path: string,
-  init: { method?: string; body?: unknown; csrf?: string } = {},
+  init: { method?: string; body?: unknown; csrf?: string; adminCsrf?: string } = {},
 ): Promise<T> {
   const method = init.method ?? "GET";
   const headers: Record<string, string> = { accept: "application/json" };
   if (init.body !== undefined) headers["content-type"] = "application/json";
   if (init.csrf) headers[CSRF_HEADER] = init.csrf;
+  if (init.adminCsrf) headers[ADMIN_CSRF_HEADER] = init.adminCsrf;
   const res = await fetch(`${BASE}${path}`, {
     method,
     credentials: "same-origin",

--- a/console/lib/platform-format.test.ts
+++ b/console/lib/platform-format.test.ts
@@ -1,0 +1,121 @@
+// The four decisions on the Developer Platform lane that the obvious version
+// gets wrong.
+//
+// Each one is a case where the shorter implementation is not merely uglier, it
+// is a different and false claim on a screen somebody makes a security decision
+// from. They are written down here because a helper nobody exercises is a
+// helper that gets simplified back to the wrong answer by the next reader.
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import {
+  approvalWording,
+  deliveryStanding,
+  shortSha,
+  standingTone,
+} from "./platform-format.ts";
+
+describe("what colour a credential's standing wears", () => {
+  test("a revoked credential is not a failure", () => {
+    // The reflex is red, and red is wrong. Somebody revoked it deliberately,
+    // and the person reading the list is usually that somebody checking that it
+    // worked. A column of red beside every credential that was correctly killed
+    // trains the reader to ignore the colour.
+    assert.equal(standingTone("revoked"), "neutral");
+  });
+
+  test("an expired credential is the one that deserves attention", () => {
+    // Nothing decided this. It stopped working on a clock, and whoever depended
+    // on it has a pipeline that fails for a reason nobody was told about.
+    assert.equal(standingTone("expired"), "warn");
+  });
+
+  test("a live credential reads as live", () => {
+    assert.equal(standingTone("live"), "pass");
+  });
+});
+
+describe("what to say about a fork approval", () => {
+  const fork = { fromFork: true, approvedSha: null, approvalCoversHead: false };
+
+  test("an approval that no longer covers the head is its own answer", () => {
+    // THE CASE THIS FUNCTION EXISTS FOR. A boolean would call this "approved",
+    // and it is the exact state 0021 stores approved_sha rather than a boolean
+    // to make visible: a maintainer approved one commit and somebody pushed
+    // another after it. Reading that as approved is reading unreviewed code as
+    // reviewed.
+    const stale = approvalWording({ ...fork, approvedSha: "abc123", approvalCoversHead: false });
+    assert.equal(stale.label, "stale approval");
+    assert.equal(stale.tone, "warn");
+    assert.ok(stale.hint, "the stale case says nothing about why it is stale");
+  });
+
+  test("an approval that covers the head is an approval", () => {
+    const good = approvalWording({ ...fork, approvedSha: "abc123", approvalCoversHead: true });
+    assert.equal(good.label, "approved");
+    assert.equal(good.tone, "pass");
+  });
+
+  test("a fork nobody approved is not the same as a branch that needs no approval", () => {
+    // Two absences that a boolean collapses into one. The first is a pull
+    // request waiting on a person; the second is an ordinary branch where the
+    // gate does not apply, and showing "not approved" beside it would send
+    // somebody looking for an approver who was never needed.
+    assert.equal(approvalWording(fork).label, "not approved");
+    assert.equal(approvalWording(fork).tone, "warn");
+    const internal = approvalWording({ ...fork, fromFork: false });
+    assert.equal(internal.label, "not required");
+    assert.equal(internal.tone, "neutral");
+  });
+});
+
+describe("a commit, shortened", () => {
+  test("seven characters, the way git shortens one", () => {
+    assert.equal(shortSha("0123456789abcdef0123456789abcdef01234567"), "0123456");
+  });
+
+  test("a head that was never reported stays null rather than becoming an empty string", () => {
+    // An empty string renders as a cell with nothing in it, which reads as a
+    // value that failed to load. Null reaches the component that says the
+    // record does not have this field.
+    assert.equal(shortSha(null), null);
+  });
+});
+
+describe("whether a delivery was handled", () => {
+  test("Stripe's unresolved is not the same as never looked at", () => {
+    // The two ledgers say it differently and this is the one place that
+    // reconciles them. An unresolved billing event HAS a processed_at in some
+    // paths: the webhook looked at it and could not decide what it meant, which
+    // is a different thing to report than silence.
+    const unresolved = deliveryStanding({ handledAt: new Date().toISOString(), outcome: "unresolved" });
+    assert.equal(unresolved.label, "unresolved");
+    assert.equal(unresolved.tone, "warn");
+  });
+
+  test("a GitHub delivery with no handled time was not handled", () => {
+    const silent = deliveryStanding({ handledAt: null, outcome: null });
+    assert.equal(silent.label, "not handled");
+    assert.equal(silent.tone, "warn");
+  });
+
+  test("a stale event was handled and still says so", () => {
+    // It was decided, and the decision was to ignore it because a newer event
+    // had already been applied. Reporting it as a failure would send somebody
+    // investigating ordinary webhook reordering.
+    const stale = deliveryStanding({ handledAt: new Date().toISOString(), outcome: "stale" });
+    assert.equal(stale.label, "stale");
+    assert.equal(stale.tone, "warn");
+  });
+
+  test("an outcome the ledger recorded is shown in the ledger's own words", () => {
+    const applied = deliveryStanding({ handledAt: new Date().toISOString(), outcome: "applied" });
+    assert.equal(applied.label, "applied");
+    assert.equal(applied.tone, "pass");
+    // GitHub records no outcome word for a delivery it handled cleanly, so the
+    // fallback has to be a word rather than a blank.
+    const handled = deliveryStanding({ handledAt: new Date().toISOString(), outcome: null });
+    assert.equal(handled.label, "handled");
+    assert.equal(handled.tone, "pass");
+  });
+});

--- a/console/lib/platform-format.ts
+++ b/console/lib/platform-format.ts
@@ -1,0 +1,89 @@
+// The Developer Platform lane's pure helpers.
+//
+// No imports, on purpose. Console unit tests are `node --test lib/*.test.ts`,
+// so anything that has to be tested has to load outside a browser, and every
+// decision worth arguing about on this lane is in here rather than inline in a
+// cell where nothing could reach it. Each of the four functions below answers a
+// question the obvious version gets wrong, and platform-format.test.ts is where
+// the wrong answers are written down.
+
+/** live, expired or revoked. Declared here rather than in admin-platform.ts so
+ *  that the module a test can load carries its own vocabulary, and re-exported
+ *  from there so a page still imports one thing. */
+export type CredentialStanding = "live" | "expired" | "revoked";
+
+/**
+ * The tone a credential's standing should wear.
+ *
+ * Its own function rather than `toneFor`, because `toneFor` maps engine states
+ * and would read "revoked" as an ordinary word. A revoked credential is not a
+ * failure and must not be red: somebody revoked it on purpose, usually the
+ * person now reading the list to check that it worked. Expired is the one that
+ * deserves attention, because nothing decided it.
+ */
+export function standingTone(standing: CredentialStanding): "pass" | "warn" | "neutral" {
+  if (standing === "live") return "pass";
+  if (standing === "expired") return "warn";
+  return "neutral";
+}
+
+/**
+ * What to say about an approval, given a pull request.
+ *
+ * Three answers rather than two. "Approved" and "not approved" hides the state
+ * that matters: an approval recorded against a commit that is no longer at the
+ * head. 0021 stores approved_sha rather than a boolean for exactly that reason,
+ * and collapsing it back to a boolean here would undo it.
+ */
+export function approvalWording(pr: {
+  fromFork: boolean;
+  approvedSha: string | null;
+  approvalCoversHead: boolean;
+}): { label: string; tone: "pass" | "warn" | "neutral"; hint: string | null } {
+  if (!pr.fromFork) {
+    return {
+      label: "not required",
+      tone: "neutral",
+      hint: "The head branch is in this repository, so no approval gate applies.",
+    };
+  }
+  if (pr.approvedSha === null) {
+    return {
+      label: "not approved",
+      tone: "warn",
+      hint: "From a fork and never approved, so nothing has run against it.",
+    };
+  }
+  if (!pr.approvalCoversHead) {
+    return {
+      label: "stale approval",
+      tone: "warn",
+      hint: "The approved commit is not the one at the head now. A push landed after the approval.",
+    };
+  }
+  return { label: "approved", tone: "pass", hint: null };
+}
+
+/** A commit, shortened the way git shortens one. Kept here rather than inline
+ *  so the two screens that show a head cannot pick different lengths. */
+export function shortSha(sha: string | null): string | null {
+  return sha === null ? null : sha.slice(0, 7);
+}
+
+/**
+ * Whether a delivery was handled, in one word.
+ *
+ * The two ledgers disagree about how they say it, and this is the one place
+ * that reconciles them. A GitHub delivery is handled when handled_at is set; a
+ * Stripe event carries an outcome, and 'unresolved' means the webhook could not
+ * decide what it meant, which is not the same as not having been looked at.
+ */
+export function deliveryStanding(d: {
+  handledAt: string | null;
+  outcome: string | null;
+}): { label: string; tone: "pass" | "warn" | "fail" } {
+  if (d.outcome === "unresolved") return { label: "unresolved", tone: "warn" };
+  if (d.handledAt === null) return { label: "not handled", tone: "warn" };
+  if (d.outcome === "stale") return { label: "stale", tone: "warn" };
+  return { label: d.outcome ?? "handled", tone: "pass" };
+}

--- a/web/apps/api/src/admin/mcp.ts
+++ b/web/apps/api/src/admin/mcp.ts
@@ -1,0 +1,142 @@
+// What this control plane can truthfully say about the MCP server, which is
+// almost nothing, and why that is the honest answer rather than a gap.
+//
+// THE FACT THIS FILE EXISTS TO STATE. `af mcp` is a shipped engine feature and
+// the control plane holds no record of it. That is not an oversight waiting for
+// a table. The server binds one checkout, speaks JSON-RPC on standard input and
+// output, and keeps its runs in the project's own state directory on the
+// developer's disk. It opens no connection to this control plane, presents no
+// engine token, and emits no event. There is therefore no fleet of MCP servers,
+// no connection count, no last seen time and no per tenant adoption figure, and
+// any screen showing one would be showing a number nobody measured.
+//
+// engine/internal/mcp/project.go says the tenancy model outright: one project,
+// fixed at startup, chosen by whoever launched the process, and a project id in
+// a call is an assertion rather than a selector. A page that listed servers
+// would be inventing a second tenancy model with nothing behind it.
+//
+// SO WHAT IS THE PAGE FOR. One question an operator is actually asked, usually
+// by a customer's security reviewer: can an agent use this to make a check
+// easier on itself. The answer is no, and it is provable rather than a promise,
+// because the refusal is a property of the tool schemas rather than a rule the
+// tools ask a model to respect. This file carries that answer with its
+// provenance attached, and mcp.test.ts opens each named file and greps it for
+// each named symbol, so a claim here cannot outlive the code it describes.
+//
+// The technique is admin/controls.ts's `enforcedBy`, for the same reason: a
+// bare symbol name proves only that some file declares one, and a description
+// with no file behind it is a sentence that stops being true silently.
+
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * The tools the engine serves, as `path/from/engine:symbol`.
+ *
+ * The path is from the repository root because the engine is Go and this is
+ * TypeScript, so there is no import that could go stale instead. `servedBy`
+ * names the constructor, and `registeredIn` names the one file that must call
+ * it: a constructor nothing registers is a tool no agent can reach, which is
+ * exactly the dead capability shape this project keeps deleting.
+ */
+export interface McpToolFact {
+  /** The name an agent calls, exactly as the engine registers it. */
+  name: string
+  /** What it does, in the words the reference documentation uses. */
+  does: string
+  /** What an agent cannot ask it for, which is the answer to the question. */
+  refuses: string
+  /** `path/from/repository/root:symbol` for the constructor. */
+  servedBy: string
+}
+
+export const MCP_REGISTRATION_FILE = 'engine/internal/mcp/serve.go'
+
+export const MCP_TOOLS: readonly McpToolFact[] = [
+  {
+    name: 'rehearse_migration_safety',
+    does:
+      'Applies the branch\'s pending migrations to a throwaway branch of a sanitized copy of ' +
+      'production and reports which statements were slow, which tables Postgres rewrote, which ' +
+      'locks were held and for how long, and what the schema linter objected to at production\'s ' +
+      'table sizes.',
+    refuses:
+      'It cannot be pointed at a database, and it cannot be asked to rehearse a subset. Every ' +
+      'pending migration runs, because a migration cannot be judged apart from the ones that run ' +
+      'before it.',
+    servedBy: 'engine/internal/mcp/tools_migration.go:newRehearseMigrationTool',
+  },
+  {
+    name: 'inspect_egress_firewall',
+    does:
+      'Reports what the environment may reach, what it actually reached, and whether containment ' +
+      'held, including whether a live credential was really swapped for a sandbox one on the way ' +
+      'out.',
+    refuses:
+      'It cannot widen the policy, and the count it reports as sandbox_credential_not_substituted ' +
+      'always fails. There is no manifest level that turns that one down.',
+    servedBy: 'engine/internal/mcp/tools_egress.go:newInspectEgressTool',
+  },
+  {
+    name: 'get_rehearsal_run',
+    does:
+      'Reads a submitted run\'s status and, once it has finished, its verdict, with evidence ' +
+      'references paginated by cursor.',
+    refuses:
+      'It cannot change a verdict or a status. A run that did not finish reports INCONCLUSIVE, ' +
+      'which is not a weaker PASS.',
+    servedBy: 'engine/internal/mcp/tools_runs.go:newGetRunTool',
+  },
+  {
+    name: 'cancel_rehearsal_run',
+    does:
+      'Asks a running rehearsal to stop. The experiment stops at the next point it can do so ' +
+      'safely and tears down the environment it created.',
+    refuses:
+      'It is a request rather than a kill, because an environment abandoned mid run is the leak ' +
+      'this product exists to prevent. A cancelled run is INCONCLUSIVE, never PASS.',
+    servedBy: 'engine/internal/mcp/tools_runs.go:newCancelRunTool',
+  },
+]
+
+/**
+ * The one sentence that decides whether the tools can be talked into anything,
+ * and where it is enforced.
+ *
+ * Unknown members are refused rather than ignored, which is what makes the
+ * published contract and the validator the same contract. Without it an
+ * argument the server does not know is an argument the server silently drops,
+ * and "there is no field that disables sanitization" becomes "there is no field
+ * we implemented", which is a different and much weaker claim.
+ */
+export const MCP_UNKNOWN_FIELD_REFUSAL = 'engine/internal/mcp/schema.go:FaultUnknownField'
+
+/** Where an operator goes next, because this console is not where MCP is run. */
+export const MCP_ELSEWHERE = {
+  command: 'af mcp',
+  commandDeclaredIn: 'engine/internal/cli/mcp.go:newMCPCommand',
+  documentation: '/reference/mcp/',
+} as const
+
+/**
+ * Resolves a repository path for the test that checks these claims.
+ *
+ * Exported from here rather than written in the test so that the catalog and
+ * the checker agree about what a path in this file means. Five levels up from
+ * `web/apps/api/src/admin` is the repository root: src, api, apps, web, root.
+ */
+export function repositoryPath(relative: string): string {
+  const here = path.dirname(fileURLToPath(import.meta.url))
+  return path.resolve(here, '..', '..', '..', '..', '..', relative)
+}
+
+/** Reads a file named by a `path:symbol` pair and reports whether the symbol is
+ *  declared in it. Used by the test, and by nothing at runtime: the page shows
+ *  the strings, and the test is what keeps them true. */
+export async function declares(reference: string): Promise<boolean> {
+  const [file, symbol] = reference.split(':')
+  if (!file || !symbol) return false
+  const source = await readFile(repositoryPath(file), 'utf8')
+  return new RegExp(`\\b${symbol}\\b`).test(source)
+}

--- a/web/apps/api/src/admin/permissions.ts
+++ b/web/apps/api/src/admin/permissions.ts
@@ -76,6 +76,31 @@ export const ADMIN_PERMISSIONS = [
   // none of them should be able to pause it.
   'admin.emergency.read',
   'admin.emergency.engage',
+
+  // The developer platform: what customers connect to this installation, and
+  // the credentials that can act as one of them.
+  //
+  // Read on repositories is one permission rather than two because a pull
+  // request cannot be read usefully without the repository it is on, and a
+  // split there produces a role that can see a number and not what it is a
+  // number of.
+  'admin.repos.read',
+
+  // Credentials. Read and revoke are separate, and the split is the same one
+  // billing makes: everybody who answers "which key is this" should be able to
+  // answer it, and revoking a customer's credential stops their pipeline
+  // within seconds, which is an incident decision rather than a support one.
+  'admin.keys.read',
+  'admin.keys.revoke',
+
+  // What arrives here from GitHub and from Stripe, and whether it was handled.
+  'admin.webhooks.read',
+
+  // The MCP page, which reads no customer data at all. It is guarded because
+  // every route in this tree is guarded, not because what it returns is
+  // sensitive: it describes the engine's own tool surface and states that this
+  // control plane holds no MCP record.
+  'admin.mcp.read',
 ] as const
 
 export type AdminPermission = (typeof ADMIN_PERMISSIONS)[number]
@@ -104,9 +129,18 @@ export const RESERVED_PREFIXES: Record<string, string> = {
   'admin.entitlements': 'money',
   'admin.flags': 'money',
   'admin.infra': 'infra',
-  'admin.deploys': 'infra',
-  'admin.webhooks': 'infra',
-  'admin.keys': 'infra',
+  'admin.deploys': 'the developer platform',
+  // Moved from infra to the developer platform, which is where the API Keys and
+  // Integrations & Webhooks sections live and where these two are now
+  // implemented. w-admin-infra implemented admin.infra.* and admin.emergency.*
+  // and neither of these, so nothing was taken from a lane that was using it.
+  'admin.webhooks': 'the developer platform',
+  'admin.keys': 'the developer platform',
+  // Repositories and pull requests, and the MCP surface. New prefixes rather
+  // than borrowed ones: admin.deploys does not describe a pull request, and a
+  // permission filed under a name that does not fit it is one nobody can find.
+  'admin.repos': 'the developer platform',
+  'admin.mcp': 'the developer platform',
   'admin.logs': 'infra',
   'admin.security': 'infra',
   'admin.emergency': 'infra',
@@ -147,6 +181,20 @@ export const ADMIN_PERMISSION_DESCRIPTIONS: Record<AdminPermission, string> = {
     'See whether maintenance mode, new sign-ups, or new runs are paused, and why.',
   'admin.emergency.engage':
     'Pause or resume the whole installation: maintenance mode, new sign-ups, and new runs.',
+  'admin.repos.read':
+    'See every repository connected to this installation, its pull requests, and the check ' +
+    'generations behind them.',
+  'admin.keys.read':
+    'See every credential that can act as a customer: its name, its prefix, what created it and ' +
+    'when it was last used. Never its value, which is stored only as a hash.',
+  'admin.keys.revoke':
+    'Stop a credential working, and revoke a GitHub OIDC repository binding along with every ' +
+    'token it has minted.',
+  'admin.webhooks.read':
+    'See the GitHub App installations and the deliveries that arrived from GitHub and Stripe, ' +
+    'including the ones that were never handled.',
+  'admin.mcp.read':
+    'See what this control plane records about the MCP server, and the tools the engine serves.',
   'admin.billing.read':
     'See a customer\'s Stripe customer, subscription, invoices, charges, payment methods and ' +
     'credit balance, and the record of every administrative money action taken on the account.',
@@ -221,6 +269,8 @@ export const ADMIN_ROLE_PERMISSIONS: Record<AdminRole, readonly AdminPermission[
     // permission rather than on rank: ordering roles and comparing ranks is how
     // a permission model stops being a table and starts being an assumption.
     'admin.emergency.read', 'admin.emergency.engage',
+    'admin.repos.read', 'admin.webhooks.read', 'admin.mcp.read',
+    'admin.keys.read', 'admin.keys.revoke',
   ],
   infrastructure: [
     'admin.portal.access', 'admin.audit.read',
@@ -235,6 +285,13 @@ export const ADMIN_ROLE_PERMISSIONS: Record<AdminRole, readonly AdminPermission[
     // debugging "their runs will not start" must be able to discover that runs
     // are frozen; pausing the installation is a different decision.
     'admin.emergency.read',
+    // The repositories, the deliveries and the credentials, because "their
+    // checks are not running" is an infrastructure question and the answer is
+    // usually a delivery that never arrived or a credential that stopped
+    // working. Revoke as well as read: a leaked engine token is an incident and
+    // the pager holder is who reaches it first.
+    'admin.repos.read', 'admin.webhooks.read', 'admin.mcp.read',
+    'admin.keys.read', 'admin.keys.revoke',
   ],
   security: [
     'admin.portal.access', 'admin.audit.read', 'admin.audit.export',
@@ -248,6 +305,11 @@ export const ADMIN_ROLE_PERMISSIONS: Record<AdminRole, readonly AdminPermission[
     'admin.billing.read', 'admin.entitlements.read',
     'admin.flags.read', 'admin.flags.write',
     'admin.infra.read', 'admin.emergency.read',
+    // Credentials are security's surface more than anybody's: a key that
+    // appeared in a public repository is the report they receive, and revoking
+    // it is the first thing they do about it.
+    'admin.repos.read', 'admin.webhooks.read', 'admin.mcp.read',
+    'admin.keys.read', 'admin.keys.revoke',
   ],
   billing: [
     'admin.portal.access', 'admin.audit.read',
@@ -266,9 +328,23 @@ export const ADMIN_ROLE_PERMISSIONS: Record<AdminRole, readonly AdminPermission[
     // Support answers "why was I charged this" every day and must never be the
     // rota that can refund. Read without write is the whole point of the split.
     'admin.billing.read', 'admin.entitlements.read', 'admin.flags.read',
+    // Read across the whole developer platform and revoke on none of it. This
+    // is the rota that answers "why did our check not run", which needs the
+    // repository, the delivery and whether the key is still live, and it is
+    // emphatically not the rota that should be able to stop a customer's
+    // pipeline while answering.
+    'admin.repos.read', 'admin.keys.read', 'admin.webhooks.read', 'admin.mcp.read',
   ],
   analytics: ['admin.portal.access', 'admin.audit.read', 'admin.tenants.read', 'admin.users.read'],
-  read_only: ['admin.portal.access', 'admin.audit.read', 'admin.tenants.read', 'admin.users.read'],
+  read_only: [
+    'admin.portal.access', 'admin.audit.read', 'admin.tenants.read', 'admin.users.read',
+    // The auditor's read of the developer platform. Every one of these is a
+    // read, and the credential list holds no secret: only the prefix, which is
+    // what the customer's own console shows them. A role that can see which
+    // credentials exist and cannot touch one is exactly the role an auditor
+    // should be given.
+    'admin.repos.read', 'admin.keys.read', 'admin.webhooks.read', 'admin.mcp.read',
+  ],
 }
 
 export function adminRoleHas(role: AdminRole, permission: AdminPermission): boolean {

--- a/web/apps/api/src/admin/platform.ts
+++ b/web/apps/api/src/admin/platform.ts
@@ -1,56 +1,992 @@
 // The Developer Platform lane of the operator portal.
 //
-// WHAT THIS FILE IS FOR, and why it is empty rather than absent. The portal has
-// six navigation groups and they are built in parallel. One module per group,
-// mounted once, is what lets that happen without two people editing the same
-// file: the Developer Platform sections own THIS file and console/app/admin/platform, and
-// nothing else. A lane that had to add its routes to router.ts instead would
-// put six writers in one object literal, and a duplicate key in an object
-// literal is the one merge conflict git does not report. It has already
-// happened once in this directory: see the note in infra.ts about a second
-// `admin:` key silently winning.
+// WHAT THIS FILE IS FOR. The portal has six navigation groups and they were
+// built in parallel. One module per group, mounted once, is what let that
+// happen without two people editing the same file: the Developer Platform
+// sections own THIS file and console/app/admin/platform, and nothing else. A
+// lane that added its routes to router.ts instead would put six writers in one
+// object literal, and a duplicate key in an object literal is the one merge
+// conflict git does not report.
 //
-// So the mount is made first and the routes come later. The empty router below
-// is not a placeholder nobody reads: it is mounted in router.ts and
-// admin-namespaces.test.ts asserts that it is, exactly once, which is what
-// makes this a reserved namespace rather than a file somebody forgot.
+// THE SECTIONS THIS LANE OWNS: Repositories & Pull Requests, MCP Management,
+// API Keys, and Integrations & Webhooks.
 //
-// THE SECTIONS THIS LANE OWNS: Repositories & Pull Requests, MCP Management, API Keys, and Integrations & Webhooks.
+// PERMISSION PREFIXES RESERVED FOR IT: admin.repos.*, admin.keys.*,
+// admin.webhooks.*, admin.mcp.*, admin.deploys.*. The catalog and the
+// reservations are in permissions.ts, and adding a permission under another
+// lane's prefix is the kind of thing a review misses.
 //
-// PERMISSION PREFIXES RESERVED FOR IT: admin.keys.*, admin.webhooks.*, admin.deploys.*. The
-// catalog and the reservations are in permissions.ts, and adding a permission
-// under another lane's prefix is the kind of thing a review misses.
+// A KEY IS NEVER RETURNED BY A ROUTE IN THIS FILE. An operator needs to know
+// that a credential exists, when it was last used and how to revoke it. The
+// value itself answers no operator question and holding it is the whole risk.
+// Only the hash is stored, so there is nothing here that could return one even
+// if a route asked.
 //
-// A key or a webhook secret is never returned by a route in this file. An operator needs to know that a key exists, when it was last used and how to revoke it; the value itself answers no operator question and reading it is the whole risk.
+// WHAT IS AND IS NOT HERE, in the shape router.ts states for its own three
+// writes. Reads across every tenant, and two writes: revoke a credential, and
+// revoke an OIDC repository binding. Both were chosen because the enforcement
+// already exists somewhere a test can watch it:
 //
-// HOW TO ADD A ROUTE. Build it with adminProcedure(permission), which is the
-// only exported way to make one, so declaring the permission and creating the
-// route are a single act. There is no unguarded builder to reach for. Every
-// read goes through ctx.adminDb, which is the operator pool: a cross tenant
-// read has to be a credential the application cannot acquire rather than a
-// claim it makes about itself. A mutation records what it changed with
-// adminAudit, inside the same transaction as the change.
+//   revoke a token    -> engine_tokens.revoked_at, read by authenticateEngine
+//                        in ingest.ts on every POST /v1/events before anything
+//                        else, so the next event from that credential is
+//                        refused.
+//   revoke a binding  -> oidc_repository_bindings.revoked_at, read by
+//                        src/github/exchange.ts before it mints anything, and
+//                        the same statement revokes the tokens that binding
+//                        already produced, because a revocation that leaves
+//                        live credentials behind is not a revocation.
 //
-//   import { z } from 'zod'
-//   import { adminProcedure, type AdminContext } from './trpc.ts'
+// WHAT IS DELIBERATELY ABSENT, AND WHY IT IS NOT A GAP.
 //
-//   export const platformRouter = router({
-//     list: adminProcedure('admin.example.read')
-//       .input(z.object({ limit: z.number().int().min(1).max(200).default(50) }))
-//       .query(async ({ ctx, input }) => {
-//         const c = ctx as AdminContext
-//         return c.adminDb((db) => db.execute(sql`...`))
-//       }),
-//   })
+// There is no rotate button. Rotation means minting a replacement, and a
+// replacement is a secret: an operator route that minted one would have to
+// return it through this portal, and a portal that can display a customer's
+// credential is a portal that can leak one. Only the hash is stored, so there
+// is no route anywhere in this product that can show a token after the moment
+// it was created. The honest operator action is revoke, and the customer mints
+// the replacement themselves with `af token create`. The console says exactly
+// that rather than offering a button that would have to lie.
+//
+// There is no outbound webhook anything. This product has no outbound webhook
+// subscription table, no delivery attempt table for one, and no signing secret
+// store. What it has is two INBOUND delivery ledgers, github_deliveries and
+// billing_events, which record what arrived here and whether it was handled. A
+// delivery log is what an operator opens this page for; drawing an outbound one
+// over an inbound table would answer the wrong question confidently.
+//
+// SCIM tokens are not listed. scim_tokens has existed since 0014 and nothing
+// under src/ reads it, so a SCIM token authenticates nothing today. Listing one
+// beside credentials that do work would present a row that cannot be used as
+// though revoking it mattered.
 
+import { z } from 'zod'
+import { sql } from 'drizzle-orm'
+import { TRPCError } from '@trpc/server'
 import { router } from '../trpc.ts'
+import { adminProcedure, adminAudit, type AdminContext } from './trpc.ts'
+import {
+  MCP_ELSEWHERE,
+  MCP_REGISTRATION_FILE,
+  MCP_TOOLS,
+  MCP_UNKNOWN_FIELD_REFUSAL,
+} from './mcp.ts'
 
 /**
- * The Developer Platform namespace, mounted at `admin.platform`.
+ * A page of rows, and how to ask for the next one.
  *
- * Empty today. It is still reachable, still walked by the operator route
- * matrix, and still exempt from maintenance mode by its `admin.` prefix, so a
- * route added to it inherits all three without anybody remembering to arrange
- * them.
+ * A local copy of router.ts's helper rather than an import, and the reason is
+ * structural: router.ts imports this module to mount it, so importing back from
+ * it would be a cycle. Nine lines duplicated is the cheaper of the two, and the
+ * shape is pinned by the same tests either way.
  */
-export const platformRouter = router({})
+function pageOf<Row, Out>(
+  rows: Row[],
+  limit: number,
+  cursorOf: (row: Row) => string,
+  map: (row: Row) => Out,
+): { rows: Out[]; nextCursor: string | null } {
+  const more = rows.length > limit
+  const visible = more ? rows.slice(0, limit) : rows
+  return {
+    rows: visible.map(map),
+    nextCursor: more && visible.length > 0 ? cursorOf(visible[visible.length - 1]!) : null,
+  }
+}
+
+function iso(value: Date | string): string {
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString()
+}
+
+function isoOrNull(value: Date | string | null): string | null {
+  return value === null ? null : iso(value)
+}
+
+/**
+ * A keyset cursor over two columns.
+ *
+ * Two rather than one because none of the sort keys on this surface is unique
+ * on its own. Two organizations can both own `acme/app`, two tokens can be
+ * created in the same millisecond, and a delivery ledger receives in bursts. A
+ * single column cursor over any of those skips rows or repeats them, and the
+ * reader cannot tell which.
+ *
+ * A tab is the separator because no value on either side of one can contain a
+ * tab: a GitHub full name is `owner/name` from GitHub's own character set, a
+ * timestamp is ISO 8601, and the second half is always an identifier.
+ */
+const CURSOR_SEPARATOR = '\t'
+
+/* Both halves fall back to NULL rather than to an empty string wherever one of
+ * these is interpolated. A bound parameter is cast before the guard beside it is
+ * evaluated, so `''::timestamptz` raises 22007 on the very first page, when
+ * there is no cursor at all, even though the comparison it belongs to is
+ * unreachable. NULL casts to anything. */
+function splitCursor(cursor: string | null | undefined): { a: string; b: string } | null {
+  if (!cursor) return null
+  const at = cursor.indexOf(CURSOR_SEPARATOR)
+  if (at < 0) return null
+  return { a: cursor.slice(0, at), b: cursor.slice(at + 1) }
+}
+
+function joinCursor(a: string, b: string): string {
+  return `${a}${CURSOR_SEPARATOR}${b}`
+}
+
+const page = z.object({
+  limit: z.number().int().min(1).max(200).default(50),
+  cursor: z.string().nullish(),
+})
+
+const uuid = z.string().uuid()
+
+/**
+ * Every credential write says why, in at least eight characters.
+ *
+ * The stricter minimum from routers.ts rather than the min(1) on the tenant
+ * routes, and deliberately so: revoking a customer's credential stops their
+ * pipeline within seconds, and "x" as a reason is a row that cannot be
+ * defended to the customer who asks the next morning.
+ */
+const reason = z.string().trim().min(8).max(500)
+
+// Every write below reads the organization's slug on the same row it is acting
+// on, rather than through a second lookup. subject_org_label is what still
+// names the tenant a year from now when the row is gone, and reading it from
+// the join the write already needs is one query instead of two.
+
+// ---------------------------------------------------------------------------
+// Repositories and pull requests
+// ---------------------------------------------------------------------------
+//
+// The question this answers: a customer says the check on one pull request
+// never appeared, and support has a repository name and a number. The path is
+// repository, then its pull requests, then that pull request's generations,
+// because a generation is where the answer lives. state and detail together say
+// what happened in one sentence, which is what pr_generations.detail was
+// written to hold.
+
+const repositoriesRouter = router({
+  list: adminProcedure('admin.repos.read')
+    .input(page.extend({ query: z.string().trim().max(200).optional() }))
+    .query(async ({ ctx, input }) => {
+      const c = ctx as AdminContext
+      const key = splitCursor(input.cursor)
+      const rows = await c.adminDb(async (db) =>
+        db.execute<{
+          id: string
+          org_id: string
+          org_slug: string
+          full_name: string
+          default_branch: string
+          private: boolean
+          archived_at: Date | string | null
+          created_at: Date | string
+          open_pull_requests: string
+          last_pull_request_at: Date | string | null
+        }>(sql`
+          SELECT r.id, r.org_id, o.slug AS org_slug, r.full_name, r.default_branch,
+                 r.private, r.archived_at, r.created_at,
+                 (SELECT count(*) FROM pull_requests p
+                   WHERE p.repository_id = r.id AND p.state = 'open') AS open_pull_requests,
+                 (SELECT max(p.updated_at) FROM pull_requests p
+                   WHERE p.repository_id = r.id) AS last_pull_request_at
+          FROM repositories r
+          JOIN organizations o ON o.id = r.org_id
+          WHERE (${input.query ?? null}::text IS NULL
+                 OR r.full_name ILIKE ${'%' + (input.query ?? '') + '%'}
+                 OR o.slug ILIKE ${'%' + (input.query ?? '') + '%'})
+            AND (${key?.a ?? null}::text IS NULL
+                 OR (r.full_name, r.id::text) > (${key?.a ?? null}, ${key?.b ?? null}))
+          ORDER BY r.full_name ASC, r.id ASC
+          LIMIT ${input.limit + 1}`),
+      )
+      return pageOf(
+        rows,
+        input.limit,
+        (r) => joinCursor(r.full_name, r.id),
+        (r) => ({
+          id: r.id,
+          orgId: r.org_id,
+          orgSlug: r.org_slug,
+          fullName: r.full_name,
+          defaultBranch: r.default_branch,
+          private: r.private,
+          archived: r.archived_at !== null,
+          createdAt: iso(r.created_at),
+          openPullRequests: Number(r.open_pull_requests),
+          lastPullRequestAt: isoOrNull(r.last_pull_request_at),
+        }),
+      )
+    }),
+
+  get: adminProcedure('admin.repos.read')
+    .input(z.object({ repositoryId: uuid }))
+    .query(async ({ ctx, input }) => {
+      const c = ctx as AdminContext
+      const rows = await c.adminDb(async (db) =>
+        db.execute<{
+          id: string
+          org_id: string
+          org_slug: string
+          org_name: string
+          full_name: string
+          default_branch: string
+          private: boolean
+          github_id: string | null
+          archived_at: Date | string | null
+          created_at: Date | string
+        }>(sql`
+          SELECT r.id, r.org_id, o.slug AS org_slug, o.name AS org_name, r.full_name,
+                 r.default_branch, r.private, r.github_id::text AS github_id,
+                 r.archived_at, r.created_at
+          FROM repositories r
+          JOIN organizations o ON o.id = r.org_id
+          WHERE r.id = ${input.repositoryId}::uuid`),
+      )
+      const row = rows[0]
+      if (!row) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'No repository with that id.' })
+      }
+      // The installations are a SECOND query rather than a join, because an
+      // organization can hold more than one and a join would have paired the
+      // repository with whichever one sorted first. An empty array is a real
+      // and important state: it is the first thing to check when a customer
+      // reports that nothing arrives, since a repository row survives an
+      // installation being removed.
+      const installations = await c.adminDb(async (db) =>
+        db.execute<{
+          account_login: string
+          account_type: string
+          suspended_at: Date | string | null
+        }>(sql`
+          SELECT account_login, account_type, suspended_at
+          FROM github_installations
+          WHERE org_id = ${row.org_id}::uuid
+          ORDER BY account_login ASC
+          LIMIT 20`),
+      )
+      return {
+        id: row.id,
+        orgId: row.org_id,
+        orgSlug: row.org_slug,
+        orgName: row.org_name,
+        fullName: row.full_name,
+        defaultBranch: row.default_branch,
+        private: row.private,
+        githubId: row.github_id,
+        archived: row.archived_at !== null,
+        createdAt: iso(row.created_at),
+        installations: installations.map((g) => ({
+          accountLogin: g.account_login,
+          accountType: g.account_type,
+          suspended: g.suspended_at !== null,
+        })),
+      }
+    }),
+
+  /**
+   * One repository's pull requests, with the newest generation attached.
+   *
+   * The generation comes back on the same row through a LATERAL rather than as
+   * a second round trip, because the question is "which of these is stuck" and
+   * that cannot be answered from the pull request columns alone. One extra
+   * query per row from the client would be fifty queries to read one screen.
+   */
+  pullRequests: adminProcedure('admin.repos.read')
+    .input(
+      page.extend({
+        repositoryId: uuid,
+        state: z.enum(['open', 'closed', 'merged']).optional(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      const c = ctx as AdminContext
+      const rows = await c.adminDb(async (db) =>
+        db.execute<{
+          id: string
+          number: number
+          title: string | null
+          state: string
+          draft: boolean
+          from_fork: boolean
+          head_ref: string
+          base_ref: string
+          head_repository: string
+          head_sha: string
+          approved_sha: string | null
+          approved_by: string | null
+          approved_at: Date | string | null
+          opened_at: Date | string | null
+          updated_at: Date | string
+          generation_state: string | null
+          generation_detail: string | null
+          generation_attempt: number | null
+          generation_head_sha: string | null
+          generation_verdict: unknown
+          generation_updated_at: Date | string | null
+        }>(sql`
+          SELECT p.id, p.number, p.title, p.state, p.draft, p.from_fork,
+                 p.head_ref, p.base_ref, p.head_repository, p.head_sha,
+                 p.approved_sha, p.approved_by, p.approved_at,
+                 p.opened_at, p.updated_at,
+                 g.state::text AS generation_state, g.detail AS generation_detail,
+                 g.attempt AS generation_attempt, g.head_sha AS generation_head_sha,
+                 g.verdict AS generation_verdict, g.updated_at AS generation_updated_at
+          FROM pull_requests p
+          LEFT JOIN LATERAL (
+            SELECT gg.state, gg.detail, gg.attempt, gg.head_sha, gg.verdict, gg.updated_at
+            FROM pr_generations gg
+            WHERE gg.pull_request_id = p.id
+            ORDER BY gg.updated_at DESC
+            LIMIT 1
+          ) g ON true
+          WHERE p.repository_id = ${input.repositoryId}::uuid
+            AND (${input.state ?? null}::text IS NULL OR p.state = ${input.state ?? ''})
+            AND (${input.cursor ?? null}::text IS NULL
+                 OR p.number < ${input.cursor ? Number(input.cursor) : 0})
+          ORDER BY p.number DESC
+          LIMIT ${input.limit + 1}`),
+      )
+      return pageOf(
+        rows,
+        input.limit,
+        (r) => String(r.number),
+        (r) => ({
+          id: r.id,
+          number: r.number,
+          title: r.title,
+          state: r.state,
+          draft: r.draft,
+          fromFork: r.from_fork,
+          headRef: r.head_ref,
+          baseRef: r.base_ref,
+          headRepository: r.head_repository,
+          headSha: r.head_sha,
+          // The approval is of a COMMIT, never of the pull request, so it is
+          // reported beside the current head rather than as a boolean. An
+          // approval that no longer matches the head is the state the column
+          // exists to make visible.
+          approvedSha: r.approved_sha,
+          approvedBy: r.approved_by,
+          approvedAt: isoOrNull(r.approved_at),
+          approvalCoversHead: r.approved_sha !== null && r.approved_sha === r.head_sha,
+          openedAt: isoOrNull(r.opened_at),
+          updatedAt: iso(r.updated_at),
+          latestGeneration:
+            r.generation_state === null
+              ? null
+              : {
+                  state: r.generation_state,
+                  detail: r.generation_detail,
+                  attempt: r.generation_attempt ?? 1,
+                  headSha: r.generation_head_sha,
+                  verdict: r.generation_verdict,
+                  updatedAt: isoOrNull(r.generation_updated_at),
+                },
+        }),
+      )
+    }),
+
+  /** Every generation for one pull request, newest first.
+   *
+   *  Bounded rather than paged, and the bound is safe because of a UNIQUE the
+   *  schema already carries: one row per (pull_request_id, head_sha), with
+   *  `attempt` bumped in place when somebody presses Re-run. So fifty rows
+   *  means fifty distinct heads, and a pull request that has pushed more than
+   *  fifty commits with a check on each is itself the finding. */
+  generations: adminProcedure('admin.repos.read')
+    .input(z.object({ pullRequestId: uuid }))
+    .query(async ({ ctx, input }) => {
+      const c = ctx as AdminContext
+      const rows = await c.adminDb(async (db) =>
+        db.execute<{
+          id: string
+          head_sha: string
+          attempt: number
+          state: string
+          detail: string | null
+          check_run_id: string | null
+          workflow_run_id: string | null
+          reported_by: string | null
+          env_id: string | null
+          verdict: unknown
+          superseded_by: string | null
+          queued_at: Date | string | null
+          started_at: Date | string | null
+          finished_at: Date | string | null
+          deadline_at: Date | string | null
+          updated_at: Date | string
+        }>(sql`
+          SELECT id, head_sha, attempt, state::text AS state, detail,
+                 check_run_id::text AS check_run_id,
+                 workflow_run_id::text AS workflow_run_id,
+                 reported_by, env_id, verdict, superseded_by::text AS superseded_by,
+                 queued_at, started_at, finished_at, deadline_at, updated_at
+          FROM pr_generations
+          WHERE pull_request_id = ${input.pullRequestId}::uuid
+          ORDER BY updated_at DESC
+          LIMIT 50`),
+      )
+      return rows.map((r) => ({
+        id: r.id,
+        headSha: r.head_sha,
+        attempt: r.attempt,
+        state: r.state,
+        detail: r.detail,
+        // Null while the installation does not hold `checks: write`, which is
+        // a state to serve rather than hide: the comment still lands and this
+        // is how an operator sees which permission is missing.
+        checkRunId: r.check_run_id,
+        workflowRunId: r.workflow_run_id,
+        reportedBy: r.reported_by,
+        envId: r.env_id,
+        verdict: r.verdict,
+        supersededBy: r.superseded_by,
+        queuedAt: isoOrNull(r.queued_at),
+        startedAt: isoOrNull(r.started_at),
+        finishedAt: isoOrNull(r.finished_at),
+        deadlineAt: isoOrNull(r.deadline_at),
+        updatedAt: iso(r.updated_at),
+      }))
+    }),
+})
+
+// ---------------------------------------------------------------------------
+// Credentials
+// ---------------------------------------------------------------------------
+//
+// COLUMN SAFETY IS THE WHOLE POINT ON THIS SURFACE. RLS is row level and cannot
+// restrict a column, and the operator pool holds BYPASSRLS, so nothing in the
+// database stops `SELECT *` here. Every query below names its columns and none
+// of them names token_hash. router.ts states the same rule; this is the table
+// where breaking it would be worst.
+//
+// What is shown instead of a secret: the prefix, which is the first twelve
+// characters and is what the customer's own console shows them, so an operator
+// and a customer can agree which credential they are talking about without
+// either of them holding one.
+
+const KEY_KINDS = ['engine', 'cli', 'oidc'] as const
+
+const credentialsRouter = router({
+  list: adminProcedure('admin.keys.read')
+    .input(
+      page.extend({
+        query: z.string().trim().max(200).optional(),
+        kind: z.enum(KEY_KINDS).optional(),
+        /** Live means not revoked and not expired, evaluated against the
+         *  server's clock rather than the database's, so this filter and
+         *  authenticateEngine answer the same question. */
+        liveOnly: z.boolean().default(false),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      const c = ctx as AdminContext
+      const key = splitCursor(input.cursor)
+      const now = c.clock.now().toISOString()
+      const rows = await c.adminDb(async (db) =>
+        db.execute<{
+          id: string
+          org_id: string
+          org_slug: string
+          name: string
+          prefix: string
+          kind: string
+          scopes: string[] | null
+          created_at: Date | string
+          last_used_at: Date | string | null
+          expires_at: Date | string | null
+          revoked_at: Date | string | null
+          created_by_login: string | null
+          created_by_email: string | null
+          acts_as_login: string | null
+          binding_repository: string | null
+        }>(sql`
+          SELECT t.id, t.org_id, o.slug AS org_slug, t.name, t.prefix, t.kind,
+                 t.scopes, t.created_at, t.last_used_at, t.expires_at, t.revoked_at,
+                 c.github_login AS created_by_login, c.email AS created_by_email,
+                 a.github_login AS acts_as_login,
+                 b.repository AS binding_repository
+          FROM engine_tokens t
+          JOIN organizations o ON o.id = t.org_id
+          LEFT JOIN users c ON c.id = t.created_by
+          -- Who the credential ACTS AS, which is not who created it and is null
+          -- for an engine token on purpose. 0012 states the reason: a machine is
+          -- not a person, and putting a machine's actions in a human's audit
+          -- trail is the thing the null prevents.
+          LEFT JOIN users a ON a.id = t.user_id
+          LEFT JOIN oidc_repository_bindings b ON b.id = t.binding_id
+          WHERE (${input.query ?? null}::text IS NULL
+                 OR o.slug ILIKE ${'%' + (input.query ?? '') + '%'}
+                 OR t.name ILIKE ${'%' + (input.query ?? '') + '%'}
+                 OR t.prefix ILIKE ${'%' + (input.query ?? '') + '%'})
+            AND (${input.kind ?? null}::text IS NULL OR t.kind = ${input.kind ?? ''})
+            AND (${input.liveOnly ? 1 : 0} = 0
+                 OR (t.revoked_at IS NULL
+                     AND (t.expires_at IS NULL OR t.expires_at > ${now}::timestamptz)))
+            AND (${key?.a ?? null}::text IS NULL
+                 OR (t.created_at, t.id::text) < (${key?.a ?? null}::timestamptz, ${key?.b ?? null}))
+          ORDER BY t.created_at DESC, t.id DESC
+          LIMIT ${input.limit + 1}`),
+      )
+      const nowMs = c.clock.now().getTime()
+      return pageOf(
+        rows,
+        input.limit,
+        (r) => joinCursor(iso(r.created_at), r.id),
+        (r) => {
+          const expired =
+            r.expires_at !== null && new Date(r.expires_at).getTime() <= nowMs
+          return {
+            id: r.id,
+            orgId: r.org_id,
+            orgSlug: r.org_slug,
+            name: r.name,
+            prefix: r.prefix,
+            kind: r.kind,
+            scopes: r.scopes ?? [],
+            createdAt: iso(r.created_at),
+            lastUsedAt: isoOrNull(r.last_used_at),
+            expiresAt: isoOrNull(r.expires_at),
+            revokedAt: isoOrNull(r.revoked_at),
+            expired,
+            // One word for the state, computed once here, so the console does
+            // not reimplement the precedence and disagree with the server about
+            // which of revoked and expired wins.
+            standing: r.revoked_at !== null ? 'revoked' : expired ? 'expired' : 'live',
+            createdBy: r.created_by_login ?? r.created_by_email,
+            actsAs: r.acts_as_login,
+            bindingRepository: r.binding_repository,
+          }
+        },
+      )
+    }),
+
+  /**
+   * Stops a credential working, now.
+   *
+   * The effect sentence is returned by the route rather than written in the
+   * console, the same way tenants.suspend does it: two sentences that mean the
+   * same thing today are two sentences that disagree after somebody edits one.
+   *
+   * Idempotent on an already revoked token, because during an incident the same
+   * action gets taken twice and the second attempt must not read as a new
+   * problem. The audit entry is written only when something changed, so the
+   * chain does not gain a row for an action that did nothing.
+   */
+  revoke: adminProcedure('admin.keys.revoke')
+    .input(z.object({ tokenId: uuid, reason }))
+    .mutation(async ({ ctx, input }) => {
+      const c = ctx as AdminContext
+      return c.adminDb(async (db) => {
+        const rows = await db.execute<{
+          id: string
+          org_id: string
+          org_slug: string
+          name: string
+          prefix: string
+          kind: string
+          revoked_at: Date | string | null
+        }>(sql`
+          SELECT t.id, t.org_id, o.slug AS org_slug, t.name, t.prefix, t.kind, t.revoked_at
+          FROM engine_tokens t JOIN organizations o ON o.id = t.org_id
+          WHERE t.id = ${input.tokenId}::uuid`)
+        const token = rows[0]
+        if (!token) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'No credential with that id.' })
+        }
+        if (token.revoked_at !== null) {
+          return {
+            revoked: true,
+            alreadyRevoked: true,
+            prefix: token.prefix,
+            effect: 'It was already revoked. Nothing changed and nothing was recorded.',
+          }
+        }
+
+        // The record first, in the same transaction. If the UPDATE fails the
+        // entry goes with it, and the UPDATE cannot commit without it.
+        await adminAudit(db, c, {
+          action: 'credential.revoked',
+          targetType: 'engine_token',
+          // The prefix, never the id alone, because the prefix is what the
+          // customer sees in their own console and in `af token list`, so this
+          // is the entry they can match against what stopped working.
+          targetId: token.prefix,
+          subjectOrgId: token.org_id,
+          subjectOrgLabel: token.org_slug,
+          severity: 'high',
+          detail: { name: token.name, kind: token.kind, reason: input.reason },
+        })
+        await db.execute(sql`
+          UPDATE engine_tokens SET revoked_at = ${c.clock.now().toISOString()}
+          WHERE id = ${token.id}::uuid AND revoked_at IS NULL`)
+
+        return {
+          revoked: true,
+          alreadyRevoked: false,
+          prefix: token.prefix,
+          effect:
+            'The next request presenting this credential is refused. Anything already running ' +
+            'keeps running until it next calls the control plane. Nobody can recover the value: ' +
+            'the customer creates a replacement with af token create.',
+        }
+      })
+    }),
+
+  /** The GitHub OIDC repository bindings, which are what let a workflow trade
+   *  its own identity for a short lived token. A binding nobody recognises is
+   *  the thing somebody scrolls this list looking for. */
+  bindings: adminProcedure('admin.keys.read')
+    .input(page.extend({ query: z.string().trim().max(200).optional() }))
+    .query(async ({ ctx, input }) => {
+      const c = ctx as AdminContext
+      const key = splitCursor(input.cursor)
+      const rows = await c.adminDb(async (db) =>
+        db.execute<{
+          id: string
+          org_id: string
+          org_slug: string
+          repository: string
+          created_at: Date | string
+          last_used_at: Date | string | null
+          revoked_at: Date | string | null
+          created_by_login: string | null
+          live_tokens: string
+        }>(sql`
+          SELECT b.id, b.org_id, o.slug AS org_slug, b.repository, b.created_at,
+                 b.last_used_at, b.revoked_at, u.github_login AS created_by_login,
+                 (SELECT count(*) FROM engine_tokens t
+                   WHERE t.binding_id = b.id AND t.revoked_at IS NULL) AS live_tokens
+          FROM oidc_repository_bindings b
+          JOIN organizations o ON o.id = b.org_id
+          LEFT JOIN users u ON u.id = b.created_by
+          WHERE (${input.query ?? null}::text IS NULL
+                 OR b.repository ILIKE ${'%' + (input.query ?? '') + '%'}
+                 OR o.slug ILIKE ${'%' + (input.query ?? '') + '%'})
+            AND (${key?.a ?? null}::text IS NULL
+                 OR (b.created_at, b.id::text) < (${key?.a ?? null}::timestamptz, ${key?.b ?? null}))
+          ORDER BY b.created_at DESC, b.id DESC
+          LIMIT ${input.limit + 1}`),
+      )
+      return pageOf(
+        rows,
+        input.limit,
+        (r) => joinCursor(iso(r.created_at), r.id),
+        (r) => ({
+          id: r.id,
+          orgId: r.org_id,
+          orgSlug: r.org_slug,
+          repository: r.repository,
+          createdAt: iso(r.created_at),
+          lastUsedAt: isoOrNull(r.last_used_at),
+          revokedAt: isoOrNull(r.revoked_at),
+          createdBy: r.created_by_login,
+          // Tokens this binding has produced that are still live. The number an
+          // operator needs before revoking, because revoking the binding
+          // revokes them too and this says how much that will stop.
+          liveTokens: Number(r.live_tokens),
+        }),
+      )
+    }),
+
+  /**
+   * Revokes a binding and, in the same statement, every live token it minted.
+   *
+   * Both halves, because revoking only the binding would stop new tokens being
+   * issued while the ones already issued kept working, which is the shape of a
+   * revocation that does not revoke. This is what src/github/exchange.ts does
+   * for the customer's own command, and doing less here would mean the operator
+   * button was weaker than the one the customer already has.
+   */
+  revokeBinding: adminProcedure('admin.keys.revoke')
+    .input(z.object({ bindingId: uuid, reason }))
+    .mutation(async ({ ctx, input }) => {
+      const c = ctx as AdminContext
+      return c.adminDb(async (db) => {
+        const rows = await db.execute<{
+          id: string
+          org_id: string
+          org_slug: string
+          repository: string
+          revoked_at: Date | string | null
+        }>(sql`
+          SELECT b.id, b.org_id, o.slug AS org_slug, b.repository, b.revoked_at
+          FROM oidc_repository_bindings b JOIN organizations o ON o.id = b.org_id
+          WHERE b.id = ${input.bindingId}::uuid`)
+        const binding = rows[0]
+        if (!binding) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'No binding with that id.' })
+        }
+        if (binding.revoked_at !== null) {
+          return {
+            revoked: true,
+            alreadyRevoked: true,
+            repository: binding.repository,
+            tokensRevoked: 0,
+            effect: 'It was already revoked. Nothing changed and nothing was recorded.',
+          }
+        }
+
+        const now = c.clock.now().toISOString()
+        await adminAudit(db, c, {
+          action: 'oidc_binding.revoked',
+          targetType: 'oidc_repository_binding',
+          targetId: binding.id,
+          subjectOrgId: binding.org_id,
+          subjectOrgLabel: binding.org_slug,
+          severity: 'high',
+          detail: { repository: binding.repository, reason: input.reason },
+        })
+        await db.execute(sql`
+          UPDATE oidc_repository_bindings SET revoked_at = ${now}
+          WHERE id = ${binding.id}::uuid AND revoked_at IS NULL`)
+        const killed = await db.execute<{ id: string }>(sql`
+          UPDATE engine_tokens SET revoked_at = ${now}
+          WHERE binding_id = ${binding.id}::uuid AND revoked_at IS NULL
+          RETURNING id`)
+
+        return {
+          revoked: true,
+          alreadyRevoked: false,
+          repository: binding.repository,
+          tokensRevoked: killed.length,
+          effect:
+            'No workflow in that repository can trade its identity for a token again, and every ' +
+            'token this binding had already minted stops working on its next request.',
+        }
+      })
+    }),
+})
+
+// ---------------------------------------------------------------------------
+// Integrations and inbound webhooks
+// ---------------------------------------------------------------------------
+//
+// Two ledgers with the same shape, kept as two routes rather than one union.
+// They record different things from different senders with different identifier
+// spaces, and a union would need a discriminator that the console would then
+// have to branch on anyway. Two routes say which sender is being asked about.
+
+const DELIVERY_SOURCES = ['github', 'stripe'] as const
+
+/**
+ * One row of either ledger, in one shape.
+ *
+ * The two SELECTs below are written to produce exactly these columns, aliasing
+ * where the tables disagree, so the mapping afterwards is one function rather
+ * than two that drift. Stripe has no `action`, which is the one place the two
+ * ledgers genuinely differ, and it is selected as a literal null rather than
+ * omitted so the shape holds.
+ */
+interface DeliveryRow extends Record<string, unknown> {
+  id: string
+  org_slug: string | null
+  account: string | null
+  event: string
+  action: string | null
+  received_at: Date | string
+  handled_at: Date | string | null
+  outcome: string | null
+}
+
+const integrationsRouter = router({
+  /** Every GitHub App installation, with the repositories it covers. The first
+   *  thing to check when a customer reports that nothing arrives. */
+  installations: adminProcedure('admin.webhooks.read')
+    .input(page.extend({ query: z.string().trim().max(200).optional() }))
+    .query(async ({ ctx, input }) => {
+      const c = ctx as AdminContext
+      const key = splitCursor(input.cursor)
+      const rows = await c.adminDb(async (db) =>
+        db.execute<{
+          id: string
+          org_id: string
+          org_slug: string
+          installation_id: string
+          account_login: string
+          account_type: string
+          suspended_at: Date | string | null
+          created_at: Date | string
+          repositories: string
+          last_delivery_at: Date | string | null
+        }>(sql`
+          SELECT gi.id, gi.org_id, o.slug AS org_slug,
+                 gi.installation_id::text AS installation_id,
+                 gi.account_login, gi.account_type, gi.suspended_at, gi.created_at,
+                 (SELECT count(*) FROM repositories r WHERE r.org_id = gi.org_id) AS repositories,
+                 (SELECT max(d.received_at) FROM github_deliveries d
+                   WHERE d.org_id = gi.org_id) AS last_delivery_at
+          FROM github_installations gi
+          JOIN organizations o ON o.id = gi.org_id
+          WHERE (${input.query ?? null}::text IS NULL
+                 OR gi.account_login ILIKE ${'%' + (input.query ?? '') + '%'}
+                 OR o.slug ILIKE ${'%' + (input.query ?? '') + '%'})
+            AND (${key?.a ?? null}::text IS NULL
+                 OR (gi.account_login, gi.id::text) > (${key?.a ?? null}, ${key?.b ?? null}))
+          ORDER BY gi.account_login ASC, gi.id ASC
+          LIMIT ${input.limit + 1}`),
+      )
+      return pageOf(
+        rows,
+        input.limit,
+        (r) => joinCursor(r.account_login, r.id),
+        (r) => ({
+          id: r.id,
+          orgId: r.org_id,
+          orgSlug: r.org_slug,
+          installationId: r.installation_id,
+          accountLogin: r.account_login,
+          accountType: r.account_type,
+          suspended: r.suspended_at !== null,
+          createdAt: iso(r.created_at),
+          repositories: Number(r.repositories),
+          lastDeliveryAt: isoOrNull(r.last_delivery_at),
+        }),
+      )
+    }),
+
+  /**
+   * What arrived, and whether it was handled.
+   *
+   * `unhandledOnly` reads the same partial index the sweeper uses, so asking
+   * for the small set costs what the sweeper's own query costs rather than a
+   * scan of the ledger.
+   *
+   * A row with no organization is kept rather than filtered out. 0021 says why
+   * the column is nullable: a delivery about an account this installation has
+   * never seen resolves to nobody, and those are precisely the rows worth
+   * looking at when somebody reports that their events go nowhere.
+   */
+  deliveries: adminProcedure('admin.webhooks.read')
+    .input(
+      page.extend({
+        source: z.enum(DELIVERY_SOURCES),
+        unhandledOnly: z.boolean().default(false),
+        query: z.string().trim().max(200).optional(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      const c = ctx as AdminContext
+      const key = splitCursor(input.cursor)
+      const like = '%' + (input.query ?? '') + '%'
+      const rows = await c.adminDb(async (db) =>
+        input.source === 'github'
+          ? db.execute<DeliveryRow>(sql`
+              SELECT d.delivery_id AS id, o.slug AS org_slug, d.account_login AS account,
+                     d.event, d.action, d.received_at, d.handled_at, d.outcome
+              FROM github_deliveries d
+              LEFT JOIN organizations o ON o.id = d.org_id
+              WHERE (${input.unhandledOnly ? 1 : 0} = 0 OR d.handled_at IS NULL)
+                AND (${input.query ?? null}::text IS NULL
+                     OR d.event ILIKE ${like}
+                     OR d.account_login ILIKE ${like}
+                     OR o.slug ILIKE ${like})
+                AND (${key?.a ?? null}::text IS NULL
+                     OR (d.received_at, d.delivery_id)
+                        < (${key?.a ?? null}::timestamptz, ${key?.b ?? null}))
+              ORDER BY d.received_at DESC, d.delivery_id DESC
+              LIMIT ${input.limit + 1}`)
+          : db.execute<DeliveryRow>(sql`
+              SELECT b.stripe_event_id AS id, o.slug AS org_slug,
+                     b.stripe_customer_id AS account,
+                     b.type AS event, NULL::text AS action,
+                     b.received_at, b.processed_at AS handled_at, b.outcome
+              FROM billing_events b
+              LEFT JOIN organizations o ON o.id = b.org_id
+              -- outcome rather than processed_at, and the difference is not
+              -- cosmetic. billing_events carries a partial index on
+              -- outcome = 'unresolved', which is the set this filter is for, and
+              -- 'unresolved' is what the webhook writes when it could not decide
+              -- what an event meant. A row with a processed_at and outcome
+              -- 'stale' was handled; a row with neither is the one somebody is
+              -- looking for.
+              WHERE (${input.unhandledOnly ? 1 : 0} = 0 OR b.outcome = 'unresolved')
+                AND (${input.query ?? null}::text IS NULL
+                     OR b.type ILIKE ${like}
+                     OR o.slug ILIKE ${like})
+                AND (${key?.a ?? null}::text IS NULL
+                     OR (b.received_at, b.stripe_event_id)
+                        < (${key?.a ?? null}::timestamptz, ${key?.b ?? null}))
+              ORDER BY b.received_at DESC, b.stripe_event_id DESC
+              LIMIT ${input.limit + 1}`),
+      )
+      return pageOf(
+        rows,
+        input.limit,
+        (r) => joinCursor(iso(r.received_at), r.id),
+        (r) => ({
+          id: r.id,
+          orgSlug: r.org_slug,
+          account: r.account,
+          event: r.event,
+          action: r.action,
+          receivedAt: iso(r.received_at),
+          handledAt: isoOrNull(r.handled_at),
+          outcome: r.outcome,
+        }),
+      )
+    }),
+})
+
+// ---------------------------------------------------------------------------
+// MCP
+// ---------------------------------------------------------------------------
+
+const mcpRouter = router({
+  /**
+   * What this control plane knows about MCP, which is that it knows nothing.
+   *
+   * `recordsAnything: false` is the answer, sent as a field rather than left
+   * for the console to assume, so the day a write path does exist the page
+   * changes because the server changed. A console that hardcoded the absence
+   * would keep saying it after it stopped being true.
+   *
+   * Everything else here is a checked-in fact about the engine, carrying the
+   * file and symbol it came from. mcp.test.ts opens each one, so a tool renamed
+   * or unregistered in the engine fails this suite rather than leaving a page
+   * describing a product that changed underneath it.
+   */
+  surface: adminProcedure('admin.mcp.read').query(() => ({
+    recordsAnything: false,
+    why:
+      'af mcp binds one checkout, speaks the protocol on standard input and output, and keeps ' +
+      'its runs in that project\'s own state directory. It opens no connection to this control ' +
+      'plane, presents no credential and sends no event, so there is nothing here to list, ' +
+      'count or manage.',
+    tools: MCP_TOOLS.map((t) => ({
+      name: t.name,
+      does: t.does,
+      refuses: t.refuses,
+      servedBy: t.servedBy,
+    })),
+    registeredIn: MCP_REGISTRATION_FILE,
+    unknownFieldRefusal: MCP_UNKNOWN_FIELD_REFUSAL,
+    command: MCP_ELSEWHERE.command,
+    documentation: MCP_ELSEWHERE.documentation,
+  })),
+})
+
+/**
+ * The Developer Platform namespace, mounted once at `admin.platform` by
+ * admin/router.ts.
+ *
+ * ONE MOUNT, FOUR SECTIONS. The route path and the permission are deliberately
+ * not the same word here. The path says which lane owns the file, so six agents
+ * cannot land in one object literal; the permission says what the operator is
+ * allowed to do, and those are different questions. `admin.platform.keys.revoke`
+ * carries `admin.keys.revoke`, and a role that holds it can revoke a credential
+ * whatever the module it happens to live in is called.
+ *
+ * Every path under this object inherits three things from the `admin.` prefix
+ * it sits below without anybody arranging them: the operator route matrix walks
+ * it, adminProcedure guards it, and maintenance mode exempts it so an operator
+ * can still reach these during an outage.
+ */
+export const platformRouter = router({
+  repositories: repositoriesRouter,
+  keys: credentialsRouter,
+  integrations: integrationsRouter,
+  mcp: mcpRouter,
+})

--- a/web/apps/api/src/server.ts
+++ b/web/apps/api/src/server.ts
@@ -2667,7 +2667,19 @@ export function createServer(options: ServerOptions) {
       // token. Something between a browser and this process may strip those
       // headers, and refusing every such request would break the portal for a
       // reason nobody could diagnose.
-      const adminToken = readCookie(c.req.header('cookie'), ADMIN_SESSION_COOKIE)
+      //
+      // readAdminSessionCookie, NOT readCookie with the bare name, and this
+      // line was the bare name until somebody drove a browser at it.
+      // adminSessionCookie writes `__Host-af_admin_session` whenever the cookie
+      // is Secure, which is every deployment that matters and none of the tests
+      // in this repository, because the test server speaks plain HTTP. So this
+      // read returned null in production, the operator was resolved a hundred
+      // lines below by readAdminSessionCookie regardless, and the entire
+      // operator CSRF check was skipped on exactly the deployments it exists
+      // for while admincsrf.test.ts went on passing. The suite below now
+      // presents the prefixed name as well, which is the assertion that can say
+      // no to this.
+      const adminToken = readAdminSessionCookie(c.req.header('cookie'))
       if (adminToken) {
         const operator = await resolveAdminSession(options.pool, adminToken, clock.now())
         if (operator) {

--- a/web/apps/api/test/admin-platform.test.ts
+++ b/web/apps/api/test/admin-platform.test.ts
@@ -1,0 +1,470 @@
+// The Developer Platform lane, and the one thing a credential list has to do.
+//
+// A list of keys an operator cannot revoke from is a report, not management.
+// So the assertion this suite is built around is not that the route returns
+// `revoked: true`: it is that the SAME token which authenticated a moment ago
+// stops authenticating afterwards, checked through authenticateEngine, which is
+// the function POST /v1/events actually calls. A write that reports success and
+// changes nothing is the failure mode admin-routes.test.ts names, and on this
+// surface it would be a credential somebody believed they had killed.
+//
+// The other half is the MCP section, which claims things about a Go package
+// this file cannot import. Every one of those claims carries the file and the
+// symbol it came from, and the block at the bottom opens each file and looks
+// for each symbol. A tool renamed or unregistered in the engine fails here
+// rather than leaving a page describing a product that has moved.
+
+import { test, describe, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { randomUUID } from 'node:crypto'
+import { readFile } from 'node:fs/promises'
+import { appRouter } from '../src/routers/index.ts'
+import { adminSignIn, hashPassword } from '../src/admin/session.ts'
+import { type AdminRole } from '../src/admin/permissions.ts'
+import {
+  MCP_ELSEWHERE,
+  MCP_REGISTRATION_FILE,
+  MCP_TOOLS,
+  MCP_UNKNOWN_FIELD_REFUSAL,
+  repositoryPath,
+} from '../src/admin/mcp.ts'
+import { mintEngineToken } from '../src/tokens.ts'
+import { authenticateEngine } from '../src/ingest.ts'
+import { createAdminPool, type AdminPool } from '@antifailure/db'
+import { available, startApi, seedOrg, signInAs, adminUrl, type ApiHarness, type Org } from './harness.ts'
+
+const hasDb = await available()
+
+/* -------------------------------------------------------------------------
+ * The MCP claims, which need no database and no Go toolchain
+ * ---------------------------------------------------------------------- */
+
+describe('the MCP section describes the engine that exists', () => {
+  test('every tool names a file that declares its constructor', async () => {
+    // The file as well as the symbol, for the reason admin/controls.ts gives
+    // about enforcedBy: a bare name proves only that SOME file declares one,
+    // and a tool moving into a package nothing serves would still satisfy that.
+    for (const tool of MCP_TOOLS) {
+      const [file, symbol] = tool.servedBy.split(':')
+      assert.ok(file && symbol, `${tool.name}.servedBy is not file:symbol`)
+      const source = await readFile(repositoryPath(file!), 'utf8')
+      assert.match(
+        source,
+        new RegExp(`func ${symbol}\\b`),
+        `${tool.name} says ${tool.servedBy} builds it, and that file declares no such function`,
+      )
+    }
+  })
+
+  test('every tool is REGISTERED, so none of them is a constructor nobody serves', async () => {
+    // The second claim, and the one that catches a dead capability. A tool
+    // whose constructor exists and which serve.go never registers is a tool no
+    // agent can call, and a page listing it would be describing a capability
+    // that is not served.
+    const serve = await readFile(repositoryPath(MCP_REGISTRATION_FILE), 'utf8')
+    for (const tool of MCP_TOOLS) {
+      const symbol = tool.servedBy.split(':')[1]!
+      assert.match(
+        serve,
+        new RegExp(`Register\\(${symbol}\\(`),
+        `${MCP_REGISTRATION_FILE} does not register ${symbol}, so ${tool.name} is not served`,
+      )
+    }
+  })
+
+  test('the engine serves exactly the tools this page lists, and no others', async () => {
+    // Both directions. The two tests above catch a tool that stopped existing;
+    // this one catches a tool that STARTED existing, which is the failure that
+    // leaves the page quietly incomplete rather than visibly wrong.
+    const serve = await readFile(repositoryPath(MCP_REGISTRATION_FILE), 'utf8')
+    const registered = [...serve.matchAll(/Register\((new\w+Tool)\(/g)].map((m) => m[1]!)
+    const listed = MCP_TOOLS.map((t) => t.servedBy.split(':')[1]!)
+    assert.deepEqual(
+      [...new Set(registered)].sort(),
+      [...listed].sort(),
+      'the engine registers a different set of tools than the MCP page lists',
+    )
+  })
+
+  test('unknown fields really are refused, which is what the whole claim rests on', async () => {
+    // "There is no argument that can weaken an experiment" is only true if an
+    // argument the server does not know is refused rather than dropped. Without
+    // this line the claim degrades to "there is no field we implemented".
+    const [file, symbol] = MCP_UNKNOWN_FIELD_REFUSAL.split(':')
+    const source = await readFile(repositoryPath(file!), 'utf8')
+    assert.match(
+      source,
+      new RegExp(`\\b${symbol}\\b`),
+      `${MCP_UNKNOWN_FIELD_REFUSAL} does not appear, so unknown arguments may be ignored`,
+    )
+  })
+
+  test('the command the page sends an operator to exists', async () => {
+    const [file, symbol] = MCP_ELSEWHERE.commandDeclaredIn.split(':')
+    const source = await readFile(repositoryPath(file!), 'utf8')
+    assert.match(source, new RegExp(`func ${symbol}\\b`))
+    assert.match(source, /Use:\s+"mcp"/, 'the command is not spelled mcp any more')
+  })
+
+  test('the documentation page it links to is in the tree', async () => {
+    // A link to a page that does not exist is worse on this section than
+    // anywhere else in the portal, because the link IS the answer here: the
+    // console has nothing else to offer about MCP.
+    const slug = MCP_ELSEWHERE.documentation.replace(/^\/|\/$/g, '')
+    await assert.doesNotReject(
+      () => readFile(repositoryPath(`docs/src/content/docs/${slug}.md`), 'utf8'),
+      `${MCP_ELSEWHERE.documentation} does not resolve to a documentation file`,
+    )
+  })
+})
+
+/* -------------------------------------------------------------------------
+ * The routes
+ * ---------------------------------------------------------------------- */
+
+describe('the developer platform routes', { skip: hasDb ? false : 'no database' }, () => {
+  let h: ApiHarness
+  let alice: Org
+  let bob: Org
+  let aliceOwner: { userId: string }
+  let adminPool: AdminPool
+  const password = 'provisioned-at-deploy-not-in-source'
+
+  async function callerFor(role: AdminRole) {
+    const email = `${role}-${randomUUID().slice(0, 8)}@example.test`
+    const { hash, salt } = await hashPassword(password)
+    await h.admin`
+      INSERT INTO admin_users (email, name, role, password_hash, password_salt, password_set_at)
+      VALUES (${email}, ${role}, ${role}, ${hash}, ${salt}, now())`
+    // Real time rather than h.clock, for the reason admin-routes.test.ts sets
+    // out: resolveAdminSession compares against the injected clock and the RLS
+    // policy behind current_admin_user() compares against the DATABASE's now(),
+    // and a fake past clock makes every operator write fail with an RLS
+    // violation that reads like a permissions bug.
+    const signedIn = await adminSignIn(h.pool, { email, password }, new Date())
+    const { resolveAdminSession } = await import('../src/admin/session.ts')
+    const resolved = await resolveAdminSession(h.pool, signedIn.token, new Date())
+    assert.ok(resolved, 'the operator session did not resolve')
+    return appRouter.createCaller({
+      pool: h.pool,
+      adminPool,
+      clock: h.clock,
+      github: h.github,
+      stripe: null,
+      appBaseUrl: 'http://localhost',
+      mailer: null,
+      productName: 'Antifailure',
+      hostedRequiredPlan: null,
+      actor: null,
+      origin: 'web' as const,
+      admin: {
+        adminUserId: resolved.adminUserId,
+        label: resolved.label,
+        email: resolved.email,
+        role: resolved.role,
+        sessionId: resolved.sessionId,
+        sessionHash: resolved.sessionHash,
+        impersonating: resolved.impersonating,
+        impersonatedUserId: resolved.impersonatedUserId,
+      },
+    } as never)
+  }
+
+  /** A real engine token for alice, minted through the route the product uses
+   *  rather than by inserting a row: a fixture that writes its own hash proves
+   *  nothing about the credential the customer actually holds. */
+  async function mintForAlice(name: string) {
+    return mintEngineToken(h.pool, h.clock, {
+      orgId: alice.orgId,
+      name,
+      actorUserId: aliceOwner.userId,
+      actorLabel: 'alice owner',
+      origin: 'web',
+    })
+  }
+
+  before(async () => {
+    h = await startApi()
+    alice = await seedOrg(h.admin, 'alice')
+    bob = await seedOrg(h.admin, 'bob')
+    aliceOwner = await signInAs(h, alice, 'owner')
+
+    await h.admin.unsafe(`ALTER ROLE antifailure_admin LOGIN PASSWORD 'operator-test-password'`)
+    const u = new URL(adminUrl)
+    u.username = 'antifailure_admin'
+    u.password = 'operator-test-password'
+    adminPool = createAdminPool({ url: u.toString() })
+    await adminPool.ensureBypass()
+  })
+
+  after(async () => {
+    await adminPool?.close()
+    await h?.close()
+  })
+
+  test('an operator sees repositories in every organization', async () => {
+    const { caller } = { caller: await callerFor('support') }
+    const page = await caller.admin.platform.repositories.list({ limit: 200 })
+    const names = page.rows.map((r) => r.fullName)
+    assert.ok(names.includes(alice.repository), "the operator cannot see alice's repository")
+    assert.ok(names.includes(bob.repository), "the operator cannot see bob's repository")
+  })
+
+  test('the repository list pages rather than claiming a short list is the whole one', async () => {
+    const caller = await callerFor('support')
+    const first = await caller.admin.platform.repositories.list({ limit: 1 })
+    assert.equal(first.rows.length, 1)
+    assert.ok(first.nextCursor, 'two repositories exist and the first page reported no cursor')
+    const second = await caller.admin.platform.repositories.list({
+      limit: 1,
+      cursor: first.nextCursor,
+    })
+    assert.equal(second.rows.length, 1)
+    assert.notEqual(
+      second.rows[0]!.id,
+      first.rows[0]!.id,
+      'the cursor returned the same row again, so paging repeats rather than advances',
+    )
+  })
+
+  test('a repository detail names its organization and its installations', async () => {
+    const caller = await callerFor('support')
+    const repo = await caller.admin.platform.repositories.get({ repositoryId: alice.repoId })
+    assert.equal(repo.fullName, alice.repository)
+    assert.equal(repo.orgSlug, alice.slug)
+    // No installation was seeded, and an empty array is the honest answer
+    // rather than a missing field. It is also the first thing to check when a
+    // customer reports that nothing arrives from GitHub.
+    assert.deepEqual(repo.installations, [])
+  })
+
+  describe('credentials', () => {
+    test('the list never returns anything usable as a credential', async () => {
+      const created = await mintForAlice('ci')
+      const caller = await callerFor('read_only')
+      const page = await caller.admin.platform.keys.list({ limit: 200 })
+      const row = page.rows.find((r) => r.id === created.id)
+      assert.ok(row, 'the credential just minted is not in the operator list')
+
+      // The same assertion admin-routes.test.ts makes about the operators
+      // response, applied to the table where it matters most.
+      const serialized = JSON.stringify(page)
+      assert.ok(
+        !/password|hash|salt|secret|token_hash/i.test(Object.keys(row!).join(' ')),
+        `the credential row has a field named like a secret: ${Object.keys(row!).join(', ')}`,
+      )
+      assert.ok(
+        !serialized.includes(created.token),
+        'the operator list returned the token value itself',
+      )
+      assert.equal(row!.prefix, created.prefix)
+      assert.equal(row!.standing, 'live')
+    })
+
+    test('REVOKING ACTUALLY STOPS THE CREDENTIAL, checked through the ingest path', async () => {
+      const created = await mintForAlice('the one that leaks')
+
+      // Prove it works BEFORE, or the assertion afterwards proves nothing: a
+      // token that never authenticated would fail the second check for a
+      // reason that has nothing to do with the button.
+      const before = await authenticateEngine(h.pool, h.clock, created.token)
+      assert.ok(before, 'the freshly minted token did not authenticate, so this test proves nothing')
+      assert.equal(before!.orgId, alice.orgId)
+
+      const caller = await callerFor('security')
+      const result = await caller.admin.platform.keys.revoke({
+        tokenId: created.id,
+        reason: 'found in a public gist, reported by the customer',
+      })
+      assert.equal(result.revoked, true)
+      assert.equal(result.alreadyRevoked, false)
+
+      // The whole point. authenticateEngine is what POST /v1/events calls, and
+      // it reads revoked_at before it reads anything else.
+      const after = await authenticateEngine(h.pool, h.clock, created.token)
+      assert.equal(after, null, 'the revoked credential still authenticates against the ingest path')
+    })
+
+    test('revoking records itself in the operator chain and in the customer\'s own log', async () => {
+      const created = await mintForAlice('audited')
+      const caller = await callerFor('security')
+      const [before] = await h.admin<{ n: string }[]>`
+        SELECT count(*)::text AS n FROM admin_audit_entries WHERE action = 'credential.revoked'`
+
+      await caller.admin.platform.keys.revoke({
+        tokenId: created.id,
+        reason: 'rotating after an employee left',
+      })
+
+      const [after] = await h.admin<{ n: string }[]>`
+        SELECT count(*)::text AS n FROM admin_audit_entries WHERE action = 'credential.revoked'`
+      assert.equal(
+        Number(after!.n),
+        Number(before!.n) + 1,
+        'a credential was revoked with no entry in the operator chain',
+      )
+
+      // The double write. A record only the vendor can read is a vendor's
+      // private note; the customer whose pipeline just stopped is the person
+      // who most needs to find out why.
+      const tenant = await h.admin<{ origin: string; actor_label: string; target_id: string }[]>`
+        SELECT origin, actor_label, target_id FROM audit_entries
+        WHERE org_id = ${alice.orgId}::uuid AND action = 'credential.revoked'
+        ORDER BY seq DESC LIMIT 1`
+      assert.equal(tenant.length, 1, "the customer's own audit log has no record of the revocation")
+      assert.equal(tenant[0]!.origin, 'admin')
+      assert.match(tenant[0]!.actor_label, /@example\.test/)
+      // The prefix, so the customer can match the entry against the credential
+      // that stopped working. Never the value.
+      assert.equal(tenant[0]!.target_id, created.prefix)
+    })
+
+    test('revoking twice changes nothing the second time and records nothing either', async () => {
+      const created = await mintForAlice('twice')
+      const caller = await callerFor('security')
+      await caller.admin.platform.keys.revoke({ tokenId: created.id, reason: 'the first attempt' })
+
+      const [before] = await h.admin<{ n: string }[]>`
+        SELECT count(*)::text AS n FROM admin_audit_entries WHERE action = 'credential.revoked'`
+      const [firstRow] = await h.admin<{ revoked_at: Date }[]>`
+        SELECT revoked_at FROM engine_tokens WHERE id = ${created.id}::uuid`
+
+      const second = await caller.admin.platform.keys.revoke({
+        tokenId: created.id,
+        reason: 'the same thing again during the same incident',
+      })
+      assert.equal(second.alreadyRevoked, true)
+
+      const [after] = await h.admin<{ n: string }[]>`
+        SELECT count(*)::text AS n FROM admin_audit_entries WHERE action = 'credential.revoked'`
+      assert.equal(
+        Number(after!.n),
+        Number(before!.n),
+        'a second revocation of an already revoked credential wrote an audit entry for doing nothing',
+      )
+      const [secondRow] = await h.admin<{ revoked_at: Date }[]>`
+        SELECT revoked_at FROM engine_tokens WHERE id = ${created.id}::uuid`
+      assert.equal(
+        new Date(secondRow!.revoked_at).getTime(),
+        new Date(firstRow!.revoked_at).getTime(),
+        'the second attempt moved the revocation time, rewriting when the credential stopped',
+      )
+    })
+
+    test('a role that can read credentials cannot necessarily revoke one', async () => {
+      // The split this lane's two permissions exist for. support answers "which
+      // key is this" every day and must never be the rota that can stop a
+      // customer's pipeline while answering.
+      const created = await mintForAlice('support cannot touch this')
+      const caller = await callerFor('support')
+      await assert.doesNotReject(() => caller.admin.platform.keys.list({ limit: 5 }))
+      await assert.rejects(
+        () => caller.admin.platform.keys.revoke({ tokenId: created.id, reason: 'should not happen' }),
+        (err: Error) => /admin\.keys\.revoke/.test(err.message),
+        'support revoked a customer credential',
+      )
+      const still = await authenticateEngine(h.pool, h.clock, created.token)
+      assert.ok(still, 'the refused revocation revoked it anyway')
+    })
+
+    test('revoking a binding revokes the tokens it minted, not just the binding', async () => {
+      // A revocation that stops new tokens being issued while the issued ones
+      // keep working is not a revocation. The customer's own command already
+      // does both halves; the operator button has to do no less.
+      const [binding] = await h.admin<{ id: string }[]>`
+        INSERT INTO oidc_repository_bindings (org_id, repository)
+        VALUES (${alice.orgId}, ${alice.repository.toLowerCase()})
+        RETURNING id`
+      const minted = await mintForAlice('exchanged')
+      await h.admin`
+        UPDATE engine_tokens
+        SET kind = 'oidc', binding_id = ${binding!.id}, expires_at = now() + interval '1 hour'
+        WHERE id = ${minted.id}`
+
+      const authenticated = await authenticateEngine(h.pool, h.clock, minted.token)
+      assert.ok(authenticated, 'the exchanged token did not authenticate before the test began')
+
+      const caller = await callerFor('security')
+      const result = await caller.admin.platform.keys.revokeBinding({
+        bindingId: binding!.id,
+        reason: 'the repository was transferred to another owner',
+      })
+      assert.equal(result.tokensRevoked, 1, 'the binding was revoked and its token was left alive')
+
+      const after = await authenticateEngine(h.pool, h.clock, minted.token)
+      assert.equal(after, null, 'a token minted by the revoked binding still authenticates')
+    })
+  })
+
+  test('the operator credential can revoke and nothing else, asked of the database', async () => {
+    // The migration's intent, checked against the catalog rather than against
+    // the comment in the file. 0023 states the rule: reading every tenant is
+    // what support work needs and rewriting every tenant's rows is not, so what
+    // is granted is exactly the set of actions the portal offers as buttons.
+    //
+    // The withheld half is the half worth testing. A later blanket
+    // GRANT ALL ... TO antifailure_admin would leave every assertion above
+    // passing and would quietly give the operator credential the ability to
+    // mint a token, which is the one thing this portal must never be able to do.
+    const rows = await h.admin<{ table_name: string; privilege_type: string }[]>`
+      SELECT table_name, privilege_type FROM information_schema.role_table_grants
+      WHERE grantee = 'antifailure_admin' AND table_schema = 'public'
+        AND table_name IN ('engine_tokens', 'oidc_repository_bindings', 'scim_tokens',
+                           'provider_keys')`
+    const holds = (table: string, verb: string) =>
+      rows.some((r) => r.table_name === table && r.privilege_type === verb)
+
+    assert.ok(holds('engine_tokens', 'UPDATE'), 'the revoke button cannot write, so it is a report')
+    assert.ok(holds('oidc_repository_bindings', 'UPDATE'), 'a binding cannot be revoked')
+    assert.ok(holds('engine_tokens', 'SELECT'), 'the list cannot read the table it lists')
+
+    for (const [table, verb] of [
+      // Minting is creating a secret, and a route that minted one would have to
+      // return it through the operator portal.
+      ['engine_tokens', 'INSERT'],
+      // A revoked credential is the record of what was allowed to act as this
+      // organization and when that stopped. Deleting it destroys the evidence.
+      ['engine_tokens', 'DELETE'],
+      ['oidc_repository_bindings', 'INSERT'],
+      ['oidc_repository_bindings', 'DELETE'],
+      // Nothing authenticates a SCIM token today, and a customer's own key to a
+      // third party is not ours to rewrite.
+      ['scim_tokens', 'UPDATE'],
+      ['provider_keys', 'UPDATE'],
+    ] as const) {
+      assert.ok(
+        !holds(table, verb),
+        `the operator credential holds ${verb} on ${table}, which no button asks for`,
+      )
+    }
+  })
+
+  test('the delivery ledgers are readable and page', async () => {
+    await h.admin`
+      INSERT INTO github_deliveries (delivery_id, org_id, account_login, event, action, outcome)
+      VALUES (${randomUUID()}, ${alice.orgId}, ${alice.slug}, 'pull_request', 'opened', 'handled'),
+             (${randomUUID()}, NULL, 'somebody-else', 'installation', 'created', NULL)`
+    const caller = await callerFor('support')
+    const page = await caller.admin.platform.integrations.deliveries({
+      source: 'github',
+      limit: 200,
+    })
+    assert.ok(page.rows.length >= 2)
+    // The row with no organization is KEPT. 0021 makes the column nullable
+    // because a delivery about an account this installation has never seen
+    // resolves to nobody, and those are exactly the rows worth reading when
+    // somebody reports that their events go nowhere.
+    assert.ok(
+      page.rows.some((r) => r.orgSlug === null),
+      'a delivery that resolved to no organization was filtered out of the ledger',
+    )
+  })
+
+  test('the MCP route says the control plane records nothing, rather than the console assuming it', async () => {
+    const caller = await callerFor('read_only')
+    const surface = await caller.admin.platform.mcp.surface()
+    assert.equal(surface.recordsAnything, false)
+    assert.equal(surface.tools.length, MCP_TOOLS.length)
+    assert.ok(surface.why.length > 0, 'the page states an absence without saying why')
+  })
+})

--- a/web/apps/api/test/admin-routes.test.ts
+++ b/web/apps/api/test/admin-routes.test.ts
@@ -36,7 +36,11 @@ describe('every operator route declares a permission', () => {
     name: 'appRouter',
     router: appRouter,
     prefix: 'admin.',
-    atLeast: 18,
+    // Raised from 18 by the developer platform lane, which adds eleven routes
+    // under admin.platform. The floor has to move with the tree or it stops
+    // being a floor: an atLeast that a shrinking router still clears is a test
+    // that has quietly stopped checking anything.
+    atLeast: 29,
   })
 })
 

--- a/web/apps/api/test/admincsrf.test.ts
+++ b/web/apps/api/test/admincsrf.test.ts
@@ -114,5 +114,55 @@ describe(
     const read = await h.fetch('/trpc/admin.flags.list', { headers: { cookie } })
     assert.equal(read.status, 200)
   })
+
+  describe('the cookie NAME a real browser sends', () => {
+    // THE HOLE THIS BLOCK EXISTS FOR, found by driving an actual browser at an
+    // actual server rather than by reading the middleware.
+    //
+    // adminSessionCookie writes `__Host-af_admin_session` whenever the cookie
+    // is Secure, and Secure is every deployment that matters. The guard read
+    // the BARE name, so in production it found no cookie, skipped the whole
+    // check, and let the request through; the tRPC context then resolved the
+    // operator anyway through readAdminSessionCookie, which knows both names.
+    // Every assertion above passed throughout, because this test server speaks
+    // plain HTTP and the fixture above builds the bare name by hand.
+    //
+    // So the fix is one function call, and this is the instrument that can say
+    // no to it: the same four questions, asked with the name a browser actually
+    // sends. Without it the next person to write `readCookie` here gets a green
+    // suite and a portal with no cross-site protection.
+    const prefixed = () => `__Host-${cookie}`
+
+    it('refuses a mutation with no token, under the prefixed name too', async () => {
+      const refused = await h.fetch('/trpc/admin.flags.kill', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', cookie: prefixed() },
+        body: JSON.stringify({ key: 'nothing.here', reason: 'a reason long enough' }),
+      })
+      assert.equal(
+        refused.status,
+        403,
+        'a prefixed operator cookie reached a mutation with no cross-site token',
+      )
+      assert.match(await refused.text(), /x-antifailure-admin-csrf/)
+    })
+
+    it('lets the real token through under the prefixed name, so the fix is not a blanket refusal', async () => {
+      // The other half. A guard that refuses every prefixed cookie would also
+      // make this test pass if it only asserted the 403 above, and it would
+      // break the portal for every operator in production.
+      const allowed = await h.fetch('/trpc/admin.flags.kill', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          cookie: prefixed(),
+          'x-antifailure-admin-csrf': csrf,
+        },
+        body: JSON.stringify({ key: 'nothing.here', reason: 'a reason long enough' }),
+      })
+      assert.equal(allowed.status, 404)
+      assert.match(await allowed.text(), /no flag called nothing.here/)
+    })
+  })
   },
 )

--- a/web/packages/db/migrations/0032_the_credential_an_operator_can_actually_revoke.sql
+++ b/web/packages/db/migrations/0032_the_credential_an_operator_can_actually_revoke.sql
@@ -1,0 +1,68 @@
+-- The two write grants that make the operator portal's revoke button real.
+--
+-- WHY A MIGRATION IS UNAVOIDABLE HERE, rather than a nicety. 0023 gives
+-- antifailure_admin SELECT on every table in the schema and enumerates its
+-- writes one at a time: users, organizations, members, sessions. 0029 adds the
+-- operator's own tables, 0030 adds the money ledger. Nothing anywhere grants it
+-- UPDATE on engine_tokens or on oidc_repository_bindings. So an operator route
+-- that revoked a credential would read the row, show it, offer the button, and
+-- fail with 42501 at the instant somebody pressed it, during whatever incident
+-- made them press it.
+--
+-- 0023 states the rule this file follows: reading every tenant is what support
+-- work needs, changing every tenant's rows is not, and what is granted is
+-- EXACTLY the set of actions the portal offers as buttons. These are two more
+-- buttons, so these are two more grants, named one at a time.
+--
+-- WHY REVOKING IS A WRITE THE PLATFORM SHOULD HOLD AT ALL. A credential that
+-- has leaked is the platform's problem before it is the customer's. The
+-- customer can already revoke their own with `af token create` and
+-- `af token revoke`, and when the report arrives from a third party at three in
+-- the morning the person who can act on it is the operator on call, not
+-- somebody at the customer who has not been woken up yet.
+--
+-- WHY UPDATE AND NOT DELETE. A revoked credential is a row that records what
+-- was allowed to act as this organization and when that stopped. Deleting it
+-- would destroy the evidence somebody comes looking for, which is the same
+-- argument 0025 makes when it withholds DELETE on oidc_repository_bindings from
+-- the application. Withheld here explicitly, so a later blanket grant has to
+-- overwrite a line saying why it should not be given rather than merely forget
+-- to add one.
+--
+-- WHAT THIS DOES NOT GRANT, and each absence is a decision:
+--
+--   INSERT on engine_tokens. Minting is creating a secret, and a route that
+--   minted one would have to return it through the operator portal. Only the
+--   hash is stored, so no route in this product can show a token after the
+--   moment it is created, and the portal must not become the one exception. An
+--   operator revokes; the customer creates the replacement.
+--
+--   Anything on scim_tokens. The table has existed since 0014 and nothing under
+--   web/apps/api/src reads it, so a SCIM token authenticates nothing today.
+--   Granting a write against it would be arranging for a button that stops
+--   something already stopped.
+--
+--   Anything on provider_keys. A customer's own key to a third party is theirs,
+--   the ciphertext is not ours to touch, and revoking one breaks their runs
+--   without answering an operator question. If that changes, it changes with
+--   its own migration and its own argument.
+
+BEGIN;
+
+-- Revoking an engine, cli or oidc token. authenticateEngine in
+-- apps/api/src/ingest.ts reads revoked_at on every POST /v1/events before it
+-- reads anything else, so this grant is what stands between a leaked credential
+-- and the next event it would have been accepted for.
+GRANT UPDATE ON engine_tokens TO antifailure_admin;
+REVOKE INSERT, DELETE, TRUNCATE ON engine_tokens FROM antifailure_admin;
+
+-- Revoking a GitHub OIDC repository binding. The route revokes the binding AND
+-- every live token it minted in one statement, which is what apps/api/src/
+-- github/exchange.ts already does for the customer's own command: a revocation
+-- that stops new tokens being issued while the issued ones keep working is not
+-- a revocation. That second half is why the grant above is needed for this
+-- action too.
+GRANT UPDATE ON oidc_repository_bindings TO antifailure_admin;
+REVOKE INSERT, DELETE, TRUNCATE ON oidc_repository_bindings FROM antifailure_admin;
+
+COMMIT;


### PR DESCRIPTION
The Developer Platform lane of the operator portal: Repositories & Pull
Requests, MCP Management, API Keys, and Integrations & Webhooks. Eleven routes
under `admin.platform`, five permissions, one migration, four pages, and one
security fix found while proving the fourth page works.

## The security fix, first, because it affects every lane

**The cross-site guard on operator mutations did not run on any deployment where
the session cookie is Secure, and never had.**

`adminSessionCookie` writes `__Host-af_admin_session` when Secure and the bare
name when not. Two readers exist. The tRPC context uses
`readAdminSessionCookie`, which tries both names, so the operator was resolved
correctly in production. The guard in front of it used `readCookie` with the
bare name, found nothing, and skipped the origin check and the token check
entirely. The request then reached the mutation fully authenticated. The
mutations behind that cookie suspend tenants, change plans, move money, and now
revoke credentials.

`admincsrf.test.ts` has four assertions and all four passed throughout. It
builds its cookie by hand as the bare name against a test server that speaks
plain HTTP, so it exercises the one configuration where the bug cannot appear.
It was found by driving a real browser at a real control plane and watching a
revoke succeed with no `x-antifailure-admin-csrf` header, then reproducing it
with curl.

The fix is one function call. The suite now asks two of its questions again
under the name a browser sends: refused with no token, and allowed with the real
one, the second so a blanket refusal cannot pass as a fix. With the one line
reverted the new refusal fails and the five older assertions stay green, which
is the whole story in one run.

Because the server now really does refuse, `adminMutate` sends the token it was
already able to fetch. Its comment argued that SameSite=Strict made a token
unnecessary; SameSite is site scoped rather than origin scoped, so a subdomain an
attacker controls is inside it. Fetched once, cached as a promise so two buttons
share one request, retried exactly once on the refusal that names the header.

## What each page answers

**Repositories & Pull Requests.** A customer says the check on one pull request
never appeared. Repository, then its pull requests with the newest generation
attached to each row, then that pull request's whole check history in a panel.
A fork approval that no longer covers the head is reported as a stale approval
rather than as an approval, because `approved_sha` is stored rather than a
boolean for exactly that reason.

**API Keys.** Every credential that can act as a customer, with its prefix, what
created it, what it acts as and when it was last used. Never a value: only a
hash is stored. Revoking a GitHub workflow identity binding also revokes every
token that binding minted, because a revocation that leaves the issued
credentials alive is not one. No rotate button, and the page says why rather
than leaving the absence for somebody to file: a route that minted a replacement
would have to return a secret through this portal. An expired credential shows
no button at all, because `authenticateEngine` already refuses it and a control
whose effect cannot be observed is the shape of a feature that is not built.

**Integrations & Webhooks.** Inbound only. There is no outbound webhook
subscription table, no delivery attempt table and no signing secret store, so
none is drawn. Deliveries that resolved to no organization are kept rather than
filtered, because those are the rows worth reading when a customer says their
events go nowhere.

**MCP Management.** This is outcome (c) from the brief, and the reasoning is
worth reading. The survey said MCP has no table and concluded a page would be
entirely invented. That is right about the control plane and wrong about the
product: `af mcp` is a shipped engine feature. I read `serve.go`, `engine.go`,
`project.go` and `runs.go`: it binds one checkout, speaks the protocol on
standard input and output, keeps its runs in that project's own state directory,
and makes no HTTP call to the control plane at all. `project.go` states the
tenancy model outright. So there is no fleet, no connection count, and no honest
write path short of building agent telemetry nobody asked for.

The page therefore says the control plane holds no MCP record, and
`recordsAnything: false` is a field on the route rather than an assumption in
the console, so the day a write path exists the page changes because the server
changed. It then lists the four tools the engine actually serves and what each
refuses, each carrying the file and symbol it came from. `admin-platform.test.ts`
opens every one of those files and greps for every one of those symbols, checks
that `serve.go` registers each constructor, and asserts the set both ways so a
tool that STARTED existing fails too.

## The migration

`0032` grants the operator role `UPDATE` on `engine_tokens` and on
`oidc_repository_bindings`, and nothing else. Migration 0023 enumerates that
role's writes one at a time and neither table was in the list, so the revoke
button would have failed with 42501 at the instant somebody pressed it. `INSERT`
is withheld and said out loud. A test asks the catalog directly and asserts both
halves: the two grants exist, and `INSERT`, `DELETE`, `scim_tokens` and
`provider_keys` are absent, so a later blanket grant fails here rather than
quietly giving the portal the ability to mint a credential.

## Defined, wired, effective

Proved end to end rather than inferred:

- A credential minted through `mintEngineToken`, authenticated through
  `authenticateEngine`, revoked through the route, and refused by
  `authenticateEngine` afterwards. The assertion before the revoke is what makes
  the one after it mean anything.
- Both audit chains gain exactly one entry, and the customer's own copy carries
  `origin: admin`, names the operator, and carries the prefix rather than the id.
- A second revocation of the same credential writes nothing and does not move
  the recorded time.
- `support` can read the credential list and is refused the revoke, naming the
  permission.
- Revoking a binding revokes the token it minted, checked through
  `authenticateEngine` rather than through a count.
- The whole flow driven in a real browser: the button, the confirmation, the
  server's own refusal message rendered in the error state before the token fix,
  and the row revoked with both audit entries after it.

## Verified by looking

All four pages rendered against a real control plane serving the real static
export, with seeded rows, at 320, 390 and 1280 pixels. No horizontal scroll at
any width, no console errors, and the detail panel and the confirmation dialog
opened at both ends of the range. `just prosecheck` and `just motioncheck` pass
against the built stylesheet and HTML. Console unit tests 84 passing, and the
admin suites 428 passing with the invocation CI uses.

## Two things for review

`RESERVED_PREFIXES` moved `admin.keys`, `admin.webhooks` and `admin.deploys`
from infra to this lane, because the stub in `platform.ts` already claimed the
first two and `w-admin-infra` implemented neither. `admin.repos` and `admin.mcp`
are new.

Two navigation summaries were rewritten. MCP Management promised "the MCP
servers customers have connected", and Integrations promised "outbound
deliveries and the endpoints that keep refusing them". Neither exists. The
summary is rendered on the overview directory, so leaving them would have put
the invented dashboard back one screen away from the page that refuses to draw
it. Labels, order, routes and icons are untouched.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR
