### PR TITLE
ci: a deploy check that could not pass, describing a failure that was not happening

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -214,7 +214,24 @@ jobs:
             head -c 500 /tmp/api-404.json || true
             exit 1
           fi
-          if ! grep -q '"code":"endpoint_not_found"' /tmp/api-404.json; then
+          # Read the field, do not pattern match the serialization.
+          #
+          # This was `grep -q '"code":"endpoint_not_found"'` and it could never
+          # match, because the function pretty prints and the body carries
+          # `"code": "endpoint_not_found"` with a space after the colon. So the
+          # step failed on a deploy where the function was answering correctly,
+          # and the sentence it printed described a missing function app. An
+          # assertion that cannot succeed is indistinguishable from a real
+          # failure, and this one turned main red while telling whoever read it
+          # to go and look at the wrong thing.
+          #
+          # `jq -e` still fails on a body that is not JSON, on one with no
+          # `code`, and on one whose code is a different value, so nothing is
+          # weakened by no longer caring where the whitespace falls. Checked
+          # both ways against the live body before this was written: the old
+          # pattern matched zero times, and `jq` reported true for the real
+          # value and false for a wrong one.
+          if ! jq -e '.code == "endpoint_not_found"' /tmp/api-404.json >/dev/null 2>&1; then
             echo "::error::the 404 under /api did not come from this function app. A managed function"
             echo "::error::that is missing altogether also 404s, from the CDN, with an empty body, so"
             echo "::error::the status line alone cannot tell a working app from an absent one."


### PR DESCRIPTION
## main is red and the thing it names is not broken

The site deploy at `d8be4f3f` failed on **The API answers**:

```
##[error]the 404 under /api did not come from this function app. A managed function
##[error]that is missing altogether also 404s, from the CDN, with an empty body, so
##[error]the status line alone cannot tell a working app from an absent one.
```

The function app is answering. Probed live while the job was still red:

```
$ curl -s https://antifailure.dev/api/nothing-serves-this
{
  "ok": false,
  "code": "endpoint_not_found",
  "message": "No such endpoint.",
  ...
```

## The assertion could not pass

The step asserted the body with `grep -q '"code":"endpoint_not_found"'`. The function pretty prints, so the real body carries `"code": "endpoint_not_found"` with a space after the colon.

Checked both ways against the live body rather than reasoned about:

| Instrument | Result on the real body |
| --- | --- |
| `grep -q '"code":"endpoint_not_found"'` | **0 matches** |
| `grep -q '"code": "endpoint_not_found"'` | 1 match |
| `jq -e '.code == "endpoint_not_found"'` | pass |
| `jq -e '.code == "something_else"'` | fail, which is the negative control |

So the pattern could never have matched any response that function produces. This is the worst shape an assertion can take: it cannot succeed, so it is indistinguishable from a real failure, and the sentence it prints sends whoever reads it to investigate a function app that is fine.

## The change

Read the field, do not pattern match the serialization.

Nothing is weakened. `jq -e` still fails on a body that is not JSON, on one carrying no `code`, and on one whose `code` is a different value, which the negative control above demonstrates. What it stops doing is caring where the whitespace falls, which was never the property this check exists to hold.

The rest of the step is untouched, including the retry loop on `GET /api`, the origin assertion, and the status code check on the unrouted path.