### PR TITLE
infra: findings nobody had to act on, and ignores nothing could check

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -28,6 +28,7 @@ on:
       - 'infra/**'
       - 'tools/azguard/**'
       - 'tools/cost/**'
+      - 'tools/tfsecignores/**'
       - '.github/workflows/infra.yml'
   push:
     branches: [main]
@@ -35,6 +36,7 @@ on:
       - 'infra/**'
       - 'tools/azguard/**'
       - 'tools/cost/**'
+      - 'tools/tfsecignores/**'
 
 permissions:
   contents: read
@@ -86,6 +88,22 @@ jobs:
       # tfsec reads the configuration and needs no credentials, so it runs on
       # every pull request including one from a fork.
       #
+      # IT BLOCKS, and it did not until the findings were dealt with. Both
+      # halves of that matter. `--soft-fail` was the right setting while the
+      # step was broken and it is the reason eight findings sat unseen once it
+      # was fixed: a scanner whose output nobody has to act on becomes a scanner
+      # nobody reads. Every finding in this tree is now either fixed or carries
+      # an inline decision with an expiry, so there is nothing left for a soft
+      # failure to be soft about.
+      #
+      # It is also what makes those expiries mean anything. tfsec stops
+      # honouring an ignore on its date and reports the finding again; under
+      # `--soft-fail` that produces a green run and tells nobody, so every date
+      # in infra/terraform would be decorative. The version pinned above is
+      # archived upstream in favour of Trivy, so its ruleset does not move,
+      # which removes the usual cost of a blocking scanner: a branch that was
+      # green cannot go red because somebody else shipped a new rule.
+      #
       # INSTALLED BY HAND RATHER THAN BY THE ACTION, and the reason is the whole
       # of this block. aquasecurity/tfsec-action downloads tfsec by asking the
       # GitHub releases API which version is `latest`, and that request returned
@@ -110,7 +128,7 @@ jobs:
       # published one for that release. A mismatch fails the step, because a
       # scanner downloaded over the network with no integrity check is a worse
       # thing to run than no scanner.
-      - name: tfsec
+      - name: Install tfsec
         env:
           TFSEC_VERSION: v1.28.14
           TFSEC_SHA256: a32d0799bbefababaa4fcd814da9f4d251cd932789590b99d1d5fcb89ace6f68
@@ -124,10 +142,33 @@ jobs:
           }
           chmod +x /tmp/tfsec
           /tmp/tfsec --version
-          # --soft-fail is the same decision the action carried: findings are
-          # reported and do not break the build. What is no longer soft is the
-          # scanner failing to run.
-          /tmp/tfsec infra/terraform --soft-fail
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: tools/go.mod
+          cache-dependency-path: tools/go.sum
+
+      # THE RULE TFSEC HAS NO VERSION OF, AND IT RUNS BEFORE THE SCAN ON PURPOSE.
+      #
+      # A finding that cannot be fixed is recorded inline as
+      # `#tfsec:ignore:<rule>:exp:<date>` with the reasoning in prose beside it,
+      # which is the shape .govulncheck.yaml uses for the Go half. tfsec
+      # enforces the date and nothing else: it accepts a directive with no
+      # expiry at all, and it says nothing whatever about one that no longer
+      # suppresses anything. A suppression left behind after the finding is
+      # fixed reads as protection that is not there, and it hides the fact that
+      # the real finding moved or changed shape.
+      #
+      # Before the scan, because the two failures need telling apart. When an
+      # ignore lapses, tfsec reports the original finding and gives no hint that
+      # a decision expired, which sends the reader looking for a change nobody
+      # made. This step says "the decision to accept this expired on such a
+      # date" first, and the scan never runs.
+      - name: tfsec ignores are still true
+        run: GOTOOLCHAIN=local go run ./tools/tfsecignores -tfsec /tmp/tfsec .
+
+      - name: tfsec
+        run: /tmp/tfsec infra/terraform
 
   plan:
     name: plan

--- a/.gitignore
+++ b/.gitignore
@@ -170,6 +170,7 @@ runner/artifacts/
 /statuscheck
 /surfacecheck
 /tagsync
+/tfsecignores
 /varcheck
 /vulncheck
 /walkthrough

--- a/infra/terraform/modules/control-plane/keyvault.tf
+++ b/infra/terraform/modules/control-plane/keyvault.tf
@@ -60,9 +60,81 @@ resource "azurerm_key_vault" "this" {
   soft_delete_retention_days = 7
   purge_protection_enabled   = var.key_vault_purge_protection
 
+  # REACHABLE, AND NOT READABLE, AND THE SECOND HALF DOES ALL THE WORK.
+  #
+  # tfsec reports these four lines as CRITICAL under
+  # azure-keyvault-specify-network-acl: "Vault network ACL does not block access
+  # by default." It is right about the configuration. A scanner severity is a
+  # prior rather than a verdict, so this block says what reaching this endpoint
+  # actually gets somebody, and what closing it would cost.
+  #
+  # WHAT REACHING IT GETS YOU. Nothing without a Microsoft Entra token, and
+  # nothing with one unless its principal holds a Key Vault DATA role here.
+  # rbac_authorization_enabled above means vault access policies do not exist on
+  # this vault, so the complete list of principals that can read a secret is the
+  # list of role assignments in this file:
+  #
+  #   app_reads_secrets        Key Vault Secrets User, on the user-assigned
+  #                            identity the Container App and both jobs run as.
+  #   deployer_writes_secrets  Key Vault Secrets Officer, on the one operator
+  #                            object id both stacks pin in their tfvars.
+  #
+  # And one identity is deliberately absent: the pull request plan job.
+  # stacks/control-plane/ci.tf grants it Reader on the resource group and says
+  # in prose why it holds no Key Vault data role, and infra.yml plans with
+  # -refresh=false so it never reads a secret value. Subscription Owner does not
+  # help an attacker either. Under RBAC authorization Owner is a control plane
+  # role and grants nothing on the data plane, which is the same split
+  # stacks/tfstate/main.tf documents for storage: reachable is not readable.
+  #
+  # So this is a missing layer, not an open door. Saying so plainly is the
+  # point. A pull request that inflates its own finding is one nobody trusts the
+  # next time.
+  #
+  # WHY THE ONE LINE FIX IS AN OUTAGE. Setting default_action = "Deny" here
+  # stops the control plane at its next revision, and the failure would read as
+  # an application defect rather than as a firewall.
+  #
+  # The application never calls Key Vault. app.tf declares Key Vault secret
+  # REFERENCES, and the Container Apps platform resolves those with the app's
+  # user-assigned identity before the container starts. The bypass on the line
+  # below does not cover that fetch, because Azure Container Apps is not on Key
+  # Vault's trusted services list, and a service that is not on that list is
+  # blocked by the firewall whether or not the bypass is enabled:
+  # learn.microsoft.com/azure/key-vault/general/overview-vnet-service-endpoints
+  #
+  # A virtual network rule does not rescue it. The environment is integrated
+  # with the apps subnet in network.tf, so a Microsoft.KeyVault service endpoint
+  # there looks like the answer and is not: the platform's fetch does not
+  # present as coming from that subnet, and the only reported workaround is to
+  # allow-list the environment's egress addresses, which are not stable and are
+  # not known until after the app exists.
+  # github.com/microsoft/azure-container-apps/issues/1287
+  #
+  # WHAT WOULD ACTUALLY CLOSE IT, so the next person does not rediscover this. A
+  # private endpoint, which is four resources rather than one word: a third
+  # subnet that is NOT delegated, because both subnets in network.tf are
+  # delegated and a private endpoint cannot sit in a delegated subnet; a
+  # privatelink.vaultcore.azure.net private DNS zone; a link from that zone to
+  # this network; and the endpoint itself. Deny is then safe for the app and is
+  # still in front of the operator, because `az keyvault secret set`, which the
+  # seeded secret comment below tells people to use for rotation, runs from
+  # wherever that person happens to be. A vault they cannot reach makes that
+  # instruction quietly untrue, which is the failure this file already refuses
+  # once.
+  #
+  # No plan can prove any of that, and getting it wrong is a production outage,
+  # so it belongs with somebody who can apply it and watch what happens.
+  # Recorded rather than silently accepted, and the expiry below is the whole
+  # point of recording it that way. tfsec stops honouring that line on
+  # 2027-03-03 and the CRITICAL comes back, into a job that now fails on it.
   public_network_access_enabled = true
   network_acls {
-    bypass         = "AzureServices"
+    bypass = "AzureServices"
+
+    # The directive sits on the line it excuses rather than above the block, so
+    # that changing this value means reading the reason. See the block above it.
+    #tfsec:ignore:azure-keyvault-specify-network-acl:exp:2027-03-03
     default_action = "Allow"
   }
 
@@ -271,6 +343,72 @@ data "azurerm_key_vault_secret" "resend_api_key" {
   key_vault_id = azurerm_key_vault.this.id
 }
 
+# NO EXPIRY ON THESE THREE, AND THE REPORT THAT ASKS FOR ONE IS THREE THINGS
+# WRONG AT ONCE.
+#
+# tfsec reports six LOW results here under azure-keyvault-ensure-secret-expiry,
+# "Secret should have an expiry date specified". Three things about that:
+#
+# IT IS THREE SECRETS, NOT SIX. tfsec emits each one twice, once against this
+# resource and once against the module call in stacks/control-plane. The three
+# are github-client-id, github-client-secret and github-redirect-uri, and two of
+# them are not credentials at all: an OAuth client id is in the address bar of
+# every person who signs in, and the redirect URI is written in plain text in
+# production.tfvars in this repository. Only github-client-secret is a secret,
+# and it is the one an operator rotates by hand at GitHub.
+#
+# IT DOES NOT SEE THE SECRETS THAT MATTER, AND THE LIST GREW WHILE THIS WAS
+# BEING WRITTEN. azurerm_key_vault_secret.owned above sets no expiration_date
+# either and tfsec reports nothing at all about it. It holds five:
+#
+#   database-url                the application's database credential
+#   migration-database-url      the one that can run DDL
+#   provider-key-secret         the sealing key for customers' provider keys
+#   admin-database-url          the operator portal's antifailure_admin login
+#   analytics-surrogate-secret  the key every analytics surrogate is derived from
+#
+# The last two arrived after this comment was first written, which is the point
+# rather than an aside: the unscanned half of this vault grows and the scanner
+# stays quiet about it. Rewriting local.owned_secrets as a literal map makes the
+# same rule fire on all five, so the silence is tfsec failing to evaluate that
+# expression rather than a difference in this configuration. Anybody who "fixed"
+# the six results the scanner prints would leave both database credentials, the
+# provider sealing key and the analytics key carrying the exact property the rule
+# exists to complain about, and the report would come back clean. That is worse
+# than the finding.
+#
+# AND AN EXPIRY WOULD ENFORCE NOTHING. This is the part that looks backwards and
+# is not. Key Vault's own documentation says exp on a SECRET "is for
+# informational purposes only", and that "a secret's get operation works for
+# not-yet-valid and expired secrets". So a date here is neither the scheduled
+# outage it resembles nor a control: the app keeps reading the secret either
+# way. It is metadata.
+#
+# Both ways to write that metadata in Terraform are worse than leaving it out:
+#
+#   A literal date is a date somebody has to edit by hand, and when it passes
+#   nothing breaks, so nobody finds out. An expiry whose lapsing is invisible is
+#   protection that is not there, which is the failure tools/vulncheck exists to
+#   catch in the file next door.
+#
+#   timeadd(timestamp(), ...) is evaluated on every plan, so it would show these
+#   three secrets as changed forever. stacks/tfstate/variables.tf already refuses
+#   timestamp() for that reason on the policy exemption, and this file argues at
+#   length that a plan which always shows a diff is a plan people stop reading.
+#
+# The seeded half has a third problem on top. `az keyvault secret set`, which
+# self-hosting/control-plane.md tells the operator to use, writes a NEW VERSION
+# carrying no expiry at all. Terraform would put one back at the next apply,
+# which might be months later, and in between the vault says one thing and the
+# configuration says another.
+#
+# WHAT WOULD MAKE IT REAL, which is the trigger to revisit rather than a date
+# picked to look responsible. Key Vault raises SecretNearExpiry and
+# SecretExpired through Event Grid, and modules/alerting already owns this
+# stack's action groups. An expiry wired to those is a rotation reminder for
+# github-client-secret and worth having. An expiry with nothing watching it is a
+# date in a portal.
+#tfsec:ignore:azure-keyvault-ensure-secret-expiry:exp:2027-03-03
 resource "azurerm_key_vault_secret" "seeded" {
   for_each     = local.seeded_secrets
   name         = each.key

--- a/tools/gatecheck/main.go
+++ b/tools/gatecheck/main.go
@@ -695,6 +695,26 @@ var exemptFromGate = map[string]string{
 		"against, and `just test-web` covers that inside `gate`: the migrations " +
 		"run and the suites read what they wrote.",
 
+	"tool tfsecignores": "" +
+		"It needs a scanner this repository does not carry. tools/tfsecignores " +
+		"asks tfsec what is failing with every inline suppression disabled, so " +
+		"that an ignore which no longer suppresses anything can be told from one " +
+		"that does, and tfsec is a pinned release asset infra.yml downloads and " +
+		"checksums rather than a dependency in tools/go.mod. A laptop with no " +
+		"tfsec on it would have to fetch one, and `just gate` has to work on a " +
+		"plane. " +
+		"What IS a function of the tree is every decision the tool makes about a " +
+		"directive, and `go test ./tools/tfsecignores` covers it inside `gate`: " +
+		"an ignore with no expiry is refused, an ignore with no reason written " +
+		"above it is refused, an expired one fails, one that suppressed nothing " +
+		"fails, a rule that merely PASSED is not counted as suppressed, a " +
+		"suppression in one file does not cover an ignore in another, a scanner " +
+		"that printed nothing is an error rather than an empty result, and a " +
+		"positive control asserts a live ignore IS accepted so that a checker " +
+		"which refuses everything cannot pass the suite. " +
+		"It runs on every pull request touching infra/ in infra.yml, in the step " +
+		"before the scan it governs.",
+
 	"tool cost": "" +
 		"Its input is not in the tree. tools/cost reads a Terraform plan, and a " +
 		"plan only exists after authenticating to Azure and resolving every " +

--- a/tools/tfsecignores/main.go
+++ b/tools/tfsecignores/main.go
@@ -1,0 +1,377 @@
+// Command tfsecignores holds tfsec's inline suppressions to the same policy
+// tools/vulncheck holds .govulncheck.yaml to.
+//
+// tfsec answers "does this configuration break a rule". A finding that cannot
+// be fixed still needs a written decision rather than a flag that turns the
+// scanner off, and tfsec's mechanism for that is an inline comment:
+//
+//	#tfsec:ignore:azure-keyvault-specify-network-acl:exp:2027-03-03
+//
+// That mechanism is most of what is needed and it is missing the parts that
+// make a suppression trustworthy. tfsec accepts a directive with no expiry at
+// all, and it says nothing whatever about a directive that no longer suppresses
+// anything. So this tool applies three rules, and the third is the one that
+// matters:
+//
+//  1. A directive with no expiry, or with no prose beside it. A suppression
+//     with no shelf life is a policy change wearing a temporary hat, and one
+//     with no stated reason is not a decision.
+//  2. A directive past its expiry. tfsec already stops honouring it, so the
+//     finding comes back on its own; what tfsec does not do is say WHY it came
+//     back. A reader who is told "CRITICAL, vault network ACL" and not "the
+//     decision to accept this lapsed on such a date" goes looking for a change
+//     that nobody made.
+//  3. A directive that suppressed nothing. This is the rule tfsec has no
+//     version of. Somebody fixes the configuration, the finding goes away, and
+//     the comment explaining why it was tolerated stays behind. From then on it
+//     reads as protection that is not there, and it hides the fact that the
+//     real finding moved or changed shape.
+//
+// WHY IT REFUSES TO GUESS. tfsec failing to run and tfsec finding nothing look
+// identical in an exit code, and that is not a hypothetical here: the installer
+// asked the GitHub releases API for the latest version, got HTTP 403, and the
+// step failed before reading a single file. Eight findings sat unseen behind a
+// green-looking check. So output this tool cannot parse is an error, never an
+// empty result set.
+//
+// AND WHY IT ASKS THE QUESTION THE WAY IT DOES, because the obvious way is
+// wrong and looks right. tfsec has an --include-ignored flag that adds the
+// suppressed results to its output with status 2, which reads exactly like
+// "here is what your directives suppressed". It is not that. tfsec marks a
+// check ignored whenever a directive NAMES it, whether or not the check would
+// have failed: point a directive at azure-keyvault-no-purge on a vault that
+// already has purge protection and the check moves from passed to ignored, with
+// nothing suppressed. A staleness rule built on that flag calls every stale
+// directive live, which is the one answer it exists to prevent, and it does so
+// silently.
+//
+// So the source of truth is a --no-ignores run instead: the findings that exist
+// with every suppression disabled. A directive is live only if its rule is
+// actually failing in its own file in that run. That is a question with a no in
+// it.
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+// dateLayout is the only accepted spelling of an expiry, and it is tfsec's own:
+// the directive is read by tfsec as well as by this tool, and a date the two
+// disagree about would be worse than no date.
+const dateLayout = "2006-01-02"
+
+// reasonFloor is how much prose has to sit directly above a directive before it
+// counts as a stated reason. It is deliberately low. The bar is "somebody wrote
+// something" rather than a word count nobody can defend, because the thing
+// worth catching is a bare directive parachuted in with no explanation at all.
+const reasonFloor = 40
+
+// directive is one inline suppression, as written in a .tf file.
+type directive struct {
+	File    string
+	Line    int
+	Rule    string
+	Expires string
+
+	expires time.Time
+}
+
+func (d directive) where() string {
+	return fmt.Sprintf("%s:%d", d.File, d.Line)
+}
+
+// result is the subset of tfsec's JSON this tool decides on. Status 2 is
+// "ignored"; anything else is a finding that was reported.
+type result struct {
+	RuleID   string `json:"rule_id"`
+	LongID   string `json:"long_id"`
+	Status   int    `json:"status"`
+	Location struct {
+		Filename string `json:"filename"`
+	} `json:"location"`
+}
+
+// tfsec's statuses: 0 failed, 1 passed, 2 ignored. Under --no-ignores nothing
+// is ignored and passed results are not emitted, so a failure is the only thing
+// expected; it is filtered for explicitly anyway, because a tool that counts
+// whatever it is handed stops being able to say no when the shape changes.
+const statusFailed = 0
+
+type report struct {
+	Results []result `json:"results"`
+}
+
+// directiveRe matches tfsec's inline form. The trailing group is everything
+// after the rule id, which tfsec spells as colon separated key/value pairs
+// (`exp` and `ws`), so it is split rather than matched with a second pattern:
+// a new key added upstream should be ignored here, not rejected.
+var directiveRe = regexp.MustCompile(`#tfsec:ignore:(\S+)`)
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "tfsecignores: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, out io.Writer) error {
+	fl := flag.NewFlagSet("tfsecignores", flag.ContinueOnError)
+	fl.SetOutput(out)
+	bin := fl.String("tfsec", "tfsec", "path to the tfsec binary")
+	dir := fl.String("dir", filepath.Join("infra", "terraform"), "directory to scan, relative to the root")
+	if err := fl.Parse(args); err != nil {
+		return err
+	}
+
+	root := "."
+	if fl.NArg() > 0 {
+		root = fl.Arg(0)
+	}
+	root, err := filepath.Abs(root)
+	if err != nil {
+		return err
+	}
+	scan := filepath.Join(root, *dir)
+
+	directives, err := parseDirectives(os.DirFS(scan), *dir)
+	if err != nil {
+		return err
+	}
+
+	failing, err := unsuppressedFindings(*bin, scan, root)
+	if err != nil {
+		return err
+	}
+
+	return decide(directives, failing, out)
+}
+
+// parseDirectives reads every .tf file under fsys and returns the suppressions
+// in it, in file and line order.
+//
+// prefix is only cosmetic: it is what a path is reported as, so that a failure
+// names infra/terraform/... rather than a path relative to a directory the
+// reader cannot see from the message.
+func parseDirectives(fsys fs.FS, prefix string) ([]directive, error) {
+	var found []directive
+	err := fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			// .terraform holds downloaded providers and modules. A directive
+			// in somebody else's module is not ours to hold to a policy, and
+			// on a machine that has run `terraform init` there are thousands
+			// of files in there.
+			if d.Name() == ".terraform" {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if filepath.Ext(path) != ".tf" {
+			return nil
+		}
+		raw, err := fs.ReadFile(fsys, path)
+		if err != nil {
+			return err
+		}
+		ds, err := parseFile(filepath.ToSlash(filepath.Join(prefix, path)), string(raw))
+		if err != nil {
+			return err
+		}
+		found = append(found, ds...)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(found, func(i, j int) bool {
+		if found[i].File != found[j].File {
+			return found[i].File < found[j].File
+		}
+		return found[i].Line < found[j].Line
+	})
+	return found, nil
+}
+
+// parseFile pulls the directives out of one file's text and applies the rules
+// that can be decided from the text alone: an expiry that is present and well
+// formed, and a reason that exists.
+func parseFile(name, text string) ([]directive, error) {
+	lines := strings.Split(text, "\n")
+	var found []directive
+	for i, line := range lines {
+		m := directiveRe.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		parts := strings.Split(m[1], ":")
+		d := directive{File: name, Line: i + 1, Rule: parts[0]}
+
+		for j := 1; j+1 < len(parts); j += 2 {
+			if parts[j] == "exp" {
+				d.Expires = parts[j+1]
+			}
+		}
+		if d.Rule == "" {
+			return nil, fmt.Errorf("%s:%d: a tfsec ignore names no rule", name, i+1)
+		}
+		if d.Expires == "" {
+			return nil, fmt.Errorf(
+				"%s:%d: the ignore for %s has no expiry. Write it as "+
+					"#tfsec:ignore:%s:exp:YYYY-MM-DD. A suppression with no date is one nobody rereads",
+				name, i+1, d.Rule, d.Rule)
+		}
+		t, err := time.Parse(dateLayout, d.Expires)
+		if err != nil {
+			return nil, fmt.Errorf("%s:%d: the ignore for %s has expiry %q, which is not a %s date",
+				name, i+1, d.Rule, d.Expires, dateLayout)
+		}
+		d.expires = t
+
+		if len(reasonAbove(lines, i)) < reasonFloor {
+			return nil, fmt.Errorf(
+				"%s:%d: the ignore for %s has no reason written above it. tfsec has no field for one, "+
+					"so the prose beside the directive is the only place a reader can find out why this "+
+					"was accepted, and a suppression nobody explained is not a decision",
+				name, i+1, d.Rule)
+		}
+		found = append(found, d)
+	}
+	return found, nil
+}
+
+// reasonAbove collects the run of comment lines directly above index i and
+// returns their text with the comment markers removed.
+//
+// A run rather than one line, because the reason for a suppression worth
+// keeping is usually a paragraph, and because a rule that only looked at the
+// line above would be satisfied by a comment that says "see above".
+func reasonAbove(lines []string, i int) string {
+	var prose []string
+	for j := i - 1; j >= 0; j-- {
+		t := strings.TrimSpace(lines[j])
+		if !strings.HasPrefix(t, "#") {
+			break
+		}
+		// Another directive is not prose about this one.
+		if directiveRe.MatchString(t) {
+			break
+		}
+		prose = append(prose, strings.TrimSpace(strings.TrimPrefix(t, "#")))
+	}
+	return strings.TrimSpace(strings.Join(prose, " "))
+}
+
+// unsuppressedFindings runs tfsec with every suppression disabled and returns,
+// per file, the set of rules that are actually failing there. That set is what
+// a directive has to match to be earning its place. Both the short and the long
+// id are recorded, because a directive may name either and tfsec reports both.
+func unsuppressedFindings(bin, scan, root string) (map[string]map[string]bool, error) {
+	cmd := exec.Command(bin, scan, "--no-ignores", "--format", "json", "--no-colour")
+	cmd.Dir = root
+	stdout, err := cmd.Output()
+	// tfsec exits non-zero when it reports a finding, which is the ordinary
+	// case here and says nothing about whether it ran. Whether the output
+	// parses is what says that, so the exit code is deliberately not consulted
+	// and a parse failure below carries the diagnosis instead.
+	if err != nil && len(stdout) == 0 {
+		detail := err.Error()
+		var ee *exec.ExitError
+		if errors.As(err, &ee) && len(ee.Stderr) > 0 {
+			detail = strings.TrimSpace(string(ee.Stderr))
+		}
+		return nil, fmt.Errorf("running %s: %s\nIt produced no output at all, so nothing was scanned. "+
+			"This is the shape of the failure that hid eight findings behind a green check: "+
+			"a scanner that did not run is not a scanner that found nothing", bin, detail)
+	}
+
+	var rep report
+	if err := json.Unmarshal(stdout, &rep); err != nil {
+		return nil, fmt.Errorf("reading tfsec output as JSON: %w\nThe first bytes were: %.200q", err, stdout)
+	}
+
+	byFile := map[string]map[string]bool{}
+	for _, r := range rep.Results {
+		if r.Status != statusFailed {
+			continue
+		}
+		file := normalise(r.Location.Filename, root)
+		if byFile[file] == nil {
+			byFile[file] = map[string]bool{}
+		}
+		if r.LongID != "" {
+			byFile[file][r.LongID] = true
+		}
+		if r.RuleID != "" {
+			byFile[file][r.RuleID] = true
+		}
+	}
+	return byFile, nil
+}
+
+// normalise turns tfsec's absolute filename into the repository relative path
+// the directives are reported under, so the two can be compared.
+func normalise(name, root string) string {
+	if rel, err := filepath.Rel(root, name); err == nil && !strings.HasPrefix(rel, "..") {
+		return filepath.ToSlash(rel)
+	}
+	return filepath.ToSlash(name)
+}
+
+// decide applies the expiry and staleness rules and writes a report.
+func decide(directives []directive, failing map[string]map[string]bool, out io.Writer) error {
+	return decideAt(directives, failing, out, time.Now())
+}
+
+// decideAt takes the clock as an argument so the expiry rule is testable
+// without waiting for a date to pass.
+func decideAt(directives []directive, failing map[string]map[string]bool, out io.Writer, now time.Time) error {
+	var problems []string
+	var live int
+
+	for _, d := range directives {
+		expired := now.After(d.expires)
+		used := failing[d.File][d.Rule]
+
+		switch {
+		case expired:
+			fmt.Fprintf(out, "EXPIRED  %s  %s  accepted until %s\n", d.where(), d.Rule, d.Expires)
+			problems = append(problems, fmt.Sprintf(
+				"the decision to accept %s at %s expired on %s. tfsec has already stopped honouring it, "+
+					"so the finding is back; reread the reason written above it and either fix the "+
+					"configuration or set a new date on purpose",
+				d.Rule, d.where(), d.Expires))
+		case !used:
+			fmt.Fprintf(out, "STALE    %s  %s  nothing in this file breaks that rule\n", d.where(), d.Rule)
+			problems = append(problems, fmt.Sprintf(
+				"the ignore for %s at %s suppressed nothing: with every ignore disabled, that rule is "+
+					"not failing in that file. So either the finding was fixed and this comment now "+
+					"reads as protection that is not there, or the finding moved and this is no longer "+
+					"pointed at it. Delete it or move it",
+				d.Rule, d.where()))
+		default:
+			live++
+		}
+	}
+
+	fmt.Fprintf(out, "\n%d ignores, %d live, %d expired or stale\n",
+		len(directives), live, len(directives)-live)
+
+	if len(problems) > 0 {
+		return errors.New(strings.Join(problems, "\n  "))
+	}
+	return nil
+}

--- a/tools/tfsecignores/main_test.go
+++ b/tools/tfsecignores/main_test.go
@@ -1,0 +1,301 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"testing/fstest"
+	"time"
+)
+
+// A well formed directive: a rule, an expiry, and a paragraph above it.
+const good = `
+# The vault is reachable and not readable, and the RBAC assignments in this
+# file are the whole list of principals that can read a secret.
+#tfsec:ignore:azure-keyvault-specify-network-acl:exp:2027-03-03
+default_action = "Allow"
+`
+
+func TestParseFileReadsRuleExpiryAndLine(t *testing.T) {
+	got, err := parseFile("a.tf", good)
+	if err != nil {
+		t.Fatalf("parseFile: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 directive, got %d", len(got))
+	}
+	d := got[0]
+	if d.Rule != "azure-keyvault-specify-network-acl" {
+		t.Errorf("rule = %q", d.Rule)
+	}
+	if d.Expires != "2027-03-03" {
+		t.Errorf("expires = %q", d.Expires)
+	}
+	if d.Line != 4 {
+		t.Errorf("line = %d, want 4", d.Line)
+	}
+}
+
+// Rule 1, first half. tfsec accepts a bare directive; this does not, because a
+// suppression with no shelf life is one nobody rereads.
+func TestParseFileRefusesADirectiveWithNoExpiry(t *testing.T) {
+	_, err := parseFile("a.tf", "# a reason long enough to clear the floor comfortably\n#tfsec:ignore:azure-keyvault-specify-network-acl\n")
+	if err == nil {
+		t.Fatal("want an error for a directive with no expiry")
+	}
+	if !strings.Contains(err.Error(), "no expiry") {
+		t.Errorf("error should say what is missing, got %v", err)
+	}
+}
+
+func TestParseFileRefusesAMalformedExpiry(t *testing.T) {
+	_, err := parseFile("a.tf", "# a reason long enough to clear the floor comfortably\n#tfsec:ignore:some-rule:exp:next-march\n")
+	if err == nil || !strings.Contains(err.Error(), "not a 2006-01-02 date") {
+		t.Fatalf("want a date format error, got %v", err)
+	}
+}
+
+// Rule 1, second half. tfsec has no field for a reason, so the prose beside the
+// directive is the only place one can live.
+func TestParseFileRefusesADirectiveWithNoReason(t *testing.T) {
+	_, err := parseFile("a.tf", "resource \"x\" \"y\" {\n#tfsec:ignore:some-rule:exp:2099-01-01\n}\n")
+	if err == nil || !strings.Contains(err.Error(), "no reason") {
+		t.Fatalf("want a missing reason error, got %v", err)
+	}
+}
+
+// A one word comment is not a reason. The floor is low on purpose, and it is
+// still a floor.
+func TestParseFileRefusesAReasonTooShortToBeOne(t *testing.T) {
+	_, err := parseFile("a.tf", "# later\n#tfsec:ignore:some-rule:exp:2099-01-01\n")
+	if err == nil || !strings.Contains(err.Error(), "no reason") {
+		t.Fatalf("want a missing reason error, got %v", err)
+	}
+}
+
+// Another directive sitting above this one is not prose about this one, so a
+// stack of bare directives under a single paragraph does not launder them all.
+func TestParseFileDoesNotCountAnotherDirectiveAsAReason(t *testing.T) {
+	src := "# a reason long enough to clear the floor comfortably\n" +
+		"#tfsec:ignore:rule-one:exp:2099-01-01\n" +
+		"#tfsec:ignore:rule-two:exp:2099-01-01\n"
+	_, err := parseFile("a.tf", src)
+	if err == nil || !strings.Contains(err.Error(), "rule-two") {
+		t.Fatalf("want the second directive refused, got %v", err)
+	}
+}
+
+// A workspace qualifier is tfsec's, not ours, and an unknown key added upstream
+// must not break the parse.
+func TestParseFileToleratesOtherDirectiveKeys(t *testing.T) {
+	src := "# a reason long enough to clear the floor comfortably\n" +
+		"#tfsec:ignore:some-rule:ws:staging:exp:2099-01-01\n"
+	got, err := parseFile("a.tf", src)
+	if err != nil {
+		t.Fatalf("parseFile: %v", err)
+	}
+	if len(got) != 1 || got[0].Expires != "2099-01-01" {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestParseDirectivesReadsOnlyTerraformAndSkipsDownloadedModules(t *testing.T) {
+	fsys := fstest.MapFS{
+		"modules/kv.tf":          {Data: []byte(good)},
+		"modules/notes.md":       {Data: []byte("#tfsec:ignore:not-a-rule\n")},
+		".terraform/vendor/z.tf": {Data: []byte("#tfsec:ignore:someone-elses-rule\n")},
+	}
+	got, err := parseDirectives(fsys, "infra/terraform")
+	if err != nil {
+		t.Fatalf("parseDirectives: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 directive, got %d: %+v", len(got), got)
+	}
+	if got[0].File != "infra/terraform/modules/kv.tf" {
+		t.Errorf("file = %q, want it reported under the scanned prefix", got[0].File)
+	}
+}
+
+func decideFor(t *testing.T, ds []directive, failing map[string]map[string]bool, now time.Time) (string, error) {
+	t.Helper()
+	var buf bytes.Buffer
+	err := decideAt(ds, failing, &buf, now)
+	return buf.String(), err
+}
+
+func live(rule, expires string) directive {
+	t, _ := time.Parse(dateLayout, expires)
+	return directive{File: "infra/terraform/kv.tf", Line: 4, Rule: rule, Expires: expires, expires: t}
+}
+
+var march2026 = time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+
+// THE POSITIVE CONTROL. A checker that refuses everything would pass every
+// negative test above and be worthless, so one case has to come back clean.
+func TestDecideAcceptsALiveIgnoreThatSuppressedSomething(t *testing.T) {
+	ds := []directive{live("azure-keyvault-specify-network-acl", "2027-03-03")}
+	failing := map[string]map[string]bool{
+		"infra/terraform/kv.tf": {"azure-keyvault-specify-network-acl": true},
+	}
+	out, err := decideFor(t, ds, failing, march2026)
+	if err != nil {
+		t.Fatalf("a live, used ignore must pass: %v", err)
+	}
+	if !strings.Contains(out, "1 ignores, 1 live, 0 expired or stale") {
+		t.Errorf("summary = %q", out)
+	}
+}
+
+func TestDecideFailsAnExpiredIgnore(t *testing.T) {
+	ds := []directive{live("azure-keyvault-specify-network-acl", "2025-01-01")}
+	failing := map[string]map[string]bool{
+		"infra/terraform/kv.tf": {"azure-keyvault-specify-network-acl": true},
+	}
+	out, err := decideFor(t, ds, failing, march2026)
+	if err == nil {
+		t.Fatal("want an error for an expired ignore")
+	}
+	if !strings.Contains(out, "EXPIRED") {
+		t.Errorf("report should say EXPIRED, got %q", out)
+	}
+	// The message has to explain why the finding reappeared, because tfsec's
+	// own output will not.
+	if !strings.Contains(err.Error(), "expired on 2025-01-01") {
+		t.Errorf("error should name the date, got %v", err)
+	}
+}
+
+// RULE 3, THE ONE TFSEC HAS NO VERSION OF.
+func TestDecideFailsAnIgnoreThatSuppressedNothing(t *testing.T) {
+	ds := []directive{live("azure-keyvault-specify-network-acl", "2027-03-03")}
+	out, err := decideFor(t, ds, map[string]map[string]bool{}, march2026)
+	if err == nil {
+		t.Fatal("want an error for an ignore that matched nothing")
+	}
+	if !strings.Contains(out, "STALE") {
+		t.Errorf("report should say STALE, got %q", out)
+	}
+	if !strings.Contains(err.Error(), "protection that is not there") {
+		t.Errorf("error should say what a stale suppression costs, got %v", err)
+	}
+}
+
+// Matching is per file, not per rule. Without this, an ignore left behind in
+// one file would be kept alive by a live ignore for the same rule in another,
+// which is the quietest possible way for rule 3 to stop working.
+func TestDecideDoesNotLetOneFileCoverAnotherFilesIgnore(t *testing.T) {
+	ds := []directive{live("azure-keyvault-specify-network-acl", "2027-03-03")}
+	failing := map[string]map[string]bool{
+		"infra/terraform/other.tf": {"azure-keyvault-specify-network-acl": true},
+	}
+	if _, err := decideFor(t, ds, failing, march2026); err == nil {
+		t.Fatal("a suppression in another file must not cover this one")
+	}
+}
+
+// tfsec reports both ids and a directive may be written with either.
+func TestDecideAcceptsTheShortRuleId(t *testing.T) {
+	ds := []directive{live("AVD-AZU-0013", "2027-03-03")}
+	failing := map[string]map[string]bool{
+		"infra/terraform/kv.tf": {"AVD-AZU-0013": true, "azure-keyvault-specify-network-acl": true},
+	}
+	if _, err := decideFor(t, ds, failing, march2026); err != nil {
+		t.Fatalf("an ignore written with the short id must be recognised: %v", err)
+	}
+}
+
+// fakeTfsec writes a script that prints what it is told and exits how it is
+// told, so the two ways of not knowing can be tested without a real scanner.
+func fakeTfsec(t *testing.T, stdout string, code int) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("the fake scanner is a shell script")
+	}
+	path := filepath.Join(t.TempDir(), "tfsec")
+	body := "#!/bin/sh\nprintf '%s' " + shellQuote(stdout) + "\nexit " + strconv.Itoa(code) + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func shellQuote(s string) string { return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'" }
+func itoa(i int) string {
+	return strings.TrimSpace(strings.Fields(strings.Repeat(" ", 0) + string(rune('0'+i)))[0])
+}
+
+// THE FAILURE THAT STARTED ALL OF THIS. A scanner that did not run must not
+// read as a scanner that found nothing.
+func TestIgnoredResultsRefusesASilentScanner(t *testing.T) {
+	bin := fakeTfsec(t, "", 1)
+	_, err := unsuppressedFindings(bin, t.TempDir(), t.TempDir())
+	if err == nil {
+		t.Fatal("a scanner that printed nothing must be an error, not an empty result")
+	}
+	if !strings.Contains(err.Error(), "nothing was scanned") {
+		t.Errorf("error should say nothing was scanned, got %v", err)
+	}
+}
+
+func TestIgnoredResultsRefusesOutputItCannotParse(t *testing.T) {
+	bin := fakeTfsec(t, "Error: 403 rate limited\n", 1)
+	_, err := unsuppressedFindings(bin, t.TempDir(), t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "as JSON") {
+		t.Fatalf("want a parse error naming the output, got %v", err)
+	}
+}
+
+// ONLY A FAILING RESULT COUNTS, AND THIS IS THE TEST THAT KEEPS THE TOOL ABLE
+// TO SAY NO.
+//
+// The first version of this asked tfsec --include-ignored which rules it had
+// suppressed, which reads like the right question and is not: tfsec marks a
+// check ignored whenever a directive NAMES it, even when the check was passing
+// and there was nothing to suppress. Pointed at a real tree, that version
+// called a made up directive for azure-keyvault-no-purge "live". Status 1 is a
+// pass and status 2 is tfsec repeating the directive back; neither is evidence.
+func TestUnsuppressedFindingsCountsOnlyFailures(t *testing.T) {
+	root := t.TempDir()
+	body := `{"results":[
+	  {"rule_id":"AVD-AZU-0013","long_id":"acl","status":0,"location":{"filename":"` + root + `/kv.tf"}},
+	  {"rule_id":"AVD-AZU-0031","long_id":"purge","status":1,"location":{"filename":"` + root + `/kv.tf"}},
+	  {"rule_id":"AVD-AZU-0017","long_id":"exp","status":2,"location":{"filename":"` + root + `/kv.tf"}}
+	]}`
+	got, err := unsuppressedFindings(fakeTfsec(t, body, 1), root, root)
+	if err != nil {
+		t.Fatalf("unsuppressedFindings: %v", err)
+	}
+	if !got["kv.tf"]["acl"] {
+		t.Error("a failing rule should be recorded")
+	}
+	if got["kv.tf"]["purge"] {
+		t.Error("a rule that PASSED is not one a directive is suppressing")
+	}
+	if got["kv.tf"]["exp"] {
+		t.Error("a rule tfsec calls ignored is not evidence that anything was suppressed")
+	}
+}
+
+// The directives this repository actually ships have to satisfy rule 1. This
+// is the check that keeps the tool honest about its own tree, and it needs no
+// scanner: an expiry and a reason are properties of the text.
+func TestThisRepositorysDirectivesCarryAnExpiryAndAReason(t *testing.T) {
+	dir := filepath.Join("..", "..", "infra", "terraform")
+	if _, err := os.Stat(dir); err != nil {
+		t.Skipf("no %s to read: %v", dir, err)
+	}
+	got, err := parseDirectives(os.DirFS(dir), "infra/terraform")
+	if err != nil {
+		t.Fatalf("the tfsec ignores in this repository do not satisfy the policy: %v", err)
+	}
+	for _, d := range got {
+		if d.expires.Before(time.Now()) {
+			t.Errorf("%s: the ignore for %s expired on %s", d.where(), d.Rule, d.Expires)
+		}
+	}
+}


### PR DESCRIPTION
Closes the loop on the eight findings tfsec reported the first time it actually ran. **No Azure setting changes.** The vault's configuration is byte for byte what it was; this decides each finding, records the decisions where somebody editing the file will read them, and makes the records checkable.

## Every finding, and what happened to it

tfsec prints 8 results. They are **4 distinct findings**, each emitted twice: once against the resource and once against the `module.control_plane` call site.

| # | Rule | Where | Verdict |
|---|---|---|---|
| 1, 2 | `azure-keyvault-specify-network-acl` CRITICAL | `azurerm_key_vault.this` | **Recorded**, expires 2027-03-03. Cannot be fixed without a private endpoint. Reasoning below. |
| 3, 4 | `azure-keyvault-ensure-secret-expiry` LOW | `seeded["github-client-id"]` | **Recorded**, expires 2027-03-03. A client id is public by construction. |
| 5, 6 | `azure-keyvault-ensure-secret-expiry` LOW | `seeded["github-client-secret"]` | **Recorded**, expires 2027-03-03. The only real credential of the three. An expiry would not be a control. |
| 7, 8 | `azure-keyvault-ensure-secret-expiry` LOW | `seeded["github-redirect-uri"]` | **Recorded**, expires 2027-03-03. A public URL, printed in `production.tfvars`. |

Nothing is left unaccounted for. `tfsec infra/terraform` now exits 0 with `8 ignored, 0 problems`.

## How bad the CRITICAL actually is

**A missing layer, not an open door.** I would rather say that plainly than inflate it.

The vault sets `rbac_authorization_enabled = true`, so vault access policies do not exist here and the complete list of principals that can read a secret is the role assignments in `keyvault.tf`:

- `app_reads_secrets`, Key Vault Secrets User, on the user assigned identity the Container App and both jobs run as.
- `deployer_writes_secrets`, Key Vault Secrets Officer, on the one operator object id both stacks pin.

The pull request plan job holds neither, deliberately, and `ci.tf` says why in prose. Subscription Owner does not help an attacker either: under RBAC authorization, Owner is a control plane role and grants nothing on the data plane, the same split `stacks/tfstate/main.tf` already documents for storage. Reaching the endpoint gets you 401 without a Microsoft Entra token and 403 with one.

So the fix is worth making. It is not urgent, and the PR should not pretend it is.

## Why I did not write the deny

Setting `default_action = "Deny"` today takes the production control plane down at its next revision, and the failure would read as an application bug.

- The app never calls Key Vault. `app.tf` declares Key Vault secret **references**, resolved by the Container Apps platform with the app's user assigned identity before the container starts.
- `bypass = "AzureServices"` does not cover that fetch. **Azure Container Apps is not on Key Vault's trusted services list**, and Microsoft's documentation is explicit that a service not in that table "is blocked by the firewall whether or not the bypass option is enabled". [Trusted services table](https://learn.microsoft.com/azure/key-vault/general/overview-vnet-service-endpoints#trusted-services)
- A virtual network rule does not rescue it. The environment is integrated with the apps subnet, so a `Microsoft.KeyVault` service endpoint there looks like the answer. It is not: the platform's fetch does not present as coming from that subnet, and the only reported workaround is allow-listing the environment's egress addresses, which are not stable and are not known until the app exists. [microsoft/azure-container-apps#1287](https://github.com/microsoft/azure-container-apps/issues/1287)

**What would actually close it**, written into the file so the next person does not rediscover it: a private endpoint. That is four resources, not one word. A third subnet that is *not* delegated, because both subnets in `network.tf` are delegated and a private endpoint cannot sit in a delegated one; a `privatelink.vaultcore.azure.net` private DNS zone; a link to the VNet; and the endpoint. It also lands in front of the operator, because `az keyvault secret set`, which `self-hosting/control-plane.md` tells them to use for rotation, runs from wherever that person is. None of it is provable from a plan and getting it wrong is a production outage, so it belongs with somebody who can apply and watch.

I did not run `terraform plan`. The credentials that would produce one are the credentials that could change something, and `local.key_vault_name` is untouched, so no plan can propose a rename.

## The LOW findings, decided individually

The brief said six secrets. It is **three**, doubled by the module call site. And they are not the three that matter.

**`azurerm_key_vault_secret.owned` sets no `expiration_date` either, and tfsec reports nothing at all about it.** It holds five: both database URLs, the provider sealing key, the operator portal's `antifailure_admin` login, and the analytics surrogate key. The last two landed on main while this branch was open, which is the point rather than an aside: the unscanned half of this vault grows and the scanner stays quiet about it. Rewriting `local.owned_secrets` as a literal map makes the same rule fire on all five, so the silence is tfsec failing to evaluate that expression rather than a difference in the configuration. Anyone who "fixed" the six printed results would leave every one of those five carrying exactly the property the rule is about, and the report would come back clean. That is worse than the finding.

Of the three that are reported, two are not credentials: an OAuth client id is in the address bar of every person who signs in, and the redirect URI is written in plain text in `production.tfvars` in this repository. Only `github-client-secret` is a secret.

**And an expiry would enforce nothing.** This is the part that looks backwards and is not. Azure's own documentation says `exp` on a secret "is for informational purposes only", and that "a secret's **get** operation works for not-yet-valid and expired secrets". So a date here is neither the scheduled outage it resembles nor a control. Both ways to write it in Terraform are worse than leaving it out:

- A literal date is one somebody must edit by hand, and when it passes nothing breaks, so nobody notices. An expiry whose lapsing is invisible is protection that is not there.
- `timeadd(timestamp(), ...)` is evaluated on every plan and would show three secrets as changed forever. `stacks/tfstate/variables.tf` already refuses `timestamp()` for exactly that reason, and `keyvault.tf` argues at length that a plan which always shows a diff is a plan people stop reading.

On the seeded half there is a third problem: `az keyvault secret set` writes a new version carrying no expiry at all, so between a rotation and the next apply the vault and the configuration would disagree.

**What would make it real** is written down as the trigger to revisit: Key Vault raises `SecretNearExpiry` and `SecretExpired` through Event Grid, and `modules/alerting` already owns this stack's action groups. An expiry wired to those is a rotation reminder for `github-client-secret`. An expiry with nothing watching it is a date in a portal.

## tfsec now blocks, and here is the argument

`--soft-fail` was the right setting while the step was broken. It is also the reason eight findings sat unseen the moment it was fixed: a scanner whose output nobody has to act on becomes a scanner nobody reads.

The decisive argument is narrower than that, though. **Soft fail makes every expiry in this PR decorative.** tfsec stops honouring a lapsed ignore and reports the finding again; under `--soft-fail` that is a green run that tells nobody. The dates only mean something if a lapse fails a build.

The usual cost of a blocking scanner is that a branch which was green goes red because somebody upstream shipped a new rule. That cost is not present here: the pinned version is archived in favour of Trivy, so the ruleset does not move. (Migrating to Trivy is a separate change and not this one.)

Every finding is now fixed or recorded, so there is nothing left for a soft failure to be soft about. It runs in `static`, needs no credentials, and works on a fork.

## The rule tfsec has no version of

tfsec's ignore mechanism gives an expiry and nothing else. It accepts a directive with no expiry at all, and it says nothing whatever about a directive that no longer suppresses anything. That third case is the one `tools/vulncheck` calls out as mattering most: a suppression left behind after the finding is fixed reads as protection that is not there.

`tools/tfsecignores` holds the inline directives to the same three rules, in the shape `.govulncheck.yaml` uses for the Go half:

1. No expiry, or no reason in prose beside it. Refused.
2. Past its expiry. Fails, and says the decision lapsed on such a date, which tfsec's own output will not.
3. Suppressed nothing. Fails.

It runs *before* the scan, so a lapsed decision is reported as a lapsed decision rather than as a CRITICAL nobody can account for. It is exempt from `just gate` for the same reason `azguard` and `cost` are, with the reason recorded in `gatecheck`, and `go test ./tools/tfsecignores` covers every decision it makes inside `gate`.

**Its first implementation could not say no, and that is worth reading.** It asked tfsec `--include-ignored` which rules had been suppressed. That reads like the right question. It is not: tfsec marks a check ignored whenever a directive *names* it, even when the check was passing and there was nothing to suppress. Pointed at this tree with a made up directive for `azure-keyvault-no-purge`, it reported the directive as live. The source of truth is a `--no-ignores` run instead, and a test now asserts that a passed or ignored status is not evidence.

Verified against the real tree, not only in unit tests: a stale directive for a passing rule fails, a back-dated expiry fails with the date named, a bare directive with no expiry fails, and setting `default_action = "Deny"` (which makes the CRITICAL genuinely go away) makes the leftover ignore fail as stale.

## Applying this, in order

1. **Merge.** Nothing to apply. The Terraform edits are comments, so they produce no diff. **Verified against a control**: the plan job on this PR and the plan job on `main` propose the identical three changes, `ci_reads_the_group` created and two container app resources updated in place, `0 to destroy`, and the Key Vault appears in neither. The only new gate is CI-side.
2. **Watch the first `infra` run on a PR touching `infra/`.** It should show `tfsec ignores are still true` green and `tfsec` green with `8 ignored`.
3. **Before 2027-03-03**, either build the private endpoint described above and drop the ignore, or set a new date on purpose. The `tfsecignores` gate fails the build if neither happens, and it also fails if somebody fixes the ACL and leaves the comment behind.

## Verification

- `terraform fmt -check -recursive` and `terraform validate` on all five directories: green.
- `tfsec infra/terraform`: `No problems detected`, exit 0, 8 ignored.
- `go run ./tools/tfsecignores`: `2 ignores, 2 live, 0 expired or stale`.
- `go run ./tools/gatecheck`: 72 gates, 7 exempt by name.
- `go run ./tools/inputcheck`: the 243 promised values are unchanged.
- `go run ./tools/changecheck`: no externally visible behaviour, so no fragment.
- `go vet ./...` and `go test ./...` in `tools`: green except `installcheck` and `prosecheck`, both of which fail identically on pristine `main` here (stale local `node_modules`, and `PROGRESS.md`, which is untracked and invisible to CI).
- I ran no `terraform plan` locally and applied nothing.

**Re-verified after rebasing onto `369236fb`**, because #196 and #199 added roughly twenty env blocks and two more secrets to this module:

- `tfsec --no-ignores` on the merged tree reports the same eight findings, two rules, same three seeded secrets. Both ignore rows still match a finding that is genuinely there, which is the staleness half of the argument applied to my own rows.
- `owned_secrets` grew from three entries to five. The comment named three, so it was wrong by omission and is corrected. The literal-map experiment was re-run on the merged tree and now fires on all five.
- The vault still carries exactly two role assignments, so the CRITICAL's list of who can read a secret is unchanged.
- I read `keyvault.tf` whole rather than only the hunks: no duplicated resource, `locals`, `moved` block or map key, and the other lane's Stripe and Resend data sources sit cleanly above my block.

## Note for the `hostedconfig` lane

This touches `keyvault.tf` in two places: a comment block above `network_acls`, and one above `resource "azurerm_key_vault_secret" "seeded"`. It adds no variables and no resources, so a rebase should be clean against new secrets and environment variables. If you add a `azurerm_key_vault_secret` resource, tfsec will report `azure-keyvault-ensure-secret-expiry` against it and the build will now fail until it is decided, which is the intended behaviour.
