### PR TITLE
status: a renderer test that answered about the hour

### DIFF
--- a/.changes/a-suite-that-answered-about-the-hour.internal.md
+++ b/.changes/a-suite-that-answered-about-the-hour.internal.md
@@ -1,0 +1,43 @@
+# fixed
+
+`deploy/status/render_test.sh` gave a different answer depending on the hour it
+ran at, and on the morning of 2026-09-03 the answer was five failures against a
+renderer nobody had touched. Every open pull request that changed anything
+under `deploy/status/` inherited that red, so the gate was reporting on the
+clock rather than on the branch.
+
+Nothing had regressed. The suite built its fixtures from the wall clock and
+then asserted things about a moment, and the moment moved. It moved in two
+separate ways.
+
+The hour. "Three checks today, one of them failed" was three readings at two
+hours, one hour and ten minutes before now. That is one UTC day at noon and two
+UTC days at half past midnight. The case did not fail when the day split under
+it, it quietly became a different case: two days holding one and two checks,
+neither of them partly failed, so no bar was drawn as partial and no strip
+label said one of three. The same split runs through the outage case, where a
+pass and a fail an hour apart have to land on one day, and through the rounding
+case, whose four hours of readings have to sit inside one day.
+
+The date. The incident fixtures carry real dates and the page shows a rolling
+fourteen days of incident history. The closed incident is dated 2026-08-20. It
+left the window on 2026-09-03 and took three assertions with it, and the
+2026-09-20 maintenance window would have stopped being called scheduled on
+2026-09-21.
+
+So the clock is a fixture now. `render.sh` reads `STATUS_NOW_EPOCH` when it is
+set and the system clock when it is not, which is what the workflow does and
+what the published page keeps doing. It reads the clock exactly once and hands
+the number to `page.jq` and `feed.jq`, neither of which ever asks for itself.
+The suite pins it at 2026-09-01T12:00:00Z.
+
+Measured rather than argued, under a `date` that lies about now and tells the
+truth about everything else. The suite as it stood returned between zero and
+ten failures across ten clocks, a different set of failures at almost every
+one. The suite as it stands returns zero across twenty-seven clocks, spanning a
+year back, every three hours of a day, and five years forward.
+
+The pin is not passing vacuously. Remove the injection from `render.sh` so it
+reads the wall clock again and six assertions go red at once. Mutate `page.jq`
+five times, one mutation per originally failing assertion, each removing
+exactly the capability that assertion names, and every one of the five says no.

--- a/deploy/status/render.sh
+++ b/deploy/status/render.sh
@@ -56,13 +56,41 @@ KEEP_READING_DAYS=35
 KEEP_DAILY_DAYS=400
 STRIP_DAYS=90
 
-now_iso() { date -u +%Y-%m-%dT%H:%M:%SZ; }
-NOW_EPOCH="$(date -u +%s)"
-GENERATED="$(now_iso)"
+# Time, as a dependency, the way the control plane already treats it.
+#
+# The clock is read exactly once, here, and the number is passed on to every
+# program below. Nothing else in this script or in page.jq asks what time it
+# is. That matters because almost every claim this page makes is a claim about
+# a moment: how long ago a check landed, whether a component has gone quiet,
+# which UTC day a reading belongs to, which fourteen days of incidents are
+# still shown, how far back the ninety day strip reaches.
+#
+# A suite that cannot pin the moment cannot test any of them. It has to build
+# its fixtures from the wall clock, and then a case saying "three checks on one
+# day, one of them failed" means three checks on one day when it runs at noon
+# and two days when it runs at half past midnight. It quietly becomes a
+# different case rather than failing, and the assertion that goes red is red
+# about the hour rather than about the renderer.
+#
+# So the clock is injectable, and render_test.sh pins it. Nothing in the
+# workflow sets this, and unset it is the system clock exactly as before.
+NOW_EPOCH="${STATUS_NOW_EPOCH:-$(date -u +%s)}"
+case "$NOW_EPOCH" in
+  '' | *[!0-9]*)
+    echo "render.sh: STATUS_NOW_EPOCH must be whole seconds since the epoch, not \"$NOW_EPOCH\"" >&2
+    exit 1
+    ;;
+esac
 
 for tool in jq date; do
   command -v "$tool" > /dev/null || { echo "render.sh needs $tool" >&2; exit 1; }
 done
+
+# Formatted by jq rather than by date, because turning an epoch back into a
+# stamp is `date -r` on a BSD userland and `date -d @` on a GNU one, and jq is
+# already a hard requirement one line above.
+GENERATED="$(jq -rn --argjson now "$NOW_EPOCH" '$now | todate')"
+
 [ -f "$TARGETS" ] || { echo "render.sh: no targets at $TARGETS" >&2; exit 1; }
 [ -f "$PAGE_JQ" ] || { echo "render.sh: no page program at $PAGE_JQ" >&2; exit 1; }
 [ -f "$FEED_JQ" ] || { echo "render.sh: no feed program at $FEED_JQ" >&2; exit 1; }

--- a/deploy/status/render_test.sh
+++ b/deploy/status/render_test.sh
@@ -22,6 +22,34 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 
+# The moment this suite runs at, pinned.
+#
+# Every case below is a statement about a moment, and read against the wall
+# clock those statements decay in two separate ways.
+#
+# One is the hour. "Three checks today, one of them failed" is built as three
+# readings at two hours, one hour and ten minutes ago, and that is one UTC day
+# at noon and two UTC days at half past midnight. The case does not fail when
+# the day splits under it, it becomes a different case: two days of one and two
+# checks, neither of them part passed, no bar drawn as partly failed and no
+# strip label saying one of three. The same split runs through the outage case,
+# where a pass and a fail an hour apart have to land on one day for the day to
+# be a partial one, and through the rounding case, whose four hours of readings
+# have to sit inside one day for the record to be one day deep.
+#
+# The other is the date. The incident fixtures carry real dates, and the page
+# shows a rolling fourteen days of incident history and calls a maintenance
+# window scheduled only while it is still in the future. A fixture dated
+# 2026-08-20 was inside the window when it was written and left it on
+# 2026-09-03, taking three assertions with it, and the September 20 maintenance
+# would have followed on September 21.
+#
+# So the clock is a fixture like any other. render.sh reads STATUS_NOW_EPOCH
+# when it is set, every timestamp below is measured from the same number, and
+# the suite gives the same answer at every hour of every day forever.
+NOW=1788264000   # 2026-09-01T12:00:00Z
+export STATUS_NOW_EPOCH="$NOW"
+
 pass=0
 fail=0
 current=""
@@ -67,12 +95,12 @@ run() { # run <out-dir> <readings> <scripts-dir>
   "$HERE/render.sh" "$1" "$2" "$3" > "$1/render.log" 2>&1
 }
 
-iso() { # iso <seconds-ago>
+iso() { # iso <seconds-ago>, measured from the pinned clock and not from now
   local ago="$1"
   if date -u -r 0 > /dev/null 2>&1; then
-    date -u -r "$(( $(date -u +%s) - ago ))" +%Y-%m-%dT%H:%M:%SZ   # BSD
+    date -u -r "$(( NOW - ago ))" +%Y-%m-%dT%H:%M:%SZ   # BSD
   else
-    date -u -d "@$(( $(date -u +%s) - ago ))" +%Y-%m-%dT%H:%M:%SZ  # GNU
+    date -u -d "@$(( NOW - ago ))" +%Y-%m-%dT%H:%M:%SZ  # GNU
   fi
 }
 
@@ -311,7 +339,7 @@ refute "no unreadable warning when nothing is unreadable" "$d/index.html" "could
 # the rounding decides the answer.
 case_start "799 of 800 checks passed: 99.875% must print as 99.8 and never as 99.9 or 100"
 d="$WORK/round"; mkdir -p "$d"; s="$(scripts round)"
-jq -nr --arg now "$(date -u +%s)" '
+jq -nr --arg now "$NOW" '
   [ range(0; 800)
     | { checked_at: (($now | tonumber) - 14400 + (. * 7) | todate),
         id: "control-plane-api", name: "control-plane-api", group: "g",
@@ -330,7 +358,7 @@ expect "and says how much record that figure covers" "$d/index.html" "day record
 # forever on a page whose record holds a year. It did exactly that.
 case_start "a rollup reaching back a year, with no raw readings that old"
 d="$WORK/window"; mkdir -p "$d"; s="$(scripts window)"
-jq -n --arg now "$(date -u +%s)" '
+jq -n --arg now "$NOW" '
   ($now | tonumber) as $n
   | { counted_through: {},
       days: [ range(1; 200) | { id: "control-plane-api",
@@ -345,7 +373,7 @@ expect "the figure itself is stated" "$d/index.html" "100% uptime"
 # ---------------------------------------------------------------------------
 case_start "the raw retention cap holds, and the rollup keeps the count it truncated"
 d="$WORK/cap"; mkdir -p "$d"; s="$(scripts cap)"
-jq -nr --arg now "$(date -u +%s)" '
+jq -nr --arg now "$NOW" '
   [ range(0; 1400)
     | { checked_at: (($now | tonumber) - 12600 + (. * 9) | todate),
         id: "control-plane-api", name: "control-plane-api", group: "g",


### PR DESCRIPTION
`bash deploy/status/render_test.sh` was failing on a clean `main` with five
failures, so every open pull request that touched `deploy/status/` came back
red for a reason that was not its own.

The renderer had not regressed and the test was not asserting stale markup.
Both were right. The suite built its fixtures from the wall clock and then
asserted things about a moment, and the moment moved.

## The five, and what decided each

Every one of them is the same root cause reached by two different routes. No
assertion was changed, weakened or removed, and `page.jq` is untouched.

The hour took two:

1. the day is drawn as partly failed, sized by the share
2. the strip says how many failed that day

The date took three:

3. the closed incident is in the history
4. the closed one shows how long it lasted
5. the closed one appears once

**The hour.** "Three checks today, one of them failed" was built as three
readings at two hours, one hour and ten minutes before now. That is one UTC day
at noon and two UTC days at half past midnight. The case did not fail when the
day split under it, it quietly became a different case: two days holding one
and two checks, neither of them partly failed. So `class="b b-part"` was never
emitted and the strip never said `1 of 3 checks failed`. The same split runs
through the outage case, where a pass and a fail an hour apart have to land on
one day, and through the rounding case, whose four hours of readings have to
sit inside one day for the record to be one day deep.

**The date.** The incident fixtures carry real dates, and the page shows a
rolling fourteen days of incident history. The closed incident is dated
2026-08-20. It left the window on 2026-09-03 and took all three of its
assertions with it. The 2026-09-20 maintenance window would have stopped being
called scheduled on 2026-09-21.

The evidence that decided it: under a `date` that lies about now and tells the
truth about everything else, the unfixed suite returns a different set of
failures at almost every clock. The exact five in the report reproduce at
2026-09-04T00:46Z. At 2026-09-02T15:46Z the same unfixed suite is fully green.
At 2027-09-03 it is ten failures. A suite whose verdict is a function of the
hour is not reporting on the renderer.

## The fix

The clock becomes a fixture. `render.sh` reads `STATUS_NOW_EPOCH` when it is
set and the system clock when it is not, which is what `status.yml` does and
what the published page keeps doing. It reads the clock exactly once and hands
the number to `page.jq` and `feed.jq`, neither of which ever asks for itself.
The value is validated, so a typo is a refusal and not a page dated 1970.
`render_test.sh` pins it at 2026-09-01T12:00:00Z, which puts the closed
incident twelve days inside the fourteen day window and the maintenance window
in the future, permanently.

Formatting the stamp moved from `date` to `jq` because turning an epoch back
into a stamp is `date -r` on a BSD userland and `date -d @` on a GNU one, and
`jq` is already a hard requirement one line above.

## Determinism, measured

* Five consecutive runs, byte identical output, 81 passed 0 failed.
* Twenty seven clocks, spanning a year back, every three hours across a day,
  and five years forward: zero failures at every one. The same sweep over the
  unfixed suite ranges from zero to ten.
* Nothing is left behind: no delta in the repository tree or in `git status`
  after a run, zero residue in a dedicated `TMPDIR`, and a second run in that
  same dirty `TMPDIR` is identical. It runs the same from a foreign working
  directory and from a fresh copy of the tree.

## Proof the assertions can still say no

A check that cannot fail is worse than no check, so each of the five was made
to fail on purpose. One mutation of `page.jq` at a time, each deleting exactly
the capability the assertion names, and the assertions that went red:

* a partly failed day is drawn as fully passing, which reddens "the day is
  drawn as partly failed" in both cases that assert it
* the strip label stops naming how many of how many, which reddens "the strip
  says how many failed that day"
* the incident history drops everything that has ended, which reddens "the
  closed incident is in the history", "resolved after 41 minutes", and "the
  closed one appears once"
* a resolved incident stops saying how long it lasted, which reddens "the
  closed one shows how long it lasted"
* every past incident is rendered twice, which reddens "the open incident
  appears in the banner and again under its day" and "the closed one appears
  once"

And the pin itself is load bearing: delete the injection so `render.sh` reads
the wall clock again, and six assertions go red immediately.

The published page is unaffected. `status.yml` sets nothing, so the probe job
reads the system clock exactly as before.
