### PR TITLE
onboarding: a sign in that connected nothing, and no screen that mentioned it

### DIFF
--- a/.changes/a-sign-in-that-connected-nothing.md
+++ b/.changes/a-sign-in-that-connected-nothing.md
@@ -38,3 +38,13 @@ keychain prompt. The command returned an error and left a ninety day credential
 nobody held, nobody could see and nobody could revoke, with another one beside
 it on every retry. It now revokes what it cannot keep, and says the token is
 still live, and where to revoke it, when the revocation fails too.
+
+The credential CI needs was the other half of the same silence. `POST /v1/tokens`
+mints an engine token, it answers a bearer credential and has no cookie path at
+all, and that is deliberate: a browser session that could mint would be a
+credential factory behind a cookie. So no screen can reach it and none should,
+which leaves telling somebody as the only thing a console can do, and nothing
+did. The page now carries the two commands, says the scope has to be asked for
+by name, and says first that a GitHub Actions job needs no token at all, so
+nobody pastes a permanent secret into a repository to solve a problem the
+identity exchange already solves.

--- a/.changes/a-sign-in-that-connected-nothing.md
+++ b/.changes/a-sign-in-that-connected-nothing.md
@@ -1,0 +1,40 @@
+# fixed
+
+A person who signed up, signed a terminal in with `af login`, and ran `af up`
+watched an empty environments list forever, and every part of it looked
+configured. `attachControlPlane` took a token from `AF_CONTROL_PLANE_TOKEN` or
+from a GitHub Actions identity and from nowhere else, so the credential the
+device grant so carefully protects was read by `af env pull` and by nothing
+that reports a run. The CLI now hands the stored credential and the origin it
+was issued by to the orchestrator, which passes both to telemetry, and `af up`,
+`af test`, `af ci` and `af workload` report with it. The environment token still
+wins, because exporting one is a decision and a credential on the machine is a
+default. A machine nobody has signed in behaves exactly as it did before.
+
+Nothing in the console had ever mentioned the command line. A new organization
+landed on an environments list whose three empty cards each explained that
+something appears when the engine reports one, and no screen anywhere said how
+to get an engine, sign it in, or run it: the install command was on the
+marketing site and in the documentation, which is where somebody who has not
+signed up yet is. There is now a **Command line** screen carrying the install
+command, the sign-in command, and the first two commands worth running, and both
+empty states on the environments page lead to it.
+
+The sign-in command on that screen names the control plane the console is being
+served from, and says nothing when that is already the hosted instance. A plain
+`af login` on a self hosted plane signs a terminal in to somewhere else and
+stores a credential for an origin nothing that person runs will ever talk to.
+
+`tokens.list` and `tokens.revoke` were written, permissioned and audited, and no
+console called either of them, so a ninety day credential granted by `af login`
+could be neither seen nor taken away from any screen in the product. Both are on
+the new page, telling a terminal apart from an engine token because revoking
+your own laptop and revoking a build machine are not the same act.
+
+A login whose token could not be stored used to leave that token live. It is
+minted the moment somebody approves, and on macOS the write that follows can be
+refused: over ssh or under a launchd agent there is nobody to authorise the
+keychain prompt. The command returned an error and left a ninety day credential
+nobody held, nobody could see and nobody could revoke, with another one beside
+it on every retry. It now revokes what it cannot keep, and says the token is
+still live, and where to revoke it, when the revocation fails too.

--- a/console/app/(app)/cli/layout.tsx
+++ b/console/app/(app)/cli/layout.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from "next";
+
+/** The same string as this screen's heading, so a tab says which screen it is.
+ *  Why a layout: the page under it is a client component and cannot export
+ *  metadata. See app/layout.tsx. */
+export const metadata: Metadata = { title: "Command line" };
+
+export default function CliLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/console/app/(app)/cli/page.tsx
+++ b/console/app/(app)/cli/page.tsx
@@ -201,6 +201,83 @@ function FirstRun() {
 }
 
 /**
+ * The credential CI needs, which is a different credential and is deliberately
+ * not mintable from here.
+ *
+ * `POST /v1/tokens` answers a bearer token and has no cookie path at all, so no
+ * screen in this console can reach it. That is the design rather than a gap:
+ * the mint produces a credential, so it is gated on a terminal already holding
+ * one that was approved for `tokens.manage` by name, on a screen that showed
+ * the words. A browser session that could mint would be a credential factory
+ * behind a cookie.
+ *
+ * What was missing was anybody being told. The two commands are the only way to
+ * get a token into CI, `af token --help` has always said so, and nothing a
+ * person could see while thinking "how do I put this in my pipeline" mentioned
+ * either of them.
+ */
+function ForCI({ origin }: { origin: string | null }) {
+  const plane = origin === null || origin === HOSTED ? "" : ` --control-plane ${origin}`;
+  return (
+    <Card
+      title="Wire it into CI"
+      note="Only where GitHub cannot vouch for the job. A different credential, and it comes last."
+    >
+      <div className="space-y-5 px-4 py-4">
+        <p className="max-w-[74ch] text-[13px] leading-6 text-muted">
+          A GitHub Actions job needs none of this. Give the job{" "}
+          <code className="font-mono">permissions: id-token: write</code> and the
+          engine trades the identity GitHub signs for that job for a short lived
+          credential of its own, so nothing is stored in your repository and
+          nothing has to be rotated. What follows is for an engine running
+          somewhere GitHub will not vouch for it: a self hosted runner outside
+          Actions, another CI system, or a machine that is nobody&rsquo;s laptop.
+        </p>
+        <div className="space-y-2">
+          {plane === "" && origin === null ? (
+            <div className="flex items-center gap-3" aria-hidden>
+              <div className="min-w-0 flex-1 rounded-md border border-rule bg-[rgba(16,16,16,0.03)] px-3 py-2.5">
+                <Bar className="h-4 w-[28ch] max-w-full" />
+              </div>
+            </div>
+          ) : (
+            <CommandBlock
+              command={`af login --scope tokens.manage${plane}`}
+              said="Scoped sign-in command copied to the clipboard"
+            />
+          )}
+          <p className="max-w-[74ch] text-[13px] leading-6 text-muted">
+            Minting is a capability, so it is asked for by name and approved on
+            the screen that shows the words. A token from a plain{" "}
+            <code className="font-mono">af login</code> cannot make another one,
+            which is deliberate: a credential that can make credentials is a
+            credential worth stealing twice.
+          </p>
+        </div>
+        <div className="space-y-2">
+          <CommandBlock command="af token create ci" said="Mint command copied to the clipboard" />
+          <p className="max-w-[74ch] text-[13px] leading-6 text-muted">
+            Prints the token once and stores nothing but its hash, so nothing
+            can show it again. It goes in{" "}
+            <code className="font-mono">AF_CONTROL_PLANE_TOKEN</code> wherever
+            that engine runs. It belongs to the organization rather than to you,
+            so it keeps working after you leave, and it carries no identity: it
+            can send events and read an environment back, and it cannot reach a
+            provider key, a member, or another token.
+          </p>
+        </div>
+        <p className="max-w-[74ch] text-[12px] leading-5 text-dim">
+          No screen here can mint one. The route answers a terminal holding a
+          credential and never a browser holding a cookie, so a stolen session
+          cannot become a permanent one. It appears in the list below the moment
+          it exists.
+        </p>
+      </div>
+    </Card>
+  );
+}
+
+/**
  * Every credential this organization has handed out, of both kinds.
  *
  * The two are shown together and told apart, because they are one question with
@@ -346,12 +423,13 @@ export default function CliPage() {
   return (
     <Page
       title="Command line"
-      lede="The engine runs on your machine and in your CI, never on this control plane. These three commands take you from nothing to a signed in terminal whose runs are recorded here."
+      lede="The engine runs on your machine and in your CI, never on this control plane. Install it, sign this terminal in, and run it: three commands, and the runs appear here. What CI needs is a different credential and it comes last."
     >
       <div className="space-y-6">
         <Install />
         <SignIn origin={origin} />
         <FirstRun />
+        <ForCI origin={origin} />
         <Tokens mayManage={may(role, "tokens.manage")} csrf={csrf} />
       </div>
     </Page>

--- a/console/app/(app)/cli/page.tsx
+++ b/console/app/(app)/cli/page.tsx
@@ -245,11 +245,15 @@ function Tokens({ mayManage, csrf }: { mayManage: boolean; csrf: string }) {
             </Empty>
           ) : (
             <TableWrap>
-              <Table>
+              {/* Five columns, one of them a button. The kind rides under the
+                  name rather than taking a column of its own, which is what the
+                  members table does with a login and a display name: six
+                  columns did not fit at a tablet width, and the one that got
+                  squeezed was the one holding Revoke. */}
+              <Table className="sm:min-w-[600px]">
                 <thead>
                   <tr>
                     <Th>Name</Th>
-                    <Th>Kind</Th>
                     <Th>Prefix</Th>
                     <Th>Last used</Th>
                     <Th>State</Th>
@@ -267,8 +271,12 @@ function Tokens({ mayManage, csrf }: { mayManage: boolean; csrf: string }) {
                       new Date(t.expires_at as string).getTime() <= Date.now();
                     return (
                       <Row key={t.id}>
-                        <Td>{t.name}</Td>
-                        <Td label="Kind">{t.kind === "cli" ? "terminal" : "engine token"}</Td>
+                        <Td>
+                          <span className="block text-ink">{t.name}</span>
+                          <span className="block text-[12px] text-dim">
+                            {t.kind === "cli" ? "terminal" : "engine token"}
+                          </span>
+                        </Td>
                         <Td label="Prefix" mono>
                           {t.prefix}
                         </Td>
@@ -284,7 +292,7 @@ function Tokens({ mayManage, csrf }: { mayManage: boolean; csrf: string }) {
                             <Badge tone="pass">live</Badge>
                           )}
                         </Td>
-                        <Td label="">
+                        <Td className="w-px whitespace-nowrap">
                           {revoked || expired ? null : (
                             <Button
                               variant="danger"

--- a/console/app/(app)/cli/page.tsx
+++ b/console/app/(app)/cli/page.tsx
@@ -136,9 +136,9 @@ function SignIn({ origin }: { origin: string | null }) {
         <p className="max-w-[74ch] text-[13px] leading-6 text-muted">
           It prints an eight character code and opens this control plane in a
           browser. Check that the code on the screen is the code in your
-          terminal, approve it, and the token arrives in the terminal over TLS
-          and goes straight into the operating system&rsquo;s credential store.
-          It is never shown to anybody and never reaches a shell history file.
+          terminal, approve it, and the token goes from here straight into the
+          operating system&rsquo;s credential store. Nobody is ever shown it, no
+          clipboard carries it, and it never reaches a shell history file.
         </p>
         <p className="max-w-[74ch] text-[13px] leading-6 text-muted">
           The token can read environments and runs and write events, and nothing

--- a/console/app/(app)/cli/page.tsx
+++ b/console/app/(app)/cli/page.tsx
@@ -1,0 +1,351 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { mutate, query, useApi } from "@/lib/api";
+import { useSessionContext } from "@/components/session";
+import { may } from "@/lib/roles";
+import {
+  Badge,
+  Bar,
+  Button,
+  Card,
+  CommandBlock,
+  Empty,
+  LinkButton,
+  Loaded,
+  Page,
+  Row,
+  Table,
+  TableSkeleton,
+  TableWrap,
+  Td,
+  Th,
+  When,
+} from "@/components/ui";
+
+/**
+ * How somebody gets from this browser tab to a working command line.
+ *
+ * WHY THIS PAGE EXISTS. Everything a person actually does with this product
+ * happens in a terminal: the engine builds environments on their machine and in
+ * their CI, and this control plane is where the result is recorded. Until this
+ * screen there was nothing anywhere in the console that said so. A new
+ * organization landed on an environments list with three empty cards, each of
+ * which explained that something appears "when the engine reports one", and no
+ * screen in the product said how to get an engine, sign it in, or run it. The
+ * install command was on the marketing site and in the documentation, which is
+ * where somebody who has not signed up yet is, not where somebody who just did
+ * is.
+ *
+ * THE ADDRESS IN THE LOGIN COMMAND IS NOT A DETAIL. `af login` with no flag
+ * signs in to the hosted instance, because that is the sensible default for the
+ * people there are most of. On any other control plane, which is every self
+ * hosted installation and every preview, a plain `af login` sends somebody's
+ * terminal to a company they may not have an account with and stores a
+ * credential for an origin nothing else they run will ever talk to. The command
+ * shown here names the control plane this console is being served from, and
+ * says nothing when that is already the default, so the shortest correct
+ * command is always the one on the screen.
+ *
+ * The tokens below are the other half of the same relationship. `af login`
+ * grants a credential that is good for ninety days, and until this table
+ * existed there was no screen anywhere that listed one or took one away: both
+ * procedures were written, permissioned and audited, and nothing in any console
+ * called either of them. A credential you cannot see is a credential you cannot
+ * revoke.
+ */
+
+/** The hosted instance, which is what `af login` uses when nothing says
+ *  otherwise. The same string as controlplane.DefaultBaseURL in the engine. */
+const HOSTED = "https://app.antifailure.dev";
+
+const INSTALL = "curl -fsSL https://antifailure.dev/install.sh | sh";
+
+/**
+ * The origin this console is served from, once there is a window to ask.
+ *
+ * In an effect rather than at first render, because the console is a static
+ * export: the HTML is built with no window at all, and reading one during the
+ * first client render would make the markup React hydrated disagree with the
+ * markup it was given. The wait is one frame and the command's place is held
+ * rather than left empty, so nothing moves when it arrives.
+ */
+function useOrigin(): string | null {
+  const [origin, setOrigin] = useState<string | null>(null);
+  useEffect(() => setOrigin(window.location.origin), []);
+  return origin;
+}
+
+interface TokenRow {
+  id: string;
+  name: string;
+  prefix: string;
+  kind: string;
+  created_at: string;
+  last_used_at: string | null;
+  revoked_at: string | null;
+  expires_at: string | null;
+}
+
+function Install() {
+  return (
+    <Card
+      title="Install the engine"
+      note="One command, on the machine the work happens on."
+    >
+      <div className="space-y-3 px-4 py-4">
+        <CommandBlock command={INSTALL} said="Install command copied to the clipboard" />
+        <p className="max-w-[74ch] text-[13px] leading-6 text-muted">
+          Downloads the release for your platform, checks it against the
+          published checksum, and puts <code className="font-mono">af</code> and
+          its runner under <code className="font-mono">~/.antifailure</code>,
+          with that directory added to the file your login shell reads. It is
+          POSIX <code className="font-mono">sh</code> rather than bash, so it
+          works in a container as well as on a laptop, and it is the same file
+          served at that address if you would rather read it first.
+        </p>
+      </div>
+    </Card>
+  );
+}
+
+function SignIn({ origin }: { origin: string | null }) {
+  // Null while the origin is still being read, and the plain command once it
+  // turns out to be the hosted instance. Both render the shortest command that
+  // is correct for the reader.
+  const command =
+    origin === null ? null : origin === HOSTED ? "af login" : `af login --control-plane ${origin}`;
+
+  return (
+    <Card
+      title="Sign this terminal in"
+      note="The device authorization grant. Nothing is pasted and nothing is copied through a clipboard."
+    >
+      <div className="space-y-3 px-4 py-4">
+        {command === null ? (
+          // The shape of the command, held so the card does not resize under
+          // somebody's eyes when the address arrives.
+          <div className="flex items-center gap-3" aria-hidden>
+            <div className="min-w-0 flex-1 rounded-md border border-rule bg-[rgba(16,16,16,0.03)] px-3 py-2.5">
+              <Bar className="h-4 w-[22ch] max-w-full" />
+            </div>
+          </div>
+        ) : (
+          <CommandBlock command={command} said="Sign-in command copied to the clipboard" />
+        )}
+        <p className="max-w-[74ch] text-[13px] leading-6 text-muted">
+          It prints an eight character code and opens this control plane in a
+          browser. Check that the code on the screen is the code in your
+          terminal, approve it, and the token arrives in the terminal over TLS
+          and goes straight into the operating system&rsquo;s credential store.
+          It is never shown to anybody and never reaches a shell history file.
+        </p>
+        <p className="max-w-[74ch] text-[13px] leading-6 text-muted">
+          The token can read environments and runs and write events, and nothing
+          else. It cannot manage members, change policy, or touch a provider
+          key. <code className="font-mono">af login --scope providers.write</code>{" "}
+          asks for more, and what was asked for is on the approval screen, so a
+          capability cannot be granted without being read.
+        </p>
+        <div className="flex flex-wrap gap-2 pt-1">
+          <LinkButton href="/device" variant="secondary">
+            Approve a terminal
+          </LinkButton>
+        </div>
+        <p className="max-w-[74ch] text-[12px] leading-5 text-dim">
+          On a machine with no browser of its own, over ssh for instance, run{" "}
+          <code className="font-mono">af login --no-browser</code> and bring the
+          code here.
+        </p>
+      </div>
+    </Card>
+  );
+}
+
+function FirstRun() {
+  return (
+    <Card
+      title="Get a first result"
+      note="Neither of these needs an account. Both run entirely on your machine."
+    >
+      <div className="space-y-5 px-4 py-4">
+        <div className="space-y-2">
+          <CommandBlock command="af init" said="af init copied to the clipboard" />
+          <p className="max-w-[74ch] text-[13px] leading-6 text-muted">
+            Reads the repository and writes{" "}
+            <code className="font-mono">antifailure.yaml</code>: the services it
+            found, the port each listens on, the migration command, and a
+            network policy derived from the SDKs you depend on. It runs nothing
+            from the repository, and everything it reports names the file it
+            came from.
+          </p>
+        </div>
+        <div className="space-y-2">
+          <CommandBlock command="af start" said="af start copied to the clipboard" />
+          <p className="max-w-[74ch] text-[13px] leading-6 text-muted">
+            Says where you are and what the single next command is, read off
+            that machine as it is right now rather than off a record of what it
+            last did. It is the one command worth remembering, and it is safe to
+            run at any point because it writes nothing.
+          </p>
+        </div>
+        <p className="max-w-[74ch] text-[13px] leading-6 text-muted">
+          Once a signed in terminal runs an environment, it appears under
+          Environments and its runs under Runs. Until then those screens are
+          empty because nothing has happened yet, which is a different thing
+          from being broken.
+        </p>
+      </div>
+    </Card>
+  );
+}
+
+/**
+ * Every credential this organization has handed out, of both kinds.
+ *
+ * The two are shown together and told apart, because they are one question with
+ * two answers: what can act as us. A terminal is a person who ran af login; an
+ * engine token is a secret somebody pasted into a build machine. Revoking
+ * either takes effect on the next request, since every route re-reads the row.
+ */
+function Tokens({ mayManage, csrf }: { mayManage: boolean; csrf: string }) {
+  const state = useApi<TokenRow[]>(() => query<TokenRow[]>("tokens.list"), []);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!mayManage) {
+    return (
+      <Card title="Terminals and tokens">
+        <p className="max-w-[74ch] px-4 py-4 text-[13px] leading-6 text-muted">
+          Seeing which machines can act as this organization, and taking one
+          away, is an owner&rsquo;s or an administrator&rsquo;s. Your role is
+          not one of those, so this list is not shown to you. Signing your own
+          terminal in above still works.
+        </p>
+      </Card>
+    );
+  }
+
+  return (
+    <Card
+      title="Terminals and tokens"
+      note="Everything that can act as this organization from outside a browser."
+    >
+      {error ? (
+        <p role="alert" className="border-b border-rule px-4 py-3 text-[12.5px] text-fail">
+          {error}
+        </p>
+      ) : null}
+      <Loaded state={state} skeleton={<TableSkeleton rows={3} cols={5} />}>
+        {(rows) =>
+          rows.length === 0 ? (
+            <Empty title="No terminal is signed in">
+              Nothing outside a browser can act as this organization yet. Run
+              the sign-in command above on a machine and it appears here.
+            </Empty>
+          ) : (
+            <TableWrap>
+              <Table>
+                <thead>
+                  <tr>
+                    <Th>Name</Th>
+                    <Th>Kind</Th>
+                    <Th>Prefix</Th>
+                    <Th>Last used</Th>
+                    <Th>State</Th>
+                    <Th>
+                      <span className="sr-only">Actions</span>
+                    </Th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {rows.map((t) => {
+                    const revoked = Boolean(t.revoked_at);
+                    const expired =
+                      !revoked &&
+                      Boolean(t.expires_at) &&
+                      new Date(t.expires_at as string).getTime() <= Date.now();
+                    return (
+                      <Row key={t.id}>
+                        <Td>{t.name}</Td>
+                        <Td label="Kind">{t.kind === "cli" ? "terminal" : "engine token"}</Td>
+                        <Td label="Prefix" mono>
+                          {t.prefix}
+                        </Td>
+                        <Td label="Last used">
+                          {t.last_used_at ? <When value={t.last_used_at} /> : "never"}
+                        </Td>
+                        <Td label="State">
+                          {revoked ? (
+                            <Badge tone="fail">revoked</Badge>
+                          ) : expired ? (
+                            <Badge tone="neutral">expired</Badge>
+                          ) : (
+                            <Badge tone="pass">live</Badge>
+                          )}
+                        </Td>
+                        <Td label="">
+                          {revoked || expired ? null : (
+                            <Button
+                              variant="danger"
+                              busy={busy === t.id}
+                              onClick={async () => {
+                                setBusy(t.id);
+                                setError(null);
+                                try {
+                                  await mutate("tokens.revoke", { id: t.id }, csrf);
+                                  state.reload();
+                                } catch (e) {
+                                  setError(
+                                    e instanceof Error
+                                      ? e.message
+                                      : "The control plane refused it.",
+                                  );
+                                } finally {
+                                  setBusy(null);
+                                }
+                              }}
+                            >
+                              Revoke
+                            </Button>
+                          )}
+                        </Td>
+                      </Row>
+                    );
+                  })}
+                </tbody>
+              </Table>
+            </TableWrap>
+          )
+        }
+      </Loaded>
+      <p className="max-w-[74ch] border-t border-rule px-4 py-3 text-[12px] leading-5 text-dim">
+        Revoking takes effect on the next request that machine makes, because
+        every route reads the row rather than trusting the token. It does not
+        reach the machine itself: whatever is stored there stays stored and
+        stops working.
+      </p>
+    </Card>
+  );
+}
+
+export default function CliPage() {
+  const session = useSessionContext();
+  const origin = useOrigin();
+  const role = session.data?.role ?? null;
+  const csrf = session.data?.csrfToken ?? "";
+
+  return (
+    <Page
+      title="Command line"
+      lede="The engine runs on your machine and in your CI, never on this control plane. These three commands take you from nothing to a signed in terminal whose runs are recorded here."
+    >
+      <div className="space-y-6">
+        <Install />
+        <SignIn origin={origin} />
+        <FirstRun />
+        <Tokens mayManage={may(role, "tokens.manage")} csrf={csrf} />
+      </div>
+    </Page>
+  );
+}

--- a/console/app/(app)/environments/page.tsx
+++ b/console/app/(app)/environments/page.tsx
@@ -14,6 +14,7 @@ import {
   CellLink,
   Empty,
   Field,
+  LinkButton,
   Loaded,
   Page,
   Row,
@@ -223,9 +224,17 @@ function Create({ onRequested }: { onRequested: () => void }) {
       <Loaded state={repositories} skeleton={<TableSkeleton rows={1} cols={3} />}>
         {(repos) =>
           repos.length === 0 ? (
-            <Empty title="No repositories connected">
-              An environment belongs to a repository. One appears here when the
-              GitHub App reports an installation that includes it.
+            <Empty
+              title="No repositories connected"
+              action={
+                <LinkButton href="/cli" variant="secondary">
+                  Bring one up from a terminal
+                </LinkButton>
+              }
+            >
+              One appears here once the GitHub App reports an installation that
+              includes it. That is not the only way in: the engine brings an
+              environment up from the checkout you already have.
             </Empty>
           ) : (
             <form
@@ -509,9 +518,17 @@ function Environments() {
         <Loaded state={state} skeleton={<TableSkeleton rows={6} cols={5} />}>
           {(data) =>
             data.length === 0 ? (
-              <Empty title="No environments yet">
-                An environment appears here when the engine reports one, which
-                happens the first time a run starts on a connected repository.
+              <Empty
+                title="No environments yet"
+                action={
+                  <LinkButton href="/cli" variant="secondary">
+                    Start with the command line
+                  </LinkButton>
+                }
+              >
+                An environment appears here the first time an engine reports
+                one. Nothing has yet, which is what an organization looks like
+                before its first run, not something being wrong.
               </Empty>
             ) : (
               <>

--- a/console/components/Shell.tsx
+++ b/console/components/Shell.tsx
@@ -17,6 +17,7 @@ import {
   IconRuns,
   IconSettings,
   IconSignOut,
+  IconTerminal,
   LogoMark,
 } from "@/components/icons";
 import { rest, type Session } from "@/lib/api";
@@ -60,6 +61,7 @@ const NAV = [
   { href: "/members", label: "Members", Icon: IconMembers },
   { href: "/plan", label: "Plan", Icon: IconPlan },
   { href: "/keys", label: "Provider keys", Icon: IconKeys },
+  { href: "/cli", label: "Command line", Icon: IconTerminal },
   { href: "/analytics", label: "Analytics", Icon: IconAnalytics },
   { href: "/settings", label: "Settings", Icon: IconSettings },
 ];

--- a/console/components/icons.tsx
+++ b/console/components/icons.tsx
@@ -45,6 +45,12 @@ export const IconAudit = stroke("M4 2.6h8v10.8H4zM6.2 5.6h3.6M6.2 8h3.6M6.2 10.4
 export const IconMembers = stroke("M6 7.6a2 2 0 1 0 0-4 2 2 0 0 0 0 4ZM2.6 13c0-2 1.5-3.2 3.4-3.2S9.4 11 9.4 13M10.6 4a2 2 0 0 1 0 3.6M11.4 9.9c1.3.3 2 1.4 2 3.1");
 export const IconKeys = stroke("M10.4 2.6a3.4 3.4 0 1 1-3.2 4.5L2.6 11.7v1.7h1.7v-1.3h1.3v-1.3h1.3l1.3-1.3");
 export const IconPlan = stroke("M2.6 12.6V7.4M6.2 12.6V3.4M9.8 12.6V9M13.4 12.6V5.6");
+// A shell prompt, unframed. The obvious terminal glyph is a rounded rectangle
+// with a chevron inside it, and at 16 pixels in this rail that rectangle is the
+// same shape as IconAudit's document: two entries a reader tells apart by
+// squinting at what is inside a box. The chevron and the caret carry the whole
+// meaning, so the box is what goes.
+export const IconTerminal = stroke("M3.2 4.6 6.6 8l-3.4 3.4M8.4 11.4h4.4");
 // A rising trend inside an axis. Distinct from IconPlan, which is a bar chart:
 // two icons that are both bars are two rail entries a reader cannot tell apart
 // at 16 pixels, and the rail is scanned rather than read.

--- a/console/components/load/bodies.tsx
+++ b/console/components/load/bodies.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useRef, useState, type ReactNode } from "react";
-import { Button, Empty, Field, inputClass } from "@/components/ui";
+import { useState, type ReactNode } from "react";
+import { Button, CopyButton, Empty, Field, inputClass } from "@/components/ui";
 import { Fact, Facts, KindMark } from "@/components/load/primitives";
 import {
   KIND_FACTS,
@@ -176,15 +176,6 @@ export function BodyView({ body, manifest = false }: { body: Body | null; manife
  * unverified and they need to know what was never pasted in.
  */
 export function ManifestBlock({ block, heading }: { block: string; heading?: string }) {
-  const [copied, setCopied] = useState(false);
-  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  useEffect(
-    () => () => {
-      if (timer.current) clearTimeout(timer.current);
-    },
-    [],
-  );
-
   return (
     <div className="border-t border-rule px-4 py-4">
       <div className="flex flex-wrap items-start justify-between gap-3">
@@ -197,24 +188,12 @@ export function ManifestBlock({ block, heading }: { block: string; heading?: str
             pasted into somebody's manifest stays there forever, and folding
             them into what this button copies would reverse that decision from
             the other end. They belong beside the block, once, on this screen. */}
-        <Button
-          onClick={() => {
-            void navigator.clipboard
-              ?.writeText(block)
-              .then(() => {
-                setCopied(true);
-                if (timer.current) clearTimeout(timer.current);
-                timer.current = setTimeout(() => setCopied(false), 2000);
-              })
-              .catch(() => undefined);
-          }}
-        >
-          {copied ? "Copied" : "Copy the block"}
-        </Button>
+        <CopyButton
+          value={block}
+          label="Copy the block"
+          said="Manifest block copied to the clipboard"
+        />
       </div>
-      <span aria-live="polite" className="sr-only">
-        {copied ? "Manifest block copied to the clipboard" : ""}
-      </span>
       <p className="mt-1 max-w-[74ch] text-[12.5px] leading-6 text-muted">
         This block has to be in the repository before anything can run this
         version. The control plane cannot put a file in your repository, and{" "}

--- a/console/components/load/states.tsx
+++ b/console/components/load/states.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { type ReactNode } from "react";
 import { ApiError } from "@/lib/api";
-import { Bar, Button, Card, TableSkeleton } from "@/components/ui";
+import { Bar, Button, Card, CommandBlock, TableSkeleton } from "@/components/ui";
 
 /* -------------------------------------------------------------------------
  * Failure
@@ -199,16 +199,6 @@ export function PartialNotice({ reason }: { reason: "cancelled" | "timed_out" })
  * hung half outside the block over the paragraph beneath it.
  */
 export function Command({ command }: { command: string | null }) {
-  const [copied, setCopied] = useState(false);
-  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(
-    () => () => {
-      if (timer.current) clearTimeout(timer.current);
-    },
-    [],
-  );
-
   if (command === null) {
     return (
       <p className="px-4 py-4 text-[13px] leading-6 text-muted">
@@ -221,42 +211,7 @@ export function Command({ command }: { command: string | null }) {
 
   return (
     <div className="px-4 py-4">
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        {/* overflow-x-auto by hand, NOT the shared .scroll-x helper. That
-            class turns itself off below 640px (globals.css sets it to
-            overflow-x: visible there) because at that width the tables it was
-            written for stop scrolling and stack instead. A command block does
-            not stack, so borrowing the class clipped a long command dead at
-            the card edge on a phone: no scrollbar, no ellipsis, just a
-            sentence that stopped. */}
-        <pre className="min-w-0 flex-1 overflow-x-auto rounded-md border border-rule bg-[rgba(16,16,16,0.03)] px-3 py-2.5 font-mono text-[12.5px] leading-6 text-ink">
-          <code>{command}</code>
-        </pre>
-        <Button
-          onClick={() => {
-            // Not every browser and not every context has the clipboard API:
-            // it needs a secure origin, and a control plane on plain http over
-            // a LAN is a real way this console gets used. Failing quietly and
-            // leaving the button saying "Copy" is correct, because the command
-            // is selectable text either way.
-            void navigator.clipboard
-              ?.writeText(command)
-              .then(() => {
-                setCopied(true);
-                if (timer.current) clearTimeout(timer.current);
-                timer.current = setTimeout(() => setCopied(false), 2000);
-              })
-              .catch(() => undefined);
-          }}
-        >
-          {copied ? "Copied" : "Copy"}
-        </Button>
-      </div>
-      {/* aria-live rather than a tooltip, so the confirmation reaches somebody
-          who is not looking at the button they just pressed. */}
-      <span aria-live="polite" className="sr-only">
-        {copied ? "Command copied to the clipboard" : ""}
-      </span>
+      <CommandBlock command={command} />
     </div>
   );
 }

--- a/console/components/ui.tsx
+++ b/console/components/ui.tsx
@@ -456,6 +456,95 @@ export const selectClass =
 export const inputClass =
   "mt-1.5 h-11 w-full rounded-md border border-rule bg-card px-2.5 text-[13px] text-ink outline-none placeholder:text-dim focus:border-rule-strong sm:h-9";
 
+/**
+ * Puts a string on the clipboard and says so.
+ *
+ * Three screens had written this by hand: the same two second timer, the same
+ * cleanup on unmount that two of them remembered, and the same swallowed
+ * rejection. The swallow is the part worth keeping and worth explaining, so it
+ * lives in one place: `navigator.clipboard` needs a secure origin, and a
+ * control plane reached over plain http on a LAN is a real way this console is
+ * used. Failing quietly there is correct, because the text beside the button
+ * is selectable either way and a red error about a convenience is worse than
+ * the convenience not happening.
+ */
+export function CopyButton({
+  value,
+  label = "Copy",
+  said,
+}: {
+  value: string;
+  /** What the button says at rest. It always says "Copied" afterwards. */
+  label?: string;
+  /** The whole sentence announced to a screen reader, since somebody who
+   *  cannot see the button change is otherwise told nothing at all. */
+  said?: string;
+}) {
+  const [copied, setCopied] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(
+    () => () => {
+      if (timer.current) clearTimeout(timer.current);
+    },
+    [],
+  );
+  return (
+    <>
+      <Button
+        onClick={() => {
+          void navigator.clipboard
+            ?.writeText(value)
+            .then(() => {
+              setCopied(true);
+              if (timer.current) clearTimeout(timer.current);
+              timer.current = setTimeout(() => setCopied(false), 2000);
+            })
+            .catch(() => undefined);
+        }}
+      >
+        {copied ? "Copied" : label}
+      </Button>
+      {/* aria-live rather than a tooltip, so the confirmation reaches somebody
+          who is not looking at the button they just pressed. */}
+      <span aria-live="polite" className="sr-only">
+        {copied ? (said ?? "Copied to the clipboard") : ""}
+      </span>
+    </>
+  );
+}
+
+/**
+ * A command to run somewhere else, with the button that copies it.
+ *
+ * overflow-x-auto by hand, NOT the shared `.scroll-x` helper. That class turns
+ * itself off below 640px, because the tables it was written for stop scrolling
+ * and stack instead at that width. A command does not stack, so borrowing the
+ * class clipped a long one dead at the card edge on a phone: no scrollbar, no
+ * ellipsis, just a sentence that stopped.
+ */
+export function CommandBlock({
+  command,
+  said,
+  label,
+}: {
+  command: string;
+  said?: string;
+  label?: string;
+}) {
+  return (
+    <div className="flex flex-wrap items-start justify-between gap-3">
+      <pre className="min-w-0 flex-1 overflow-x-auto rounded-md border border-rule bg-[rgba(16,16,16,0.03)] px-3 py-2.5 font-mono text-[12.5px] leading-6 text-ink">
+        <code>{command}</code>
+      </pre>
+      <CopyButton
+        value={command}
+        label={label}
+        said={said ?? "Command copied to the clipboard"}
+      />
+    </div>
+  );
+}
+
 /* -------------------------------------------------------------------------
  * The three states a screen is usually missing
  * ---------------------------------------------------------------------- */

--- a/console/components/ui.tsx
+++ b/console/components/ui.tsx
@@ -179,9 +179,23 @@ export function TableWrap({ children }: { children: ReactNode }) {
   return <div className="scroll-x w-full">{children}</div>;
 }
 
-export function Table({ children }: { children: ReactNode }) {
+export function Table({
+  children,
+  className = "sm:min-w-[520px]",
+}: {
+  children: ReactNode;
+  /**
+   * The minimum width, which decides whether the wrapper scrolls or the
+   * columns squeeze. 520 suits the four and five column tables it was written
+   * for. A wider one has to say so: when the columns' own minimum widths add
+   * up to more than this, the browser does not scroll, it overflows the last
+   * cell out of the table box, and a button in that cell paints past the last
+   * rule and flush against the card edge.
+   */
+  className?: string;
+}) {
   return (
-    <table className="af-table w-full border-collapse text-left text-[13px] sm:min-w-[520px]">
+    <table className={`af-table w-full border-collapse text-left text-[13px] ${className}`}>
       {children}
     </table>
   );

--- a/docs/src/content/docs/guides/signing-in.md
+++ b/docs/src/content/docs/guides/signing-in.md
@@ -9,6 +9,11 @@ sidebar:
 opens a browser, and waits while you approve it somewhere that already has a
 session.
 
+The console has the whole of this on one screen, under **Command line**: the
+install command, the sign-in command already carrying the address of the control
+plane you are looking at, and every terminal currently signed in to your
+organization.
+
 ```
 $ af login
 
@@ -107,17 +112,50 @@ working tree, so there is nothing for a commit or a support bundle to pick up.
 One entry per control plane, so signing in to staging does not sign you out of
 production.
 
+## What the credential is for
+
+Everything on this machine that talks to a control plane. `af up`, `af test`,
+`af ci` and `af workload` report their runs with it, which is what makes an
+environment appear under Environments in the console and its events under Runs.
+`af env pull`, `af token`, `af provider` and `af whoami` read and write your
+account with it.
+
+Signing in changes nothing about where the work happens. The engine still builds
+the environment on this machine, from the manifest in this repository, and the
+control plane still only receives a record of what happened.
+
 ## Where the token is read from
 
 In this order:
 
 1. `AF_CONTROL_PLANE_TOKEN` in the environment.
 2. The credential `af login` stored.
+3. A GitHub Actions workflow identity, exchanged for a short lived credential.
 
 The environment wins because exporting a token is somebody deliberately
 overriding what is on the machine, usually to debug or because they are in CI.
-CI should use an engine token in the environment and not `af login`: the device
-grant needs a person, by design.
+CI should use an engine token in the environment, or the workflow identity, and
+not `af login`: the device grant needs a person, by design.
+
+## When the credential cannot be stored
+
+The token is minted the moment somebody approves, before this machine has
+written it anywhere. If the write then fails, which on macOS means a keychain
+that will not take one, `af login` tells the control plane to revoke the token
+it has just been given and says so:
+
+```
+Error: store the credential: write to the keyring: the authorization was canceled
+
+       The token that had just been issued was revoked, so nothing was left
+       behind. Nothing is signed in
+```
+
+That matters because the alternative is a live ninety day credential nobody
+holds, nobody can see, and nobody can revoke, with another one beside it on
+every retry. If the revocation fails too, the message says the token is still
+live and where to go and revoke it: **Command line** in the console lists every
+terminal signed in to your organization and takes one away.
 
 ## Signing out
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -289,8 +289,8 @@ the manifest in the repository, on the machine the environment is on. A control
 plane that could change what an environment runs would be a control plane that
 could change what it masks.
 
-Needs a token in AF_CONTROL_PLANE_TOKEN. Create one in the control plane under
-engine tokens.
+Needs a credential. Run af login, or set AF_CONTROL_PLANE_TOKEN to an engine
+token, which is what a build machine with nobody sitting at it uses.
 
 ```
 af env pull <environment> [flags]

--- a/engine/internal/cli/env.go
+++ b/engine/internal/cli/env.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/antifailure/antifailure/engine/internal/auth"
 	"github.com/antifailure/antifailure/engine/internal/controlplane"
 	aferrors "github.com/antifailure/antifailure/engine/internal/errors"
 	"github.com/antifailure/antifailure/engine/internal/runtime/local"
@@ -70,8 +69,8 @@ the manifest in the repository, on the machine the environment is on. A control
 plane that could change what an environment runs would be a control plane that
 could change what it masks.
 
-Needs a token in AF_CONTROL_PLANE_TOKEN. Create one in the control plane under
-engine tokens.`),
+Needs a credential. Run af login, or set AF_CONTROL_PLANE_TOKEN to an engine
+token, which is what a build machine with nobody sitting at it uses.`),
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := controlPlaneClient(e, baseURL)
@@ -144,14 +143,10 @@ func controlPlaneClient(e *Env, baseURL string) (*controlplane.Client, error) {
 		return v, v != ""
 	})
 	if token == "" {
-		// A credential stored by af login. Expiry is checked here so that the
-		// failure is "your session expired, run af login" rather than a 401
-		// from a server the user then goes and investigates.
-		if cred, err := e.CredentialStore().Load(auth.Normalise(baseURL)); err == nil {
-			if !cred.Expired(e.Clock.Now()) {
-				token = cred.Token
-			}
-		}
+		// A credential stored by af login. Expiry is checked inside storedToken
+		// so that the failure is "your session expired, run af login" rather
+		// than a 401 from a server the user then goes and investigates.
+		token = storedToken(e, baseURL)
 	}
 
 	client, err := controlplane.New(controlplane.Options{

--- a/engine/internal/cli/lifecycle.go
+++ b/engine/internal/cli/lifecycle.go
@@ -128,10 +128,20 @@ func orchestratorWithManifest2(env2 *Env, opts lifecycleOptions) (*env.Orchestra
 	}
 
 	r := redact.New()
+	// What this run reports to, when somebody has signed this terminal in.
+	//
+	// Read here rather than inside the orchestrator for the reason the field's
+	// own comment gives: nothing under env or telemetry may open a credential
+	// store. Read on every lifecycle command rather than only on af up, because
+	// af test and af down emit events about the same environment and a run that
+	// appeared in the console and then stopped reporting is worse than one that
+	// never appeared.
+	cpURL, cpToken := signedInControlPlane(env2)
 	o, err := env.New(env.Options{
 		Root: root, Manifest: m, Branch: branch, Clock: env2.Clock,
 		Repository: currentRepository(env2, root), PullRequest: currentPullRequest(env2),
 		Rebuild: rebuild, Redactor: r, Verbose: env2.Out.Verbose, Getenv: env2.Getenv,
+		ControlPlaneURL: cpURL, ControlPlaneToken: cpToken,
 		Progress: func(line string) {
 			// Progress is prose, not data, so it is suppressed in JSON mode
 			// rather than interleaved into a document a script is parsing,

--- a/engine/internal/cli/login.go
+++ b/engine/internal/cli/login.go
@@ -94,6 +94,42 @@ func controlPlaneFor(e *Env, flag string) string {
 	return defaultControlPlane
 }
 
+// storedToken is the credential af login left for an origin, or "".
+//
+// WHY THIS IS A FUNCTION AND NOT THREE COPIES. Every caller wants the same
+// three things and one of them used to be forgotten: the origin resolved the
+// way af login resolves it, a credential looked up under exactly that origin,
+// and an expiry checked here so that an old credential is absent rather than a
+// 401 somebody goes and investigates.
+//
+// Expired returns "" rather than an error on purpose. Nothing that calls this
+// is failing: a run with no credential reports to nobody and is not broken,
+// which is what makes it safe to consult on every command.
+func storedToken(e *Env, origin string) string {
+	cred, err := e.CredentialStore().Load(auth.Normalise(origin))
+	if err != nil || cred.Expired(e.Clock.Now()) {
+		return ""
+	}
+	return cred.Token
+}
+
+// signedInControlPlane is the origin and token af login left, or two empty
+// strings.
+//
+// Both or neither, which is what every caller of it needs and is why it returns
+// a pair rather than a token somebody then has to find an address for. An
+// address with no token turns on the GitHub Actions identity exchange for runs
+// that never asked for a control plane; a token with no address goes to the
+// hosted instance whatever the credential was actually issued by.
+func signedInControlPlane(e *Env) (string, string) {
+	origin := auth.Normalise(controlPlaneFor(e, ""))
+	token := storedToken(e, origin)
+	if token == "" {
+		return "", ""
+	}
+	return origin, token
+}
+
 func newLoginCommand(e *Env) *cobra.Command {
 	var baseURL string
 	var noBrowser bool
@@ -207,7 +243,33 @@ Run af logout to remove it from this machine and revoke it everywhere.`),
 				cred.ExpiresAt = time.Now().Add(time.Duration(token.ExpiresIn) * time.Second).UTC()
 			}
 			if err := store.Save(cred); err != nil {
-				return fmt.Errorf("store the credential: %w", err)
+				// The token exists on the server by now: it was minted the
+				// moment the poll returned, it is good for ninety days, and
+				// nothing on this machine is holding it any more. Returning
+				// here without this would leave a live credential nobody can
+				// see, use or revoke, and every retry of af login would leave
+				// another one beside it.
+				//
+				// The commonest way to reach this line is a macOS keychain
+				// that will not take a write, which is exactly the machine
+				// with no browser that the device grant is for: over ssh or
+				// under a launchd agent there is nobody to authorise the
+				// prompt and `security` reports that the authorization was
+				// cancelled.
+				//
+				// The revocation is best effort and its failure is reported
+				// rather than swallowed, because the remaining remedy is
+				// somebody revoking it in the console and they have to be told
+				// that it is there.
+				if rerr := client.Revoke(ctx, token.AccessToken); rerr != nil {
+					return fmt.Errorf(
+						"store the credential: %w\n\nThe token was issued and could not be "+
+							"withdrawn either (%v), so it is still live. Revoke it in the "+
+							"control plane under Command line", err, rerr)
+				}
+				return fmt.Errorf("store the credential: %w\n\n"+
+					"The token that had just been issued was revoked, so nothing was left "+
+					"behind. Nothing is signed in", err)
 			}
 
 			where := store.Location(cred.ControlPlane)

--- a/engine/internal/cli/login.go
+++ b/engine/internal/cli/login.go
@@ -409,7 +409,12 @@ a token is dead when it is not.`),
 			if note != "" {
 				e.Out.Println("")
 				e.Out.Printf("  %s\n", note)
-				e.Out.Println("  Revoke it in the control plane under Settings, tokens.")
+				// Named for the screen that actually lists tokens. This said
+				// "Settings, tokens" and Settings has never had any: somebody
+				// following it found an organization name and a billing
+				// contact, and the credential they had been told to revoke was
+				// on no screen at all until Command line existed.
+				e.Out.Println("  Revoke it in the control plane under Command line.")
 			}
 			return nil
 		},

--- a/engine/internal/cli/login_orphan_test.go
+++ b/engine/internal/cli/login_orphan_test.go
@@ -1,0 +1,267 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/internal/auth"
+	"github.com/antifailure/antifailure/engine/internal/clock"
+	"github.com/antifailure/antifailure/engine/internal/redact"
+	"github.com/antifailure/antifailure/engine/internal/secrets"
+)
+
+// The credential that could not be stored, and what happens to it.
+//
+// THE FAILURE. `af login` polls, the control plane approves, and a token good
+// for ninety days is minted and handed over. The command then writes it to the
+// operating system's credential store, and on macOS that write can be refused:
+// over ssh or under a launchd agent there is nobody to authorise the keychain
+// prompt and `security` reports the authorization was cancelled. That is
+// exactly the machine with no browser the device grant exists for.
+//
+// What used to happen next was a returned error and nothing else. The token was
+// live on the server, no longer held by anything on this machine, invisible to
+// the person who caused it, and every retry of `af login` left another one
+// beside it. Nobody can revoke a credential they cannot see.
+//
+// So a login that cannot keep its token gives it back.
+
+// refusingRing is a keychain that exists and will not take a write. Not
+// ErrKeyringUnavailable, which is the different case of no keyring at all and
+// which Store.Save deliberately handles by falling through to a file.
+type refusingRing struct{}
+
+func (refusingRing) Get(string, string) (string, error) { return "", secrets.ErrNotFound }
+func (refusingRing) Set(string, string, string) error {
+	return errors.New("secrets: the keychain refused the write: the authorization was canceled")
+}
+func (refusingRing) Delete(string, string) error { return nil }
+
+// devicePlane is the half of the control plane af login talks to: the two
+// endpoints the terminal calls, whoami, and logout. It records every token
+// presented for revocation.
+type devicePlane struct {
+	mu      sync.Mutex
+	revoked []string
+	// refuseLogout makes the revocation fail, which is the second case: the
+	// token could not be stored AND could not be withdrawn.
+	refuseLogout bool
+}
+
+func (d *devicePlane) revocations() []string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return append([]string(nil), d.revoked...)
+}
+
+func (d *devicePlane) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	write := func(v any) {
+		w.Header().Set("content-type", "application/json")
+		_ = json.NewEncoder(w).Encode(v)
+	}
+	switch r.URL.Path {
+	case "/auth/device/code":
+		write(map[string]any{
+			"device_code":               "the-device-code",
+			"user_code":                 "BCDF-GHJK",
+			"verification_uri":          "http://" + r.Host + "/device",
+			"verification_uri_complete": "http://" + r.Host + "/device?code=BCDF-GHJK",
+			"expires_in":                900,
+			"interval":                  1,
+		})
+	case "/auth/device/token":
+		// Approved already, so Poll returns on its first ask and no test here
+		// waits out a polling interval.
+		write(map[string]any{
+			"access_token": "afu_the_minted_token",
+			"token_type":   "Bearer",
+			"expires_in":   7776000,
+			"scope":        "environments.view runs.view events.write",
+		})
+	case "/v1/whoami":
+		write(map[string]any{
+			"login": "newcomer", "organization": "newcomer", "role": "owner",
+			"scopes": []string{"environments.view", "runs.view", "events.write"},
+		})
+	case "/v1/logout":
+		d.mu.Lock()
+		d.revoked = append(d.revoked, r.Header.Get("authorization"))
+		refuse := d.refuseLogout
+		d.mu.Unlock()
+		if refuse {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		write(map[string]any{"revoked": true})
+	default:
+		w.WriteHeader(http.StatusNotFound)
+	}
+}
+
+// loginAgainst runs the real command against a real server and returns the
+// error, what was printed, and the origin the credential belongs under.
+func loginAgainst(t *testing.T, plane *devicePlane, store *auth.Store) (string, string, error) {
+	t.Helper()
+	srv := httptest.NewServer(plane)
+	t.Cleanup(srv.Close)
+
+	var buf bytes.Buffer
+	e := &Env{
+		Out:         NewOutput(&buf, &buf),
+		Getenv:      func(k string) string { return map[string]string{"AF_CONTROL_PLANE_URL": srv.URL}[k] },
+		Clock:       clock.NewFake(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)),
+		Credentials: store,
+		Redactor:    redact.New(),
+	}
+	cmd := newLoginCommand(e)
+	cmd.SetArgs([]string{"--no-browser"})
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SilenceUsage, cmd.SilenceErrors = true, true
+	err := cmd.Execute()
+	return buf.String(), auth.Normalise(srv.URL), err
+}
+
+func TestLogin_ACredentialThatCannotBeStoredIsGivenBackRatherThanLeftLive(t *testing.T) {
+	plane := &devicePlane{}
+	store := &auth.Store{Ring: refusingRing{}, Dir: t.TempDir()}
+
+	_, origin, err := loginAgainst(t, plane, store)
+
+	require.Error(t, err, "a login that kept nothing must not report success")
+	require.Contains(t, err.Error(), "store the credential")
+	require.Contains(t, err.Error(), "was revoked",
+		"and it has to say the token is gone, or the reader has to guess")
+
+	// The observable end state, which is the only thing worth asserting: the
+	// control plane was told to withdraw the token it had just issued.
+	require.Equal(t, []string{"Bearer afu_the_minted_token"}, plane.revocations())
+
+	// And nothing was left behind on this machine either. A keychain that
+	// refuses is not permission to write the token to a file instead.
+	_, loadErr := store.Load(origin)
+	require.ErrorIs(t, loadErr, auth.ErrNotSignedIn)
+}
+
+// The revocation can itself fail, and then the token really is live. Saying so
+// is the difference between somebody revoking it in the console and somebody
+// never learning it exists.
+func TestLogin_AStoreFailureAndAFailedRevocationSayTheTokenIsStillLive(t *testing.T) {
+	plane := &devicePlane{refuseLogout: true}
+	store := &auth.Store{Ring: refusingRing{}, Dir: t.TempDir()}
+
+	_, _, err := loginAgainst(t, plane, store)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "still live", "the one fact somebody has to act on")
+	require.Contains(t, err.Error(), "Command line", "and where to go and act on it")
+	require.Len(t, plane.revocations(), 1, "it did try")
+}
+
+// The ordinary path is unchanged: a store that works keeps the token and
+// revokes nothing. Without this the change above could be "revoke every login".
+func TestLogin_ASuccessfulLoginKeepsItsTokenAndRevokesNothing(t *testing.T) {
+	plane := &devicePlane{}
+	store := storeForTest(t)
+
+	out, origin, err := loginAgainst(t, plane, store)
+
+	require.NoError(t, err)
+	require.Empty(t, plane.revocations(), "a successful login withdraws nothing")
+	require.Contains(t, out, "Signed in as newcomer")
+
+	cred, loadErr := store.Load(origin)
+	require.NoError(t, loadErr)
+	require.Equal(t, "afu_the_minted_token", cred.Token)
+	require.Equal(t, "newcomer", cred.Organization)
+}
+
+// The last hop, which is a struct field and therefore the easiest to lose.
+//
+// The credential goes af login's store -> signedInControlPlane ->
+// env.Options -> telemetry -> the bearer on a batch. The env package's own test
+// covers the second half against a real HTTP server. This covers the first,
+// through the function every lifecycle command actually calls, because a
+// literal that stopped copying the field would leave every part of the chain
+// passing and the product reporting nothing.
+func TestLifecycle_AnOrchestratorCarriesTheCredentialAfLoginStored(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "Dockerfile"),
+		[]byte("FROM scratch\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "antifailure.yaml"),
+		[]byte(manifestForTest), 0o600))
+
+	store := storeForTest(t)
+	require.NoError(t, store.Save(auth.Credential{
+		ControlPlane: auth.Normalise("https://cp.example.test"),
+		Token:        "afu_from_af_login",
+		Login:        "newcomer",
+		Organization: "newcomer",
+	}))
+
+	e := &Env{
+		Out:         NewOutput(io.Discard, io.Discard),
+		WorkDir:     root,
+		Getenv:      func(k string) string { return map[string]string{"AF_CONTROL_PLANE_URL": "https://cp.example.test"}[k] },
+		Clock:       clock.NewFake(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)),
+		Credentials: store,
+		Redactor:    redact.New(),
+	}
+
+	o, _, err := orchestratorWithManifest2(e, lifecycleOptions{branch: "main", silent: true})
+	require.NoError(t, err)
+
+	url, token := o.ControlPlane()
+	require.Equal(t, "https://cp.example.test", url)
+	require.Equal(t, "afu_from_af_login", token)
+}
+
+// And a machine nobody signed in carries neither, so a run that never asked for
+// a control plane does not acquire one.
+func TestLifecycle_NoCredentialLeavesTheOrchestratorWithNoControlPlane(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "Dockerfile"),
+		[]byte("FROM scratch\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "antifailure.yaml"),
+		[]byte(manifestForTest), 0o600))
+
+	e := &Env{
+		Out:         NewOutput(io.Discard, io.Discard),
+		WorkDir:     root,
+		Getenv:      func(string) string { return "" },
+		Clock:       clock.NewFake(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)),
+		Credentials: storeForTest(t),
+		Redactor:    redact.New(),
+	}
+
+	o, _, err := orchestratorWithManifest2(e, lifecycleOptions{branch: "main", silent: true})
+	require.NoError(t, err)
+
+	url, token := o.ControlPlane()
+	require.Empty(t, url, "an address with no token would turn on the CI identity exchange")
+	require.Empty(t, token)
+}
+
+// The smallest manifest the loader accepts, so these two tests are about the
+// credential rather than about schema validation.
+const manifestForTest = `version: 1
+name: shop
+services:
+  - name: web
+    kind: web
+    build:
+      strategy: dockerfile
+      dockerfile: Dockerfile
+    port: 3000
+`

--- a/engine/internal/cli/workload_report.go
+++ b/engine/internal/cli/workload_report.go
@@ -121,15 +121,22 @@ type hostedReporter struct {
 // error here is a control plane that is configured and unusable, which is worth
 // saying out loud.
 func newHostedReporter(e *Env, stateDir, envID string) (*hostedReporter, error) {
+	origin := controlPlaneFor(e, "")
 	token := controlplane.TokenFromEnvironment(func(k string) (string, bool) {
 		v := e.Getenv(k)
 		return v, v != ""
 	})
 	if token == "" {
+		// The credential af login stored. Without this line a person who had
+		// signed this terminal in still reported their workload run to nobody,
+		// which is the same gap telemetry had.
+		token = storedToken(e, origin)
+	}
+	if token == "" {
 		return nil, nil
 	}
 	client, err := controlplane.New(controlplane.Options{
-		BaseURL:  controlPlaneFor(e, ""),
+		BaseURL:  origin,
 		Token:    token,
 		Clock:    e.Clock,
 		Redactor: e.Redactor,

--- a/engine/internal/env/env.go
+++ b/engine/internal/env/env.go
@@ -119,6 +119,16 @@ type Options struct {
 	// Getenv reads the environment this command is running in, for sandbox
 	// credentials. Nil uses the process environment.
 	Getenv func(string) string
+	// ControlPlaneURL and ControlPlaneToken are the credential af login stored
+	// on this machine, resolved by the CLI and passed through to telemetry.
+	//
+	// BOTH OR NEITHER. An address on its own would turn on the GitHub Actions
+	// identity exchange for every CI run in the world, which attachControlPlane
+	// deliberately leaves off unless a repository has said it uses a control
+	// plane. They are set together, only when a credential was actually found,
+	// so a machine nobody has signed in behaves exactly as it did before.
+	ControlPlaneURL   string
+	ControlPlaneToken string
 	// Secrets is where declared variables are looked up. Nil builds the
 	// default chain: this process's environment, then a .env beside the
 	// manifest, then the encrypted local store.
@@ -143,6 +153,19 @@ type Orchestrator struct {
 	envID    string
 	progress func(string)
 	sinks    []events.Sink
+}
+
+// ControlPlane reports where this orchestrator will report, and with what.
+//
+// Two empty strings mean nowhere, which is the ordinary state of a laptop.
+//
+// It exists because the credential travels CLI -> Options -> telemetry as two
+// struct field copies, and a copy that is forgotten is invisible from every
+// direction: the engine still builds, still runs, and still reports to nobody,
+// which is the state af login was in for as long as it existed. This is what
+// lets the CLI assert its half of that chain rather than trusting the literal.
+func (o *Orchestrator) ControlPlane() (string, string) {
+	return o.opts.ControlPlaneURL, o.opts.ControlPlaneToken
 }
 
 // New returns an orchestrator for a branch.
@@ -370,13 +393,15 @@ func (o *Orchestrator) openLocking(ctx context.Context, command, lockName string
 	// A failure to attach is reported and survived. An environment must not
 	// fail to come up because a log directory is read only.
 	tel, terr := telemetry.Attach(ctx, s.bus, telemetry.Options{
-		StateDir: stateDir,
-		EnvID:    o.envID,
-		Redactor: o.opts.Redactor,
-		Clock:    o.opts.Clock,
-		State:    s.db,
-		Getenv:   o.opts.Getenv,
-		Version:  o.opts.Version,
+		StateDir:          stateDir,
+		EnvID:             o.envID,
+		Redactor:          o.opts.Redactor,
+		Clock:             o.opts.Clock,
+		State:             s.db,
+		Getenv:            o.opts.Getenv,
+		Version:           o.opts.Version,
+		ControlPlaneURL:   o.opts.ControlPlaneURL,
+		ControlPlaneToken: o.opts.ControlPlaneToken,
 		OnWarning: func(msg string) {
 			o.progress(msg)
 		},

--- a/engine/internal/env/reporting.go
+++ b/engine/internal/env/reporting.go
@@ -62,13 +62,15 @@ func (o *Orchestrator) openReporting(ctx context.Context) *session {
 	s.bus = events.NewBus(o.opts.Clock)
 
 	tel, terr := telemetry.Attach(ctx, s.bus, telemetry.Options{
-		StateDir: stateDir,
-		EnvID:    o.envID,
-		Redactor: o.opts.Redactor,
-		Clock:    o.opts.Clock,
-		State:    s.db,
-		Getenv:   o.opts.Getenv,
-		Version:  o.opts.Version,
+		StateDir:          stateDir,
+		EnvID:             o.envID,
+		Redactor:          o.opts.Redactor,
+		Clock:             o.opts.Clock,
+		State:             s.db,
+		Getenv:            o.opts.Getenv,
+		Version:           o.opts.Version,
+		ControlPlaneURL:   o.opts.ControlPlaneURL,
+		ControlPlaneToken: o.opts.ControlPlaneToken,
 		OnWarning: func(msg string) {
 			o.progress(msg)
 		},

--- a/engine/internal/env/signedin_internal_test.go
+++ b/engine/internal/env/signedin_internal_test.go
@@ -1,0 +1,133 @@
+package env
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/internal/clock"
+	"github.com/antifailure/antifailure/engine/internal/events"
+	"github.com/antifailure/antifailure/engine/internal/redact"
+	"github.com/antifailure/antifailure/engine/pkg/schema"
+)
+
+// The seam between the CLI and telemetry, exercised rather than read.
+//
+// The credential af login stored travels CLI -> env.Options -> telemetry.Options
+// -> the sink's bearer, and three of those four hops are one struct field being
+// copied into another. A field copy is exactly the kind of change that looks
+// done in a diff and is missing in the product, so this runs the real code:
+// openReporting is the reporting-only session `af test` opens, it is the one
+// path that attaches telemetry without needing Docker, and what it produces is
+// asserted at an HTTP server rather than at a variable.
+
+// ingest is a control plane that records the bearer of every batch it takes.
+type ingest struct {
+	mu      sync.Mutex
+	bearers []string
+	ids     []string
+}
+
+func (i *ingest) seen() ([]string, []string) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return append([]string(nil), i.bearers...), append([]string(nil), i.ids...)
+}
+
+func (i *ingest) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+	var batch struct {
+		Events []struct {
+			ID string `json:"id"`
+		} `json:"events"`
+	}
+	_ = json.Unmarshal(body, &batch)
+
+	i.mu.Lock()
+	i.bearers = append(i.bearers, r.Header.Get("authorization"))
+	for _, e := range batch.Events {
+		i.ids = append(i.ids, e.ID)
+	}
+	i.mu.Unlock()
+
+	w.Header().Set("content-type", "application/json")
+	_, _ = w.Write([]byte(`{"accepted":` + itoa(len(batch.Events)) + `}`))
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}
+
+func reportingOrchestrator(t *testing.T, url, token string) *Orchestrator {
+	t.Helper()
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, StateDir), 0o755))
+	return &Orchestrator{
+		opts: Options{
+			Root:              root,
+			Manifest:          &schema.Manifest{Version: 1},
+			Branch:            "main",
+			Clock:             clock.NewFake(time.Unix(1700000000, 0).UTC()),
+			Redactor:          redact.New(),
+			Getenv:            func(string) string { return "" },
+			Progress:          func(string) {},
+			ControlPlaneURL:   url,
+			ControlPlaneToken: token,
+		},
+		envID:    "shop-main-a1b2",
+		progress: func(string) {},
+	}
+}
+
+func TestReportingSessionUsesTheCredentialAfLoginStored(t *testing.T) {
+	plane := &ingest{}
+	srv := httptest.NewServer(plane)
+	t.Cleanup(srv.Close)
+
+	o := reportingOrchestrator(t, srv.URL, "afu_from_af_login")
+	s := o.openReporting(t.Context())
+	require.NotNil(t, s, "the reporting session opened")
+
+	s.bus.Info("shop-main-a1b2", events.EnvReady, "the environment is ready")
+	s.close()
+
+	bearers, ids := plane.seen()
+	require.NotEmpty(t, ids, "the event reached the control plane")
+	require.Equal(t, []string{"Bearer afu_from_af_login"}, bearers,
+		"and it was authenticated with the credential the CLI passed in")
+}
+
+// Nothing signed in reports to nobody, which is what every laptop with no
+// account does and what this change must not have altered.
+func TestReportingSessionWithNoCredentialSendsNothing(t *testing.T) {
+	plane := &ingest{}
+	srv := httptest.NewServer(plane)
+	t.Cleanup(srv.Close)
+
+	o := reportingOrchestrator(t, srv.URL, "")
+	s := o.openReporting(t.Context())
+	require.NotNil(t, s)
+
+	s.bus.Info("shop-main-a1b2", events.EnvReady, "the environment is ready")
+	s.close()
+
+	bearers, ids := plane.seen()
+	require.Empty(t, ids)
+	require.Empty(t, bearers)
+}

--- a/engine/internal/telemetry/oidc_test.go
+++ b/engine/internal/telemetry/oidc_test.go
@@ -210,16 +210,26 @@ type mintingRun struct {
 // closes, which is the whole lifecycle a command has.
 func runOne(t *testing.T, r *runner, h *hosted, env map[string]string) *mintingRun {
 	t.Helper()
-	return runWith(t, r, h, env, true)
+	return runWith(t, r, h, env, true, "")
 }
 
 // runWithoutAddress is the same, for a repository that names no control plane.
 func runWithoutAddress(t *testing.T, r *runner, h *hosted, env map[string]string) *mintingRun {
 	t.Helper()
-	return runWith(t, r, h, env, false)
+	return runWith(t, r, h, env, false, "")
 }
 
-func runWith(t *testing.T, r *runner, h *hosted, env map[string]string, addressed bool) *mintingRun {
+// runSignedIn is the same, for a machine somebody has run af login on. The CLI
+// hands the stored credential over rather than telemetry reading it, so a test
+// hands it over the same way.
+func runSignedIn(t *testing.T, r *runner, h *hosted, env map[string]string, stored string) *mintingRun {
+	t.Helper()
+	return runWith(t, r, h, env, true, stored)
+}
+
+func runWith(
+	t *testing.T, r *runner, h *hosted, env map[string]string, addressed bool, stored string,
+) *mintingRun {
 	t.Helper()
 
 	runnerSrv := httptest.NewServer(r)
@@ -252,14 +262,15 @@ func runWith(t *testing.T, r *runner, h *hosted, env map[string]string, addresse
 
 	out := &mintingRun{runner: r, plane: h, dir: dir}
 	tel, err := Attach(t.Context(), bus, Options{
-		StateDir:        dir,
-		EnvID:           "shop-main-a1b2",
-		Redactor:        redact.New(),
-		Clock:           fake,
-		State:           db,
-		ControlPlaneURL: address,
-		Getenv:          func(k string) string { return full[k] },
-		OnWarning:       func(s string) { out.warned = append(out.warned, s) },
+		StateDir:          dir,
+		EnvID:             "shop-main-a1b2",
+		Redactor:          redact.New(),
+		Clock:             fake,
+		State:             db,
+		ControlPlaneURL:   address,
+		ControlPlaneToken: stored,
+		Getenv:            func(k string) string { return full[k] },
+		OnWarning:         func(s string) { out.warned = append(out.warned, s) },
 	})
 	require.NoError(t, err)
 

--- a/engine/internal/telemetry/signedin_test.go
+++ b/engine/internal/telemetry/signedin_test.go
@@ -1,0 +1,86 @@
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// What af login is for, tested where it was missing.
+//
+// THE FAILURE THESE EXIST TO PREVENT. `af login` runs the device grant, a
+// person approves a terminal in their browser, and the token goes into the
+// operating system's keyring. Nothing then read it: `attachControlPlane` took a
+// token from AF_CONTROL_PLANE_TOKEN or from a GitHub Actions identity and from
+// nowhere else, so somebody who signed in, ran `af up`, and opened the console
+// saw an empty environments list forever. Every part looked configured. No
+// event was ever sent.
+//
+// It is tested here rather than in the cli package because here is where the
+// question is answerable end to end: the assertion is that the event arrives at
+// a control plane carrying that bearer, not that a field was copied from one
+// struct into another.
+
+// The one this fixes.
+func TestASignedInTerminalReportsWithTheCredentialAfLoginStored(t *testing.T) {
+	r := &runner{value: "signed.workflow.identity"}
+	h := &hosted{issued: "minted-for-this-job"}
+
+	// No AF_CONTROL_PLANE_TOKEN, and no GitHub Actions either: a laptop.
+	run := runSignedIn(t, r, h, map[string]string{}, "afu_from_af_login")
+
+	require.Len(t, run.log, 1, "the local log still gets it")
+	require.Equal(t, []string{run.log[0].ID}, run.plane.ingested(),
+		"the event reached the control plane, which is the whole point of signing in")
+	// The bearer rather than merely the arrival: an ingestion endpoint that
+	// ignored the header would let a broken credential pass this test.
+	require.Equal(t, []string{"Bearer afu_from_af_login"}, run.plane.bearers())
+	require.Equal(t, 0, run.runner.calls(),
+		"and no workflow identity was minted, there being a credential already")
+}
+
+// The environment still wins, which keeps CI and every deliberate override
+// working. A token somebody exported is a decision; a credential on the machine
+// is a default, and a default does not get to overrule a decision.
+func TestTheEnvironmentTokenWinsOverTheStoredCredential(t *testing.T) {
+	r := &runner{value: "signed.workflow.identity"}
+	h := &hosted{issued: "minted-for-this-job"}
+
+	run := runSignedIn(t, r, h, map[string]string{
+		"AF_CONTROL_PLANE_TOKEN": "from-the-environment",
+	}, "afu_from_af_login")
+
+	require.Equal(t, []string{"Bearer from-the-environment"}, run.plane.bearers())
+}
+
+// And the stored credential wins over the workflow identity, which only
+// arises on a self hosted runner somebody has also signed in on. Either would
+// work; using the one a person chose means the run is attributed to them.
+func TestTheStoredCredentialWinsOverTheWorkflowIdentity(t *testing.T) {
+	r := &runner{value: "signed.workflow.identity"}
+	h := &hosted{issued: "minted-for-this-job"}
+
+	run := runSignedIn(t, r, h, map[string]string{
+		identityURLEnv:   "present",
+		identityTokenEnv: "the-runners-request-token",
+	}, "afu_from_af_login")
+
+	require.Equal(t, []string{"Bearer afu_from_af_login"}, run.plane.bearers())
+	require.Equal(t, 0, run.plane.exchangeCount(), "nothing was exchanged")
+	require.Equal(t, 0, run.runner.calls())
+}
+
+// A machine nobody has signed in behaves exactly as it did before this existed.
+// Worth a test of its own: the change is a new source of credentials, and the
+// way a new source breaks things is by producing one where there was none.
+func TestNoCredentialAnywhereStillReportsToNobodyAndDoesNotFail(t *testing.T) {
+	r := &runner{value: "signed.workflow.identity"}
+	h := &hosted{issued: "minted-for-this-job"}
+
+	run := runSignedIn(t, r, h, map[string]string{}, "")
+
+	require.Empty(t, run.plane.ingested(), "no credential, no report")
+	require.Empty(t, run.plane.bearers())
+	require.Len(t, run.log, 1, "and the run is unaffected and still logged locally")
+	require.Equal(t, 0, run.runner.calls())
+}

--- a/engine/internal/telemetry/telemetry.go
+++ b/engine/internal/telemetry/telemetry.go
@@ -81,8 +81,20 @@ type Options struct {
 	Getenv func(string) string
 	// Version is the engine version, reported as a trace attribute.
 	Version string
-	// ControlPlaneURL overrides AF_CONTROL_PLANE_URL, for tests.
+	// ControlPlaneURL overrides AF_CONTROL_PLANE_URL, for tests and for a
+	// caller that already knows which control plane the credential below
+	// belongs to.
 	ControlPlaneURL string
+	// ControlPlaneToken is the credential af login stored on this machine, or
+	// "" when nobody has signed this terminal in.
+	//
+	// PASSED IN RATHER THAN READ HERE, and that is the whole reason it is a
+	// field. This package must not open a credential store: it is the package
+	// that writes support bundles and event logs, and a token it could read is
+	// a token it could spill into one. The CLI knows where the credential lives
+	// and hands over the value, which keeps the rule that nothing under
+	// telemetry or controlplane touches a secret on disk.
+	ControlPlaneToken string
 	// TraceExporter replaces the OTLP exporter, for tests.
 	TraceExporter sdktrace.SpanExporter
 	// OnWarning receives the reasons a consumer could not be attached. Nil
@@ -193,14 +205,22 @@ func Attach(ctx context.Context, bus *events.Bus, opts Options) (*Telemetry, err
 // No token is not a failure. Most runs are on a laptop with no control plane at
 // all, and the engine is designed so that everything works without one.
 //
-// Where the token comes from is the whole reason this function has two sources.
-// The environment is first, because a user who has set one has said what they
-// want and a self hosted installation has no runner to ask. Failing that, a job
-// running in GitHub Actions can prove what it is and trade that proof for a
-// short lived credential, which is what makes a hosted control plane work with
-// no secret in the repository at all. Before that existed this function reached
-// the empty token on every CI run in the world, returned here, and built no
-// sink: forty event types went to the local log and nowhere else.
+// Where the token comes from is the whole reason this function has three
+// sources. The environment is first, because a user who has set one has said
+// what they want and a self hosted installation has no runner to ask. Then the
+// credential af login stored, which is how a person who signed this terminal in
+// gets their own runs into their own console without exporting anything. Then a
+// job running in GitHub Actions, which can prove what it is and trade that proof
+// for a short lived credential, and is what makes a hosted control plane work
+// with no secret in the repository at all. Before that existed this function
+// reached the empty token on every CI run in the world, returned here, and built
+// no sink: forty event types went to the local log and nowhere else.
+//
+// The stored credential was missing for as long as af login existed. Somebody
+// signed a terminal in, ran af up, and watched an empty environments list,
+// because the only thing that ever read that credential was af env pull. A
+// sign-in that connects nothing is the same shape of failure as the sink with
+// no token: everything looks configured and no event arrives.
 func (t *Telemetry) attachControlPlane(
 	ctx context.Context, bus *events.Bus, opts Options, c clock.Clock, getenv func(string) string,
 ) error {
@@ -229,6 +249,13 @@ func (t *Telemetry) attachControlPlane(
 	var renew func(context.Context) (string, error)
 
 	token := controlplane.TokenFromEnvironment(lookup)
+	if token == "" {
+		// The credential af login stored, handed over by the CLI. Whoever sets
+		// it sets ControlPlaneURL with it, to the origin the credential was
+		// stored under, so a terminal signed in to a self hosted plane reports
+		// there rather than to the hosted default an empty address resolves to.
+		token = opts.ControlPlaneToken
+	}
 	// An address is what says this repository uses a control plane at all.
 	//
 	// Only for the minted path, and the asymmetry is the point. Setting a token

--- a/web/apps/api/src/routers/index.ts
+++ b/web/apps/api/src/routers/index.ts
@@ -1226,11 +1226,28 @@ const orgRouter = router({
 })
 
 const tokensRouter = router({
+  /**
+   * Every token this organization holds, of both kinds.
+   *
+   * `kind` and `expires_at` are selected because the console shows the two
+   * kinds side by side and they are not the same thing to a reader: an
+   * `engine` token is a secret somebody pasted into CI and it does not expire,
+   * a `cli` token is a terminal a person signed in through the device grant
+   * and it dies after ninety days. A list that called both "token" and gave
+   * neither an expiry would make revoking your own laptop look like revoking a
+   * build machine.
+   *
+   * Deliberately unfiltered by kind, unlike `/v1/tokens`, which serves
+   * `af token` and sees `engine` rows only so that a command about CI cannot
+   * revoke the credential the person running it is holding. Here the whole
+   * point is the opposite: this is the only place a person can see which
+   * terminals are signed in to their account and take one away.
+   */
   list: orgProcedure('tokens.manage').query(async ({ ctx }) => {
     const c = ctx as OrgContext
     return c.pool.withTenant(c.tenant, async (db) =>
       db.execute(sql`
-        SELECT id, name, prefix, created_at, last_used_at, revoked_at
+        SELECT id, name, prefix, kind, created_at, last_used_at, revoked_at, expires_at
         FROM engine_tokens ORDER BY created_at DESC`),
     )
   }),

--- a/web/apps/api/src/server.ts
+++ b/web/apps/api/src/server.ts
@@ -1485,7 +1485,7 @@ export function createServer(options: ServerOptions) {
           {
             error:
               'That login was not declined: it was already approved, already answered, or is no longer live. ' +
-              'If a terminal has a token it should not have, revoke it under Keys.',
+              'If a terminal has a token it should not have, revoke it under Command line.',
           },
           409,
         )


### PR DESCRIPTION
## The path this was meant to prove

A person lands on the site, signs up for free, and gets to a working command
line. Every step was traced by reading the code and then by running it against
a local control plane with a real free plan organization on it.

The device authorization grant is complete and correct. `af login` prints a
code, `/device` shows what is being asked for, approval mints a scoped ninety
day token, and none of that is gated behind a plan or an operator: a free
organization's owner can sign a terminal in. That was verified by running it,
including the browser half.

Three things were not.

## A sign in that connected nothing

`attachControlPlane` in the telemetry package took a token from
`AF_CONTROL_PLANE_TOKEN` or from a GitHub Actions workflow identity and from
nowhere else. The credential `af login` stores was read by `af env pull`,
`af token`, `af provider` and `af whoami`, and by nothing that reports a run.

So somebody signed up, signed their terminal in, ran `af up`, and watched an
empty environments list forever. Every part looked configured and no event was
ever sent, which is the same failure the sink with no token had before the
workflow identity existed.

The CLI now resolves the credential and the origin it was issued by, together
or not at all, and passes both through `env.Options` to telemetry. `af up`,
`af test`, `af ci` and `af workload` report with it. The environment token
still wins, because exporting one is a decision and a credential on the machine
is a default. A machine nobody has signed in behaves exactly as it did before,
which has its own test: the way a new credential source breaks things is by
producing one where there was none.

Nothing under `telemetry` or `controlplane` opens a credential store. Those are
the packages that write support bundles and event logs, and a token they could
read is a token they could spill into one, so the value is handed to them.

## No screen that mentioned the terminal

Nothing in the console had ever said the command line exists. `grep` for
`af login`, `af init` or `install.sh` across `console/` returned nothing at all.
A new organization landed on an environments list whose three empty cards each
explained that something appears "when the engine reports one", and no screen
in the product said how to get an engine, sign it in, or run it. The install
command lives on the marketing site and in the documentation, which is where
somebody who has not signed up yet is.

There is now a **Command line** page: the install command, the sign-in command,
`af init` and `af start`, and the terminals signed in. Both empty states on the
environments page lead to it.

The sign-in command names the control plane the console is being served from,
and says nothing when that is already the hosted instance, so the shortest
correct command is always the one on screen. A plain `af login` on a self
hosted plane signs a terminal in to somebody else's control plane and stores a
credential for an origin nothing that person runs will ever talk to.

## A token that could be granted and not seen

`tokens.list` and `tokens.revoke` were written, permissioned and audited, and no
console called either of them. A ninety day credential granted by `af login`
could be neither seen nor taken away from any screen in the product. Both are
on the new page, telling a terminal apart from an engine token, because
revoking your own laptop and revoking a build machine are not the same act.

## A login that could not keep its token and kept it anyway

The token is minted the moment somebody approves, before this machine has
written it anywhere. If the write then fails, `af login` returned an error and
stopped: a live ninety day credential nobody held, nobody could see and nobody
could revoke, with another one beside it on every retry.

It is not hypothetical. On macOS over ssh or under a launchd agent there is
nobody to authorise the keychain prompt and `security` reports the
authorization was cancelled, which is exactly the machine with no browser the
device grant exists for. It happened on the first `af login` run here.

The login now revokes what it cannot keep, and when the revocation fails too it
says the token is still live and where to go and revoke it.

## The credential CI needs

`mintEngineToken` exists and has a real call site: `POST /v1/tokens` answers 201
with the token exactly once, prefixed `aft_`. What it does not have, and must
not, is a browser path: the route is gated on a bearer credential and there is
no cookie route to it, because a browser session that could mint would be a
credential factory behind a cookie. So no screen can reach it, which leaves
telling somebody as the only thing a console can do, and nothing did.

The page carries the two commands now, and it leads with the case that needs no
token at all: a GitHub Actions job gives itself `id-token: write` and the engine
trades that identity for a short lived credential. Saying that second would have
had people pasting a permanent secret into a repository to solve a problem the
identity exchange already solves.

Proved by running, against a free plan organization on a local control plane:

- a device code asking for `tokens.manage`, and the approval screen showed
  `TOKENS.MANAGE` before anything was granted, which is the whole of the claim
  that a capability cannot be granted without being read
- `POST /v1/tokens` answered **201** with `aft_...`, so the mint is reachable by
  a free organization
- that engine token could not mint a second one: **401**, because `identify`
  accepts only `kind='cli'`
- the minted token appears in the console's own list, as `engine`, where it can
  be revoked

The one plan gate on it is read rather than run. `cliCaller` checks
`hasHostedAccess` first, so a plane that sets `AF_HOSTED_REQUIRED_PLAN` answers
402 to a free organization before anything else. I could not exercise that:
`main.ts` refuses to start with a plan gate and no billing, and configuring
Stripe was out of bounds.

## What was proved by running

- A free plan organization with one owner, no repositories and no environments,
  which is what self serve signup leaves behind.
- `af login` against that control plane, approved by clicking Approve on
  `/device` in a real browser. Token minted, scoped `environments.view`,
  `runs.view`, `events.write`.
- The store failure and the revocation, against the real macOS keychain and the
  real control plane.
- Revoke on the new page: `GET /v1/whoami` with the token answered 200, the
  button was clicked in the rendered page, and the same request then answered
  401.
- `af init` in a scratch repository, which writes a manifest in a second with no
  account, and `af start`, which names the next command.
- Both pages photographed at 320 and 1440, signed in, measured for horizontal
  overflow: none. Owner and member roles both.

Each engine change has a test that was watched failing without the change:
the telemetry credential, the lifecycle wiring, and the revocation.

## Out of scope, and written down rather than fixed

- Self serve signup itself is #187. Until it lands, `completeSignIn` gives an
  organization only where a membership already exists, and
  `/auth/device/approve` refuses a session with no organization, so `af login`
  cannot complete for a brand new account. This work assumes that PR's
  `provision.ts`.
- `AF_HOSTED_REQUIRED_PLAN` only accepts `enterprise`, so on a plane that sets
  it every operational route answers 402 for a free organization. The console
  explains that wall honestly. Whether the hosted plane should set it at all,
  now that free is a plan, is a decision for whoever owns hosted.
- `af mcp` builds its orchestrator without a CLI `Env`, so it still reads only
  `AF_CONTROL_PLANE_TOKEN`. Giving the mcp package a credential reader would
  contradict the rule this change relies on.
