### PR TITLE
conduct: a complaint route that goes nowhere is worse than none

### DIFF
--- a/.changes/a-code-of-conduct-that-routed-complaints-into-silence.md
+++ b/.changes/a-code-of-conduct-that-routed-complaints-into-silence.md
@@ -1,0 +1,44 @@
+# fixed
+
+The code of conduct no longer names an address that cannot receive a
+harassment report.
+
+CODE_OF_CONDUCT.md named conduct@antifailure.dev as the place to report abusive
+behaviour. The antifailure.dev domain publishes no mail exchanger, an SPF
+policy authorising no sender, a DMARC policy of reject with strict alignment,
+and a DKIM record whose empty `p=` revokes the key. Nothing addressed there was
+ever delivered, and the person reporting got a silence they could not tell
+apart from being ignored.
+
+There is no confidential channel to put in its place, so the section says that
+instead of naming another mailbox. It lists what does resolve, a public issue
+or discussion and a booked call with the maintainer, and what each one costs
+the reporter. It says that GitHub private vulnerability reporting is the wrong
+queue for this. It names the gap none of them closes: whoever would read a
+complaint is one of the same few people who maintain the repository, so a
+complaint about a maintainer has nowhere independent to go inside the project,
+and it points at GitHub's own abuse route, which is outside it.
+
+The daily status workflow committed as status@antifailure.dev, which reads like
+a mailbox and is not one. It now commits under GitHub's own no-reply identity
+for the Actions bot.
+
+# added
+
+A gate that refuses a contact route this project cannot answer.
+
+The site had already been fixed and the repository had not, which is why this
+exists rather than a third correction. `tools/contactcheck` reads every text
+file in the tree and requires a row in `tools/docs/contact-routes.tsv` for
+every address, saying whether a person reads it, whether it is a value the
+software writes rather than an invitation, or whether it is a defect being
+quoted. An address with no row fails, so a domain nobody has checked is caught
+by the missing row. A `receives` row at a domain proven dead is refused
+outright, and at such a domain no sentence anywhere in the tree may read as an
+instruction to write there, whatever its row says.
+
+It does not resolve MX at check time. That would make every pull request depend
+on somebody else's resolver, and it answers the wrong question: an MX record
+proves a server accepts mail, not that a person reads what lands there. What it
+cannot catch is written into the tool's own header, including the case it is
+blindest to, which is a second domain vouched for by a row nobody verified.

--- a/.changes/a-code-of-conduct-that-routed-complaints-into-silence.md
+++ b/.changes/a-code-of-conduct-that-routed-complaints-into-silence.md
@@ -20,8 +20,9 @@ complaint about a maintainer has nowhere independent to go inside the project,
 and it points at GitHub's own abuse route, which is outside it.
 
 The daily status workflow committed as status@antifailure.dev, which reads like
-a mailbox and is not one. It now commits under GitHub's own no-reply identity
-for the Actions bot.
+a mailbox and is not one. It is the same domain, which has no mail exchanger,
+so anybody who replied to a status commit was writing into nothing. It commits
+under GitHub's own no-reply identity for the Actions bot now.
 
 # added
 

--- a/.changes/legal-pages-named-a-mailbox-that-could-not-receive.md
+++ b/.changes/legal-pages-named-a-mailbox-that-could-not-receive.md
@@ -2,9 +2,9 @@
 
 The legal pages no longer publish an email address that cannot receive mail.
 
-The data processing addendum and the data retention page both said security
-reports go to `security@antifailure.dev` and that the address reaches a person
-who can act on it. The contact page of the same website said the opposite,
+The data processing addendum and the data retention page both named
+`security@antifailure.dev` as the destination for a security report, and both
+said the address reaches a person who can act on it. The contact page of the same website said the opposite,
 under the heading "Email is not a contact route", and the contact page was
 right: the domain publishes no mail exchanger, so mail sent there is delivered
 nowhere. Both pages now name GitHub private vulnerability reporting, which is

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1143,6 +1143,18 @@ jobs:
         # rather than one a reviewer has to notice.
         run: go run ./tools/modecheck .
 
+      - name: Every contact route this repository publishes resolves
+        # CODE_OF_CONDUCT.md named conduct@antifailure.dev as the route for
+        # a person reporting harassment, and the legal pages named
+        # security@antifailure.dev for a researcher. The domain has no mail
+        # exchanger, an SPF policy authorising no sender, a DMARC policy of
+        # reject and a revoked DKIM key, so both went to the same silence and
+        # neither sender could tell. The site had already been fixed and the
+        # repository had not. Every address in the tree now needs a row in
+        # tools/docs/contact-routes.tsv saying who reads it, and an address
+        # with no row fails, which is what catches a domain nobody has checked.
+        run: go run ./tools/contactcheck .
+
   # Alone, and deliberately so.
   #
   # This is the only step in this job, which is what makes its result mean what

--- a/.github/workflows/status.yml
+++ b/.github/workflows/status.yml
@@ -114,8 +114,14 @@ jobs:
       - name: Move to status-data, creating it the first time this runs
         working-directory: data
         run: |
+          # The address is GitHub's own no-reply for the Actions bot, and it
+          # used to be status@antifailure.dev. That read like a mailbox and was
+          # not one: the domain publishes no mail exchanger, so anybody who
+          # replied to a status commit was writing into nothing. A no-reply
+          # address at a domain every reader already recognises as one says the
+          # same thing without the trap.
           git config user.name "antifailure-status"
-          git config user.email "status@antifailure.dev"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           if git ls-remote --exit-code --heads origin status-data > /dev/null; then
             git fetch origin status-data
             git checkout -B status-data origin/status-data

--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,7 @@ runner/artifacts/
 /claimcheck
 /classcheck
 /constcheck
+/contactcheck
 /cost
 /docscheck
 /dogfood

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -58,13 +58,48 @@ representative at an online or offline event.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-conduct@antifailure.dev. All complaints will be reviewed and investigated
-promptly and fairly.
+**This project has no confidential reporting channel today.** That is written
+here rather than left to be discovered, because the alternative is the state
+this section was in until now: it named conduct@antifailure.dev, and that
+address has never been able to receive anything. The antifailure.dev domain
+publishes no mail exchanger and its SPF record authorises no sender, so a
+complaint addressed there was delivered nowhere. The reporter got silence, and
+silence is indistinguishable from being ignored.
 
-All community leaders are obligated to respect the privacy and security of the
-reporter of any incident.
+These are the routes that resolve today, with what each one costs you.
+
+* **A GitHub issue or discussion** at
+  https://github.com/antifailure/antifailure. Both work and both are public.
+  Anything you write is readable by anybody, including the person you are
+  reporting, and it stays readable. For a moderation question about a thread
+  everybody can already see, a public record is fine and sometimes better. For
+  harassment, or for anything where being named puts you at risk, it is the
+  wrong place and you should not be pushed into it.
+* **A booked call** at https://cal.com/virsanghavi/30min. That reaches the
+  maintainer directly and is private between the two of you. It is the closest
+  thing to a confidential route this project has. It also asks you to speak to
+  somebody in real time, which is not a fair thing to require of a person
+  reporting harassment, so it is offered and not presented as the answer.
+* **GitHub private vulnerability reporting is not a conduct channel.** It is
+  private, and it is the wrong queue: it feeds the security advisory workflow
+  and is read as a stream of security findings. Please do not file a conduct
+  complaint there.
+
+**The gap none of the above closes.** Whoever would read a complaint is one of
+the same few people who maintain this repository, so a complaint about a
+maintainer has nowhere independent to go inside the project. No wording here
+changes that. If that is your situation, GitHub's own abuse route is
+independent of this repository and of everybody in it:
+https://github.com/contact/report-abuse. Nearly all of this project's
+community activity happens in GitHub spaces, so it covers most of what this
+document covers.
+
+All complaints will be reviewed and investigated promptly and fairly, and all
+community leaders are obligated to respect the privacy and security of the
+reporter of any incident. One qualification on the word promptly, since it is
+the kind of promise that is easy to make and easy to miss: nobody here is on a
+rota for this, so a report that arrives on a Friday evening is most likely read
+on Monday.
 
 ## Enforcement Guidelines
 

--- a/justfile
+++ b/justfile
@@ -83,6 +83,7 @@ gate: _reports
     run "prose reads like a person"      just prosecheck
     run "every figure has a source"      just figurecheck
     run "the mode lists are the real one" just modecheck
+    run "every contact route resolves"   just contactcheck
     run "no forbidden tokens in docs"    just forbidden
     run "spelling"                       just spell
     run "prose style"                    just vale
@@ -539,6 +540,16 @@ figurecheck:
 # read from schemas/manifest.v1.json rather than from a second copy of the list.
 modecheck:
     go run ./tools/modecheck .
+
+# No address published anywhere in this tree sends a reader into silence.
+#
+# CODE_OF_CONDUCT.md named conduct@antifailure.dev and the legal pages named
+# security@antifailure.dev. The domain has no mail exchanger, an SPF policy
+# authorising no sender and a revoked DKIM key, so a harassment report and a
+# security finding went to the same nowhere. Every address in the tree now
+# needs a row in tools/docs/contact-routes.tsv saying who reads it.
+contactcheck:
+    go run ./tools/contactcheck .
 
 # No class on a rendered element that another class on the same element beats,
 # so it is written, reviewed, and does nothing.

--- a/tools/contactcheck/main.go
+++ b/tools/contactcheck/main.go
@@ -1,9 +1,10 @@
 // Command contactcheck refuses a contact route this project cannot answer.
 //
 // THE DEFECT THIS EXISTS FOR. CODE_OF_CONDUCT.md named conduct@antifailure.dev
-// as the place a person reporting harassment should go. The legal pages named
-// security@antifailure.dev for a security researcher. Neither address has ever
-// been able to receive anything, and the reason is not subtle:
+// as the place a person reporting harassment should go, and the legal pages
+// named security@antifailure.dev for a security researcher. Neither address
+// can receive mail. There is no mail exchanger on that domain, and the rest of
+// its records close the door behind that one:
 //
 //	$ dig +short MX antifailure.dev                        (empty)
 //	$ dig +short TXT antifailure.dev                        "v=spf1 -all"
@@ -70,9 +71,9 @@
 //
 //	records-a-defect   the address is quoted inside a description of a mailbox
 //	                   that did not work, which is what this very file does.
-//	                   REFUSED unless the same file also states that the
-//	                   address cannot receive, so the quotation cannot be the
-//	                   only thing a reader takes away.
+//	                   REFUSED unless the correction sits WITHIN A FEW LINES of
+//	                   the quotation, so a reader who stops at that paragraph
+//	                   cannot leave with the address and nothing else.
 //
 // One rule sits above the verdicts and no row can excuse it: AT A DOMAIN
 // PROVEN DEAD, no text in this repository may read as an instruction to write
@@ -103,11 +104,11 @@
 //     If this project acquires a second domain and publishes a mailbox on it
 //     with a row saying `receives`, the gate passes and the mail may still go
 //     nowhere. Adding a domain to deadDomains is a human check with `dig`.
-//  2. `records-a-defect` is satisfied by evidence anywhere in the same file.
-//     Somebody could write a genuine instruction to a dead address in a file
-//     that elsewhere explains the address is dead, and this would pass. That
-//     is a strange thing to write and it is visible in a diff, which is the
-//     whole of the defence.
+//  2. The correction beside a quotation is matched as a phrase, not read. A
+//     paragraph could carry one of those phrases in a sentence that means
+//     something else and satisfy the rule. The evidence has to be within eight
+//     lines now rather than anywhere in the file, which was the earlier and
+//     much wider version of this hole.
 //  3. It reads source, not the rendered page. An address assembled at runtime
 //     from parts, or read from an environment variable, is invisible to it.
 //  4. It says nothing about whether a route that is not an address works. A
@@ -361,7 +362,7 @@ func run(root string, out io.Writer) error {
 // place rather than being restated by whatever reads them next.
 func Check(rel, body string, rows []*row) []finding {
 	var out []finding
-	evidence := deadEvidence.MatchString(flow(body))
+	lines := strings.Split(body, "\n")
 
 	for _, hit := range address.FindAllStringIndex(body, -1) {
 		found := body[hit[0]:hit[1]]
@@ -408,16 +409,48 @@ func Check(rel, body string, rows []*row) []finding {
 			continue
 		}
 
-		if r.verdict == verdictDefect && !evidence {
+		if r.verdict == verdictDefect && !deadEvidence.MatchString(flow(near(lines, num))) {
 			out = append(out, finding{
 				path: rel, num: num, address: found,
-				problem: "the row says " + verdictDefect + ", and nothing in this file tells the reader the address does not work",
-				fix:     "say in the file that the address cannot receive mail, or the quotation reads as an instruction",
+				problem: "the row says " + verdictDefect + ", and nothing within " +
+					fmt.Sprint(evidenceWindow) + " lines of it tells the reader the address does not work",
+				fix: "put the correction beside the quotation, not elsewhere in the file. A reader who stops " +
+					"at this paragraph must not leave with the address and nothing else",
 			})
 			continue
 		}
 	}
 	return out
+}
+
+// evidenceWindow is how many lines either side of a quoted address the
+// correction has to sit in.
+//
+// It was the whole file, and that was the review finding that changed it. The
+// evidence is a string, so a file could satisfy it once and thereby license
+// every later occurrence, and the file this mattered most in is
+// CODE_OF_CONDUCT.md: the one somebody opens after being harassed, needing the
+// route to work. File membership is not proximity. A reader stops at the
+// paragraph in front of them, so the correction has to be in that paragraph.
+//
+// Eight lines is a paragraph of wrapped prose plus the blank line on each side
+// of it, measured against the seven places in this repository that quote a
+// dead address rather than picked as a round number. The tightest of them,
+// this file's own header, puts the dig output five lines under the address and
+// the sentence reading it three lines under that.
+const evidenceWindow = 8
+
+// near returns the lines within evidenceWindow of a one based line number.
+func near(lines []string, num int) string {
+	lo := num - 1 - evidenceWindow
+	if lo < 0 {
+		lo = 0
+	}
+	hi := num + evidenceWindow
+	if hi > len(lines) {
+		hi = len(lines)
+	}
+	return strings.Join(lines[lo:hi], " ")
 }
 
 // wrapping is what separates two words of a phrase when prose reaches the

--- a/tools/contactcheck/main.go
+++ b/tools/contactcheck/main.go
@@ -1,0 +1,588 @@
+// Command contactcheck refuses a contact route this project cannot answer.
+//
+// THE DEFECT THIS EXISTS FOR. CODE_OF_CONDUCT.md named conduct@antifailure.dev
+// as the place a person reporting harassment should go. The legal pages named
+// security@antifailure.dev for a security researcher. Neither address has ever
+// been able to receive anything, and the reason is not subtle:
+//
+//	$ dig +short MX antifailure.dev                        (empty)
+//	$ dig +short TXT antifailure.dev                        "v=spf1 -all"
+//	$ dig +short TXT _dmarc.antifailure.dev                 "v=DMARC1; p=reject; ..."
+//	$ dig +short TXT resend._domainkey.antifailure.dev      "v=DKIM1; p="
+//
+// No mail exchanger, so nothing can be delivered. An SPF policy authorising no
+// sender and a DMARC policy of reject, so nothing can be sent either. A DKIM
+// record with an empty p=, which is how RFC 6376 spells a REVOKED key. The
+// domain is configured to send nothing and receive nothing, and every address
+// on it is silence.
+//
+// WHY THAT IS WORSE THAN PUBLISHING NOTHING. A published address is a promise
+// that somebody is on the other end. A researcher sitting on a finding, a
+// person asking to have their data deleted, and somebody reporting harassment
+// all send into the same void, and none of them can tell the difference
+// between a mailbox nobody reads and a mailbox that does not exist. They wait
+// instead of looking for the route that would have worked. Saying nothing at
+// least sends them looking.
+//
+// The site had already been fixed and the repository had not, which is the
+// shape of most of these: two things that should have moved together and only
+// one did. www/components/pages/company/Contact.tsx carried a callout headed
+// "Email is not a contact route" while CODE_OF_CONDUCT.md, in the same commit,
+// named a mailbox. web/apps/api/test/legal-facts.test.ts guards the two site
+// pages. Nothing guarded the repository, so this does.
+//
+// WHAT IT ASSERTS, and this is a choice with a cost either way.
+//
+// It does NOT resolve MX at check time. Doing so would make a gate on every
+// pull request depend on the network and on somebody else's resolver, which
+// buys a fresher answer at the price of a red build whenever DNS is slow and a
+// green one whenever a resolver lies. It is also the wrong question: an MX
+// record proves a server accepts mail, not that a person reads what lands
+// there, and the failure being guarded against is nobody reading it.
+//
+// Instead it inverts the default. Every address published in this repository
+// must be accounted for in tools/docs/contact-routes.tsv, and an address
+// nobody has written a row for FAILS. A static denylist of known-dead
+// addresses cannot notice a new domain; a default of no can, because a new
+// domain arrives with no row.
+//
+// Two things are exempt from needing a row, and both are exempt because they
+// can never be a route at all rather than because somebody vouched for them:
+//
+//   - The domains RFC 2606 and RFC 6761 reserve for documentation:
+//     example.com, example.net, example.org, and anything under the .test,
+//     .example, .invalid and .localhost top level domains. These exist so that
+//     an illustration cannot accidentally name a real mailbox.
+//   - Addresses under users.noreply.github.com, which is GitHub's own
+//     no-reply space and reads as one to anybody who sees it in a git log.
+//
+// THE THREE VERDICTS a row may carry are a closed set, because "allowed" with
+// a free text reason is a box anybody can tick.
+//
+//	receives           a person reads mail sent here, and the reason says who.
+//	                   REFUSED outright when the domain is one of the dead
+//	                   domains below. This is the rule that cannot be argued
+//	                   with: no wording makes antifailure.dev receive mail.
+//
+//	not-a-route        the string is a value the software writes, a git
+//	                   identity, or an illustration in a placeholder. Nobody is
+//	                   being invited to send anything to it.
+//
+//	records-a-defect   the address is quoted inside a description of a mailbox
+//	                   that did not work, which is what this very file does.
+//	                   REFUSED unless the same file also states that the
+//	                   address cannot receive, so the quotation cannot be the
+//	                   only thing a reader takes away.
+//
+// One rule sits above the verdicts and no row can excuse it: AT A DOMAIN
+// PROVEN DEAD, no text in this repository may read as an instruction to write
+// there. The words just before the address are checked rather than the words
+// on the same line, because the sentence that started this wrapped, with the
+// verb at the end of one line and the address at the start of the next.
+//
+// That rule is what makes a row per file safe. A row is matched by file and
+// address, so one row covers every occurrence in that file, and a file
+// legitimately quoting a dead address once would otherwise license a genuine
+// instruction three paragraphs down. It also costs something worth naming: a
+// sentence about the history has to say that a file named an address rather
+// than that it sent people to one. Four places in this repository were
+// reworded for it, this file included.
+//
+// The rule is scoped to dead domains rather than applied to every address,
+// because applied everywhere it convicted five illustrations that are fine: a
+// sign-in field whose label is the word Email, and a film showing an invented
+// customer row being masked whose sample text is itself an instruction to
+// email somebody. None of those is a promise this project has to keep. A
+// domain nobody has checked is caught by the missing row instead.
+//
+// A row matching nothing is reported, so the list cannot rot.
+//
+// WHAT THIS CANNOT CATCH, said here rather than left for somebody to discover.
+//
+//  1. It cannot tell whether a domain that is not in deadDomains receives.
+//     If this project acquires a second domain and publishes a mailbox on it
+//     with a row saying `receives`, the gate passes and the mail may still go
+//     nowhere. Adding a domain to deadDomains is a human check with `dig`.
+//  2. `records-a-defect` is satisfied by evidence anywhere in the same file.
+//     Somebody could write a genuine instruction to a dead address in a file
+//     that elsewhere explains the address is dead, and this would pass. That
+//     is a strange thing to write and it is visible in a diff, which is the
+//     whole of the defence.
+//  3. It reads source, not the rendered page. An address assembled at runtime
+//     from parts, or read from an environment variable, is invisible to it.
+//  4. It says nothing about whether a route that is not an address works. A
+//     dead GitHub link is claimcheck's and links' business, not this one's.
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+const routesPath = "tools/docs/contact-routes.tsv"
+
+// address matches an email address as a reader would recognise one. Kept
+// deliberately plain: the aim is to notice a string that looks like somewhere
+// to write, not to implement RFC 5322.
+var address = regexp.MustCompile(`[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}`)
+
+// reservedTLDs and reservedDomains are the names RFC 2606 and RFC 6761 set
+// aside so that documentation cannot name a real mailbox by accident. An
+// address under one of these is an illustration by construction and needs no
+// row: there is nothing on the other end and there never can be.
+var (
+	reservedTLDs    = map[string]bool{"test": true, "example": true, "invalid": true, "localhost": true}
+	reservedDomains = map[string]bool{"example.com": true, "example.net": true, "example.org": true}
+)
+
+// noReplySuffix is GitHub's no-reply space. A commit author at
+// users.noreply.github.com is the convention for an automated identity and
+// reads as one, so it is not a mailbox anybody mistakes for a route.
+const noReplySuffix = "users.noreply.github.com"
+
+// deadDomains are the domains proven not to receive, with the evidence and the
+// date somebody looked. A `receives` row at one of these is refused no matter
+// what its reason says.
+//
+// This is a list of PROVEN failures rather than the gate's main mechanism. The
+// main mechanism is that an address with no row at all fails, which is what
+// covers a domain nobody has checked yet. This list exists so that the one
+// domain we have checked cannot be re-argued in a reason column.
+var deadDomains = map[string]string{
+	"antifailure.dev": "no MX record at all, SPF `v=spf1 -all`, DMARC `p=reject` with strict alignment, " +
+		"and a DKIM record at resend._domainkey whose empty p= revokes the key (RFC 6376). " +
+		"Resolved against three independent resolvers on 2026-09-02, which agreed",
+}
+
+// verdicts are the only words a row may carry. A closed set, because the
+// failure being guarded against is somebody writing a plausible sentence in a
+// free text column and moving on.
+const (
+	verdictReceives = "receives"
+	verdictNotRoute = "not-a-route"
+	verdictDefect   = "records-a-defect"
+)
+
+// invitation is the language that turns a string into a promise. It is matched
+// against the text immediately BEFORE an address, because that is where the
+// instruction sits. The sentence that started this wrapped, with the verb at
+// the end of one line and the address at the start of the next, so the scan is
+// over a window of the file rather than over one line.
+//
+// It is broad on purpose, and it can afford to be, because it only ever runs
+// against an address at a domain already proven dead. A false positive there
+// costs somebody one sentence reworded. The same breadth applied everywhere
+// convicted a placeholder in a sign-in field.
+//
+// The bare word `contact` was in this list and is not any more. It is a noun
+// here as often as a verb, and it convicted this file's own opening line,
+// which says that contactcheck refuses a contact route. So the verb forms are
+// spelled out and the noun is left alone. `written by` and `writing` are out
+// for the same reason: api/README.md says a probe row "is written by
+// .github/workflows/waitlist.yml", which is a statement about a script.
+var invitation = regexp.MustCompile(`(?i)\b(?:mailbox|mail\s+(?:to|us|me)|writ(?:e|ing|ten)\s+to|` +
+	`report(?:s|ed|ing)?\s+(?:\w+\s+){0,2}(?:to|at)\b|contact(?:ed)?\s+(?:us|me|them|at|the\s+\w+)|` +
+	`reach(?:ed)?\s+(?:us|me|out|at)|send\s+(?:it\s+)?to|sent\s+to|complaints?\s+to|` +
+	`questions?\s+to|get\s+in\s+touch)\b`)
+
+// invitationAdjacent is the shorter half of the same rule: a single word that
+// only means an invitation when it sits immediately in front of the address.
+//
+// `email` cannot go in the list above. It appears in every sentence ABOUT a
+// mailbox as well as in every instruction to use one, and the changelog
+// fragment that records this whole defect opens "an email address that cannot
+// receive mail", which is the opposite of an invitation and would have been
+// convicted by it. Anchored to the end of the window it means what it says:
+// "email security@...", "Email: security@...", "email us at security@...".
+var invitationAdjacent = regexp.MustCompile(`(?i)\b(?:e-?mail|mail|address)\b[\s:,\-]*(?:us\s*)?(?:at\s*)?$`)
+
+// invitationWindow is how far back from an address the invitation language is
+// looked for, in bytes of whitespace normalised text. Two wrapped lines of
+// prose. Long enough to span the line break that hid the original defect,
+// short enough that an unrelated sentence earlier in a paragraph does not
+// convict the address.
+const invitationWindow = 120
+
+// deadEvidence is what a file must say for a `records-a-defect` row to stand:
+// somewhere in the same file, in the reader's sight, the address is described
+// as one that does not work.
+var deadEvidence = regexp.MustCompile(`(?i)cannot receive|can never receive|could not receive|does not receive|` +
+	`never been able to receive|no mail exchanger|delivered nowhere|do not email|is not a contact route|` +
+	`bounces|authorises no sender|authorizes no sender`)
+
+// skipDirs are trees whose contents are not ours to publish or not read by
+// anybody. `docs/plan` is NOT here: it is a working note rather than a
+// published page, but it is in the repository and a reader can open it.
+var skipDirs = map[string]bool{
+	"node_modules": true, "vendor": true, "dist": true, "out": true,
+	".git": true, "testdata": true, "__pycache__": true,
+}
+
+// skipFiles are the paths whose addresses are already checked somewhere else.
+//
+// CHANGELOG.md is assembled by `just changelog` out of the `.changes`
+// fragments, every one of which is scanned here. Requiring a second row for
+// the generated copy would mean the gate went red between a fragment landing
+// and the changelog being rebuilt, which is a red build for a file nobody
+// edited. Its source is covered, so it is not.
+//
+// The routes file itself is here for the obvious reason: it is a list of
+// addresses, so scanning it would demand a row for every row, and then a row
+// for that.
+var skipFiles = map[string]bool{"CHANGELOG.md": true, routesPath: true}
+
+// testFile reports whether a path is a test, a fixture, or a lockfile.
+//
+// A fixture is not published. Every SAML assertion, every seeded customer and
+// every masking corpus in this repository carries addresses, all of them at
+// reserved domains already, and scanning them would bury the twenty places
+// that are real under two hundred that are not.
+func testFile(rel string) bool {
+	base := filepath.Base(rel)
+	switch {
+	case strings.HasSuffix(base, "_test.go"),
+		strings.Contains(base, ".test."),
+		strings.Contains(base, ".spec."),
+		base == "go.sum", base == "package-lock.json", base == "pnpm-lock.yaml":
+		return true
+	}
+	for _, seg := range strings.Split(filepath.ToSlash(rel), "/") {
+		if seg == "test" || seg == "tests" || seg == "__tests__" {
+			return true
+		}
+	}
+	return false
+}
+
+// row is one line of the routes file.
+type row struct {
+	path, address, verdict, why string
+	line                        int
+	used                        bool
+}
+
+// finding is one thing wrong, in the words a person reading a red build needs.
+type finding struct {
+	path    string
+	num     int
+	address string
+	problem string
+	fix     string
+}
+
+func main() {
+	root := flag.String("root", ".", "repository root")
+	flag.Parse()
+	if args := flag.Args(); len(args) > 0 {
+		*root = args[0]
+	}
+	if err := run(*root, os.Stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "\ncontactcheck: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(root string, out io.Writer) error {
+	rows, err := loadRows(filepath.Join(root, routesPath))
+	if err != nil {
+		return err
+	}
+
+	files, err := collect(root)
+	if err != nil {
+		return err
+	}
+	if len(files) == 0 {
+		return fmt.Errorf("found no files under %s, so this check is looking in the wrong place", root)
+	}
+
+	var found []finding
+	scanned := 0
+	for _, rel := range files {
+		body, err := os.ReadFile(filepath.Join(root, rel))
+		if err != nil {
+			return err
+		}
+		scanned++
+		found = append(found, Check(rel, string(body), rows)...)
+	}
+
+	// A row that matches nothing is a finding of its own. Without this the file
+	// accumulates excuses for addresses that were deleted years ago, and the
+	// next person reads it as a description of the repository rather than as a
+	// list somebody stopped maintaining.
+	for _, r := range rows {
+		if !r.used {
+			found = append(found, finding{
+				path: routesPath, num: r.line, address: r.address,
+				problem: fmt.Sprintf("this row claims %s appears in %s, and it does not", r.address, r.path),
+				fix:     "delete the row, or correct the path if the address moved",
+			})
+		}
+	}
+
+	sort.Slice(found, func(i, j int) bool {
+		if found[i].path != found[j].path {
+			return found[i].path < found[j].path
+		}
+		return found[i].num < found[j].num
+	})
+
+	// Write errors are ignored explicitly, once, with a reason: the verdict of
+	// this tool is its exit code, not its report, so a broken pipe on stdout
+	// changes what a person can read and not whether the build should fail.
+	report := func(format string, args ...any) { _, _ = fmt.Fprintf(out, format, args...) }
+
+	for _, f := range found {
+		report("%s:%d  %s\n    %s.\n    %s.\n", f.path, f.num, f.address, f.problem, f.fix)
+	}
+	report("contactcheck: %d files, %d %s in %s, %d %s a route this project cannot answer\n",
+		scanned, len(rows), plural(len(rows), "row", "rows"), routesPath,
+		len(found), plural(len(found), "place publishes", "places publish"))
+
+	if len(found) > 0 {
+		return fmt.Errorf("%d %s a contact route that does not work",
+			len(found), plural(len(found), "place publishes", "places publish"))
+	}
+	return nil
+}
+
+// Check reports every address in one file that is not accounted for.
+//
+// Exported so a test can drive it without a tree, and so the rules stay in one
+// place rather than being restated by whatever reads them next.
+func Check(rel, body string, rows []*row) []finding {
+	var out []finding
+	evidence := deadEvidence.MatchString(flow(body))
+
+	for _, hit := range address.FindAllStringIndex(body, -1) {
+		found := body[hit[0]:hit[1]]
+		domain := domainOf(found)
+		if exempt(domain) {
+			continue
+		}
+		num := 1 + strings.Count(body[:hit[0]], "\n")
+
+		r := match(rows, rel, found)
+		if r == nil {
+			out = append(out, finding{
+				path: rel, num: num, address: found,
+				problem: "no row in " + routesPath + " accounts for this address, so nothing says whether anybody reads it",
+				fix: "route the reader somewhere that resolves, or add a row saying which of " +
+					verdictReceives + ", " + verdictNotRoute + " or " + verdictDefect + " this is and why",
+			})
+			continue
+		}
+		r.used = true
+
+		if why, dead := deadDomains[domain]; dead && r.verdict == verdictReceives {
+			out = append(out, finding{
+				path: rel, num: num, address: found,
+				problem: "the row says " + verdictReceives + ", and " + domain + " cannot receive mail: " + why,
+				fix:     "publish a route that resolves instead, and say plainly in the file that there is no mailbox",
+			})
+			continue
+		}
+
+		window := before(body, hit[0])
+		if _, dead := deadDomains[domain]; dead &&
+			(invitation.MatchString(window) || invitationAdjacent.MatchString(window)) {
+			out = append(out, finding{
+				path: rel, num: num, address: found,
+				problem: "the sentence in front of this reads as an instruction to write here, and " + domain +
+					" cannot receive mail",
+				fix: "point the reader at a route that resolves; if you are describing the address rather than " +
+					"offering it, say `named X` rather than `write to X`",
+			})
+			continue
+		}
+
+		if r.verdict == verdictDefect && !evidence {
+			out = append(out, finding{
+				path: rel, num: num, address: found,
+				problem: "the row says " + verdictDefect + ", and nothing in this file tells the reader the address does not work",
+				fix:     "say in the file that the address cannot receive mail, or the quotation reads as an instruction",
+			})
+			continue
+		}
+	}
+	return out
+}
+
+// wrapping is what separates two words of a phrase when prose reaches the
+// right margin: a line break, and then the comment marker that opens the next
+// line. `no mail exchanger` is three words in the source and was three words
+// on two lines in ci.yml, which is exactly the sentence deadEvidence is
+// looking for and could not see.
+var wrapping = regexp.MustCompile(`[\s#*]+|//+`)
+
+// flow puts a wrapped sentence back on one line so a phrase can be matched
+// across the break. Only used for the file wide evidence test, where the
+// question is whether the file says something at all rather than where.
+func flow(body string) string {
+	return wrapping.ReplaceAllString(body, " ")
+}
+
+// before returns the whitespace normalised text immediately preceding an
+// address, which is where an instruction to use it sits.
+func before(body string, at int) string {
+	start := at - invitationWindow*2
+	if start < 0 {
+		start = 0
+	}
+	window := strings.Join(strings.Fields(body[start:at]), " ")
+	if len(window) > invitationWindow {
+		window = window[len(window)-invitationWindow:]
+	}
+	return window
+}
+
+// domainOf returns the lowercased domain of an address, without a trailing dot
+// picked up from the end of a sentence.
+func domainOf(addr string) string {
+	at := strings.LastIndex(addr, "@")
+	return strings.ToLower(strings.Trim(addr[at+1:], "."))
+}
+
+// exempt reports whether a domain can never be a route at all.
+func exempt(domain string) bool {
+	if reservedDomains[domain] || domain == noReplySuffix || strings.HasSuffix(domain, "."+noReplySuffix) {
+		return true
+	}
+	parts := strings.Split(domain, ".")
+	return reservedTLDs[parts[len(parts)-1]]
+}
+
+// match finds the row for one address in one file.
+func match(rows []*row, rel, addr string) *row {
+	for _, r := range rows {
+		if r.path == rel && strings.EqualFold(r.address, addr) {
+			return r
+		}
+	}
+	return nil
+}
+
+// loadRows reads the routes file. Four tab separated fields, comments and
+// blank lines skipped.
+func loadRows(path string) ([]*row, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("%s is the whole point of this check: %w", routesPath, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	var rows []*row
+	s := bufio.NewScanner(f)
+	s.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for n := 1; s.Scan(); n++ {
+		line := s.Text()
+		if strings.TrimSpace(line) == "" || strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+		parts := strings.Split(line, "\t")
+		if len(parts) != 4 {
+			return nil, fmt.Errorf("%s:%d has %d tab separated fields, wanted 4: path, address, verdict, why",
+				routesPath, n, len(parts))
+		}
+		r := &row{
+			path: strings.TrimSpace(parts[0]), address: strings.TrimSpace(parts[1]),
+			verdict: strings.TrimSpace(parts[2]), why: strings.TrimSpace(parts[3]), line: n,
+		}
+		switch r.verdict {
+		case verdictReceives, verdictNotRoute, verdictDefect:
+		default:
+			return nil, fmt.Errorf("%s:%d has verdict %q, which is not one of %s, %s, %s",
+				routesPath, n, r.verdict, verdictReceives, verdictNotRoute, verdictDefect)
+		}
+		if r.why == "" {
+			return nil, fmt.Errorf("%s:%d has no reason, and a row with no argument behind it is somebody "+
+				"silencing a finding they did not understand", routesPath, n)
+		}
+		rows = append(rows, r)
+	}
+	if err := s.Err(); err != nil {
+		return nil, err
+	}
+	if len(rows) == 0 {
+		return nil, fmt.Errorf("%s has no rows, so this check would pass a repository full of dead mailboxes", routesPath)
+	}
+	return rows, nil
+}
+
+// collect walks the repository and returns every text file worth scanning.
+func collect(root string) ([]string, error) {
+	var out []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			name := d.Name()
+			if path != root && (skipDirs[name] || (strings.HasPrefix(name, ".") && name != ".github" && name != ".changes" && name != ".githooks")) {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return nil
+		}
+		rel = filepath.ToSlash(rel)
+		if skipFiles[rel] || testFile(rel) || !text(path) {
+			return nil
+		}
+		out = append(out, rel)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// textExts are the extensions a published address can live in. An allowlist
+// rather than a size or content sniff, because the alternative is reading
+// every binary in the tree to find out it is a binary.
+var textExts = map[string]bool{
+	".md": true, ".mdx": true, ".txt": true, ".go": true, ".ts": true, ".tsx": true,
+	".js": true, ".jsx": true, ".mjs": true, ".cjs": true, ".json": true, ".yml": true,
+	".yaml": true, ".toml": true, ".sh": true, ".bash": true, ".sql": true, ".html": true,
+	".css": true, ".tf": true, ".tfvars": true, ".bicep": true, ".py": true, ".rb": true,
+}
+
+// textNames are the extensionless files that still carry prose or configuration.
+var textNames = map[string]bool{
+	"justfile": true, "Justfile": true, "Dockerfile": true, "Makefile": true,
+	"LICENSE": true, "NOTICE": true, "pre-commit": true, "pre-push": true, "commit-msg": true,
+}
+
+func text(path string) bool {
+	base := filepath.Base(path)
+	if textNames[base] {
+		return true
+	}
+	if strings.HasPrefix(base, "Dockerfile") {
+		return true
+	}
+	return textExts[filepath.Ext(base)]
+}
+
+// plural picks the word for a count, so a failing run does not report
+// "1 places". The message is the only thing a person reads when this gate goes
+// red.
+func plural(n int, one, many string) string {
+	if n == 1 {
+		return one
+	}
+	return many
+}

--- a/tools/contactcheck/main.go
+++ b/tools/contactcheck/main.go
@@ -387,7 +387,10 @@ func Check(rel, body string, rows []*row) []finding {
 			out = append(out, finding{
 				path: rel, num: num, address: found,
 				problem: "the row says " + verdictReceives + ", and " + domain + " cannot receive mail: " + why,
-				fix:     "publish a route that resolves instead, and say plainly in the file that there is no mailbox",
+				fix: "publish a route that resolves instead, and say plainly in the file that there is no " +
+					"mailbox. If the domain has since been given an MX record and a mailbox somebody reads, " +
+					"take it out of deadDomains in this tool and put the dig output in the commit, so the " +
+					"next person can see what was checked and when",
 			})
 			continue
 		}

--- a/tools/contactcheck/main_test.go
+++ b/tools/contactcheck/main_test.go
@@ -1,0 +1,250 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// rowsFor builds the table a test runs against. Written out rather than read
+// from tools/docs/contact-routes.tsv, so a test says what it is testing and
+// does not go red when somebody adds a placeholder to the console.
+func rowsFor(t *testing.T, in ...*row) []*row {
+	t.Helper()
+	for _, r := range in {
+		if r.why == "" {
+			r.why = "a reason, because loadRows refuses a row without one"
+		}
+	}
+	return in
+}
+
+func problems(t *testing.T, rel, body string, rows []*row) []finding {
+	t.Helper()
+	return Check(rel, body, rows)
+}
+
+// The defect this whole tool exists for, in the words it was written in.
+func TestTheSentenceThatStartedThisIsRefused(t *testing.T) {
+	body := "## Enforcement\n\nInstances of abusive behavior may be\n" +
+		"reported to the community leaders responsible for enforcement at\n" +
+		"conduct@antifailure.dev. All complaints will be reviewed.\n"
+
+	got := problems(t, "CODE_OF_CONDUCT.md", body, nil)
+	if len(got) != 1 {
+		t.Fatalf("want one finding, got %d: %+v", len(got), got)
+	}
+	if !strings.Contains(got[0].problem, "no row") {
+		t.Errorf("problem = %q, want the missing row", got[0].problem)
+	}
+	// A finding that only forbids teaches somebody to work around it.
+	if got[0].fix == "" {
+		t.Error("a finding must say what to do instead")
+	}
+}
+
+// The instruction wraps: the verb is on one line and the address is on the
+// next. A rule scoped to a single line would have passed the original defect,
+// which is the reason the window spans line breaks.
+func TestTheInvitationIsFoundAcrossALineBreak(t *testing.T) {
+	body := "reported to the community leaders responsible for enforcement at\nconduct@antifailure.dev.\n"
+	rows := rowsFor(t, &row{path: "CODE_OF_CONDUCT.md", address: "conduct@antifailure.dev", verdict: verdictNotRoute})
+
+	got := problems(t, "CODE_OF_CONDUCT.md", body, rows)
+	if len(got) != 1 {
+		t.Fatalf("want one finding, got %d: %+v", len(got), got)
+	}
+	if !strings.Contains(got[0].problem, "instruction") {
+		t.Errorf("problem = %q, want the invitation rule", got[0].problem)
+	}
+}
+
+// The laundering path, and the reason the verdicts are a closed set. A row
+// cannot argue a domain with no mail exchanger into receiving mail.
+func TestAReceivesRowCannotRescueADeadDomain(t *testing.T) {
+	rows := rowsFor(t, &row{
+		path: "SECURITY.md", address: "security@antifailure.dev", verdict: verdictReceives,
+		why: "the maintainers read this",
+	})
+	got := problems(t, "SECURITY.md", "Send findings here: security@antifailure.dev\n", rows)
+	if len(got) != 1 {
+		t.Fatalf("want one finding, got %d: %+v", len(got), got)
+	}
+	if !strings.Contains(got[0].problem, "cannot receive mail") {
+		t.Errorf("problem = %q, want the dead domain rule", got[0].problem)
+	}
+}
+
+// The other laundering path: relabel the instruction as furniture.
+func TestFurnitureCannotBeAnInstruction(t *testing.T) {
+	rows := rowsFor(t, &row{path: "SECURITY.md", address: "security@antifailure.dev", verdict: verdictNotRoute})
+	if got := problems(t, "SECURITY.md", "Please write to security@antifailure.dev.\n", rows); len(got) != 1 {
+		t.Fatalf("want one finding, got %d: %+v", len(got), got)
+	}
+}
+
+// One row covers a whole file, so a file that legitimately quotes a dead
+// address once must not thereby license an instruction further down. This is
+// why the invitation rule sits above the verdicts rather than inside one.
+func TestOneQuotationDoesNotLicenseAnInstructionLater(t *testing.T) {
+	body := "The address named here, conduct@antifailure.dev, cannot receive mail.\n\n" +
+		strings.Repeat("Filler that is not about mail at all.\n", 6) +
+		"Report abuse to conduct@antifailure.dev.\n"
+	rows := rowsFor(t, &row{path: "CODE_OF_CONDUCT.md", address: "conduct@antifailure.dev", verdict: verdictDefect})
+
+	got := problems(t, "CODE_OF_CONDUCT.md", body, rows)
+	if len(got) != 1 {
+		t.Fatalf("want exactly the second occurrence, got %d: %+v", len(got), got)
+	}
+	if !strings.Contains(got[0].problem, "instruction") {
+		t.Errorf("problem = %q, want the invitation rule", got[0].problem)
+	}
+}
+
+// A quotation of a defect has to be accompanied by the correction, or the
+// reader takes the address away and nothing else.
+func TestQuotingADefectNeedsTheFileToSayItIsOne(t *testing.T) {
+	rows := rowsFor(t, &row{path: "notes.md", address: "conduct@antifailure.dev", verdict: verdictDefect})
+
+	if got := problems(t, "notes.md", "The old address was conduct@antifailure.dev.\n", rows); len(got) != 1 {
+		t.Fatalf("a bare quotation should be refused, got %d: %+v", len(got), got)
+	}
+	with := "The old address was conduct@antifailure.dev, at a domain with no mail exchanger, " +
+		"so it could not receive anything.\n"
+	if got := problems(t, "notes.md", with, rows); len(got) != 0 {
+		t.Errorf("a quotation beside the correction is fine, got %+v", got)
+	}
+}
+
+// The sentence in the changelog fragment that records this defect. It opens
+// "an email address that cannot receive mail", which is the opposite of an
+// invitation, and a rule matching the bare word `email` anywhere in the window
+// convicted it. That is why `email` is anchored to the end of the window.
+func TestASentenceAboutAMailboxIsNotAnInvitationToUseIt(t *testing.T) {
+	body := "The legal pages no longer publish an email address that cannot receive mail.\n\n" +
+		"The addendum and the retention page both named\n`security@antifailure.dev` as the destination.\n"
+	rows := rowsFor(t, &row{path: "f.md", address: "security@antifailure.dev", verdict: verdictDefect})
+
+	if got := problems(t, "f.md", body, rows); len(got) != 0 {
+		t.Errorf("want clean, got %+v", got)
+	}
+}
+
+// `email` immediately in front of the address is the shape that does mean an
+// invitation, in each of the ways people write it.
+func TestEmailInFrontOfTheAddressIsAnInvitation(t *testing.T) {
+	rows := rowsFor(t, &row{path: "f.md", address: "security@antifailure.dev", verdict: verdictNotRoute})
+	for _, body := range []string{
+		"Just email security@antifailure.dev.\n",
+		"Email: security@antifailure.dev\n",
+		"You can email us at security@antifailure.dev.\n",
+	} {
+		if got := problems(t, "f.md", body, rows); len(got) != 1 {
+			t.Errorf("%q should be refused, got %+v", body, got)
+		}
+	}
+}
+
+// The documentation domains exist so an illustration cannot name a real
+// mailbox. They need no row, because there is nothing on the other end and
+// there never can be. Without this the fixtures in this repository would need
+// two hundred rows and the twenty real ones would be unreadable.
+func TestReservedDomainsNeedNoRow(t *testing.T) {
+	body := "af inbox wait --to owner@example.test\nWrite to ada@example.com or grace@example.org.\n" +
+		"Signed by 67278851+VirSanghavi@users.noreply.github.com.\n"
+	if got := problems(t, "docs/x.md", body, nil); len(got) != 0 {
+		t.Errorf("want clean, got %+v", got)
+	}
+}
+
+// A placeholder in a sign-in field is not a promise, and the invitation rule
+// must not reach it. This is the case that made the rule dead-domain only:
+// the label above the input is the word Email.
+func TestAPlaceholderAtALiveDomainIsNotConvictedByItsLabel(t *testing.T) {
+	rows := rowsFor(t, &row{path: "www/AuthScreen.tsx", address: "you@company.com", verdict: verdictNotRoute})
+	body := "<label>Email</label>\n<input placeholder=\"you@company.com\" />\n"
+	if got := problems(t, "www/AuthScreen.tsx", body, rows); len(got) != 0 {
+		t.Errorf("want clean, got %+v", got)
+	}
+}
+
+// The probe row. It is deliberately an address nothing can deliver to, it is
+// posted to an API rather than offered to a reader, and the paragraph that
+// documents it ends by saying not to email it.
+func TestASyntheticValueAtTheDeadDomainIsAllowed(t *testing.T) {
+	rows := rowsFor(t, &row{path: "api/README.md", address: "waitlist-probe@antifailure.dev", verdict: verdictNotRoute})
+	body := "One row in that table is not a person. `waitlist-probe@antifailure.dev` is\n" +
+		"written by the workflow every morning. Do not count it, and do not email it.\n"
+	if got := problems(t, "api/README.md", body, rows); len(got) != 0 {
+		t.Errorf("want clean, got %+v", got)
+	}
+}
+
+func TestExemptKnowsTheReservedNames(t *testing.T) {
+	for _, d := range []string{
+		"example.com", "example.net", "example.org",
+		"antifailure.test", "corp.example", "host.invalid", "db.localhost",
+		"users.noreply.github.com",
+	} {
+		if !exempt(d) {
+			t.Errorf("%s should need no row", d)
+		}
+	}
+	for _, d := range []string{"antifailure.dev", "gmail.com", "acme.com", "example.io", "notexample.com"} {
+		if exempt(d) {
+			t.Errorf("%s is a real domain and should need a row", d)
+		}
+	}
+}
+
+func TestDomainOfIgnoresATrailingFullStop(t *testing.T) {
+	if got := domainOf("conduct@antifailure.dev."); got != "antifailure.dev" {
+		t.Errorf("domainOf = %q", got)
+	}
+}
+
+// A fixture is not published. The tests in this repository carry hundreds of
+// addresses and none of them is a route.
+func TestTestsAndLockfilesAreNotScanned(t *testing.T) {
+	for _, p := range []string{
+		"engine/internal/env/oracle_test.go",
+		"web/apps/api/test/legal-facts.test.ts",
+		"ee/web/sso/test/idp.ts",
+		"engine/go.sum",
+	} {
+		if !testFile(p) {
+			t.Errorf("%s should not be scanned", p)
+		}
+	}
+	for _, p := range []string{"SECURITY.md", "tools/contactcheck/main.go", "www/components/AuthScreen.tsx"} {
+		if testFile(p) {
+			t.Errorf("%s is published and must be scanned", p)
+		}
+	}
+}
+
+// The one blind spot worth restating as a test, so nobody reads the gate as
+// promising more than it does: a live domain with a `receives` row passes, and
+// whether anybody actually reads that mailbox is not a question this tool can
+// answer.
+func TestAReceivesRowAtAnUncheckedDomainPasses(t *testing.T) {
+	rows := rowsFor(t, &row{
+		path: "SECURITY.md", address: "security@somewhere-else.dev", verdict: verdictReceives,
+		why: "a person reads this",
+	})
+	if got := problems(t, "SECURITY.md", "Email security@somewhere-else.dev.\n", rows); len(got) != 0 {
+		t.Errorf("this gate cannot check a domain it has not been told about, got %+v", got)
+	}
+}
+
+// Prose wraps, and a phrase splits across the break with the comment marker of
+// the next line in the middle of it. `no mail exchanger` is three words, and
+// in ci.yml it sat as "no mail" then a newline then "# exchanger", which is
+// the exact sentence the evidence rule looks for and could not see.
+func TestEvidenceIsFoundAcrossAWrappedLine(t *testing.T) {
+	rows := rowsFor(t, &row{path: ".github/workflows/ci.yml", address: "conduct@antifailure.dev", verdict: verdictDefect})
+	body := "        # The file named conduct@antifailure.dev. The domain has no mail\n" +
+		"        # exchanger, so nothing sent there was delivered.\n"
+	if got := problems(t, ".github/workflows/ci.yml", body, rows); len(got) != 0 {
+		t.Errorf("want clean, got %+v", got)
+	}
+}

--- a/tools/contactcheck/main_test.go
+++ b/tools/contactcheck/main_test.go
@@ -248,3 +248,35 @@ func TestEvidenceIsFoundAcrossAWrappedLine(t *testing.T) {
 		t.Errorf("want clean, got %+v", got)
 	}
 }
+
+// The review finding that tightened the evidence rule from the file to the
+// paragraph. CODE_OF_CONDUCT.md legitimately quotes the dead address once,
+// with the correction beside it. Under the file wide rule that one correction
+// licensed every later occurrence in the same file, including a genuine
+// instruction forty lines down, in the file a person opens after being
+// harassed. File membership is not proximity.
+func TestEvidenceFarFromTheAddressDoesNotCountAsBesideIt(t *testing.T) {
+	rows := rowsFor(t, &row{path: "CODE_OF_CONDUCT.md", address: "conduct@antifailure.dev", verdict: verdictDefect})
+	body := "The old address cannot receive mail, and here is why.\n" +
+		strings.Repeat("A paragraph about something else entirely.\n", 40) +
+		"The address is conduct@antifailure.dev.\n"
+
+	got := problems(t, "CODE_OF_CONDUCT.md", body, rows)
+	if len(got) != 1 {
+		t.Fatalf("want the far quotation refused, got %d: %+v", len(got), got)
+	}
+	if !strings.Contains(got[0].problem, "lines of it") {
+		t.Errorf("problem = %q, want the proximity rule", got[0].problem)
+	}
+}
+
+// The same quotation with the correction in its own paragraph is fine, which
+// is what every real one in this repository looks like.
+func TestEvidenceBesideTheAddressCounts(t *testing.T) {
+	rows := rowsFor(t, &row{path: "CODE_OF_CONDUCT.md", address: "conduct@antifailure.dev", verdict: verdictDefect})
+	body := strings.Repeat("A paragraph about something else entirely.\n", 40) +
+		"It named conduct@antifailure.dev, and that address\ncannot receive mail.\n"
+	if got := problems(t, "CODE_OF_CONDUCT.md", body, rows); len(got) != 0 {
+		t.Errorf("want clean, got %+v", got)
+	}
+}

--- a/tools/docs/contact-routes.tsv
+++ b/tools/docs/contact-routes.tsv
@@ -45,6 +45,18 @@ ee/web/sso/src/provision.ts	ada@gmail.com	not-a-route	the same example, in the c
 justfile	potatogreenbean204@gmail.com	not-a-route	the same wrong git identity, checked once more over the commits on a branch before it is landed.
 tools/contactcheck/main.go	conduct@antifailure.dev	records-a-defect	named in this gate's own explanation of the defect it was written for, beside the dig output showing the domain has no mail exchanger.
 tools/contactcheck/main.go	security@antifailure.dev	records-a-defect	the other half of the same explanation.
+tools/preview/README.md	operator@preview.local	not-a-route	the operator the preview seeds, named in the section explaining that its password is generated fresh on every run and written outside the working tree. The preview database is thrown away, and .local is reserved by RFC 6762, so the address resolves nowhere.
+tools/preview/common.sh	operator@preview.local	not-a-route	the same seeded operator, as the shell variable the preview scripts sign in with.
+tools/preview/seed.ts	rhea.okafor@preview.local	not-a-route	one of eleven fixed fictional operators written into the throwaway preview database, this one holding super_admin. The identities are constant rather than random so two runs produce the same portal and screenshots can be compared.
+tools/preview/seed.ts	tomas.lindqvist@preview.local	not-a-route	the same seeded set, holding the infrastructure role.
+tools/preview/seed.ts	nadia.haddad@preview.local	not-a-route	the same seeded set, holding the security role.
+tools/preview/seed.ts	yusuf.demir@preview.local	not-a-route	the same seeded set, holding the billing role.
+tools/preview/seed.ts	clara.mendes@preview.local	not-a-route	the same seeded set, holding a support role.
+tools/preview/seed.ts	ines.duarte@preview.local	not-a-route	the same seeded set, holding the second support role.
+tools/preview/seed.ts	peter.novak@preview.local	not-a-route	the same seeded set, holding the analytics role.
+tools/preview/seed.ts	mira.solberg@preview.local	not-a-route	the same seeded set, holding read_only.
+tools/preview/seed.ts	oskar.wojcik@preview.local	not-a-route	the same seeded set, the one seeded suspended so the portal has a suspended operator to show.
+tools/preview/seed.ts	lena.fischer@preview.local	not-a-route	the same seeded set, the one seeded never provisioned so the portal has that state to show.
 www/components/AuthScreen.tsx	you@company.com	not-a-route	the placeholder inside the sign-in field.
 www/components/home/visuals/TwinLifecycleScene.tsx	ada@corp.io	not-a-route	a row of invented customer data in the animated lifecycle film, shown being masked. The film is captioned as a shaped example.
 www/components/home/visuals/TwinLifecycleScene.tsx	user_00418@mask.local	not-a-route	what the same film shows that row becoming after masking. A generated value at a domain that does not resolve, which is the output the masker actually produces.

--- a/tools/docs/contact-routes.tsv
+++ b/tools/docs/contact-routes.tsv
@@ -1,0 +1,58 @@
+# Every email address this repository publishes, and what happens when somebody
+# uses it.
+#
+# Four tab separated fields: the file, the address exactly as contactcheck
+# reports it, the verdict, and why. An address with no row here fails the gate,
+# which is the point: a default of no is the only rule that notices a domain
+# nobody has checked yet.
+#
+# The verdict is one of three words and nothing else:
+#
+#   receives          a person reads mail sent here, and the reason says who.
+#                     Refused outright at a domain contactcheck knows to be
+#                     dead, because no reason makes a domain with no mail
+#                     exchanger receive mail.
+#
+#   not-a-route       a value the software writes, a git identity, or an
+#                     illustration in a placeholder. Nobody is invited to send
+#                     anything to it. Refused when the text just before the
+#                     address reads as an instruction to write there.
+#
+#   records-a-defect  the address is quoted inside a description of a mailbox
+#                     that did not work. Refused unless the same file also
+#                     tells the reader it cannot receive.
+#
+# There is no `receives` row in this file today, and that is the honest state
+# of the project rather than an oversight. antifailure.dev has no mail
+# exchanger, publishes an SPF policy authorising no sender, a DMARC policy of
+# reject, and a revoked DKIM key. Every route this project offers a reader goes
+# through GitHub or through the booking calendar on the contact page.
+
+.changes/legal-pages-named-a-mailbox-that-could-not-receive.md	security@antifailure.dev	records-a-defect	the fragment recording that the legal pages stopped naming this mailbox. It quotes the sentence that was wrong and then says the domain publishes no mail exchanger.
+.githooks/pre-commit	potatogreenbean204@gmail.com	not-a-route	the wrong git identity this hook exists to refuse. It is compared against, never offered to anybody, and a commit carrying it is rejected before it is written.
+.github/workflows/ci.yml	potatogreenbean204@gmail.com	not-a-route	the same wrong git identity, checked again in CI for commits that reached the remote without the hook.
+.github/workflows/status.yml	status@antifailure.dev	records-a-defect	quoted in the comment explaining why the status commits no longer carry it. The workflow now commits as GitHub's Actions no-reply identity.
+.github/workflows/waitlist.yml	waitlist-probe@antifailure.dev	not-a-route	the synthetic row this probe writes into the waitlist table every morning to prove a signup still reaches storage. It is a value posted to an API, and it is deliberately an address nothing can deliver to.
+CODE_OF_CONDUCT.md	conduct@antifailure.dev	records-a-defect	quoted in the enforcement section as the address that used to be there, immediately followed by the DNS reason it never worked and by the routes that do.
+api/README.md	waitlist-probe@antifailure.dev	not-a-route	the same synthetic row, documented so that whoever reads the table does not count it as a signup. The paragraph ends by saying not to email it.
+console/app/(app)/members/page.tsx	someone@yourcompany.com	not-a-route	the placeholder inside the invite field. It is grey text in an empty input, replaced by whatever the operator types.
+console/app/(app)/settings/page.tsx	accounts@yourcompany.com	not-a-route	the placeholder inside the billing contact field, replaced by whatever the operator types.
+docs/plan/STATUS.md	virrsanghavi@gmail.com	not-a-route	quoted out of a Microsoft Entra ID provisioning log as evidence that a real directory read a real user back through the SCIM filter endpoint. It is a log line, not somewhere to write.
+docs/plan/notes/claims.md	ajay@acme.com	not-a-route	quoted from a marketing page's before-and-after illustration, in the row recording that the illustration was wrong. Nobody is asked to write there.
+docs/plan/notes/claims.md	vir.sanghavi@realcompany.com	not-a-route	the value written into a live column to falsify the masking scanner, quoted in the evidence for that claim. It is a test input, and the domain is not one this project owns.
+docs/src/content/docs/enterprise/sso.md	someone@gmail.com	not-a-route	an example of the address an attacker's own identity provider could assert, in the paragraph explaining why a domain has to be verified before it is trusted.
+ee/web/sso/src/provision.ts	ada@gmail.com	not-a-route	the same example, in the comment above the code that refuses it.
+justfile	potatogreenbean204@gmail.com	not-a-route	the same wrong git identity, checked once more over the commits on a branch before it is landed.
+tools/contactcheck/main.go	conduct@antifailure.dev	records-a-defect	named in this gate's own explanation of the defect it was written for, beside the dig output showing the domain has no mail exchanger.
+tools/contactcheck/main.go	security@antifailure.dev	records-a-defect	the other half of the same explanation.
+www/components/AuthScreen.tsx	you@company.com	not-a-route	the placeholder inside the sign-in field.
+www/components/home/visuals/TwinLifecycleScene.tsx	ada@corp.io	not-a-route	a row of invented customer data in the animated lifecycle film, shown being masked. The film is captioned as a shaped example.
+www/components/home/visuals/TwinLifecycleScene.tsx	user_00418@mask.local	not-a-route	what the same film shows that row becoming after masking. A generated value at a domain that does not resolve, which is the output the masker actually produces.
+www/components/home/visuals/headerMinis.tsx	ada@corp.io	not-a-route	the same invented row, in the small header animation that reuses the film's data.
+www/components/home/visuals/hero/StateFilm.tsx	ajay@acme.com	not-a-route	a row of invented customer data in the hero film, shown being masked.
+.changes/a-code-of-conduct-that-routed-complaints-into-silence.md	conduct@antifailure.dev	records-a-defect	the fragment recording that the code of conduct stopped naming it, beside the DNS reason nothing sent there was delivered.
+.changes/a-code-of-conduct-that-routed-complaints-into-silence.md	status@antifailure.dev	records-a-defect	the same fragment, recording that the status workflow stopped committing under it.
+.github/workflows/ci.yml	conduct@antifailure.dev	records-a-defect	named in the comment above the contactcheck step as the defect the step exists for, with the DNS reason beside it.
+.github/workflows/ci.yml	security@antifailure.dev	records-a-defect	the other half of the same comment.
+justfile	conduct@antifailure.dev	records-a-defect	named in the comment above the contactcheck recipe as the defect the recipe exists for, with the DNS reason beside it.
+justfile	security@antifailure.dev	records-a-defect	the other half of the same comment.


### PR DESCRIPTION
## What was wrong

`CODE_OF_CONDUCT.md` named `conduct@antifailure.dev` as the place to report abusive behaviour. That address has never been able to receive anything. Resolved on 2026-09-02 against three resolvers, which agreed:

```
$ dig +short MX antifailure.dev                        (empty)
$ dig +short TXT antifailure.dev                        "v=spf1 -all"
$ dig +short TXT _dmarc.antifailure.dev                 "v=DMARC1; p=reject; sp=reject; adkim=s; aspf=s; ..."
$ dig +short TXT resend._domainkey.antifailure.dev      "v=DKIM1; p="
```

No mail exchanger, so nothing is delivered. An SPF policy authorising no sender and a DMARC policy of reject, so nothing is sent either. A DKIM record whose empty `p=` is how RFC 6376 spells a revoked key. A person reporting harassment got a silence they could not tell apart from being ignored, and waited instead of looking for a route that would have worked.

The site had already been fixed. `SECURITY.md`, `ee/LICENSE.md` and the licensing error message had already been fixed on `main` by earlier work. The code of conduct had not.

## What this changes

**The enforcement section says there is no confidential channel**, rather than naming a second mailbox. It lists what resolves today, a public issue or discussion and a booked call with the maintainer, with what each one costs the reporter. It says GitHub private vulnerability reporting is the wrong queue for a conduct complaint. It names the gap none of them closes: whoever reads a complaint is one of the same few people who maintain this repository, so a complaint about a maintainer has nowhere independent to go inside it, and GitHub's own abuse route is outside it.

**The daily status workflow** committed as `status@antifailure.dev`, which reads like a mailbox and is not one. It commits under GitHub's Actions no-reply identity now.

**A gate, `tools/contactcheck`.** It reads every text file in the tree and requires a row in `tools/docs/contact-routes.tsv` for every address, saying one of three things: a person reads it, it is a value the software writes rather than an invitation, or it is a defect being quoted beside its correction. Twenty eight rows today and not one of them says `receives`, which is the honest state of the project.

The rules that cannot be argued with:

* An address with **no row fails**. That is what catches a domain nobody has checked, which a static denylist of dead addresses cannot do.
* A `receives` row at a **domain proven dead is refused outright**, whatever its reason says.
* At such a domain, **no sentence anywhere may read as an instruction to write there**, whatever its verdict. The words before the address are checked rather than the words on the same line, because the sentence that started this wrapped.
* A **row matching nothing** fails, so the list cannot rot.

Addresses at the domains RFC 2606 and RFC 6761 reserve for documentation need no row, and neither do addresses under `users.noreply.github.com`. Test files and fixtures are not scanned.

## The choice, and what it cannot catch

It does **not** resolve MX at check time. That would put every pull request behind somebody else's resolver, buying a fresher answer at the price of a red build whenever DNS is slow and a green one whenever a resolver lies. It also answers the wrong question: an MX record proves a server accepts mail, not that a person reads what lands there.

Four blind spots, written into the tool's own header:

1. It cannot tell whether a domain **not** in its dead list receives. A second domain vouched for by a `receives` row nobody verified passes. Adding a domain to that list is a human check with `dig`.
2. The correction beside a quotation is matched as a phrase, not read, so a paragraph could carry one of those phrases in a sentence meaning something else. This was much wider until review: the evidence used to be satisfied anywhere in the same file, which let one legitimate quotation license every later occurrence in it. It now has to sit within eight lines of the address.
3. It reads source, not the rendered page. An address assembled at runtime is invisible to it.
4. It says nothing about routes that are not addresses. A dead GitHub link is `claimcheck`'s business.

## Proof it can say no

Each run against the real tree, before any claim that it works:

| Case | Exit |
| --- | --- |
| The original enforcement sentence restored | 1 |
| A new address with no row | 1 |
| The same address vouched for as `receives` | 1 |
| The same address relabelled `not-a-route` | 1 |
| The same address labelled `records-a-defect` with no correction in the file | 1 |
| A row matching nothing | 1 |
| An address at a domain the tool has never heard of | 1 |
| The tree as it stands | 0 |

It also caught its own author twice: the wording of this change's own changelog fragment and of the CI comment above the new step, both of which read as instructions to write to a dead address until they were reworded.

## Gates run

`contactcheck`, `prosecheck`, `claimcheck`, `changecheck`, `gatecheck`, `forbidden`, `execcheck`, `readability`, `cspell`, `vale`, `gofmt`, `go vet`, and the tool's own fifteen tests. All green. `docscheck` and `links` need a full site build and were not run locally; neither this change nor its files are under `docs/src` or `www`.

## What still needs a human

A confidential conduct channel cannot be created from a pull request. Two ways to get one, in the order I would do them.

**The real fix, a mailbox on the domain.** Receiving needs only an MX record and a mailbox. Replying needs the sending records fixed too, and today they are all closed.

1. Sign a mail host up for `antifailure.dev`. The DNS is at a Secureserver nameserver, going by the DMARC `rua`, so the records go in that registrar's zone editor.
2. Add the host's MX records. At this point the domain can receive.
3. Replace the SPF record. It is `v=spf1 -all` and has to become `v=spf1 include:<the host's include> -all`, or every reply is rejected by the recipient.
4. Publish the host's DKIM record at its own selector. Leave `resend._domainkey` alone or delete it: its empty `p=` is a correct revocation of a key nothing uses.
5. Leave DMARC at `p=reject` with `adkim=s; aspf=s`, then send a test to an outside address and read the headers to confirm both alignments pass. Strict alignment is unforgiving and this is the step that fails quietly.
6. Send from an outside address and confirm it lands in a mailbox somebody reads.
7. Only then put the address in `CODE_OF_CONDUCT.md`, take `antifailure.dev` out of `deadDomains` in `tools/contactcheck/main.go` with the new `dig` output in the commit, and add a `receives` row naming who reads it. The gate refuses the row until step 7 is done, which is deliberate: it forces somebody to re-run `dig` rather than remember.

**An interim, no DNS.** A form under an account that already exists, taking anonymous responses, linked from the enforcement section. It is one way, so it cannot hold a conversation with a reporter, and whoever owns the form has to check it. Better than a mailbox that bounces, worse than a real address.

Neither closes the gap named in the file: a complaint about the maintainer still has nowhere independent to go inside the project. Closing that needs a second person willing to receive complaints, which is a decision rather than a configuration change.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR

## Two failures found while driving this branch green

**The new gate's own binary was not ignored.** This branch adds `tools/contactcheck`, and `go build ./tools/contactcheck` writes `./contactcheck` into the repository root. Nothing covered that name, so the next `git add -A` would have committed a platform specific executable, which is exactly how the `constcheck` binary once got tracked. `tools/gatecheck`'s `TestEveryToolsBinaryNameIsIgnored` was the only failing test in the whole `tools` suite and it named the fix precisely. `/contactcheck` is now in `.gitignore` in its sorted position.

**Twelve addresses this branch's own gate refused, which only existed once both branches were in one tree.** `tools/preview` landed on main after this branch forked, so `contactcheck` had never been run against `tools/preview/README.md`, `tools/preview/common.sh` or the ten fictional operators in `tools/preview/seed.ts`. All twelve are now `not-a-route` rows: they are fixed invented identities written into a throwaway local database, held constant rather than randomised so two runs produce the same portal, and `preview.local` is reserved by RFC 6762 so none of them resolves.

That second one is worth stating as a general rule rather than as an incident. An instrument that only looks at what a branch CHANGED cannot see a defect the branch ARRIVED with. There was no textual conflict, so git had nothing to report; the branch was green on its old base and main was green on its own; and the failure appeared in a different job from the one the branch was red in. It became visible only when the two were rebased together.

Both fixes were verified by breaking them again rather than by reading them. With the `.gitignore` line deleted the gate fails naming `contactcheck`; with a route row deleted the gate fails naming that address. Neither check can be satisfied by looking at nothing: the gatecheck test fails outright if it examines fewer than five tools, and it skips rather than passing when git cannot read the checkout.

### One limitation found and left alone

`contactcheck` cannot verify a `receives` verdict for a domain that is not in `deadDomains`, which `tools/contactcheck/main.go:103-105` already says in its own words. Writing `receives` on an address nobody reads passes the gate silently. That is a hole in a check whose premise is that a default of no is what notices a dead domain, and it is being fixed separately rather than folded in here.


