### PR TITLE
tools: the preview seeded rows, not the states the pages branch on

### DIFF
--- a/tools/preview/README.md
+++ b/tools/preview/README.md
@@ -41,6 +41,23 @@ eleven operators including one suspended and one never provisioned, ten feature
 flags across all three states with one killed, and sixty operator audit entries
 appended through the real chain so the log verifies rather than merely existing.
 
+## Seed the states the pages branch on
+
+Rows are not enough. A page that distinguishes a live credential from an
+expired one from a revoked one renders one branch out of many against a seed of
+live credentials, and a screenshot of it passes review while showing none of the
+thinking in it. So the seeder writes the STATES: suspended organizations beside
+active ones, an operator who has never been provisioned beside one who has, a
+flag that was killed beside one that is merely off, an expired token and a
+revoked token, and a webhook delivery that matched no organization, which is the
+row an operator goes looking for when a customer says their events go nowhere.
+
+The other half of that rule is not seeding what the product does not write.
+There are no MCP servers and no outbound webhook subscriptions here, because
+this product registers neither, and the pages that say so are stating a finding.
+A seeder that invented rows for them would make exactly the pages that refuse to
+draw invented data start drawing it, in the one place a reviewer looks.
+
 ## Nothing in the tree carries a credential
 
 The seeded operator is `operator@preview.local`. Its password is **generated for

--- a/tools/preview/seed.ts
+++ b/tools/preview/seed.ts
@@ -233,6 +233,15 @@ async function main(): Promise<void> {
     await seedFlags(admin)
     line(`${FLAGS.length} feature flags, which are also this installation's kill switches`)
 
+    const credentials = await seedCredentials(admin)
+    line(
+      `${credentials} further credentials: a cli token, an oidc token behind its binding, ` +
+        'one revoked and one expired',
+    )
+
+    const deliveries = await seedDeliveries(admin)
+    line(`${deliveries} webhook deliveries, one of which matched no organization`)
+
     const switched = await seedPlatformControls(admin)
     line(
       switched === null
@@ -388,6 +397,109 @@ async function seedFlags(admin: Sql): Promise<void> {
         ON CONFLICT DO NOTHING`
     }
   }
+}
+
+/**
+ * The credentials a page has to draw more than one branch for.
+ *
+ * seedStaging writes live `engine` tokens and nothing else, and a page that
+ * distinguishes live from expired from revoked, and an organization's engine
+ * token from a person's cli token from a workflow's oidc token, renders one
+ * branch out of nine against that. Asked for by the lane building API Keys,
+ * who found a revoke button being offered on a credential the authenticator
+ * already refuses.
+ *
+ * The three CHECK constraints are the shape of the thing rather than an
+ * obstacle to it. A cli token must carry a user, an oidc token must carry an
+ * expiry, and an oidc token must carry a binding, which is why the binding is
+ * written first and the token points at it: revoking a binding has to be able
+ * to reach the credentials it produced.
+ */
+async function seedCredentials(admin: Sql): Promise<number> {
+  const [org] = await admin<{ id: string }[]>`
+    SELECT id FROM organizations WHERE slug = 'antifailure' LIMIT 1`
+  if (!org) return 0
+  const [user] = await admin<{ id: string }[]>`
+    SELECT user_id AS id FROM members WHERE org_id = ${org.id} ORDER BY created_at LIMIT 1`
+  if (!user) return 0
+
+  const day = 86_400_000
+  const ago = (days: number) => new Date(Date.now() - days * day)
+  const ahead = (days: number) => new Date(Date.now() + days * day)
+
+  const [binding] = await admin<{ id: string }[]>`
+    INSERT INTO oidc_repository_bindings (org_id, repository, created_by, created_at, last_used_at)
+    VALUES (${org.id}, 'antifailure/checkout', ${user.id}, ${ago(60)}, ${ago(1)})
+    ON CONFLICT DO NOTHING
+    RETURNING id`
+  const [live] = await admin<{ id: string }[]>`
+    SELECT id FROM oidc_repository_bindings WHERE repository = 'antifailure/checkout' LIMIT 1`
+  const bindingId = binding?.id ?? live?.id
+  if (!bindingId) return 0
+
+  // name, kind, prefix, user, binding, created, last used, expires, revoked
+  const rows: [string, string, string, string | null, string | null, Date, Date | null, Date | null, Date | null][] = [
+    ['grace on her laptop', 'cli', 'afc_ur41', user.id, null, ago(40), ago(2), null, null],
+    ['checkout workflow', 'oidc', 'afo_9k2p', null, bindingId, ago(9), ago(1), ahead(1), null],
+    ['an expired workflow token', 'oidc', 'afo_3xd7', null, bindingId, ago(30), ago(28), ago(27), null],
+    ['a laptop that was lost', 'cli', 'afc_7q1w', user.id, null, ago(120), ago(96), null, ago(95)],
+    ['a rotated engine token', 'engine', 'afe_5m8z', null, null, ago(200), ago(150), null, ago(149)],
+  ]
+
+  let made = 0
+  for (const [name, kind, prefix, userId, binding_id, created, lastUsed, expires, revoked] of rows) {
+    const [row] = await admin<{ id: string }[]>`
+      INSERT INTO engine_tokens
+        (org_id, name, kind, token_hash, prefix, user_id, binding_id,
+         created_at, last_used_at, expires_at, revoked_at)
+      VALUES (${org.id}, ${name}, ${kind},
+              decode(md5(${`${prefix}${name}`}) || md5(${name}), 'hex'), ${prefix},
+              ${userId}, ${binding_id}, ${created}, ${lastUsed}, ${expires}, ${revoked})
+      ON CONFLICT DO NOTHING
+      RETURNING id`
+    if (row) made += 1
+  }
+  return made
+}
+
+/**
+ * The webhook ledger, including a delivery that matched nobody.
+ *
+ * org_id is nullable because a delivery about an account this installation has
+ * never seen resolves to no organization, and that row is precisely the one an
+ * operator goes looking for when a customer reports their events go nowhere. A
+ * seed where every delivery resolved would never draw that branch, so this
+ * writes one that does not.
+ */
+async function seedDeliveries(admin: Sql): Promise<number> {
+  const orgs = await admin<{ id: string; slug: string }[]>`
+    SELECT id, slug FROM organizations ORDER BY created_at LIMIT 3`
+  if (orgs.length === 0) return 0
+
+  const minute = 60_000
+  const rows: [string, string | null, string | null, string, string | null, number, boolean, string | null][] = [
+    ['d0f1a2b3-0001', orgs[0]!.id, orgs[0]!.slug, 'pull_request', 'opened', 4, true, 'environment created'],
+    ['d0f1a2b3-0002', orgs[0]!.id, orgs[0]!.slug, 'pull_request', 'closed', 9, true, 'environment torn down'],
+    ['d0f1a2b3-0003', orgs[1]?.id ?? null, orgs[1]?.slug ?? null, 'push', null, 17, true, 'no environment for this branch'],
+    ['d0f1a2b3-0004', orgs[2]?.id ?? null, orgs[2]?.slug ?? null, 'installation', 'created', 40, true, 'installation recorded'],
+    // The one that matters. Never resolved, and never will be.
+    ['d0f1a2b3-0005', null, 'somebody-elses-org', 'pull_request', 'opened', 55, false, null],
+    ['d0f1a2b3-0006', null, 'a-fork-nobody-installed', 'push', null, 90, true, 'no organization holds this installation'],
+  ]
+
+  let made = 0
+  for (const [id, orgId, login, event, action, minutesAgo, handled, outcome] of rows) {
+    const received = new Date(Date.now() - minutesAgo * minute)
+    const [row] = await admin<{ delivery_id: string }[]>`
+      INSERT INTO github_deliveries
+        (delivery_id, org_id, account_login, event, action, received_at, handled_at, outcome)
+      VALUES (${id}, ${orgId}, ${login}, ${event}, ${action}, ${received},
+              ${handled ? new Date(received.getTime() + 900) : null}, ${outcome})
+      ON CONFLICT (delivery_id) DO NOTHING
+      RETURNING delivery_id`
+    if (row) made += 1
+  }
+  return made
 }
 
 /**


### PR DESCRIPTION
Follow up to 181, which landed the harness. This is the part that makes the
visual gate worth running.

`seedStaging` writes live `engine` tokens and nothing else. The API Keys page
distinguishes live from expired from revoked, and an organization's engine token
from a person's cli token from a workflow's oidc token, so against that seed it
drew one branch out of nine. A screenshot of it would have passed a visual
review while showing none of the behaviour in it, including the deliberate one:
an expired credential offers no revoke button, because the engine already
refuses it and a control whose effect cannot be observed is a dead capability.

## What it seeds

Five further credentials: a cli token belonging to a person, an oidc token
behind the binding that minted it, one expired, one revoked, and a rotated
engine token. The three CHECK constraints are the shape of the thing rather than
an obstacle to it. A cli token must carry a user, an oidc token must carry an
expiry and a binding, and the binding is written first so that revoking it can
reach the credentials it produced.

Six `github_deliveries` rows, one of them with a NULL `org_id`. That column is
nullable because a delivery about an account this installation has never seen
resolves to nobody, and that row is the page's actual purpose rather than an
edge case: it is what an operator hunts for when a customer reports their events
go nowhere.

Every column is on main and has been for a long time, so nothing is gated and
this cannot break a lane: `kind` and the cli constraint from 0012, `binding_id`
and the oidc constraints from 0025, the nullable `org_id` from 0021.

## What it deliberately does not seed

MCP servers and outbound webhook deliveries. This product registers neither, the
pages that say so are stating a finding, and a seeder inventing rows would make
exactly the pages that refuse to draw invented data start drawing it, in the one
place a reviewer looks. Both asked for by the lane that built those pages.

## Proved, not asserted

Ran the harness on this branch and photographed all 23 operator routes at 320
and 1440. 23 of 23 rendered cleanly, no horizontal overflow. Two of the pictures
are the point of the change, and here is which branch each one shows.

API Keys at 1440 now draws every standing and every kind in one table. The
expired workflow token reads `EXPIRED`, `27d ago`, and in the action column
"Expired, already refused" where every live row has a Revoke button. The revoked
person token and the revoked engine token read `REVOKED` with no button. The
live person token reads `PERSON` and names who it acts as. Below the table, the
GitHub workflow identities panel is no longer empty: it lists
`antifailure/checkout` as `LIVE` with 2 live tokens and its own Revoke, because
the binding and the two oidc tokens that point at it now exist. Before this
change every row in that table said `ENGINE` and `LIVE`, and that panel had
nothing in it.

Integrations and Webhooks at 1440 draws the deliveries table with four resolved
rows and two that were not: `somebody-elses-org` and `a-fork-nobody-installed`,
both showing "Matched no organization" in the warn colour, with outcomes
`NOT HANDLED` and `NO ORGANIZATION HOLDS THIS INSTALLATION`. That is the branch
a fully resolved seed can never draw, and it is the row the page exists for.

## The rule this adds to the README

Seed the states the pages branch on, not just the rows the tables hold. A
screenshot of a page whose interesting branches never render is a picture of a
page, not a verification of it. The second half of the rule is in the same
section: do not seed what the product does not write.

## Rebase note

Cherry picked onto main rather than rebased. The branch was 69 commits behind
and a two dot diff of its tip showed 20 deletions from `.gitignore` that were
not mine, they were main's newer file that the branch predated. Rebasing without
noticing would have turned this into a quiet revert of somebody else's ignore
rules. The file list against main is now exactly two entries, both under
`tools/preview`, 129 insertions and zero deletions.