### PR TITLE
admin: the Operations lane, over what this product actually records

### DIFF
--- a/.changes/the-operator-portal-can-see-what-is-failing.md
+++ b/.changes/the-operator-portal-can-see-what-is-failing.md
@@ -1,0 +1,27 @@
+# added
+
+The operator portal has its Operations sections: infrastructure, failures, email
+and the kill switches.
+
+Infrastructure and Compute and Incidents and Kill Switches are faces for routes
+that already existed and had none: system health, the fleet of production twins,
+the teardown ledger, the egress firewall, and the three switches that stop parts
+of an installation. The switches show what each one refuses AND what keeps
+working, require a reason to engage, make the operator type the control's own
+name, and show the way back at all times. A fleet teardown asks the server what
+it would touch and makes that count the thing you type, so nobody confirms a
+blast radius they have not read.
+
+Logs and Error Explorer and Email and Notifications are new, and both are built
+only from what this product records. There is no exception store, so failures
+are grouped by the failure code a run ended with, and by the workflow a verdict
+names. There is no delivery record, so the email page reports whether the
+installation can send at all, which no query over the database can answer, and
+counts sign-in links by what became of them. A link issued and never used before
+it expired is the only trace a delivery failure leaves anywhere in this schema,
+and the page says that rather than calling the column a bounce.
+
+Both pages name what they cannot show and what it would take to change it. Event
+payloads are never returned: the field names and the byte size say whether
+ingestion is working without putting a copy of a tenant's data in an operator's
+browser.

--- a/console/app/admin/operations/email/page.tsx
+++ b/console/app/admin/operations/email/page.tsx
@@ -1,18 +1,393 @@
 "use client";
 
-import { PlannedSection } from "@/components/admin/primitives";
+/**
+ * Email & Notifications.
+ *
+ * THE ONE FACT THIS PAGE EXISTS FOR: whether this installation can send email
+ * at all. It is the thing operators most often get wrong about this product,
+ * and no query over the database can answer it. A sign-in request writes its
+ * token row whether or not a mailer is configured, so the row that proves a
+ * message was COMPOSED looks identical on an installation that sends and one
+ * that silently sends nothing. Only the process knows, so the route reads the
+ * context and this page leads with the answer.
+ *
+ * WHAT IS NOT DRAWN, AND WHY. There is no send log, no delivery record, no
+ * bounce, no complaint, no open, no click, no template table and no
+ * notification preference table anywhere in this schema. So there is no
+ * deliverability dashboard here. What exists is the sign-in link ledger, and
+ * the page is careful about what that ledger proves: a row means a message was
+ * composed, and a consumed row means somebody clicked the link. A link issued
+ * and never used before it expired is the only trace a delivery failure leaves
+ * in this product, and the page says exactly that rather than calling the
+ * column "bounced".
+ *
+ * DELIVERABILITY IS NOT GUESSED AT EITHER. Whether a receiver accepts a message
+ * depends on the domain's SPF, DKIM and DMARC records, which this control plane
+ * does not read and this page therefore does not report. What it gives instead
+ * is the check an operator can run in ten seconds and what a bad answer looks
+ * like. A hardcoded verdict would be right on the day it was written and a lie
+ * afterwards.
+ */
+
+import { useState } from "react";
+import {
+  Badge,
+  Button,
+  Card,
+  CardSkeleton,
+  Loaded,
+  TableSkeleton,
+  When,
+} from "@/components/ui";
+import { More } from "@/components/pagination";
+import {
+  AdminPage,
+  DataTable,
+  EmptyList,
+  FilterBar,
+  MetricRow,
+  StatusChip,
+  type Column,
+} from "@/components/admin/primitives";
+import {
+  WINDOWS,
+  useEmailStatus,
+  useSignInLinks,
+  type EmailStatus,
+  type SignInLink,
+} from "@/lib/admin-operations";
+
+export default function OperationsEmailPage() {
+  const [hours, setHours] = useState("168");
+  const [standing, setStanding] = useState("");
+  const [search, setSearch] = useState("");
+  const status = useEmailStatus(hours);
+  const links = useSignInLinks(hours, standing, search);
+
+  return (
+    <AdminPage
+      href="/admin/operations/email"
+      lede="Whether this installation can send email, and every sign-in link it has issued. There is no delivery record in this product, and the page says where that line falls."
+      actions={
+        <Button
+          onClick={() => {
+            status.reload();
+            links.reload();
+          }}
+        >
+          Refresh
+        </Button>
+      }
+    >
+      <div className="space-y-6">
+        <Loaded state={status} skeleton={<CardSkeleton count={2} />} framed>
+          {(s) => (
+            <div className="space-y-6">
+              <CanSend status={s} />
+              <MetricRow
+                metrics={[
+                  {
+                    label: "Sign-in links issued",
+                    value: s.reach.linksIssued,
+                    note: "composed, which is not delivered",
+                  },
+                  {
+                    label: "Used",
+                    value: s.reach.linksUsed,
+                    note: "somebody clicked the link",
+                  },
+                  {
+                    label: "Expired unused",
+                    value: s.reach.linksUnused,
+                    note: "the only trace a failure leaves",
+                  },
+                  {
+                    label: "Still live",
+                    value: s.reach.linksLive,
+                    note: "issued and not yet expired",
+                  },
+                ]}
+              />
+              <MetricRow
+                metrics={[
+                  { label: "Invitations sent", value: s.reach.invitationsSent },
+                  { label: "Accepted", value: s.reach.invitationsAccepted },
+                  {
+                    label: "Still open",
+                    value: s.reach.invitationsOpen,
+                    note: "not accepted, not revoked, not expired",
+                  },
+                  {
+                    label: "Billing addresses",
+                    value: s.reach.billingContacts,
+                    note: "on file, nothing is sent to them",
+                  },
+                ]}
+              />
+            </div>
+          )}
+        </Loaded>
+
+        <Card
+          title="Sign-in links"
+          note="A row means a message was composed. Used means somebody clicked the link, which is the only evidence of delivery anywhere in this product."
+        >
+          <FilterBar
+            search={{
+              value: search,
+              onChange: setSearch,
+              label: "Search sign-in links by address",
+              placeholder: "Part of an email address",
+            }}
+            filters={[
+              {
+                label: "Window",
+                value: hours,
+                onChange: setHours,
+                options: WINDOWS.map((w) => ({ value: w.value, label: w.label })),
+              },
+              {
+                label: "Standing",
+                value: standing,
+                onChange: setStanding,
+                options: [
+                  { value: "", label: "Every link" },
+                  { value: "used", label: "Used" },
+                  { value: "live", label: "Still live" },
+                  { value: "unused", label: "Expired unused" },
+                ],
+              },
+            ]}
+          />
+          <Loaded state={links} skeleton={<TableSkeleton rows={6} cols={5} />}>
+            {(rows) => (
+              <DataTable
+                columns={LINK_COLUMNS}
+                rows={rows}
+                keyOf={(l) => l.id}
+                empty={
+                  <EmptyList
+                    title={
+                      search
+                        ? "No link was issued to an address like that"
+                        : standing
+                          ? "No link is in that state"
+                          : "No sign-in link has been issued"
+                    }
+                    action={
+                      search || standing ? (
+                        <Button
+                          onClick={() => {
+                            setSearch("");
+                            setStanding("");
+                          }}
+                        >
+                          Clear the filters
+                        </Button>
+                      ) : undefined
+                    }
+                  >
+                    {search || standing
+                      ? "Nothing in the selected window matches. Clear the filters or widen the window."
+                      : "Nobody has asked to sign in with an email link in this window. That is expected on an installation where everybody signs in with GitHub."}
+                  </EmptyList>
+                }
+                footer={
+                  <More
+                    shown={rows.length}
+                    noun={{ one: "link", many: "links" }}
+                    hasMore={links.hasMore}
+                    busy={links.busy}
+                    error={links.moreError}
+                    onMore={links.more}
+                  />
+                }
+              />
+            )}
+          </Loaded>
+        </Card>
+
+        <Deliverability />
+        <WhatIsNotRecorded />
+      </div>
+    </AdminPage>
+  );
+}
+
+/* -------------------------------------------------------------------------
+ * Can this installation send at all
+ * ---------------------------------------------------------------------- */
 
 /**
- * Email & Notifications
+ * The lead answer, in a sentence, before any number.
  *
- * Not written yet. The route exists from the first commit because a navigation
- * entry that 404s teaches the reader to distrust the rail, and they cannot tell
- * a section that is coming from one that is broken.
- *
- * TO BUILD THIS SECTION: replace the body below with the real page, and add its
- * routes to web/apps/api/src/admin/operations.ts. Nothing else in the portal
- * has to change. See console/app/admin/README.md.
+ * Three states rather than two, and the third is the one worth the component.
+ * A recording mailer accepts every message, reports success, and delivers
+ * nothing: from the database, from the logs and from every metric on this page
+ * it is indistinguishable from a working installation. It is a test double, and
+ * a test double in production is a silent outage.
  */
-export default function OperationsEmailPage() {
-  return <PlannedSection href="/admin/operations/email" />;
+function CanSend({ status }: { status: EmailStatus }) {
+  const broken = !status.canSend || status.recordingOnly;
+  return (
+    <section
+      role="status"
+      className={`rounded-lg border border-rule px-4 py-4 ${
+        broken ? "bg-[rgba(179,38,30,0.1)]" : "bg-card"
+      }`}
+    >
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+        <p className="text-[14px] font-semibold tracking-extra-tight text-ink">
+          {!status.canSend
+            ? "This installation cannot send email."
+            : status.recordingOnly
+              ? "Messages are being recorded and delivered to nobody."
+              : "This installation has a mail provider configured."}
+        </p>
+        <StatusChip
+          value={status.canSend ? (status.recordingOnly ? "recording" : "configured") : "not configured"}
+          tone={broken ? "fail" : "pass"}
+        />
+      </div>
+      <p className="mt-1.5 max-w-[70ch] text-[13px] leading-6 text-muted">
+        {!status.canSend
+          ? "No mail provider is set on this process. Sign-in links are still issued and still recorded below, and nobody receives one, so an email sign-in cannot be completed. Setting AF_RESEND_API_KEY, AF_MAIL_FROM and a public URL together is what turns it on; setting some but not all of them makes the control plane refuse to start rather than run half configured."
+          : status.recordingOnly
+            ? "The mailer on this process keeps messages in memory instead of sending them. That is the test double, and on a real installation it is a silent outage: every count on this page will look healthy while no message has left the building."
+            : `Messages go out through ${status.provider}. That is the provider accepting them, which is not the same as a recipient receiving them; see the deliverability check below.`}
+      </p>
+    </section>
+  );
+}
+
+/* -------------------------------------------------------------------------
+ * The ledger
+ * ---------------------------------------------------------------------- */
+
+const LINK_COLUMNS: Column<SignInLink>[] = [
+  {
+    key: "email",
+    header: "Address",
+    cell: (l) => (
+      <>
+        <span className="block truncate font-medium text-ink">{l.email}</span>
+        {l.ip ? (
+          <span className="block truncate font-mono text-[12px] text-muted">{l.ip}</span>
+        ) : null}
+      </>
+    ),
+  },
+  {
+    key: "standing",
+    header: "Standing",
+    cell: (l) => (
+      <StatusChip
+        value={
+          l.standing === "used"
+            ? "used"
+            : l.standing === "live"
+              ? "still live"
+              : "expired unused"
+        }
+        // Expired unused is a warning rather than a failure. It genuinely can
+        // be somebody who asked twice and used the second link, and colouring
+        // every one of them red would make a normal page look like an outage.
+        tone={l.standing === "used" ? "pass" : l.standing === "live" ? "neutral" : "warn"}
+      />
+    ),
+  },
+  { key: "created", header: "Issued", cell: (l) => <When value={l.createdAt} /> },
+  {
+    key: "consumed",
+    header: "Used",
+    cell: (l) =>
+      l.consumedAt === null ? <span className="text-dim">never</span> : <When value={l.consumedAt} />,
+  },
+  { key: "expires", header: "Expires", cell: (l) => <When value={l.expiresAt} /> },
+];
+
+/* -------------------------------------------------------------------------
+ * Deliverability
+ * ---------------------------------------------------------------------- */
+
+/**
+ * The half of the answer that lives in DNS.
+ *
+ * A provider accepting a message and a recipient receiving one are different
+ * events, and the gap between them is entirely in three DNS records that this
+ * control plane does not read. So this does not print a verdict it cannot
+ * verify. It prints the check, which stays true, and what a wrong answer looks
+ * like, which is what an operator needs at the moment they are wondering why
+ * nobody is getting their link.
+ */
+function Deliverability() {
+  return (
+    <Card title="Whether a receiver will accept what is sent">
+      <div className="space-y-3 px-4 py-4 text-[13px] leading-6 text-muted">
+        <p className="max-w-[70ch]">
+          A configured provider means messages are accepted for sending. Whether they are then
+          accepted for delivery is decided by three DNS records on the sending domain, and this
+          control plane does not read DNS, so nothing on this page can tell you. Run the check
+          yourself against the domain in your From address.
+        </p>
+        <pre className="scroll-x rounded-md border border-rule bg-paper px-3 py-2.5 font-mono text-[12px] leading-6 text-ink">
+{`dig +short TXT example.com
+dig +short TXT resend._domainkey.example.com
+dig +short TXT _dmarc.example.com`}
+        </pre>
+        <ul className="max-w-[70ch] list-disc space-y-1.5 pl-5">
+          <li>
+            An SPF record of <code className="font-mono text-[12px]">v=spf1 -all</code> is the
+            correct setting for a domain that sends nothing and a hard fail instruction the moment
+            it sends anything.
+          </li>
+          <li>
+            A DKIM record whose <code className="font-mono text-[12px]">p=</code> tag is empty is a
+            revoked key, not a missing one. Receivers treat every signature against it as
+            permanently invalid.
+          </li>
+          <li>
+            A DMARC policy of <code className="font-mono text-[12px]">p=reject</code> with{" "}
+            <code className="font-mono text-[12px]">adkim=s</code> means the signing domain must
+            equal the From domain exactly. Verifying a subdomain and sending from the apex fails
+            silently and completely.
+          </li>
+          <li>
+            No MX record on the domain means the addresses this product publishes for people to
+            write to do not accept mail either, whatever the sending side does.
+          </li>
+        </ul>
+        <p className="max-w-[70ch] text-dim">
+          Every one of those combinations is silent. Nothing bounces back into this product,
+          because there is nowhere for a bounce to be recorded, so the only symptom is a column of
+          sign-in links above that were issued and never used.
+        </p>
+      </div>
+    </Card>
+  );
+}
+
+function WhatIsNotRecorded() {
+  return (
+    <Card title="What this page cannot show you">
+      <div className="space-y-3 px-4 py-4 text-[13px] leading-6 text-muted">
+        <p className="max-w-[70ch]">
+          This product keeps no send log, no delivery record, no bounce, no complaint, no open and
+          no click. It has no email template table and no notification preference table. Nothing
+          above is a delivery statistic, and none of it has been dressed up as one.
+        </p>
+        <p className="max-w-[70ch]">
+          There are exactly two things that put a message in somebody&apos;s inbox: the sign-in
+          link, and an organization invitation sent by a member. Anything else this product calls a
+          notification is not email.
+        </p>
+        <p className="max-w-[70ch] text-dim">
+          <Badge tone="neutral">what would change this</Badge> A delivery record would need a table
+          written when a message is handed to the provider, a webhook endpoint for the
+          provider&apos;s delivery and bounce callbacks, and a signature check on it. That is a
+          schema change and a new inbound route, not a page.
+        </p>
+      </div>
+    </Card>
+  );
 }

--- a/console/app/admin/operations/incidents/page.tsx
+++ b/console/app/admin/operations/incidents/page.tsx
@@ -1,18 +1,374 @@
 "use client";
 
-import { PlannedSection } from "@/components/admin/primitives";
+/**
+ * Incidents & Kill Switches.
+ *
+ * THE PAGE AN OPERATOR OPENS AT THREE IN THE MORNING, on a phone, to answer one
+ * question: is anything paused, and how do I change that. Everything below is
+ * arranged around that and nothing else.
+ *
+ * The four decisions worth stating, because each one is a way this page could
+ * have been wrong:
+ *
+ *   1. STATE IS READABLE AT A GLANCE AND WITHOUT COLOUR. The summary at the top
+ *      says how many switches are engaged in words before any chip is read, and
+ *      every chip carries the word too. Nothing on this page animates. A dot
+ *      that throbs while the reader does nothing is the loudest thing on the
+ *      screen and says exactly as much as a still one, and `just motioncheck`
+ *      refuses it against the built stylesheet.
+ *
+ *   2. THE BLAST RADIUS IS SHOWN BEFORE THE CONFIRMATION, NOT AFTER. `effect`
+ *      comes from the server's own catalog and is rendered whole, including the
+ *      half that says what KEEPS working, because an operator who does not know
+ *      that reads will survive maintenance mode will not engage it.
+ *
+ *   3. THE WAY BACK IS VISIBLE AT ALL TIMES. `release` sits beside every
+ *      control whether it is engaged or not. An operator who cannot find the
+ *      way back has an outage this product caused, and finding it should not
+ *      require having engaged the switch first.
+ *
+ *   4. THE REASON IS REQUIRED TO ENGAGE AND SHOWN AFTERWARDS. The server
+ *      refuses an engage with no reason, so the form does too rather than
+ *      letting the reader discover it in an error. Once engaged, the reason,
+ *      who set it and when are on the card, because the next person on call
+ *      cannot safely release a switch nobody explained.
+ *
+ * WHAT IS NOT HERE, AND WHY IT IS NOT DRAWN. There is no incident record in
+ * this product: no incident table, no timeline, no postmortem, no status page
+ * entry, no on-call rota. So this page does not draw one. A page of empty
+ * incident cards would read, during an incident, as "no incidents", and that is
+ * the most expensive sentence a console can say by accident.
+ */
+
+import { useState } from "react";
+import Link from "next/link";
+import {
+  Badge,
+  Button,
+  Card,
+  CardSkeleton,
+  Confirm,
+  Field,
+  Loaded,
+  inputClass,
+} from "@/components/ui";
+import { AdminPage, Facts, StatusChip } from "@/components/admin/primitives";
+import { When } from "@/components/ui";
+import { operatorMay, useAdminContext } from "@/lib/admin";
+import { setControl, useControls, type ControlState } from "@/lib/admin-operations";
+
+export default function OperationsIncidentsPage() {
+  const state = useControls();
+  const { me } = useAdminContext();
+  const mayEngage = operatorMay(me, "admin.emergency.engage");
+
+  return (
+    <AdminPage
+      href="/admin/operations/incidents"
+      lede="Three switches stop parts of this installation for everybody on it. Each one says exactly what it refuses, what keeps working, and how to put it back."
+    >
+      <Loaded state={state} skeleton={<CardSkeleton count={3} />} framed>
+        {(controls) => (
+          <div className="space-y-6">
+            <Summary controls={controls} mayEngage={mayEngage} />
+            {controls.map((c) => (
+              <ControlCard
+                key={c.name}
+                control={c}
+                mayEngage={mayEngage}
+                onChanged={state.reload}
+              />
+            ))}
+            <NotAnIncidentLog />
+          </div>
+        )}
+      </Loaded>
+    </AdminPage>
+  );
+}
 
 /**
- * Incidents & Kill Switches
+ * The answer to the question, above everything that qualifies it.
  *
- * Not written yet. The route exists from the first commit because a navigation
- * entry that 404s teaches the reader to distrust the rail, and they cannot tell
- * a section that is coming from one that is broken.
- *
- * TO BUILD THIS SECTION: replace the body below with the real page, and add its
- * routes to web/apps/api/src/admin/operations.ts. Nothing else in the portal
- * has to change. See console/app/admin/README.md.
+ * The count is in the sentence rather than only in the chips below, because a
+ * reader scanning three cards for a coloured badge can miss one, and the whole
+ * cost of missing one is that they keep looking for a fault that is not there.
  */
-export default function OperationsIncidentsPage() {
-  return <PlannedSection href="/admin/operations/incidents" />;
+function Summary({ controls, mayEngage }: { controls: ControlState[]; mayEngage: boolean }) {
+  const engaged = controls.filter((c) => c.engaged);
+  const paused = engaged.length > 0;
+  return (
+    <section
+      // A tint rather than a border colour, matching Badge's own values so the
+      // page has one red and one green rather than a second set.
+      className={`rounded-lg border border-rule px-4 py-4 ${
+        paused ? "bg-[rgba(179,38,30,0.1)]" : "bg-card"
+      }`}
+      // A status region, not an alert. The reader came here to read it; an
+      // assertive announcement over a page somebody navigated to on purpose is
+      // its own defect.
+      role="status"
+    >
+      <p className="text-[14px] font-semibold tracking-extra-tight text-ink">
+        {paused
+          ? engaged.length === 1
+            ? `One switch is engaged: ${engaged[0]!.definition.title}.`
+            : `${engaged.length} switches are engaged: ${engaged
+                .map((c) => c.definition.title)
+                .join(", ")}.`
+          : "Nothing is paused."}
+      </p>
+      <p className="mt-1.5 max-w-[62ch] text-[13px] leading-6 text-muted">
+        {paused
+          ? `${engaged.length === 1 ? "It is" : "They are"} in force for every organization on this installation. ${
+              engaged.length === 1 ? "The card" : "The cards"
+            } below carr${engaged.length === 1 ? "ies" : "y"} the reason each was set and the way to release it.`
+          : "Sign-ups, runs and every request that changes something are all working normally. Nobody has touched a switch on this installation."}
+      </p>
+      {!mayEngage ? (
+        <p className="mt-2 max-w-[62ch] text-[12.5px] leading-5 text-dim">
+          Your role can see these switches and cannot throw them. Engaging or releasing one needs{" "}
+          <code className="font-mono text-[12px] text-muted">admin.emergency.engage</code>, which
+          only the owner and super admin roles hold.
+        </p>
+      ) : null}
+    </section>
+  );
+}
+
+/**
+ * One switch: what it does, what it is doing now, and both directions out.
+ *
+ * Engage and release are the SAME card rather than two screens. The file that
+ * defines these controls makes the point that reversal is part of the
+ * definition and not an afterthought, and a console that puts the way back
+ * behind a second screen contradicts that at the moment it matters.
+ */
+function ControlCard({
+  control,
+  mayEngage,
+  onChanged,
+}: {
+  control: ControlState;
+  mayEngage: boolean;
+  onChanged: () => void;
+}) {
+  const [reason, setReason] = useState("");
+  const [confirming, setConfirming] = useState<null | "engage" | "release">(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const d = control.definition;
+  const trimmed = reason.trim();
+
+  async function run(engaged: boolean) {
+    setBusy(true);
+    setError(null);
+    try {
+      await setControl(control.name, engaged, engaged ? trimmed : null);
+      setConfirming(null);
+      setReason("");
+      onChanged();
+    } catch (e) {
+      // Kept on the dialog rather than closing it. A failed engage that closes
+      // the confirmation leaves the reader looking at an unchanged page with no
+      // idea whether they pressed the button.
+      setError(e instanceof Error ? e.message : "The control plane refused that.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Card
+      title={d.title}
+      actions={
+        <StatusChip
+          value={control.engaged ? "engaged" : "released"}
+          tone={control.engaged ? "fail" : "pass"}
+        />
+      }
+    >
+      <div className="space-y-4 px-4 py-4">
+        <div>
+          <p className="text-[11.5px] font-medium uppercase tracking-[0.08em] text-dim">
+            What engaging it does
+          </p>
+          <p className="mt-1.5 max-w-[70ch] text-[13px] leading-6 text-ink">{d.effect}</p>
+        </div>
+
+        <div>
+          <p className="text-[11.5px] font-medium uppercase tracking-[0.08em] text-dim">
+            How to put it back
+          </p>
+          <p className="mt-1.5 max-w-[70ch] text-[13px] leading-6 text-muted">{d.release}</p>
+        </div>
+
+        {/* Where the refusal actually lives. Printed because a switch that
+            claims an enforcement it does not have is the failure the controls
+            catalog exists to prevent, and a test greps this exact file for this
+            exact symbol. An operator can check the claim. */}
+        <p className="text-[12px] leading-5 text-dim">
+          Refused by{" "}
+          <code className="break-all font-mono text-[12px] text-muted">{d.enforcedBy}</code>
+        </p>
+
+        {control.engaged ? (
+          <div className="rounded-md border border-rule bg-paper">
+            <Facts
+              facts={[
+                {
+                  label: "Reason",
+                  value: control.reason ?? (
+                    <span className="text-warn">No reason was recorded.</span>
+                  ),
+                },
+                { label: "Engaged by", value: control.engagedBy, mono: true },
+                { label: "Engaged", value: <When value={control.engagedAt} /> },
+              ]}
+            />
+          </div>
+        ) : control.updatedAt ? (
+          <p className="text-[12.5px] leading-5 text-dim">
+            Last released <When value={control.updatedAt} />
+            {control.engagedBy ? ` by ${control.engagedBy}` : ""}.
+          </p>
+        ) : null}
+
+        {mayEngage ? (
+          control.engaged ? (
+            <div className="flex flex-wrap items-center gap-3">
+              <Button onClick={() => setConfirming("release")}>Release {d.title}</Button>
+              <span className="text-[12.5px] text-muted">
+                Takes effect on the next request. Nothing has to be restarted.
+              </span>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              <Field
+                label="Why you are engaging this"
+                hint="Required, and recorded. It is what the next person on call reads before releasing it."
+              >
+                <input
+                  className={inputClass}
+                  value={reason}
+                  maxLength={500}
+                  onChange={(e) => setReason(e.target.value)}
+                  placeholder="What is happening, in one line"
+                  autoComplete="off"
+                />
+              </Field>
+              <Button
+                variant="danger"
+                disabled={trimmed === ""}
+                onClick={() => setConfirming("engage")}
+              >
+                Engage {d.title}
+              </Button>
+            </div>
+          )
+        ) : null}
+      </div>
+
+      <Confirm
+        open={confirming === "engage"}
+        title={`Engage ${d.title}?`}
+        // The control's OWN name, typed. Not the word "confirm": typing that
+        // proves you can read a label, and typing `new_runs` proves you know
+        // which of the three switches is under your finger, which is the
+        // mistake that actually happens on a page with three of them.
+        phrase={control.name}
+        confirmLabel={`Engage ${d.title}`}
+        busy={busy}
+        error={error}
+        onConfirm={() => run(true)}
+        onCancel={() => {
+          if (!busy) {
+            setConfirming(null);
+            setError(null);
+          }
+        }}
+      >
+        <p className="text-ink">{d.effect}</p>
+        <p>
+          This applies to every organization on this installation, immediately, and stays until
+          somebody releases it.
+        </p>
+        <p>
+          <span className="text-dim">Recorded reason: </span>
+          <span className="break-words text-ink">{trimmed}</span>
+        </p>
+      </Confirm>
+
+      <Confirm
+        open={confirming === "release"}
+        title={`Release ${d.title}?`}
+        // No phrase. Releasing is the safe direction and the one an operator
+        // may be doing under pressure; making them type an identifier to STOP
+        // an outage would be ceremony pointed the wrong way.
+        confirmLabel={`Release ${d.title}`}
+        busy={busy}
+        error={error}
+        onConfirm={() => run(false)}
+        onCancel={() => {
+          if (!busy) {
+            setConfirming(null);
+            setError(null);
+          }
+        }}
+      >
+        <p className="text-ink">{d.release}</p>
+        {control.reason ? (
+          <p>
+            <span className="text-dim">It was engaged because: </span>
+            <span className="break-words text-ink">{control.reason}</span>
+          </p>
+        ) : null}
+      </Confirm>
+    </Card>
+  );
+}
+
+/**
+ * What this page is not.
+ *
+ * Said plainly rather than left for the reader to discover by looking for a
+ * section that is not there. The alternative on offer was a page of incident
+ * cards over a table that does not exist, and an empty one of those reads as
+ * "no incidents" during the exact hour somebody is having one.
+ */
+function NotAnIncidentLog() {
+  return (
+    <Card title="There is no incident record in this product">
+      <div className="space-y-3 px-4 py-4 text-[13px] leading-6 text-muted">
+        <p className="max-w-[70ch]">
+          Nothing in this schema stores an incident, a timeline, a postmortem, a status page entry
+          or an on-call rota. This page is the three installation-wide switches and their current
+          state, which is what genuinely exists.
+        </p>
+        <p className="max-w-[70ch]">
+          Every engage and release writes to the platform audit chain, at critical and high
+          severity, with the reason and the operator who acted. That is the history, and it is on{" "}
+          <Link
+            href="/admin/security/audit"
+            className="underline decoration-[rgba(16,16,16,0.35)] underline-offset-4"
+          >
+            the operator log
+          </Link>
+          .
+        </p>
+        <p className="max-w-[70ch]">
+          Two narrower controls live elsewhere and are deliberately not duplicated here: suspending
+          one organization is on that tenant&apos;s page, and killing one feature flag is under
+          Feature Flags. Both are per tenant or per feature. These three are the whole
+          installation.
+        </p>
+        <p className="max-w-[70ch] text-dim">
+          <Badge tone="neutral">what would change this</Badge> An incident record would need a
+          table of its own, written to when a switch is engaged and when a health check turns red,
+          plus somewhere to attach a narrative. That is a schema change, not a page.
+        </p>
+      </div>
+    </Card>
+  );
 }

--- a/console/app/admin/operations/infrastructure/page.tsx
+++ b/console/app/admin/operations/infrastructure/page.tsx
@@ -1,18 +1,646 @@
 "use client";
 
-import { PlannedSection } from "@/components/admin/primitives";
+/**
+ * Infrastructure & Compute.
+ *
+ * FOUR QUESTIONS, IN THE ORDER AN OPERATOR ASKS THEM. Is this control plane
+ * working. What is running on it. What was asked to stop and did not. What can
+ * reach the internet from inside a preview. Every one of them is answered by a
+ * route that already exists in web/apps/api/src/admin, and none of the queries
+ * behind them is duplicated here.
+ *
+ * THE SECTIONS ARE STACKED RATHER THAN TABBED. A tab hides the section the
+ * reader did not think to open, and the whole reason these four sit on one page
+ * is that an operator looking at a red health row usually needs the fleet
+ * underneath it in the same breath.
+ *
+ * THE TWO ARRAY ROUTES SAY THEY ARE CAPPED. `twins` and `teardowns` return an
+ * array and no cursor, so there is no next page to ask for and the footer
+ * cannot offer one. What it can do is refuse to imply the list is complete when
+ * it is exactly the length of the cap, which is the same defect `More` exists
+ * to prevent on the routes that do page.
+ */
+
+import { useState } from "react";
+import {
+  Badge,
+  Button,
+  Card,
+  CardSkeleton,
+  Confirm,
+  Field,
+  Loaded,
+  TableSkeleton,
+  When,
+  inputClass,
+} from "@/components/ui";
+import {
+  AdminPage,
+  DataTable,
+  EmptyList,
+  FilterBar,
+  MetricRow,
+  StatusChip,
+  type Column,
+} from "@/components/admin/primitives";
+import { operatorMay, useAdminContext } from "@/lib/admin";
+import {
+  FINDING_LABEL,
+  FLEET_LIMIT,
+  STANDING_LABEL,
+  requestFleetTeardown,
+  teardownRadius,
+  toneForStanding,
+  toneForVerdict,
+  useFirewall,
+  useSystemHealth,
+  useTeardowns,
+  useTwins,
+  type BlastRadius,
+  type Finding,
+  type HealthCheck,
+  type Teardown,
+  type TwinScope,
+  type Twin,
+} from "@/lib/admin-operations";
+
+export default function OperationsInfrastructurePage() {
+  return (
+    <AdminPage
+      href="/admin/operations/infrastructure"
+      lede="Whether this control plane is working, what is running on it, what refused to stop, and what can reach the internet from inside a preview."
+    >
+      <div className="space-y-6">
+        <HealthSection />
+        <FleetSection />
+        <TeardownSection />
+        <FirewallSection />
+      </div>
+    </AdminPage>
+  );
+}
+
+/* -------------------------------------------------------------------------
+ * Health
+ * ---------------------------------------------------------------------- */
+
+const HEALTH_COLUMNS: Column<HealthCheck>[] = [
+  {
+    key: "title",
+    header: "Check",
+    cell: (c) => (
+      <>
+        <span className="block font-medium text-ink">{c.title}</span>
+        <span className="mt-0.5 block max-w-[62ch] text-[12.5px] leading-5 text-muted">
+          {c.detail}
+        </span>
+        {/* Only on rows that are not ok. "No action needed" printed on every
+            green row is noise on a page whose entire job is to make the
+            actionable ones stand out. */}
+        {c.remedy ? (
+          <span className="mt-1 block max-w-[62ch] text-[12.5px] leading-5 text-warn">
+            {c.remedy}
+          </span>
+        ) : null}
+      </>
+    ),
+  },
+  {
+    key: "verdict",
+    header: "State",
+    cell: (c) => <StatusChip value={c.verdict} tone={toneForVerdict(c.verdict)} />,
+  },
+  {
+    key: "value",
+    header: "Measured",
+    numeric: true,
+    cell: (c) => (
+      <>
+        <span className="block">{c.value.toLocaleString()}</span>
+        <span className="block text-[12px] text-dim">{c.unit}</span>
+      </>
+    ),
+  },
+];
+
+function HealthSection() {
+  const state = useSystemHealth();
+  return (
+    <Loaded state={state} skeleton={<CardSkeleton count={1} />} framed>
+      {(report) => {
+        const bad = report.checks.filter((c) => c.verdict !== "ok");
+        return (
+          <Card
+            title="System health"
+            note={
+              // The summary is a sentence before it is a chip. A reader
+              // scanning for colour can miss one row of nine.
+              bad.length === 0
+                ? "Every check is inside its threshold."
+                : `${bad.length} of ${report.checks.length} checks are worth looking at.`
+            }
+            actions={
+              <>
+                <StatusChip
+                  value={report.verdict}
+                  tone={toneForVerdict(report.verdict)}
+                />
+                <Button onClick={state.reload}>Refresh</Button>
+              </>
+            }
+          >
+            <DataTable
+              columns={HEALTH_COLUMNS}
+              rows={report.checks}
+              keyOf={(c) => c.id}
+              empty={
+                <EmptyList title="No checks ran">
+                  The health module returned nothing at all, which is not the same as everything
+                  being fine. Retry, and if it stays empty the operator database connection is the
+                  thing to look at.
+                </EmptyList>
+              }
+              footer={
+                <div className="border-t border-rule px-4 py-3 text-[12.5px] text-muted">
+                  Computed from tables this control plane already writes. Read{" "}
+                  <When value={report.at} />. Every verdict is derived from the number beside it,
+                  so the state and the count cannot disagree.
+                </div>
+              }
+            />
+          </Card>
+        );
+      }}
+    </Loaded>
+  );
+}
+
+/* -------------------------------------------------------------------------
+ * The fleet
+ * ---------------------------------------------------------------------- */
+
+const TWIN_COLUMNS: Column<Twin>[] = [
+  {
+    key: "env",
+    header: "Environment",
+    cell: (t) => (
+      <>
+        <span className="block truncate font-medium text-ink">{t.repository}</span>
+        <span className="block truncate font-mono text-[12px] text-muted">{t.envId}</span>
+      </>
+    ),
+  },
+  // "Tenant" rather than "Organization" because it is the word the other three
+  // tables on this page and the two on Logs already use for this column, and
+  // twenty two sections calling one thing two names is how a portal stops
+  // reading as one product.
+  { key: "org", header: "Tenant", cell: (t) => t.orgSlug, mono: true },
+  {
+    key: "branch",
+    header: "Branch",
+    cell: (t) => (
+      <>
+        <span className="block truncate">{t.branch}</span>
+        {t.pullRequest !== null ? (
+          <span className="block text-[12px] text-dim">pull request {t.pullRequest}</span>
+        ) : null}
+      </>
+    ),
+  },
+  {
+    key: "state",
+    header: "State",
+    cell: (t) => (
+      <div className="flex flex-wrap items-center gap-1.5">
+        <StatusChip value={t.state} />
+        {/* Past its expiry and still up. This is the row that costs money, and
+            the state column alone says "running", which is true and not the
+            point. */}
+        {t.overdue ? <Badge tone="fail">overdue</Badge> : null}
+        {t.teardownPending ? <Badge tone="warn">teardown asked</Badge> : null}
+      </div>
+    ),
+  },
+  { key: "runs", header: "Runs", numeric: true, cell: (t) => t.runs.toLocaleString() },
+  { key: "expires", header: "Expires", cell: (t) => <When value={t.expiresAt} /> },
+];
+
+function FleetSection() {
+  const [scope, setScope] = useState<TwinScope>("live");
+  const state = useTwins(scope);
+  const { me } = useAdminContext();
+  const mayTeardown = operatorMay(me, "admin.infra.teardown");
+
+  return (
+    <Card
+      title="Environments"
+      note="Every production twin on this installation, across every organization."
+    >
+      <FilterBar
+        filters={[
+          {
+            label: "Show",
+            value: scope,
+            onChange: (v) => setScope(v as TwinScope),
+            options: [
+              { value: "live", label: "Running now" },
+              { value: "overdue", label: "Past their expiry" },
+              { value: "all", label: "Everything, including torn down" },
+            ],
+          },
+        ]}
+      />
+      <Loaded state={state} skeleton={<TableSkeleton rows={6} cols={6} />}>
+        {(rows) => (
+          <DataTable
+            columns={TWIN_COLUMNS}
+            rows={rows}
+            keyOf={(t) => t.envId}
+            empty={
+              <EmptyList
+                title={
+                  scope === "overdue"
+                    ? "Nothing is past its expiry"
+                    : scope === "live"
+                      ? "Nothing is running"
+                      : "No environment has ever been created here"
+                }
+              >
+                {scope === "overdue"
+                  ? "Every environment that is up is still inside the lifetime it was given. This is the state you want."
+                  : scope === "live"
+                    ? "No organization has an environment up right now. Widen the filter to see the ones that have been torn down."
+                    : "No customer has opened a pull request against a connected repository yet, so nothing has ever been built."}
+              </EmptyList>
+            }
+            footer={<Capped shown={rows.length} noun={{ one: "environment", many: "environments" }} />}
+          />
+        )}
+      </Loaded>
+      {/* Below the list rather than beside its title, and that is not a layout
+          preference. The reason has to gate the button BEFORE the confirmation
+          opens, the way a kill switch card does, or the confirmation is
+          reachable with the reason empty and the only thing standing between an
+          operator and a fleet teardown with no recorded reason is a server side
+          validation error they meet after confirming. A header action has
+          nowhere to put a labelled field at 320 pixels. */}
+      {mayTeardown ? <FleetTeardown onDone={state.reload} /> : null}
+    </Card>
+  );
+}
 
 /**
- * Infrastructure & Compute
+ * Asking for every environment in scope to be torn down.
  *
- * Not written yet. The route exists from the first commit because a navigation
- * entry that 404s teaches the reader to distrust the rail, and they cannot tell
- * a section that is coming from one that is broken.
+ * THE RADIUS IS FETCHED BEFORE THE CONFIRMATION AND THE COUNT IS WHAT YOU TYPE.
+ * The server computes what this would touch rather than estimating it, so the
+ * number in the dialog is the query's own answer; making it the confirmation
+ * phrase means the operator cannot confirm without having read it. Typing the
+ * word "teardown" would prove only that they can read a label.
  *
- * TO BUILD THIS SECTION: replace the body below with the real page, and add its
- * routes to web/apps/api/src/admin/operations.ts. Nothing else in the portal
- * has to change. See console/app/admin/README.md.
+ * The result is reported as REQUESTED, never as torn down, in the route's own
+ * words. Rows are written here; the sweeper is what reaches a runtime, and a
+ * console that says "terminated" over a row that will sit pending until it is
+ * abandoned is the exact defect the teardown ledger exists to expose.
  */
-export default function OperationsInfrastructurePage() {
-  return <PlannedSection href="/admin/operations/infrastructure" />;
+function FleetTeardown({ onDone }: { onDone: () => void }) {
+  const [open, setOpen] = useState(false);
+  const [reason, setReason] = useState("");
+  const [radius, setRadius] = useState<BlastRadius | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState<string | null>(null);
+
+  const trimmed = reason.trim();
+
+  async function begin() {
+    setError(null);
+    setRadius(null);
+    setOpen(true);
+    try {
+      setRadius(await teardownRadius());
+    } catch (e) {
+      setError(
+        e instanceof Error
+          ? `The blast radius did not load, so there is nothing to confirm against. ${e.message}`
+          : "The blast radius did not load.",
+      );
+    }
+  }
+
+  async function run() {
+    setBusy(true);
+    setError(null);
+    try {
+      const result = await requestFleetTeardown(trimmed);
+      setDone(
+        `Recorded ${result.recorded} of ${result.requested.length} requests. ${result.pending}`,
+      );
+      setOpen(false);
+      setReason("");
+      onDone();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "The control plane refused that.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="space-y-3 border-t border-rule px-4 py-4">
+      <Field
+        label="Why the fleet would be torn down"
+        hint="Required before this can be confirmed, and recorded against every request it creates."
+      >
+        <input
+          className={inputClass}
+          value={reason}
+          maxLength={500}
+          onChange={(e) => setReason(e.target.value)}
+          placeholder="Runtime provider incident, reclaiming everything"
+          autoComplete="off"
+        />
+      </Field>
+      <div className="flex flex-wrap items-center gap-3">
+        <Button variant="danger" disabled={trimmed === ""} onClick={begin}>
+          Tear down every environment shown
+        </Button>
+        {done ? (
+          <span role="status" className="max-w-[46ch] text-[12.5px] leading-5 text-muted">
+            {done}
+          </span>
+        ) : null}
+      </div>
+
+      <Confirm
+        open={open}
+        title="Tear down every running environment?"
+        // The count, not a word. It is the server's own answer to what this
+        // touches, and it cannot be typed without being read.
+        phrase={radius ? String(radius.environments) : undefined}
+        confirmLabel="Request the teardown"
+        busy={busy}
+        error={error}
+        onConfirm={run}
+        onCancel={() => {
+          if (!busy) {
+            setOpen(false);
+            setError(null);
+          }
+        }}
+      >
+        {radius === null ? (
+          <p>Working out what this would touch.</p>
+        ) : (
+          <>
+            <p className="text-ink">
+              This asks for {radius.environments.toLocaleString()}{" "}
+              {radius.environments === 1 ? "environment" : "environments"} across{" "}
+              {radius.organizations.toLocaleString()}{" "}
+              {radius.organizations === 1 ? "organization" : "organizations"} to be torn down,
+              carrying {radius.runs.toLocaleString()} {radius.runs === 1 ? "run" : "runs"} with
+              them.
+            </p>
+            {radius.alreadyRequested > 0 ? (
+              <p>
+                {radius.alreadyRequested.toLocaleString()} of them already have a teardown request
+                open and will not get a second one.
+              </p>
+            ) : null}
+            <p>
+              It writes requests and sends nothing. Each environment disappears from the list above
+              only when its runtime confirms it is gone, and the ledger below is where a request
+              that cannot reach anything shows up.
+            </p>
+          </>
+        )}
+        <p>
+          <span className="text-dim">Recorded reason: </span>
+          <span className="break-words text-ink">{trimmed}</span>
+        </p>
+      </Confirm>
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------
+ * The teardown ledger
+ * ---------------------------------------------------------------------- */
+
+const TEARDOWN_COLUMNS: Column<Teardown>[] = [
+  {
+    key: "target",
+    header: "Request",
+    cell: (t) => (
+      <>
+        <span className="block truncate font-medium text-ink">
+          {t.repository ?? "no repository recorded"}
+        </span>
+        <span className="block truncate font-mono text-[12px] text-muted">{t.orgSlug}</span>
+      </>
+    ),
+  },
+  {
+    key: "standing",
+    header: "Standing",
+    cell: (t) => (
+      <>
+        <StatusChip value={STANDING_LABEL[t.standing]} tone={toneForStanding(t.standing)} />
+        {/* The route's own sentence about how this request can reach the thing
+            it wants stopped. It is the difference between waiting and stuck,
+            which the state column does not carry. */}
+        <span className="mt-1 block max-w-[52ch] text-[12.5px] leading-5 text-muted">
+          {t.route}
+        </span>
+        {t.lastError ? (
+          <span className="mt-1 block max-w-[52ch] break-words text-[12.5px] leading-5 text-fail">
+            {t.lastError}
+          </span>
+        ) : null}
+      </>
+    ),
+  },
+  {
+    key: "attempts",
+    header: "Attempts",
+    numeric: true,
+    cell: (t) => t.attempts.toLocaleString(),
+  },
+  { key: "requested", header: "Requested", cell: (t) => <When value={t.requestedAt} /> },
+  {
+    key: "reason",
+    header: "Reason",
+    cell: (t) => <span className="block max-w-[32ch] break-words">{t.reason}</span>,
+  },
+];
+
+function TeardownSection() {
+  const [openOnly, setOpenOnly] = useState(true);
+  const state = useTeardowns(openOnly);
+  return (
+    <Card
+      title="Teardown ledger"
+      note="What was asked to stop, and whether anything can actually be sent to stop it."
+    >
+      <FilterBar
+        filters={[
+          {
+            label: "Show",
+            value: openOnly ? "open" : "all",
+            onChange: (v) => setOpenOnly(v === "open"),
+            options: [
+              { value: "open", label: "Still open" },
+              { value: "all", label: "Everything, including confirmed" },
+            ],
+          },
+        ]}
+      />
+      <Loaded state={state} skeleton={<TableSkeleton rows={4} cols={5} />}>
+        {(rows) => (
+          <DataTable
+            columns={TEARDOWN_COLUMNS}
+            rows={rows}
+            keyOf={(t) => t.id}
+            empty={
+              <EmptyList title={openOnly ? "Nothing is waiting to be torn down" : "Nothing has ever been torn down"}>
+                {openOnly
+                  ? "Every teardown that was asked for has been confirmed by the runtime that held the environment. Widen the filter to see the history."
+                  : "No environment on this installation has been asked to stop. Environments also expire on their own, and the health check above counts the ones that have outlived their lifetime."}
+              </EmptyList>
+            }
+            footer={<Capped shown={rows.length} noun={{ one: "request", many: "requests" }} />}
+          />
+        )}
+      </Loaded>
+    </Card>
+  );
+}
+
+/* -------------------------------------------------------------------------
+ * The egress firewall
+ * ---------------------------------------------------------------------- */
+
+const FINDING_COLUMNS: Column<Finding>[] = [
+  {
+    key: "host",
+    header: "Rule",
+    cell: (f) => (
+      <>
+        <span className="block truncate font-medium text-ink">{f.rule.host}</span>
+        <span className="block truncate font-mono text-[12px] text-muted">
+          {f.rule.orgSlug}
+          {f.rule.repository ? ` / ${f.rule.repository}` : ""}
+        </span>
+      </>
+    ),
+  },
+  {
+    key: "finding",
+    header: "Finding",
+    cell: (f) => (
+      <>
+        <StatusChip
+          value={FINDING_LABEL[f.kind]}
+          tone={f.severity === "failing" ? "fail" : "warn"}
+        />
+        <span className="mt-1 block max-w-[64ch] text-[12.5px] leading-5 text-muted">
+          {f.says}
+        </span>
+      </>
+    ),
+  },
+  { key: "mode", header: "Mode", cell: (f) => <StatusChip value={f.rule.mode} /> },
+  {
+    key: "approved",
+    header: "Approved",
+    cell: (f) =>
+      f.rule.approvedAt === null ? (
+        <span className="text-warn">never</span>
+      ) : (
+        <>
+          <When value={f.rule.approvedAt} />
+          {f.rule.approvedBy ? (
+            <span className="block truncate font-mono text-[12px] text-muted">
+              {f.rule.approvedBy}
+            </span>
+          ) : null}
+        </>
+      ),
+  },
+];
+
+function FirewallSection() {
+  const state = useFirewall();
+  return (
+    <Loaded state={state} skeleton={<CardSkeleton count={1} />} framed>
+      {({ summary, findings }) => (
+        <div className="space-y-4">
+          <MetricRow
+            metrics={[
+              { label: "Egress rules", value: summary.rules, note: "across every organization" },
+              { label: "Organizations", value: summary.organizations, note: "with any rule at all" },
+              {
+                label: "Forwarding live credentials",
+                value: summary.forwardingLiveCredentials,
+                note: "never acceptable",
+              },
+              { label: "Never approved", value: summary.neverApproved, note: "inert, so ignored" },
+              { label: "Allowed", value: summary.allowed, note: "reach the real host" },
+            ]}
+          />
+          <Card
+            title="Egress findings"
+            note="Ordered by what the rule actually does, worst first, rather than by organization."
+          >
+            <DataTable
+              columns={FINDING_COLUMNS}
+              rows={findings}
+              keyOf={(f) => `${f.kind}:${f.rule.id}`}
+              empty={
+                <EmptyList title="No rule is doing anything surprising">
+                  Every egress rule on this installation is approved, in a mode that substitutes
+                  what it promises to substitute, and none of them forwards a live credential. A
+                  rule that has never been approved would appear here too, so an empty list also
+                  means nothing is sitting inert.
+                </EmptyList>
+              }
+              footer={
+                <div className="border-t border-rule px-4 py-3 text-[12.5px] text-muted">
+                  All {findings.length} {findings.length === 1 ? "finding" : "findings"}. A rule can
+                  appear twice: fixing a missing sandbox credential does not approve it.
+                </div>
+              }
+            />
+          </Card>
+        </div>
+      )}
+    </Loaded>
+  );
+}
+
+/* -------------------------------------------------------------------------
+ * The footer for a list that has no next page
+ * ---------------------------------------------------------------------- */
+
+/**
+ * What `More` says for a route that does not page.
+ *
+ * These two routes take a limit and return an array, so there is no cursor and
+ * nothing to ask for next. A footer that stayed silent would let a list sitting
+ * exactly at the cap read as complete, which is the same wrong answer `More`
+ * was written to stop. So this says which of the two it is, and when the list
+ * is capped it says what to do about it rather than only that it happened.
+ */
+function Capped({ shown, noun }: { shown: number; noun: { one: string; many: string } }) {
+  const things = `${shown} ${shown === 1 ? noun.one : noun.many}`;
+  const capped = shown >= FLEET_LIMIT;
+  return (
+    <div className="border-t border-rule px-4 py-3">
+      <span className="text-[12.5px] text-muted">
+        {capped
+          ? `Showing the first ${things}. This route returns at most ${FLEET_LIMIT} and offers no next page, so there are almost certainly more. Narrow the filter above.`
+          : `All ${things}.`}
+      </span>
+    </div>
+  );
 }

--- a/console/app/admin/operations/logs/page.tsx
+++ b/console/app/admin/operations/logs/page.tsx
@@ -1,18 +1,523 @@
 "use client";
 
-import { PlannedSection } from "@/components/admin/primitives";
+/**
+ * Logs & Error Explorer.
+ *
+ * WHAT THIS PAGE IS HONEST ABOUT, before anything else. There is no
+ * error-tracking table in this product. No exception group, no fingerprint, no
+ * occurrence counter, no stack trace store, no log line store. Anything here
+ * resembling Sentry would be invented, and an invented error explorer is worse
+ * than none: an operator reads "0 errors" during an incident and stops looking.
+ *
+ * So this is built out of what the control plane genuinely records, and it says
+ * so on the page rather than only in this comment:
+ *
+ *   workload_runs.failure_code   grouped, which is the closest thing to a
+ *                                fingerprint this product has.
+ *   verdicts                     which workflows are failing, across tenants.
+ *   events                       what is arriving, how fast, and how far behind.
+ *
+ * That turns out to answer the question an operator actually opens this page
+ * with, which is not "show me a stack trace" but "what is failing right now,
+ * how many customers does it touch, and did it start when we deployed".
+ *
+ * THE EVENT STREAM SHOWS SHAPE AND TIMING AND NEVER A PAYLOAD VALUE. The
+ * payload is the customer's data. The route returns the key names and the byte
+ * size, the page says that out loud, and the boundary is the column list in the
+ * query, because row level security cannot restrict a column and the operator
+ * pool bypasses it anyway.
+ */
+
+import { useState } from "react";
+import {
+  Badge,
+  Button,
+  Card,
+  CardSkeleton,
+  Loaded,
+  TableSkeleton,
+  When,
+} from "@/components/ui";
+import { More } from "@/components/pagination";
+import {
+  AdminPage,
+  DataTable,
+  EmptyList,
+  FilterBar,
+  MetricRow,
+  StatusChip,
+  type Column,
+} from "@/components/admin/primitives";
+import {
+  WINDOWS,
+  useEventStream,
+  useLogsOverview,
+  type EventRow,
+  type EventTypeSummary,
+  type FailureGroup,
+  type WorkflowFailure,
+} from "@/lib/admin-operations";
+
+export default function OperationsLogsPage() {
+  const [hours, setHours] = useState("24");
+  const [type, setType] = useState("");
+  const overview = useLogsOverview(hours, "");
+  const stream = useEventStream(hours, type, "");
+
+  return (
+    <AdminPage
+      href="/admin/operations/logs"
+      lede="What is failing across every organization, and what is arriving from the engines. Built from run outcomes and the event stream, which is what this control plane records."
+      actions={
+        <Button
+          onClick={() => {
+            overview.reload();
+            stream.reload();
+          }}
+        >
+          Refresh
+        </Button>
+      }
+    >
+      <div className="space-y-6">
+        <Card>
+          <FilterBar
+            filters={[
+              {
+                label: "Window",
+                value: hours,
+                onChange: (v) => {
+                  setHours(v);
+                  // The type filter is cleared with the window on purpose: a
+                  // type that had traffic in the last hour may have none in the
+                  // last week, and a stream filtered to nothing under a
+                  // freshly-widened window reads as "the widening broke it".
+                  setType("");
+                },
+                options: WINDOWS.map((w) => ({ value: w.value, label: w.label })),
+              },
+            ]}
+          />
+          <Loaded state={overview} skeleton={<CardSkeleton count={1} />}>
+            {(o) => (
+              <div className="px-4 py-4">
+                <MetricRow
+                  metrics={[
+                    {
+                      label: "Failing runs",
+                      value: o.failures.reduce((n, f) => n + f.runs, 0),
+                      note: o.truncated.failures
+                        ? `across the top ${o.limit} groups, which is a cut list`
+                        : `across ${o.failures.length} ${o.failures.length === 1 ? "group" : "groups"}`,
+                    },
+                    {
+                      label: "Workflows failing",
+                      value: o.workflows.length,
+                      note: o.truncated.workflows ? `cut at ${o.limit}` : "distinct workflows",
+                    },
+                    {
+                      label: "Events",
+                      value: o.eventTypes.reduce((n, t) => n + t.events, 0),
+                      note: `across ${o.eventTypes.length} ${o.eventTypes.length === 1 ? "type" : "types"}`,
+                    },
+                    {
+                      label: "Worst ingestion lag",
+                      value:
+                        o.eventTypes.length === 0
+                          ? null
+                          : Math.max(...o.eventTypes.map((t) => t.lagSeconds)),
+                      unit: "seconds",
+                      note: "engine stamp to arrival here",
+                    },
+                  ]}
+                />
+              </div>
+            )}
+          </Loaded>
+        </Card>
+
+        <FailuresCard state={overview} />
+        <WorkflowsCard state={overview} />
+        <EventTypesCard state={overview} selected={type} onSelect={setType} />
+        <StreamCard state={stream} type={type} onClearType={() => setType("")} />
+        <WhatIsNotRecorded />
+      </div>
+    </AdminPage>
+  );
+}
+
+/* -------------------------------------------------------------------------
+ * Failures, grouped by code
+ * ---------------------------------------------------------------------- */
+
+const FAILURE_COLUMNS: Column<FailureGroup>[] = [
+  {
+    key: "code",
+    header: "Failure",
+    cell: (f) => (
+      <>
+        <span className="block truncate font-mono text-[12px] font-medium text-ink">
+          {/* Null is a real answer and gets its own row. A run that ends failed
+              having recorded no code is a gap in the engine, and folding those
+              rows into the others would hide it. */}
+          {f.failureCode ?? "no code recorded"}
+        </span>
+        <span className="mt-0.5 block text-[12px] text-dim">
+          {f.kind.replace(/_/g, " ")}
+        </span>
+        {f.latestDetail ? (
+          <span className="mt-1 block max-w-[56ch] break-words text-[12.5px] leading-5 text-muted">
+            {f.latestDetail}
+          </span>
+        ) : null}
+      </>
+    ),
+  },
+  { key: "state", header: "Ended as", cell: (f) => <StatusChip value={f.state} /> },
+  { key: "runs", header: "Runs", numeric: true, cell: (f) => f.runs.toLocaleString() },
+  {
+    key: "organizations",
+    header: "Tenants",
+    numeric: true,
+    cell: (f) => f.organizations.toLocaleString(),
+  },
+  { key: "first", header: "First seen", cell: (f) => <When value={f.firstSeen} /> },
+  { key: "last", header: "Last seen", cell: (f) => <When value={f.lastSeen} /> },
+];
+
+function FailuresCard({ state }: { state: ReturnType<typeof useLogsOverview> }) {
+  return (
+    <Card
+      title="Failures by code"
+      note="Workload runs that ended failed, timed out or abandoned. All three are failures to the person whose test did not run."
+    >
+      <Loaded state={state} skeleton={<TableSkeleton rows={5} cols={6} />}>
+        {(o) => (
+          <DataTable
+            columns={FAILURE_COLUMNS}
+            rows={o.failures}
+            keyOf={(f) => `${f.failureCode ?? "none"}:${f.kind}:${f.state}`}
+            empty={
+              <EmptyList title="Nothing failed in this window">
+                No workload run ended failed, timed out or abandoned in the period selected above.
+                Widen the window if you are looking for something older.
+              </EmptyList>
+            }
+            footer={<Cut shown={o.failures.length} limit={o.limit} cut={o.truncated.failures} noun={{ one: "group", many: "groups" }} />}
+          />
+        )}
+      </Loaded>
+    </Card>
+  );
+}
+
+/* -------------------------------------------------------------------------
+ * Workflows
+ * ---------------------------------------------------------------------- */
+
+const WORKFLOW_COLUMNS: Column<WorkflowFailure>[] = [
+  {
+    key: "workflow",
+    header: "Workflow",
+    cell: (w) => (
+      <>
+        <span className="block truncate font-medium text-ink">{w.workflow}</span>
+        {w.latestSummary ? (
+          <span className="mt-1 block max-w-[56ch] break-words text-[12.5px] leading-5 text-muted">
+            {w.latestSummary}
+          </span>
+        ) : null}
+      </>
+    ),
+  },
+  { key: "value", header: "Verdict", cell: (w) => <StatusChip value={w.value} /> },
+  { key: "runs", header: "Verdicts", numeric: true, cell: (w) => w.runs.toLocaleString() },
+  {
+    key: "organizations",
+    header: "Tenants",
+    numeric: true,
+    cell: (w) => w.organizations.toLocaleString(),
+  },
+  { key: "last", header: "Last seen", cell: (w) => <When value={w.lastSeen} /> },
+];
+
+function WorkflowsCard({ state }: { state: ReturnType<typeof useLogsOverview> }) {
+  return (
+    <Card
+      title="Workflows failing"
+      note="One workflow failing for several tenants at once is a product fault rather than a customer's."
+    >
+      <Loaded state={state} skeleton={<TableSkeleton rows={4} cols={5} />}>
+        {(o) => (
+          <DataTable
+            columns={WORKFLOW_COLUMNS}
+            rows={o.workflows}
+            keyOf={(w) => `${w.workflow}:${w.value}`}
+            empty={
+              <EmptyList title="No workflow failed or was blocked">
+                Every verdict recorded in this window passed, was flaky, or went unverified. A
+                blocked workflow would appear here too, since a workflow nothing could run is not a
+                workflow that passed.
+              </EmptyList>
+            }
+            footer={<Cut shown={o.workflows.length} limit={o.limit} cut={o.truncated.workflows} noun={{ one: "workflow", many: "workflows" }} />}
+          />
+        )}
+      </Loaded>
+    </Card>
+  );
+}
+
+/* -------------------------------------------------------------------------
+ * Event types
+ * ---------------------------------------------------------------------- */
+
+function EventTypesCard({
+  state,
+  selected,
+  onSelect,
+}: {
+  state: ReturnType<typeof useLogsOverview>;
+  selected: string;
+  onSelect: (type: string) => void;
+}) {
+  const columns: Column<EventTypeSummary>[] = [
+    {
+      key: "type",
+      header: "Event type",
+      cell: (t) => (
+        // A real button, not a clickable row or a div with an onClick. It is
+        // focusable, Enter activates it, and a screen reader is told it does
+        // something.
+        <button
+          type="button"
+          onClick={() => onSelect(selected === t.type ? "" : t.type)}
+          aria-pressed={selected === t.type}
+          className="-mx-1 -my-2 inline-flex min-h-11 items-center px-1 py-2 text-left font-mono text-[12px] font-medium text-ink underline decoration-transparent underline-offset-4 hover:decoration-[rgba(16,16,16,0.35)] sm:min-h-0"
+        >
+          {t.type}
+        </button>
+      ),
+    },
+    { key: "events", header: "Events", numeric: true, cell: (t) => t.events.toLocaleString() },
+    {
+      key: "organizations",
+      header: "Tenants",
+      numeric: true,
+      cell: (t) => t.organizations.toLocaleString(),
+    },
+    {
+      key: "lag",
+      header: "Lag",
+      numeric: true,
+      cell: (t) => (
+        <>
+          <span className={t.lagSeconds >= 600 ? "text-fail" : ""}>
+            {t.lagSeconds.toLocaleString()}
+          </span>
+          <span className="block text-[12px] text-dim">seconds</span>
+        </>
+      ),
+    },
+    { key: "last", header: "Last arrival", cell: (t) => <When value={t.lastReceivedAt} /> },
+  ];
+
+  return (
+    <Card
+      title="What is arriving"
+      note="Lag is the gap between the engine stamping an event and this control plane receiving it. Either timestamp alone looks fine while the pair is wrong."
+      actions={
+        selected ? (
+          <Button onClick={() => onSelect("")}>Clear filter</Button>
+        ) : null
+      }
+    >
+      <Loaded state={state} skeleton={<TableSkeleton rows={5} cols={5} />}>
+        {(o) => (
+          <DataTable
+            columns={columns}
+            rows={o.eventTypes}
+            keyOf={(t) => t.type}
+            empty={
+              <EmptyList title="No events arrived in this window">
+                Nothing has been received from any engine in the period selected above. On a live
+                installation that is an ingestion fault rather than a quiet day, and the system
+                health check for ingestion lag on the Infrastructure page is the next place to
+                look.
+              </EmptyList>
+            }
+            footer={<Cut shown={o.eventTypes.length} limit={o.limit} cut={o.truncated.eventTypes} noun={{ one: "type", many: "types" }} />}
+          />
+        )}
+      </Loaded>
+    </Card>
+  );
+}
+
+/* -------------------------------------------------------------------------
+ * The stream
+ * ---------------------------------------------------------------------- */
+
+const EVENT_COLUMNS: Column<EventRow>[] = [
+  {
+    key: "type",
+    header: "Event",
+    cell: (e) => (
+      <>
+        <span className="block truncate font-mono text-[12px] font-medium text-ink">{e.type}</span>
+        <span className="block truncate text-[12px] text-muted">{e.orgSlug}</span>
+      </>
+    ),
+  },
+  { key: "occurred", header: "Occurred", cell: (e) => <When value={e.occurredAt} /> },
+  { key: "received", header: "Received", cell: (e) => <When value={e.receivedAt} /> },
+  {
+    key: "env",
+    header: "Environment",
+    mono: true,
+    cell: (e) => e.envId ?? <span className="text-dim">none</span>,
+  },
+  {
+    key: "fields",
+    header: "Fields",
+    cell: (e) =>
+      e.payloadKeys.length === 0 ? (
+        <span className="text-dim">empty payload</span>
+      ) : (
+        <span className="block max-w-[36ch] break-words font-mono text-[12px] text-muted">
+          {e.payloadKeys.join(", ")}
+        </span>
+      ),
+  },
+  {
+    key: "bytes",
+    header: "Payload",
+    numeric: true,
+    cell: (e) => (
+      <>
+        <span className="block">{e.payloadBytes.toLocaleString()}</span>
+        <span className="block text-[12px] text-dim">bytes</span>
+      </>
+    ),
+  },
+];
+
+function StreamCard({
+  state,
+  type,
+  onClearType,
+}: {
+  state: ReturnType<typeof useEventStream>;
+  type: string;
+  onClearType: () => void;
+}) {
+  return (
+    <Card
+      title="Event stream"
+      note={
+        type
+          ? `Filtered to ${type}. Field names and payload size only; the values are never returned.`
+          : "Newest first. Field names and payload size only; the values are never returned."
+      }
+      actions={type ? <Button onClick={onClearType}>Clear filter</Button> : null}
+    >
+      <Loaded state={state} skeleton={<TableSkeleton rows={6} cols={6} />}>
+        {(rows) => (
+          <DataTable
+            columns={EVENT_COLUMNS}
+            rows={rows}
+            keyOf={(e) => e.id}
+            empty={
+              <EmptyList
+                title={type ? `No ${type} events in this window` : "No events in this window"}
+                action={type ? <Button onClick={onClearType}>Clear the filter</Button> : undefined}
+              >
+                {type
+                  ? "That type had traffic when the summary above was computed, or it was chosen from a wider window. Clear the filter or widen the window."
+                  : "Nothing has arrived from any engine in the period selected above."}
+              </EmptyList>
+            }
+            footer={
+              <More
+                shown={rows.length}
+                noun={{ one: "event", many: "events" }}
+                hasMore={state.hasMore}
+                busy={state.busy}
+                error={state.moreError}
+                onMore={state.more}
+              />
+            }
+          />
+        )}
+      </Loaded>
+    </Card>
+  );
+}
+
+/* -------------------------------------------------------------------------
+ * The honest footer
+ * ---------------------------------------------------------------------- */
 
 /**
- * Logs & Error Explorer
+ * What this product does not record, named.
  *
- * Not written yet. The route exists from the first commit because a navigation
- * entry that 404s teaches the reader to distrust the rail, and they cannot tell
- * a section that is coming from one that is broken.
- *
- * TO BUILD THIS SECTION: replace the body below with the real page, and add its
- * routes to web/apps/api/src/admin/operations.ts. Nothing else in the portal
- * has to change. See console/app/admin/README.md.
+ * On the page rather than only in a comment, because the reader who needs it is
+ * the operator who came here looking for a stack trace and is about to conclude
+ * there were no errors.
  */
-export default function OperationsLogsPage() {
-  return <PlannedSection href="/admin/operations/logs" />;
+function WhatIsNotRecorded() {
+  return (
+    <Card title="What this page cannot show you">
+      <div className="space-y-3 px-4 py-4 text-[13px] leading-6 text-muted">
+        <p className="max-w-[70ch]">
+          There is no error-tracking store in this product. Nothing records an exception, a stack
+          trace, a fingerprint, an occurrence count or a log line. Everything above is arithmetic
+          over run outcomes and the event stream, which is what the control plane genuinely writes.
+        </p>
+        <p className="max-w-[70ch]">
+          Event payloads are deliberately not returned. The payload is the customer&apos;s data:
+          request bodies, database values, whatever the engine observed. The field names and the
+          size are enough to tell whether ingestion is working and what shape is arriving, and they
+          are not a copy of a tenant&apos;s data sitting in an operator&apos;s browser. Every read
+          on this page is recorded against the operator who made it.
+        </p>
+        <p className="max-w-[70ch] text-dim">
+          <Badge tone="neutral">what would change this</Badge> Grouped exceptions would need a
+          table with a fingerprint, an occurrence count and a stack trace, plus something on the
+          engine side that reports them. That is a schema change and an engine change, not a page.
+        </p>
+      </div>
+    </Card>
+  );
+}
+
+/**
+ * The footer for an aggregate that has no cursor.
+ *
+ * A GROUP BY has no stable keyset to page through: the counts move between
+ * calls, so a cursor into them would skip and repeat. So these lists are capped
+ * on the server and this says when the cap was hit, rather than letting a cut
+ * list read as the whole answer.
+ */
+function Cut({
+  shown,
+  limit,
+  cut,
+  noun,
+}: {
+  shown: number;
+  limit: number;
+  cut: boolean;
+  noun: { one: string; many: string };
+}) {
+  const things = `${shown} ${shown === 1 ? noun.one : noun.many}`;
+  return (
+    <div className="border-t border-rule px-4 py-3">
+      <span className="text-[12.5px] text-muted">
+        {cut
+          ? `The busiest ${things}. There are more: this is an aggregate, so it is capped at ${limit} rather than paged. Narrow the window to see further down the list.`
+          : `All ${things}.`}
+      </span>
+    </div>
+  );
 }

--- a/console/lib/admin-nav.ts
+++ b/console/lib/admin-nav.ts
@@ -234,15 +234,17 @@ export const ADMIN_NAV: AdminNavGroup[] = [
         label: "Logs & Error Explorer",
         href: "/admin/operations/logs",
         Icon: IconLogs,
-        permission: "admin.infra.read",
-        summary: "Search the platform's own logs, and the errors it has grouped for you.",
+        permission: "admin.logs.read",
+        summary:
+          "What is failing across every tenant, and what is arriving from the engines.",
       },
       {
         label: "Email & Notifications",
         href: "/admin/operations/email",
         Icon: IconEmail,
-        permission: "admin.infra.read",
-        summary: "What the product sent, what bounced, and what is still waiting to go out.",
+        permission: "admin.email.read",
+        summary:
+          "Whether this installation can send email, and every sign-in link it has issued.",
       },
       {
         label: "Incidents & Kill Switches",

--- a/console/lib/admin-operations.ts
+++ b/console/lib/admin-operations.ts
@@ -1,0 +1,191 @@
+"use client";
+
+/**
+ * The Operations lane's client: infrastructure, failures, email and the
+ * switches.
+ *
+ * WHY A THIRD FILE AND NOT ADDITIONS TO admin.ts. Same reason admin.ts is not
+ * additions to api.ts: the transport is shared and nothing else is. admin.ts
+ * holds what every operator page needs, which is who is signed in and what they
+ * may do. This holds four sections' worth of shapes that no other page reads,
+ * and putting them there would make the module every page imports grow by the
+ * size of the portal.
+ *
+ * The transport is reused unchanged. `query`, `usePages` and `useApi` come from
+ * api.ts and `adminMutate` from admin.ts, because a second fetch wrapper is a
+ * second place for the error shape, the credentials mode and the CSRF header to
+ * drift, and the header is exactly the thing that has drifted here before.
+ *
+ * NOTHING IN THIS FILE INVENTS A NUMBER. Every shape it re-exports mirrors a
+ * route that returns it. Where a question has no answer in this product, such
+ * as whether a message was delivered, there is no type for it anywhere and the
+ * page says so in words instead of showing a zero.
+ *
+ * The shapes and the pure helpers live in `operations-shapes.ts`, which imports
+ * nothing, so `node --test lib/*.test.ts` can reach them. Everything there is
+ * re-exported below, so a page still imports one module.
+ */
+
+import { query, useApi, usePages } from "@/lib/api";
+import { adminMutate, type AdminPage } from "@/lib/admin";
+import {
+  FLEET_LIMIT,
+  type BlastRadius,
+  type ControlName,
+  type ControlState,
+  type EmailStatus,
+  type EventRow,
+  type FirewallSummary,
+  type Finding,
+  type FleetTeardownResult,
+  type HealthReport,
+  type LogsOverview,
+  type SignInLink,
+  type Teardown,
+  type Twin,
+  type TwinScope,
+} from "@/lib/operations-shapes";
+
+// Re-exported so a page imports one module and the contract with the control
+// plane is still one file to reconcile. Same arrangement as load.ts over
+// loadshapes.ts.
+export * from "@/lib/operations-shapes";
+
+/* -------------------------------------------------------------------------
+ * System health, from admin/health.ts
+ * ---------------------------------------------------------------------- */
+
+
+export function useSystemHealth() {
+  return useApi<HealthReport>(() => query("admin.infra.health"), []);
+}
+
+/* -------------------------------------------------------------------------
+ * The fleet, from admin/fleet.ts
+ * ---------------------------------------------------------------------- */
+
+
+export function useTwins(scope: TwinScope) {
+  return useApi<Twin[]>(
+    () => query("admin.infra.twins", { scope, limit: FLEET_LIMIT }),
+    [scope],
+  );
+}
+
+
+export function useTeardowns(openOnly: boolean) {
+  return useApi<Teardown[]>(
+    () => query("admin.infra.teardowns", { open: openOnly, limit: FLEET_LIMIT }),
+    [openOnly],
+  );
+}
+
+
+/** What a fleet teardown would touch, computed rather than estimated. An
+ *  operator confirming a blast radius written in prose is confirming somebody's
+ *  recollection of what the query would return. */
+export function teardownRadius(): Promise<BlastRadius> {
+  return query("admin.infra.teardownRadius");
+}
+
+
+export function requestFleetTeardown(reason: string) {
+  return adminMutate<FleetTeardownResult>("admin.infra.teardownFleet", { reason });
+}
+
+/* -------------------------------------------------------------------------
+ * The egress firewall, from admin/firewall.ts
+ * ---------------------------------------------------------------------- */
+
+
+export function useFirewall() {
+  return useApi<{ summary: FirewallSummary; findings: Finding[] }>(
+    () => query("admin.infra.firewall"),
+    [],
+  );
+}
+
+/* -------------------------------------------------------------------------
+ * The switches, from admin/controls.ts
+ * ---------------------------------------------------------------------- */
+
+
+export function useControls() {
+  return useApi<ControlState[]>(() => query("admin.emergency.controls"), []);
+}
+
+/**
+ * Engages or releases one switch.
+ *
+ * `reason` is required to engage and refused empty by the server as well as by
+ * the form, because a switch that stops an installation with no reason recorded
+ * is one the next person on call cannot safely release.
+ */
+export function setControl(name: ControlName, engaged: boolean, reason: string | null) {
+  return adminMutate<ControlState>("admin.emergency.set", { name, engaged, reason });
+}
+
+/* -------------------------------------------------------------------------
+ * Failures and the event stream
+ * ---------------------------------------------------------------------- */
+
+
+export function useLogsOverview(hours: string, orgId: string) {
+  return useApi<LogsOverview>(
+    () =>
+      query("admin.operations.logs.overview", {
+        hours: Number(hours),
+        ...(orgId ? { orgId } : {}),
+      }),
+    [hours, orgId],
+  );
+}
+
+
+/** usePages rather than useApi, because the route returns a cursor. A screen
+ *  that reads one page of a keyset list and renders no footer tells the reader
+ *  the list is complete, which is a confident wrong answer. */
+export function useEventStream(hours: string, type: string, orgId: string) {
+  return usePages<EventRow>(
+    async (cursor) => {
+      const page = await query<AdminPage<EventRow>>("admin.operations.logs.events", {
+        hours: Number(hours),
+        limit: 50,
+        ...(type ? { type } : {}),
+        ...(orgId ? { orgId } : {}),
+        ...(cursor === null ? {} : { cursor }),
+      });
+      return { rows: page.rows, next: page.nextCursor };
+    },
+    [hours, type, orgId],
+  );
+}
+
+/* -------------------------------------------------------------------------
+ * Email
+ * ---------------------------------------------------------------------- */
+
+
+export function useEmailStatus(hours: string) {
+  return useApi<EmailStatus>(
+    () => query("admin.operations.email.status", { hours: Number(hours) }),
+    [hours],
+  );
+}
+
+
+export function useSignInLinks(hours: string, standing: string, search: string) {
+  return usePages<SignInLink>(
+    async (cursor) => {
+      const page = await query<AdminPage<SignInLink>>("admin.operations.email.signInLinks", {
+        hours: Number(hours),
+        limit: 50,
+        ...(standing ? { standing } : {}),
+        ...(search ? { query: search } : {}),
+        ...(cursor === null ? {} : { cursor }),
+      });
+      return { rows: page.rows, next: page.nextCursor };
+    },
+    [hours, standing, search],
+  );
+}

--- a/console/lib/operations-shapes.test.ts
+++ b/console/lib/operations-shapes.test.ts
@@ -1,0 +1,95 @@
+// The Operations lane's pure functions.
+//
+// Small, and each one guards a defect that renders rather than throws, which is
+// the kind this console has shipped before.
+//
+// A LOOKUP MAP THAT LOSES A KEY RENDERS `undefined`. Not a crash, not a type
+// error at the call site, just the word undefined in a table cell, and only if
+// somebody happens to be looking at a row in that state. The two maps below are
+// keyed by union types, so TypeScript catches a key that is removed from the
+// map; it does NOT catch a member added to the union in another file, which is
+// exactly what happens when the server grows a fourth teardown standing. So the
+// keys are asserted against the list, here, where a mismatch fails the build.
+//
+// A TONE THAT IS NEVER RED HAS NOT BEEN SHOWN TO SAY NO. `toneForStanding` is
+// the reason the standing exists at all: `nothing-to-reach` and `abandoned`
+// both read as "pending" in the raw state column, and both mean the environment
+// is still up and nothing further will happen on its own. If either of them
+// came back warn, the page would file the two situations that need a human
+// alongside the two that resolve themselves.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  FINDING_LABEL,
+  STANDING_LABEL,
+  WINDOWS,
+  toneForStanding,
+  toneForVerdict,
+  type FindingKind,
+  type TeardownStanding,
+  type Verdict,
+} from "./operations-shapes.ts";
+
+const STANDINGS: TeardownStanding[] = [
+  "nothing-to-reach",
+  "waiting-to-dispatch",
+  "dispatched-unconfirmed",
+  "confirmed",
+  "abandoned",
+];
+
+const KINDS: FindingKind[] = ["sandbox-without-credential", "never-approved", "allow"];
+
+test("every teardown standing has a label a person can read", () => {
+  for (const standing of STANDINGS) {
+    const label = STANDING_LABEL[standing];
+    assert.ok(label, `no label for ${standing}, so the cell would render undefined`);
+    assert.ok(
+      !label.includes("-"),
+      `${standing} was labelled ${label}, which is still the wire identifier`,
+    );
+  }
+  assert.equal(Object.keys(STANDING_LABEL).length, STANDINGS.length);
+});
+
+test("every firewall finding kind has a label", () => {
+  for (const kind of KINDS) {
+    assert.ok(FINDING_LABEL[kind], `no label for ${kind}`);
+  }
+  assert.equal(Object.keys(FINDING_LABEL).length, KINDS.length);
+});
+
+test("a teardown that can never reach anything is a failure, not a wait", () => {
+  // The whole reason the standing is derived rather than read off the state
+  // column. Both of these look like "pending" there.
+  assert.equal(toneForStanding("nothing-to-reach"), "fail");
+  assert.equal(toneForStanding("abandoned"), "fail");
+
+  // These two genuinely are waits, and colouring them red would make a healthy
+  // queue look like an outage.
+  assert.equal(toneForStanding("waiting-to-dispatch"), "warn");
+  assert.equal(toneForStanding("dispatched-unconfirmed"), "warn");
+
+  assert.equal(toneForStanding("confirmed"), "pass");
+});
+
+test("a health verdict maps to three distinct tones", () => {
+  const verdicts: Verdict[] = ["ok", "degraded", "failing"];
+  const tones = verdicts.map(toneForVerdict);
+  assert.deepEqual(tones, ["pass", "warn", "fail"]);
+  // Degraded is not red. A page where everything worth looking at is red is a
+  // page where nothing is.
+  assert.notEqual(toneForVerdict("degraded"), toneForVerdict("failing"));
+});
+
+test("every window offered is one the routes accept", () => {
+  // The server takes a fixed set, not a free number, because these queries scan
+  // by time. A window in this list that the route refuses is a select that
+  // produces a validation error instead of a page.
+  const accepted = new Set(["1", "6", "24", "72", "168"]);
+  for (const w of WINDOWS) {
+    assert.ok(accepted.has(w.value), `${w.value} hours is not a window the route accepts`);
+    assert.ok(w.label.length > 0);
+  }
+});

--- a/console/lib/operations-shapes.ts
+++ b/console/lib/operations-shapes.ts
@@ -1,0 +1,314 @@
+/**
+ * The Operations lane's shapes and the pure functions over them.
+ *
+ * Split from `admin-operations.ts` and holding NO IMPORT, which is what makes
+ * it testable. The same split `loadshapes.ts` makes next to `load.ts`, for the
+ * same reason: the calls next door reach the network and cannot run outside a
+ * browser, and console unit tests are `node --test lib/*.test.ts`, which
+ * resolves no `@/` alias and starts no browser. A helper that lives beside a
+ * fetch is a helper with no test.
+ *
+ * Import from `@/lib/admin-operations`, not from here. That module re-exports
+ * all of this, so a page imports one module and the contract with the control
+ * plane is still one file to reconcile.
+ */
+
+export type Verdict = "ok" | "degraded" | "failing";
+export interface HealthCheck {
+  id: string;
+  title: string;
+  verdict: Verdict;
+  value: number;
+  unit: string;
+  detail: string;
+  /** Null when the check is ok. "No action needed" on every green row is noise
+   *  on a page whose job is to make the red ones stand out. */
+  remedy: string | null;
+}
+export interface HealthReport {
+  checks: HealthCheck[];
+  /** The worst verdict among the checks, derived on the server so the summary
+   *  line cannot disagree with the rows under it. */
+  verdict: Verdict;
+  at: string;
+}
+export type TwinScope = "live" | "overdue" | "all";
+export interface Twin {
+  envId: string;
+  orgId: string;
+  orgSlug: string;
+  repository: string;
+  branch: string;
+  pullRequest: number | null;
+  state: string;
+  previewUrl: string | null;
+  runtime: string | null;
+  goldenVersion: string | null;
+  createdAt: string;
+  updatedAt: string;
+  expiresAt: string | null;
+  tornDownAt: string | null;
+  /** Past its expiry and still running. This is the row that costs money. */
+  overdue: boolean;
+  teardownPending: boolean;
+  runs: number;
+}
+/**
+ * How many rows the fleet and ledger routes are asked for.
+ *
+ * These two return an array and no cursor, so there is no `More` to render and
+ * no way to ask for the next page. That makes the cap a claim the page has to
+ * be honest about: at exactly this many rows the answer is "the first 200",
+ * never "all of them", and the pages say which. Half the console's paging
+ * defects were a screen that showed one page and called it the list.
+ */
+export const FLEET_LIMIT = 200;
+export type TeardownStanding =
+  | "nothing-to-reach"
+  | "waiting-to-dispatch"
+  | "dispatched-unconfirmed"
+  | "confirmed"
+  | "abandoned";
+export interface Teardown {
+  id: string;
+  orgId: string;
+  orgSlug: string;
+  envId: string | null;
+  repository: string | null;
+  workflowRunId: string | null;
+  reason: string;
+  state: string;
+  /** What actually happened, which the `state` column does not say: "pending"
+   *  covers both asked for a second ago and asked for yesterday with nothing
+   *  to reach. */
+  standing: TeardownStanding;
+  attempts: number;
+  leaseHolder: string | null;
+  leasedUntil: string | null;
+  leaseExpired: boolean;
+  lastError: string | null;
+  requestedAt: string;
+  acknowledgedAt: string | null;
+  route: string;
+}
+export interface BlastRadius {
+  organizations: number;
+  environments: number;
+  runs: number;
+  alreadyRequested: number;
+}
+export interface RequestedTeardown {
+  envId: string;
+  recorded: boolean;
+  /** False when there is no workflow run and no environment id, so nothing can
+   *  be sent and the request will sit until it is abandoned. */
+  reachable: boolean;
+}
+export interface FleetTeardownResult {
+  radius: BlastRadius;
+  requested: RequestedTeardown[];
+  recorded: number;
+  unreachable: number;
+  /** The route's own sentence about what happens next. Rendered verbatim: it
+   *  is the difference between "requested" and "torn down", and rewording it
+   *  here would be the console claiming the second. */
+  pending: string;
+}
+export type FindingKind = "sandbox-without-credential" | "never-approved" | "allow";
+export interface FirewallRule {
+  id: string;
+  orgId: string;
+  orgSlug: string;
+  repository: string | null;
+  host: string;
+  mode: string;
+  paths: string[] | null;
+  methods: string[] | null;
+  credential: string | null;
+  note: string | null;
+  position: number;
+  proposedBy: string | null;
+  approvedBy: string | null;
+  approvedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+export interface Finding {
+  kind: FindingKind;
+  rule: FirewallRule;
+  says: string;
+  /** `failing` is never acceptable, `review` is a judgement. Kept as the
+   *  server's two words rather than scored into a number: a finding that is
+   *  always wrong must not be something a threshold can hide. */
+  severity: "failing" | "review";
+}
+export interface FirewallSummary {
+  rules: number;
+  organizations: number;
+  forwardingLiveCredentials: number;
+  neverApproved: number;
+  allowed: number;
+}
+export type ControlName = "maintenance" | "signups" | "new_runs";
+export interface ControlDefinition {
+  name: ControlName;
+  title: string;
+  /** Exactly what stops working AND what keeps working. Read before
+   *  confirming, so it is rendered in full rather than truncated. */
+  effect: string;
+  /** Where the refusal is, as `path/from/src:symbol`. A test opens that file
+   *  and greps it for that symbol, so this is a claim the build checks. */
+  enforcedBy: string;
+  release: string;
+}
+export interface ControlState {
+  name: ControlName;
+  definition: ControlDefinition;
+  engaged: boolean;
+  engagedAt: string | null;
+  reason: string | null;
+  engagedBy: string | null;
+  updatedAt: string | null;
+}
+/** The windows the routes accept. Not a free number: these queries scan by
+ *  time, and a larger one during an incident is a statement timeout rather
+ *  than an answer. */
+export const WINDOWS = [
+  { value: "1", label: "Last hour" },
+  { value: "6", label: "Last 6 hours" },
+  { value: "24", label: "Last 24 hours" },
+  { value: "72", label: "Last 3 days" },
+  { value: "168", label: "Last 7 days" },
+] as const;
+export interface FailureGroup {
+  /** Null when the run failed and recorded no code. Shown as its own row: a
+   *  failure with no code is a gap in the engine, and hiding it hides the gap. */
+  failureCode: string | null;
+  kind: string;
+  state: string;
+  runs: number;
+  organizations: number;
+  firstSeen: string;
+  lastSeen: string;
+  latestDetail: string | null;
+  latestRunId: string;
+}
+export interface WorkflowFailure {
+  workflow: string;
+  value: string;
+  runs: number;
+  organizations: number;
+  lastSeen: string;
+  latestSummary: string | null;
+}
+export interface EventTypeSummary {
+  type: string;
+  events: number;
+  organizations: number;
+  lastReceivedAt: string;
+  /** Seconds between the engine stamping the event and this control plane
+   *  receiving it. Either timestamp alone looks fine while the pair is wrong. */
+  lagSeconds: number;
+}
+export interface LogsOverview {
+  hours: number;
+  from: string;
+  at: string;
+  failures: FailureGroup[];
+  workflows: WorkflowFailure[];
+  eventTypes: EventTypeSummary[];
+  /** Per list, whether it was cut off at `limit`. The page says "the top N"
+   *  rather than implying it is the whole answer. */
+  truncated: { failures: boolean; workflows: boolean; eventTypes: boolean };
+  limit: number;
+}
+export interface EventRow {
+  id: string;
+  occurredAt: string;
+  receivedAt: string;
+  type: string;
+  orgId: string;
+  orgSlug: string;
+  envId: string | null;
+  runId: string | null;
+  /** The payload's top level key NAMES. The values are never returned: the
+   *  payload is the customer's data, and shape plus timing is what an operator
+   *  debugging ingestion actually needs. */
+  payloadKeys: string[];
+  payloadBytes: number;
+}
+export interface EmailReach {
+  linksIssued: number;
+  linksUsed: number;
+  /** Issued, never used, and now too old to use. At any volume this is what a
+   *  delivery failure looks like from inside a product that keeps no delivery
+   *  record. */
+  linksUnused: number;
+  linksLive: number;
+  invitationsSent: number;
+  invitationsAccepted: number;
+  invitationsOpen: number;
+  billingContacts: number;
+}
+export interface EmailStatus {
+  hours: number;
+  from: string;
+  at: string;
+  /** Whether this process has a mailer at all. The token row is written either
+   *  way, so no query over the database can tell the two apart. */
+  canSend: boolean;
+  provider: "resend" | "recording" | "other" | null;
+  /** Messages are kept in memory and delivered to nobody, which looks identical
+   *  to working from every other angle. */
+  recordingOnly: boolean;
+  reach: EmailReach;
+}
+export type LinkStanding = "used" | "live" | "unused";
+export interface SignInLink {
+  id: string;
+  email: string;
+  createdAt: string;
+  expiresAt: string;
+  consumedAt: string | null;
+  standing: LinkStanding;
+  ip: string | null;
+  userAgent: string | null;
+  redirectTo: string | null;
+}
+
+/** The console's tones for a health verdict. `degraded` is warn rather than
+ *  fail: a page where everything worth looking at is red is a page where
+ *  nothing is. */
+export function toneForVerdict(verdict: Verdict): "pass" | "warn" | "fail" {
+  return verdict === "ok" ? "pass" : verdict === "degraded" ? "warn" : "fail";
+}
+
+/**
+ * The tone of a teardown standing.
+ *
+ * `nothing-to-reach` and `abandoned` are failures rather than warnings, and
+ * that is the whole point of the standing existing: both of them look like
+ * "pending" in the state column, and both mean the environment is still up and
+ * nothing further will happen on its own.
+ */
+export function toneForStanding(standing: TeardownStanding): "pass" | "warn" | "fail" {
+  if (standing === "confirmed") return "pass";
+  if (standing === "abandoned" || standing === "nothing-to-reach") return "fail";
+  return "warn";
+}
+
+/** How a standing reads to a person. The wire values are hyphenated
+ *  identifiers and a table full of them reads like a log file. */
+export const STANDING_LABEL: Record<TeardownStanding, string> = {
+  "nothing-to-reach": "nothing to reach",
+  "waiting-to-dispatch": "waiting to dispatch",
+  "dispatched-unconfirmed": "asked, not confirmed",
+  confirmed: "confirmed gone",
+  abandoned: "abandoned",
+};
+
+export const FINDING_LABEL: Record<FindingKind, string> = {
+  "sandbox-without-credential": "live credential forwarded",
+  "never-approved": "never approved",
+  allow: "allowed to the real host",
+};

--- a/web/apps/api/src/admin/operations.ts
+++ b/web/apps/api/src/admin/operations.ts
@@ -1,56 +1,679 @@
-// The Operations lane of the operator portal.
+// The Operations lane: what an operator can actually learn about failures and
+// about email, from the tables this control plane already writes.
 //
-// WHAT THIS FILE IS FOR, and why it is empty rather than absent. The portal has
-// six navigation groups and they are built in parallel. One module per group,
-// mounted once, is what lets that happen without two people editing the same
-// file: the Operations sections own THIS file and console/app/admin/operations, and
-// nothing else. A lane that had to add its routes to router.ts instead would
-// put six writers in one object literal, and a duplicate key in an object
-// literal is the one merge conflict git does not report. It has already
-// happened once in this directory: see the note in infra.ts about a second
-// `admin:` key silently winning.
+// THE SECTIONS THIS LANE OWNS: Infrastructure & Compute, Logs & Error
+// Explorer, Email & Notifications, and Incidents & Kill Switches. Two of those
+// four are served entirely by routes that already exist. Infrastructure &
+// Compute reads `admin.infra.*` and Incidents & Kill Switches reads
+// `admin.emergency.*`, both from infra.ts, and neither is duplicated here: a
+// second copy of a query is a second place for it to drift, and the emergency
+// switches in particular stay where they are because maintenance mode exempts
+// them by path and a move would take them out of the exemption exactly when an
+// operator needs them to end an outage.
 //
-// So the mount is made first and the routes come later. The empty router below
-// is not a placeholder nobody reads: it is mounted in router.ts and
-// admin-namespaces.test.ts asserts that it is, exactly once, which is what
-// makes this a reserved namespace rather than a file somebody forgot.
+// So what is new is the two sections that had no routes at all, and they are
+// mounted below under `operationsRouter`, which admin-namespaces.test.ts
+// asserts is mounted once and under the key that names it.
 //
-// THE SECTIONS THIS LANE OWNS: Infrastructure & Compute, Logs & Error Explorer, Email & Notifications, and Incidents & Kill Switches.
+// THE RULE THIS FILE IS BUILT AROUND: NOTHING HERE IS INVENTED. There is no
+// exception group table, no fingerprint, no occurrence counter, no stack trace
+// store, no log line store, no send log, no bounce record and no template
+// table anywhere in this schema. So this file does not pretend there is one.
+// Every number below is an aggregate over a column that exists, and the two
+// pages that read it say in their own words which questions this installation
+// cannot answer at all. A dashboard over invented data is a worse outcome than
+// a page that says a capability is not wired, because the reader acts on the
+// first one.
 //
-// PERMISSION PREFIXES RESERVED FOR IT: admin.infra.*, admin.logs.*, admin.emergency.*. The
-// catalog and the reservations are in permissions.ts, and adding a permission
-// under another lane's prefix is the kind of thing a review misses.
+// What that leaves is genuinely useful, and it is the shape an error explorer
+// has when it is built out of run outcomes rather than out of exceptions:
 //
-// The emergency switches already exist as emergencyRouter in infra.ts and stay there, because maintenance mode exempts them by path and a move would take them out of the exemption exactly when an operator needs them to end an outage.
+//   workload_runs.failure_code    the closest thing to a fingerprint this
+//                                 product has. A code plus the workload kind
+//                                 is a group, and the group carries a count,
+//                                 how many organizations it reached, when it
+//                                 was first and last seen, and the most recent
+//                                 run to open.
+//   verdicts.value / .workflow    which workflows are failing, across tenants.
+//   events.type                   what is flowing in, and whether it stopped.
 //
-// HOW TO ADD A ROUTE. Build it with adminProcedure(permission), which is the
-// only exported way to make one, so declaring the permission and creating the
-// route are a single act. There is no unguarded builder to reach for. Every
-// read goes through ctx.adminDb, which is the operator pool: a cross tenant
-// read has to be a credential the application cannot acquire rather than a
-// claim it makes about itself. A mutation records what it changed with
-// adminAudit, inside the same transaction as the change.
+// EVENT PAYLOADS ARE NOT RETURNED, and that is a boundary rather than an
+// oversight. `events.payload` is the customer's data: request bodies, database
+// values, whatever the engine observed. An operator debugging ingestion needs
+// to know that events of a type are arriving, at what rate, with what shape,
+// and how far behind they are. None of that needs the values. So the stream
+// returns the key NAMES and the byte size, and the page says so out loud. RLS
+// is row level and cannot restrict a column, and the operator pool bypasses it
+// entirely, so the only place this boundary can exist is here, in the columns
+// the query names. That is the same argument as SAFE_COLUMNS in router.ts.
 //
-//   import { z } from 'zod'
-//   import { adminProcedure, type AdminContext } from './trpc.ts'
-//
-//   export const operationsRouter = router({
-//     list: adminProcedure('admin.example.read')
-//       .input(z.object({ limit: z.number().int().min(1).max(200).default(50) }))
-//       .query(async ({ ctx, input }) => {
-//         const c = ctx as AdminContext
-//         return c.adminDb((db) => db.execute(sql`...`))
-//       }),
-//   })
+// `email_signin_tokens.token_hash` is likewise never selected. A hash is not a
+// secret in the way a token is, and it is also of no use to a person and of
+// considerable use to anybody who should not have it.
 
+import { z } from 'zod'
+import { sql } from 'drizzle-orm'
+import type { Db } from '@antifailure/db'
 import { router } from '../trpc.ts'
+import { adminProcedure, type AdminContext } from './trpc.ts'
+import { RecordingMailer, ResendMailer } from '../auth/mail.ts'
 
 /**
- * The Operations namespace, mounted at `admin.operations`.
+ * How far back a page looks.
  *
- * Empty today. It is still reachable, still walked by the operator route
- * matrix, and still exempt from maintenance mode by its `admin.` prefix, so a
- * route added to it inherits all three without anybody remembering to arrange
- * them.
+ * A fixed set rather than a free number, because the two expensive queries
+ * here scan by time and an operator typing 8760 during an incident would get a
+ * statement timeout instead of an answer. A week is the longest window offered
+ * and it is already the one that reads the most partitions.
  */
-export const operationsRouter = router({})
+export const WINDOWS = [1, 6, 24, 72, 168] as const
+export type WindowHours = (typeof WINDOWS)[number]
+
+const windowHours = z
+  .union([z.literal(1), z.literal(6), z.literal(24), z.literal(72), z.literal(168)])
+  .optional()
+
+/** How many groups a page will show before it stops. Past this the list is not
+ *  being read, it is being scrolled. */
+const GROUP_LIMIT = 60
+
+function iso(value: Date | string): string {
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString()
+}
+
+/**
+ * Turns one extra row into a cursor.
+ *
+ * The same shape as `pageOf` in router.ts, and a deliberate second copy rather
+ * than an import: router.ts imports this file to mount it, so importing back
+ * would be a cycle. Ten lines of arithmetic is the cheaper of the two.
+ */
+function pageOf<Row, Out>(
+  rows: Row[],
+  limit: number,
+  cursorOf: (row: Row) => string,
+  map: (row: Row) => Out,
+): { rows: Out[]; nextCursor: string | null } {
+  const more = rows.length > limit
+  const visible = more ? rows.slice(0, limit) : rows
+  return {
+    rows: visible.map(map),
+    nextCursor: more && visible.length > 0 ? cursorOf(visible[visible.length - 1]!) : null,
+  }
+}
+
+function since(now: Date, hours: number): Date {
+  return new Date(now.getTime() - hours * 60 * 60 * 1000)
+}
+
+/* -------------------------------------------------------------------------
+ * Failures
+ * ---------------------------------------------------------------------- */
+
+export interface FailureGroup {
+  /** The failure code, or null when the run failed without recording one.
+   *  Null is a real answer and the page shows it as one: a run that ends
+   *  failed with no code is a gap in the engine, and hiding those rows would
+   *  hide the gap. */
+  failureCode: string | null
+  kind: string
+  state: string
+  runs: number
+  organizations: number
+  firstSeen: string
+  lastSeen: string
+  /**
+   * The most recent run's own `detail`, truncated.
+   *
+   * Included on purpose, and it is the one field here that carries text a
+   * tenant's code produced. Without it the group is a code and a count, which
+   * tells an operator that something is failing and nothing about what. Every
+   * read of this route writes an audit entry naming the operator, which is the
+   * accountability that makes showing it acceptable.
+   */
+  latestDetail: string | null
+  latestRunId: string
+}
+
+/**
+ * Which run states count as a failure here.
+ *
+ * `timed_out` and `abandoned` are in, and leaving them out is the mistake this
+ * constant exists to prevent: a run that was killed by its deadline and a run
+ * whose engine died are both failures to the person whose test did not run,
+ * and both of them carry a failure code. A list of only `failed` reports a
+ * smaller, calmer, wrong number.
+ */
+export const FAILED_STATES = ['failed', 'timed_out', 'abandoned'] as const
+
+/**
+ * Why the window has an upper bound here and not on the event queries.
+ *
+ * `workload_runs.updated_at` and `verdicts.created_at` are written by THIS
+ * control plane, so a value after now is clock skew between the process and the
+ * database and nothing else. Unbounded, such a row sits inside every window
+ * that has ever been offered, forever, and never ages out of the failure list.
+ *
+ * `events.occurred_at` is the ENGINE's stamp and may legitimately run ahead of
+ * ours. Dropping those would hide exactly the skew the ingestion lag check
+ * exists to surface, so the event queries take a lower bound only.
+ */
+export async function failureGroups(
+  db: Db,
+  from: Date,
+  to: Date,
+  orgId: string | null,
+): Promise<FailureGroup[]> {
+  const rows = await db.execute<{
+    failure_code: string | null
+    kind: string
+    state: string
+    runs: string | number
+    organizations: string | number
+    first_seen: Date | string
+    last_seen: Date | string
+    latest_detail: string | null
+    latest_run_id: string
+  }>(sql`
+    SELECT r.failure_code, w.kind::text AS kind, r.state::text AS state,
+           count(*) AS runs,
+           count(DISTINCT r.org_id) AS organizations,
+           min(r.updated_at) AS first_seen,
+           max(r.updated_at) AS last_seen,
+           (array_agg(r.detail ORDER BY r.updated_at DESC))[1] AS latest_detail,
+           (array_agg(r.id ORDER BY r.updated_at DESC))[1] AS latest_run_id
+    FROM workload_runs r
+    JOIN workloads w ON w.id = r.workload_id
+    WHERE r.updated_at >= ${from.toISOString()}::timestamptz
+      AND r.updated_at <= ${to.toISOString()}::timestamptz
+      AND r.state::text IN ('failed', 'timed_out', 'abandoned')
+      AND (${orgId}::uuid IS NULL OR r.org_id = ${orgId}::uuid)
+    GROUP BY r.failure_code, w.kind, r.state
+    ORDER BY runs DESC, last_seen DESC
+    LIMIT ${GROUP_LIMIT}`)
+
+  return rows.map((r) => ({
+    failureCode: r.failure_code,
+    kind: r.kind,
+    state: r.state,
+    runs: Number(r.runs),
+    organizations: Number(r.organizations),
+    firstSeen: iso(r.first_seen),
+    lastSeen: iso(r.last_seen),
+    latestDetail: r.latest_detail === null ? null : r.latest_detail.slice(0, 400),
+    latestRunId: r.latest_run_id,
+  }))
+}
+
+export interface WorkflowFailure {
+  workflow: string
+  value: string
+  runs: number
+  organizations: number
+  lastSeen: string
+  /** The newest verdict's summary. The engine writes this; it is the sentence
+   *  that says what the workflow was doing when it stopped. */
+  latestSummary: string | null
+}
+
+export async function failingWorkflows(
+  db: Db,
+  from: Date,
+  to: Date,
+  orgId: string | null,
+): Promise<WorkflowFailure[]> {
+  const rows = await db.execute<{
+    workflow: string
+    value: string
+    runs: string | number
+    organizations: string | number
+    last_seen: Date | string
+    latest_summary: string | null
+  }>(sql`
+    SELECT v.workflow, v.value::text AS value,
+           count(*) AS runs,
+           count(DISTINCT v.org_id) AS organizations,
+           max(v.created_at) AS last_seen,
+           (array_agg(v.summary ORDER BY v.created_at DESC))[1] AS latest_summary
+    FROM verdicts v
+    WHERE v.created_at >= ${from.toISOString()}::timestamptz
+      AND v.created_at <= ${to.toISOString()}::timestamptz
+      AND v.value::text IN ('fail', 'blocked')
+      AND (${orgId}::uuid IS NULL OR v.org_id = ${orgId}::uuid)
+    GROUP BY v.workflow, v.value
+    ORDER BY runs DESC, last_seen DESC
+    LIMIT ${GROUP_LIMIT}`)
+
+  return rows.map((r) => ({
+    workflow: r.workflow,
+    value: r.value,
+    runs: Number(r.runs),
+    organizations: Number(r.organizations),
+    lastSeen: iso(r.last_seen),
+    latestSummary: r.latest_summary === null ? null : r.latest_summary.slice(0, 400),
+  }))
+}
+
+export interface EventType {
+  type: string
+  events: number
+  organizations: number
+  lastReceivedAt: string
+  /**
+   * Seconds between the engine stamping the newest event and this control
+   * plane receiving it.
+   *
+   * The gap rather than either timestamp, because either one alone looks fine
+   * while the pair is wrong: events arriving now for work that finished an
+   * hour ago make every run view stale without making any of them look stale.
+   */
+  lagSeconds: number
+}
+
+export async function eventTypes(
+  db: Db,
+  from: Date,
+  orgId: string | null,
+): Promise<EventType[]> {
+  // occurred_at, not received_at, and that is what makes this query affordable.
+  // `events` is partitioned by month on occurred_at, so a predicate on it
+  // prunes to the partitions the window touches; the same predicate on
+  // received_at reads every partition that has ever existed.
+  const rows = await db.execute<{
+    type: string
+    events: string | number
+    organizations: string | number
+    last_received_at: Date | string
+    lag_seconds: string | number | null
+  }>(sql`
+    SELECT e.type,
+           count(*) AS events,
+           count(DISTINCT e.org_id) AS organizations,
+           max(e.received_at) AS last_received_at,
+           EXTRACT(EPOCH FROM (max(e.received_at) - max(e.occurred_at))) AS lag_seconds
+    FROM events e
+    WHERE e.occurred_at >= ${from.toISOString()}::timestamptz
+      AND (${orgId}::uuid IS NULL OR e.org_id = ${orgId}::uuid)
+    GROUP BY e.type
+    ORDER BY events DESC
+    LIMIT ${GROUP_LIMIT}`)
+
+  return rows.map((r) => ({
+    type: r.type,
+    events: Number(r.events),
+    organizations: Number(r.organizations),
+    lastReceivedAt: iso(r.last_received_at),
+    lagSeconds: Math.round(Number(r.lag_seconds ?? 0)),
+  }))
+}
+
+/* -------------------------------------------------------------------------
+ * Email
+ * ---------------------------------------------------------------------- */
+
+/** How a sign-in link ended up, which the columns do not say on their own. */
+export type LinkStanding =
+  /** Somebody clicked it and is signed in. */
+  | 'used'
+  /** Issued, unused, still valid. */
+  | 'live'
+  /** Issued, never used, and now too old to use. The interesting one: at any
+   *  volume this is what a delivery failure looks like from inside a product
+   *  that keeps no delivery record. */
+  | 'unused'
+
+export function standingOf(row: {
+  consumed_at: Date | string | null
+  expires_at: Date | string
+}, now: Date): LinkStanding {
+  if (row.consumed_at !== null) return 'used'
+  return new Date(iso(row.expires_at)).getTime() > now.getTime() ? 'live' : 'unused'
+}
+
+export interface EmailReach {
+  /** Sign-in links issued in the window, and what became of them. */
+  linksIssued: number
+  linksUsed: number
+  linksUnused: number
+  linksLive: number
+  /** Invitations, which are the other thing this product puts in an inbox. */
+  invitationsSent: number
+  invitationsAccepted: number
+  invitationsOpen: number
+  /** Addresses on file that a bill would go to, if billing mail existed. */
+  billingContacts: number
+}
+
+export async function emailReach(db: Db, from: Date, now: Date): Promise<EmailReach> {
+  const [links] = await db.execute<{
+    issued: string | number
+    used: string | number
+    unused: string | number
+    live: string | number
+  }>(sql`
+    SELECT count(*) AS issued,
+           count(*) FILTER (WHERE consumed_at IS NOT NULL) AS used,
+           count(*) FILTER (WHERE consumed_at IS NULL
+                              AND expires_at <= ${now.toISOString()}::timestamptz) AS unused,
+           count(*) FILTER (WHERE consumed_at IS NULL
+                              AND expires_at > ${now.toISOString()}::timestamptz) AS live
+    FROM email_signin_tokens
+    WHERE created_at >= ${from.toISOString()}::timestamptz`)
+
+  const [invites] = await db.execute<{
+    sent: string | number
+    accepted: string | number
+    open: string | number
+  }>(sql`
+    SELECT count(*) AS sent,
+           count(*) FILTER (WHERE accepted_at IS NOT NULL) AS accepted,
+           count(*) FILTER (WHERE accepted_at IS NULL AND revoked_at IS NULL
+                              AND expires_at > ${now.toISOString()}::timestamptz) AS open
+    FROM invitations
+    WHERE created_at >= ${from.toISOString()}::timestamptz`)
+
+  const [contacts] = await db.execute<{ n: string | number }>(
+    sql`SELECT count(*) AS n FROM billing_contacts`,
+  )
+
+  return {
+    linksIssued: Number(links?.issued ?? 0),
+    linksUsed: Number(links?.used ?? 0),
+    linksUnused: Number(links?.unused ?? 0),
+    linksLive: Number(links?.live ?? 0),
+    invitationsSent: Number(invites?.sent ?? 0),
+    invitationsAccepted: Number(invites?.accepted ?? 0),
+    invitationsOpen: Number(invites?.open ?? 0),
+    billingContacts: Number(contacts?.n ?? 0),
+  }
+}
+
+/* -------------------------------------------------------------------------
+ * The routes
+ * ---------------------------------------------------------------------- */
+
+const logsRouter = router({
+  /**
+   * What is failing on this installation, grouped.
+   *
+   * Three aggregates in one round trip rather than three routes, because they
+   * are one question asked from three angles and a page that loads them
+   * separately shows an operator three windows that do not agree about when
+   * "now" was.
+   */
+  overview: adminProcedure('admin.logs.read')
+    .input(
+      z
+        .object({
+          hours: windowHours,
+          orgId: z.string().uuid().nullish(),
+        })
+        .optional(),
+    )
+    .query(async ({ ctx, input }) => {
+      const c = ctx as AdminContext
+      const now = c.clock.now()
+      const hours: WindowHours = input?.hours ?? 24
+      const from = since(now, hours)
+      const orgId = input?.orgId ?? null
+      return c.adminDb(async (db) => {
+        const [failures, workflows, types] = await Promise.all([
+          failureGroups(db, from, now, orgId),
+          failingWorkflows(db, from, now, orgId),
+          eventTypes(db, from, orgId),
+        ])
+        return {
+          hours,
+          from: from.toISOString(),
+          at: now.toISOString(),
+          failures,
+          workflows,
+          eventTypes: types,
+          /** True when a list was cut off, so the page can say the list is a
+           *  top slice rather than the whole answer. `More` is the wrong shape
+           *  here: these are aggregates and there is no stable cursor into a
+           *  GROUP BY whose counts move between calls. */
+          truncated: {
+            failures: failures.length === GROUP_LIMIT,
+            workflows: workflows.length === GROUP_LIMIT,
+            eventTypes: types.length === GROUP_LIMIT,
+          },
+          limit: GROUP_LIMIT,
+        }
+      })
+    }),
+
+  /**
+   * The event stream, newest first, paged.
+   *
+   * Shape and timing, never contents. See the header.
+   */
+  events: adminProcedure('admin.logs.read')
+    .input(
+      z.object({
+        hours: windowHours,
+        type: z.string().max(200).nullish(),
+        orgId: z.string().uuid().nullish(),
+        limit: z.number().int().min(1).max(200).default(50),
+        cursor: z.string().max(200).nullish(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      const c = ctx as AdminContext
+      const now = c.clock.now()
+      const from = since(now, input.hours ?? 24)
+
+      // The cursor is the sort key, both halves of it. occurred_at alone is
+      // not unique: a batch of events sharing a millisecond would repeat a row
+      // on one page and drop another, which is the failure mode nobody
+      // notices because the page still looks full.
+      let cursorAt: string | null = null
+      let cursorId: string | null = null
+      if (input.cursor) {
+        const at = input.cursor.indexOf('|')
+        if (at > 0) {
+          cursorAt = input.cursor.slice(0, at)
+          cursorId = input.cursor.slice(at + 1)
+        }
+      }
+
+      return c.adminDb(async (db) => {
+        const rows = await db.execute<{
+          id: string
+          occurred_at: Date | string
+          received_at: Date | string
+          type: string
+          org_id: string
+          org_slug: string
+          env_id: string | null
+          run_id: string | null
+          payload_keys: string[] | null
+          payload_bytes: string | number
+        }>(sql`
+          SELECT e.id, e.occurred_at, e.received_at, e.type, e.org_id,
+                 o.slug AS org_slug, e.env_id, e.run_id,
+                 (SELECT array_agg(k ORDER BY k) FROM jsonb_object_keys(e.payload) k)
+                   AS payload_keys,
+                 octet_length(e.payload::text) AS payload_bytes
+          FROM events e
+          JOIN organizations o ON o.id = e.org_id
+          WHERE e.occurred_at >= ${from.toISOString()}::timestamptz
+            AND (${input.type ?? null}::text IS NULL OR e.type = ${input.type ?? null}::text)
+            AND (${input.orgId ?? null}::uuid IS NULL
+                 OR e.org_id = ${input.orgId ?? null}::uuid)
+            AND (${cursorAt}::timestamptz IS NULL
+                 OR (e.occurred_at, e.id) < (${cursorAt}::timestamptz, ${cursorId}::uuid))
+          ORDER BY e.occurred_at DESC, e.id DESC
+          LIMIT ${input.limit + 1}`)
+
+        return pageOf(
+          rows,
+          input.limit,
+          (r) => `${iso(r.occurred_at)}|${r.id}`,
+          (r) => ({
+            id: r.id,
+            occurredAt: iso(r.occurred_at),
+            receivedAt: iso(r.received_at),
+            type: r.type,
+            orgId: r.org_id,
+            orgSlug: r.org_slug,
+            envId: r.env_id,
+            runId: r.run_id,
+            payloadKeys: r.payload_keys ?? [],
+            payloadBytes: Number(r.payload_bytes),
+          }),
+        )
+      })
+    }),
+})
+
+const emailRouter = router({
+  /**
+   * Whether this installation can send email at all, and what it has tried to
+   * send.
+   *
+   * `canSend` is the fact the page leads with, and it is the one an operator
+   * most often gets wrong: the mailer is nullable and an installation with no
+   * provider configured accepts a sign-in request, writes a token row, and
+   * puts nothing in anybody's inbox. The row exists either way, so no query
+   * over `email_signin_tokens` can tell the two apart. Only the context can.
+   */
+  status: adminProcedure('admin.email.read')
+    .input(z.object({ hours: windowHours }).optional())
+    .query(async ({ ctx, input }) => {
+      const c = ctx as AdminContext
+      const now = c.clock.now()
+      const hours: WindowHours = input?.hours ?? 168
+      const from = since(now, hours)
+
+      // instanceof rather than a name string. A constructor name survives this
+      // codebase but not a bundler, and the thing being decided here is
+      // whether real messages leave the process.
+      const mailer = c.mailer
+      const provider =
+        mailer === null
+          ? null
+          : mailer instanceof ResendMailer
+            ? 'resend'
+            : mailer instanceof RecordingMailer
+              ? 'recording'
+              : 'other'
+
+      const reach = await c.adminDb((db) => emailReach(db, from, now))
+      return {
+        hours,
+        from: from.toISOString(),
+        at: now.toISOString(),
+        canSend: mailer !== null,
+        provider,
+        /** True when messages are being kept in memory instead of sent, which
+         *  looks identical to working from every other angle. */
+        recordingOnly: provider === 'recording',
+        reach,
+      }
+    }),
+
+  /**
+   * Every sign-in link issued recently, and what became of it.
+   *
+   * This is the closest this product comes to a send log, and the page says so
+   * rather than dressing it up: a row here proves a message was COMPOSED, and
+   * `used` proves somebody clicked the link, which is the only evidence of
+   * delivery that exists anywhere in this schema.
+   */
+  signInLinks: adminProcedure('admin.email.read')
+    .input(
+      z.object({
+        hours: windowHours,
+        standing: z.enum(['used', 'live', 'unused']).nullish(),
+        query: z.string().trim().max(200).nullish(),
+        limit: z.number().int().min(1).max(200).default(50),
+        cursor: z.string().max(200).nullish(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      const c = ctx as AdminContext
+      const now = c.clock.now()
+      const from = since(now, input.hours ?? 168)
+
+      let cursorAt: string | null = null
+      let cursorId: string | null = null
+      if (input.cursor) {
+        const at = input.cursor.indexOf('|')
+        if (at > 0) {
+          cursorAt = input.cursor.slice(0, at)
+          cursorId = input.cursor.slice(at + 1)
+        }
+      }
+      const nowIso = now.toISOString()
+      const standing = input.standing ?? null
+
+      return c.adminDb(async (db) => {
+        // Columns named one by one. `token_hash` is deliberately absent: it is
+        // useless to a person and useful to anybody who should not have it,
+        // and a SELECT * here would have shipped it to a browser.
+        const rows = await db.execute<{
+          id: string
+          email: string
+          created_at: Date | string
+          expires_at: Date | string
+          consumed_at: Date | string | null
+          ip: string | null
+          user_agent: string | null
+          redirect_to: string | null
+        }>(sql`
+          SELECT t.id, t.email, t.created_at, t.expires_at, t.consumed_at,
+                 host(t.ip) AS ip, t.user_agent, t.redirect_to
+          FROM email_signin_tokens t
+          WHERE t.created_at >= ${from.toISOString()}::timestamptz
+            AND (${input.query ?? null}::text IS NULL
+                 OR t.email LIKE ${'%' + (input.query ?? '').toLowerCase() + '%'})
+            AND (${standing}::text IS NULL
+                 OR (${standing}::text = 'used' AND t.consumed_at IS NOT NULL)
+                 OR (${standing}::text = 'live' AND t.consumed_at IS NULL
+                     AND t.expires_at > ${nowIso}::timestamptz)
+                 OR (${standing}::text = 'unused' AND t.consumed_at IS NULL
+                     AND t.expires_at <= ${nowIso}::timestamptz))
+            AND (${cursorAt}::timestamptz IS NULL
+                 OR (t.created_at, t.id) < (${cursorAt}::timestamptz, ${cursorId}::uuid))
+          ORDER BY t.created_at DESC, t.id DESC
+          LIMIT ${input.limit + 1}`)
+
+        return pageOf(
+          rows,
+          input.limit,
+          (r) => `${iso(r.created_at)}|${r.id}`,
+          (r) => ({
+            id: r.id,
+            email: r.email,
+            createdAt: iso(r.created_at),
+            expiresAt: iso(r.expires_at),
+            consumedAt: r.consumed_at === null ? null : iso(r.consumed_at),
+            standing: standingOf(r, now),
+            ip: r.ip,
+            userAgent: r.user_agent,
+            redirectTo: r.redirect_to,
+          }),
+        )
+      })
+    }),
+})
+
+/**
+ * The Operations namespace, mounted at `admin.operations` and nowhere else.
+ *
+ * The two sub-routers are nested rather than spread, so every path reads
+ * `admin.operations.logs.*` or `admin.operations.email.*` and says which lane
+ * owns it from the path alone. Spreading them into adminRouter as `logs:` and
+ * `email:` would work identically and would put two more keys in the one
+ * object literal six lanes edit, which is the collision the group namespaces
+ * exist to remove.
+ *
+ * NOT a second `admin:` key, for the reason written at the bottom of infra.ts:
+ * a second one does not conflict in git, does not fail to compile, and wins or
+ * loses on object key order.
+ */
+export const operationsRouter = router({
+  logs: logsRouter,
+  email: emailRouter,
+})

--- a/web/apps/api/src/admin/permissions.ts
+++ b/web/apps/api/src/admin/permissions.ts
@@ -76,6 +76,15 @@ export const ADMIN_PERMISSIONS = [
   // none of them should be able to pause it.
   'admin.emergency.read',
   'admin.emergency.engage',
+
+  // Failures across every tenant, and the event stream by shape. Read only,
+  // and there is deliberately no write half: nothing on that page changes
+  // anything, so a write permission would guard no route.
+  'admin.logs.read',
+  // Whether this installation can send email, and what it has tried to send.
+  // Separate from admin.logs.read because it reaches addresses, which is
+  // personal data, and because the roles that need one rarely need the other.
+  'admin.email.read',
 ] as const
 
 export type AdminPermission = (typeof ADMIN_PERMISSIONS)[number]
@@ -110,6 +119,10 @@ export const RESERVED_PREFIXES: Record<string, string> = {
   'admin.logs': 'infra',
   'admin.security': 'infra',
   'admin.emergency': 'infra',
+  // Same lane as admin.logs. Claimed here rather than left unlisted, because
+  // an unlisted prefix is one two agents can both reach for and neither will
+  // see the other take.
+  'admin.email': 'infra',
 }
 
 export const ADMIN_ROLES = [
@@ -147,6 +160,12 @@ export const ADMIN_PERMISSION_DESCRIPTIONS: Record<AdminPermission, string> = {
     'See whether maintenance mode, new sign-ups, or new runs are paused, and why.',
   'admin.emergency.engage':
     'Pause or resume the whole installation: maintenance mode, new sign-ups, and new runs.',
+  'admin.logs.read':
+    'See failing runs grouped by failure code across every organization, which workflows are ' +
+    'failing, and the event stream by type, timing and shape. Event payloads are never returned.',
+  'admin.email.read':
+    'See whether this installation can send email at all, and every sign-in link it has issued ' +
+    'recently with the address it was issued to and whether it was used.',
   'admin.billing.read':
     'See a customer\'s Stripe customer, subscription, invoices, charges, payment methods and ' +
     'credit balance, and the record of every administrative money action taken on the account.',
@@ -221,6 +240,7 @@ export const ADMIN_ROLE_PERMISSIONS: Record<AdminRole, readonly AdminPermission[
     // permission rather than on rank: ordering roles and comparing ranks is how
     // a permission model stops being a table and starts being an assumption.
     'admin.emergency.read', 'admin.emergency.engage',
+    'admin.logs.read', 'admin.email.read',
   ],
   infrastructure: [
     'admin.portal.access', 'admin.audit.read',
@@ -235,6 +255,10 @@ export const ADMIN_ROLE_PERMISSIONS: Record<AdminRole, readonly AdminPermission[
     // debugging "their runs will not start" must be able to discover that runs
     // are frozen; pausing the installation is a different decision.
     'admin.emergency.read',
+    // The failure explorer and the mail surface. "Their runs will not start"
+    // and "the sign-in link never arrived" are both infrastructure questions
+    // before they are anybody else's, and neither is answerable without these.
+    'admin.logs.read', 'admin.email.read',
   ],
   security: [
     'admin.portal.access', 'admin.audit.read', 'admin.audit.export',
@@ -248,6 +272,9 @@ export const ADMIN_ROLE_PERMISSIONS: Record<AdminRole, readonly AdminPermission[
     'admin.billing.read', 'admin.entitlements.read',
     'admin.flags.read', 'admin.flags.write',
     'admin.infra.read', 'admin.emergency.read',
+    // Sign-in links carry an address, an IP and a user agent, and an account
+    // takeover investigation starts by reading exactly those three.
+    'admin.logs.read', 'admin.email.read',
   ],
   billing: [
     'admin.portal.access', 'admin.audit.read',
@@ -266,6 +293,9 @@ export const ADMIN_ROLE_PERMISSIONS: Record<AdminRole, readonly AdminPermission[
     // Support answers "why was I charged this" every day and must never be the
     // rota that can refund. Read without write is the whole point of the split.
     'admin.billing.read', 'admin.entitlements.read', 'admin.flags.read',
+    // The two questions support is actually asked: why did this run fail, and
+    // why has this person not received their sign-in link. Both are reads.
+    'admin.logs.read', 'admin.email.read',
   ],
   analytics: ['admin.portal.access', 'admin.audit.read', 'admin.tenants.read', 'admin.users.read'],
   read_only: ['admin.portal.access', 'admin.audit.read', 'admin.tenants.read', 'admin.users.read'],

--- a/web/apps/api/test/admin-routes.test.ts
+++ b/web/apps/api/test/admin-routes.test.ts
@@ -36,7 +36,11 @@ describe('every operator route declares a permission', () => {
     name: 'appRouter',
     router: appRouter,
     prefix: 'admin.',
-    atLeast: 18,
+    // Raised as lanes land, and it has to be: a floor that stays at the number
+    // it was written for stops being a floor the moment routes are added, and
+    // then this test passes over a tree that has lost half of itself. 18 on
+    // main, plus six infra and two emergency routes, plus four here.
+    atLeast: 30,
   })
 })
 

--- a/web/apps/api/test/adminoperations.test.ts
+++ b/web/apps/api/test/adminoperations.test.ts
@@ -1,0 +1,554 @@
+// The failure explorer and the mail surface, driven through the real router.
+//
+// Four things are asserted here and each one is a defect that has shipped
+// somewhere before:
+//
+//   1. A COLUMN THAT MUST NEVER LEAVE THE PROCESS DOES. `events.payload` is
+//      the customer's data and `email_signin_tokens.token_hash` is a
+//      credential's shadow. Both live one `SELECT *` away from a browser, and
+//      RLS cannot help: it is row level, and the operator pool bypasses it
+//      anyway. So the boundary is the column list, and the only way to know it
+//      held is to seed a recognisable value and assert the response does not
+//      contain it anywhere.
+//
+//   2. A KEYSET PAGE REPEATS OR DROPS A ROW. Ordering by a timestamp alone is
+//      the usual cause and it is invisible: the page still looks full. Every
+//      row here is seeded at the SAME instant on purpose, which is the case
+//      that breaks a one-column cursor, and the test walks the whole list one
+//      row at a time and asserts it saw each id exactly once.
+//
+//   3. A COUNT THAT QUIETLY MEANS SOMETHING NARROWER THAN ITS LABEL. A failure
+//      list that counts only `failed` and not `timed_out` or `abandoned`
+//      reports a smaller, calmer, wrong number, and nobody checks a number
+//      that looks reasonable.
+//
+//   4. A PAGE THAT SAYS EMAIL WORKS WHEN NOTHING IS SENDING IT. The token row
+//      is written whether or not a mailer exists, so no query can tell the two
+//      apart. `canSend` reads the context, and it is asserted in both
+//      directions, because a flag only ever seen true has not been shown to be
+//      able to say no.
+
+import { test, describe, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { createHash, randomUUID } from 'node:crypto'
+import { createAdminPool, type AdminPool } from '@antifailure/db'
+import { appRouter } from '../src/routers/index.ts'
+import { adminSignIn, hashPassword } from '../src/admin/session.ts'
+import type { AdminRole } from '../src/admin/permissions.ts'
+import { RecordingMailer } from '../src/auth/mail.ts'
+import { standingOf } from '../src/admin/operations.ts'
+import { available, startApi, seedOrg, adminUrl, type ApiHarness, type Org } from './harness.ts'
+
+const hasDb = await available()
+
+/**
+ * One instant for every seeded row, so the keyset test exercises the case a
+ * single-column cursor gets wrong rather than the case it happens to survive.
+ *
+ * Taken from the harness clock rather than written as a literal. The routes
+ * compute their window from `ctx.clock`, which starts in the past, so a
+ * hardcoded date would put every fixture in the future: the lower bound would
+ * still match it, and the lag and the standing would both be nonsense.
+ */
+let SAME_INSTANT: Date
+
+/** A string that appears in no schema, no fixture and no other test, so
+ *  finding it in a response means it came out of the column under test and
+ *  from nowhere else. */
+const CANARY = 'canary-6f2b1d9e-must-not-leave-the-process'
+
+/**
+ * A tag on every fixture this run creates.
+ *
+ * Not decoration. These routes read ACROSS tenants by design, so a fixture
+ * named the same thing as a previous run's fixture is counted alongside it and
+ * the assertion fails on a number that is right about the database and wrong
+ * about this test. Borrowing a row is the same defect the harness wrote
+ * seedImpersonationTarget to avoid, and it shows up here as a count that drifts
+ * upward every time the suite is run.
+ */
+const RUN = randomUUID().slice(0, 8)
+const FAILURE_CODE = `af-e-refused-${RUN}`
+const WORKFLOW = `checkout-${RUN}`
+const EVENT_TYPE = `run.started.${RUN}`
+const PAGING_TYPE = `paging.probe.${RUN}`
+/** A real sha256 hex string. `workload_versions_digest_shape` refuses anything
+ *  else, which is the constraint doing its job. */
+const DIGEST = createHash('sha256').update(RUN).digest('hex')
+
+describe('the operations routes', { skip: hasDb ? false : 'no database' }, () => {
+  let h: ApiHarness
+  let org: Org
+  let other: Org
+  let adminPool: AdminPool
+  const password = 'provisioned-at-deploy-not-in-source'
+
+  async function callerFor(role: AdminRole, mailer: unknown = null) {
+    const email = `${role}-${randomUUID().slice(0, 8)}@example.test`
+    const { hash, salt } = await hashPassword(password)
+    await h.admin`
+      INSERT INTO admin_users (email, name, role, password_hash, password_salt, password_set_at)
+      VALUES (${email}, ${role}, ${role}, ${hash}, ${salt}, now())`
+    // Real time, never h.clock. resolveAdminSession compares against the
+    // injected clock and the RLS policy behind current_admin_user() compares
+    // expires_at against the DATABASE's now(); a fake past clock moves one and
+    // not the other, and every operator read fails as an RLS violation that
+    // reads like a permissions bug.
+    const signedIn = await adminSignIn(h.pool, { email, password }, new Date())
+    const { resolveAdminSession } = await import('../src/admin/session.ts')
+    const resolved = await resolveAdminSession(h.pool, signedIn.token, new Date())
+    assert.ok(resolved, 'the operator session did not resolve')
+    return appRouter.createCaller({
+      pool: h.pool,
+      adminPool,
+      clock: h.clock,
+      github: h.github,
+      stripe: null,
+      appBaseUrl: 'http://localhost',
+      mailer,
+      productName: 'Antifailure',
+      hostedRequiredPlan: null,
+      actor: null,
+      origin: 'web' as const,
+      admin: {
+        adminUserId: resolved.adminUserId,
+        label: resolved.label,
+        email: resolved.email,
+        role: resolved.role,
+        sessionId: resolved.sessionId,
+        sessionHash: resolved.sessionHash,
+        impersonating: resolved.impersonating,
+        impersonatedUserId: resolved.impersonatedUserId,
+      },
+    } as never)
+  }
+
+  /** Seeds one workload run in a terminal state, with a failure code. */
+  async function seedFailedRun(
+    o: Org,
+    state: string,
+    failureCode: string | null,
+    detail: string | null,
+  ): Promise<string> {
+    const [workload] = await h.admin<{ id: string }[]>`
+      INSERT INTO workloads (org_id, repository_id, slug, name, kind)
+      VALUES (${o.orgId}, ${o.repoId}, ${`w-${randomUUID().slice(0, 8)}`}, 'w', 'http_scenario')
+      RETURNING id`
+    const [version] = await h.admin<{ id: string }[]>`
+      INSERT INTO workload_versions (org_id, workload_id, version, body, body_digest, source)
+      VALUES (${o.orgId}, ${workload!.id}, 1, ${h.admin.json({})}, ${DIGEST}, 'authored')
+      RETURNING id`
+    const [env] = await h.admin<{ id: string }[]>`
+      SELECT id FROM environments WHERE org_id = ${o.orgId} LIMIT 1`
+    const [run] = await h.admin<{ id: string }[]>`
+      INSERT INTO workload_runs (
+        org_id, workload_id, workload_version_id, environment_id, state,
+        request_key, repository, git_ref, deadline_at, finished_at, failure_code, detail,
+        created_at, updated_at)
+      VALUES (
+        ${o.orgId}, ${workload!.id}, ${version!.id}, ${env!.id}, ${state}::workload_run_state,
+        ${randomUUID()}, ${o.repository}, 'main', ${SAME_INSTANT},
+        -- workload_runs_terminal_has_an_end. A terminal state without one is
+        -- refused, which is the constraint keeping a finished run out of every
+        -- duration computed from these columns.
+        ${SAME_INSTANT}, ${failureCode}, ${detail}, ${SAME_INSTANT}, ${SAME_INSTANT})
+      RETURNING id`
+    return run!.id
+  }
+
+  before(async () => {
+    h = await startApi()
+    org = await seedOrg(h.admin, 'ops')
+    other = await seedOrg(h.admin, 'opstwo')
+
+    await h.admin.unsafe(`ALTER ROLE antifailure_admin LOGIN PASSWORD 'operator-test-password'`)
+    const u = new URL(adminUrl)
+    u.username = 'antifailure_admin'
+    u.password = 'operator-test-password'
+    adminPool = createAdminPool({ url: u.toString() })
+    // Loudly here rather than as an empty page later, which is what a pool
+    // pointed at a non-bypassing role produces.
+    await adminPool.ensureBypass()
+
+    // Fixtures land at the clock's own instant and then the clock moves one
+    // minute, so every row is a minute old and sits inside the shortest window
+    // the routes offer.
+    SAME_INSTANT = h.clock.now()
+    h.clock.advance(60_000)
+  })
+
+  after(async () => {
+    await adminPool?.close()
+    await h?.close()
+  })
+
+  /* ---------------------------------------------------------------------
+   * Failures
+   * ------------------------------------------------------------------ */
+
+  test('a timed out run and an abandoned one are failures, not just a failed one', async () => {
+    await seedFailedRun(org, 'failed', FAILURE_CODE, 'the target refused the connection')
+    await seedFailedRun(org, 'timed_out', FAILURE_CODE, 'ran past its deadline')
+    await seedFailedRun(other, 'abandoned', FAILURE_CODE, 'the engine went away')
+    // Not a failure. Present so the counts below are counts of something and
+    // not counts of everything.
+    await seedFailedRun(org, 'succeeded', null, null)
+
+    const caller = await callerFor('infrastructure')
+    const view = await caller.admin.operations.logs.overview({ hours: 24 })
+
+    const codes = view.failures.filter((f) => f.failureCode === FAILURE_CODE)
+    assert.equal(codes.length, 3, 'each terminal state is its own group')
+    const states = codes.map((c) => c.state).sort()
+    assert.deepEqual(states, ['abandoned', 'failed', 'timed_out'])
+
+    const totalRuns = codes.reduce((n, c) => n + c.runs, 0)
+    assert.equal(totalRuns, 3, 'a failure list that counts only `failed` reports a wrong number')
+
+    const orgsReached = new Set(codes.flatMap((c) => Array(c.organizations).fill(c.failureCode)))
+    assert.ok(orgsReached.size > 0)
+    const abandoned = codes.find((c) => c.state === 'abandoned')!
+    assert.equal(abandoned.organizations, 1)
+
+    assert.ok(
+      codes.every((c) => c.latestRunId && c.firstSeen && c.lastSeen),
+      'a group with no run to open is a count nobody can act on',
+    )
+  })
+
+  test('a run that failed with no code is its own group rather than a hidden row', async () => {
+    const caller = await callerFor('infrastructure')
+    const uncodedIn = (view: { failures: { failureCode: string | null; state: string }[] }) =>
+      view.failures.filter((f) => f.failureCode === null && f.state === 'failed').length
+
+    // Counted before and after rather than asserted absolutely: a null failure
+    // code carries no per-run tag, so the only honest question is whether this
+    // row made the group appear or grow.
+    const before = uncodedIn(await caller.admin.operations.logs.overview({ hours: 24 }))
+    await seedFailedRun(org, 'failed', null, 'something went wrong and said nothing')
+    const view = await caller.admin.operations.logs.overview({ hours: 24 })
+    const uncoded = view.failures.find((f) => f.failureCode === null && f.state === 'failed')
+    assert.ok(
+      uncoded,
+      'a failure with no code is a gap in the engine, and dropping the row hides the gap',
+    )
+    assert.ok(uncoded.runs >= 1)
+    assert.ok(uncodedIn(view) >= Math.max(before, 1))
+  })
+
+  test('the window is a filter and not decoration', async () => {
+    const caller = await callerFor('infrastructure')
+    // Every seeded run is one minute old, so an hour holds them and a window
+    // that ended before they happened must not.
+    const anHour = await caller.admin.operations.logs.overview({ hours: 1 })
+    assert.ok(anHour.failures.length > 0)
+
+    const eightDays = 8 * 24 * 60 * 60 * 1000
+    h.clock.advance(eightDays)
+    try {
+      const stale = await caller.admin.operations.logs.overview({ hours: 1 })
+      assert.equal(stale.failures.length, 0, 'rows older than the window came back inside it')
+    } finally {
+      // In a finally, because this clock is shared with every test after this
+      // one. Without it a single failed assertion here left the clock eight
+      // days ahead and took seven unrelated tests down with it, which buries
+      // the one real failure under a screen of consequences.
+      h.clock.rollBack(eightDays)
+    }
+  })
+
+  test('a row stamped ahead of the clock is outside the window, not inside every one', async () => {
+    // Unbounded above, a row from the future sits in the last hour, the last
+    // day and the last week at once, forever, and never ages out. It is clock
+    // skew between this process and the database rather than a real failure,
+    // and the list an operator reads during an incident is the wrong place for
+    // it to be permanently pinned to the top.
+    const caller = await callerFor('infrastructure')
+    const code = `af-e-from-the-future-${RUN}`
+    const ahead = new Date(h.clock.now().getTime() + 3 * 60 * 60 * 1000)
+    const [w] = await h.admin<{ id: string }[]>`
+      INSERT INTO workloads (org_id, repository_id, slug, name, kind)
+      VALUES (${org.orgId}, ${org.repoId}, ${`fut-${randomUUID().slice(0, 8)}`}, 'w', 'http_scenario')
+      RETURNING id`
+    const [v] = await h.admin<{ id: string }[]>`
+      INSERT INTO workload_versions (org_id, workload_id, version, body, body_digest, source)
+      VALUES (${org.orgId}, ${w!.id}, 1, ${h.admin.json({})}, ${DIGEST}, 'authored')
+      RETURNING id`
+    const [env] = await h.admin<{ id: string }[]>`
+      SELECT id FROM environments WHERE org_id = ${org.orgId} LIMIT 1`
+    await h.admin`
+      INSERT INTO workload_runs (org_id, workload_id, workload_version_id, environment_id, state,
+        request_key, repository, git_ref, deadline_at, finished_at, failure_code, created_at, updated_at)
+      VALUES (${org.orgId}, ${w!.id}, ${v!.id}, ${env!.id}, 'failed'::workload_run_state,
+        ${randomUUID()}, ${org.repository}, 'main', ${ahead}, ${ahead}, ${code}, ${ahead}, ${ahead})`
+
+    const view = await caller.admin.operations.logs.overview({ hours: 168 })
+    assert.equal(
+      view.failures.filter((f) => f.failureCode === code).length,
+      0,
+      'a run stamped three hours ahead of the clock was counted as having already failed',
+    )
+  })
+
+  test('a failing workflow is grouped by name across organizations', async () => {
+    const [runA] = await h.admin<{ id: string }[]>`
+      INSERT INTO runs (org_id, environment_id, kind, state)
+      VALUES (${org.orgId},
+              (SELECT id FROM environments WHERE org_id = ${org.orgId} LIMIT 1),
+              'agent', 'failed')
+      RETURNING id`
+    const [runB] = await h.admin<{ id: string }[]>`
+      INSERT INTO runs (org_id, environment_id, kind, state)
+      VALUES (${other.orgId},
+              (SELECT id FROM environments WHERE org_id = ${other.orgId} LIMIT 1),
+              'agent', 'failed')
+      RETURNING id`
+    for (const [o, run] of [
+      [org, runA!.id],
+      [other, runB!.id],
+    ] as const) {
+      await h.admin`
+        INSERT INTO verdicts (org_id, run_id, workflow, value, summary, created_at)
+        VALUES (${o.orgId}, ${run}, ${WORKFLOW}, 'fail', 'the basket was empty at step 4',
+                ${SAME_INSTANT})`
+    }
+
+    const caller = await callerFor('infrastructure')
+    const view = await caller.admin.operations.logs.overview({ hours: 24 })
+    const checkout = view.workflows.find((w) => w.workflow === WORKFLOW && w.value === 'fail')
+    assert.ok(checkout, 'the failing workflow did not appear')
+    assert.equal(checkout.runs, 2)
+    assert.equal(checkout.organizations, 2, 'one workflow failing for two tenants is the signal')
+    assert.match(checkout.latestSummary ?? '', /basket/)
+  })
+
+  /* ---------------------------------------------------------------------
+   * The event stream, and the column boundary
+   * ------------------------------------------------------------------ */
+
+  test('the event stream returns shape and timing and never a payload value', async () => {
+    for (let i = 0; i < 3; i++) {
+      await h.admin`
+        INSERT INTO events (org_id, idempotency_key, env_id, type, payload,
+                            occurred_at, received_at)
+        VALUES (${org.orgId}, ${randomUUID()}, ${org.envId}, ${EVENT_TYPE},
+                ${h.admin.json({ secretField: CANARY, another: 1 })},
+                ${SAME_INSTANT}, ${new Date(SAME_INSTANT.getTime() + 5000)})`
+    }
+
+    const caller = await callerFor('infrastructure')
+    // Filtered to this run's own type. Unfiltered, the first page is whatever
+    // else is in the database and the assertions below would be about somebody
+    // else's rows.
+    const page = await caller.admin.operations.logs.events({ hours: 24, type: EVENT_TYPE, limit: 50 })
+    assert.equal(page.rows.length, 3)
+
+    const serialised = JSON.stringify(page)
+    assert.ok(
+      !serialised.includes(CANARY),
+      'an event payload value reached the response. The column list is the only boundary here: ' +
+        'RLS is row level and the operator pool bypasses it.',
+    )
+
+    const row = page.rows.find((r) => r.type === EVENT_TYPE)
+    assert.ok(row)
+    assert.deepEqual(
+      row.payloadKeys.slice().sort(),
+      ['another', 'secretField'],
+      'the key names are what makes the stream diagnostic without being a data leak',
+    )
+    assert.ok(row.payloadBytes > 0, 'the size says whether anything is in there')
+    assert.equal(row.orgSlug, org.slug)
+    assert.equal(row.envId, org.envId)
+  })
+
+  test('the event type summary reports the lag between engine and control plane', async () => {
+    const caller = await callerFor('infrastructure')
+    const view = await caller.admin.operations.logs.overview({ hours: 24 })
+    const started = view.eventTypes.find((t) => t.type === EVENT_TYPE)
+    assert.ok(started, 'the seeded event type is missing from the summary')
+    assert.equal(started.lagSeconds, 5, 'occurred_at and received_at were seeded five apart')
+    assert.ok(started.events >= 3)
+  })
+
+  test('paging the event stream sees every row exactly once', async () => {
+    // Ten rows sharing one instant. A cursor on the timestamp alone repeats
+    // rows and drops others here, and the page still looks full while it does
+    // it, which is why this walks the list rather than checking a count.
+    const seeded: string[] = []
+    for (let i = 0; i < 10; i++) {
+      const [row] = await h.admin<{ id: string }[]>`
+        INSERT INTO events (org_id, idempotency_key, env_id, type, payload,
+                            occurred_at, received_at)
+        VALUES (${other.orgId}, ${randomUUID()}, ${other.envId}, ${PAGING_TYPE},
+                ${h.admin.json({})}, ${SAME_INSTANT}, ${SAME_INSTANT})
+        RETURNING id`
+      seeded.push(row!.id)
+    }
+
+    const caller = await callerFor('infrastructure')
+    const seen: string[] = []
+    let cursor: string | null = null
+    for (let guard = 0; guard < 20; guard++) {
+      const page = await caller.admin.operations.logs.events({
+        hours: 24,
+        type: PAGING_TYPE,
+        limit: 3,
+        cursor,
+      })
+      seen.push(...page.rows.map((r) => r.id))
+      cursor = page.nextCursor
+      if (cursor === null) break
+    }
+    assert.equal(cursor, null, 'the walk did not reach the end of the list')
+    assert.equal(seen.length, new Set(seen).size, 'a row came back on two pages')
+    assert.deepEqual(seen.slice().sort(), seeded.slice().sort(), 'a row was never returned')
+  })
+
+  test('the stream filters by organization, which is what makes it usable in an incident',
+    async () => {
+      const caller = await callerFor('infrastructure')
+      const mine = await caller.admin.operations.logs.events({ hours: 24, orgId: org.orgId, limit: 100 })
+      assert.ok(mine.rows.length > 0)
+      assert.ok(
+        mine.rows.every((r) => r.orgSlug === org.slug),
+        'the filter let another tenant through',
+      )
+    })
+
+  /* ---------------------------------------------------------------------
+   * Email
+   * ------------------------------------------------------------------ */
+
+  test('canSend answers no when nothing is configured and yes when something is', async () => {
+    const blind = await callerFor('support', null)
+    const off = await blind.admin.operations.email.status({ hours: 168 })
+    assert.equal(off.canSend, false, 'an installation with no mailer must say so')
+    assert.equal(off.provider, null)
+
+    const wired = await callerFor('support', new RecordingMailer())
+    const on = await wired.admin.operations.email.status({ hours: 168 })
+    assert.equal(on.canSend, true)
+    assert.equal(on.provider, 'recording')
+    assert.equal(
+      on.recordingOnly,
+      true,
+      'a recording mailer looks identical to a working one from every angle except this flag',
+    )
+  })
+
+  test('a sign-in link is counted by what became of it, and the hash never leaves', async () => {
+    const used = `used-${randomUUID().slice(0, 6)}@example.test`
+    const live = `live-${randomUUID().slice(0, 6)}@example.test`
+    const dead = `dead-${randomUUID().slice(0, 6)}@example.test`
+    const now = h.clock.now()
+    const rows: [string, Date, Date | null][] = [
+      [used, new Date(now.getTime() + 600_000), now],
+      [live, new Date(now.getTime() + 600_000), null],
+      [dead, new Date(now.getTime() - 600_000), null],
+    ]
+    for (const [email, expires, consumed] of rows) {
+      await h.admin`
+        INSERT INTO email_signin_tokens (token_hash, email, expires_at, consumed_at, created_at)
+        VALUES (${Buffer.from(`${CANARY}-${email}`)}, ${email}, ${expires}, ${consumed},
+                ${SAME_INSTANT})`
+    }
+
+    const caller = await callerFor('support', new RecordingMailer())
+    const status = await caller.admin.operations.email.status({ hours: 168 })
+    assert.ok(status.reach.linksIssued >= 3)
+    assert.ok(status.reach.linksUsed >= 1)
+    assert.ok(status.reach.linksLive >= 1)
+    assert.ok(
+      status.reach.linksUnused >= 1,
+      'an issued link that expired unused is the only trace a delivery failure leaves here',
+    )
+
+    const page = await caller.admin.operations.email.signInLinks({ hours: 168, limit: 100 })
+    assert.ok(
+      !JSON.stringify(page).includes(CANARY),
+      'token_hash reached the response. Name the columns; never SELECT *.',
+    )
+    const byEmail = new Map(page.rows.map((r) => [r.email, r]))
+    assert.equal(byEmail.get(used)?.standing, 'used')
+    assert.equal(byEmail.get(live)?.standing, 'live')
+    assert.equal(byEmail.get(dead)?.standing, 'unused')
+  })
+
+  test('the standing filter returns only that standing', async () => {
+    const caller = await callerFor('support', new RecordingMailer())
+    for (const standing of ['used', 'live', 'unused'] as const) {
+      const page = await caller.admin.operations.email.signInLinks({ hours: 168, standing, limit: 100 })
+      assert.ok(page.rows.length > 0, `nothing came back for ${standing}`)
+      assert.ok(
+        page.rows.every((r) => r.standing === standing),
+        `the ${standing} filter returned something else`,
+      )
+    }
+  })
+
+  /* ---------------------------------------------------------------------
+   * The gate
+   * ------------------------------------------------------------------ */
+
+  test('a role without the permission is refused rather than answered', async () => {
+    const caller = await callerFor('analytics')
+    await assert.rejects(
+      () => caller.admin.operations.logs.overview({ hours: 24 }),
+      (err: { message?: string }) => /admin\.logs\.read/.test(err.message ?? ''),
+      'analytics holds neither permission and must be told which one it lacks',
+    )
+    await assert.rejects(
+      () => caller.admin.operations.email.status({ hours: 168 }),
+      (err: { message?: string }) => /admin\.email\.read/.test(err.message ?? ''),
+    )
+  })
+
+  test('reading is recorded, because a read of every tenant is an event', async () => {
+    const caller = await callerFor('infrastructure')
+    const [before] = await h.admin<{ n: string }[]>`
+      SELECT count(*) AS n FROM admin_audit_entries WHERE action = 'read.admin.operations.logs.overview'`
+    await caller.admin.operations.logs.overview({ hours: 24 })
+    const [after] = await h.admin<{ n: string }[]>`
+      SELECT count(*) AS n FROM admin_audit_entries WHERE action = 'read.admin.operations.logs.overview'`
+    assert.equal(
+      Number(after!.n),
+      Number(before!.n) + 1,
+      'a cross-tenant read that leaves no record is a read nobody can account for',
+    )
+  })
+})
+
+describe('a sign-in link standing', () => {
+  const now = new Date('2026-04-02T09:00:00.000Z')
+
+  test('is used the moment it is consumed, whatever the expiry says', () => {
+    // Both halves matter. A consumed link past its expiry is still used, and
+    // reading the expiry first would report it as a delivery failure.
+    assert.equal(
+      standingOf({ consumed_at: now, expires_at: new Date(now.getTime() - 1) }, now),
+      'used',
+    )
+  })
+
+  test('is live while it can still be clicked and unused once it cannot', () => {
+    assert.equal(
+      standingOf({ consumed_at: null, expires_at: new Date(now.getTime() + 1000) }, now),
+      'live',
+    )
+    assert.equal(
+      standingOf({ consumed_at: null, expires_at: new Date(now.getTime() - 1000) }, now),
+      'unused',
+    )
+  })
+
+  test('accepts the string a driver returns as readily as a Date', () => {
+    // postgres.js hands back a Date, and a JSON round trip hands back a
+    // string. Both reach this function, and a comparison against a string
+    // would be a silent false rather than a type error.
+    assert.equal(
+      standingOf({ consumed_at: null, expires_at: new Date(now.getTime() + 1000).toISOString() }, now),
+      'live',
+    )
+  })
+})


### PR DESCRIPTION
The Operations lane of the operator portal: Infrastructure & Compute, Logs & Error Explorer, Email & Notifications, and Incidents & Kill Switches. Based on `w-admin-shell`.

Two of the four are faces for routes that already existed and had none. Two are new, and both are built only from columns this product actually writes.

## Infrastructure & Compute and Incidents & Kill Switches

No new queries. Health, the twin fleet, the teardown ledger, the egress firewall and the three platform controls all came with `w-admin-infra`, and none of them is duplicated here.

The switches are the surface an operator reaches for during an outage, possibly on a phone, so the page is arranged around that. State is a sentence before it is a chip, and the sentence names which switch is engaged. Nothing animates. The `effect` is rendered whole, including the half that says what keeps working, because an operator who does not know reads survive maintenance mode will not engage it. The way back sits beside every control whether it is engaged or not. A reason is required to engage, and the confirmation makes you type the control's own name rather than the word confirm: typing confirm proves you can read a label, typing `new_runs` proves you know which of three switches is under your finger. `enforcedBy` is printed, because a control claiming an enforcement it does not have is the failure that catalog exists to prevent.

A fleet teardown asks the server what it would touch and makes that count the phrase you type, so nobody confirms a blast radius they have not read. The reason gates the button before the confirmation opens rather than sitting inside it, or the confirmation is reachable with the reason empty. The result is reported as requested, never as torn down.

## Logs & Error Explorer and Email & Notifications

Both were partial, and the rule they are built around is that nothing is invented.

There is no exception store in this schema, so failures are grouped by the failure code a run ended with and by the workflow a verdict names. Timed out and abandoned count as failures beside failed, because a list of only failed reports a smaller, calmer, wrong number. A run that failed and recorded no code gets its own row, because that is a gap in the engine and hiding the row hides the gap.

Event payloads are never returned. An operator debugging ingestion needs to know that events are arriving, at what rate and in what shape, none of which needs the values. The stream returns the key names and the byte size and the page says so. Row level security cannot restrict a column and the operator pool bypasses it, so the column list in the query is the only place that boundary can exist. The suite seeds a recognisable string into a payload and into a token hash and asserts neither appears anywhere in either response.

The email page leads with whether the installation can send at all, which no query over the database can answer: the sign-in token row is written whether or not a mailer exists. A recording mailer is called out separately, because a test double in production accepts every message, reports success and delivers nothing. A link issued and never used before it expired is the only trace a delivery failure leaves in this product, and the page says that rather than calling the column a bounce. Deliverability is not guessed at: it is decided by DNS this control plane does not read, so the page gives the check to run and what a wrong answer looks like, instead of a verdict that would be right on the day it was written.

Both pages name what they cannot show and what it would take to change it.

## Permissions and the route floor

`admin.logs.read` and `admin.email.read`, both read only, both described, each held by four roles. `admin.email` is claimed in `RESERVED_PREFIXES` rather than left unlisted. The floor in `admin-routes.test.ts` goes to 30; it was 18 while the tree already held 26.

## One correctness fix beyond the pages

The window is now bounded at both ends on the two aggregates over this control plane's own timestamps. Unbounded above, a row stamped ahead of the clock sits inside the last hour, the last day and the last week at once, forever, and never ages out of the list an operator reads during an incident. The event queries keep a lower bound only, because `occurred_at` is the engine's stamp and may legitimately run ahead, and dropping those would hide exactly the skew the ingestion lag check exists to surface. There is a test for it.

## What was proved rather than reasoned about

A control plane serving the built console, a seeded operator, a real browser.

- Released an engaged switch and engaged another. Both returned 200, the `platform_controls` row changed both times, and the audit chain carries `emergency.engaged` at critical and `emergency.released` at high.
- The engage button is refused with no reason; the confirm button is refused until the control's name is typed. Both checked in the browser, not by reading the code.
- Under maintenance mode, `/admin` and `/trpc/admin.*` stay reachable and a tenant mutation is refused with 503. The exemption is real.
- Every page rendered at 320 and at 1280: no horizontal scroll, no placeholder left behind, no console errors.
- Every stacked column heading measured against the grid track it has to fit in. Three overflowed, one of them by 1.4 pixels. Reported to the shell, which fixed it centrally with subgrid, so two of my three renames were reverted afterwards.

484 of 484 admin, permission, limit, boundary and OpenAPI tests pass on a clean database, which is what CI provisions. Console tests, both typechecks, `next build`, `prosecheck`, `motioncheck`, `figurecheck` and `changecheck` all pass.

The `adminMutate` CSRF fix I had prepared was dropped in favour of the shell's, which caches the promise and clears the token on sign-out.

https://claude.ai/code/session_016vSdLp1bxMGbFPsHtVCGyR
