### PR TITLE
infra: two variables landed between the gate being written and merged

### DIFF
--- a/.changes/a-deploy-that-could-deliver-a-third-of-the-configuration.md
+++ b/.changes/a-deploy-that-could-deliver-a-third-of-the-configuration.md
@@ -21,6 +21,15 @@ real ones: `AF_VERSION` and `AF_COMMIT` are stamped into the image at build
 time, `AF_MIGRATE` is absent from the serving process on purpose, and Enterprise
 has no Stripe price because it is arranged with a person.
 
+What it proves is narrow on purpose: a supported deploy path can DELIVER the
+variable. Not that the feature works. Mail is the live example and the guide now
+says so, because `antifailure.dev` publishes `v=spf1 -all`, a DMARC policy of
+`p=reject` with strict alignment, and a revoked Resend DKIM key, so the module
+can carry the mail configuration and the domain still cannot send. Nothing that
+was working stopped: sign-in is GitHub and the mailed link is an extra method,
+invitations return their link to the inviter whether or not mail is configured,
+and enterprise leads are recorded either way.
+
 `tools/wirecheck` is the gate. Two checks already covered this ground and both
 answered a nearby question: `tools/varcheck` and `config-docs.test.ts` prove a
 variable is DOCUMENTED, and a variable that is documented, read by the

--- a/docs/src/content/docs/self-hosting/azure.md
+++ b/docs/src/content/docs/self-hosting/azure.md
@@ -269,8 +269,48 @@ az keyvault secret set --vault-name "$VAULT" -n stripe-webhook-secret --value "$
 
 # Signing in with a link, and inviting somebody who is not in your GitHub
 # organization. mail_from is the switch and public_url is then required.
+# READ THE DNS SECTION BELOW FIRST: a verified key is not a domain that can send.
 az keyvault secret set --vault-name "$VAULT" -n resend-api-key --value "$RESEND_API_KEY"
 ```
+
+#### Mail needs DNS before it needs a key
+
+Setting `mail_from` and putting a Resend key in the vault does not make mail
+arrive. The domain has to be able to send, and that is DNS, which is not in this
+repository and no `terraform apply` will fix it. Check before you set the
+variable, because the failure is silent at the sender:
+
+```sh
+dig +short MX example.com
+dig +short TXT example.com                    # the SPF record
+dig +short TXT _dmarc.example.com
+dig +short TXT resend._domainkey.example.com  # the DKIM key Resend published
+```
+
+`antifailure.dev` today answers with no MX, `v=spf1 -all`, a DMARC policy of
+`p=reject; sp=reject; adkim=s; aspf=s`, and `v=DKIM1; p=` on the Resend selector.
+Read in order: nothing receives mail for the domain, **no** sender is authorised
+to send as it, receivers are told to reject anything that fails alignment, and
+the DKIM key is **revoked** rather than merely absent, since an empty `p=` is
+how a key is withdrawn. Somebody set Resend up for this domain and then revoked
+it. Mail sent as anything at that domain fails SPF, fails DKIM, and is rejected
+outright by every receiver that honours DMARC, which is all the large ones.
+
+So the order for mail is: fix the DNS, verify the domain in Resend, then set
+`mail_from`. Until then leave it empty. Nothing breaks in the meantime and it is
+worth knowing exactly what still works, because it is more than it sounds:
+
+- **Sign-in is unaffected.** GitHub is the front door and is always offered; the
+  mailed link is an additional method for a preview environment or an isolated
+  network, and its route is not registered at all when mail is not set up, so
+  there is no button that fails on press.
+- **Invitations work by copy and paste.** The link is returned to the inviter
+  and shown on screen whether or not mail is configured, because an invitation
+  that existed only as an email would silently do nothing on a self-hosted plane
+  with no mailer. A send that fails does not fail the invitation either.
+- **Enterprise leads are still recorded**, and are read with
+  `af-control-plane-backup leads`. `lead_notify_email` is what announces them,
+  and the module refuses a plan that sets it without `mail_from`.
 
 Then the switches, in a tfvars file:
 
@@ -282,8 +322,9 @@ analytics_enabled      = true               # generates the surrogate secret
 analytics_operator_org = "your-org-slug"    # who may read the dashboard
 site_origin            = "https://example.com"
 
-mail_from  = "no-reply@example.com"
-public_url = "https://cp.example.com"
+mail_from         = "no-reply@example.com"   # only once the DNS below is right
+public_url        = "https://cp.example.com"
+lead_notify_email = "sales@example.com"
 
 stripe_price_team = "price_..."
 

--- a/infra/terraform/modules/control-plane/app.tf
+++ b/infra/terraform/modules/control-plane/app.tf
@@ -599,6 +599,22 @@ resource "azurerm_container_app" "this" {
         }
       }
 
+      # Where an enterprise lead is announced.
+      #
+      # Dynamic on its own value rather than on the mail switch, and the
+      # difference matters. Gating it on mail_from would silently DROP an
+      # address somebody set, leaving them with "nobody is mailed" and no
+      # explanation. The precondition below refuses the combination instead, so
+      # the address is either delivered with a mailer behind it or the plan says
+      # why not.
+      dynamic "env" {
+        for_each = var.lead_notify_email == "" ? [] : [var.lead_notify_email]
+        content {
+          name  = "AF_LEAD_NOTIFY_EMAIL"
+          value = env.value
+        }
+      }
+
       # The name in a sign-in link's subject line, for a white-labelled
       # deployment. Dynamic; the application already treats an empty string as
       # unset, and a subject line addressed from nothing is not an intent.
@@ -768,6 +784,17 @@ resource "azurerm_container_app" "this" {
     precondition {
       condition     = var.mail_from == "" || var.public_url != ""
       error_message = "mail_from is set and public_url is empty, so this deployment would set AF_MAIL_FROM and AF_RESEND_API_KEY without AF_PUBLIC_URL. The control plane exits at start-up on a half-configured mailer, because two of the three is a link that goes nowhere or mail that cannot be sent. Set public_url to the origin a browser reaches this deployment on, or clear mail_from to turn the path off."
+    }
+
+    # A lead notification nobody receives.
+    #
+    # Not a start-up refusal in the application, which records the lead and
+    # prints that the address CANNOT be told. That is the right runtime
+    # behaviour and it is a poor deploy-time one: the sentence scrolls past in a
+    # log and the deployment goes on believing it announces leads.
+    precondition {
+      condition     = var.lead_notify_email == "" || var.mail_from != ""
+      error_message = "lead_notify_email is set and mail_from is empty, so this deployment would name an address it has no mailer to reach. Enterprise leads are still recorded and readable with `af-control-plane-backup leads`; set mail_from to announce them, or clear lead_notify_email."
     }
 
     # A plan gate nobody can satisfy.

--- a/infra/terraform/modules/control-plane/variables.tf
+++ b/infra/terraform/modules/control-plane/variables.tf
@@ -520,6 +520,20 @@ variable "public_url" {
   description = "The origin a browser reaches this deployment on, which is where a sign-in link points. Required when mail_from is set."
 }
 
+# Where an enterprise lead is announced.
+#
+# Needs a mailer, and the application says so at startup rather than failing:
+# set with no mailer it prints that this deployment believes it is announcing
+# leads and CANNOT, which is its own state and a worse one than either end. The
+# precondition in app.tf refuses that combination at plan time so the module
+# cannot produce it. Leads are recorded either way and read with
+# `af-control-plane-backup leads`.
+variable "lead_notify_email" {
+  type        = string
+  default     = ""
+  description = "Where an enterprise lead is announced. Empty records leads and mails nobody. Requires mail_from."
+}
+
 variable "resend_api_key_secret_name" {
   type        = string
   default     = "resend-api-key"

--- a/infra/terraform/stacks/control-plane/main.tf
+++ b/infra/terraform/stacks/control-plane/main.tf
@@ -147,6 +147,7 @@ module "control_plane" {
   mail_from                  = var.mail_from
   public_url                 = var.public_url
   resend_api_key_secret_name = var.resend_api_key_secret_name
+  lead_notify_email          = var.lead_notify_email
   product_name               = var.product_name
 
   stripe_price_team                 = var.stripe_price_team

--- a/infra/terraform/stacks/control-plane/variables.tf
+++ b/infra/terraform/stacks/control-plane/variables.tf
@@ -395,6 +395,12 @@ variable "public_url" {
   description = "The origin a browser reaches this deployment on. Required when mail_from is set."
 }
 
+variable "lead_notify_email" {
+  type        = string
+  default     = ""
+  description = "Where an enterprise lead is announced. Empty records leads and mails nobody. Requires mail_from."
+}
+
 variable "resend_api_key_secret_name" {
   type        = string
   default     = "resend-api-key"

--- a/tools/docs/dictionary.txt
+++ b/tools/docs/dictionary.txt
@@ -3,6 +3,7 @@
 # Words this project uses that no general dictionary has.
 # line diff a reviewer can read, and so the list stays sorted.
 BYPASSRLS
+DMARC
 PKCE
 Procfile
 SCIM

--- a/tools/docs/wiring-exemptions.tsv
+++ b/tools/docs/wiring-exemptions.tsv
@@ -19,10 +19,18 @@
 # secret and the App install address are every one of them things somebody
 # running this is meant to set, and there was nothing true to write for them.
 #
-# AF_CONTROL_PLANE_TOKEN is deliberately absent from this file. The reference
-# already carries it under its own heading, "Set on the engine, not here", and
-# says that setting it on the control plane process does nothing at all.
-# wirecheck reads that section rather than a row restating it.
+# A ROW HERE MEANS "THE MODULE CANNOT SET IT", NOT "THE FEATURE DOES NOT WORK",
+# and the absence of a row means only that the module CAN set it. Neither says
+# anything about whether the feature functions once it is set. Mail is the live
+# example: AF_MAIL_FROM and AF_RESEND_API_KEY have no row because the module
+# carries them, and mail from antifailure.dev is still rejected by every
+# receiver honouring DMARC until its DNS is fixed. This file is about delivery.
+#
+# AF_CONTROL_PLANE_TOKEN and AF_ADMIN_BOOTSTRAP_PASSWORD are deliberately absent
+# from this file. The reference already says where each one is set, in a table
+# whose second column is "Where it is set" rather than "Default": on the engine
+# or in a CI job for the first, in the shell that runs the command for the
+# second. wirecheck reads that column rather than a row restating it.
 
 AF_VERSION	stamped into the image at build time by the release pipeline and reported by /readyz. A value set here would not change the build; it would make the endpoint lie about which one is running.
 AF_COMMIT	stamped into the image at build time, exactly as AF_VERSION is, and reported by the same endpoint for the same purpose.

--- a/tools/inputcheck/surface-v1.tsv
+++ b/tools/inputcheck/surface-v1.tsv
@@ -183,6 +183,7 @@ terraform:modules/control-plane	variable	image_repository	string	optional
 terraform:modules/control-plane	variable	image_tag	string	optional
 terraform:modules/control-plane	variable	key_vault_name	string	optional
 terraform:modules/control-plane	variable	key_vault_purge_protection	bool	optional
+terraform:modules/control-plane	variable	lead_notify_email	string	optional
 terraform:modules/control-plane	variable	location	string	required
 terraform:modules/control-plane	variable	log_analytics_id	string	optional
 terraform:modules/control-plane	variable	mail_from	string	optional
@@ -268,6 +269,7 @@ terraform:stacks/control-plane	variable	image_digest	string	optional
 terraform:stacks/control-plane	variable	image_repository	string	optional
 terraform:stacks/control-plane	variable	image_tag	string	optional
 terraform:stacks/control-plane	variable	key_vault_name	string	optional
+terraform:stacks/control-plane	variable	lead_notify_email	string	optional
 terraform:stacks/control-plane	variable	location	string	optional
 terraform:stacks/control-plane	variable	log_retention_days	number	optional
 terraform:stacks/control-plane	variable	mail_from	string	optional

--- a/tools/wirecheck/main.go
+++ b/tools/wirecheck/main.go
@@ -50,11 +50,32 @@
 // process on purpose, because migrations racing across replicas at start-up is
 // a worse way to apply a schema than a job that runs once.
 //
-// WHAT IT DOES NOT CLAIM. That a variable CAN be set is not that it IS set on
-// any particular installation: that is a tfvars file's decision and this tool
-// never reads one, deliberately, because a tfvars file is the operator's and
-// lives in their repository. The claim is narrower and it is the one that was
-// false: there exists a supported way to set it.
+// WHAT IT DOES NOT PROVE, AND THIS PARAGRAPH IS NOT A DISCLAIMER. It is the
+// same mistake this tool was written about, aimed at this tool.
+//
+// It proves a variable can be DELIVERED. It does not prove the feature works.
+// Those are different sentences and the distance between them is exactly where
+// the last finding lived: varcheck and config-docs.test.ts proved a variable
+// was DOCUMENTED, everybody read them as proving it was USABLE, and twenty nine
+// unreachable variables sat under two green checks for months.
+//
+// The live example is mail. This gate will go green on AF_MAIL_FROM and
+// AF_RESEND_API_KEY the moment the module can set them, and mail sent from
+// antifailure.dev is still rejected by every receiver that honours DMARC: the
+// domain publishes `v=spf1 -all`, which authorises no sender, a DMARC policy of
+// p=reject with strict alignment, and a Resend DKIM record whose empty `p=` is
+// a REVOKED key. Nothing in this repository can see that and nothing in this
+// repository should pretend to. It is DNS, and self-hosting/azure.md names it
+// as the step before AF_MAIL_FROM is worth setting.
+//
+// Nor is "can be set" the same as "is set". Whether a particular installation
+// sets a variable is a tfvars file's decision, and this tool never reads one,
+// deliberately: a tfvars file is the operator's and lives in their repository.
+//
+// So the claim is narrow, and it is the one that was false: for every variable
+// the reference documents, a supported deploy path exists that can deliver it.
+// Read it as anything wider and this gate becomes the third one answering a
+// nearby question.
 //
 // It also reads the module and not the stack. The stack passes inputs through
 // to the module, and the module is what owns the container template, so the
@@ -77,14 +98,30 @@ const (
 	modulePath     = "infra/terraform/modules/control-plane"
 	exemptionsPath = "tools/docs/wiring-exemptions.tsv"
 
-	// The one section of the reference whose variables are not the control
-	// plane's to receive. The page says so itself, in the section body: an
-	// engine token is issued and verified by the control plane and never read
-	// from its own environment, and "setting it on the control plane process
-	// does nothing at all". Reading the document's own statement is better than
-	// copying it into a TSV, and if the section is ever removed those variables
-	// become ordinary and need rows like everything else.
-	engineSection = "Set on the engine, not here"
+	// HOW THE PAGE SAYS "THIS ONE IS NOT SET HERE", read off the table itself.
+	//
+	// Some variables on this page are not the control plane's environment to
+	// carry. AF_CONTROL_PLANE_TOKEN is issued and verified by the control plane
+	// and never read from its own environment; AF_ADMIN_BOOTSTRAP_PASSWORD is
+	// typed into the shell that runs a command and the serving process never
+	// reads it. The page declares both the same way: their tables carry a
+	// "Where it is set" column instead of a "Default" one, and the cell answers
+	// it -- "On the engine, or in a CI job", "In the shell that runs the
+	// command".
+	//
+	// Keyed on that column rather than on the section titles, and the reason is
+	// not tidiness. This gate first read the titles, and the very next thing
+	// that happened was a new section, "Read by a command, not by the server",
+	// arriving on main with a variable under it. The gate went red, correctly,
+	// but a rule that needs a new constant for every heading somebody writes is
+	// a rule that will one day be widened by whoever is in a hurry. The column
+	// is the page's own statement about the row, it travels with the table, and
+	// a section written in that shape tomorrow needs nothing added here.
+	//
+	// It fails in the safe direction. Rename the column and these variables
+	// become ordinary and demand an env block or a row, which is loud. There is
+	// no spelling of it that makes a variable disappear from the gate quietly.
+	notSetHereColumn = "Where it is set"
 
 	// A FLOOR, because a parser that stops matching looks exactly like a
 	// codebase with nothing to find. Both numbers are far below what the two
@@ -246,14 +283,17 @@ func documentedVariables(root string) (map[string]string, error) {
 		return nil, err
 	}
 	out := map[string]string{}
-	inEngineSection := false
+	// Reset at every heading, so the shape of one table never leaks into the
+	// next: a section that opens with no table of its own must not inherit the
+	// previous section's answer.
+	inNotSetHereTable := false
 	for i, line := range strings.Split(string(b), "\n") {
 		line = strings.TrimRight(line, "\r")
 		if strings.HasPrefix(line, "#") {
-			inEngineSection = strings.Contains(line, engineSection)
+			inNotSetHereTable = false
 			continue
 		}
-		if inEngineSection || !strings.HasPrefix(strings.TrimSpace(line), "|") {
+		if !strings.HasPrefix(strings.TrimSpace(line), "|") {
 			continue
 		}
 		if tableSeparator.MatchString(strings.TrimSpace(line)) {
@@ -264,6 +304,14 @@ func documentedVariables(root string) (map[string]string, error) {
 			continue
 		}
 		first := strings.TrimSpace(cells[0])
+		// A header row, which is where the table declares its own shape.
+		if first == "Variable" {
+			inNotSetHereTable = len(cells) > 1 && strings.TrimSpace(cells[1]) == notSetHereColumn
+			continue
+		}
+		if inNotSetHereTable {
+			continue
+		}
 		// Backticked and nothing else, so that a cell of prose that happens to
 		// begin with a variable name is not read as a definition.
 		if !strings.HasPrefix(first, "`") || !strings.HasSuffix(first, "`") {

--- a/tools/wirecheck/main_test.go
+++ b/tools/wirecheck/main_test.go
@@ -150,27 +150,96 @@ func TestOnlyTheFirstCellOfARowDefinesAVariable(t *testing.T) {
 	}
 }
 
-// The one section whose variables the control plane never reads from its own
-// environment. The page states it; this reads the statement rather than keeping
-// a second copy of it in a TSV.
-func TestSkipsTheSectionTheReferenceSaysIsNotSetHere(t *testing.T) {
-	page := oneRow + "\n## " + engineSection + "\n\n| Variable | Where | What |\n| --- | --- | --- |\n" +
-		"| `AF_ON_THE_ENGINE` | On the engine | Not read here. |\n" +
+// A table that declares its variables are set somewhere else.
+//
+// The page says it with the column, not with the heading: a "Where it is set"
+// column in place of a "Default" one, and a cell that answers it. Two sections
+// are written that way today and the second arrived AFTER this gate did, which
+// is the argument for reading the column rather than a list of titles.
+func TestSkipsATableThatSaysTheVariableIsSetElsewhere(t *testing.T) {
+	notHere := func(heading, name, where string) string {
+		return "\n## " + heading + "\n\n| Variable | " + notSetHereColumn + " | What it is |\n" +
+			"| --- | --- | --- |\n| `" + name + "` | " + where + " | Not read here. |\n"
+	}
+	page := oneRow +
+		notHere("Set on the engine, not here", "AF_ON_THE_ENGINE", "On the engine, or in a CI job") +
+		notHere("Read by a command, not by the server", "AF_IN_A_SHELL", "In the shell that runs the command") +
 		"\n## Analytics\n\n| Variable | Default | What |\n| --- | --- | --- |\n" +
 		"| `AF_AFTER_THE_SECTION` | unset | Read here again. |\n"
+
 	documented, err := documentedVariables(tree(t, page, "", ""))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if where := documented["AF_ON_THE_ENGINE"]; where != "" {
-		t.Fatalf("a variable under %q was read as one this module must set, at %s", engineSection, where)
+	for _, name := range []string{"AF_ON_THE_ENGINE", "AF_IN_A_SHELL"} {
+		if where := documented[name]; where != "" {
+			t.Errorf("%s sits under a %q column and was still demanded of the module, at %s",
+				name, notSetHereColumn, where)
+		}
 	}
-	// The section ENDS at the next heading. A skip that ran to the end of the
-	// file would swallow the analytics table, which is where AF_SITE_ORIGIN and
-	// the surrogate secret live -- five of the variables this gate was written
-	// for.
+	// The skip ENDS with the table. One that ran to the end of the file would
+	// swallow the analytics table, which is where AF_SITE_ORIGIN and the
+	// surrogate secret live: five of the variables this gate was written for.
 	if documented["AF_AFTER_THE_SECTION"] == "" {
-		t.Fatal("the skip did not stop at the next heading, so every later table was ignored")
+		t.Error("the skip did not end with the table, so every later one was ignored")
+	}
+	// And the row that opened the page is still there, so the skip did not
+	// start early either.
+	if documented["AF_WANTED"] == "" {
+		t.Error("an ordinary table before the skipped one was ignored")
+	}
+}
+
+// A "Default" table is an ordinary one however it is worded, and each case below
+// is a DIFFERENT way a looser reading would wrongly skip one. They are separate
+// because a substring test over the whole line passes the first and fails the
+// second, so one of them alone would report a rule it is not testing.
+func TestATableWithADefaultColumnIsNeverSkipped(t *testing.T) {
+	for _, tc := range []struct{ name, page string }{
+		{"the phrase appears in a data cell", "## Optional\n\n" +
+			"| Variable | Default | What it does |\n| --- | --- | --- |\n" +
+			"| `AF_WANTED` | unset | Where it is set is discussed at length here. |\n"},
+		// The one that separates "the header's SECOND CELL is the column" from
+		// "the header LINE mentions the words somewhere".
+		{"the phrase appears in another header cell", "## Optional\n\n" +
+			"| Variable | Default | Where it is set, and why that matters |\n| --- | --- | --- |\n" +
+			"| `AF_WANTED` | unset | Something. |\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			documented, err := documentedVariables(tree(t, tc.page, "", ""))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if documented["AF_WANTED"] == "" {
+				t.Fatal("an ordinary table was skipped, so a variable nothing can set would pass unseen")
+			}
+		})
+	}
+}
+
+// A HEADING ALWAYS RESETS THE SHAPE, and this is the case that proves the reset
+// is load-bearing rather than decoration.
+//
+// A well-formed table declares itself in its header row, so on a tidy page the
+// reset never decides anything. On a page somebody has edited badly -- a
+// section whose header row was dropped -- it decides everything: without it the
+// rows inherit the PREVIOUS table's "not set here" and the variables in them
+// vanish from the gate silently, which is the one failure this whole tool
+// exists to make impossible. With it they are read, and an unsettable one is
+// reported loudly.
+func TestAHeadingResetsTheTableShape(t *testing.T) {
+	page := "\n## Set on the engine, not here\n\n| Variable | " + notSetHereColumn + " | What it is |\n" +
+		"| --- | --- | --- |\n| `AF_ON_THE_ENGINE` | On the engine | Not read here. |\n" +
+		"\n## Optional\n\n| `AF_WANTED` | unset | A row whose header row somebody deleted. |\n"
+	documented, err := documentedVariables(tree(t, page, "", ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if documented["AF_ON_THE_ENGINE"] != "" {
+		t.Error("the not-set-here table was read after all")
+	}
+	if documented["AF_WANTED"] == "" {
+		t.Fatal("a row under a later heading inherited the previous table's shape and was skipped silently")
 	}
 }
 


### PR DESCRIPTION
## main is red right now, and this is the fix

#196 added `tools/wirecheck` and merged at 06:14. `AF_LEAD_NOTIFY_EMAIL` and
`AF_ADMIN_BOOTSTRAP_PASSWORD` had landed just before it in #187, #189 and #191.
The gate is now in CI and neither variable could be set by the Terraform module,
so `main` fails:

```
$ go run ./tools/wirecheck .   # at 7a7d0be2
  AF_ADMIN_BOOTSTRAP_PASSWORD is documented at ...control-plane.md:75 and no supported deploy can set it
  AF_LEAD_NOTIFY_EMAIL is documented at ...control-plane.md:57 and no supported deploy can set it
exit status 1
```

That is the gate working rather than misfiring, on code it had never seen, which
is better evidence than any mutation I wrote for it. It is still a red main and
it blocks every branch, so this goes first and the rest of the PR explains it.

## The two variables

**`AF_LEAD_NOTIFY_EMAIL` is a hosted setting and is now wired.** It needs a
mailer. Set without one, `leadNotifierFrom` records the lead and prints that the
address **CANNOT** be told, which is its own state and worse than either end: the
deployment believes it announces leads and does not. The application does not
exit on it, correctly, so a precondition refuses the combination at plan time
instead, where it is a review comment rather than a line scrolling past in a log.

**`AF_ADMIN_BOOTSTRAP_PASSWORD` is not the server's to receive**, and the page
says so itself. It arrived under a new heading, "Read by a command, not by the
server", whose table carries a `Where it is set` column instead of a `Default`
one and answers it with "In the shell that runs the command". The serving process
never reads it.

So the skip now keys on **that column** rather than on a list of section titles.
The column is the page's own statement about the row, it travels with the table,
and the next section written that way needs nothing added here. It also fails in
the safe direction: rename the column and those variables become ordinary and
demand an env block or a row, loudly. There is no spelling that makes a variable
vanish from the gate quietly.

| Assertion added | Mutation that made it red |
| --- | --- |
| `the phrase appears in another header cell` | skip keyed on the whole header line rather than its second cell |
| `TestAHeadingResetsTheTableShape` | the heading no longer resets the table shape |

I wrote two other assertions first and threw them away: they passed under both
mutations, so they were describing a rule they could not test. The two above
each catch exactly one break, verified by making it.

## Three corrections to #196's own account, which the lead caught

**The mail row was overstated.** #196's table said unset mail meant "no sign-in
link and no invitation could be sent at all". Wrong on both halves.

Invitations degrade by design. `enterprise/invitations.ts` opens with "THE LINK
IS RETURNED TO THE INVITER, ALWAYS", because an invitation that only existed as
an email would silently do nothing on a plane with no mailer. The link is on
screen and a failed send does not fail the invitation.

Sign-in never depended on mail, and I checked rather than assuming. `server.ts`
builds `['github', ...(options.emailSignIn ? ['email'] : [])]`, so GitHub is
always offered and the mailed link is an additional way in for a preview
environment or an isolated network. `/auth/email` is not registered at all when
mail is unset, with a comment saying why: a method that cannot work should be
absent, not a button that fails on press. No sign-in route depends on a mailed
link with no fallback. Not a blocker.

**Wiring mail will not make mail arrive.** Verified with `dig`, not taken on
report:

| Record | Value | What it means |
| --- | --- | --- |
| `MX` | none | nothing receives mail for the domain |
| `TXT` | `v=spf1 -all` | no sender is authorised, at all |
| `_dmarc` | `p=reject; sp=reject; adkim=s; aspf=s` | reject on any alignment failure |
| `resend._domainkey` | `v=DKIM1; p=` | an empty `p=` is a **revoked** key |

Somebody configured Resend for this domain and then revoked it. Mail sent as
anything at `antifailure.dev` fails SPF, fails DKIM, and is rejected outright by
every receiver honouring DMARC. The DNS is not mine to change and this PR does
not touch it. It is now a section of the self-hosting guide and the step before
`AF_MAIL_FROM` is worth setting, so nobody discovers it while wondering why a
verified key sends nothing.

**And the sentence wirecheck now carries about itself.** It proves a variable can
be **delivered**. It does not prove the feature works. Mail is the live example:
the gate is green on `AF_MAIL_FROM` today and the domain still cannot send. That
distinction is the entire reason the original finding existed, since `varcheck`
and `config-docs.test.ts` proved a variable was documented and everybody read
them as proving it was usable. Saying it in the tool header and in the exemptions
file is cheaper than the next person assuming otherwise.

## Checked

`wirecheck`, `inputcheck`, `prosecheck`, `spell`, `vale`, `readability`,
`claimcheck`, `terraform fmt`, `validate` on both the module and the stack, and
`go test` on wirecheck, gatecheck and inputcheck. The db suite is 142 passing
against a real Postgres, including the 8 bootstrap tests, and `web` typechecks.

`inputcheck` records one new optional input on each of the module and the stack,
compatible, with no removal, rename or retype.
