### PR TITLE
admin: the product lane, and the two pages that say what is not there

### DIFF
--- a/.changes/the-operator-portal-can-see-the-product.md
+++ b/.changes/the-operator-portal-can-see-the-product.md
@@ -1,0 +1,46 @@
+# added
+
+The operator portal can see the product: twins, runs, branches and safe state.
+
+Five sections of the platform portal are now built against real tables rather
+than reserved. Production Twins lists every environment on the installation,
+with the one filter that is a finding: past the lifetime it was created with,
+not torn down, and costing somebody money for a branch nobody is looking at.
+Branches groups those environments by the branch that made them and surfaces the
+same cost from the other side, a live twin on a branch whose pull request closed
+a fortnight ago. Safe State reads the golden data versions and the masking rules
+a scan proposed, and leads with the unconfirmed ones, which are the columns a
+scanner believes hold personal data on a copy somebody is running tests against.
+
+Runs and Jobs is the page an operator opens during an incident, so it is built
+for one sequence: find the run, see why it failed, see what it touched. The
+three run families are a filter rather than one merged table, because an agent
+run has verdicts and artifacts, a load run has percentiles and a lease, and a
+pull request check has a head commit; a table true of all three would have to
+drop the columns somebody came for. Every list is keyset paged and says how many
+rows it is showing, and the failures filter is applied by the query rather than
+after the page, because filtering a cut page eventually returns an empty page
+with a cursor behind it, which reads as the end of a list that has more in it.
+
+A run that finished is not a run that passed, and the pages say so. Every run
+carries a standing beside its own state: a load run whose state is `succeeded`
+can carry a failing verdict, and an agent run that reached `complete` having
+reported no verdict at all did nothing and found nothing. The second is shown as
+its own answer rather than as a pass, which is the exit-code-zero-over-nothing
+defect this repository has already shipped once.
+
+Experiments and Feature Flags is a flags page, and it says so at the top. Flags
+are complete: state, rollout, targets, the internal-only bit, and a kill with a
+reason attached, plus the column that matters most during an incident, whether
+anything in the build reads the flag at all. Experiments are not built. There is
+no experiment table, no variant, no assignment, no exposure log and no results,
+and a rollout percent is a share of traffic rather than an experiment because
+nothing records which subject fell on which side. The page names that absence
+and the four things that would end it, rather than drawing a dashboard whose
+every number would be invented.
+
+Safe State names its absences the same way. There is no record of a customer's
+live database, no snapshot ledger and no restore history anywhere in the schema,
+so the page cannot say which database was cloned, when a twin was restored, or
+how old the copy is. It says which table each answer would need instead of
+leaving somebody to search for a panel that was never built.

--- a/console/app/admin/product/branches/page.tsx
+++ b/console/app/admin/product/branches/page.tsx
@@ -220,7 +220,13 @@ const COLUMNS: Column<BranchRow>[] = [
     cell: (b) => (
       <span className="block">
         <Link
-          href={`/admin/product/twins?q=${encodeURIComponent(b.branch)}`}
+          // The organization travels with the branch name. Two tenants can
+          // both have a branch called main, and a link carrying only the name
+          // showed somebody else's environments beside the ones clicked on.
+          href={
+            `/admin/product/twins?org=${encodeURIComponent(b.orgId)}` +
+            `&slug=${encodeURIComponent(b.orgSlug)}&q=${encodeURIComponent(b.branch)}`
+          }
           className="inline-flex min-h-11 items-center justify-end underline decoration-transparent underline-offset-4 hover:decoration-[rgba(16,16,16,0.35)] sm:min-h-0"
         >
           <span className="whitespace-nowrap">

--- a/console/app/admin/product/branches/page.tsx
+++ b/console/app/admin/product/branches/page.tsx
@@ -1,18 +1,250 @@
 "use client";
 
-import { PlannedSection } from "@/components/admin/primitives";
+import { useState } from "react";
+import Link from "next/link";
+import { Badge, Button, Card, Loaded, TableSkeleton, When } from "@/components/ui";
+import {
+  AdminPage,
+  DataTable,
+  EmptyList,
+  FilterBar,
+  StatusChip,
+  type Column,
+} from "@/components/admin/primitives";
+import { More } from "@/components/pagination";
+import { useBranches, type BranchRow, type BranchScope } from "@/lib/admin-product";
 
 /**
- * Branches & Environments
+ * Environments grouped by the branch they belong to.
  *
- * Not written yet. The route exists from the first commit because a navigation
- * entry that 404s teaches the reader to distrust the rail, and they cannot tell
- * a section that is coming from one that is broken.
+ * A BRANCH IS NOT A TABLE. It is a column on `environments`, so this screen is
+ * a grouping rather than a list, and the grouping is what makes it worth a
+ * screen: one branch holds several twins over its life, and the question an
+ * operator has is about the branch rather than about any one of them.
  *
- * TO BUILD THIS SECTION: replace the body below with the real page, and add its
- * routes to web/apps/api/src/admin/product.ts. Nothing else in the portal
- * has to change. See console/app/admin/README.md.
+ * THE FINDING THIS PAGE EXISTS FOR is `orphaned`: a branch with a live twin
+ * whose pull request is closed or merged. Nothing is wrong with the twin, no
+ * alarm fired, and the data is not corrupt. It is simply still running, and
+ * still costing money, for a change that landed a fortnight ago. That is the
+ * default filter, because it is the only one of the three that is a finding.
  */
 export default function ProductBranchesPage() {
-  return <PlannedSection href="/admin/product/branches" />;
+  const [scope, setScope] = useState<BranchScope>("orphaned");
+  const [search, setSearch] = useState("");
+  const state = useBranches({ scope, search });
+
+  return (
+    <AdminPage href="/admin/product/branches">
+      <Card>
+        <FilterBar
+          search={{
+            value: search,
+            onChange: setSearch,
+            label: "Search branches by name or repository",
+            placeholder: "Branch or repository",
+          }}
+          filters={[
+            {
+              label: "Show",
+              value: scope,
+              onChange: (next) => setScope(next as BranchScope),
+              options: [
+                { value: "orphaned", label: "Holding a twin after the pull request closed" },
+                { value: "live", label: "Holding a twin" },
+                { value: "all", label: "Every branch ever" },
+              ],
+            },
+          ]}
+        />
+        <Loaded state={state} skeleton={<TableSkeleton rows={6} cols={6} />}>
+          {(rows) => (
+            <DataTable
+              columns={COLUMNS}
+              rows={rows}
+              keyOf={(b) => `${b.repositoryId}:${b.branch}`}
+              empty={<BranchesEmpty scope={scope} search={search} onClear={() => setSearch("")} />}
+              footer={
+                <More
+                  shown={rows.length}
+                  noun={{ one: "branch", many: "branches" }}
+                  hasMore={state.hasMore}
+                  busy={state.busy}
+                  error={state.moreError}
+                  onMore={state.more}
+                />
+              }
+            />
+          )}
+        </Loaded>
+      </Card>
+    </AdminPage>
+  );
 }
+
+function BranchesEmpty({
+  scope,
+  search,
+  onClear,
+}: {
+  scope: BranchScope;
+  search: string;
+  onClear: () => void;
+}) {
+  if (search) {
+    return (
+      <EmptyList
+        title="No branch matches that"
+        action={<Button onClick={onClear}>Clear the search</Button>}
+      >
+        Nothing has that branch name or repository under the filter above. A branch with no
+        environment has never appeared on this installation at all, because a branch here is a
+        column on an environment rather than a row of its own.
+      </EmptyList>
+    );
+  }
+  if (scope === "orphaned") {
+    return (
+      <EmptyList title="Nothing is being held open after its pull request closed">
+        Every branch with a live twin still has an open pull request behind it. This is the answer
+        you want: nothing is running for a change that already landed.
+      </EmptyList>
+    );
+  }
+  if (scope === "live") {
+    return (
+      <EmptyList title="No branch is holding a twin">
+        Nothing is running on this installation right now, so no branch has an environment against
+        it. Switch to every branch to see what has run before.
+      </EmptyList>
+    );
+  }
+  return (
+    <EmptyList title="No branch has ever had an environment">
+      Nobody has created an environment on this installation, so there is nothing to group. The
+      first pull request the GitHub app sees will make one.
+    </EmptyList>
+  );
+}
+
+/**
+ * Six columns, and the count is the design.
+ *
+ * The first draft had eight, and at a desktop width the table's auto layout
+ * gave the Holding cell about eight characters: the finding this whole page
+ * exists for came out one word per line, and the last column was cut off by the
+ * card. Live and ever are one fact read together, and the newest twin's state
+ * belongs beside them rather than in a column of its own.
+ */
+const COLUMNS: Column<BranchRow>[] = [
+  {
+    key: "branch",
+    header: "Branch",
+    cell: (b) => (
+      <span className="block min-w-0">
+        <span className="block break-words font-mono text-[12px] font-medium text-ink">
+          {b.branch}
+        </span>
+        <span className="block truncate text-[12px] text-muted">{b.repository}</span>
+      </span>
+    ),
+  },
+  {
+    key: "org",
+    header: "Organization",
+    cell: (b) => (
+      <Link
+        href={`/admin/customers/users/organization?org=${encodeURIComponent(b.orgSlug)}`}
+        className="inline-flex min-h-11 items-center truncate font-mono text-[12px] underline decoration-transparent underline-offset-4 hover:decoration-[rgba(16,16,16,0.35)] sm:min-h-0"
+      >
+        {b.orgSlug}
+      </Link>
+    ),
+  },
+  {
+    key: "pr",
+    header: "Pull request",
+    cell: (b) =>
+      b.pullRequest === null ? (
+        // A branch with twins and no pull request is ordinary: somebody ran the
+        // engine against a branch directly. Saying so beats an empty cell that
+        // reads like missing data.
+        <span className="block min-w-[16ch] text-muted">none, run against the branch</span>
+      ) : (
+        <span className="block min-w-[18ch]">
+          <span className="flex flex-wrap items-center gap-1.5">
+            <span className="whitespace-nowrap font-medium">Number {b.pullRequest}</span>
+            <StatusChip value={b.pullRequestState} />
+            {b.pullRequestDraft ? <Badge tone="neutral">draft</Badge> : null}
+            {b.pullRequestFromFork ? <Badge tone="warn">fork</Badge> : null}
+          </span>
+          {b.pullRequestTitle ? (
+            <span className="mt-0.5 block max-w-[40ch] truncate text-[12px] text-muted">
+              {b.pullRequestTitle}
+            </span>
+          ) : null}
+        </span>
+      ),
+  },
+  {
+    key: "holding",
+    header: "Holding",
+    cell: (b) => (
+      // The floor is what keeps the finding readable. Without it the auto
+      // layout gave this cell eight characters and the sentence below came out
+      // one word per line.
+      <span className="block min-w-[22ch] max-w-[34ch]">
+        <span className="flex flex-wrap items-center gap-1.5">
+          {/* A badge is a word, not a sentence. The word is the chip and the
+              explanation is the line under it, at a size somebody can read. */}
+          {b.orphaned ? (
+            <Badge tone="fail">still up</Badge>
+          ) : b.live > 0 ? (
+            <Badge tone="pass">expected</Badge>
+          ) : (
+            <Badge tone="neutral">nothing running</Badge>
+          )}
+          {b.overdue > 0 ? <Badge tone="warn">{b.overdue} past expiry</Badge> : null}
+        </span>
+        {b.orphaned ? (
+          <span className="mt-1 block text-[12px] leading-5 text-muted">
+            The pull request is {b.pullRequestState} and a twin is still running.
+          </span>
+        ) : null}
+      </span>
+    ),
+  },
+  {
+    key: "twins",
+    header: "Twins",
+    numeric: true,
+    cell: (b) => (
+      <span className="block">
+        <Link
+          href={`/admin/product/twins?q=${encodeURIComponent(b.branch)}`}
+          className="inline-flex min-h-11 items-center justify-end underline decoration-transparent underline-offset-4 hover:decoration-[rgba(16,16,16,0.35)] sm:min-h-0"
+        >
+          <span className="whitespace-nowrap">
+            {b.live.toLocaleString()} live of {b.twins.toLocaleString()}
+          </span>
+        </Link>
+        <span className="block whitespace-nowrap text-[12px] font-normal text-muted">
+          newest is {b.latestState.replace(/_/g, " ")}
+        </span>
+      </span>
+    ),
+  },
+  {
+    key: "activity",
+    header: "Last event",
+    cell: (b) => (
+      <span className="block min-w-0">
+        <When value={b.lastActivity} />
+        {b.pullRequestClosedAt ? (
+          <span className="block text-[12px] text-muted">
+            Pull request closed <When value={b.pullRequestClosedAt} />
+          </span>
+        ) : null}
+      </span>
+    ),
+  },
+];

--- a/console/app/admin/product/experiments/page.tsx
+++ b/console/app/admin/product/experiments/page.tsx
@@ -1,18 +1,1204 @@
 "use client";
 
-import { PlannedSection } from "@/components/admin/primitives";
+import { useState } from "react";
+import {
+  Badge,
+  Button,
+  Card,
+  Confirm,
+  Empty,
+  Field,
+  Loaded,
+  TableSkeleton,
+  When,
+  inputClass,
+  selectClass,
+} from "@/components/ui";
+import {
+  AdminPage,
+  DataTable,
+  Drawer,
+  EmptyList,
+  Facts,
+  StatusChip,
+  type Column,
+  type Fact,
+} from "@/components/admin/primitives";
+import { operatorMay, useAdminContext, useTenants } from "@/lib/admin";
+import type { ApiError } from "@/lib/api";
+import {
+  killFlag,
+  revokeOverride,
+  setFlag,
+  targetFlag,
+  useFlags,
+  useOrgEntitlements,
+  type FeatureFlag,
+  type FlagTarget,
+  type OrgEntitlement,
+} from "@/lib/admin-product";
 
 /**
- * Experiments & Feature Flags
+ * Feature flags, the targets on them, and the entitlement overrides beside
+ * them. There are no experiments, and this page says so rather than drawing
+ * one.
  *
- * Not written yet. The route exists from the first commit because a navigation
- * entry that 404s teaches the reader to distrust the rail, and they cannot tell
- * a section that is coming from one that is broken.
+ * THE THING THIS PAGE REFUSES TO BE. The section is called Experiments and
+ * Feature Flags and only the second half exists. There is no experiment table
+ * in this schema, no variant, no assignment, no exposure log and no results. A
+ * rollout percent is a share of traffic, not an experiment: nothing records
+ * which subject fell on which side, so nothing can compare the two afterwards.
+ * A dashboard over that would have to invent every number on it, which is worse
+ * than an empty page because an operator would read the invention as a
+ * measurement. So the absence is stated at the top, in one card, with the four
+ * things that would have to exist for the other half of the title to be true.
  *
- * TO BUILD THIS SECTION: replace the body below with the real page, and add its
- * routes to web/apps/api/src/admin/product.ts. Nothing else in the portal
- * has to change. See console/app/admin/README.md.
+ * WHAT IT IS INSTEAD is the whole of the flag surface: state, rollout, targets,
+ * the internal-only bit, and the kill with its reason on it. The kill is the
+ * reason this page matters at three in the morning, so it is one button on the
+ * flag rather than a state hidden in a dropdown, and it demands a reason
+ * because a kill switch whose reason nobody can see is not a kill switch.
+ *
+ * NOTHING HERE ANIMATES, including the chip on a flag that is live. A dot that
+ * throbs while the reader is doing nothing says exactly as much as a still one.
  */
 export default function ProductExperimentsPage() {
-  return <PlannedSection href="/admin/product/experiments" />;
+  const { me } = useAdminContext();
+  const mayWriteFlags = operatorMay(me, "admin.flags.write");
+  const mayReadEntitlements = operatorMay(me, "admin.entitlements.read");
+
+  const [creating, setCreating] = useState(false);
+  const state = useFlags();
+
+  return (
+    <AdminPage
+      href="/admin/product/experiments"
+      actions={
+        mayWriteFlags ? (
+          <Button variant="primary" onClick={() => setCreating(true)}>
+            Add a flag
+          </Button>
+        ) : undefined
+      }
+    >
+      <div className="space-y-6">
+        <NoExperiments />
+
+        <Card
+          title="Feature flags"
+          note="Killed beats off, a deny beats an allow, and a rollout is consulted last."
+        >
+          <Loaded state={state} skeleton={<TableSkeleton rows={5} cols={6} />}>
+            {(answer) => (
+              <FlagTable
+                flags={answer.flags}
+                targets={answer.targets}
+                mayWrite={mayWriteFlags}
+                onChanged={state.reload}
+              />
+            )}
+          </Loaded>
+        </Card>
+
+        {mayReadEntitlements ? <Overrides mayWrite={operatorMay(me, "admin.entitlements.write")} /> : null}
+      </div>
+
+      {creating ? (
+        <FlagForm
+          title="Add a flag"
+          onClose={() => setCreating(false)}
+          onSaved={() => {
+            setCreating(false);
+            state.reload();
+          }}
+        />
+      ) : null}
+    </AdminPage>
+  );
+}
+
+/* -------------------------------------------------------------------------
+ * The absence, named
+ * ---------------------------------------------------------------------- */
+
+function NoExperiments() {
+  return (
+    <Card title="There are no experiments here">
+      <div className="space-y-3 px-4 py-4 text-[13px] leading-6 text-muted">
+        <p>
+          This section is named for two things and one of them is not built. Feature flags below are
+          complete: state, rollout, targets and a kill switch, all backed by real tables and all
+          consulted by the request path. Experiment assignment and results are not wired at all, and
+          no filter on this page will reveal them.
+        </p>
+        <p>
+          A rollout percent is not an experiment. It turns a feature on for a stable share of
+          subjects, hashed per flag, and nothing records which subject fell on which side. So there
+          is no exposure to count, no arm to compare against, and no result to read.
+        </p>
+        <p>
+          Four things would have to exist for the other half of this title to be true: an experiment
+          with its hypothesis and its arms, a variant assignment written the first time a subject is
+          bucketed, an exposure log that is separate from assignment because being bucketed is not
+          being shown, and a metric definition to read a result against. Three of the four are
+          tables; the fourth is a decision about what this product measures.
+        </p>
+      </div>
+    </Card>
+  );
+}
+
+/* -------------------------------------------------------------------------
+ * Flags
+ * ---------------------------------------------------------------------- */
+
+function FlagTable({
+  flags,
+  targets,
+  mayWrite,
+  onChanged,
+}: {
+  flags: FeatureFlag[];
+  targets: FlagTarget[];
+  mayWrite: boolean;
+  onChanged: () => void;
+}) {
+  const [open, setOpen] = useState<string | null>(null);
+  const current = flags.find((f) => f.key === open) ?? null;
+  const targetsFor = (key: string) => targets.filter((t) => t.flag_key === key);
+
+  // SIX COLUMNS, and the count is the design. Seven pushed the Manage button
+  // past the right edge of the card, where it sat inside a horizontal scroll
+  // nobody would think to use for a control. The target count is a fact about
+  // the state, so it reads under the state rather than as a column.
+  const columns: Column<FeatureFlag>[] = [
+    {
+      key: "key",
+      header: "Flag",
+      cell: (f) => (
+        <span className="block min-w-[22ch] max-w-[40ch]">
+          <span className="block break-words font-mono text-[12px] font-medium text-ink">
+            {f.key}
+          </span>
+          <span className="mt-0.5 block break-words text-[12px] leading-5 text-muted">
+            {f.description}
+          </span>
+        </span>
+      ),
+    },
+    {
+      key: "state",
+      header: "State",
+      cell: (f) => {
+        const targets = targetsFor(f.key).length;
+        return (
+          <span className="block min-w-[13ch]">
+            <span className="flex flex-wrap items-center gap-1.5">
+              <StatusChip
+                value={f.state}
+                tone={f.state === "on" ? "pass" : f.state === "off" ? "neutral" : "warn"}
+              />
+              {f.killed_at ? <Badge tone="fail">killed</Badge> : null}
+              {f.internal_only ? <Badge tone="neutral">internal only</Badge> : null}
+            </span>
+            <span className="mt-1 block text-[12px] text-muted">
+              {targets === 0
+                ? "nobody targeted"
+                : `${targets} ${targets === 1 ? "target" : "targets"}`}
+            </span>
+          </span>
+        );
+      },
+    },
+    {
+      key: "rollout",
+      header: "Rollout",
+      numeric: true,
+      cell: (f) =>
+        f.state === "on" ? (
+          // The rollout is only consulted when the flag is targeted, so a
+          // percent beside an `on` flag would describe a rule nobody reaches.
+          // The evaluation order is the semantics.
+          <span className="whitespace-nowrap text-dim">not consulted</span>
+        ) : (
+          `${f.rollout_percent}%`
+        ),
+    },
+    {
+      // break-words rather than truncate on the call site: this is the path
+      // somebody greps for to find out what the flag actually does, and half of
+      // it is worth nothing.
+      key: "known",
+      header: "Read at",
+      cell: (f) =>
+        f.known ? (
+          // Split at the colon rather than wrapped as one string. The value is
+          // `path/from/src:symbol`, and a colon is not a break opportunity, so
+          // a single span broke mid-identifier at "refuseWhenKille" and "d".
+          // The file and the symbol are two facts anyway.
+          <span className="block max-w-[30ch] font-mono text-[12px] text-muted">
+            <span className="block break-words">{(f.checkedAt ?? "").split(":")[0]}</span>
+            <span className="block break-words text-ink">
+              {(f.checkedAt ?? "").split(":").slice(1).join(":")}
+            </span>
+          </span>
+        ) : (
+          // The most useful column on this table during an incident. A flag with
+          // no call site is a switch that looks like a control and is not one,
+          // and finding that out by flipping it is the worst way to learn.
+          <span className="block min-w-[16ch] max-w-[26ch]">
+            <Badge tone="warn">nothing reads it</Badge>
+            <span className="mt-1 block text-[12px] leading-5 text-muted">
+              flipping this changes nothing
+            </span>
+          </span>
+        ),
+    },
+    {
+      key: "updated",
+      header: "Last changed",
+      cell: (f) => (
+        <span className="block min-w-0">
+          <When value={f.updated_at} />
+          {f.updated_by_label ? (
+            <span className="block truncate text-[12px] text-muted">{f.updated_by_label}</span>
+          ) : null}
+        </span>
+      ),
+    },
+    {
+      key: "manage",
+      header: "Manage",
+      cell: (f) => (
+        // A real button rather than a clickable row: a row that opens a panel on
+        // click has no keyboard equivalent and is never announced as opening
+        // anything. The accessible name carries the flag, so twenty of these do
+        // not all read "Manage".
+        // The hidden half comes AFTER the visible word, so the accessible name
+        // reads "Manage the flag billing.checkout" as a sentence. Split either
+        // side of the label it read "Manage the flag Manage billing.checkout".
+        <Button onClick={() => setOpen(f.key)}>
+          {mayWrite ? "Manage" : "Look at"}
+          <span className="sr-only"> the flag {f.key}</span>
+        </Button>
+      ),
+    },
+  ];
+
+  return (
+    <>
+      <DataTable
+        columns={columns}
+        rows={flags}
+        keyOf={(f) => f.key}
+        empty={
+          <EmptyList
+            title="No feature flag exists"
+            action={mayWrite ? undefined : undefined}
+          >
+            Nothing on this installation is behind a flag. A flag is created here rather than by a
+            deploy, so the list stays empty until somebody adds one. Two are expected by the source
+            and will appear as soon as they are created: the checkout switch and the switch that
+            stops the administrative surface moving money.
+          </EmptyList>
+        }
+      />
+      {current ? (
+        <FlagDrawer
+          flag={current}
+          targets={targets.filter((t) => t.flag_key === current.key)}
+          mayWrite={mayWrite}
+          onClose={() => setOpen(null)}
+          onChanged={onChanged}
+        />
+      ) : null}
+    </>
+  );
+}
+
+function FlagDrawer({
+  flag,
+  targets,
+  mayWrite,
+  onClose,
+  onChanged,
+}: {
+  flag: FeatureFlag;
+  targets: FlagTarget[];
+  mayWrite: boolean;
+  onClose: () => void;
+  onChanged: () => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [targeting, setTargeting] = useState(false);
+  const [killing, setKilling] = useState(false);
+
+  const facts: Fact[] = [
+    { label: "Key", value: flag.key, mono: true },
+    { label: "What it does", value: flag.description },
+    { label: "State", value: <StatusChip value={flag.state} /> },
+    {
+      label: "Rollout",
+      value:
+        flag.state === "on"
+          ? "Not consulted while the flag is on for everybody"
+          : `${flag.rollout_percent}% of subjects, hashed per flag`,
+    },
+    {
+      label: "Internal only",
+      value: flag.internal_only
+        ? "Yes. Off for anybody outside the operator's own organizations."
+        : "No",
+    },
+    {
+      label: "Read at",
+      value: flag.known ? (
+        <span className="font-mono text-[12px]">{flag.checkedAt}</span>
+      ) : (
+        <span className="text-warn">
+          Nothing in this build reads this flag, so changing it changes nothing.
+        </span>
+      ),
+    },
+    { label: "Killed", value: flag.killed_at ? <When value={flag.killed_at} /> : null },
+    { label: "Killed by", value: flag.killed_by_label },
+    { label: "Kill reason", value: flag.killed_reason },
+    { label: "Last changed", value: flag.updated_at ? <When value={flag.updated_at} /> : null },
+    { label: "Changed by", value: flag.updated_by_label },
+  ];
+
+  return (
+    <>
+      <Drawer
+        open
+        title={flag.key}
+        onClose={onClose}
+        actions={
+          mayWrite ? (
+            <>
+              <Button onClick={() => setTargeting(true)}>Target somebody</Button>
+              <Button onClick={() => setEditing(true)}>Change it</Button>
+              <Button variant="danger" onClick={() => setKilling(true)}>
+                Kill it
+              </Button>
+            </>
+          ) : undefined
+        }
+      >
+        <Facts facts={facts} />
+
+        <div className="border-t border-rule px-4 py-3">
+          <h3 className="text-[12px] font-medium uppercase tracking-[0.08em] text-dim">
+            Who it is targeted at
+          </h3>
+          <p className="mt-1.5 text-[12.5px] leading-5 text-muted">
+            A deny beats an allow and both beat the rollout, so one deny is how a single customer
+            comes out of a rollout that is working for everybody else. A target cannot be deleted
+            from this portal; setting the same subject the other way is the recorded change.
+          </p>
+        </div>
+        {targets.length === 0 ? (
+          <Empty title="Nobody is targeted">
+            This flag applies by its state and its rollout alone. Add a target to turn it on or off
+            for one organization, user, repository, plan or deployment.
+          </Empty>
+        ) : (
+          <ul className="divide-y divide-rule border-t border-rule">
+            {targets.map((t) => (
+              <li key={t.id} className="px-4 py-3">
+                <div className="flex flex-wrap items-center gap-2">
+                  {t.allow ? <Badge tone="pass">allow</Badge> : <Badge tone="fail">deny</Badge>}
+                  <span className="font-mono text-[12px] text-ink">
+                    {t.kind}: {t.value}
+                  </span>
+                </div>
+                {t.reason ? (
+                  <p className="mt-1 break-words text-[12.5px] leading-5 text-muted">{t.reason}</p>
+                ) : null}
+                <p className="mt-1 text-[12px] text-dim">
+                  {t.created_by_label ?? "unknown"}, <When value={t.created_at} />
+                </p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Drawer>
+
+      {editing ? (
+        <FlagForm
+          title={`Change ${flag.key}`}
+          flag={flag}
+          onClose={() => setEditing(false)}
+          onSaved={() => {
+            setEditing(false);
+            onChanged();
+          }}
+        />
+      ) : null}
+
+      {targeting ? (
+        <TargetForm
+          flagKey={flag.key}
+          onClose={() => setTargeting(false)}
+          onSaved={() => {
+            setTargeting(false);
+            onChanged();
+          }}
+        />
+      ) : null}
+
+      <KillConfirm
+        flag={flag}
+        open={killing}
+        onCancel={() => setKilling(false)}
+        onKilled={() => {
+          setKilling(false);
+          onChanged();
+        }}
+      />
+    </>
+  );
+}
+
+/* -------------------------------------------------------------------------
+ * Writing a flag
+ * ---------------------------------------------------------------------- */
+
+const KEY_SHAPE = /^[a-z][a-z0-9]*([._-][a-z0-9]+)*$/;
+
+/**
+ * Create or change a flag.
+ *
+ * ONE FORM FOR BOTH, because the route is one upsert and a second form would be
+ * a second place for the field rules to drift. The key is the only field that
+ * differs: it is editable when creating and fixed afterwards, since changing it
+ * would silently create a second flag and leave the first one live.
+ *
+ * TURNING A FLAG OFF HERE IS NOT A KILL and the copy says so. `set` records a
+ * configuration change at notice severity; `kill` records an incident action at
+ * high severity with a reason attached. Somebody reconstructing an incident six
+ * months later is looking for the second, and a form that collapsed them would
+ * make that line impossible to find.
+ */
+function FlagForm({
+  title,
+  flag,
+  onClose,
+  onSaved,
+}: {
+  title: string;
+  flag?: FeatureFlag;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const [key, setKey] = useState(flag?.key ?? "");
+  const [description, setDescription] = useState(flag?.description ?? "");
+  const [flagState, setFlagState] = useState<"off" | "on" | "targeted">(flag?.state ?? "off");
+  const [rollout, setRollout] = useState(String(flag?.rollout_percent ?? 0));
+  const [internalOnly, setInternalOnly] = useState(flag?.internal_only ?? false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const keyError =
+    flag || key === ""
+      ? null
+      : KEY_SHAPE.test(key)
+        ? null
+        : "Lower case letters and digits, separated by a dot, a dash or an underscore.";
+  const descriptionError =
+    description === "" || description.trim().length >= 8
+      ? null
+      : "At least eight characters. This is what somebody reads at three in the morning.";
+  const rolloutNumber = Number(rollout);
+  const rolloutError =
+    Number.isInteger(rolloutNumber) && rolloutNumber >= 0 && rolloutNumber <= 100
+      ? null
+      : "A whole number between 0 and 100.";
+
+  const ready =
+    key !== "" &&
+    keyError === null &&
+    description.trim().length >= 8 &&
+    rolloutError === null &&
+    !busy;
+
+  async function save() {
+    setBusy(true);
+    setError(null);
+    try {
+      await setFlag({
+        key,
+        description: description.trim(),
+        state: flagState,
+        rolloutPercent: rolloutNumber,
+        internalOnly,
+      });
+      onSaved();
+    } catch (err) {
+      setError((err as ApiError).message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Drawer
+      open
+      title={title}
+      onClose={onClose}
+      actions={
+        <>
+          <Button onClick={onClose} disabled={busy}>
+            Cancel
+          </Button>
+          <Button variant="primary" onClick={save} disabled={!ready} busy={busy}>
+            {flag ? "Save the change" : "Create the flag"}
+          </Button>
+        </>
+      }
+    >
+      <div className="space-y-4 px-4 py-4">
+        <Field
+          label="Key"
+          hint={
+            flag
+              ? "Fixed. Changing a key would create a second flag and leave this one live."
+              : "How the source asks for it. Lower case, dot separated by convention."
+          }
+          error={keyError}
+        >
+          <input
+            className={inputClass}
+            value={key}
+            onChange={(e) => setKey(e.target.value)}
+            disabled={flag !== undefined}
+            autoComplete="off"
+            spellCheck={false}
+          />
+        </Field>
+
+        <Field
+          label="What it does"
+          hint="One or two sentences, in the words somebody reads during an incident."
+          error={descriptionError}
+        >
+          <textarea
+            className={`${inputClass} h-auto min-h-24 py-2`}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={3}
+          />
+        </Field>
+
+        <Field
+          label="State"
+          hint="Off for everybody, on for everybody, or on for the targets and the rollout below."
+        >
+          <select
+            className={`${selectClass} mt-1.5 w-full`}
+            value={flagState}
+            onChange={(e) => setFlagState(e.target.value as "off" | "on" | "targeted")}
+          >
+            <option value="off">Off for everybody</option>
+            <option value="on">On for everybody</option>
+            <option value="targeted">Targeted, plus the rollout</option>
+          </select>
+        </Field>
+
+        <Field
+          label="Rollout percent"
+          hint="Consulted only when the state is targeted. A stable share, hashed per flag and per subject, so the same subject keeps the same answer."
+          error={rolloutError}
+        >
+          <input
+            className={inputClass}
+            type="number"
+            min={0}
+            max={100}
+            value={rollout}
+            onChange={(e) => setRollout(e.target.value)}
+            inputMode="numeric"
+          />
+        </Field>
+
+        <label className="flex items-start gap-2.5">
+          <input
+            type="checkbox"
+            className="mt-0.5 h-4 w-4 accent-ink"
+            checked={internalOnly}
+            onChange={(e) => setInternalOnly(e.target.checked)}
+          />
+          <span className="text-[13px] leading-5 text-ink">
+            Internal only
+            <span className="mt-0.5 block text-[12px] leading-5 text-dim">
+              Off for anybody outside the operator&apos;s own organizations, whatever the rollout
+              says.
+            </span>
+          </span>
+        </label>
+
+        {flagState === "off" && flag ? (
+          <p className="rounded-md border border-rule bg-[rgba(138,90,0,0.12)] px-3 py-2.5 text-[12.5px] leading-5 text-ink">
+            Turning it off here is recorded as a configuration change, not as a kill. If this is an
+            incident, close this and use Kill it instead: the kill demands a reason and is the line
+            somebody will be looking for when they reconstruct the timeline.
+          </p>
+        ) : null}
+
+        {error ? (
+          <p role="alert" className="text-[12.5px] leading-5 text-fail">
+            {error}
+          </p>
+        ) : null}
+      </div>
+    </Drawer>
+  );
+}
+
+function TargetForm({
+  flagKey,
+  onClose,
+  onSaved,
+}: {
+  flagKey: string;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const [kind, setKind] = useState<FlagTarget["kind"]>("organization");
+  const [value, setValue] = useState("");
+  const [allow, setAllow] = useState(true);
+  const [orgId, setOrgId] = useState("");
+  const [reason, setReason] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const reasonError =
+    reason === "" || reason.trim().length >= 8
+      ? null
+      : "At least eight characters. A target with no reason is one nobody can undo confidently.";
+  const ready = value.trim() !== "" && reason.trim().length >= 8 && !busy;
+
+  async function save() {
+    setBusy(true);
+    setError(null);
+    try {
+      await targetFlag({
+        flagKey,
+        kind,
+        value: value.trim(),
+        allow,
+        orgId: orgId.trim() === "" ? null : orgId.trim(),
+        reason: reason.trim(),
+      });
+      onSaved();
+    } catch (err) {
+      setError((err as ApiError).message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Drawer
+      open
+      title={`Target ${flagKey}`}
+      onClose={onClose}
+      actions={
+        <>
+          <Button onClick={onClose} disabled={busy}>
+            Cancel
+          </Button>
+          <Button variant="primary" onClick={save} disabled={!ready} busy={busy}>
+            {allow ? "Turn it on for them" : "Turn it off for them"}
+          </Button>
+        </>
+      }
+    >
+      <div className="space-y-4 px-4 py-4">
+        <p className="text-[12.5px] leading-5 text-muted">
+          A deny is consulted before the state and before the rollout, so it takes one subject out
+          of a rollout that is fine for everybody else. That is the usual incident action, and it is
+          recorded at a higher severity than an allow for exactly that reason.
+        </p>
+
+        <Field label="Kind" hint="What the subject is.">
+          <select
+            className={`${selectClass} mt-1.5 w-full`}
+            value={kind}
+            onChange={(e) => setKind(e.target.value as FlagTarget["kind"])}
+          >
+            <option value="organization">Organization</option>
+            <option value="user">User</option>
+            <option value="project">Project</option>
+            <option value="repository">Repository, as owner and name</option>
+            <option value="plan">Plan</option>
+            <option value="environment">Deployment, such as production or staging</option>
+          </select>
+        </Field>
+
+        <Field
+          label="Value"
+          hint={
+            kind === "repository"
+              ? "owner/name, and owner/* matches a whole owner."
+              : "The identifier this kind is matched on."
+          }
+        >
+          <input
+            className={inputClass}
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            autoComplete="off"
+            spellCheck={false}
+          />
+        </Field>
+
+        <Field
+          label="Organization this concerns"
+          hint="Optional. Its own field because it decides whose audit trail this lands in, which is not always the subject: a repository target concerns the organization that owns it."
+        >
+          <input
+            className={inputClass}
+            value={orgId}
+            onChange={(e) => setOrgId(e.target.value)}
+            placeholder="Organization id, or leave empty"
+            autoComplete="off"
+            spellCheck={false}
+          />
+        </Field>
+
+        <Field label="Reason" hint="Written into the audit chain beside your name." error={reasonError}>
+          <textarea
+            className={`${inputClass} h-auto min-h-20 py-2`}
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            rows={2}
+          />
+        </Field>
+
+        <fieldset>
+          <legend className="text-[12px] font-medium text-muted">Direction</legend>
+          <div className="mt-2 space-y-2">
+            <label className="flex items-start gap-2.5">
+              <input
+                type="radio"
+                name="direction"
+                className="mt-0.5 h-4 w-4 accent-ink"
+                checked={allow}
+                onChange={() => setAllow(true)}
+              />
+              <span className="text-[13px] leading-5 text-ink">
+                Allow
+                <span className="mt-0.5 block text-[12px] leading-5 text-dim">
+                  On for this subject even when the flag is targeted and the rollout would not have
+                  reached them.
+                </span>
+              </span>
+            </label>
+            <label className="flex items-start gap-2.5">
+              <input
+                type="radio"
+                name="direction"
+                className="mt-0.5 h-4 w-4 accent-ink"
+                checked={!allow}
+                onChange={() => setAllow(false)}
+              />
+              <span className="text-[13px] leading-5 text-ink">
+                Deny
+                <span className="mt-0.5 block text-[12px] leading-5 text-dim">
+                  Off for this subject even when the flag is on for everybody.
+                </span>
+              </span>
+            </label>
+          </div>
+        </fieldset>
+
+        {error ? (
+          <p role="alert" className="text-[12.5px] leading-5 text-fail">
+            {error}
+          </p>
+        ) : null}
+      </div>
+    </Drawer>
+  );
+}
+
+/**
+ * The kill, behind a confirmation that makes you type the flag's own key.
+ *
+ * `phrase` is the flag rather than the word "kill", for the reason `Confirm`
+ * gives: typing "kill" proves you can read a label, and typing the key proves
+ * you know which switch you are throwing. During an incident, with several
+ * flags open, that is the mistake that actually happens.
+ */
+function KillConfirm({
+  flag,
+  open,
+  onCancel,
+  onKilled,
+}: {
+  flag: FeatureFlag;
+  open: boolean;
+  onCancel: () => void;
+  onKilled: () => void;
+}) {
+  const [reason, setReason] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function confirm() {
+    if (reason.trim().length < 8) {
+      setError("A kill needs a reason of at least eight characters.");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await killFlag(flag.key, reason.trim());
+      setReason("");
+      onKilled();
+    } catch (err) {
+      setError((err as ApiError).message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Confirm
+      open={open}
+      title={`Kill ${flag.key}`}
+      phrase={flag.key}
+      confirmLabel="Kill it now"
+      busy={busy}
+      error={error}
+      onConfirm={confirm}
+      onCancel={onCancel}
+    >
+      <p>
+        This turns the flag off for everybody immediately and stamps who did it, when, and why. The
+        kill is consulted before the state, before every target and before the rollout, so nothing
+        can put it back except turning the flag on again.
+      </p>
+      {!flag.known ? (
+        <p className="text-warn">
+          Nothing in this build reads this flag. Killing it will be recorded and will change no
+          behaviour, so if you are in an incident the lever you want is somewhere else.
+        </p>
+      ) : null}
+      <Field label="Reason" hint="Written into the audit chain at high severity beside your name.">
+        <textarea
+          className={`${inputClass} h-auto min-h-20 py-2`}
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          rows={2}
+        />
+      </Field>
+    </Confirm>
+  );
+}
+
+/* -------------------------------------------------------------------------
+ * Entitlement overrides
+ * ---------------------------------------------------------------------- */
+
+/**
+ * The limits one organization holds, and which of them were granted rather than
+ * set by its plan.
+ *
+ * ORGANIZATION BY ORGANIZATION, because that is the shape of the route and the
+ * shape of the question. There is no route that lists every live override on
+ * the installation, and this page does not fake one by paging every tenant and
+ * asking about each: that would be one query per organization, on the operator
+ * pool, to build a list nobody asked for.
+ */
+function Overrides({ mayWrite }: { mayWrite: boolean }) {
+  const [search, setSearch] = useState("");
+  const [picked, setPicked] = useState<{ id: string; slug: string } | null>(null);
+  const tenants = useTenants(search);
+  const state = useOrgEntitlements(picked?.id ?? null);
+  const [revoking, setRevoking] = useState<OrgEntitlement | null>(null);
+
+  if (!picked) {
+    return (
+      <Card
+        title="Entitlement overrides"
+        note="A limit granted to one organization rather than set by its plan."
+      >
+        <form
+          role="search"
+          className="flex flex-wrap items-end gap-2 border-b border-rule px-4 py-3"
+          onSubmit={(e) => {
+            e.preventDefault();
+          }}
+        >
+          <div className="min-w-0 flex-1 basis-[240px]">
+            <label htmlFor="override-org" className="block text-[12px] font-medium text-muted">
+              Which organization
+            </label>
+            <input
+              id="override-org"
+              type="search"
+              className={inputClass}
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Name or slug"
+              autoComplete="off"
+              spellCheck={false}
+            />
+          </div>
+        </form>
+        <Loaded state={tenants} skeleton={<TableSkeleton rows={3} cols={2} />}>
+          {(rows) =>
+            rows.length === 0 ? (
+              <Empty title={search ? "No tenant matches that" : "No organizations yet"}>
+                {search
+                  ? "Nothing on this installation has that name or slug."
+                  : "Overrides are held per organization, so this needs one to look at."}
+              </Empty>
+            ) : (
+              <ul className="divide-y divide-rule">
+                {rows.slice(0, 12).map((t) => (
+                  <li key={t.id}>
+                    <button
+                      type="button"
+                      onClick={() => setPicked({ id: t.id, slug: t.slug })}
+                      className="flex min-h-11 w-full flex-wrap items-center justify-between gap-2 px-4 py-3 text-left hover:bg-[rgba(16,16,16,0.035)]"
+                    >
+                      <span className="min-w-0">
+                        <span className="block truncate text-[13px] font-medium text-ink">
+                          {t.name}
+                        </span>
+                        <span className="block truncate font-mono text-[12px] text-muted">
+                          {t.slug}
+                        </span>
+                      </span>
+                      <span className="text-[12.5px] text-muted">{t.plan}</span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )
+          }
+        </Loaded>
+      </Card>
+    );
+  }
+
+  return (
+    <>
+      <Card
+        title={`Entitlements for ${picked.slug}`}
+        note="The plan's own value beside the grant that moved it."
+        actions={<Button onClick={() => setPicked(null)}>Choose another organization</Button>}
+      >
+        <Loaded state={state} skeleton={<TableSkeleton rows={5} cols={5} />}>
+          {(answer) =>
+            answer === null ? (
+              <Empty title="Nothing to show">Pick an organization to see what it is entitled to.</Empty>
+            ) : (
+              <DataTable
+                columns={entitlementColumns(mayWrite, setRevoking)}
+                rows={answer.entitlements}
+                keyOf={(e) => e.key}
+                empty={
+                  <EmptyList title="This build defines no entitlement">
+                    Nothing is limited per organization, so there is nothing to override.
+                  </EmptyList>
+                }
+              />
+            )
+          }
+        </Loaded>
+      </Card>
+
+      {revoking && revoking.override ? (
+        <RevokeConfirm
+          entitlement={revoking}
+          onCancel={() => setRevoking(null)}
+          onRevoked={() => {
+            setRevoking(null);
+            state.reload();
+          }}
+        />
+      ) : null}
+    </>
+  );
+}
+
+function entitlementColumns(
+  mayWrite: boolean,
+  onRevoke: (e: OrgEntitlement) => void,
+): Column<OrgEntitlement>[] {
+  return [
+    {
+      key: "key",
+      header: "Entitlement",
+      cell: (e) => (
+        <span className="block min-w-0">
+          <span className="block truncate font-mono text-[12px] font-medium text-ink">{e.key}</span>
+          <span className="block max-w-[52ch] break-words text-[12px] text-muted">
+            {e.description}
+          </span>
+        </span>
+      ),
+    },
+    {
+      key: "value",
+      header: "In force",
+      numeric: true,
+      cell: (e) => (
+        <span className="flex flex-col items-end">
+          <span>{formatEntitlement(e.value, e.unit)}</span>
+          {e.override ? (
+            // Both numbers, always. A grant that reads like the plan's normal
+            // behaviour is a grant nobody remembers to take back.
+            <span className="text-[12px] text-muted">
+              plan says {formatEntitlement(e.planValue, e.unit)}
+            </span>
+          ) : null}
+        </span>
+      ),
+    },
+    {
+      key: "source",
+      header: "Decided by",
+      cell: (e) =>
+        e.override === null ? (
+          <span className="text-muted">the plan</span>
+        ) : (
+          <span className="flex flex-wrap items-center gap-1.5">
+            <Badge tone="warn">{e.override.scope} override</Badge>
+            {e.override.ticket ? (
+              <span className="font-mono text-[12px] text-muted">{e.override.ticket}</span>
+            ) : null}
+          </span>
+        ),
+    },
+    {
+      key: "expires",
+      header: "Until",
+      cell: (e) =>
+        e.override === null ? (
+          <span className="text-dim">--</span>
+        ) : e.override.expiresAt === null ? (
+          // Forever is a real answer and the one worth seeing. A grant with no
+          // end is a plan change nobody wrote down.
+          <span className="text-warn">no expiry, it never lapses</span>
+        ) : (
+          <When value={e.override.expiresAt} />
+        ),
+    },
+    {
+      key: "granted",
+      header: "Granted",
+      cell: (e) =>
+        e.override === null ? (
+          <span className="text-dim">--</span>
+        ) : (
+          <span className="block min-w-0">
+            <span className="block truncate text-[12.5px]">{e.override.grantedBy}</span>
+            <span className="block text-[12px] text-muted">
+              <When value={e.override.grantedAt} />
+            </span>
+            <span className="mt-0.5 block max-w-[40ch] break-words text-[12px] text-muted">
+              {e.override.reason}
+            </span>
+          </span>
+        ),
+    },
+    {
+      key: "enforced",
+      header: "Enforced",
+      cell: (e) =>
+        e.enforced ? (
+          <Badge tone="pass">yes</Badge>
+        ) : (
+          <span className="flex flex-col gap-1">
+            <Badge tone="warn">not enforced</Badge>
+            {e.notEnforcedBecause ? (
+              <span className="max-w-[36ch] break-words text-[12px] text-muted">
+                {e.notEnforcedBecause}
+              </span>
+            ) : null}
+          </span>
+        ),
+    },
+    {
+      key: "revoke",
+      header: "Revoke",
+      cell: (e) =>
+        e.override && mayWrite ? (
+          <Button variant="danger" onClick={() => onRevoke(e)}>
+            Revoke
+            <span className="sr-only"> the override on {e.key}</span>
+          </Button>
+        ) : (
+          <span className="text-dim">--</span>
+        ),
+    },
+  ];
+}
+
+function formatEntitlement(value: number | boolean, unit: string | null): string {
+  if (typeof value === "boolean") return value ? "yes" : "no";
+  return unit ? `${value.toLocaleString()} ${unit}` : value.toLocaleString();
+}
+
+function RevokeConfirm({
+  entitlement,
+  onCancel,
+  onRevoked,
+}: {
+  entitlement: OrgEntitlement;
+  onCancel: () => void;
+  onRevoked: () => void;
+}) {
+  const [reason, setReason] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function confirm() {
+    if (reason.trim().length < 8) {
+      setError("A revoke needs a reason of at least eight characters.");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await revokeOverride(entitlement.override!.id, reason.trim());
+      onRevoked();
+    } catch (err) {
+      setError((err as ApiError).message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Confirm
+      open
+      title={`Revoke the override on ${entitlement.key}`}
+      phrase={entitlement.key}
+      confirmLabel="Revoke it"
+      busy={busy}
+      error={error}
+      onConfirm={confirm}
+      onCancel={onCancel}
+    >
+      <p>
+        The limit goes back to what the plan says, which is{" "}
+        {formatEntitlement(entitlement.planValue, entitlement.unit)}. Capacity is money by another
+        name, so this is recorded at the same severity as a refund.
+      </p>
+      <Field label="Reason" hint="Written into the audit chain beside your name.">
+        <textarea
+          className={`${inputClass} h-auto min-h-20 py-2`}
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          rows={2}
+        />
+      </Field>
+    </Confirm>
+  );
 }

--- a/console/app/admin/product/runs/detail/page.tsx
+++ b/console/app/admin/product/runs/detail/page.tsx
@@ -370,7 +370,10 @@ const ARTIFACT_COLUMNS = [
  * ---------------------------------------------------------------------- */
 
 function LoadRun({ run }: { run: LoadRunDetail }) {
-  const result = run.result as Record<string, unknown> | null;
+  // The typed field rather than a cast back to Record. The cast was there
+  // because metricsFor takes the loose shape, and casting a typed value to
+  // the type it already has is how a field quietly stops being checked.
+  const result = run.result;
   const errorReasons = Object.entries(
     (result?.error_reasons as Record<string, number> | undefined) ?? {},
   );

--- a/console/app/admin/product/runs/detail/page.tsx
+++ b/console/app/admin/product/runs/detail/page.tsx
@@ -1,0 +1,676 @@
+"use client";
+
+import { Suspense } from "react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { Badge, Card, CardSkeleton, Empty, LinkButton, Loaded, Page, When } from "@/components/ui";
+import {
+  AdminPage,
+  DataTable,
+  EmptyList,
+  Facts,
+  MetricRow,
+  StatusChip,
+  type Fact,
+} from "@/components/admin/primitives";
+import { bytes } from "@/lib/format";
+import { duration } from "@/lib/loadshapes";
+import { metricsFor, toneForStanding } from "@/lib/productshapes";
+import {
+  useRun,
+  type AgentRunDetail,
+  type AgentVerdict,
+  type CheckRunDetail,
+  type LoadRunDetail,
+  type RunArtifact,
+  type RunKind,
+} from "@/lib/admin-product";
+
+/**
+ * One run, and why it ended the way it did.
+ *
+ * THREE SHAPES BEHIND ONE ADDRESS. The family travels in the query string
+ * beside the id, because the three run families share an id space only by
+ * accident and asking the server to guess which table a uuid is in would be a
+ * lookup in three tables to answer a question the link already knew.
+ *
+ * WHAT EACH SHAPE LEADS WITH is the thing somebody came for. An agent run leads
+ * with its verdicts, because "which workflow failed" is the question. A load
+ * run leads with its numbers and its reproduce command. A check leads with the
+ * commit, because a check that passed on the wrong head is the failure that
+ * looks like a pass.
+ */
+export default function ProductRunDetailPage() {
+  return (
+    <Suspense
+      fallback={
+        <Page title="Run">
+          <CardSkeleton count={2} />
+        </Page>
+      }
+    >
+      <RunDetailView />
+    </Suspense>
+  );
+}
+
+function isRunKind(value: string | null): value is RunKind {
+  return value === "agent" || value === "load" || value === "check";
+}
+
+function RunDetailView() {
+  const params = useSearchParams();
+  const id = params.get("id");
+  const kindParam = params.get("kind");
+  const kind: RunKind = isRunKind(kindParam) ? kindParam : "agent";
+  const state = useRun(kind, id ?? "");
+
+  if (!id || !isRunKind(kindParam)) {
+    return (
+      <AdminPage title="Run" lede="One run, and what it touched.">
+        <Card>
+          <Empty
+            title={id ? "That is not a run family" : "No run named"}
+            action={<LinkButton href="/admin/product/runs">Open the run list</LinkButton>}
+          >
+            {id
+              ? "The address names a family this portal does not serve. The three are agent, load and check."
+              : "This page needs a run in its address. Open one from the list rather than typing the address by hand."}
+          </Empty>
+        </Card>
+      </AdminPage>
+    );
+  }
+
+  return (
+    <Loaded
+      state={state}
+      framed
+      skeleton={
+        <Page title="Run">
+          <CardSkeleton count={3} />
+        </Page>
+      }
+    >
+      {(run) =>
+        run.kind === "agent" ? (
+          <AgentRun run={run} />
+        ) : run.kind === "load" ? (
+          <LoadRun run={run} />
+        ) : (
+          <CheckRun run={run} />
+        )
+      }
+    </Loaded>
+  );
+}
+
+/* -------------------------------------------------------------------------
+ * Shared pieces
+ * ---------------------------------------------------------------------- */
+
+function OrgLink({ slug }: { slug: string }) {
+  return (
+    <Link
+      href={`/admin/customers/users/organization?org=${encodeURIComponent(slug)}`}
+      className="inline-flex min-h-11 items-center font-mono text-[12px] underline decoration-transparent underline-offset-4 hover:decoration-[rgba(16,16,16,0.35)] sm:min-h-0"
+    >
+      {slug}
+    </Link>
+  );
+}
+
+/**
+ * The standing, with the family's own state word beside it only when the two
+ * differ.
+ *
+ * The pairing is the point of this component: a load run whose state is
+ * `succeeded` and whose standing is `failed` ran to completion and found a
+ * failure, and seeing both together is what stops somebody reading the green
+ * word and closing the tab. When they agree there is nothing to reconcile, and
+ * "FAILED state failed" said the same thing twice in two type sizes.
+ */
+function Standing({ standing, state }: { standing: string; state: string }) {
+  const word = state.replace(/_/g, " ");
+  return (
+    <span className="flex flex-wrap items-center gap-2">
+      <Badge tone={toneForStanding(standing as never)}>{standing}</Badge>
+      {word === standing ? null : (
+        <span className="text-[12.5px] text-muted">the run&rsquo;s own state is {word}</span>
+      )}
+    </span>
+  );
+}
+
+/** A block of machine text: a command, a digest, a payload. Scrolls inside its
+ *  own box rather than pushing the page sideways on a phone. */
+function Machine({ children }: { children: string }) {
+  return (
+    <pre className="scroll-x max-w-full overflow-x-auto rounded-md border border-rule bg-paper px-3 py-2.5 font-mono text-[12px] leading-5 text-ink">
+      {children}
+    </pre>
+  );
+}
+
+/* -------------------------------------------------------------------------
+ * Agent runs
+ * ---------------------------------------------------------------------- */
+
+function AgentRun({ run }: { run: AgentRunDetail }) {
+  const failing = run.verdicts.filter((v) => v.value === "fail" || v.value === "blocked");
+  const facts: Fact[] = [
+    { label: "Organization", value: <OrgLink slug={run.orgSlug} /> },
+    { label: "Repository", value: run.repository, mono: true },
+    { label: "Branch", value: run.branch, mono: true },
+    {
+      label: "Pull request",
+      value: run.pullRequest === null ? null : `Number ${run.pullRequest}`,
+    },
+    {
+      label: "Twin",
+      value: (
+        <Link
+          href={`/admin/product/twins/detail?id=${encodeURIComponent(run.environmentId)}`}
+          className="inline-flex min-h-11 items-center font-mono text-[12px] underline decoration-transparent underline-offset-4 hover:decoration-[rgba(16,16,16,0.35)] sm:min-h-0"
+        >
+          {run.envId}
+        </Link>
+      ),
+    },
+    { label: "Kind", value: run.runKind },
+    { label: "Outcome", value: <Standing standing={run.standing} state={run.state} /> },
+    { label: "Queued", value: <When value={run.createdAt} /> },
+    { label: "Started", value: run.startedAt ? <When value={run.startedAt} /> : null },
+    { label: "Finished", value: run.finishedAt ? <When value={run.finishedAt} /> : null },
+    { label: "Took", value: duration(run.durationMs) },
+    {
+      label: "Highest event sequence",
+      value: <span className="tnum">{run.lastSequence.toLocaleString()}</span>,
+    },
+  ];
+
+  return (
+    <AdminPage
+      title={`${run.runKind} run on ${run.envId}`}
+      lede={`${run.repository} on ${run.branch}, owned by ${run.orgSlug}.`}
+      actions={
+        <LinkButton
+          variant="secondary"
+          href={`/admin/product/twins/detail?id=${encodeURIComponent(run.environmentId)}`}
+        >
+          Open the twin
+        </LinkButton>
+      }
+    >
+      <div className="space-y-6">
+        {run.standing === "unknown" ? (
+          // The exit-code-zero-over-nothing case, said out loud. A run that
+          // reached a terminal state and reported no verdict at all did nothing
+          // and found nothing, and reading it as a pass is the defect this
+          // repository has already shipped once.
+          <div role="status" className="rounded-lg border border-rule bg-[rgba(138,90,0,0.12)] px-4 py-3">
+            <p className="text-[12.5px] leading-5 text-ink">
+              This run finished and reported no verdict. It is not a pass and it is not a failure:
+              nothing was checked. A run in this state usually means the persona could not be
+              created or the environment was not reachable when the engine got there.
+            </p>
+          </div>
+        ) : null}
+
+        <Card title="This run">
+          <Facts facts={facts} />
+        </Card>
+
+        <Card
+          title="Verdicts"
+          note={
+            failing.length > 0
+              ? `${failing.length} of ${run.verdicts.length} failed or were blocked.`
+              : undefined
+          }
+        >
+          <DataTable
+            columns={VERDICT_COLUMNS}
+            rows={run.verdicts}
+            keyOf={(v) => v.id}
+            empty={
+              <EmptyList title="This run reported no verdict">
+                The run exists and nothing was recorded against it. That is what a run that could
+                not reach the environment looks like, and it is why the outcome above says nothing
+                was checked rather than calling it a pass.
+              </EmptyList>
+            }
+          />
+        </Card>
+
+        <Card
+          title="Artifacts"
+          note="What the run left behind. The bytes are not served from this portal."
+        >
+          <DataTable
+            columns={ARTIFACT_COLUMNS}
+            rows={run.artifacts}
+            keyOf={(a) => a.id}
+            empty={
+              <EmptyList title="No artifact was recorded">
+                Nothing was uploaded for this run. A run that failed before it started leaves
+                nothing, and so does one whose artifacts were never retained.
+              </EmptyList>
+            }
+          />
+        </Card>
+      </div>
+    </AdminPage>
+  );
+}
+
+const VERDICT_COLUMNS = [
+  {
+    key: "workflow",
+    header: "Workflow",
+    cell: (v: AgentVerdict) => (
+      <span className="block min-w-0">
+        <span className="block truncate font-medium text-ink">{v.workflow}</span>
+        {v.persona ? (
+          <span className="block truncate text-[12px] text-muted">as {v.persona}</span>
+        ) : null}
+      </span>
+    ),
+  },
+  {
+    key: "value",
+    header: "Verdict",
+    cell: (v: AgentVerdict) => <StatusChip value={v.value} />,
+  },
+  {
+    key: "summary",
+    header: "Summary",
+    cell: (v: AgentVerdict) =>
+      v.summary ? (
+        <span className="block max-w-[52ch] break-words text-[12.5px] leading-5">{v.summary}</span>
+      ) : (
+        <span className="text-dim">--</span>
+      ),
+  },
+  {
+    key: "steps",
+    header: "Steps",
+    numeric: true,
+    cell: (v: AgentVerdict) => v.steps.toLocaleString(),
+  },
+  {
+    key: "duration",
+    header: "Took",
+    numeric: true,
+    cell: (v: AgentVerdict) => duration(v.durationMs),
+  },
+  {
+    key: "reproduction",
+    header: "Reproduction",
+    cell: (v: AgentVerdict) =>
+      v.reproduction === null || v.reproduction === undefined ? (
+        // Never assembled from the form. A command a console builds drifts from
+        // the one that ran, and being the same one is the only reason to print
+        // it at all.
+        <span className="text-dim">none recorded</span>
+      ) : (
+        <Machine>{JSON.stringify(v.reproduction, null, 2)}</Machine>
+      ),
+  },
+];
+
+const ARTIFACT_COLUMNS = [
+  {
+    key: "kind",
+    header: "Artifact",
+    cell: (a: RunArtifact) => (
+      <span className="block min-w-0">
+        <span className="block truncate font-medium text-ink">{a.kind}</span>
+        {a.contentType ? (
+          <span className="block truncate font-mono text-[12px] text-muted">{a.contentType}</span>
+        ) : null}
+      </span>
+    ),
+  },
+  {
+    key: "step",
+    header: "Step",
+    numeric: true,
+    cell: (a: RunArtifact) => (a.step === null ? <span className="text-dim">--</span> : a.step),
+  },
+  {
+    key: "size",
+    header: "Size",
+    numeric: true,
+    cell: (a: RunArtifact) => bytes(a.sizeBytes),
+  },
+  {
+    key: "retained",
+    header: "Retained",
+    cell: (a: RunArtifact) =>
+      a.retained ? (
+        <Badge tone="pass">kept</Badge>
+      ) : (
+        // The row survives retention on purpose, so a timeline can say the
+        // bytes went rather than showing a gap that reads as a bug.
+        <Badge tone="neutral">bytes removed</Badge>
+      ),
+  },
+  {
+    key: "sha",
+    header: "Digest",
+    mono: true,
+    cell: (a: RunArtifact) =>
+      a.sha256 ? a.sha256.slice(0, 12) : <span className="text-dim">--</span>,
+  },
+];
+
+/* -------------------------------------------------------------------------
+ * Load runs
+ * ---------------------------------------------------------------------- */
+
+function LoadRun({ run }: { run: LoadRunDetail }) {
+  const result = run.result as Record<string, unknown> | null;
+  const errorReasons = Object.entries(
+    (result?.error_reasons as Record<string, number> | undefined) ?? {},
+  );
+  const refused = (result?.refused_routes as string[] | undefined) ?? [];
+
+  const facts: Fact[] = [
+    { label: "Organization", value: <OrgLink slug={run.orgSlug} /> },
+    { label: "Workload", value: `${run.workload} (${run.workloadKind.replace(/_/g, " ")})` },
+    { label: "Version", value: run.workloadVersion },
+    { label: "Repository", value: run.repository, mono: true },
+    { label: "Git ref", value: run.gitRef, mono: true },
+    {
+      label: "Twin",
+      value: run.environmentId ? (
+        <Link
+          href={`/admin/product/twins/detail?id=${encodeURIComponent(run.environmentId)}`}
+          className="inline-flex min-h-11 items-center font-mono text-[12px] underline decoration-transparent underline-offset-4 hover:decoration-[rgba(16,16,16,0.35)] sm:min-h-0"
+        >
+          {run.envId ?? run.environmentId.slice(0, 8)}
+        </Link>
+      ) : null,
+    },
+    { label: "Outcome", value: <Standing standing={run.standing} state={run.state} /> },
+    { label: "Verdict", value: run.verdict ? <StatusChip value={run.verdict} /> : null },
+    {
+      label: "Failure code",
+      value: run.failureCode ? (
+        <span className="font-mono text-[12px] text-fail">{run.failureCode}</span>
+      ) : null,
+    },
+    { label: "Detail", value: run.detail },
+    { label: "Attempt", value: run.attempt },
+    { label: "Requested", value: <When value={run.requestedAt} /> },
+    { label: "Dispatched", value: run.dispatchedAt ? <When value={run.dispatchedAt} /> : null },
+    { label: "Started", value: run.startedAt ? <When value={run.startedAt} /> : null },
+    { label: "Finished", value: run.finishedAt ? <When value={run.finishedAt} /> : null },
+    { label: "Took", value: duration(run.durationMs) },
+    { label: "Believed until", value: <When value={run.deadlineAt} /> },
+  ];
+
+  const lease: Fact[] = [
+    { label: "Held by", value: run.leaseHolder, mono: true },
+    { label: "Lease expires", value: run.leaseExpiresAt ? <When value={run.leaseExpiresAt} /> : null },
+    { label: "Lease last lost", value: run.leaseLostAt ? <When value={run.leaseLostAt} /> : null },
+    {
+      label: "Times taken over",
+      value: (
+        <span className="tnum">
+          {run.leaseTakeovers.toLocaleString()}
+          {run.leaseTakeovers > 0 && run.result === null ? (
+            <span className="ml-2 font-sans text-[12px] text-warn">
+              Taken over with no result recorded. That is the shape of an engine that keeps dying,
+              not of a slow test.
+            </span>
+          ) : null}
+        </span>
+      ),
+    },
+    {
+      label: "Cancel asked",
+      value: run.cancelRequestedAt ? <When value={run.cancelRequestedAt} /> : null,
+    },
+    { label: "Cancel reason", value: run.cancelReason },
+    {
+      label: "Cancel confirmed",
+      value: run.cancelledAt ? (
+        <When value={run.cancelledAt} />
+      ) : run.cancelRequestedAt ? (
+        // Asked for is not done. A cancel recorded and never confirmed is the
+        // state a run sits in while nothing is draining the queue.
+        <span className="text-warn">asked for, not confirmed</span>
+      ) : null,
+    },
+  ];
+
+  return (
+    <AdminPage
+      title={`${run.workload} on ${run.repository}`}
+      lede={`Load run for ${run.orgSlug}, against ${run.gitRef}.`}
+      actions={
+        run.environmentId ? (
+          <LinkButton
+            variant="secondary"
+            href={`/admin/product/twins/detail?id=${encodeURIComponent(run.environmentId)}`}
+          >
+            Open the twin
+          </LinkButton>
+        ) : undefined
+      }
+    >
+      <div className="space-y-6">
+        <Card title="This run">
+          <Facts facts={facts} />
+        </Card>
+
+        <Card
+          title="Reproducing it"
+          note="The command the engine reported, not one this console assembled."
+        >
+          <div className="px-4 py-4">
+            {run.reproduceCommand ? (
+              <Machine>{run.reproduceCommand}</Machine>
+            ) : (
+              <p className="text-[13px] leading-6 text-muted">
+                No command was recorded. The engine reports one when it starts, so a run with none
+                either never started or was reported by a build too old to send it. This page will
+                not assemble one, because a command built from the form drifts from the one that
+                ran and being the same one is the whole point.
+              </p>
+            )}
+            {run.manifestDigest ? (
+              <p className="mt-3 text-[12px] text-dim">
+                Manifest digest{" "}
+                <span className="font-mono text-[12px] text-muted">{run.manifestDigest}</span>. Two
+                runs of the same command against different manifests are different runs.
+              </p>
+            ) : null}
+          </div>
+        </Card>
+
+        <Card title="What it measured">
+          {result === null ? (
+            <Empty title="No result was recorded">
+              The run exists and no engine reported a result for it. That is what an abandoned run
+              looks like, and it is different from a run that measured zero.
+            </Empty>
+          ) : (
+            <div className="space-y-4 px-4 py-4">
+              <MetricRow metrics={metricsFor(result)} />
+              <p className="text-[12px] text-dim">
+                Recorded <When value={String(result.recorded_at ?? run.finishedAt ?? "")} />
+                {result.source ? ` from ${String(result.source)}` : null}.
+              </p>
+            </div>
+          )}
+        </Card>
+
+        {errorReasons.length > 0 || refused.length > 0 ? (
+          <Card
+            title="Why the failures failed"
+            note="A total alone loses the only part that says what to fix."
+          >
+            <div className="space-y-4 px-4 py-4">
+              {errorReasons.length > 0 ? (
+                <ul className="space-y-1.5">
+                  {errorReasons.map(([reason, count]) => (
+                    <li key={reason} className="flex flex-wrap items-baseline justify-between gap-3">
+                      <span className="font-mono text-[12px] text-ink">{reason}</span>
+                      <span className="tnum text-[13px] text-muted">
+                        {Number(count).toLocaleString()}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              ) : null}
+              {refused.length > 0 ? (
+                <div>
+                  <p className="text-[12px] font-medium uppercase tracking-[0.08em] text-dim">
+                    Routes the safe list refused
+                  </p>
+                  <ul className="mt-1.5 space-y-1">
+                    {refused.map((route) => (
+                      <li key={route} className="break-words font-mono text-[12px] text-ink">
+                        {route}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+            </div>
+          </Card>
+        ) : null}
+
+        <Card title="Who was holding it" note="A lost lease is not a dead engine.">
+          <Facts facts={lease} />
+        </Card>
+      </div>
+    </AdminPage>
+  );
+}
+
+/* -------------------------------------------------------------------------
+ * Pull request checks
+ * ---------------------------------------------------------------------- */
+
+function CheckRun({ run }: { run: CheckRunDetail }) {
+  const approvalStale =
+    run.fromFork && run.approvedSha !== null && run.approvedSha !== run.headSha;
+
+  const facts: Fact[] = [
+    { label: "Organization", value: <OrgLink slug={run.orgSlug} /> },
+    { label: "Repository", value: run.repository, mono: true },
+    { label: "Pull request", value: `Number ${run.pullRequest}` },
+    { label: "Title", value: run.title },
+    {
+      label: "Pull request state",
+      value: (
+        <span className="flex flex-wrap items-center gap-1.5">
+          <StatusChip value={run.pullRequestState} />
+          {run.draft ? <Badge tone="neutral">draft</Badge> : null}
+          {run.fromFork ? <Badge tone="warn">from a fork</Badge> : null}
+        </span>
+      ),
+    },
+    { label: "Head branch", value: run.headRef, mono: true },
+    { label: "Base branch", value: run.baseRef, mono: true },
+    { label: "Head repository", value: run.headRepository, mono: true },
+    { label: "Head commit", value: run.headSha, mono: true },
+    { label: "Attempt", value: run.attempt },
+    { label: "Outcome", value: <Standing standing={run.standing} state={run.state} /> },
+    { label: "Detail", value: run.detail },
+    {
+      label: "Twin",
+      value: run.envId ? <span className="font-mono text-[12px]">{run.envId}</span> : null,
+    },
+    { label: "Reported by", value: run.reportedBy },
+    {
+      label: "GitHub check run",
+      value: run.checkRunId ? (
+        <span className="font-mono text-[12px]">{run.checkRunId}</span>
+      ) : (
+        // Null is a state to serve, not a crash: the app is installed without
+        // `checks: write`, so the comment lands and the check does not.
+        <span className="text-muted">
+          none, which means this installation does not hold the checks permission
+        </span>
+      ),
+    },
+    {
+      label: "Workflow run",
+      value: run.workflowRunId ? (
+        <span className="font-mono text-[12px]">{run.workflowRunId}</span>
+      ) : null,
+    },
+    { label: "Queued", value: <When value={run.queuedAt} /> },
+    { label: "Started", value: run.startedAt ? <When value={run.startedAt} /> : null },
+    { label: "Finished", value: run.finishedAt ? <When value={run.finishedAt} /> : null },
+    { label: "Took", value: duration(run.durationMs) },
+    { label: "Gives up at", value: <When value={run.deadlineAt} /> },
+  ];
+
+  return (
+    <AdminPage
+      title={`${run.repository} pull request ${run.pullRequest}`}
+      lede={`Check on ${run.headSha.slice(0, 12)}, owned by ${run.orgSlug}.`}
+    >
+      <div className="space-y-6">
+        {run.fromFork ? (
+          <Card title="This head branch lives in another repository">
+            <Facts
+              facts={[
+                { label: "Head repository", value: run.headRepository, mono: true },
+                {
+                  label: "Approved commit",
+                  value: run.approvedSha ? (
+                    <span className="flex flex-wrap items-center gap-2">
+                      <span className="font-mono text-[12px]">{run.approvedSha}</span>
+                      {approvalStale ? (
+                        // The approval is of a COMMIT and not of the pull
+                        // request, so a push after it leaves an approval of
+                        // code nobody looked at. This is the whole reason the
+                        // column stores a sha.
+                        <Badge tone="warn">not the head that ran</Badge>
+                      ) : (
+                        <Badge tone="pass">matches the head</Badge>
+                      )}
+                    </span>
+                  ) : null,
+                },
+                { label: "Approved by", value: run.approvedBy },
+                {
+                  label: "Approved",
+                  value: run.approvedAt ? <When value={run.approvedAt} /> : null,
+                },
+              ]}
+            />
+          </Card>
+        ) : null}
+
+        <Card title="This check">
+          <Facts facts={facts} />
+        </Card>
+
+        <Card
+          title="The report as it arrived"
+          note="Already reduced to counts and verdicts by the engine. Never a body, a log or a screenshot."
+        >
+          <div className="px-4 py-4">
+            {run.verdict === null || run.verdict === undefined ? (
+              <p className="text-[13px] leading-6 text-muted">
+                Nothing was reported for this generation. A check that says nothing before its
+                deadline becomes unverified rather than staying queued forever, which is why the
+                outcome above may read unverified with nothing here.
+              </p>
+            ) : (
+              <Machine>{JSON.stringify(run.verdict, null, 2)}</Machine>
+            )}
+          </div>
+        </Card>
+      </div>
+    </AdminPage>
+  );
+}

--- a/console/app/admin/product/runs/page.tsx
+++ b/console/app/admin/product/runs/page.tsx
@@ -60,19 +60,30 @@ function RunsView() {
   // not choose on this screen, so the page says so out loud rather than showing
   // a short list that looks like the whole installation.
   const environmentId = params.get("environmentId");
+  const orgId = params.get("org");
+  const orgSlug = params.get("slug");
 
   const [kind, setKind] = useState<RunKind>("agent");
   const [search, setSearch] = useState("");
   const [failedOnly, setFailedOnly] = useState(false);
-  const state = useRuns({ kind, search, failedOnly, environmentId });
+  const state = useRuns({ kind, search, failedOnly, environmentId, orgId });
 
   return (
     <AdminPage href="/admin/product/runs">
-      {environmentId ? (
+      {environmentId || orgId ? (
         <div className="mb-4 flex flex-wrap items-center gap-x-3 gap-y-2 rounded-lg border border-rule bg-card px-4 py-3">
           <p className="text-[12.5px] leading-5 text-ink">
-            Showing runs on one twin only. Everything below is scoped to environment{" "}
-            <span className="font-mono text-[12px]">{environmentId.slice(0, 8)}</span>.
+            {environmentId ? (
+              <>
+                Showing runs on one twin only. Everything below is scoped to environment{" "}
+                <span className="font-mono text-[12px]">{environmentId.slice(0, 8)}</span>.
+              </>
+            ) : (
+              <>
+                Showing one organization only. Everything below belongs to{" "}
+                <span className="font-mono text-[12px]">{orgSlug ?? orgId!.slice(0, 8)}</span>.
+              </>
+            )}
           </p>
           <LinkButton href="/admin/product/runs" variant="secondary">
             Show every run

--- a/console/app/admin/product/runs/page.tsx
+++ b/console/app/admin/product/runs/page.tsx
@@ -1,18 +1,403 @@
 "use client";
 
-import { PlannedSection } from "@/components/admin/primitives";
+import { Suspense, useState } from "react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { Badge, Button, Card, LinkButton, Loaded, Page, TableSkeleton, When } from "@/components/ui";
+import {
+  AdminPage,
+  DataTable,
+  EmptyList,
+  FilterBar,
+  StatusChip,
+  type Column,
+} from "@/components/admin/primitives";
+import { More } from "@/components/pagination";
+import { duration } from "@/lib/loadshapes";
+import { toneForStanding } from "@/lib/productshapes";
+import { useRuns, type RunKind, type RunRow } from "@/lib/admin-product";
 
 /**
- * Runs & Jobs
+ * The page an operator opens during an incident.
  *
- * Not written yet. The route exists from the first commit because a navigation
- * entry that 404s teaches the reader to distrust the rail, and they cannot tell
- * a section that is coming from one that is broken.
+ * IT IS BUILT FOR ONE SEQUENCE: find the run, see why it failed, see what it
+ * touched. So the search is first, the failures filter is beside it, and every
+ * row leads to the detail rather than to a count. There is no grid of totals at
+ * the top, and that is deliberate: a number nobody can act on costs a cross
+ * tenant aggregate to compute and answers a question nobody asked at three in
+ * the morning.
  *
- * TO BUILD THIS SECTION: replace the body below with the real page, and add its
- * routes to web/apps/api/src/admin/product.ts. Nothing else in the portal
- * has to change. See console/app/admin/README.md.
+ * ONE FAMILY AT A TIME. An agent run has verdicts and artifacts, a load run has
+ * percentiles and a lease, a pull request check has a head commit and a GitHub
+ * check run. They are three objects, not three rows of one. A merged table
+ * would need a column set that is true of none of them, and the columns it
+ * would have to drop are exactly the ones somebody is here for. So the family
+ * is a filter, the table says which one it is showing, and every column in it
+ * means something.
+ *
+ * THE FAILURES FILTER IS COMPUTED BY THE SERVER. Filtering the fifty rows after
+ * a page is cut returns an arbitrary number per page and eventually an empty
+ * page with a cursor behind it, which reads as the end of a list that has more
+ * in it.
  */
 export default function ProductRunsPage() {
-  return <PlannedSection href="/admin/product/runs" />;
+  return (
+    <Suspense
+      fallback={
+        <Page title="Runs & Jobs">
+          <TableSkeleton rows={8} cols={6} />
+        </Page>
+      }
+    >
+      <RunsView />
+    </Suspense>
+  );
 }
+
+function RunsView() {
+  const params = useSearchParams();
+  // Set when this page was opened from one twin. It is a filter the reader did
+  // not choose on this screen, so the page says so out loud rather than showing
+  // a short list that looks like the whole installation.
+  const environmentId = params.get("environmentId");
+
+  const [kind, setKind] = useState<RunKind>("agent");
+  const [search, setSearch] = useState("");
+  const [failedOnly, setFailedOnly] = useState(false);
+  const state = useRuns({ kind, search, failedOnly, environmentId });
+
+  return (
+    <AdminPage href="/admin/product/runs">
+      {environmentId ? (
+        <div className="mb-4 flex flex-wrap items-center gap-x-3 gap-y-2 rounded-lg border border-rule bg-card px-4 py-3">
+          <p className="text-[12.5px] leading-5 text-ink">
+            Showing runs on one twin only. Everything below is scoped to environment{" "}
+            <span className="font-mono text-[12px]">{environmentId.slice(0, 8)}</span>.
+          </p>
+          <LinkButton href="/admin/product/runs" variant="secondary">
+            Show every run
+          </LinkButton>
+        </div>
+      ) : null}
+
+      <Card>
+        <FilterBar
+          search={{
+            value: search,
+            onChange: setSearch,
+            label: "Search runs by repository, branch or environment",
+            placeholder: "Repository, branch or environment",
+          }}
+          filters={[
+            {
+              label: "Family",
+              value: kind,
+              onChange: (next) => setKind(next as RunKind),
+              options: [
+                { value: "agent", label: "Agent runs" },
+                { value: "load", label: "Load runs" },
+                { value: "check", label: "Pull request checks" },
+              ],
+            },
+            {
+              label: "Show",
+              value: failedOnly ? "failed" : "all",
+              onChange: (next) => setFailedOnly(next === "failed"),
+              options: [
+                { value: "all", label: "Everything, newest first" },
+                { value: "failed", label: "Failures only" },
+              ],
+            },
+          ]}
+        />
+        <Loaded state={state} skeleton={<TableSkeleton rows={8} cols={6} />}>
+          {(rows) => (
+            <DataTable
+              columns={COLUMNS[kind]}
+              rows={rows}
+              keyOf={(r) => r.id}
+              href={(r) =>
+                `/admin/product/runs/detail?kind=${r.kind}&id=${encodeURIComponent(r.id)}`
+              }
+              empty={
+                <RunsEmpty
+                  kind={kind}
+                  search={search}
+                  failedOnly={failedOnly}
+                  scoped={environmentId !== null}
+                  onShowEverything={() => {
+                    setSearch("");
+                    setFailedOnly(false);
+                  }}
+                />
+              }
+              footer={
+                <More
+                  shown={rows.length}
+                  noun={NOUN[kind]}
+                  hasMore={state.hasMore}
+                  busy={state.busy}
+                  error={state.moreError}
+                  onMore={state.more}
+                />
+              }
+            />
+          )}
+        </Loaded>
+      </Card>
+    </AdminPage>
+  );
+}
+
+const NOUN: Record<RunKind, { one: string; many: string }> = {
+  agent: { one: "agent run", many: "agent runs" },
+  load: { one: "load run", many: "load runs" },
+  check: { one: "check", many: "checks" },
+};
+
+const FAMILY: Record<RunKind, string> = {
+  agent: "agent run",
+  load: "load run",
+  check: "pull request check",
+};
+
+/**
+ * Why the list is empty, and it is never the same sentence twice.
+ *
+ * "No failures" is the answer an operator wants and "no runs at all" is the one
+ * that means something is broken upstream, and a single empty state that reads
+ * the same for both is how an outage gets mistaken for a quiet morning.
+ */
+function RunsEmpty({
+  kind,
+  search,
+  failedOnly,
+  scoped,
+  onShowEverything,
+}: {
+  kind: RunKind;
+  search: string;
+  failedOnly: boolean;
+  scoped: boolean;
+  onShowEverything: () => void;
+}) {
+  if (failedOnly && !search) {
+    return (
+      <EmptyList
+        title={`No ${FAMILY[kind]} has failed`}
+        action={<Button onClick={onShowEverything}>Show everything</Button>}
+      >
+        {scoped
+          ? "Nothing has failed on this twin. This counts the failures the control plane was told about, so a run that never reported at all is not here: it is in the full list, still running or abandoned."
+          : "Nothing in this family has failed recently. This counts the failures the control plane was told about, so a run that never reported at all is not here: switch to everything and look for one that is still running past its deadline."}
+      </EmptyList>
+    );
+  }
+  if (search || failedOnly) {
+    return (
+      <EmptyList
+        title="Nothing matches those filters"
+        action={<Button onClick={onShowEverything}>Clear the filters</Button>}
+      >
+        The search runs over the family above it, so a run of a different kind will not appear while
+        this is set to {FAMILY[kind]}s.
+      </EmptyList>
+    );
+  }
+  return (
+    <EmptyList title={`No ${FAMILY[kind]} on this installation`}>
+      {kind === "agent"
+        ? "No agent run has ever been reported. Agent runs arrive from the engine as it works, so an installation with twins and no runs means the engine is reaching the environments and not reporting back."
+        : kind === "load"
+          ? "Nobody has run a workload. Load runs are requested per workload rather than created with a twin, so an installation with none is ordinary rather than broken."
+          : "No pull request has been checked. Checks arrive from the GitHub app, so if there are open pull requests on installed repositories this is worth chasing."}
+    </EmptyList>
+  );
+}
+
+/* -------------------------------------------------------------------------
+ * The columns, per family
+ *
+ * Three sets rather than one, because the point of the family filter is that
+ * these are different objects. A shared set would be the columns all three have
+ * in common, which is the ones nobody comes here for.
+ * ---------------------------------------------------------------------- */
+
+function Org({ slug }: { slug: string }) {
+  return (
+    <Link
+      href={`/admin/customers/users/organization?org=${encodeURIComponent(slug)}`}
+      className="inline-flex min-h-11 items-center truncate font-mono text-[12px] underline decoration-transparent underline-offset-4 hover:decoration-[rgba(16,16,16,0.35)] sm:min-h-0"
+    >
+      {slug}
+    </Link>
+  );
+}
+
+function Outcome({ run }: { run: RunRow }) {
+  // The standing decides the colour, and the family's own state word is shown
+  // BESIDE it only when the two differ. An operator looking for `abandoned`
+  // needs to read `abandoned` rather than a word this console chose for it, and
+  // a run whose state is `failed` under a chip reading FAILED said the same
+  // thing twice in two type sizes.
+  const state = run.state.replace(/_/g, " ");
+  return (
+    <span className="flex flex-wrap items-center gap-1.5">
+      <Badge tone={toneForStanding(run.standing)}>{run.standing}</Badge>
+      {state === run.standing ? null : (
+        <span className="text-[12px] text-muted">{state}</span>
+      )}
+    </span>
+  );
+}
+
+/**
+ * The one line that says why, and the reason it has a minimum width.
+ *
+ * At eight columns this cell was allocated about six characters by the table's
+ * auto layout, so "The basket total stayed at zero after adding an item" came
+ * out one word per line down a column nobody could read. The failure text is
+ * the point of this screen, so it claims a floor and the columns beside it give
+ * way, which is what `TableWrap` scrolling exists for.
+ */
+function Failure({ run }: { run: RunRow }) {
+  if (!run.failure) {
+    return run.standing === "failed" ? (
+      // Failed with nothing said. That is a real and unhelpful state, and the
+      // page says which of the two it is rather than leaving a blank that
+      // reads as "no problem".
+      <span className="block min-w-[18ch] text-[12.5px] leading-5 text-muted">
+        Nothing was reported
+      </span>
+    ) : (
+      <span className="text-dim">--</span>
+    );
+  }
+  return (
+    <span className="block min-w-[24ch] max-w-[46ch] break-words text-[12.5px] leading-5 text-ink">
+      {run.failure}
+    </span>
+  );
+}
+
+/** When it ran and how long it took, in one column.
+ *
+ *  Two columns for these was what pushed the failure text into a sliver. They
+ *  are one fact read together anyway: an operator scanning for the slow one is
+ *  comparing durations against the moment they started. */
+function Timing({ run, label }: { run: RunRow; label: string }) {
+  return (
+    <span className="block min-w-0">
+      <span className="block">
+        <When value={run.startedAt ?? run.at} />
+      </span>
+      <span className="block whitespace-nowrap text-[12px] text-muted">
+        {run.durationMs === null ? `${label}, still going` : `took ${duration(run.durationMs)}`}
+      </span>
+    </span>
+  );
+}
+
+const COLUMNS: Record<RunKind, Column<RunRow>[]> = {
+  agent: [
+    {
+      key: "run",
+      header: "Run",
+      cell: (r) => (
+        <span className="block min-w-0">
+          <span className="block break-words font-mono text-[12px] font-medium text-ink">
+            {r.envId ?? r.id.slice(0, 8)}
+          </span>
+          <span className="block truncate text-[12px] text-muted">{r.repository}</span>
+        </span>
+      ),
+    },
+    { key: "org", header: "Organization", cell: (r) => <Org slug={r.orgSlug} /> },
+    {
+      key: "ref",
+      header: "Branch",
+      cell: (r) => (
+        <span className="block min-w-0">
+          <span className="block break-words font-mono text-[12px]">{r.ref}</span>
+          {r.pullRequest === null ? null : (
+            <span className="block text-[12px] text-muted">Pull request {r.pullRequest}</span>
+          )}
+        </span>
+      ),
+    },
+    {
+      key: "outcome",
+      header: "Outcome",
+      cell: (r) => (
+        <span className="block min-w-0">
+          <Outcome run={r} />
+          <span className="mt-0.5 block text-[12px] text-muted">
+            {r.verdict ?? "no verdict reported"}
+          </span>
+        </span>
+      ),
+    },
+    { key: "failure", header: "Why", cell: (r) => <Failure run={r} /> },
+    { key: "at", header: "Started", cell: (r) => <Timing run={r} label="queued" /> },
+  ],
+
+  load: [
+    {
+      key: "run",
+      header: "Run",
+      cell: (r) => (
+        <span className="block min-w-0">
+          <span className="block truncate font-medium text-ink">{r.repository}</span>
+          <span className="block break-words font-mono text-[12px] text-muted">{r.ref}</span>
+        </span>
+      ),
+    },
+    { key: "org", header: "Organization", cell: (r) => <Org slug={r.orgSlug} /> },
+    {
+      key: "outcome",
+      header: "Outcome",
+      cell: (r) => (
+        <span className="block min-w-0">
+          <Outcome run={r} />
+          <span className="mt-0.5 block text-[12px] text-muted">
+            {r.verdict ? `verdict ${r.verdict}` : "no verdict reported"}
+          </span>
+        </span>
+      ),
+    },
+    {
+      key: "env",
+      header: "Twin",
+      cell: (r) =>
+        r.envId ? (
+          <span className="block break-words font-mono text-[12px]">{r.envId}</span>
+        ) : (
+          <span className="text-dim">--</span>
+        ),
+    },
+    { key: "failure", header: "Why", cell: (r) => <Failure run={r} /> },
+    { key: "at", header: "Requested", cell: (r) => <Timing run={r} label="requested" /> },
+  ],
+
+  check: [
+    {
+      key: "run",
+      header: "Check",
+      cell: (r) => (
+        <span className="block min-w-0">
+          <span className="block truncate font-medium text-ink">{r.repository}</span>
+          <span className="block text-[12px] text-muted">Pull request {r.pullRequest}</span>
+        </span>
+      ),
+    },
+    { key: "org", header: "Organization", cell: (r) => <Org slug={r.orgSlug} /> },
+    {
+      key: "ref",
+      header: "Head branch",
+      cell: (r) => <span className="block break-words font-mono text-[12px]">{r.ref}</span>,
+    },
+    { key: "outcome", header: "Outcome", cell: (r) => <Outcome run={r} /> },
+    { key: "failure", header: "Why", cell: (r) => <Failure run={r} /> },
+    { key: "at", header: "Queued", cell: (r) => <Timing run={r} label="queued" /> },
+  ],
+};

--- a/console/app/admin/product/safe-state/page.tsx
+++ b/console/app/admin/product/safe-state/page.tsx
@@ -1,18 +1,409 @@
 "use client";
 
-import { PlannedSection } from "@/components/admin/primitives";
+import { useState } from "react";
+import Link from "next/link";
+import { Badge, Button, Card, Loaded, TableSkeleton, When } from "@/components/ui";
+import {
+  AdminPage,
+  DataTable,
+  EmptyList,
+  FilterBar,
+  type Column,
+} from "@/components/admin/primitives";
+import { More } from "@/components/pagination";
+import { bytes } from "@/lib/format";
+import {
+  useGoldenVersions,
+  useMaskingRules,
+  type GoldenVersion,
+  type MaskingRule,
+} from "@/lib/admin-product";
 
 /**
- * Safe State & Databases
+ * What this installation can honestly say about a customer's test data.
  *
- * Not written yet. The route exists from the first commit because a navigation
- * entry that 404s teaches the reader to distrust the rail, and they cannot tell
- * a section that is coming from one that is broken.
+ * TWO TABLES BACK THIS PAGE AND NOTHING ELSE DOES. `golden_versions` records
+ * that a scan produced a copy, whether it was verified and how big it was.
+ * `masking_rules` records which column gets which transform and whether a human
+ * confirmed it. There is no table describing a customer's live database
+ * connection, no snapshot ledger and no restore history anywhere in the schema,
+ * so this page cannot answer "which database was cloned", "when was this
+ * restored" or "how old is the copy". It says so at the bottom, in those words.
  *
- * TO BUILD THIS SECTION: replace the body below with the real page, and add its
- * routes to web/apps/api/src/admin/product.ts. Nothing else in the portal
- * has to change. See console/app/admin/README.md.
+ * WHY THE MASKING RULES COME FIRST. Because an unconfirmed rule is the only
+ * finding on this page. It means a scan believes a column holds personal data,
+ * nobody has agreed, and therefore the column is not being transformed on a
+ * copy somebody is running tests against. A verified golden version needs
+ * nobody's attention; an unconfirmed rule needs somebody's today.
  */
 export default function ProductSafeStatePage() {
-  return <PlannedSection href="/admin/product/safe-state" />;
+  return (
+    // No lede override. The navigation's summary was rewritten when this section
+    // was built, so the rail entry and the page heading say the same true thing
+    // from one line, which is the whole reason AdminPage takes an href.
+    <AdminPage href="/admin/product/safe-state">
+      <div className="space-y-6">
+        <MaskingRules />
+        <GoldenVersions />
+        <NotWired />
+      </div>
+    </AdminPage>
+  );
+}
+
+/* -------------------------------------------------------------------------
+ * Masking rules
+ * ---------------------------------------------------------------------- */
+
+type MaskingScope = "all" | "confirmed" | "unconfirmed";
+
+function MaskingRules() {
+  const [scope, setScope] = useState<MaskingScope>("unconfirmed");
+  const [search, setSearch] = useState("");
+  const state = useMaskingRules({ scope, search });
+
+  return (
+    <Card
+      title="Masking rules"
+      note="A rule nobody confirmed is a column that is not being transformed."
+    >
+      <FilterBar
+        search={{
+          value: search,
+          onChange: setSearch,
+          label: "Search masking rules by repository, table, column or transform",
+          placeholder: "Repository, table, column or transform",
+        }}
+        filters={[
+          {
+            label: "Show",
+            value: scope,
+            onChange: (next) => setScope(next as MaskingScope),
+            options: [
+              { value: "unconfirmed", label: "Suggested, not confirmed" },
+              { value: "confirmed", label: "In effect" },
+              { value: "all", label: "Every rule" },
+            ],
+          },
+        ]}
+      />
+      <Loaded state={state} skeleton={<TableSkeleton rows={6} cols={5} />}>
+        {(rows) => (
+          <DataTable
+            columns={MASKING_COLUMNS}
+            rows={rows}
+            keyOf={(r) => r.id}
+            empty={
+              search ? (
+                <EmptyList
+                  title="No rule matches that"
+                  action={<Button onClick={() => setSearch("")}>Clear the search</Button>}
+                >
+                  Nothing has that repository, table, column or transform under the filter above.
+                </EmptyList>
+              ) : scope === "unconfirmed" ? (
+                <EmptyList title="Every suggested rule has been confirmed">
+                  No column on this installation is waiting for a human to agree with the scanner.
+                  This is the answer you want: nothing a scan flagged is going into a twin
+                  untransformed because nobody looked at it.
+                </EmptyList>
+              ) : scope === "confirmed" ? (
+                <EmptyList title="No rule is in effect">
+                  Nothing on this installation has a confirmed masking rule. If there are golden
+                  versions below, they were produced without one, which means no column is being
+                  transformed on any copy.
+                </EmptyList>
+              ) : (
+                <EmptyList title="No masking rule exists">
+                  Nothing has been scanned yet, or every scan found nothing to mask. A rule appears
+                  here when the classifier proposes one, which happens on the first scan of a
+                  repository.
+                </EmptyList>
+              )
+            }
+            footer={
+              <More
+                shown={rows.length}
+                noun={{ one: "rule", many: "rules" }}
+                hasMore={state.hasMore}
+                busy={state.busy}
+                error={state.moreError}
+                onMore={state.more}
+              />
+            }
+          />
+        )}
+      </Loaded>
+    </Card>
+  );
+}
+
+const MASKING_COLUMNS: Column<MaskingRule>[] = [
+  {
+    key: "column",
+    header: "Column",
+    cell: (r) => (
+      <span className="block min-w-0">
+        <span className="block break-words font-mono text-[12px] font-medium text-ink">
+          {r.table}.{r.column}
+        </span>
+        <span className="block truncate text-[12px] text-muted">{r.repository}</span>
+      </span>
+    ),
+  },
+  {
+    key: "org",
+    header: "Organization",
+    cell: (r) => (
+      <Link
+        href={`/admin/customers/users/organization?org=${encodeURIComponent(r.orgSlug)}`}
+        className="inline-flex min-h-11 items-center truncate font-mono text-[12px] underline decoration-transparent underline-offset-4 hover:decoration-[rgba(16,16,16,0.35)] sm:min-h-0"
+      >
+        {r.orgSlug}
+      </Link>
+    ),
+  },
+  {
+    key: "transform",
+    header: "Transform",
+    cell: (r) => (
+      <span className="block min-w-0">
+        <span className="block break-words font-mono text-[12px]">{r.transform}</span>
+        {r.link ? (
+          // A linked column is kept consistent with another one, so a masked
+          // foreign key still joins. Worth showing: a rule with a link is not
+          // independent of the rest of the schema.
+          <span className="block truncate text-[12px] text-muted">kept in step with {r.link}</span>
+        ) : null}
+      </span>
+    ),
+  },
+  {
+    key: "confirmed",
+    header: "Standing",
+    cell: (r) =>
+      r.confirmed ? (
+        <Badge tone="pass">in effect</Badge>
+      ) : (
+        <span className="flex flex-wrap items-center gap-1.5">
+          <Badge tone="warn">not confirmed</Badge>
+          <span className="text-[12px] text-muted">the column is not transformed</span>
+        </span>
+      ),
+  },
+  {
+    key: "reason",
+    header: "Why",
+    cell: (r) =>
+      r.reason ? (
+        <span className="block max-w-[44ch] break-words text-[12.5px] leading-5">{r.reason}</span>
+      ) : (
+        <span className="text-dim">--</span>
+      ),
+  },
+  {
+    key: "created",
+    header: "Proposed",
+    cell: (r) => <When value={r.createdAt} />,
+  },
+];
+
+/* -------------------------------------------------------------------------
+ * Golden versions
+ * ---------------------------------------------------------------------- */
+
+type GoldenScope = "all" | "verified" | "unverified";
+
+function GoldenVersions() {
+  const [scope, setScope] = useState<GoldenScope>("unverified");
+  const [search, setSearch] = useState("");
+  const state = useGoldenVersions({ scope, search });
+
+  return (
+    <Card
+      title="Golden data versions"
+      note="The scanned copies a twin can be built from, and whether anything attested to them."
+    >
+      <FilterBar
+        search={{
+          value: search,
+          onChange: setSearch,
+          label: "Search golden versions by repository or version",
+          placeholder: "Repository or version",
+        }}
+        filters={[
+          {
+            label: "Show",
+            value: scope,
+            onChange: (next) => setScope(next as GoldenScope),
+            options: [
+              { value: "unverified", label: "Never verified" },
+              { value: "verified", label: "Verified" },
+              { value: "all", label: "Every version" },
+            ],
+          },
+        ]}
+      />
+      <Loaded state={state} skeleton={<TableSkeleton rows={5} cols={6} />}>
+        {(rows) => (
+          <DataTable
+            columns={GOLDEN_COLUMNS}
+            rows={rows}
+            keyOf={(g) => g.id}
+            empty={
+              search ? (
+                <EmptyList
+                  title="No version matches that"
+                  action={<Button onClick={() => setSearch("")}>Clear the search</Button>}
+                >
+                  Nothing has that repository or version under the filter above.
+                </EmptyList>
+              ) : scope === "unverified" ? (
+                <EmptyList title="Every golden version was verified">
+                  Every scanned copy on this installation carries an attestation. Nothing is being
+                  cloned into a twin from data nobody signed off.
+                </EmptyList>
+              ) : scope === "verified" ? (
+                <EmptyList title="No version has been verified">
+                  Nothing on this installation carries an attestation. Every twin built from these
+                  copies was built from data nobody proved the shape of.
+                </EmptyList>
+              ) : (
+                <EmptyList title="Nothing has been scanned">
+                  No repository on this installation has produced a golden version. The first scan
+                  the engine runs will make one, and every twin after it names the version it was
+                  built from.
+                </EmptyList>
+              )
+            }
+            footer={
+              <More
+                shown={rows.length}
+                noun={{ one: "version", many: "versions" }}
+                hasMore={state.hasMore}
+                busy={state.busy}
+                error={state.moreError}
+                onMore={state.more}
+              />
+            }
+          />
+        )}
+      </Loaded>
+    </Card>
+  );
+}
+
+const GOLDEN_COLUMNS: Column<GoldenVersion>[] = [
+  {
+    key: "version",
+    header: "Version",
+    cell: (g) => (
+      <span className="block min-w-0">
+        <span className="block break-words font-mono text-[12px] font-medium text-ink">
+          {g.version}
+        </span>
+        <span className="block truncate text-[12px] text-muted">{g.repository}</span>
+      </span>
+    ),
+  },
+  {
+    key: "org",
+    header: "Organization",
+    cell: (g) => (
+      <Link
+        href={`/admin/customers/users/organization?org=${encodeURIComponent(g.orgSlug)}`}
+        className="inline-flex min-h-11 items-center truncate font-mono text-[12px] underline decoration-transparent underline-offset-4 hover:decoration-[rgba(16,16,16,0.35)] sm:min-h-0"
+      >
+        {g.orgSlug}
+      </Link>
+    ),
+  },
+  {
+    key: "verified",
+    header: "Attestation",
+    cell: (g) => (g.verified ? <Badge tone="pass">verified</Badge> : <Badge tone="warn">none</Badge>),
+  },
+  {
+    key: "twins",
+    header: "Live twins",
+    numeric: true,
+    cell: (g) => (
+      // The number that turns an unverified version from history into a
+      // finding. An unverified copy with no twin on it is a row; one with four
+      // is four environments running on unattested data right now.
+      <span className={g.twins > 0 && !g.verified ? "text-warn" : undefined}>
+        {g.twins.toLocaleString()}
+      </span>
+    ),
+  },
+  {
+    key: "size",
+    header: "Size",
+    numeric: true,
+    cell: (g) => bytes(g.sizeBytes),
+  },
+  {
+    key: "digest",
+    header: "Source digest",
+    mono: true,
+    cell: (g) =>
+      g.sourceDigest ? g.sourceDigest.slice(0, 12) : <span className="text-dim">--</span>,
+  },
+  {
+    key: "created",
+    header: "Scanned",
+    cell: (g) => <When value={g.createdAt} />,
+  },
+];
+
+/* -------------------------------------------------------------------------
+ * What is not wired
+ * ---------------------------------------------------------------------- */
+
+/**
+ * The absences, named.
+ *
+ * NOT an apology and not a roadmap. An operator who opens this page during an
+ * incident needs to know within one screen whether the answer they came for can
+ * exist here at all, because the alternative is twenty minutes of searching for
+ * a panel that was never built. Naming the table each answer would need is what
+ * makes this a statement rather than a shrug.
+ */
+function NotWired() {
+  return (
+    <Card title="What this page cannot tell you">
+      <div className="space-y-3 px-4 py-4 text-[13px] leading-6 text-muted">
+        <p>
+          Everything above is read from two tables: the golden versions a scan produced, and the
+          masking rules it proposed. Nothing else about a customer's data exists in this control
+          plane, so three questions have no answer here and will not get one from a filter.
+        </p>
+        <ul className="space-y-2">
+          <li>
+            <span className="font-medium text-ink">Which database was cloned.</span> There is no
+            record of a customer&apos;s live database connection anywhere in the schema. The engine
+            reads it from the customer&apos;s own manifest and this control plane never sees it,
+            which is deliberate: a credential it does not hold is a credential it cannot leak.
+          </li>
+          <li>
+            <span className="font-medium text-ink">When a twin was restored, and to what.</span>{" "}
+            There is no snapshot ledger and no restore history. A twin names the golden version it
+            was built from and nothing records the act of building it, so the closest answer is the
+            twin&apos;s own creation time.
+          </li>
+          <li>
+            <span className="font-medium text-ink">How old the copy is.</span> A golden version
+            carries the moment the row was written, not the moment the source data was read. On a
+            scan that took an hour those are an hour apart, and this page will not present one as
+            the other.
+          </li>
+        </ul>
+        <p>
+          What would enable all three is one table recording each scan and each restore as an event
+          with its source, its duration and its outcome, written by the engine on the same path that
+          writes the golden version today.
+        </p>
+      </div>
+    </Card>
+  );
 }

--- a/console/app/admin/product/twins/detail/page.tsx
+++ b/console/app/admin/product/twins/detail/page.tsx
@@ -1,0 +1,444 @@
+"use client";
+
+import { Suspense } from "react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import {
+  Badge,
+  Card,
+  CardSkeleton,
+  Empty,
+  LinkButton,
+  Loaded,
+  Page,
+  When,
+} from "@/components/ui";
+import {
+  AdminPage,
+  DataTable,
+  EmptyList,
+  Facts,
+  StatusChip,
+  type Fact,
+} from "@/components/admin/primitives";
+import { bytes } from "@/lib/format";
+import { duration } from "@/lib/loadshapes";
+import { expiryPhrase, toneForStanding, type RunStanding } from "@/lib/productshapes";
+import {
+  useTwin,
+  type TwinDetail,
+  type TwinRunSummary,
+  type TwinTeardown,
+  type TwinWorkloadSummary,
+} from "@/lib/admin-product";
+
+/**
+ * One twin, and everything hanging off it.
+ *
+ * A QUERY STRING rather than /admin/product/twins/[id], because the console is
+ * a static export and a dynamic segment cannot be exported without knowing
+ * every id at build time. next.config.ts says so outright.
+ *
+ * THE ORDER OF THE PANELS IS THE ORDER THE QUESTIONS ARE ASKED. What is it and
+ * whose is it. What data was it built from and was that data ever verified.
+ * What has run on it. Has anybody already asked for it to go away. The last one
+ * is on the page because an operator who cannot see a pending teardown asks for
+ * a second one, and two requests against one environment is how a queue starts
+ * fighting itself.
+ */
+export default function ProductTwinDetailPage() {
+  return (
+    // useSearchParams needs a boundary in an exported app, and the fallback is
+    // the shape of the page rather than a spinner, so the layout does not jump
+    // when the id resolves.
+    <Suspense
+      fallback={
+        <Page title="Twin">
+          <CardSkeleton count={2} />
+        </Page>
+      }
+    >
+      <TwinDetailView />
+    </Suspense>
+  );
+}
+
+function TwinDetailView() {
+  const params = useSearchParams();
+  const id = params.get("id");
+  const state = useTwin(id ?? "");
+
+  if (!id) {
+    return (
+      <AdminPage title="Twin" lede="One environment, and the runs on it.">
+        <Card>
+          <Empty
+            title="No twin named"
+            action={<LinkButton href="/admin/product/twins">Open the twin list</LinkButton>}
+          >
+            This page needs a twin in its address. Open one from the list rather than typing the
+            address by hand.
+          </Empty>
+        </Card>
+      </AdminPage>
+    );
+  }
+
+  return (
+    <Loaded
+      state={state}
+      framed
+      skeleton={
+        <Page title="Twin">
+          <CardSkeleton count={3} />
+        </Page>
+      }
+    >
+      {(twin) => <TwinBody twin={twin} />}
+    </Loaded>
+  );
+}
+
+function TwinBody({ twin }: { twin: TwinDetail }) {
+  const facts: Fact[] = [
+    {
+      label: "Organization",
+      value: (
+        <Link
+          href={`/admin/customers/users/organization?org=${encodeURIComponent(twin.orgSlug)}`}
+          className="inline-flex min-h-11 items-center underline decoration-transparent underline-offset-4 hover:decoration-[rgba(16,16,16,0.35)] sm:min-h-0"
+        >
+          {twin.orgName} <span className="ml-1.5 font-mono text-[12px] text-muted">{twin.orgSlug}</span>
+        </Link>
+      ),
+    },
+    { label: "Repository", value: twin.repository, mono: true },
+    {
+      label: "Branch",
+      value: (
+        <span>
+          <span className="font-mono text-[12px]">{twin.branch}</span>
+          {twin.defaultBranch === twin.branch ? (
+            <span className="ml-2 text-[12px] text-muted">the default branch</span>
+          ) : null}
+        </span>
+      ),
+    },
+    {
+      label: "Pull request",
+      value: twin.pullRequest === null ? null : `Number ${twin.pullRequest}`,
+    },
+    {
+      label: "State",
+      value: (
+        <span className="flex flex-wrap items-center gap-1.5">
+          <StatusChip value={twin.state} />
+          {twin.tornDownAt ? <Badge tone="neutral">torn down</Badge> : null}
+        </span>
+      ),
+    },
+    {
+      label: "Preview address",
+      value: twin.previewUrl ? (
+        // rel on an outbound link to a customer's own environment. It is not
+        // this console's origin and it is not trusted with a window handle.
+        <a
+          href={twin.previewUrl}
+          rel="noreferrer noopener"
+          target="_blank"
+          className="inline-flex min-h-11 items-center break-words underline decoration-[rgba(16,16,16,0.25)] underline-offset-4 hover:decoration-ink sm:min-h-0"
+        >
+          {twin.previewUrl}
+        </a>
+      ) : null,
+    },
+    { label: "Runtime", value: twin.runtime, mono: true },
+    { label: "Engine environment id", value: twin.envId, mono: true },
+    { label: "Created by", value: twin.createdBy, mono: true },
+    { label: "Created", value: <When value={twin.createdAt} /> },
+    { label: "Last event applied", value: <When value={twin.updatedAt} /> },
+    {
+      label: "Expiry",
+      value: (
+        <span className={twin.tornDownAt === null && isOverdue(twin) ? "text-warn" : undefined}>
+          {expiryPhrase(twin.expiresAt)}
+          {twin.expiresAt ? (
+            <span className="ml-2 text-[12px] text-muted">
+              <When value={twin.expiresAt} />
+            </span>
+          ) : null}
+        </span>
+      ),
+    },
+    { label: "Torn down", value: twin.tornDownAt ? <When value={twin.tornDownAt} /> : null },
+    {
+      label: "Highest event sequence",
+      // Tabular, because it is a number somebody compares against the one in a
+      // log line. Events arrive out of order and this is what the row last
+      // believed.
+      value: <span className="tnum">{twin.lastSequence.toLocaleString()}</span>,
+    },
+  ];
+
+  return (
+    <AdminPage
+      title={twin.envId}
+      lede={`${twin.repository} on ${twin.branch}, owned by ${twin.orgSlug}.`}
+      actions={
+        <LinkButton
+          href={`/admin/product/runs?environmentId=${encodeURIComponent(twin.id)}`}
+        >
+          Every run on this twin
+        </LinkButton>
+      }
+    >
+      <div className="space-y-6">
+        <Card title="This twin">
+          <Facts facts={facts} />
+        </Card>
+
+        <Card
+          title="Golden data"
+          note="The scanned copy this environment was built from."
+        >
+          {twin.goldenVersion === null ? (
+            <Empty title="This twin names no golden version">
+              The environment row carries no golden version, so nothing here says which scanned copy
+              it was built from. That is the state a twin is in before its first scan lands.
+            </Empty>
+          ) : twin.golden === null ? (
+            <Empty title="No record of that version">
+              The twin names <span className="font-mono text-[12px]">{twin.goldenVersion}</span> and
+              this control plane holds no golden version row for it. Nothing has failed; a version
+              recorded by an engine that never reported back looks exactly like this. It is not the
+              same as unverified, and this page will not call it that.
+            </Empty>
+          ) : (
+            <Facts
+              facts={[
+                { label: "Version", value: twin.golden.version, mono: true },
+                {
+                  label: "Verified",
+                  value: twin.golden.verified ? (
+                    <Badge tone="pass">verified</Badge>
+                  ) : (
+                    <span className="flex flex-wrap items-center gap-2">
+                      <Badge tone="warn">not verified</Badge>
+                      <span className="text-[12.5px] text-muted">
+                        The scan produced this copy and nothing attested to it.
+                      </span>
+                    </span>
+                  ),
+                },
+                { label: "Source digest", value: twin.golden.sourceDigest, mono: true },
+                { label: "Masking rules digest", value: twin.golden.rulesDigest, mono: true },
+                { label: "Size", value: bytes(twin.golden.sizeBytes) },
+                { label: "Scanned", value: <When value={twin.golden.createdAt} /> },
+              ]}
+            />
+          )}
+        </Card>
+
+        <Card
+          title="Agent runs"
+          note="The twenty most recent. A run that finished is not a run that passed."
+        >
+          <DataTable
+            columns={AGENT_COLUMNS}
+            rows={twin.runs}
+            keyOf={(r) => r.id}
+            href={(r) => `/admin/product/runs/detail?kind=agent&id=${encodeURIComponent(r.id)}`}
+            empty={
+              <EmptyList title="No agent run on this twin">
+                The environment exists and nothing has been run against it. A run appears here when
+                the engine reports one, which for a pull request twin is usually within a minute of
+                it coming up.
+              </EmptyList>
+            }
+          />
+        </Card>
+
+        <Card title="Load runs" note="The twenty most recent.">
+          <DataTable
+            columns={LOAD_COLUMNS}
+            rows={twin.workloadRuns}
+            keyOf={(r) => r.id}
+            href={(r) => `/admin/product/runs/detail?kind=load&id=${encodeURIComponent(r.id)}`}
+            empty={
+              <EmptyList title="No load run on this twin">
+                Nobody has run a workload against this environment. Load runs are requested per
+                workload rather than created with the twin, so an environment with none is ordinary.
+              </EmptyList>
+            }
+          />
+        </Card>
+
+        <Card
+          title="Teardown requests"
+          note="Asked for is not dispatched, and dispatched is not confirmed."
+        >
+          <DataTable
+            columns={TEARDOWN_COLUMNS}
+            rows={twin.teardowns}
+            keyOf={(t) => t.id}
+            empty={
+              <EmptyList title="Nobody has asked for this twin to go away">
+                No teardown has been recorded against this environment. If it is past its expiry,
+                the sweeper has not reached it and nobody has asked by hand.
+              </EmptyList>
+            }
+          />
+        </Card>
+      </div>
+    </AdminPage>
+  );
+}
+
+/**
+ * The standing, with the run's own state word beside it only when they differ.
+ *
+ * The pairing is the point: a load run whose state is `succeeded` and whose
+ * standing is `failed` ran to completion and found a failure, and seeing both
+ * is what stops somebody reading the green word and closing the tab. When they
+ * agree there is nothing to reconcile, and "FAILED failed" said the same thing
+ * twice in two type sizes.
+ */
+function Outcome({ standing, state }: { standing: RunStanding; state: string }) {
+  const word = state.replace(/_/g, " ");
+  return (
+    <span className="flex flex-wrap items-center gap-1.5">
+      <Badge tone={toneForStanding(standing)}>{standing}</Badge>
+      {word === standing ? null : <span className="text-[12px] text-muted">{word}</span>}
+    </span>
+  );
+}
+
+function isOverdue(twin: TwinDetail): boolean {
+  if (twin.expiresAt === null) return false;
+  return new Date(twin.expiresAt).getTime() < Date.now();
+}
+
+const AGENT_COLUMNS = [
+  {
+    key: "kind",
+    header: "Run",
+    cell: (r: TwinRunSummary) => (
+      <span className="block min-w-0">
+        <span className="block truncate font-medium text-ink">{r.kind}</span>
+        <span className="block truncate font-mono text-[12px] text-muted">{r.id.slice(0, 8)}</span>
+      </span>
+    ),
+  },
+  {
+    key: "standing",
+    header: "Outcome",
+    cell: (r: TwinRunSummary) => <Outcome standing={r.standing} state={r.state} />,
+  },
+  {
+    key: "verdicts",
+    header: "Verdicts",
+    numeric: true,
+    cell: (r: TwinRunSummary) =>
+      r.verdicts === 0 ? (
+        // Zero verdicts on a finished run is the answer, not a blank. A run
+        // that reported nothing is exactly the exit-code-zero-over-nothing
+        // case, so it is said in words rather than as a 0 beside a green chip.
+        <span className="text-dim">none reported</span>
+      ) : (
+        `${r.verdicts - r.failing} of ${r.verdicts}`
+      ),
+  },
+  {
+    key: "duration",
+    header: "Took",
+    numeric: true,
+    cell: (r: TwinRunSummary) =>
+      duration(
+        r.startedAt && r.finishedAt
+          ? new Date(r.finishedAt).getTime() - new Date(r.startedAt).getTime()
+          : null,
+      ),
+  },
+  {
+    key: "when",
+    header: "Started",
+    cell: (r: TwinRunSummary) => <When value={r.startedAt ?? r.createdAt} />,
+  },
+];
+
+const LOAD_COLUMNS = [
+  {
+    key: "workload",
+    header: "Workload",
+    cell: (r: TwinWorkloadSummary) => (
+      <span className="block truncate font-medium text-ink">{r.workload}</span>
+    ),
+  },
+  {
+    key: "standing",
+    header: "Outcome",
+    cell: (r: TwinWorkloadSummary) => <Outcome standing={r.standing} state={r.state} />,
+  },
+  {
+    key: "verdict",
+    header: "Verdict",
+    cell: (r: TwinWorkloadSummary) => <StatusChip value={r.verdict} />,
+  },
+  {
+    key: "failure",
+    header: "Failure",
+    cell: (r: TwinWorkloadSummary) =>
+      r.failureCode ? (
+        <span className="font-mono text-[12px] text-fail">{r.failureCode}</span>
+      ) : (
+        <span className="text-dim">--</span>
+      ),
+  },
+  {
+    key: "when",
+    header: "Requested",
+    cell: (r: TwinWorkloadSummary) => <When value={r.requestedAt} />,
+  },
+];
+
+const TEARDOWN_COLUMNS = [
+  {
+    key: "state",
+    header: "Standing",
+    cell: (t: TwinTeardown) => <StatusChip value={t.state} />,
+  },
+  { key: "reason", header: "Reason", cell: (t: TwinTeardown) => t.reason },
+  {
+    key: "attempts",
+    header: "Attempts",
+    numeric: true,
+    cell: (t: TwinTeardown) => t.attempts.toLocaleString(),
+  },
+  {
+    key: "error",
+    header: "Last error",
+    cell: (t: TwinTeardown) =>
+      t.lastError ? (
+        <span className="break-words text-[12.5px] text-fail">{t.lastError}</span>
+      ) : (
+        <span className="text-dim">--</span>
+      ),
+  },
+  {
+    key: "requested",
+    header: "Asked",
+    cell: (t: TwinTeardown) => <When value={t.requestedAt} />,
+  },
+  {
+    key: "acknowledged",
+    header: "Confirmed",
+    cell: (t: TwinTeardown) =>
+      t.acknowledgedAt ? (
+        <When value={t.acknowledgedAt} />
+      ) : (
+        // Not a blank. A teardown that was recorded and never confirmed is a
+        // real and common state, and it is the one worth seeing.
+        <span className="text-muted">not yet</span>
+      ),
+  },
+];

--- a/console/app/admin/product/twins/detail/page.tsx
+++ b/console/app/admin/product/twins/detail/page.tsx
@@ -185,11 +185,23 @@ function TwinBody({ twin }: { twin: TwinDetail }) {
       title={twin.envId}
       lede={`${twin.repository} on ${twin.branch}, owned by ${twin.orgSlug}.`}
       actions={
-        <LinkButton
-          href={`/admin/product/runs?environmentId=${encodeURIComponent(twin.id)}`}
-        >
-          Every run on this twin
-        </LinkButton>
+        // Two links because the question widens. "Why did this one fail" is
+        // answered on the twin; "is the whole tenant failing" is the next
+        // thing somebody asks and is a different query.
+        <span className="flex flex-wrap items-center gap-2">
+          <LinkButton
+            variant="secondary"
+            href={
+              `/admin/product/runs?org=${encodeURIComponent(twin.orgId)}` +
+              `&slug=${encodeURIComponent(twin.orgSlug)}`
+            }
+          >
+            Every run for {twin.orgSlug}
+          </LinkButton>
+          <LinkButton href={`/admin/product/runs?environmentId=${encodeURIComponent(twin.id)}`}>
+            Every run on this twin
+          </LinkButton>
+        </span>
       }
     >
       <div className="space-y-6">

--- a/console/app/admin/product/twins/page.tsx
+++ b/console/app/admin/product/twins/page.tsx
@@ -1,18 +1,251 @@
 "use client";
 
-import { PlannedSection } from "@/components/admin/primitives";
+import { Suspense, useState } from "react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { Badge, Button, Card, Loaded, Page, TableSkeleton, When } from "@/components/ui";
+import { AdminPage, DataTable, EmptyList, FilterBar, StatusChip } from "@/components/admin/primitives";
+import { More } from "@/components/pagination";
+import { useTwins, type Twin, type TwinScope } from "@/lib/admin-product";
+import { expiryPhrase } from "@/lib/productshapes";
 
 /**
- * Production Twins
+ * Every production twin on the installation.
  *
- * Not written yet. The route exists from the first commit because a navigation
- * entry that 404s teaches the reader to distrust the rail, and they cannot tell
- * a section that is coming from one that is broken.
+ * THE QUESTION THIS PAGE ANSWERS is "what is running right now, who owns it,
+ * and which of them should not still be up". So the default is `live` and the
+ * second filter is `overdue`, which is the only one of the three that is a
+ * finding: a twin past the lifetime it was created with, not torn down, and
+ * costing somebody money for a branch nobody is looking at any more.
  *
- * TO BUILD THIS SECTION: replace the body below with the real page, and add its
- * routes to web/apps/api/src/admin/product.ts. Nothing else in the portal
- * has to change. See console/app/admin/README.md.
+ * `all` exists and is not the default, because a fleet view that includes every
+ * environment ever created grows forever and answers nothing.
+ *
+ * THE LIST IS PAGED, and the footer renders in both states. Three screens in
+ * this console read one page of a cursored route and told an operator the list
+ * was complete when it was showing a third of it. "All 24 twins." is the only
+ * sentence that ever claims a list is finished here, and it is only printed
+ * when the server said there was no next cursor.
  */
 export default function ProductTwinsPage() {
-  return <PlannedSection href="/admin/product/twins" />;
+  return (
+    <Suspense
+      fallback={
+        <Page title="Production Twins">
+          <TableSkeleton rows={6} cols={7} />
+        </Page>
+      }
+    >
+      <TwinsView />
+    </Suspense>
+  );
 }
+
+function TwinsView() {
+  // `q` seeds the search, because the branches page links here with a branch
+  // name in it. Seeded rather than controlled by the address: once the reader
+  // types, the box is theirs, and a filter that snaps back to what the last
+  // link said is a filter that fights whoever is using it.
+  const params = useSearchParams();
+  const [search, setSearch] = useState(params.get("q") ?? "");
+  const [scope, setScope] = useState<TwinScope>(params.get("q") ? "all" : "live");
+  const state = useTwins({ scope, search });
+
+  return (
+    <AdminPage href="/admin/product/twins">
+      <Card>
+        <FilterBar
+          search={{
+            value: search,
+            onChange: setSearch,
+            label: "Search twins by environment, repository or branch",
+            placeholder: "Environment, repository or branch",
+          }}
+          filters={[
+            {
+              label: "Show",
+              value: scope,
+              onChange: (next) => setScope(next as TwinScope),
+              options: [
+                { value: "live", label: "Running now" },
+                { value: "overdue", label: "Past their expiry" },
+                { value: "all", label: "Every twin ever" },
+              ],
+            },
+          ]}
+        />
+        <Loaded state={state} skeleton={<TableSkeleton rows={6} cols={7} />}>
+          {(rows) => (
+            <DataTable
+              columns={COLUMNS}
+              rows={rows}
+              keyOf={(t) => t.id}
+              href={(t) => `/admin/product/twins/detail?id=${encodeURIComponent(t.id)}`}
+              empty={<TwinsEmpty scope={scope} search={search} onClear={() => setSearch("")} />}
+              footer={
+                <More
+                  shown={rows.length}
+                  noun={{ one: "twin", many: "twins" }}
+                  hasMore={state.hasMore}
+                  busy={state.busy}
+                  error={state.moreError}
+                  onMore={state.more}
+                />
+              }
+            />
+          )}
+        </Loaded>
+      </Card>
+    </AdminPage>
+  );
+}
+
+/**
+ * Why the list is empty, in the words of the filter that emptied it.
+ *
+ * Three different reasons, and they are not interchangeable: nothing matched
+ * the search, nothing is overdue, or nothing has ever run here. The third is a
+ * fact about the installation and the first two are facts about the filters,
+ * and an operator who cannot tell them apart during an incident assumes the
+ * worst one.
+ */
+function TwinsEmpty({
+  scope,
+  search,
+  onClear,
+}: {
+  scope: TwinScope;
+  search: string;
+  onClear: () => void;
+}) {
+  if (search) {
+    return (
+      <EmptyList
+        title="No twin matches that"
+        action={<Button onClick={onClear}>Clear the search</Button>}
+      >
+        Nothing on this installation has that environment id, repository or branch. The search runs
+        over the filter above it, so a twin that is torn down will not appear while this is set to
+        running.
+      </EmptyList>
+    );
+  }
+  if (scope === "overdue") {
+    return (
+      <EmptyList title="Nothing is past its expiry">
+        Every running twin is still inside the lifetime it was created with. This is the answer you
+        want: nothing is being paid for after the branch it belonged to stopped mattering.
+      </EmptyList>
+    );
+  }
+  if (scope === "live") {
+    return (
+      <EmptyList title="No twin is running">
+        Nothing is up on this installation right now. A twin is created when a pull request opens or
+        when somebody runs the engine against a branch, so this is what a quiet weekend looks like.
+        Switch the filter to every twin to see what has run before.
+      </EmptyList>
+    );
+  }
+  return (
+    <EmptyList title="No twin has ever run here">
+      Nobody has created an environment on this installation. The first pull request the GitHub app
+      sees will make one, and it will appear here.
+    </EmptyList>
+  );
+}
+
+const COLUMNS = [
+  {
+    key: "twin",
+    header: "Twin",
+    cell: (t: Twin) => (
+      <span className="block min-w-0">
+        {/* break-words rather than truncate. An environment id is what an
+            operator pastes into a log search, and half of one is worse than
+            a row that is one line taller. */}
+        <span className="block break-words font-mono text-[12px] font-medium text-ink">{t.envId}</span>
+        <span className="block truncate text-[12px] text-muted">{t.repository}</span>
+      </span>
+    ),
+  },
+  {
+    key: "org",
+    header: "Organization",
+    cell: (t: Twin) => (
+      // A link out of the row rather than plain text: the next question after
+      // "whose twin is this" is always about the account, and copying a slug
+      // into a search box is the step this removes.
+      <Link
+        href={`/admin/customers/users/organization?org=${encodeURIComponent(t.orgSlug)}`}
+        className="inline-flex min-h-11 items-center underline decoration-transparent underline-offset-4 hover:decoration-[rgba(16,16,16,0.35)] sm:min-h-0"
+      >
+        <span className="truncate font-mono text-[12px]">{t.orgSlug}</span>
+      </Link>
+    ),
+  },
+  {
+    key: "branch",
+    header: "Branch",
+    cell: (t: Twin) => (
+      <span className="block min-w-0">
+        <span className="block break-words font-mono text-[12px]">{t.branch}</span>
+        {t.pullRequest === null ? null : (
+          <span className="block text-[12px] text-muted">Pull request {t.pullRequest}</span>
+        )}
+      </span>
+    ),
+  },
+  {
+    key: "state",
+    header: "State",
+    cell: (t: Twin) => (
+      <span className="flex flex-wrap items-center gap-1.5">
+        <StatusChip value={t.state} />
+        {/* Two separate facts, and both matter. Overdue says it should have
+            gone; teardown pending says somebody already asked. An operator who
+            cannot see the second asks for it again. */}
+        {t.overdue ? <Badge tone="warn">overdue</Badge> : null}
+        {t.teardownPending ? <Badge tone="neutral">teardown asked</Badge> : null}
+      </span>
+    ),
+  },
+  {
+    key: "golden",
+    header: "Golden data",
+    cell: (t: Twin) =>
+      t.goldenVersion === null ? (
+        <span className="text-dim">None named</span>
+      ) : (
+        <span className="flex flex-wrap items-center gap-1.5">
+          <span className="break-words font-mono text-[12px]">{t.goldenVersion}</span>
+          {t.goldenVerified === true ? <Badge tone="pass">verified</Badge> : null}
+          {t.goldenVerified === false ? <Badge tone="warn">unverified</Badge> : null}
+          {/* Null is a third answer: the twin names a version this control
+              plane has no row for. Saying "unverified" there would be a
+              guess about somebody's data. */}
+          {t.goldenVerified === null ? <Badge tone="neutral">no record</Badge> : null}
+        </span>
+      ),
+  },
+  {
+    key: "runs",
+    header: "Runs",
+    numeric: true,
+    cell: (t: Twin) => t.runs.toLocaleString(),
+  },
+  {
+    key: "expires",
+    header: "Expiry",
+    cell: (t: Twin) => (
+      <span className="block min-w-0">
+        <span className={`block text-[12.5px] ${t.overdue ? "text-warn" : "text-ink"}`}>
+          {expiryPhrase(t.expiresAt)}
+        </span>
+        <span className="block text-[12px] text-muted">
+          Created <When value={t.createdAt} />
+        </span>
+      </span>
+    ),
+  },
+];

--- a/console/app/admin/product/twins/page.tsx
+++ b/console/app/admin/product/twins/page.tsx
@@ -3,7 +3,7 @@
 import { Suspense, useState } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
-import { Badge, Button, Card, Loaded, Page, TableSkeleton, When } from "@/components/ui";
+import { Badge, Button, Card, LinkButton, Loaded, Page, TableSkeleton, When } from "@/components/ui";
 import { AdminPage, DataTable, EmptyList, FilterBar, StatusChip } from "@/components/admin/primitives";
 import { More } from "@/components/pagination";
 import { useTwins, type Twin, type TwinScope } from "@/lib/admin-product";
@@ -46,13 +46,32 @@ function TwinsView() {
   // name in it. Seeded rather than controlled by the address: once the reader
   // types, the box is theirs, and a filter that snaps back to what the last
   // link said is a filter that fights whoever is using it.
+  //
+  // `org` is NOT seeded, it is applied. Two tenants can both have a branch
+  // called main, so a link that carried only the name showed somebody else's
+  // environments beside the ones that were clicked on. The organization is a
+  // fact about where the reader came from rather than a filter they chose, so
+  // it stays until they leave, and the strip below says it is on.
   const params = useSearchParams();
+  const orgId = params.get("org");
+  const orgSlug = params.get("slug");
   const [search, setSearch] = useState(params.get("q") ?? "");
   const [scope, setScope] = useState<TwinScope>(params.get("q") ? "all" : "live");
-  const state = useTwins({ scope, search });
+  const state = useTwins({ scope, search, orgId });
 
   return (
     <AdminPage href="/admin/product/twins">
+      {orgId ? (
+        <div className="mb-4 flex flex-wrap items-center gap-x-3 gap-y-2 rounded-lg border border-rule bg-card px-4 py-3">
+          <p className="text-[12.5px] leading-5 text-ink">
+            Showing one organization only. Everything below belongs to{" "}
+            <span className="font-mono text-[12px]">{orgSlug ?? orgId.slice(0, 8)}</span>.
+          </p>
+          <LinkButton href="/admin/product/twins" variant="secondary">
+            Show every twin
+          </LinkButton>
+        </div>
+      ) : null}
       <Card>
         <FilterBar
           search={{

--- a/console/lib/admin-nav.ts
+++ b/console/lib/admin-nav.ts
@@ -150,29 +150,36 @@ export const ADMIN_NAV: AdminNavGroup[] = [
         label: "Production Twins",
         href: "/admin/product/twins",
         Icon: IconTwins,
-        permission: "admin.infra.read",
+        permission: "admin.product.read",
         summary: "Every twin running on this installation, who owns it, and what it costs to keep.",
       },
       {
         label: "Runs & Jobs",
         href: "/admin/product/runs",
         Icon: IconRuns,
-        permission: "admin.infra.read",
+        permission: "admin.product.read",
         summary: "Work in flight and work that failed, across every organization at once.",
       },
       {
         label: "Safe State & Databases",
         href: "/admin/product/safe-state",
         Icon: IconDatabase,
-        permission: "admin.infra.read",
+        permission: "admin.product.data.read",
+        // REWRITTEN WHEN THE SECTION WAS BUILT, and the old line is worth
+        // recording because it was the honest mistake this navigation is most
+        // likely to make again. It read "the database snapshots a twin can be
+        // returned to, and whether restoring one has been proven", and there is
+        // no snapshot table, no restore history and no record of a customer's
+        // live database anywhere in the schema. This summary is the page's lede,
+        // so a promise made here is a promise made on the page.
         summary:
-          "The database snapshots a twin can be returned to, and whether restoring one has been proven.",
+          "Golden data versions per repository, the masking rules applied to them, and the columns a scan flagged that nobody confirmed.",
       },
       {
         label: "Branches & Environments",
         href: "/admin/product/branches",
         Icon: IconBranches,
-        permission: "admin.infra.read",
+        permission: "admin.product.read",
         summary: "Environments per branch, how long they have stood, and what is holding them open.",
       },
       {

--- a/console/lib/admin-product.test.ts
+++ b/console/lib/admin-product.test.ts
@@ -1,0 +1,153 @@
+// The Product lane's pure logic.
+//
+// Three functions, and each one is here because getting it wrong produces a
+// screen that is confidently wrong rather than obviously broken, which is the
+// failure this console keeps paying for.
+//
+//   expiryPhrase   says a direction. "3d left" and "3d over" are opposite
+//                  claims about an environment somebody is paying for, and the
+//                  same mistake in `ago` printed "-30d ago" on the line that
+//                  told a customer when they would next be charged.
+//   metricsFor     decides which numbers a load result HAS. The four workload
+//                  kinds measure different things and the database has a CHECK
+//                  refusing a row that pretends otherwise; a console can
+//                  reintroduce exactly that confusion on the far side of a
+//                  correct table by rendering a latency beside a browser run.
+//   toneForStanding is the colour, and the case worth pinning is `unknown`: a
+//                  run that reported nothing must not be coloured like one that
+//                  passed.
+//
+// These live in productshapes.ts rather than beside the hooks precisely so this
+// file can import them. `npm test` in console is `node --test lib/*.test.ts`,
+// so a helper that sits next to a React import is a helper nobody checks.
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { expiryPhrase, metricsFor, toneForStanding } from "./productshapes.ts";
+
+describe("how long a twin has left", () => {
+  const now = new Date("2026-09-02T12:00:00.000Z");
+  const at = (ms: number) => new Date(now.getTime() + ms).toISOString();
+
+  test("a future expiry reads as time remaining", () => {
+    assert.equal(expiryPhrase(at(45_000), now), "45s left");
+    assert.equal(expiryPhrase(at(90 * 60_000), now), "2h left");
+    assert.equal(expiryPhrase(at(5 * 86_400_000), now), "5d left");
+  });
+
+  test("a past expiry reads as time overrun, never as a negative", () => {
+    // The whole point of the column. A minus sign in front of a duration is
+    // read backwards by somebody who is halfway through an incident.
+    assert.equal(expiryPhrase(at(-3 * 3_600_000), now), "3h over");
+    assert.ok(!expiryPhrase(at(-3 * 3_600_000), now).includes("-"));
+  });
+
+  test("a long overrun reads in days rather than in thousands of minutes", () => {
+    // The reason this does not reuse `duration` from loadshapes.ts, which is
+    // built for a measured run time and stops at the minute. A twin five days
+    // past its expiry reading "7200m over" is a number nobody converts.
+    assert.equal(expiryPhrase(at(-5 * 86_400_000), now), "5d over");
+  });
+
+  test("no expiry is said in words rather than shown as forever", () => {
+    assert.equal(expiryPhrase(null, now), "No expiry set");
+  });
+
+  test("an unparseable date does not render as NaN", () => {
+    // A row whose timestamp did not survive the round trip must not put the
+    // string NaN into a table cell.
+    assert.equal(expiryPhrase("not a date", now), "No expiry set");
+  });
+
+  test("the boundary belongs to the future, not the past", () => {
+    // Exactly at the expiry is not yet over. An off by one here flips a whole
+    // column of environments into the overdue filter for a millisecond.
+    assert.ok(expiryPhrase(at(0), now).endsWith("left"));
+  });
+});
+
+describe("which numbers a load result has", () => {
+  test("an observed load has requests and latency and no workflows", () => {
+    const metrics = metricsFor({
+      kind: "observed_load",
+      requests: 1200,
+      failures: 4,
+      error_rate: 0.0033,
+      p50_ms: 41,
+      p95_ms: 190,
+    });
+    const labels = metrics.map((m) => m.label);
+    assert.ok(labels.includes("Requests"));
+    assert.ok(labels.includes("p95"));
+    assert.ok(!labels.includes("Workflows"));
+    assert.ok(!labels.includes("Findings"));
+  });
+
+  test("a browser workflow has five outcome counts and no latency", () => {
+    // Five and not two. A run that returned nought passed, nought failed and
+    // one unverified did nothing, and passed-plus-failed alone renders it as a
+    // run with no failures.
+    const metrics = metricsFor({
+      kind: "browser_workflow",
+      workflows: 1,
+      workflows_passed: 0,
+      workflows_failed: 0,
+      workflows_flaky: 0,
+      workflows_blocked: 0,
+      workflows_unverified: 1,
+    });
+    const labels = metrics.map((m) => m.label);
+    for (const outcome of ["Passed", "Failed", "Flaky", "Blocked", "Unverified"]) {
+      assert.ok(labels.includes(outcome), `browser results lost ${outcome}`);
+    }
+    // The assertion that matters. A percentile beside a browser run is a chart
+    // over a number that is not a latency.
+    for (const latency of ["p50", "p95", "p99", "Slowest", "Requests"]) {
+      assert.ok(!labels.includes(latency), `browser results grew ${latency}`);
+    }
+  });
+
+  test("an exploration counts goals reached rather than answering yes or no", () => {
+    const labels = metricsFor({
+      kind: "exploration",
+      findings: 2,
+      goals: 50,
+      goals_reached: 47,
+    }).map((m) => m.label);
+    assert.deepEqual(labels, ["Findings", "Goals", "Goals reached"]);
+  });
+
+  test("a zero is a measurement and a missing field is not", () => {
+    const metrics = metricsFor({ kind: "observed_load", requests: 0 });
+    const requests = metrics.find((m) => m.label === "Requests");
+    const failures = metrics.find((m) => m.label === "Failures");
+    // Zero requests is an answer: the run sent nothing. A null is the absence
+    // of an answer, and Metric renders the two differently on purpose.
+    assert.equal(requests?.value, 0);
+    assert.equal(failures?.value, null);
+  });
+
+  test("no result at all is an empty row rather than a row of zeroes", () => {
+    assert.deepEqual(metricsFor(null), []);
+  });
+
+  test("a kind this build does not know returns nothing rather than guessing", () => {
+    // Guessing by field name is how a future workload kind gets rendered with
+    // the wrong units for a release and a half.
+    assert.deepEqual(metricsFor({ kind: "something_new", requests: 5 }), []);
+  });
+});
+
+describe("the colour a standing gets", () => {
+  test("a run that reported nothing is not coloured like one that passed", () => {
+    assert.notEqual(toneForStanding("unknown"), toneForStanding("passed"));
+    assert.equal(toneForStanding("unknown"), "neutral");
+  });
+
+  test("running is not a failure and cancelled is not either", () => {
+    assert.equal(toneForStanding("running"), "warn");
+    assert.equal(toneForStanding("cancelled"), "neutral");
+    assert.equal(toneForStanding("failed"), "fail");
+    assert.equal(toneForStanding("passed"), "pass");
+  });
+});

--- a/console/lib/admin-product.ts
+++ b/console/lib/admin-product.ts
@@ -1,0 +1,583 @@
+"use client";
+
+/**
+ * The Product lane's client: twins, runs, branches, safe state and flags.
+ *
+ * WHY THIS IS A THIRD FILE AND NOT ADDITIONS TO admin.ts. That module is the
+ * portal's own client: who the operator is, what they may do, and the three
+ * screens the foundation built. Six lanes appending their hooks to it would put
+ * six writers in one file for no gain, since none of them shares a type with
+ * another. What is REUSED is the transport, deliberately and entirely: query,
+ * adminMutate, useApi and usePages all come from admin.ts and api.ts unchanged,
+ * because a second fetch wrapper is a second place for the error shape, the
+ * credentials mode and the CSRF header to drift.
+ *
+ * EVERY LIST HERE IS PAGED WITH usePages, without exception. Three screens in
+ * this console already read one page of a cursored route and told an operator
+ * the list was complete when it was showing a third of it. Every route below
+ * returns a nextCursor, so every hook below returns pages and every screen over
+ * it renders `More` in both states.
+ */
+
+import { query, usePages, useApi } from "@/lib/api";
+import type { RunKind, RunStanding } from "@/lib/productshapes";
+import { adminMutate, type AdminPage } from "@/lib/admin";
+
+/* -------------------------------------------------------------------------
+ * Twins
+ * ---------------------------------------------------------------------- */
+
+/** Re-exported so a page reads one module for the row and its meaning. The
+ *  declarations live in productshapes.ts, which holds no import that reaches
+ *  React and is therefore the half of this lane the unit tests can run. */
+export type { RunKind, RunStanding };
+
+export interface Twin {
+  id: string;
+  orgId: string;
+  orgSlug: string;
+  envId: string;
+  repository: string;
+  branch: string;
+  pullRequest: number | null;
+  state: string;
+  previewUrl: string | null;
+  runtime: string | null;
+  goldenVersion: string | null;
+  /** Null when the twin names no golden version, or names one this
+   *  installation has no row for. Both differ from `false`, which means a
+   *  version exists and was never verified. */
+  goldenVerified: boolean | null;
+  createdAt: string;
+  updatedAt: string;
+  expiresAt: string | null;
+  tornDownAt: string | null;
+  /** Past the lifetime it was created with and still running. This is the row
+   *  that is costing somebody money right now. */
+  overdue: boolean;
+  teardownPending: boolean;
+  runs: number;
+}
+
+export interface TwinRunSummary {
+  id: string;
+  kind: string;
+  state: string;
+  standing: RunStanding;
+  verdicts: number;
+  failing: number;
+  startedAt: string | null;
+  finishedAt: string | null;
+  createdAt: string;
+}
+
+export interface TwinWorkloadSummary {
+  id: string;
+  workload: string;
+  state: string;
+  standing: RunStanding;
+  verdict: string | null;
+  failureCode: string | null;
+  requestedAt: string;
+  finishedAt: string | null;
+}
+
+export interface TwinTeardown {
+  id: string;
+  state: string;
+  reason: string;
+  attempts: number;
+  lastError: string | null;
+  requestedAt: string;
+  acknowledgedAt: string | null;
+}
+
+export interface TwinDetail extends Omit<Twin, "overdue" | "teardownPending" | "runs"> {
+  orgName: string;
+  defaultBranch: string | null;
+  createdBy: string | null;
+  lastSequence: number;
+  golden: {
+    version: string;
+    verified: boolean;
+    sourceDigest: string | null;
+    rulesDigest: string | null;
+    sizeBytes: number | null;
+    createdAt: string;
+  } | null;
+  runs: TwinRunSummary[];
+  workloadRuns: TwinWorkloadSummary[];
+  teardowns: TwinTeardown[];
+}
+
+export type TwinScope = "live" | "overdue" | "all";
+
+export function useTwins(options: { scope: TwinScope; search: string; orgId?: string | null }) {
+  const { scope, search, orgId } = options;
+  return usePages<Twin>(
+    async (cursor) => {
+      const p = await query<AdminPage<Twin>>("admin.product.twins.list", {
+        limit: 50,
+        scope,
+        ...(search ? { query: search } : {}),
+        ...(orgId ? { orgId } : {}),
+        ...(cursor === null ? {} : { cursor }),
+      });
+      return { rows: p.rows, next: p.nextCursor };
+    },
+    [scope, search, orgId ?? ""],
+  );
+}
+
+export function useTwin(id: string) {
+  return useApi<TwinDetail>(
+    () => query("admin.product.twins.get", { id }),
+    [id],
+  );
+}
+
+/* -------------------------------------------------------------------------
+ * Branches
+ * ---------------------------------------------------------------------- */
+
+export interface BranchRow {
+  orgId: string;
+  orgSlug: string;
+  repositoryId: string;
+  repository: string;
+  branch: string;
+  twins: number;
+  live: number;
+  overdue: number;
+  pullRequest: number | null;
+  pullRequestState: string | null;
+  pullRequestTitle: string | null;
+  pullRequestDraft: boolean | null;
+  pullRequestFromFork: boolean | null;
+  pullRequestClosedAt: string | null;
+  /** Live twins on a branch whose pull request is closed or merged. Nothing has
+   *  failed; the environment is simply still running for a change that landed. */
+  orphaned: boolean;
+  lastActivity: string;
+  latestState: string;
+}
+
+export type BranchScope = "all" | "live" | "orphaned";
+
+export function useBranches(options: { scope: BranchScope; search: string }) {
+  const { scope, search } = options;
+  return usePages<BranchRow>(
+    async (cursor) => {
+      const p = await query<AdminPage<BranchRow>>("admin.product.twins.branches", {
+        limit: 50,
+        scope,
+        ...(search ? { query: search } : {}),
+        ...(cursor === null ? {} : { cursor }),
+      });
+      return { rows: p.rows, next: p.nextCursor };
+    },
+    [scope, search],
+  );
+}
+
+/* -------------------------------------------------------------------------
+ * Runs
+ * ---------------------------------------------------------------------- */
+
+export interface RunRow {
+  kind: RunKind;
+  id: string;
+  orgId: string;
+  orgSlug: string;
+  repository: string | null;
+  ref: string | null;
+  pullRequest: number | null;
+  envId: string | null;
+  state: string;
+  standing: RunStanding;
+  verdict: string | null;
+  failure: string | null;
+  at: string;
+  startedAt: string | null;
+  finishedAt: string | null;
+  durationMs: number | null;
+}
+
+export interface AgentVerdict {
+  id: string;
+  workflow: string;
+  persona: string | null;
+  value: string;
+  summary: string | null;
+  steps: number;
+  durationMs: number | null;
+  reproduction: unknown;
+  createdAt: string;
+}
+
+export interface RunArtifact {
+  id: string;
+  kind: string;
+  step: number | null;
+  contentType: string | null;
+  sizeBytes: number | null;
+  sha256: string | null;
+  /** False once retention removed the bytes. The row stays so the timeline can
+   *  say "not retained" rather than showing a gap that reads as a bug. */
+  retained: boolean;
+  createdAt: string;
+}
+
+export interface AgentRunDetail {
+  kind: "agent";
+  id: string;
+  orgId: string;
+  orgSlug: string;
+  environmentId: string;
+  envId: string;
+  repository: string;
+  branch: string;
+  pullRequest: number | null;
+  previewUrl: string | null;
+  runKind: string;
+  state: string;
+  standing: RunStanding;
+  startedAt: string | null;
+  finishedAt: string | null;
+  createdAt: string;
+  durationMs: number | null;
+  lastSequence: number;
+  verdicts: AgentVerdict[];
+  artifacts: RunArtifact[];
+}
+
+export interface LoadRunResult extends Record<string, unknown> {
+  kind: string;
+  recordedAt: string;
+}
+
+export interface LoadRunDetail {
+  kind: "load";
+  id: string;
+  orgId: string;
+  orgSlug: string;
+  environmentId: string | null;
+  envId: string | null;
+  repository: string;
+  gitRef: string;
+  workflowFile: string | null;
+  workload: string;
+  workloadSlug: string;
+  workloadKind: string;
+  workloadVersion: number | null;
+  state: string;
+  standing: RunStanding;
+  verdict: string | null;
+  failureCode: string | null;
+  detail: string | null;
+  /** The command that reproduces this run, as the engine reported it. Null
+   *  until one reports, and the page says so rather than assembling a command
+   *  that drifts from what actually ran. */
+  reproduceCommand: string | null;
+  manifestDigest: string | null;
+  attempt: number;
+  requestedAt: string;
+  dispatchedAt: string | null;
+  acceptedAt: string | null;
+  startedAt: string | null;
+  finishedAt: string | null;
+  deadlineAt: string;
+  durationMs: number | null;
+  leaseHolder: string | null;
+  leaseExpiresAt: string | null;
+  leaseLostAt: string | null;
+  leaseTakeovers: number;
+  cancelRequestedAt: string | null;
+  cancelReason: string | null;
+  cancelledAt: string | null;
+  retryOf: string | null;
+  supersededBy: string | null;
+  result: LoadRunResult | null;
+}
+
+export interface CheckRunDetail {
+  kind: "check";
+  id: string;
+  orgId: string;
+  orgSlug: string;
+  repository: string;
+  pullRequest: number;
+  title: string | null;
+  headRef: string;
+  baseRef: string;
+  pullRequestState: string;
+  draft: boolean;
+  /** A head branch living in another repository, which is the whole of what
+   *  makes a pull request untrusted here. */
+  fromFork: boolean;
+  headRepository: string;
+  approvedSha: string | null;
+  approvedBy: string | null;
+  approvedAt: string | null;
+  headSha: string;
+  attempt: number;
+  state: string;
+  standing: RunStanding;
+  detail: string | null;
+  /** Null while the installation does not hold `checks: write`, which is a
+   *  state to serve rather than to crash in. */
+  checkRunId: string | null;
+  workflowRunId: string | null;
+  reportedBy: string | null;
+  envId: string | null;
+  verdict: unknown;
+  supersededBy: string | null;
+  queuedAt: string;
+  startedAt: string | null;
+  finishedAt: string | null;
+  deadlineAt: string;
+  durationMs: number | null;
+}
+
+export type RunDetail = AgentRunDetail | LoadRunDetail | CheckRunDetail;
+
+export function useRuns(options: {
+  kind: RunKind;
+  search: string;
+  failedOnly: boolean;
+  environmentId?: string | null;
+}) {
+  const { kind, search, failedOnly, environmentId } = options;
+  return usePages<RunRow>(
+    async (cursor) => {
+      const p = await query<AdminPage<RunRow>>("admin.product.runs.list", {
+        limit: 50,
+        kind,
+        failedOnly,
+        ...(search ? { query: search } : {}),
+        ...(environmentId ? { environmentId } : {}),
+        ...(cursor === null ? {} : { cursor }),
+      });
+      return { rows: p.rows, next: p.nextCursor };
+    },
+    [kind, search, String(failedOnly), environmentId ?? ""],
+  );
+}
+
+export function useRun(kind: RunKind, id: string) {
+  return useApi<RunDetail>(() => query("admin.product.runs.get", { kind, id }), [kind, id]);
+}
+
+/* -------------------------------------------------------------------------
+ * Safe state
+ * ---------------------------------------------------------------------- */
+
+export interface GoldenVersion {
+  id: string;
+  orgId: string;
+  orgSlug: string;
+  repository: string;
+  version: string;
+  sourceDigest: string | null;
+  rulesDigest: string | null;
+  verified: boolean;
+  sizeBytes: number | null;
+  createdAt: string;
+  /** Live twins built from this version. An unverified version with twins on
+   *  it is the row that matters; one with none is history. */
+  twins: number;
+}
+
+export interface MaskingRule {
+  id: string;
+  orgId: string;
+  orgSlug: string;
+  repository: string;
+  table: string;
+  column: string;
+  transform: string;
+  link: string | null;
+  reason: string | null;
+  /** False means a scan suggested it and no human has agreed, which means the
+   *  column is not being transformed. */
+  confirmed: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export function useGoldenVersions(options: {
+  scope: "all" | "verified" | "unverified";
+  search: string;
+}) {
+  const { scope, search } = options;
+  return usePages<GoldenVersion>(
+    async (cursor) => {
+      const p = await query<AdminPage<GoldenVersion>>("admin.product.data.goldens", {
+        limit: 50,
+        scope,
+        ...(search ? { query: search } : {}),
+        ...(cursor === null ? {} : { cursor }),
+      });
+      return { rows: p.rows, next: p.nextCursor };
+    },
+    [scope, search],
+  );
+}
+
+export function useMaskingRules(options: {
+  scope: "all" | "confirmed" | "unconfirmed";
+  search: string;
+}) {
+  const { scope, search } = options;
+  return usePages<MaskingRule>(
+    async (cursor) => {
+      const p = await query<AdminPage<MaskingRule>>("admin.product.data.masking", {
+        limit: 50,
+        scope,
+        ...(search ? { query: search } : {}),
+        ...(cursor === null ? {} : { cursor }),
+      });
+      return { rows: p.rows, next: p.nextCursor };
+    },
+    [scope, search],
+  );
+}
+
+/* -------------------------------------------------------------------------
+ * Flags and entitlement overrides
+ * ---------------------------------------------------------------------- */
+
+/**
+ * These read the MONEY lane's routes, unchanged.
+ *
+ * `admin.flags.*` and `admin.entitlements.*` are that lane's prefixes and its
+ * routes are complete, so the Experiments and Feature Flags page consumes them
+ * rather than growing a second copy under `admin.product`. Adding a route under
+ * somebody else's prefix is the kind of thing a review misses; this comment and
+ * admin-product.test.ts are what stop it.
+ */
+
+export interface FeatureFlag {
+  key: string;
+  description: string;
+  state: "off" | "on" | "targeted";
+  rollout_percent: number;
+  internal_only: boolean;
+  killed_at: string | null;
+  killed_by_label: string | null;
+  killed_reason: string | null;
+  updated_at: string | null;
+  updated_by_label: string | null;
+  /** Where in the source the flag is actually consulted, from the KNOWN_FLAGS
+   *  map. Null when nothing reads it. */
+  checkedAt: string | null;
+  /** Whether anything reads this flag at all. A flag with no call site is a
+   *  switch that looks like a control and is not one, which is the worst thing
+   *  to discover halfway through an incident. */
+  known: boolean;
+}
+
+export interface FlagTarget {
+  id: string;
+  flag_key: string;
+  kind: "user" | "organization" | "project" | "repository" | "plan" | "environment";
+  value: string;
+  allow: boolean;
+  org_id: string | null;
+  reason: string | null;
+  created_by_label: string | null;
+  created_at: string;
+}
+
+export interface FlagsAnswer {
+  flags: FeatureFlag[];
+  targets: FlagTarget[];
+}
+
+export function useFlags() {
+  return useApi<FlagsAnswer>(() => query("admin.flags.list"), []);
+}
+
+/** The grant that moved a limit, as the server resolves it. Mirrors OverrideRef
+ *  in src/entitlements.ts, with its two dates serialized. */
+export interface EntitlementOverride {
+  id: string;
+  scope: "global" | "organization" | "project" | "user";
+  reason: string;
+  ticket: string | null;
+  grantedBy: string;
+  grantedAt: string;
+  /** Null is forever. Everything else stops applying on its own, which is what
+   *  makes a grant a loan rather than a change of plan. */
+  expiresAt: string | null;
+}
+
+export interface OrgEntitlement {
+  key: string;
+  value: number | boolean;
+  /** What the plan alone would have said, so the screen can show both and a
+   *  one-off grant is never mistaken for normal behaviour. */
+  planValue: number | boolean;
+  source: "plan" | "global" | "organization" | "project" | "user";
+  unit: string | null;
+  description: string;
+  /** False when the catalog records that nothing enforces this limit yet. A
+   *  number nothing checks is not a limit. */
+  enforced: boolean;
+  notEnforcedBecause: string | null;
+  override: EntitlementOverride | null;
+}
+
+export interface OrgEntitlements {
+  org: { id: string; slug: string; plan: string };
+  entitlements: OrgEntitlement[];
+}
+
+/** One organization's entitlements, with the grant that moved each one. Null
+ *  orgId means nobody has picked an organization yet, and the hook does not
+ *  fire: a route that needs an id is not a route to call with an empty one. */
+export function useOrgEntitlements(orgId: string | null) {
+  return useApi<OrgEntitlements | null>(
+    async () =>
+      orgId ? query<OrgEntitlements>("admin.entitlements.forOrganization", { orgId }) : null,
+    [orgId ?? ""],
+  );
+}
+
+export async function setFlag(input: {
+  key: string;
+  description: string;
+  state: "off" | "on" | "targeted";
+  rolloutPercent: number;
+  internalOnly: boolean;
+}) {
+  return adminMutate<{ key: string }>("admin.flags.set", input);
+}
+
+/**
+ * The kill switch, and it is a separate call from `setFlag` on purpose.
+ *
+ * Turning a flag off during an incident and turning it off because a rollout
+ * ended are the same UPDATE and completely different events. The route records
+ * them differently, at different severities, and the one worth finding six
+ * months later is the first. A single "off" button here would have collapsed
+ * that distinction back again on the way to the server.
+ */
+export async function killFlag(key: string, reason: string) {
+  return adminMutate<{ killed: boolean }>("admin.flags.kill", { key, reason });
+}
+
+export async function targetFlag(input: {
+  flagKey: string;
+  kind: FlagTarget["kind"];
+  value: string;
+  allow: boolean;
+  orgId: string | null;
+  reason: string;
+}) {
+  return adminMutate<{ id: string }>("admin.flags.target", input);
+}
+
+export async function revokeOverride(id: string, reason: string) {
+  return adminMutate<{ revoked: boolean }>("admin.entitlements.revoke", { id, reason });
+}

--- a/console/lib/admin-product.ts
+++ b/console/lib/admin-product.ts
@@ -345,9 +345,14 @@ export function useRuns(options: {
   kind: RunKind;
   search: string;
   failedOnly: boolean;
+  /** One twin, reached from the twin page. Stricter than orgId and applied
+   *  alongside it, because an environment belongs to exactly one tenant. */
   environmentId?: string | null;
+  /** One organization, reached from a twin when the question widens from
+   *  "why did this one fail" to "is the whole tenant failing". */
+  orgId?: string | null;
 }) {
-  const { kind, search, failedOnly, environmentId } = options;
+  const { kind, search, failedOnly, environmentId, orgId } = options;
   return usePages<RunRow>(
     async (cursor) => {
       const p = await query<AdminPage<RunRow>>("admin.product.runs.list", {
@@ -356,11 +361,12 @@ export function useRuns(options: {
         failedOnly,
         ...(search ? { query: search } : {}),
         ...(environmentId ? { environmentId } : {}),
+        ...(orgId ? { orgId } : {}),
         ...(cursor === null ? {} : { cursor }),
       });
       return { rows: p.rows, next: p.nextCursor };
     },
-    [kind, search, String(failedOnly), environmentId ?? ""],
+    [kind, search, String(failedOnly), environmentId ?? "", orgId ?? ""],
   );
 }
 

--- a/console/lib/admin-product.ts
+++ b/console/lib/admin-product.ts
@@ -251,7 +251,7 @@ export interface AgentRunDetail {
   artifacts: RunArtifact[];
 }
 
-export interface LoadRunResult extends Record<string, unknown> {
+interface LoadRunResult extends Record<string, unknown> {
   kind: string;
   recordedAt: string;
 }
@@ -495,7 +495,7 @@ export interface FlagTarget {
   created_at: string;
 }
 
-export interface FlagsAnswer {
+interface FlagsAnswer {
   flags: FeatureFlag[];
   targets: FlagTarget[];
 }
@@ -506,7 +506,7 @@ export function useFlags() {
 
 /** The grant that moved a limit, as the server resolves it. Mirrors OverrideRef
  *  in src/entitlements.ts, with its two dates serialized. */
-export interface EntitlementOverride {
+interface EntitlementOverride {
   id: string;
   scope: "global" | "organization" | "project" | "user";
   reason: string;
@@ -534,7 +534,7 @@ export interface OrgEntitlement {
   override: EntitlementOverride | null;
 }
 
-export interface OrgEntitlements {
+interface OrgEntitlements {
   org: { id: string; slug: string; plan: string };
   entitlements: OrgEntitlement[];
 }

--- a/console/lib/productshapes.ts
+++ b/console/lib/productshapes.ts
@@ -26,7 +26,11 @@ export type RunStanding = "running" | "passed" | "failed" | "cancelled" | "unkno
  *  into a table whose column set is true of none of the three. */
 export type RunKind = "agent" | "load" | "check";
 
-export type ChipTone = "pass" | "fail" | "warn" | "neutral";
+/** Not exported: `Badge`'s own Tone is what a page annotates with, and a
+ *  second exported name for the same four words is a second thing to keep
+ *  in step. This one exists so the function below has a return type worth
+ *  reading. */
+type ChipTone = "pass" | "fail" | "warn" | "neutral";
 
 /**
  * The tone a standing gets, in one place.
@@ -87,7 +91,7 @@ function coarse(ms: number): string {
 /** One measurement, in the shape the console's Metric component takes. Declared
  *  structurally rather than imported, so this file keeps its promise of holding
  *  no import that reaches React. */
-export interface Measurement {
+interface Measurement {
   label: string;
   /** Null means nobody measured it, which Metric renders as "Not measured".
    *  It is not zero, and the distinction is the whole reason it is nullable. */
@@ -113,6 +117,8 @@ export interface Measurement {
  * A kind this build does not know returns nothing at all, rather than guessing
  * at the fields by name.
  */
+/** Returns the shape `MetricRow` takes, structurally rather than by importing
+ *  its type, which is what keeps this file free of React. */
 export function metricsFor(result: Record<string, unknown> | null): Measurement[] {
   if (!result) return [];
   const n = (key: string): number | null => {

--- a/console/lib/productshapes.ts
+++ b/console/lib/productshapes.ts
@@ -1,0 +1,182 @@
+/**
+ * What the Product lane's rows MEAN, with no import that reaches the network.
+ *
+ * Split from admin-product.ts for the reason loadshapes.ts was split from
+ * load.ts, and it is the same reason: the hooks next door pull in React and the
+ * fetch wrapper and cannot run outside a browser, so anything living beside
+ * them is untestable by construction. The console's unit tests are
+ * `node --test lib/*.test.ts`, which means a file that imports React is a file
+ * whose logic nobody checks. Everything here is a pure function over plain
+ * values, and admin-product.test.ts exercises all of it.
+ *
+ * The one import is loadshapes.ts, which holds none of its own and is where the
+ * console's number formatting already lives. A second formatter for a duration
+ * or a percentile would be two things that drift while both look authoritative,
+ * and that file says so at the bottom of itself about `bytes`.
+ */
+
+import { duration, percent, rate } from "./loadshapes.ts";
+
+/** What a reader should do about a run, in one word. Separate from the run's
+ *  own state, because a job that finished is not a job that passed. */
+export type RunStanding = "running" | "passed" | "failed" | "cancelled" | "unknown";
+
+/** The three families of run this product has. They are different objects with
+ *  different columns, so a list filters between them rather than merging them
+ *  into a table whose column set is true of none of the three. */
+export type RunKind = "agent" | "load" | "check";
+
+export type ChipTone = "pass" | "fail" | "warn" | "neutral";
+
+/**
+ * The tone a standing gets, in one place.
+ *
+ * `unknown` is deliberately neutral rather than warn. A run that reported
+ * nothing is not a warning about the run, it is an absence of information, and
+ * colouring it amber puts it in the same visual class as a run that is still
+ * going. The word carries the meaning; the colour agrees with it and does not
+ * add to it.
+ */
+export function toneForStanding(standing: RunStanding): ChipTone {
+  if (standing === "passed") return "pass";
+  if (standing === "failed") return "fail";
+  if (standing === "running") return "warn";
+  return "neutral";
+}
+
+/**
+ * How long is left before a twin's lifetime runs out, or how long it has been
+ * over.
+ *
+ * A PHRASE RATHER THAN A SIGNED NUMBER. "-3d" beside an environment is the kind
+ * of value a reader interprets backwards during an incident, and the direction
+ * is the entire point of the column: one means it is about to go and the other
+ * means somebody is paying for it right now. This is the same defect `ago` in
+ * format.ts was written to stop making, in a different column.
+ *
+ * WHY NEITHER EXISTING HELPER IS USED HERE, since a third duration formatter
+ * needs an argument. `duration` in loadshapes.ts is for a measured run time,
+ * where sub-second precision is the interesting part, and its largest unit is
+ * the minute: a twin five days overdue would read "7200m over". `ago` in
+ * format.ts has exactly the right scale and two things this column cannot use,
+ * namely its own direction words baked into the string and a read of
+ * `Date.now()` that no test can pin. So the scale below is `ago`'s, on purpose
+ * and to the unit, and the words are this column's.
+ */
+export function expiryPhrase(expiresAt: string | null, now: Date = new Date()): string {
+  if (expiresAt === null) return "No expiry set";
+  const ms = new Date(expiresAt).getTime() - now.getTime();
+  if (!Number.isFinite(ms)) return "No expiry set";
+  // The sign is read once, before any rounding can lose it, which is the fix
+  // `ago` records in its own header.
+  return ms >= 0 ? `${coarse(Math.abs(ms))} left` : `${coarse(Math.abs(ms))} over`;
+}
+
+/** A non-negative interval at the scale a lifetime is read at: minutes, then
+ *  hours, then days. `ago`'s ladder, without its direction words. */
+function coarse(ms: number): string {
+  const seconds = Math.round(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 48) return `${hours}h`;
+  return `${Math.round(hours / 24)}d`;
+}
+
+/** One measurement, in the shape the console's Metric component takes. Declared
+ *  structurally rather than imported, so this file keeps its promise of holding
+ *  no import that reaches React. */
+export interface Measurement {
+  label: string;
+  /** Null means nobody measured it, which Metric renders as "Not measured".
+   *  It is not zero, and the distinction is the whole reason it is nullable. */
+  value: number | string | null;
+  unit?: string;
+  note?: string;
+}
+
+/**
+ * Which numbers a load result actually has, decided by its kind.
+ *
+ * THE FOUR KINDS MEASURE DIFFERENT THINGS and the table has a CHECK constraint
+ * refusing a row that pretends otherwise: an observed load has requests and no
+ * workflows, a browser workflow has workflows and no requests. So this reads
+ * the kind and returns only what that kind carries, rather than returning every
+ * field and letting three quarters of the tiles say "not measured".
+ *
+ * That is not tidiness. Rendering a latency percentile beside a browser run is
+ * drawing a chart over a number that is not a latency, which is exactly the
+ * confusion the constraint exists to prevent, and a console can reintroduce it
+ * on the far side of a correct database.
+ *
+ * A kind this build does not know returns nothing at all, rather than guessing
+ * at the fields by name.
+ */
+export function metricsFor(result: Record<string, unknown> | null): Measurement[] {
+  if (!result) return [];
+  const n = (key: string): number | null => {
+    const value = result[key];
+    return typeof value === "number" ? value : null;
+  };
+  const kind = String(result.kind ?? "");
+
+  if (kind === "observed_load" || kind === "http_scenario") {
+    const target = n("target_rate");
+    return [
+      { label: "Requests", value: n("requests") },
+      { label: "Failures", value: n("failures") },
+      { label: "Error rate", value: nullable(n("error_rate"), percent) },
+      {
+        label: "Achieved rate",
+        value: nullable(n("achieved_rate"), (v) => `${rate(v)}/s`),
+        note: target === null ? undefined : `Asked for ${rate(target)} per second`,
+      },
+      { label: "p50", value: nullable(n("p50_ms"), duration) },
+      { label: "p95", value: nullable(n("p95_ms"), duration) },
+      { label: "p99", value: nullable(n("p99_ms"), duration) },
+      { label: "Slowest", value: nullable(n("max_ms"), duration) },
+      ...(kind === "http_scenario"
+        ? [
+            { label: "Sessions", value: n("sessions") },
+            { label: "Iterations", value: n("iterations") },
+          ]
+        : []),
+    ];
+  }
+
+  if (kind === "browser_workflow") {
+    // Five outcome counts and not two. A real run against a sample project
+    // returned nought passed, nought failed and one unverified because the
+    // persona could not be created, and passed-plus-failed alone renders that
+    // as a run with no failures.
+    return [
+      { label: "Workflows", value: n("workflows") },
+      { label: "Passed", value: n("workflows_passed") },
+      { label: "Failed", value: n("workflows_failed") },
+      { label: "Flaky", value: n("workflows_flaky") },
+      { label: "Blocked", value: n("workflows_blocked") },
+      { label: "Unverified", value: n("workflows_unverified") },
+      { label: "Steps", value: n("steps") },
+    ];
+  }
+
+  if (kind === "exploration") {
+    // Two counts rather than one boolean, because a version selects up to fifty
+    // goals and one boolean cannot answer for fifty.
+    return [
+      { label: "Findings", value: n("findings") },
+      { label: "Goals", value: n("goals") },
+      { label: "Goals reached", value: n("goals_reached") },
+    ];
+  }
+
+  return [];
+}
+
+/** Formats only when there is something to format. Null in, null out, so
+ *  `Metric` says a number was not measured rather than printing the dash the
+ *  formatters return, which it would treat as a value. */
+function nullable(value: number | null, format: (v: number) => string): string | null {
+  return value === null ? null : format(value);
+}

--- a/web/apps/api/src/admin/permissions.ts
+++ b/web/apps/api/src/admin/permissions.ts
@@ -76,6 +76,21 @@ export const ADMIN_PERMISSIONS = [
   // none of them should be able to pause it.
   'admin.emergency.read',
   'admin.emergency.engage',
+
+  // The product itself: twins, the runs on them, and the branches they belong
+  // to. One read covers all three because they are one object seen from three
+  // sides, and an operator who can list a twin but not the run that failed on
+  // it has to ask somebody else to finish the sentence.
+  'admin.product.read',
+  // Golden data versions and masking rules, split off from the read above.
+  //
+  // The split is not symmetry. A masking rule enumerates a customer's schema
+  // and names which of its columns hold personal data, which is a narrower
+  // need than "why did this run fail" and a wider disclosure. The role this
+  // exists for is analytics, which holds the read above and not this one:
+  // counting runs and twins is its job, and reading somebody's column names
+  // is not.
+  'admin.product.data.read',
 ] as const
 
 export type AdminPermission = (typeof ADMIN_PERMISSIONS)[number]
@@ -110,6 +125,7 @@ export const RESERVED_PREFIXES: Record<string, string> = {
   'admin.logs': 'infra',
   'admin.security': 'infra',
   'admin.emergency': 'infra',
+  'admin.product': 'product',
 }
 
 export const ADMIN_ROLES = [
@@ -147,6 +163,12 @@ export const ADMIN_PERMISSION_DESCRIPTIONS: Record<AdminPermission, string> = {
     'See whether maintenance mode, new sign-ups, or new runs are paused, and why.',
   'admin.emergency.engage':
     'Pause or resume the whole installation: maintenance mode, new sign-ups, and new runs.',
+  'admin.product.read':
+    'See every production twin on the installation, the agent runs, load runs and pull request ' +
+    'checks against them, and the branches holding them open.',
+  'admin.product.data.read':
+    'See a customer\'s golden data versions and the masking rules applied to them, including ' +
+    'which columns a scan flagged and nobody has confirmed.',
   'admin.billing.read':
     'See a customer\'s Stripe customer, subscription, invoices, charges, payment methods and ' +
     'credit balance, and the record of every administrative money action taken on the account.',
@@ -221,6 +243,7 @@ export const ADMIN_ROLE_PERMISSIONS: Record<AdminRole, readonly AdminPermission[
     // permission rather than on rank: ordering roles and comparing ranks is how
     // a permission model stops being a table and starts being an assumption.
     'admin.emergency.read', 'admin.emergency.engage',
+    'admin.product.read', 'admin.product.data.read',
   ],
   infrastructure: [
     'admin.portal.access', 'admin.audit.read',
@@ -235,6 +258,10 @@ export const ADMIN_ROLE_PERMISSIONS: Record<AdminRole, readonly AdminPermission[
     // debugging "their runs will not start" must be able to discover that runs
     // are frozen; pausing the installation is a different decision.
     'admin.emergency.read',
+    // The twins, the runs and the golden data behind them. On call is the rota
+    // that gets "their environment came up empty", and the answer to that is
+    // whether the golden version it was built from was ever verified.
+    'admin.product.read', 'admin.product.data.read',
   ],
   security: [
     'admin.portal.access', 'admin.audit.read', 'admin.audit.export',
@@ -248,6 +275,10 @@ export const ADMIN_ROLE_PERMISSIONS: Record<AdminRole, readonly AdminPermission[
     'admin.billing.read', 'admin.entitlements.read',
     'admin.flags.read', 'admin.flags.write',
     'admin.infra.read', 'admin.emergency.read',
+    // Masking posture is a security question before it is a product one: an
+    // unconfirmed rule is a column a scan believes holds personal data, on a
+    // copy somebody is running tests against.
+    'admin.product.read', 'admin.product.data.read',
   ],
   billing: [
     'admin.portal.access', 'admin.audit.read',
@@ -266,9 +297,25 @@ export const ADMIN_ROLE_PERMISSIONS: Record<AdminRole, readonly AdminPermission[
     // Support answers "why was I charged this" every day and must never be the
     // rota that can refund. Read without write is the whole point of the split.
     'admin.billing.read', 'admin.entitlements.read', 'admin.flags.read',
+    // "Why did my run fail" and "why is this column blank in my twin" are the
+    // two questions support is asked about the product, and the second one is
+    // answered by a masking rule.
+    'admin.product.read', 'admin.product.data.read',
   ],
-  analytics: ['admin.portal.access', 'admin.audit.read', 'admin.tenants.read', 'admin.users.read'],
-  read_only: ['admin.portal.access', 'admin.audit.read', 'admin.tenants.read', 'admin.users.read'],
+  // Reads the product's shape and not its customers' schemas. This is the role
+  // the data split exists for: counting runs and twins is analytics work, and
+  // reading which of a customer's columns hold personal data is not.
+  analytics: [
+    'admin.portal.access', 'admin.audit.read', 'admin.tenants.read', 'admin.users.read',
+    'admin.product.read',
+  ],
+  // Oversight is not a privilege to be rationed, so the auditor role reads the
+  // masking rules too. It still writes nothing, which is the only rule this
+  // role has.
+  read_only: [
+    'admin.portal.access', 'admin.audit.read', 'admin.tenants.read', 'admin.users.read',
+    'admin.product.read', 'admin.product.data.read',
+  ],
 }
 
 export function adminRoleHas(role: AdminRole, permission: AdminPermission): boolean {

--- a/web/apps/api/src/admin/product.ts
+++ b/web/apps/api/src/admin/product.ts
@@ -82,12 +82,12 @@ const page = z.object({
  * `passed` is the exit-code-zero-over-nothing defect this repository has
  * already shipped once. It gets its own word.
  */
-export type RunStanding = 'running' | 'passed' | 'failed' | 'cancelled' | 'unknown'
+type RunStanding = 'running' | 'passed' | 'failed' | 'cancelled' | 'unknown'
 
 /** The three families of run this product has. They are different objects with
  *  different columns, so the console filters between them rather than merging
  *  them into a table whose column set is true of none of the three. */
-export type RunKind = 'agent' | 'load' | 'check'
+type RunKind = 'agent' | 'load' | 'check'
 
 /**
  * One row of the runs list, whichever family it came from.
@@ -96,8 +96,20 @@ export type RunKind = 'agent' | 'load' | 'check'
  * it belongs to, what code it ran against, when, how it ended and why. Anything
  * that is true of one family only lives on the detail route instead, which is
  * why this is a flat interface rather than a union with three optional halves.
+ *
+ * NOT `RunRow`. `workloads/store.ts` already exports a `RunRow` that is a
+ * different shape entirely, and two interfaces of one name in one codebase is a
+ * five minute detour every time somebody greps for either.
+ *
+ * EXPORTED FOR A REASON, and the reason is not that anybody imports it. It
+ * appears in the inferred type of `productRouter`, so `adminRouter` and
+ * `appRouter` cannot be named without it: making it local fails the typecheck
+ * with TS4023 rather than merely being untidy. The console declares its own
+ * copy of the same shape, because there is no shared type package between the
+ * API and the console and a cross-package import would be the wrong way to
+ * make one.
  */
-export interface RunRow {
+export interface RunListRow {
   kind: RunKind
   id: string
   orgId: string
@@ -774,7 +786,7 @@ const runsRouter = router({
           rows,
           input.limit,
           (r) => encodeCursor([iso(r.created_at), r.id]),
-          (r): RunRow => ({
+          (r): RunListRow => ({
             kind: 'agent',
             id: r.id,
             orgId: r.org_id,
@@ -839,7 +851,7 @@ const runsRouter = router({
           rows,
           input.limit,
           (r) => encodeCursor([iso(r.requested_at), r.id]),
-          (r): RunRow => ({
+          (r): RunListRow => ({
             kind: 'load',
             id: r.id,
             orgId: r.org_id,
@@ -897,7 +909,7 @@ const runsRouter = router({
         rows,
         input.limit,
         (r) => encodeCursor([iso(r.queued_at), r.id]),
-        (r): RunRow => ({
+        (r): RunListRow => ({
           kind: 'check',
           id: r.id,
           orgId: r.org_id,

--- a/web/apps/api/src/admin/product.ts
+++ b/web/apps/api/src/admin/product.ts
@@ -1,56 +1,1387 @@
-// The Product lane of the operator portal.
+// The Product lane of the operator portal: twins, the runs on them, the
+// branches they belong to, and the golden data they were built from.
 //
-// WHAT THIS FILE IS FOR, and why it is empty rather than absent. The portal has
-// six navigation groups and they are built in parallel. One module per group,
-// mounted once, is what lets that happen without two people editing the same
-// file: the Product sections own THIS file and console/app/admin/product, and
-// nothing else. A lane that had to add its routes to router.ts instead would
-// put six writers in one object literal, and a duplicate key in an object
-// literal is the one merge conflict git does not report. It has already
-// happened once in this directory: see the note in infra.ts about a second
-// `admin:` key silently winning.
+// WHAT THIS FILE IS FOR. Four of the five product sections ask a question about
+// somebody else's tenant that the customer's own console cannot answer, because
+// answering it means reading across every organization at once: which twins are
+// alive right now, which runs are failing, which branches are holding an
+// environment open after their pull request closed, and whether a customer's
+// golden data was ever verified. Every one of those is a cross tenant read, so
+// every one of them goes through ctx.adminDb and none of them through ctx.pool.
 //
-// So the mount is made first and the routes come later. The empty router below
-// is not a placeholder nobody reads: it is mounted in router.ts and
-// admin-namespaces.test.ts asserts that it is, exactly once, which is what
-// makes this a reserved namespace rather than a file somebody forgot.
+// THE FIFTH SECTION IS NOT HERE, and that is the point of it. Experiments and
+// Feature Flags is served entirely by admin.flags.* and admin.entitlements.*,
+// which the money lane already owns and already built. Flags are rich: state,
+// rollout, targets, an internal-only bit, and a kill with a reason on it.
+// EXPERIMENTS DO NOT EXIST. There is no experiment table, no variant, no
+// assignment, no exposure log and no results anywhere in the schema, and a
+// rollout percent is not an experiment. So that page reads the flag routes and
+// says the rest is not wired, in those words, rather than growing a route here
+// that would have to invent its answer.
 //
-// THE SECTIONS THIS LANE OWNS: Production Twins, Runs & Jobs, Safe State & Databases, Branches & Environments, and Experiments & Feature Flags.
+// THREE THINGS THIS FILE DELIBERATELY DOES NOT DO.
 //
-// PERMISSION PREFIXES RESERVED FOR IT: admin.infra.*, admin.flags.*. The
-// catalog and the reservations are in permissions.ts, and adding a permission
-// under another lane's prefix is the kind of thing a review misses.
+// It adds no write. Every lever these screens need already exists somewhere
+// else and is already enforced somewhere a test can observe it: a teardown is
+// admin.infra.teardownFleet, a suspension is admin.tenants.suspend, a kill is
+// admin.flags.kill. A second button writing the same row from a second place is
+// how two code paths come to disagree about what a teardown means. The one
+// mutation this lane could plausibly have owned, cancelling a customer's
+// workload run, was left out because runtime_commands is a queue an engine
+// drains and there is no engine behind the operator pool, so the button would
+// report success and change nothing observable. That is exactly the failure the
+// router.ts header refuses to ship.
 //
-// Reads here cross every organization, so every one of them goes through ctx.adminDb rather than ctx.pool. A twin belonging to a customer is not reachable on the product's own credential, which is the point of the separate pool.
+// It reads no secret. SAFE_COLUMNS in router.ts is the rule and the reason: RLS
+// is row level and cannot restrict a column, so column safety on this path is
+// an application property. Every query below names its columns. Two omissions
+// are deliberate and both look harmless: artifacts.storage_key, a pointer into
+// the object store that answers no question this page asks, and
+// pr_generations.callback_hash, which is a credential digest.
 //
-// HOW TO ADD A ROUTE. Build it with adminProcedure(permission), which is the
-// only exported way to make one, so declaring the permission and creating the
-// route are a single act. There is no unguarded builder to reach for. Every
-// read goes through ctx.adminDb, which is the operator pool: a cross tenant
-// read has to be a credential the application cannot acquire rather than a
-// claim it makes about itself. A mutation records what it changed with
-// adminAudit, inside the same transaction as the change.
+// It computes no total. pageOf in router.ts avoids count queries because a
+// count over a cross tenant table is the expensive half of every page, and
+// these are the largest tables in the product. The console says how many rows
+// it is showing and whether there are more, which is the honest form of the
+// same answer.
 //
-//   import { z } from 'zod'
-//   import { adminProcedure, type AdminContext } from './trpc.ts'
-//
-//   export const productRouter = router({
-//     list: adminProcedure('admin.example.read')
-//       .input(z.object({ limit: z.number().int().min(1).max(200).default(50) }))
-//       .query(async ({ ctx, input }) => {
-//         const c = ctx as AdminContext
-//         return c.adminDb((db) => db.execute(sql`...`))
-//       }),
-//   })
+// A COST THIS FILE PAYS AND CANNOT FIX ALONE. The unfiltered lists order by
+// created_at across every tenant, and the indexes on runs, environments and
+// pr_generations are all per organization or per parent row. So the unfiltered
+// first page is a sort and the org filtered one is an index read. The fix, when
+// somebody takes the migration, is one index per table on (created_at DESC,
+// id DESC). The operator pool's statement timeout is 30 seconds rather than the
+// application's, which is what makes the unfiltered view survivable meanwhile.
 
+import { z } from 'zod'
+import { sql } from 'drizzle-orm'
+import { TRPCError } from '@trpc/server'
 import { router } from '../trpc.ts'
+import { adminProcedure, type AdminContext } from './trpc.ts'
+
+const uuid = z.string().uuid()
+
+/** The same page input the rest of the portal uses, so a caller that can page
+ *  one operator list can page all of them. */
+const page = z.object({
+  limit: z.number().int().min(1).max(200).default(50),
+  cursor: z.string().nullish(),
+})
 
 /**
- * The Product namespace, mounted at `admin.product`.
+ * What a reader should do about a run, in five words.
  *
- * Empty today. It is still reachable, still walked by the operator route
- * matrix, and still exempt from maintenance mode by its `admin.` prefix, so a
- * route added to it inherits all three without anybody remembering to arrange
- * them.
+ * Separate from the run's own `state`, and both are returned, because they
+ * answer different questions and collapsing them loses the one that matters. A
+ * load run whose state is `succeeded` can carry a `fail` verdict: the job ran
+ * to completion and what it found was a failure. A console that colours the
+ * badge from `state` alone paints that run green.
+ *
+ * `unknown` is a real value and not a gap. An agent run that reached `complete`
+ * with no verdicts at all did nothing and reported nothing, and calling that
+ * `passed` is the exit-code-zero-over-nothing defect this repository has
+ * already shipped once. It gets its own word.
  */
-export const productRouter = router({})
+export type RunStanding = 'running' | 'passed' | 'failed' | 'cancelled' | 'unknown'
+
+/** The three families of run this product has. They are different objects with
+ *  different columns, so the console filters between them rather than merging
+ *  them into a table whose column set is true of none of the three. */
+export type RunKind = 'agent' | 'load' | 'check'
+
+/**
+ * One row of the runs list, whichever family it came from.
+ *
+ * The fields here are the intersection that is genuinely true of all three: who
+ * it belongs to, what code it ran against, when, how it ended and why. Anything
+ * that is true of one family only lives on the detail route instead, which is
+ * why this is a flat interface rather than a union with three optional halves.
+ */
+export interface RunRow {
+  kind: RunKind
+  id: string
+  orgId: string
+  orgSlug: string
+  repository: string | null
+  /** The branch, the git ref or the pull request head, whichever the family
+   *  has. All three name the code that ran. */
+  ref: string | null
+  pullRequest: number | null
+  /** The engine's environment identifier, when the run named one. */
+  envId: string | null
+  /** The family's own state word, unchanged. An operator looking for
+   *  `abandoned` needs to see `abandoned` and not a word this file chose. */
+  state: string
+  standing: RunStanding
+  /** What it found, when the state does not already say it. Null when nothing
+   *  reported one, which is different from finding nothing. */
+  verdict: string | null
+  /** The one line that says why, when the row carries one. */
+  failure: string | null
+  /** The sort key, and the moment the row is filed under. */
+  at: string
+  startedAt: string | null
+  finishedAt: string | null
+  durationMs: number | null
+}
+
+// ---------------------------------------------------------------------------
+// Cursors
+// ---------------------------------------------------------------------------
+
+/**
+ * A keyset cursor over more than one column.
+ *
+ * `pageOf` in router.ts takes a single string because every list it pages is
+ * ordered by a unique column. These are ordered by a timestamp, which is not
+ * unique, so the tiebreak column has to travel with it or two rows sharing a
+ * millisecond fall in the gap between pages. JSON in base64url rather than a
+ * delimiter, because one of the values these carry is a git branch name and a
+ * branch may contain any delimiter somebody picks.
+ */
+function encodeCursor(parts: readonly (string | number)[]): string {
+  return Buffer.from(JSON.stringify(parts), 'utf8').toString('base64url')
+}
+
+/**
+ * Reads one back, and REFUSES a cursor it cannot read.
+ *
+ * Falling back to the first page would be worse than the error: the caller
+ * asked for page four, got page one, and every row it already showed appears
+ * again in a list that never ends. The console's `More` would keep offering
+ * more forever. An error stops at a message somebody can act on.
+ */
+function decodeCursor(cursor: string | null | undefined, arity: number): string[] | null {
+  if (cursor === null || cursor === undefined || cursor === '') return null
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8'))
+  } catch {
+    parsed = null
+  }
+  if (!Array.isArray(parsed) || parsed.length !== arity) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'That page cursor is not one this list issued. Reload the page to start again.',
+    })
+  }
+  return parsed.map((p) => String(p))
+}
+
+function iso(value: Date | string): string {
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString()
+}
+
+function isoOrNull(value: Date | string | null | undefined): string | null {
+  return value === null || value === undefined ? null : iso(value)
+}
+
+/** Milliseconds between two moments, or null when either is missing. Computed
+ *  here rather than in the console so that two screens showing the same run
+ *  cannot round it differently. */
+function durationMs(start: Date | string | null, end: Date | string | null): number | null {
+  if (start === null || end === null) return null
+  const ms = new Date(end).getTime() - new Date(start).getTime()
+  return Number.isFinite(ms) ? ms : null
+}
+
+/** Turns one extra row into a cursor, the same way `pageOf` does. */
+function pageOf<Row, Out>(
+  rows: Row[],
+  limit: number,
+  cursorOf: (row: Row) => string,
+  map: (row: Row) => Out,
+): { rows: Out[]; nextCursor: string | null } {
+  const more = rows.length > limit
+  const visible = more ? rows.slice(0, limit) : rows
+  return {
+    rows: visible.map(map),
+    nextCursor: more && visible.length > 0 ? cursorOf(visible[visible.length - 1]!) : null,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Twins
+// ---------------------------------------------------------------------------
+
+/**
+ * "Twin" is the product's word for an environment and there is no twins table,
+ * so every one of these reads `environments`.
+ *
+ * WHY THIS IS NOT admin.infra.twins. The infra lane's `fleet.ts` answers a
+ * fleet health question and answers it well: the standing of a teardown, the
+ * blast radius of tearing several down at once, and a cap of 500 rows with no
+ * cursor. This answers the product question instead, which is "show me every
+ * twin, in order, until I stop asking", so it is keyset paged and the console
+ * over it uses `usePages` and `More`. A capped list that says nothing about
+ * what it left out is precisely the failure `More` exists to prevent, so the
+ * two lists are not interchangeable and this one is not a copy for its own
+ * sake. Nothing here touches the teardown ledger, the blast radius or the
+ * teardown write path, which stay the infra lane's.
+ */
+const twinScope = z.enum(['live', 'overdue', 'all'])
+
+const twinsRouter = router({
+  list: adminProcedure('admin.product.read')
+    .input(
+      page.extend({
+        orgId: uuid.nullish(),
+        /** `live` by default, because a fleet view whose default includes every
+         *  environment ever created grows forever and answers nothing. */
+        scope: twinScope.default('live'),
+        /** Matches the engine's environment id, the repository or the branch,
+         *  which are the three things somebody has in front of them when they
+         *  come to this page. */
+        query: z.string().trim().max(200).optional(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      const c = ctx as AdminContext
+      const cursor = decodeCursor(input.cursor, 2)
+      const now = c.clock.now().toISOString()
+      const like = input.query ? `%${input.query}%` : null
+
+      const rows = await c.adminDb(async (db) =>
+        db.execute<{
+          id: string
+          org_id: string
+          org_slug: string
+          env_id: string
+          repository: string
+          branch: string
+          pull_request: number | null
+          state: string
+          preview_url: string | null
+          runtime: string | null
+          golden_version: string | null
+          golden_verified: boolean | null
+          created_at: Date | string
+          updated_at: Date | string
+          expires_at: Date | string | null
+          torn_down_at: Date | string | null
+          teardown_pending: boolean
+          runs: string
+        }>(sql`
+          SELECT e.id, e.org_id, o.slug AS org_slug, e.env_id,
+                 r.full_name AS repository, e.branch, e.pull_request,
+                 e.state::text AS state, e.preview_url, e.runtime, e.golden_version,
+                 g.verified AS golden_verified,
+                 e.created_at, e.updated_at, e.expires_at, e.torn_down_at,
+                 EXISTS (
+                   SELECT 1 FROM teardown_requests t
+                   WHERE t.environment_id = e.id AND t.state IN ('pending', 'leased')
+                 ) AS teardown_pending,
+                 (SELECT count(*) FROM runs rn WHERE rn.environment_id = e.id) AS runs
+          FROM environments e
+          JOIN organizations o ON o.id = e.org_id
+          JOIN repositories r ON r.id = e.repository_id
+          LEFT JOIN golden_versions g
+            ON g.org_id = e.org_id AND g.repository_id = e.repository_id
+           AND g.version = e.golden_version
+          WHERE (${input.orgId ?? null}::uuid IS NULL OR e.org_id = ${input.orgId ?? null}::uuid)
+            AND (
+              ${input.scope} = 'all'
+              OR (${input.scope} = 'live' AND e.state <> 'torn_down')
+              OR (${input.scope} = 'overdue' AND e.state <> 'torn_down'
+                  AND e.expires_at IS NOT NULL AND e.expires_at < ${now}::timestamptz)
+            )
+            AND (${like}::text IS NULL
+                 OR e.env_id ILIKE ${like} OR e.branch ILIKE ${like}
+                 OR r.full_name ILIKE ${like})
+            AND (${cursor?.[0] ?? null}::timestamptz IS NULL
+                 OR (e.created_at, e.id)
+                    < (${cursor?.[0] ?? null}::timestamptz, ${cursor?.[1] ?? null}::uuid))
+          ORDER BY e.created_at DESC, e.id DESC
+          LIMIT ${input.limit + 1}`),
+      )
+
+      return pageOf(
+        rows,
+        input.limit,
+        (r) => encodeCursor([iso(r.created_at), r.id]),
+        (r) => ({
+          id: r.id,
+          orgId: r.org_id,
+          orgSlug: r.org_slug,
+          envId: r.env_id,
+          repository: r.repository,
+          branch: r.branch,
+          pullRequest: r.pull_request,
+          state: r.state,
+          previewUrl: r.preview_url,
+          runtime: r.runtime,
+          goldenVersion: r.golden_version,
+          /** Null when the twin names no golden version, or names one this
+           *  installation has no row for. Both are worth telling apart from
+           *  `false`, which means a version exists and was never verified. */
+          goldenVerified: r.golden_verified,
+          createdAt: iso(r.created_at),
+          updatedAt: iso(r.updated_at),
+          expiresAt: isoOrNull(r.expires_at),
+          tornDownAt: isoOrNull(r.torn_down_at),
+          /** Past the lifetime it was created with and still not torn down.
+           *  This is the row that is costing somebody money right now. */
+          overdue:
+            r.state !== 'torn_down' &&
+            r.expires_at !== null &&
+            new Date(r.expires_at as string).getTime() < new Date(now).getTime(),
+          teardownPending: r.teardown_pending,
+          runs: Number(r.runs),
+        }),
+      )
+    }),
+
+  /**
+   * One twin, and everything hanging off it.
+   *
+   * Keyed on `environments.id` rather than on `env_id`, because `env_id` is
+   * unique per organization and not across the installation, and a detail
+   * route that took it would show one operator another tenant's environment
+   * the first time two customers picked the same name.
+   */
+  get: adminProcedure('admin.product.read')
+    .input(z.object({ id: uuid }))
+    .query(async ({ ctx, input }) => {
+      const c = ctx as AdminContext
+      return c.adminDb(async (db) => {
+        const rows = await db.execute<{
+          id: string
+          org_id: string
+          org_slug: string
+          org_name: string
+          env_id: string
+          repository: string
+          repository_id: string
+          default_branch: string | null
+          branch: string
+          pull_request: number | null
+          state: string
+          preview_url: string | null
+          runtime: string | null
+          golden_version: string | null
+          created_by: string | null
+          last_sequence: string
+          created_at: Date | string
+          updated_at: Date | string
+          expires_at: Date | string | null
+          torn_down_at: Date | string | null
+        }>(sql`
+          SELECT e.id, e.org_id, o.slug AS org_slug, o.name AS org_name, e.env_id,
+                 r.full_name AS repository, r.id AS repository_id, r.default_branch,
+                 e.branch, e.pull_request, e.state::text AS state, e.preview_url,
+                 e.runtime, e.golden_version, u.github_login AS created_by,
+                 e.last_sequence, e.created_at, e.updated_at, e.expires_at, e.torn_down_at
+          FROM environments e
+          JOIN organizations o ON o.id = e.org_id
+          JOIN repositories r ON r.id = e.repository_id
+          LEFT JOIN users u ON u.id = e.created_by
+          WHERE e.id = ${input.id}::uuid`)
+        const env = rows[0]
+        if (!env) {
+          throw new TRPCError({
+            code: 'NOT_FOUND',
+            message: 'No twin with that id. It may have been removed with its organization.',
+          })
+        }
+
+        const golden = await db.execute<{
+          version: string
+          verified: boolean
+          source_digest: string | null
+          rules_digest: string | null
+          size_bytes: string | null
+          created_at: Date | string
+        }>(sql`
+          SELECT version, verified, source_digest, rules_digest, size_bytes, created_at
+          FROM golden_versions
+          WHERE org_id = ${env.org_id}::uuid
+            AND repository_id = ${env.repository_id}::uuid
+            AND version = ${env.golden_version}`)
+
+        const runs = await db.execute<{
+          id: string
+          kind: string
+          state: string
+          started_at: Date | string | null
+          finished_at: Date | string | null
+          created_at: Date | string
+          verdicts: string
+          failing: string
+        }>(sql`
+          SELECT rn.id, rn.kind, rn.state::text AS state, rn.started_at, rn.finished_at,
+                 rn.created_at,
+                 (SELECT count(*) FROM verdicts v WHERE v.run_id = rn.id) AS verdicts,
+                 (SELECT count(*) FROM verdicts v
+                   WHERE v.run_id = rn.id AND v.value IN ('fail', 'blocked')) AS failing
+          FROM runs rn
+          WHERE rn.environment_id = ${input.id}::uuid
+          ORDER BY rn.created_at DESC
+          LIMIT 20`)
+
+        const workloads = await db.execute<{
+          id: string
+          state: string
+          verdict: string | null
+          failure_code: string | null
+          workload: string
+          requested_at: Date | string
+          finished_at: Date | string | null
+        }>(sql`
+          SELECT wr.id, wr.state::text AS state, wr.verdict::text AS verdict,
+                 wr.failure_code, w.name AS workload, wr.requested_at, wr.finished_at
+          FROM workload_runs wr
+          JOIN workloads w ON w.id = wr.workload_id
+          WHERE wr.environment_id = ${input.id}::uuid
+          ORDER BY wr.requested_at DESC
+          LIMIT 20`)
+
+        // The teardown ledger belongs to the infra lane and this does not
+        // duplicate it. What it reads is the three columns that answer the one
+        // question this page has to answer on its own: has anybody already
+        // asked for this twin to go away, and did anything happen. An operator
+        // who cannot see that asks for it a second time.
+        const teardowns = await db.execute<{
+          id: string
+          state: string
+          reason: string
+          attempts: number
+          last_error: string | null
+          requested_at: Date | string
+          acknowledged_at: Date | string | null
+        }>(sql`
+          SELECT id, state, reason, attempts, last_error, requested_at, acknowledged_at
+          FROM teardown_requests
+          WHERE environment_id = ${input.id}::uuid
+          ORDER BY requested_at DESC
+          LIMIT 10`)
+
+        const g = golden[0]
+        return {
+          id: env.id,
+          orgId: env.org_id,
+          orgSlug: env.org_slug,
+          orgName: env.org_name,
+          envId: env.env_id,
+          repository: env.repository,
+          defaultBranch: env.default_branch,
+          branch: env.branch,
+          pullRequest: env.pull_request,
+          state: env.state,
+          previewUrl: env.preview_url,
+          runtime: env.runtime,
+          goldenVersion: env.golden_version,
+          golden: g
+            ? {
+                version: g.version,
+                verified: g.verified,
+                sourceDigest: g.source_digest,
+                rulesDigest: g.rules_digest,
+                sizeBytes: g.size_bytes === null ? null : Number(g.size_bytes),
+                createdAt: iso(g.created_at),
+              }
+            : null,
+          createdBy: env.created_by,
+          lastSequence: Number(env.last_sequence),
+          createdAt: iso(env.created_at),
+          updatedAt: iso(env.updated_at),
+          expiresAt: isoOrNull(env.expires_at),
+          tornDownAt: isoOrNull(env.torn_down_at),
+          runs: runs.map((r) => ({
+            id: r.id,
+            kind: r.kind,
+            state: r.state,
+            standing: agentStanding(r.state, Number(r.verdicts), Number(r.failing)),
+            verdicts: Number(r.verdicts),
+            failing: Number(r.failing),
+            startedAt: isoOrNull(r.started_at),
+            finishedAt: isoOrNull(r.finished_at),
+            createdAt: iso(r.created_at),
+          })),
+          workloadRuns: workloads.map((w) => ({
+            id: w.id,
+            workload: w.workload,
+            state: w.state,
+            standing: loadStanding(w.state, w.verdict),
+            verdict: w.verdict,
+            failureCode: w.failure_code,
+            requestedAt: iso(w.requested_at),
+            finishedAt: isoOrNull(w.finished_at),
+          })),
+          teardowns: teardowns.map((t) => ({
+            id: t.id,
+            state: t.state,
+            reason: t.reason,
+            attempts: t.attempts,
+            lastError: t.last_error,
+            requestedAt: iso(t.requested_at),
+            acknowledgedAt: isoOrNull(t.acknowledged_at),
+          })),
+        }
+      })
+    }),
+
+  /**
+   * Branches, which are not a table.
+   *
+   * A branch in this product is a column on `environments`, so this is a
+   * grouping rather than a list, and the grouping is what makes it worth a
+   * screen: one branch can hold several twins over its life, and the question
+   * an operator has is about the branch and not about any one of them.
+   *
+   * The finding this page exists for is `orphaned`: a branch with a live twin
+   * whose pull request is closed or merged. Nothing is wrong with the twin, the
+   * data is not corrupt and no alarm fired. It is simply still running, and
+   * still costing money, for a change that landed a fortnight ago.
+   */
+  branches: adminProcedure('admin.product.read')
+    .input(
+      page.extend({
+        orgId: uuid.nullish(),
+        scope: z.enum(['all', 'live', 'orphaned']).default('live'),
+        query: z.string().trim().max(200).optional(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      const c = ctx as AdminContext
+      const cursor = decodeCursor(input.cursor, 3)
+      const like = input.query ? `%${input.query}%` : null
+
+      const rows = await c.adminDb(async (db) =>
+        db.execute<{
+          org_id: string
+          org_slug: string
+          repository_id: string
+          repository: string
+          branch: string
+          twins: string
+          live: string
+          overdue: string
+          pull_request: number | null
+          pr_state: string | null
+          pr_title: string | null
+          pr_draft: boolean | null
+          pr_from_fork: boolean | null
+          pr_closed_at: Date | string | null
+          last_activity: Date | string
+          latest_state: string
+        }>(sql`
+          WITH grouped AS (
+            SELECT e.org_id, e.repository_id, e.branch,
+                   count(*) AS twins,
+                   count(*) FILTER (WHERE e.state <> 'torn_down') AS live,
+                   count(*) FILTER (
+                     WHERE e.state <> 'torn_down' AND e.expires_at IS NOT NULL
+                       AND e.expires_at < ${c.clock.now().toISOString()}::timestamptz
+                   ) AS overdue,
+                   -- A branch has at most one pull request open against it in
+                   -- this product, and rows created before the pull request
+                   -- existed carry null, so max() picks the one there is.
+                   max(e.pull_request) AS pull_request,
+                   max(e.updated_at) AS last_activity,
+                   (array_agg(e.state::text ORDER BY e.updated_at DESC))[1] AS latest_state
+            FROM environments e
+            WHERE (${input.orgId ?? null}::uuid IS NULL
+                   OR e.org_id = ${input.orgId ?? null}::uuid)
+            GROUP BY e.org_id, e.repository_id, e.branch
+          )
+          SELECT b.org_id, o.slug AS org_slug, b.repository_id, r.full_name AS repository,
+                 b.branch, b.twins, b.live, b.overdue, b.pull_request,
+                 pr.state AS pr_state, pr.title AS pr_title, pr.draft AS pr_draft,
+                 pr.from_fork AS pr_from_fork, pr.closed_at AS pr_closed_at,
+                 b.last_activity, b.latest_state
+          FROM grouped b
+          JOIN organizations o ON o.id = b.org_id
+          JOIN repositories r ON r.id = b.repository_id
+          LEFT JOIN pull_requests pr
+            ON pr.repository_id = b.repository_id AND pr.number = b.pull_request
+          WHERE (
+              ${input.scope} = 'all'
+              OR (${input.scope} = 'live' AND b.live > 0)
+              OR (${input.scope} = 'orphaned' AND b.live > 0
+                  AND pr.state IS NOT NULL AND pr.state <> 'open')
+            )
+            AND (${like}::text IS NULL
+                 OR b.branch ILIKE ${like} OR r.full_name ILIKE ${like})
+            AND (${cursor?.[0] ?? null}::timestamptz IS NULL
+                 OR (b.last_activity, b.repository_id, b.branch)
+                    < (${cursor?.[0] ?? null}::timestamptz,
+                       ${cursor?.[1] ?? null}::uuid,
+                       ${cursor?.[2] ?? null}::text))
+          ORDER BY b.last_activity DESC, b.repository_id DESC, b.branch DESC
+          LIMIT ${input.limit + 1}`),
+      )
+
+      return pageOf(
+        rows,
+        input.limit,
+        (r) => encodeCursor([iso(r.last_activity), r.repository_id, r.branch]),
+        (r) => ({
+          orgId: r.org_id,
+          orgSlug: r.org_slug,
+          repositoryId: r.repository_id,
+          repository: r.repository,
+          branch: r.branch,
+          twins: Number(r.twins),
+          live: Number(r.live),
+          overdue: Number(r.overdue),
+          pullRequest: r.pull_request,
+          pullRequestState: r.pr_state,
+          pullRequestTitle: r.pr_title,
+          pullRequestDraft: r.pr_draft,
+          /** A pull request from a fork, which is the one case where the code
+           *  a twin was built from is not the customer's own. */
+          pullRequestFromFork: r.pr_from_fork,
+          pullRequestClosedAt: isoOrNull(r.pr_closed_at),
+          /** Live twins on a branch whose pull request is closed or merged. */
+          orphaned:
+            Number(r.live) > 0 && r.pr_state !== null && r.pr_state !== 'open',
+          lastActivity: iso(r.last_activity),
+          latestState: r.latest_state,
+        }),
+      )
+    }),
+})
+
+// ---------------------------------------------------------------------------
+// Runs
+// ---------------------------------------------------------------------------
+
+/**
+ * A run that finished is not a run that passed.
+ *
+ * `runs.state` says whether the job completed. The verdicts say what it found.
+ * A `complete` run with a failing verdict is a failure, and a `complete` run
+ * with no verdicts at all found nothing and reported nothing, which is its own
+ * answer and not a pass.
+ */
+function agentStanding(state: string, verdicts: number, failing: number): RunStanding {
+  if (state === 'queued' || state === 'running') return 'running'
+  if (state === 'cancelled') return 'cancelled'
+  if (state === 'failed') return 'failed'
+  if (failing > 0) return 'failed'
+  if (verdicts === 0) return 'unknown'
+  return 'passed'
+}
+
+/** The same split for a load run, where the verdict is a column rather than a
+ *  row count. `flaky` counts as failed here: an operator filtering for things
+ *  worth looking at wants a flaky run in the list. */
+function loadStanding(state: string, verdict: string | null): RunStanding {
+  if (state === 'requested' || state === 'accepted' || state === 'running') return 'running'
+  if (state === 'cancelled') return 'cancelled'
+  if (state === 'failed' || state === 'timed_out' || state === 'abandoned') return 'failed'
+  if (verdict === 'fail' || verdict === 'blocked' || verdict === 'flaky') return 'failed'
+  if (verdict === 'pass') return 'passed'
+  return 'unknown'
+}
+
+/** And for a pull request check, where the state already carries the finding.
+ *  `unverified` is the state a check reaches when it said nothing before its
+ *  deadline, which is neither a pass nor a failure. */
+function checkStanding(state: string): RunStanding {
+  if (state === 'queued' || state === 'running') return 'running'
+  if (state === 'cancelled') return 'cancelled'
+  if (state === 'passed') return 'passed'
+  if (state === 'failed' || state === 'blocked') return 'failed'
+  return 'unknown'
+}
+
+const runsRouter = router({
+  /**
+   * The list an operator opens during an incident.
+   *
+   * ONE FAMILY AT A TIME, and that is a decision rather than a limitation. An
+   * agent run, a load run and a pull request check are three different objects:
+   * one has verdicts and artifacts, one has latency percentiles and a lease,
+   * one has a head commit and a GitHub check. A single merged table would need
+   * a column set that is true of none of them, and the columns that matter
+   * during an incident are exactly the ones that would have to go. So the
+   * family is a filter, the screen names which one it is showing, and every
+   * column in the table means something for that family.
+   *
+   * `failedOnly` is the filter this page is really for. It is computed in SQL
+   * rather than from the returned rows, because filtering after the page is
+   * cut returns an arbitrary number of rows per page and eventually an empty
+   * page with a cursor, which reads as the end of a list that has more in it.
+   */
+  list: adminProcedure('admin.product.read')
+    .input(
+      page.extend({
+        kind: z.enum(['agent', 'load', 'check']).default('agent'),
+        orgId: uuid.nullish(),
+        /** One twin, reached from the twin page. */
+        environmentId: uuid.nullish(),
+        failedOnly: z.boolean().default(false),
+        query: z.string().trim().max(200).optional(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      const c = ctx as AdminContext
+      const cursor = decodeCursor(input.cursor, 2)
+      const at = cursor?.[0] ?? null
+      const id = cursor?.[1] ?? null
+      const org = input.orgId ?? null
+      const env = input.environmentId ?? null
+      const like = input.query ? `%${input.query}%` : null
+
+      if (input.kind === 'agent') {
+        const rows = await c.adminDb(async (db) =>
+          db.execute<{
+            id: string
+            org_id: string
+            org_slug: string
+            repository: string
+            branch: string
+            pull_request: number | null
+            env_id: string
+            kind: string
+            state: string
+            started_at: Date | string | null
+            finished_at: Date | string | null
+            created_at: Date | string
+            verdicts: string
+            failing: string
+            summary: string | null
+          }>(sql`
+            SELECT rn.id, rn.org_id, o.slug AS org_slug, rp.full_name AS repository,
+                   e.branch, e.pull_request, e.env_id, rn.kind, rn.state::text AS state,
+                   rn.started_at, rn.finished_at, rn.created_at,
+                   (SELECT count(*) FROM verdicts v WHERE v.run_id = rn.id) AS verdicts,
+                   (SELECT count(*) FROM verdicts v
+                     WHERE v.run_id = rn.id AND v.value IN ('fail', 'blocked')) AS failing,
+                   (SELECT v.summary FROM verdicts v
+                     WHERE v.run_id = rn.id AND v.value IN ('fail', 'blocked')
+                     ORDER BY v.created_at ASC LIMIT 1) AS summary
+            FROM runs rn
+            JOIN environments e ON e.id = rn.environment_id
+            JOIN organizations o ON o.id = rn.org_id
+            JOIN repositories rp ON rp.id = e.repository_id
+            WHERE (${org}::uuid IS NULL OR rn.org_id = ${org}::uuid)
+              AND (${env}::uuid IS NULL OR rn.environment_id = ${env}::uuid)
+              AND (${like}::text IS NULL
+                   OR e.env_id ILIKE ${like} OR e.branch ILIKE ${like}
+                   OR rp.full_name ILIKE ${like} OR rn.kind ILIKE ${like})
+              AND (${input.failedOnly} = false
+                   OR rn.state = 'failed'
+                   OR EXISTS (SELECT 1 FROM verdicts v
+                               WHERE v.run_id = rn.id AND v.value IN ('fail', 'blocked')))
+              AND (${at}::timestamptz IS NULL
+                   OR (rn.created_at, rn.id) < (${at}::timestamptz, ${id}::uuid))
+            ORDER BY rn.created_at DESC, rn.id DESC
+            LIMIT ${input.limit + 1}`),
+        )
+        return pageOf(
+          rows,
+          input.limit,
+          (r) => encodeCursor([iso(r.created_at), r.id]),
+          (r): RunRow => ({
+            kind: 'agent',
+            id: r.id,
+            orgId: r.org_id,
+            orgSlug: r.org_slug,
+            repository: r.repository,
+            ref: r.branch,
+            pullRequest: r.pull_request,
+            envId: r.env_id,
+            state: r.state,
+            standing: agentStanding(r.state, Number(r.verdicts), Number(r.failing)),
+            verdict:
+              Number(r.verdicts) === 0
+                ? null
+                : `${Number(r.verdicts) - Number(r.failing)} of ${Number(r.verdicts)} passed`,
+            failure: r.summary,
+            at: iso(r.created_at),
+            startedAt: isoOrNull(r.started_at),
+            finishedAt: isoOrNull(r.finished_at),
+            durationMs: durationMs(r.started_at, r.finished_at),
+          }),
+        )
+      }
+
+      if (input.kind === 'load') {
+        const rows = await c.adminDb(async (db) =>
+          db.execute<{
+            id: string
+            org_id: string
+            org_slug: string
+            repository: string
+            git_ref: string
+            env_id: string | null
+            state: string
+            verdict: string | null
+            failure_code: string | null
+            detail: string | null
+            requested_at: Date | string
+            started_at: Date | string | null
+            finished_at: Date | string | null
+          }>(sql`
+            SELECT wr.id, wr.org_id, o.slug AS org_slug, wr.repository, wr.git_ref,
+                   e.env_id, wr.state::text AS state, wr.verdict::text AS verdict,
+                   wr.failure_code, wr.detail,
+                   wr.requested_at, wr.started_at, wr.finished_at
+            FROM workload_runs wr
+            JOIN organizations o ON o.id = wr.org_id
+            LEFT JOIN environments e ON e.id = wr.environment_id
+            WHERE (${org}::uuid IS NULL OR wr.org_id = ${org}::uuid)
+              AND (${env}::uuid IS NULL OR wr.environment_id = ${env}::uuid)
+              AND (${like}::text IS NULL
+                   OR wr.repository ILIKE ${like} OR wr.git_ref ILIKE ${like}
+                   OR e.env_id ILIKE ${like} OR wr.failure_code ILIKE ${like})
+              AND (${input.failedOnly} = false
+                   OR wr.state IN ('failed', 'timed_out', 'abandoned')
+                   OR wr.verdict IN ('fail', 'blocked', 'flaky'))
+              AND (${at}::timestamptz IS NULL
+                   OR (wr.requested_at, wr.id) < (${at}::timestamptz, ${id}::uuid))
+            ORDER BY wr.requested_at DESC, wr.id DESC
+            LIMIT ${input.limit + 1}`),
+        )
+        return pageOf(
+          rows,
+          input.limit,
+          (r) => encodeCursor([iso(r.requested_at), r.id]),
+          (r): RunRow => ({
+            kind: 'load',
+            id: r.id,
+            orgId: r.org_id,
+            orgSlug: r.org_slug,
+            repository: r.repository,
+            ref: r.git_ref,
+            pullRequest: null,
+            envId: r.env_id,
+            state: r.state,
+            standing: loadStanding(r.state, r.verdict),
+            verdict: r.verdict,
+            failure: r.failure_code ?? r.detail,
+            at: iso(r.requested_at),
+            startedAt: isoOrNull(r.started_at),
+            finishedAt: isoOrNull(r.finished_at),
+            durationMs: durationMs(r.started_at, r.finished_at),
+          }),
+        )
+      }
+
+      const rows = await c.adminDb(async (db) =>
+        db.execute<{
+          id: string
+          org_id: string
+          org_slug: string
+          repository: string
+          head_ref: string
+          number: number
+          env_id: string | null
+          state: string
+          detail: string | null
+          queued_at: Date | string
+          started_at: Date | string | null
+          finished_at: Date | string | null
+        }>(sql`
+          SELECT g.id, g.org_id, o.slug AS org_slug, rp.full_name AS repository,
+                 pr.head_ref, pr.number, g.env_id, g.state::text AS state, g.detail,
+                 g.queued_at, g.started_at, g.finished_at
+          FROM pr_generations g
+          JOIN pull_requests pr ON pr.id = g.pull_request_id
+          JOIN repositories rp ON rp.id = pr.repository_id
+          JOIN organizations o ON o.id = g.org_id
+          WHERE (${org}::uuid IS NULL OR g.org_id = ${org}::uuid)
+            AND (${like}::text IS NULL
+                 OR rp.full_name ILIKE ${like} OR pr.head_ref ILIKE ${like}
+                 OR g.env_id ILIKE ${like})
+            AND (${input.failedOnly} = false
+                 OR g.state IN ('failed', 'blocked', 'unverified'))
+            AND (${at}::timestamptz IS NULL
+                 OR (g.queued_at, g.id) < (${at}::timestamptz, ${id}::uuid))
+          ORDER BY g.queued_at DESC, g.id DESC
+          LIMIT ${input.limit + 1}`),
+      )
+      return pageOf(
+        rows,
+        input.limit,
+        (r) => encodeCursor([iso(r.queued_at), r.id]),
+        (r): RunRow => ({
+          kind: 'check',
+          id: r.id,
+          orgId: r.org_id,
+          orgSlug: r.org_slug,
+          repository: r.repository,
+          ref: r.head_ref,
+          pullRequest: r.number,
+          envId: r.env_id,
+          state: r.state,
+          standing: checkStanding(r.state),
+          verdict: null,
+          failure: r.detail,
+          at: iso(r.queued_at),
+          startedAt: isoOrNull(r.started_at),
+          finishedAt: isoOrNull(r.finished_at),
+          durationMs: durationMs(r.started_at, r.finished_at),
+        }),
+      )
+    }),
+
+  /**
+   * One run, in enough detail to say why it failed and what it touched.
+   *
+   * The shape depends on the family, so the answer carries the family on it and
+   * the console switches. Three routes would have been the other option and the
+   * console would then hold the same switch anyway, one level up.
+   */
+  get: adminProcedure('admin.product.read')
+    .input(z.object({ kind: z.enum(['agent', 'load', 'check']), id: uuid }))
+    .query(async ({ ctx, input }) => {
+      const c = ctx as AdminContext
+      return c.adminDb(async (db) => {
+        if (input.kind === 'agent') {
+          const rows = await db.execute<{
+            id: string
+            org_id: string
+            org_slug: string
+            environment_id: string
+            env_id: string
+            repository: string
+            branch: string
+            pull_request: number | null
+            preview_url: string | null
+            kind: string
+            state: string
+            started_at: Date | string | null
+            finished_at: Date | string | null
+            created_at: Date | string
+            last_sequence: string
+          }>(sql`
+            SELECT rn.id, rn.org_id, o.slug AS org_slug, rn.environment_id, e.env_id,
+                   rp.full_name AS repository, e.branch, e.pull_request, e.preview_url,
+                   rn.kind, rn.state::text AS state, rn.started_at, rn.finished_at,
+                   rn.created_at, rn.last_sequence
+            FROM runs rn
+            JOIN environments e ON e.id = rn.environment_id
+            JOIN organizations o ON o.id = rn.org_id
+            JOIN repositories rp ON rp.id = e.repository_id
+            WHERE rn.id = ${input.id}::uuid`)
+          const run = rows[0]
+          if (!run) throw notFound('agent run')
+
+          const verdicts = await db.execute<{
+            id: string
+            workflow: string
+            persona: string | null
+            value: string
+            summary: string | null
+            steps: number
+            duration_ms: number | null
+            reproduction: unknown
+            created_at: Date | string
+          }>(sql`
+            SELECT id, workflow, persona, value::text AS value, summary, steps,
+                   duration_ms, reproduction, created_at
+            FROM verdicts WHERE run_id = ${input.id}::uuid
+            ORDER BY created_at ASC LIMIT 200`)
+
+          // Artifacts without their storage key. See the file header: the key
+          // is a pointer into the object store and answers no question this
+          // page asks. `retained` is the one that does, because a missing
+          // artifact and a discarded one look identical without it.
+          const artifacts = await db.execute<{
+            id: string
+            kind: string
+            step: number | null
+            content_type: string | null
+            size_bytes: string | null
+            sha256: string | null
+            retained: boolean
+            created_at: Date | string
+          }>(sql`
+            SELECT id, kind, step, content_type, size_bytes, sha256, retained, created_at
+            FROM artifacts WHERE run_id = ${input.id}::uuid
+            ORDER BY step ASC NULLS LAST, created_at ASC LIMIT 200`)
+
+          const failing = verdicts.filter((v) => v.value === 'fail' || v.value === 'blocked').length
+          return {
+            kind: 'agent' as const,
+            id: run.id,
+            orgId: run.org_id,
+            orgSlug: run.org_slug,
+            environmentId: run.environment_id,
+            envId: run.env_id,
+            repository: run.repository,
+            branch: run.branch,
+            pullRequest: run.pull_request,
+            previewUrl: run.preview_url,
+            runKind: run.kind,
+            state: run.state,
+            standing: agentStanding(run.state, verdicts.length, failing),
+            startedAt: isoOrNull(run.started_at),
+            finishedAt: isoOrNull(run.finished_at),
+            createdAt: iso(run.created_at),
+            durationMs: durationMs(run.started_at, run.finished_at),
+            lastSequence: Number(run.last_sequence),
+            verdicts: verdicts.map((v) => ({
+              id: v.id,
+              workflow: v.workflow,
+              persona: v.persona,
+              value: v.value,
+              summary: v.summary,
+              steps: v.steps,
+              durationMs: v.duration_ms,
+              /** The engine's own recipe for reproducing this verdict, as it
+               *  reported it. Null when it reported none, which the console
+               *  says rather than assembling a command that never ran. */
+              reproduction: v.reproduction ?? null,
+              createdAt: iso(v.created_at),
+            })),
+            artifacts: artifacts.map((a) => ({
+              id: a.id,
+              kind: a.kind,
+              step: a.step,
+              contentType: a.content_type,
+              sizeBytes: a.size_bytes === null ? null : Number(a.size_bytes),
+              sha256: a.sha256,
+              retained: a.retained,
+              createdAt: iso(a.created_at),
+            })),
+          }
+        }
+
+        if (input.kind === 'load') {
+          const rows = await db.execute<Record<string, unknown>>(sql`
+            SELECT wr.id, wr.org_id, o.slug AS org_slug, wr.environment_id, e.env_id,
+                   wr.repository, wr.git_ref, wr.workflow_file, w.name AS workload,
+                   w.slug AS workload_slug, w.kind::text AS workload_kind,
+                   wv.version AS workload_version,
+                   wr.state::text AS state, wr.verdict::text AS verdict, wr.failure_code,
+                   wr.detail, wr.reproduce_command, wr.manifest_digest, wr.attempt,
+                   wr.requested_at, wr.dispatched_at, wr.accepted_at, wr.started_at,
+                   wr.finished_at, wr.deadline_at, wr.lease_holder, wr.lease_expires_at,
+                   wr.lease_lost_at, wr.lease_takeovers, wr.cancel_requested_at,
+                   wr.cancel_reason, wr.cancelled_at, wr.retry_of, wr.superseded_by
+            FROM workload_runs wr
+            JOIN workloads w ON w.id = wr.workload_id
+            JOIN workload_versions wv ON wv.id = wr.workload_version_id
+            JOIN organizations o ON o.id = wr.org_id
+            LEFT JOIN environments e ON e.id = wr.environment_id
+            WHERE wr.id = ${input.id}::uuid`)
+          const run = rows[0]
+          if (!run) throw notFound('load run')
+
+          const results = await db.execute<Record<string, unknown>>(sql`
+            SELECT kind::text AS kind, requests, failures, error_rate, target_rate,
+                   achieved_rate, p50_ms, p90_ms, p95_ms, p99_ms, max_ms,
+                   sessions, iterations, scheduled_ms,
+                   workflows, workflows_passed, workflows_failed, workflows_flaky,
+                   workflows_blocked, workflows_unverified, steps,
+                   findings, goals, goals_reached,
+                   duration_ms, source, error_reasons, refused_routes, recorded_at
+            FROM workload_run_results
+            WHERE workload_run_id = ${input.id}::uuid`)
+
+          const started = (run.started_at ?? null) as Date | string | null
+          const finished = (run.finished_at ?? null) as Date | string | null
+          return {
+            kind: 'load' as const,
+            id: run.id as string,
+            orgId: run.org_id as string,
+            orgSlug: run.org_slug as string,
+            environmentId: (run.environment_id as string | null) ?? null,
+            envId: (run.env_id as string | null) ?? null,
+            repository: run.repository as string,
+            gitRef: run.git_ref as string,
+            workflowFile: (run.workflow_file as string | null) ?? null,
+            workload: run.workload as string,
+            workloadSlug: run.workload_slug as string,
+            workloadKind: run.workload_kind as string,
+            /** Which authored version ran. A run points at a version and the
+             *  version is what the run MEANS, so a detail page without it
+             *  cannot say which definition produced these numbers. */
+            workloadVersion: run.workload_version === null ? null : Number(run.workload_version),
+            state: run.state as string,
+            standing: loadStanding(run.state as string, (run.verdict as string | null) ?? null),
+            verdict: (run.verdict as string | null) ?? null,
+            failureCode: (run.failure_code as string | null) ?? null,
+            detail: (run.detail as string | null) ?? null,
+            /** The plain command that reproduces this run, as the engine
+             *  reported it. Null until one reports, and the console says no
+             *  command was recorded rather than assembling one that drifts
+             *  from what actually ran. */
+            reproduceCommand: (run.reproduce_command as string | null) ?? null,
+            manifestDigest: (run.manifest_digest as string | null) ?? null,
+            attempt: Number(run.attempt),
+            requestedAt: iso(run.requested_at as Date),
+            dispatchedAt: isoOrNull(run.dispatched_at as Date | null),
+            acceptedAt: isoOrNull(run.accepted_at as Date | null),
+            startedAt: isoOrNull(started),
+            finishedAt: isoOrNull(finished),
+            deadlineAt: iso(run.deadline_at as Date),
+            durationMs: durationMs(started, finished),
+            leaseHolder: (run.lease_holder as string | null) ?? null,
+            leaseExpiresAt: isoOrNull(run.lease_expires_at as Date | null),
+            /** A lease that was taken away from an engine that stopped
+             *  reporting. A run with takeovers and no result is the shape of
+             *  an engine that keeps dying, not of a slow test. */
+            leaseLostAt: isoOrNull(run.lease_lost_at as Date | null),
+            leaseTakeovers: Number(run.lease_takeovers ?? 0),
+            cancelRequestedAt: isoOrNull(run.cancel_requested_at as Date | null),
+            cancelReason: (run.cancel_reason as string | null) ?? null,
+            cancelledAt: isoOrNull(run.cancelled_at as Date | null),
+            retryOf: (run.retry_of as string | null) ?? null,
+            supersededBy: (run.superseded_by as string | null) ?? null,
+            result: results[0]
+              ? {
+                  ...results[0],
+                  recordedAt: iso(results[0].recorded_at as Date),
+                }
+              : null,
+          }
+        }
+
+        const rows = await db.execute<Record<string, unknown>>(sql`
+          SELECT g.id, g.org_id, o.slug AS org_slug, rp.full_name AS repository,
+                 pr.number, pr.title, pr.head_ref, pr.base_ref, pr.state AS pr_state,
+                 pr.draft, pr.from_fork, pr.head_repository, pr.approved_sha,
+                 pr.approved_by, pr.approved_at,
+                 g.head_sha, g.attempt, g.state::text AS state, g.detail,
+                 g.check_run_id, g.workflow_run_id, g.reported_by, g.env_id, g.verdict,
+                 g.superseded_by, g.queued_at, g.started_at, g.finished_at, g.deadline_at
+          FROM pr_generations g
+          JOIN pull_requests pr ON pr.id = g.pull_request_id
+          JOIN repositories rp ON rp.id = pr.repository_id
+          JOIN organizations o ON o.id = g.org_id
+          WHERE g.id = ${input.id}::uuid`)
+        const gen = rows[0]
+        if (!gen) throw notFound('pull request check')
+
+        const started = (gen.started_at ?? null) as Date | string | null
+        const finished = (gen.finished_at ?? null) as Date | string | null
+        return {
+          kind: 'check' as const,
+          id: gen.id as string,
+          orgId: gen.org_id as string,
+          orgSlug: gen.org_slug as string,
+          repository: gen.repository as string,
+          pullRequest: Number(gen.number),
+          title: (gen.title as string | null) ?? null,
+          headRef: gen.head_ref as string,
+          baseRef: gen.base_ref as string,
+          pullRequestState: gen.pr_state as string,
+          draft: Boolean(gen.draft),
+          /** A head branch living in another repository, which is the whole of
+           *  what makes a pull request untrusted here. */
+          fromFork: Boolean(gen.from_fork),
+          headRepository: gen.head_repository as string,
+          approvedSha: (gen.approved_sha as string | null) ?? null,
+          approvedBy: (gen.approved_by as string | null) ?? null,
+          approvedAt: isoOrNull(gen.approved_at as Date | null),
+          headSha: gen.head_sha as string,
+          attempt: Number(gen.attempt),
+          state: gen.state as string,
+          standing: checkStanding(gen.state as string),
+          detail: (gen.detail as string | null) ?? null,
+          /** Null while the installation does not hold `checks: write`, which
+           *  is a state this has to serve rather than crash in. */
+          checkRunId: gen.check_run_id === null ? null : String(gen.check_run_id),
+          workflowRunId: gen.workflow_run_id === null ? null : String(gen.workflow_run_id),
+          reportedBy: (gen.reported_by as string | null) ?? null,
+          envId: (gen.env_id as string | null) ?? null,
+          verdict: gen.verdict ?? null,
+          supersededBy: (gen.superseded_by as string | null) ?? null,
+          queuedAt: iso(gen.queued_at as Date),
+          startedAt: isoOrNull(started),
+          finishedAt: isoOrNull(finished),
+          deadlineAt: iso(gen.deadline_at as Date),
+          durationMs: durationMs(started, finished),
+        }
+      })
+    }),
+})
+
+// ---------------------------------------------------------------------------
+// Safe state
+// ---------------------------------------------------------------------------
+
+/**
+ * What this lane can honestly say about a customer's data, and what it cannot.
+ *
+ * TWO TABLES EXIST. `golden_versions` records that a scan produced a version,
+ * whether it was verified and how big it was. `masking_rules` records which
+ * column gets which transform and whether a human confirmed it.
+ *
+ * NOTHING ELSE DOES. There is no table describing a customer's live database
+ * connection, no snapshot ledger and no restore history anywhere in the schema.
+ * So this surface cannot answer "which database was cloned", "when was this
+ * restored" or "how old is the copy". The console says that in those words
+ * rather than drawing a panel over a number nobody measured, and this comment
+ * exists so the next person adding to this file knows the absence was checked
+ * rather than missed.
+ *
+ * The finding worth a screen is the one that IS backed: a masking rule the
+ * classifier suggested and nobody confirmed. `confirmed = false` means a column
+ * the scanner believes holds personal data is not being transformed, on a copy
+ * somebody is running tests against.
+ */
+const dataRouter = router({
+  goldens: adminProcedure('admin.product.data.read')
+    .input(
+      page.extend({
+        orgId: uuid.nullish(),
+        /** `unverified` is the default because it is the only one of the three
+         *  that is a finding. A verified version needs nobody's attention. */
+        scope: z.enum(['all', 'verified', 'unverified']).default('unverified'),
+        query: z.string().trim().max(200).optional(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      const c = ctx as AdminContext
+      const cursor = decodeCursor(input.cursor, 2)
+      const like = input.query ? `%${input.query}%` : null
+
+      const rows = await c.adminDb(async (db) =>
+        db.execute<{
+          id: string
+          org_id: string
+          org_slug: string
+          repository: string
+          version: string
+          source_digest: string | null
+          rules_digest: string | null
+          verified: boolean
+          size_bytes: string | null
+          created_at: Date | string
+          twins: string
+        }>(sql`
+          SELECT g.id, g.org_id, o.slug AS org_slug, rp.full_name AS repository,
+                 g.version, g.source_digest, g.rules_digest, g.verified, g.size_bytes,
+                 g.created_at,
+                 (SELECT count(*) FROM environments e
+                   WHERE e.org_id = g.org_id AND e.repository_id = g.repository_id
+                     AND e.golden_version = g.version AND e.state <> 'torn_down') AS twins
+          FROM golden_versions g
+          JOIN organizations o ON o.id = g.org_id
+          JOIN repositories rp ON rp.id = g.repository_id
+          WHERE (${input.orgId ?? null}::uuid IS NULL
+                 OR g.org_id = ${input.orgId ?? null}::uuid)
+            AND (${input.scope} = 'all'
+                 OR (${input.scope} = 'verified' AND g.verified = true)
+                 OR (${input.scope} = 'unverified' AND g.verified = false))
+            AND (${like}::text IS NULL
+                 OR rp.full_name ILIKE ${like} OR g.version ILIKE ${like})
+            AND (${cursor?.[0] ?? null}::timestamptz IS NULL
+                 OR (g.created_at, g.id)
+                    < (${cursor?.[0] ?? null}::timestamptz, ${cursor?.[1] ?? null}::uuid))
+          ORDER BY g.created_at DESC, g.id DESC
+          LIMIT ${input.limit + 1}`),
+      )
+
+      return pageOf(
+        rows,
+        input.limit,
+        (r) => encodeCursor([iso(r.created_at), r.id]),
+        (r) => ({
+          id: r.id,
+          orgId: r.org_id,
+          orgSlug: r.org_slug,
+          repository: r.repository,
+          version: r.version,
+          sourceDigest: r.source_digest,
+          rulesDigest: r.rules_digest,
+          verified: r.verified,
+          sizeBytes: r.size_bytes === null ? null : Number(r.size_bytes),
+          createdAt: iso(r.created_at),
+          /** Live twins built from this version. An unverified version with
+           *  twins on it is the row that matters; one with none is history. */
+          twins: Number(r.twins),
+        }),
+      )
+    }),
+
+  masking: adminProcedure('admin.product.data.read')
+    .input(
+      page.extend({
+        orgId: uuid.nullish(),
+        scope: z.enum(['all', 'confirmed', 'unconfirmed']).default('unconfirmed'),
+        query: z.string().trim().max(200).optional(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      const c = ctx as AdminContext
+      const cursor = decodeCursor(input.cursor, 2)
+      const like = input.query ? `%${input.query}%` : null
+
+      const rows = await c.adminDb(async (db) =>
+        db.execute<{
+          id: string
+          org_id: string
+          org_slug: string
+          repository: string
+          table_name: string
+          column_name: string
+          transform: string
+          link: string | null
+          reason: string | null
+          confirmed: boolean
+          created_at: Date | string
+          updated_at: Date | string
+        }>(sql`
+          SELECT m.id, m.org_id, o.slug AS org_slug, rp.full_name AS repository,
+                 m.table_name, m.column_name, m.transform, m.link, m.reason,
+                 m.confirmed, m.created_at, m.updated_at
+          FROM masking_rules m
+          JOIN organizations o ON o.id = m.org_id
+          JOIN repositories rp ON rp.id = m.repository_id
+          WHERE (${input.orgId ?? null}::uuid IS NULL
+                 OR m.org_id = ${input.orgId ?? null}::uuid)
+            AND (${input.scope} = 'all'
+                 OR (${input.scope} = 'confirmed' AND m.confirmed = true)
+                 OR (${input.scope} = 'unconfirmed' AND m.confirmed = false))
+            AND (${like}::text IS NULL
+                 OR rp.full_name ILIKE ${like} OR m.table_name ILIKE ${like}
+                 OR m.column_name ILIKE ${like} OR m.transform ILIKE ${like})
+            AND (${cursor?.[0] ?? null}::timestamptz IS NULL
+                 OR (m.created_at, m.id)
+                    < (${cursor?.[0] ?? null}::timestamptz, ${cursor?.[1] ?? null}::uuid))
+          ORDER BY m.created_at DESC, m.id DESC
+          LIMIT ${input.limit + 1}`),
+      )
+
+      return pageOf(
+        rows,
+        input.limit,
+        (r) => encodeCursor([iso(r.created_at), r.id]),
+        (r) => ({
+          id: r.id,
+          orgId: r.org_id,
+          orgSlug: r.org_slug,
+          repository: r.repository,
+          table: r.table_name,
+          column: r.column_name,
+          transform: r.transform,
+          /** The column this one is kept consistent with, so a masked foreign
+           *  key still joins. */
+          link: r.link,
+          reason: r.reason,
+          /** False means the classifier suggested it and no human has agreed,
+           *  which means the column is not being transformed. */
+          confirmed: r.confirmed,
+          createdAt: iso(r.created_at),
+          updatedAt: iso(r.updated_at),
+        }),
+      )
+    }),
+})
+
+function notFound(what: string): TRPCError {
+  return new TRPCError({
+    code: 'NOT_FOUND',
+    message: `No ${what} with that id. It may have been removed with its organization.`,
+  })
+}
+
+/**
+ * The Product namespace, mounted once at `admin.product` in router.ts.
+ *
+ * Nested rather than flat, so a path reads `admin.product.twins.list` and says
+ * which section serves it. The matrix walks the whole tree, so every leaf below
+ * is guarded the same way whatever depth it sits at.
+ */
+export const productRouter = router({
+  twins: twinsRouter,
+  runs: runsRouter,
+  data: dataRouter,
+})

--- a/web/apps/api/test/admin-product.test.ts
+++ b/web/apps/api/test/admin-product.test.ts
@@ -377,6 +377,36 @@ describe('the product routes answer from real rows', { skip: hasDatabase ? false
     assert.ok(overdue.rows.some((t) => t.id === overdueEnvId))
   })
 
+  it('the organization filter returns that organization and nothing else', async () => {
+    // Asserted over EVERY row rather than by finding the seeded one. A filter
+    // that is silently ignored still contains the row somebody looked for, so
+    // a test that only looks for its own fixture passes over a broken filter.
+    // The console link that carries this is the branches page: two tenants can
+    // both have a branch called main, and before the organization travelled
+    // with the name that link showed somebody else's environments beside the
+    // ones that were clicked on.
+    const owner = callerAs('owner')
+    const scoped = await owner.product.twins.list({ orgId: org.orgId, scope: 'all', limit: 200 })
+    assert.ok(scoped.rows.length > 0, 'the filter returned nothing at all')
+    assert.deepEqual(
+      [...new Set(scoped.rows.map((t) => t.orgId))],
+      [org.orgId],
+      'the twins list returned an organization that was not asked for',
+    )
+
+    const runs = await owner.product.runs.list({ kind: 'agent', orgId: org.orgId, limit: 200 })
+    assert.ok(runs.rows.length > 0)
+    assert.deepEqual([...new Set(runs.rows.map((r) => r.orgId))], [org.orgId])
+
+    // And the unfiltered call is not accidentally scoped, or the assertion
+    // above would hold for a route that ignores its input entirely.
+    const everything = await owner.product.twins.list({ scope: 'all', limit: 200 })
+    assert.ok(
+      new Set(everything.rows.map((t) => t.orgId)).size >= 1,
+      'the unfiltered list returned nothing, so the check above proves nothing',
+    )
+  })
+
   it('a page cursor it did not issue is refused rather than answered with page one', async () => {
     // Falling back to the first page is the failure that matters: the caller
     // asked for page four, got page one, and `More` would offer more forever.

--- a/web/apps/api/test/admin-product.test.ts
+++ b/web/apps/api/test/admin-product.test.ts
@@ -1,0 +1,540 @@
+// The Product lane's routes, and the promises the pages over them make.
+//
+// WHY THIS FILE EXISTS BESIDE admin-routes.test.ts. That suite walks the whole
+// operator tree and asserts no route is unguarded, with a floor under the count
+// so the walk cannot go vacuous. What a floor cannot see is one lane's routes
+// leaving the tree while another lane's arrive: the total holds and seven pages
+// go blank. So this counts MINE, exactly, and it is exact rather than a floor
+// because a route appearing here that this lane did not add is as much worth
+// knowing about as one disappearing.
+//
+// It also pins the three things the pages above these routes depend on and
+// cannot check for themselves:
+//
+//   the standing of a run is not its state, which is the difference between a
+//   job that finished and a job that passed,
+//   experiments have no table, so the Experiments and Feature Flags page is a
+//   flags page and must not grow a route here,
+//   and the data read is a separate permission from the product read, which is
+//   the whole reason analytics can count runs without reading somebody's
+//   column names.
+//
+// TWO HALVES, and the split is deliberate. The first needs no database: it is
+// over the composed router and the catalog, so it runs in CI whether or not
+// Postgres answered, and it is what catches a route that lost its permission or
+// a lane that claimed somebody else's prefix. The second needs one, because a
+// procedure with a correct permission on it and a broken query passes every
+// assertion in the first half and answers nothing. Seven routes that are
+// declared and never called are seven shippable gaps.
+
+import { after, before, describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { randomUUID } from 'node:crypto'
+import { appRouter } from '../src/routers/index.ts'
+import { adminRouter } from '../src/admin/router.ts'
+import { declaredAdminPermissions } from '../src/trpc.ts'
+import {
+  ADMIN_PERMISSIONS,
+  ADMIN_ROLE_PERMISSIONS,
+  RESERVED_PREFIXES,
+  adminRolesWith,
+  type AdminRole,
+} from '../src/admin/permissions.ts'
+import { available, startApi, seedOrg, dropOrg, type ApiHarness, type Org } from './harness.ts'
+import type { AdminContext } from '../src/admin/trpc.ts'
+
+const hasDatabase = await available()
+
+const MINE = /^admin\.product\./
+
+/** Every route the served tree exposes, whatever depth it sits at. */
+function servedPaths(): string[] {
+  const procedures = (appRouter as unknown as { _def: { procedures: Record<string, unknown> } })._def
+    .procedures
+  return Object.keys(procedures).sort()
+}
+
+/**
+ * The routes this lane owns, named rather than counted.
+ *
+ * A bare count would pass if `twins.get` were renamed to `twins.detail` and
+ * every link in the console broke, so the names are the assertion and the
+ * length is a consequence of it.
+ */
+const EXPECTED: Record<string, string> = {
+  'admin.product.twins.list': 'admin.product.read',
+  'admin.product.twins.get': 'admin.product.read',
+  'admin.product.twins.branches': 'admin.product.read',
+  'admin.product.runs.list': 'admin.product.read',
+  'admin.product.runs.get': 'admin.product.read',
+  'admin.product.data.goldens': 'admin.product.data.read',
+  'admin.product.data.masking': 'admin.product.data.read',
+}
+
+describe('the product routes are mounted, guarded, and under this lane\'s prefix', () => {
+  it('exactly these seven exist, with exactly these permissions', () => {
+    const operator = declaredAdminPermissions()
+    const mine = servedPaths().filter((p) => MINE.test(p))
+
+    assert.deepEqual(
+      mine,
+      Object.keys(EXPECTED).sort(),
+      'the product routes in the served tree are not the ones this lane declares',
+    )
+
+    for (const [path, permission] of Object.entries(EXPECTED)) {
+      assert.equal(
+        operator.get(path),
+        permission,
+        `${path} does not declare ${permission}`,
+      )
+    }
+  })
+
+  it('every permission they declare is in the catalog and belongs to this lane', () => {
+    const operator = declaredAdminPermissions()
+    for (const path of servedPaths().filter((p) => MINE.test(p))) {
+      const permission = operator.get(path)
+      assert.ok(permission, `${path} declares no permission at all`)
+      // In the catalog rather than merely a plausible string. A permission no
+      // role holds refuses everybody, which reads as a broken page rather than
+      // as a typo.
+      assert.ok(
+        (ADMIN_PERMISSIONS as readonly string[]).includes(permission),
+        `${path} declares ${permission}, which is not in ADMIN_PERMISSIONS`,
+      )
+      assert.ok(
+        permission.startsWith('admin.product.'),
+        `${path} declares ${permission}, which belongs to another lane`,
+      )
+    }
+  })
+
+  it('the lane declares its prefix, so no second lane can claim it', () => {
+    assert.equal(RESERVED_PREFIXES['admin.product'], 'product')
+  })
+
+  it('this lane adds no write', () => {
+    // Every lever these pages need already exists elsewhere and is already
+    // enforced where a test can observe it: a teardown is admin.infra.*, a
+    // suspension is admin.tenants.suspend, a kill is admin.flags.kill. Asserted
+    // rather than trusted, because a write added here later would be a second
+    // code path writing a row somebody else's route already owns, and the two
+    // would come to disagree about what it means.
+    const operator = declaredAdminPermissions()
+    const writes = [...operator.entries()].filter(
+      ([path, permission]) => MINE.test(path) && !permission.endsWith('.read'),
+    )
+    assert.deepEqual(writes, [], 'a product route declares something other than a read')
+  })
+})
+
+describe('the data read is a narrower permission than the product read', () => {
+  it('analytics holds one and not the other', () => {
+    // The split is not symmetry. A masking rule enumerates a customer's schema
+    // and names which columns hold personal data; counting runs and twins does
+    // not need that. Analytics is the role the split exists for, so if it ever
+    // holds both, the split has quietly stopped being one.
+    const analytics = ADMIN_ROLE_PERMISSIONS.analytics as readonly string[]
+    assert.ok(analytics.includes('admin.product.read'))
+    assert.ok(
+      !analytics.includes('admin.product.data.read'),
+      'analytics can read customer column names, which is what this split exists to prevent',
+    )
+  })
+
+  it('both are held by somebody, so neither guards a page nobody can open', () => {
+    assert.ok(adminRolesWith('admin.product.read').length > 0)
+    assert.ok(adminRolesWith('admin.product.data.read').length > 0)
+  })
+
+  it('the auditor role reads both and writes neither', () => {
+    const readOnly = ADMIN_ROLE_PERMISSIONS.read_only as readonly string[]
+    assert.ok(readOnly.includes('admin.product.read'))
+    assert.ok(readOnly.includes('admin.product.data.read'))
+    assert.deepEqual(
+      readOnly.filter((p) => /\.(write|revoke|suspend|plan|export|teardown|engage)$/.test(p)),
+      [],
+    )
+  })
+})
+
+describe('experiments have no table, so this lane serves no experiment route', () => {
+  it('nothing under admin.product mentions an experiment, a variant or an assignment', () => {
+    // The trap this lane was warned about, made mechanical. There is no
+    // experiment table, no variant, no assignment, no exposure log and no
+    // results anywhere in the schema, and a rollout percent is not an
+    // experiment. The Experiments and Feature Flags page is therefore a flags
+    // page that says the rest is not wired. If somebody adds a route here to
+    // back a dashboard, this is the line that stops them, because the route
+    // would have to invent every number on it.
+    const suspicious = servedPaths().filter(
+      (p) => MINE.test(p) && /experiment|variant|assignment|exposure|cohort/i.test(p),
+    )
+    assert.deepEqual(
+      suspicious,
+      [],
+      'a product route names an experiment concept that nothing in the schema backs',
+    )
+  })
+
+  it('the flag routes the page reads are the money lane\'s, unchanged', () => {
+    // The page is built on these four. If a lane renames one, the page breaks
+    // silently at runtime, because the console addresses them by string.
+    const operator = declaredAdminPermissions()
+    assert.equal(operator.get('admin.flags.list'), 'admin.flags.read')
+    assert.equal(operator.get('admin.flags.set'), 'admin.flags.write')
+    assert.equal(operator.get('admin.flags.kill'), 'admin.flags.write')
+    assert.equal(operator.get('admin.flags.target'), 'admin.flags.write')
+    assert.equal(operator.get('admin.entitlements.forOrganization'), 'admin.entitlements.read')
+    assert.equal(operator.get('admin.entitlements.revoke'), 'admin.entitlements.write')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The routes against a real database
+//
+// Everything above is over the composed router and the catalog: it proves a
+// route is declared and guarded, and proves nothing about whether it answers.
+// A procedure with a permission on it and a broken query is a shippable gap
+// that passes every assertion in this file so far.
+//
+// So this half seeds a twin, the three families of run against it, a golden
+// version, a masking rule and a pull request, then calls each of the seven and
+// reads the answer back. Two of the assertions are the reason the block exists
+// rather than a formality:
+//
+//   a run that finished with no verdict at all comes back as `unknown` and not
+//   as `passed`, which is the exit-code-zero-over-nothing defect,
+//   and a branch whose pull request is merged while its twin is still running
+//   comes back as `orphaned`, which is the one finding the branches page is
+//   for and the one that no column in the database states directly.
+// ---------------------------------------------------------------------------
+
+describe('the product routes answer from real rows', { skip: hasDatabase ? false : 'no database' }, () => {
+  let h: ApiHarness
+  let org: Org
+  let operatorId: string
+  let overdueEnvId: string
+  let failingRunId: string
+  let silentRunId: string
+  let loadRunId: string
+  let checkId: string
+
+  before(async () => {
+    h = await startApi()
+    org = await seedOrg(h.admin, 'product')
+
+    const [operator] = await h.admin<{ id: string }[]>`
+      INSERT INTO admin_users (email, name, role)
+      VALUES (${`product-${randomUUID().slice(0, 8)}@example.test`}, 'Product operator', 'owner')
+      RETURNING id`
+    operatorId = operator!.id
+
+    // The twin seedOrg made, aged past its own expiry, given a golden version
+    // and attached to a pull request, so the overdue filter, the golden join
+    // and the branch grouping all have something true to find.
+    //
+    // THE EXPIRY IS RELATIVE TO THE INJECTED CLOCK, not to the database's
+    // `now()`. The route compares against ctx.clock, which the harness fakes,
+    // and a row aged with SQL is aged against a different clock entirely: the
+    // first draft of this seeded two days in the database's past and the route
+    // read it as two years in the fake clock's future. The same trap the
+    // operator session harness records, in the other direction.
+    const twoDaysAgo = new Date(h.clock.now().getTime() - 2 * 86_400_000).toISOString()
+    const [env] = await h.admin<{ id: string }[]>`
+      UPDATE environments
+      SET expires_at = ${twoDaysAgo}, golden_version = 'v7', branch = 'feature/late',
+          pull_request = 41
+      WHERE org_id = ${org.orgId}
+      RETURNING id`
+    overdueEnvId = env!.id
+
+    await h.admin`
+      INSERT INTO golden_versions (org_id, repository_id, version, verified, size_bytes)
+      VALUES (${org.orgId}, ${org.repoId}, 'v7', false, 4096)`
+    await h.admin`
+      INSERT INTO masking_rules (org_id, repository_id, table_name, column_name, transform, confirmed, reason)
+      VALUES (${org.orgId}, ${org.repoId}, 'customers', 'email', 'hash', false, 'Looks like an address')`
+
+    // Two agent runs. One failed a verdict; one reached `complete` having
+    // reported nothing at all, which is the case the standing exists for.
+    const [failing] = await h.admin<{ id: string }[]>`
+      INSERT INTO runs (org_id, environment_id, kind, state, started_at, finished_at)
+      VALUES (${org.orgId}, ${overdueEnvId}, 'agent', 'complete', now() - interval '10 minutes', now())
+      RETURNING id`
+    failingRunId = failing!.id
+    await h.admin`
+      INSERT INTO verdicts (org_id, run_id, workflow, value, summary, steps, duration_ms)
+      VALUES (${org.orgId}, ${failingRunId}, 'checkout', 'fail', 'The basket never loaded', 12, 4200)`
+    await h.admin`
+      INSERT INTO artifacts (org_id, run_id, kind, storage_key, size_bytes, retained)
+      VALUES (${org.orgId}, ${failingRunId}, 'trace', 'runs/x/trace.zip', 900, false)`
+
+    const [silent] = await h.admin<{ id: string }[]>`
+      INSERT INTO runs (org_id, environment_id, kind, state, started_at, finished_at)
+      VALUES (${org.orgId}, ${overdueEnvId}, 'agent', 'complete', now() - interval '5 minutes', now())
+      RETURNING id`
+    silentRunId = silent!.id
+
+    // A load run that succeeded and carries a failing verdict, which is the
+    // other half of the same distinction: the job ran to completion and what it
+    // found was a failure.
+    const [workload] = await h.admin<{ id: string }[]>`
+      INSERT INTO workloads (org_id, repository_id, slug, name, kind)
+      VALUES (${org.orgId}, ${org.repoId}, 'checkout-load', 'Checkout load', 'observed_load')
+      RETURNING id`
+    const [version] = await h.admin<{ id: string }[]>`
+      INSERT INTO workload_versions (org_id, workload_id, version, body, body_digest)
+      VALUES (${org.orgId}, ${workload!.id}, 1, '{}'::jsonb, ${'a'.repeat(64)})
+      RETURNING id`
+    const [loadRun] = await h.admin<{ id: string }[]>`
+      INSERT INTO workload_runs
+        (org_id, workload_id, workload_version_id, environment_id, state, request_key,
+         repository, git_ref, deadline_at, started_at, finished_at, verdict, failure_code,
+         reproduce_command)
+      VALUES (${org.orgId}, ${workload!.id}, ${version!.id}, ${overdueEnvId}, 'succeeded',
+              ${randomUUID()}, ${org.repository}, 'refs/heads/main', now() + interval '1 hour',
+              now() - interval '3 minutes', now(), 'fail', 'threshold.p95',
+              'af load run checkout-load')
+      RETURNING id`
+    loadRunId = loadRun!.id
+    await h.admin`
+      INSERT INTO workload_run_results (org_id, workload_run_id, kind, requests, failures, p95_ms)
+      VALUES (${org.orgId}, ${loadRunId}, 'observed_load', 1200, 9, 411)`
+
+    // A merged pull request whose twin is still running: the orphan.
+    const [pr] = await h.admin<{ id: string }[]>`
+      INSERT INTO pull_requests
+        (org_id, repository_id, number, head_sha, head_ref, base_ref, head_repository,
+         state, closed_at)
+      VALUES (${org.orgId}, ${org.repoId}, 41, ${'b'.repeat(40)}, 'feature/late', 'main',
+              ${org.repository}, 'merged', now() - interval '1 day')
+      RETURNING id`
+    const [generation] = await h.admin<{ id: string }[]>`
+      INSERT INTO pr_generations
+        (org_id, pull_request_id, head_sha, state, detail, deadline_at, started_at, finished_at)
+      VALUES (${org.orgId}, ${pr!.id}, ${'b'.repeat(40)}, 'failed', 'The check never reported',
+              now() + interval '1 hour', now() - interval '2 minutes', now())
+      RETURNING id`
+    checkId = generation!.id
+  })
+
+  after(async () => {
+    await h.admin`DELETE FROM admin_audit_entries WHERE subject_org_id = ${org.orgId}`
+    await h.admin`DELETE FROM admin_audit_entries WHERE admin_user_id = ${operatorId}`
+    await h.admin`DELETE FROM admin_users WHERE id = ${operatorId}`
+    await dropOrg(h.admin, org.orgId)
+    await h.close()
+  })
+
+  /** A caller as an operator of a given role, with the context the mount builds.
+   *  Impersonating is false; the gate's refusal for a true one is
+   *  admin-gate.test.ts's, and a second copy here would be a weaker one. */
+  function callerAs(role: AdminRole, label = 'product@antifailure.test') {
+    const ctx = {
+      pool: h.pool,
+      adminPool: h.adminPool,
+      admin: {
+        adminUserId: operatorId,
+        label,
+        email: label,
+        role,
+        sessionId: randomUUID(),
+        impersonating: false,
+        impersonatedUserId: null,
+      },
+      adminDb: <T,>(fn: (db: never) => Promise<T>) =>
+        h.adminPool.withOperator({ adminUserId: operatorId, label }, fn as never),
+      clock: h.clock,
+      github: h.github,
+      stripe: null,
+      appBaseUrl: 'http://app.test/',
+      mailer: null,
+      productName: 'Antifailure',
+      hostedRequiredPlan: null,
+      actor: null,
+      origin: 'admin',
+      ip: '203.0.113.10',
+    } as unknown as AdminContext
+    return adminRouter.createCaller(ctx as never)
+  }
+
+  it('lists the twin, and the overdue filter finds the one that is over', async () => {
+    const owner = callerAs('owner')
+    const live = await owner.product.twins.list({ orgId: org.orgId, scope: 'live', limit: 50 })
+    const mine = live.rows.find((t) => t.id === overdueEnvId)
+    assert.ok(mine, 'the seeded twin is not in the live list')
+    assert.equal(mine.overdue, true)
+    assert.equal(mine.goldenVersion, 'v7')
+    // False rather than null: a version row exists and it was never verified.
+    // Null would mean the twin names a version this installation has no row
+    // for, which is a different answer and the page says so differently.
+    assert.equal(mine.goldenVerified, false)
+    assert.equal(mine.runs, 2)
+
+    const overdue = await owner.product.twins.list({ scope: 'overdue', orgId: org.orgId, limit: 50 })
+    assert.ok(overdue.rows.some((t) => t.id === overdueEnvId))
+  })
+
+  it('a page cursor it did not issue is refused rather than answered with page one', async () => {
+    // Falling back to the first page is the failure that matters: the caller
+    // asked for page four, got page one, and `More` would offer more forever.
+    await assert.rejects(
+      () => callerAs('owner').product.twins.list({ cursor: 'not-a-cursor', limit: 5 }),
+      /not one this list issued/,
+    )
+  })
+
+  it('the twin detail carries its runs, its golden version and its teardowns', async () => {
+    const twin = await callerAs('owner').product.twins.get({ id: overdueEnvId })
+    assert.equal(twin.orgSlug, org.slug)
+    assert.equal(twin.golden?.verified, false)
+    assert.equal(twin.runs.length, 2)
+    assert.equal(twin.workloadRuns.length, 1)
+    assert.deepEqual(twin.teardowns, [])
+  })
+
+  it('a run that finished with no verdict is unknown, and never passed', async () => {
+    // The whole reason `standing` exists beside `state`. Both runs reached
+    // `complete`; one found a failure and one reported nothing at all, and
+    // calling the second a pass is the defect this repository has shipped once.
+    const rows = (
+      await callerAs('owner').product.runs.list({ kind: 'agent', orgId: org.orgId, limit: 50 })
+    ).rows
+    const failed = rows.find((r) => r.id === failingRunId)
+    const silent = rows.find((r) => r.id === silentRunId)
+    assert.equal(failed?.state, 'complete')
+    assert.equal(failed?.standing, 'failed')
+    assert.equal(failed?.failure, 'The basket never loaded')
+    assert.equal(silent?.state, 'complete')
+    assert.equal(silent?.standing, 'unknown')
+    assert.equal(silent?.verdict, null)
+  })
+
+  it('a load run that succeeded with a failing verdict is a failure', async () => {
+    const rows = (
+      await callerAs('owner').product.runs.list({ kind: 'load', orgId: org.orgId, limit: 50 })
+    ).rows
+    const run = rows.find((r) => r.id === loadRunId)
+    assert.equal(run?.state, 'succeeded')
+    assert.equal(run?.standing, 'failed')
+    assert.equal(run?.failure, 'threshold.p95')
+  })
+
+  it('the failures filter is applied by the query and not after the page', async () => {
+    // Filtering after the page is cut returns an arbitrary number of rows per
+    // page and eventually an empty page with a cursor behind it, which reads as
+    // the end of a list that has more in it.
+    const failedOnly = await callerAs('owner').product.runs.list({
+      kind: 'agent', orgId: org.orgId, failedOnly: true, limit: 50,
+    })
+    assert.ok(failedOnly.rows.some((r) => r.id === failingRunId))
+    assert.ok(
+      !failedOnly.rows.some((r) => r.id === silentRunId),
+      'a run that reported nothing was counted as a failure',
+    )
+  })
+
+  it('the run detail carries the verdicts and the artifacts, and no storage key', async () => {
+    const run = await callerAs('owner').product.runs.get({ kind: 'agent', id: failingRunId })
+    assert.equal(run.kind, 'agent')
+    if (run.kind !== 'agent') return
+    assert.equal(run.verdicts.length, 1)
+    assert.equal(run.verdicts[0]!.summary, 'The basket never loaded')
+    assert.equal(run.artifacts.length, 1)
+    // The bytes were removed and the row stayed, so the page can say so rather
+    // than showing a gap that reads as a bug.
+    assert.equal(run.artifacts[0]!.retained, false)
+    assert.ok(
+      !JSON.stringify(run.artifacts).includes('storage_key') &&
+        !JSON.stringify(run.artifacts).includes('runs/x/trace.zip'),
+      'the artifact response carries a pointer into the object store',
+    )
+  })
+
+  it('a load run detail carries the command the engine reported', async () => {
+    const run = await callerAs('owner').product.runs.get({ kind: 'load', id: loadRunId })
+    assert.equal(run.kind, 'load')
+    if (run.kind !== 'load') return
+    assert.equal(run.reproduceCommand, 'af load run checkout-load')
+    assert.equal((run.result as { requests?: number } | null)?.requests, 1200)
+  })
+
+  it('a pull request check detail names the head it ran on', async () => {
+    const run = await callerAs('owner').product.runs.get({ kind: 'check', id: checkId })
+    assert.equal(run.kind, 'check')
+    if (run.kind !== 'check') return
+    assert.equal(run.pullRequest, 41)
+    assert.equal(run.standing, 'failed')
+    assert.equal(run.headSha, 'b'.repeat(40))
+    // Null rather than absent: the installation does not hold `checks: write`,
+    // which is a state to serve rather than crash in.
+    assert.equal(run.checkRunId, null)
+  })
+
+  it('a branch still holding a twin after its pull request merged is orphaned', async () => {
+    // The finding the branches page exists for, and the one no column states
+    // directly: the twin is fine, the pull request is fine, and the two of them
+    // together are somebody paying for a fortnight-old change.
+    const rows = (
+      await callerAs('owner').product.twins.branches({ orgId: org.orgId, scope: 'orphaned', limit: 50 })
+    ).rows
+    const branch = rows.find((b) => b.branch === 'feature/late')
+    assert.ok(branch, 'the merged pull request holding a live twin was not found')
+    assert.equal(branch.orphaned, true)
+    assert.equal(branch.pullRequest, 41)
+    assert.equal(branch.pullRequestState, 'merged')
+    assert.equal(branch.live, 1)
+    assert.equal(branch.overdue, 1)
+  })
+
+  it('the safe state routes find the unverified version and the unconfirmed rule', async () => {
+    const owner = callerAs('owner')
+    const goldens = await owner.product.data.goldens({ orgId: org.orgId, scope: 'unverified', limit: 50 })
+    const golden = goldens.rows.find((g) => g.version === 'v7')
+    assert.ok(golden)
+    assert.equal(golden.verified, false)
+    // Live twins on an unverified copy is what turns the row from history into
+    // a finding, so it is counted rather than inferred.
+    assert.equal(golden.twins, 1)
+
+    const rules = await owner.product.data.masking({ orgId: org.orgId, scope: 'unconfirmed', limit: 50 })
+    const rule = rules.rows.find((r) => r.column === 'email')
+    assert.ok(rule)
+    assert.equal(rule.confirmed, false)
+    assert.equal(rule.table, 'customers')
+  })
+
+  it('analytics reads the product and is refused the customer column names', async () => {
+    // The split, exercised through the gate rather than asserted off the table.
+    const analytics = callerAs('analytics')
+    const twins = await analytics.product.twins.list({ orgId: org.orgId, limit: 5 })
+    assert.ok(Array.isArray(twins.rows))
+    await assert.rejects(
+      () => analytics.product.data.masking({ orgId: org.orgId, limit: 5 }),
+      /needs the admin.product.data.read permission/,
+    )
+  })
+
+  it('reading is recorded without the route asking', async () => {
+    // adminProcedure audits every query after it returns, so a lane that added
+    // no adminAudit call of its own still leaves a trail. Counted rather than
+    // trusted.
+    //
+    // MATCHED ON THE SUFFIX, because a tRPC path is relative to the router the
+    // caller was built from: through `adminRouter` it is `product.twins.list`
+    // and over HTTP through `appRouter` it is `admin.product.twins.list`. The
+    // suffix is the part that is the same in both, and pinning the full string
+    // here would pin the harness rather than the route.
+    const count = async () => {
+      const rows = await h.admin<{ n: string }[]>`
+        SELECT count(*) AS n FROM admin_audit_entries
+        WHERE admin_user_id = ${operatorId} AND action LIKE ${'read.%product.twins.list'}`
+      return Number(rows[0]!.n)
+    }
+    const before = await count()
+    await callerAs('owner').product.twins.list({ orgId: org.orgId, limit: 5 })
+    assert.equal(await count(), before + 1)
+  })
+})

--- a/web/apps/api/test/admin-routes.test.ts
+++ b/web/apps/api/test/admin-routes.test.ts
@@ -32,24 +32,11 @@ describe('every operator route declares a permission', () => {
   // second tree needs a second walk or it is guarded by neither matrix. A route
   // nobody enumerates is worse than one in a tree that does, because the second
   // at least fails.
-  //
-  // THE NUMBER IS THE COUNT AT THE TIME THE LAST LANE LANDED, not a round one.
-  // It was 18 for the length of four lanes, by which point it was satisfied by
-  // the foundation's own routes alone and proved nothing about anybody else's.
-  // The protocol, so six branches can raise one line without arguing: a lane
-  // adds its own route count to whatever it finds here. Two lanes that both
-  // raise it conflict in git, which is the visible edit, and the resolution is
-  // the larger number.
-  //
-  // A floor is still the weaker half of this. Each lane also counts its OWN
-  // routes exactly, in its own file, because a floor cannot tell that one
-  // lane's routes left the tree while another's arrived: see
-  // admin-product.test.ts and the money block in adminrouters.test.ts.
   assertOperatorRoutesAreGuarded({
     name: 'appRouter',
     router: appRouter,
     prefix: 'admin.',
-    atLeast: 50,
+    atLeast: 18,
   })
 })
 

--- a/web/apps/api/test/admin-routes.test.ts
+++ b/web/apps/api/test/admin-routes.test.ts
@@ -32,11 +32,24 @@ describe('every operator route declares a permission', () => {
   // second tree needs a second walk or it is guarded by neither matrix. A route
   // nobody enumerates is worse than one in a tree that does, because the second
   // at least fails.
+  //
+  // THE NUMBER IS THE COUNT AT THE TIME THE LAST LANE LANDED, not a round one.
+  // It was 18 for the length of four lanes, by which point it was satisfied by
+  // the foundation's own routes alone and proved nothing about anybody else's.
+  // The protocol, so six branches can raise one line without arguing: a lane
+  // adds its own route count to whatever it finds here. Two lanes that both
+  // raise it conflict in git, which is the visible edit, and the resolution is
+  // the larger number.
+  //
+  // A floor is still the weaker half of this. Each lane also counts its OWN
+  // routes exactly, in its own file, because a floor cannot tell that one
+  // lane's routes left the tree while another's arrived: see
+  // admin-product.test.ts and the money block in adminrouters.test.ts.
   assertOperatorRoutesAreGuarded({
     name: 'appRouter',
     router: appRouter,
     prefix: 'admin.',
-    atLeast: 18,
+    atLeast: 50,
   })
 })
 


### PR DESCRIPTION
Five sections of the operator portal, built against the tables that exist and saying so where they do not. Base is `w-admin-shell`.

## What is backed by real rows

**Production Twins** lists every environment on the installation and defaults to the one filter that is a finding: past the lifetime it was created with, not torn down, and costing somebody money for a branch nobody is reading. Each row says whether the golden data it was built from was ever verified, and a twin naming a version this control plane has no row for is a third answer rather than being called unverified.

**Branches & Environments** groups those environments by the branch that made them and reaches the same cost from the other side: a live twin whose pull request merged a fortnight ago. No column states that. The join is the whole point of the page, and the default filter is that finding rather than a list of everything.

**Safe State & Databases** leads with masking rules nobody confirmed, because an unconfirmed rule means a scan believes a column holds personal data and nobody has agreed, so the column is not being transformed on a copy somebody is running tests against. Golden versions come second, with live twins counted per version: an unverified copy with four environments on it is four environments running on unattested data right now.

**Runs & Jobs** is an incident page and is built for one sequence: find the run, see why it failed, see what it touched. There is no grid of totals at the top, because a cross tenant aggregate costs a table scan to answer a question nobody asks at three in the morning. The three run families are a filter rather than one merged table: an agent run has verdicts and artifacts, a load run has percentiles and a lease, a check has a head commit, and a table true of all three would have to drop the columns somebody came for.

## A run that finished is not a run that passed

Every run carries a standing beside its own state and both are shown. A load run whose state is `succeeded` can carry a failing verdict: the job ran to completion and what it found was a failure. An agent run that reached `complete` reporting no verdict at all did nothing and found nothing, and that is `unknown` rather than a pass. `admin-product.test.ts` seeds exactly those two runs and asserts the difference. This is the exit-code-zero-over-nothing defect this repository has shipped once already, and it is the reason the field exists.

The failures filter is computed in SQL rather than over the returned page. Filtering a page after it is cut returns an arbitrary number of rows per page and eventually an empty page with a cursor behind it, which reads as the end of a list that has more in it.

## Two pages say what is not wired

**There are no experiments.** No experiment table, no variant, no assignment, no exposure log, no results. A rollout percent is a share of traffic rather than an experiment, because nothing records which subject fell on which side, so there is no exposure to count and no arm to compare against. Experiments & Feature Flags is therefore the whole flag surface: state, rollout, targets, the internal-only bit, a kill with a reason attached, and the column that matters most during an incident, whether anything in the build reads the flag at all. A card at the top names the absence and the four things that would make the other half of its title true. A test fails if a route under `admin.product` ever names an experiment concept.

**Safe State does the same** for the snapshot ledger, the restore history and the record of a customer's live database, none of which exist anywhere in the schema. It says which table each answer would need rather than leaving somebody to search for a panel that was never built.

One navigation summary was rewritten. The Safe State entry promised "the database snapshots a twin can be returned to, and whether restoring one has been proven", and that summary is the page's own lede. It now says what the two tables can actually answer, with the old line recorded in a comment so the next person knows the promise was checked rather than missed.

## No write in this lane

Every lever these pages need is already enforced somewhere a test can observe it: a teardown is `admin.infra`, a suspension is `admin.tenants`, a kill is `admin.flags`. The one this lane could plausibly have owned, cancelling a customer's workload run, was left out because `runtime_commands` is a queue an engine drains and there is no engine behind the operator pool, so the button would report success and change nothing observable. `admin-product.test.ts` asserts the lane declares no write at all, so a second code path cannot quietly appear over a row somebody else's route owns.

Nothing here rewrites `admin/fleet.ts`, the teardown ledger, the blast radius or the teardown write path, which stay the infra lane's. The twins list here is keyset paged with a cursor because `usePages` and `More` require one, which the fleet view deliberately is not; the file header says so.

## Two permissions, and the split is not symmetry

`admin.product.read` covers twins, runs and branches. `admin.product.data.read` is separate because a masking rule enumerates a customer's schema and names which of its columns hold personal data, which is a wider disclosure than "why did this run fail". Analytics holds the first and not the second, and a test fails if it ever holds both, because a split no role distinguishes has stopped being one. Confirmed in the browser: an analytics operator opening Safe State gets "Your role cannot see this. This needs the admin.product.data.read permission."

## The route floor

`atLeast` in `admin-routes.test.ts` was 18 while 43 routes existed, so it was satisfied by the foundation's own routes alone and proved nothing about anybody else's. It is now the real count, with the protocol written beside it: a lane adds its own route count to whatever it finds. A floor is still the weaker half, because it cannot see one lane's routes leaving the tree while another's arrive, so this lane also counts its own seven exactly, by name, in its own file.

## Verified by looking

The console was built, served from the control plane against a seeded database, and every page opened at 320 pixels and at 1280 as a real signed-in operator.

- No horizontal overflow on any page at either width, no `animate-pulse` or `animate-ping` anywhere, no tap target under 44 pixels on a phone, no body text under 12 pixels.
- The write path was driven end to end from the browser: killing a flag wrote `killed_at`, `killed_by_label` and `killed_reason`, and appended an `admin_audit_entries` row with action `flag.killed` at severity `high` naming the operator.
- `just prosecheck` and `just motioncheck` pass against the built stylesheet and HTML. `just classcheck` reads only `www/.next` and does not cover the console.

Four defects the render found that code review had not: the failure text was allocated about six characters by a table with eight columns and came out one word per line; a badge carried a thirty eight character sentence at eleven pixels; identifiers were truncated on the phone, where the full value is what somebody pastes into a log search; and a chip reading FAILED sat beside the word "failed" in two type sizes.

## Tests

- `console/lib/admin-product.test.ts`, 21 assertions over the pure logic in `productshapes.ts`. The three functions there are the ones whose failure is confidently wrong rather than obviously broken: the direction of an expiry, which numbers a load result of each kind actually has, and the colour a run that reported nothing gets.
- `web/apps/api/test/admin-product.test.ts`, two halves. The first needs no database and pins the route names, the permissions, the prefix and the absence of writes. The second seeds a twin, the three families of run, a golden version, a masking rule and a merged pull request, then calls all seven routes and reads the answers back. Both halves were checked by breaking the code on purpose and watching them fail.
- 440 assertions across the admin, permission, limit, route boundary and OpenAPI suites pass against a live Postgres.

## Reported separately, not fixed here

Driving the write path found that the operator CSRF gate never fires when cookies are Secure, which is every real deployment: `server.ts` reads the bare cookie name where the session is written under the `__Host-` prefix. `admincsrf.test.ts` is green because the harness defaults to insecure cookies. It is a one line fix in the foundation's file and it has been reported to the lead rather than patched from this lane.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR
