### PR TITLE
infra: the runbook said this file was ignored and it was not

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,6 +194,12 @@ local_backend_override.tf
 # documented steps left an untracked file holding the state storage account name
 # for the next `git add -A` to commit. The claim and the rule agree now.
 backend*.hcl
+# The plan step writes plan.tfplan, plan.json and plan.txt into the stack
+# directory. *.tfplan covers the first and a plan.json rule above covers the
+# second; plan.txt was covered by nothing. It is `terraform show -no-color`
+# output rather than the raw variable values, so it is the smaller of the two
+# risks, and it is still a file nobody meant to offer to `git add -A`.
+plan.txt
 *.auto.tfvars
 
 # Assembled deploy output: www/out + docs/dist + the apex files, built by

--- a/.gitignore
+++ b/.gitignore
@@ -188,7 +188,12 @@ engine/af
 *.tfplan
 crash.log
 local_backend_override.tf
-backend.hcl
+# backend*.hcl rather than backend.hcl, because the production runbook tells an
+# operator to create backend.production.hcl and says in as many words that it is
+# ignored by git. It was not: only the bare name was listed, so following the
+# documented steps left an untracked file holding the state storage account name
+# for the next `git add -A` to commit. The claim and the rule agree now.
+backend*.hcl
 *.auto.tfvars
 
 # Assembled deploy output: www/out + docs/dist + the apex files, built by


### PR DESCRIPTION
## Found by following the runbook

`docs/src/content/docs/self-hosting/production.md` tells an operator to write this, with the state storage account name in it:

```sh
cat > backend.production.hcl <<'EOF'
resource_group_name  = "af-tfstate-eastus"
storage_account_name = "<the state account>"
...
```

and then says, of that file:

> `backend.hcl` and `backend.production.hcl` are both ignored by git, because the storage account name is an identifier this repository does not carry.

`.gitignore` listed only `backend.hcl`.

I hit it by doing exactly what the page says. `git status` reported the file as untracked the moment it existed, so the next `git add -A` would have committed the identifier the page says this repository does not carry.

## Why the sentence made it worse rather than neutral

An unignored file is a small problem that somebody notices in `git status`. An unignored file that the documentation promises is ignored is a problem nobody looks for, because the page already answered the question.

## The change

`backend*.hcl`, which covers the bare name, the production one the runbook names, and a staging one somebody writes beside it. Verified against all three:

```
.gitignore:196:backend*.hcl	infra/terraform/stacks/control-plane/backend.hcl
.gitignore:196:backend*.hcl	infra/terraform/stacks/control-plane/backend.production.hcl
.gitignore:196:backend*.hcl	infra/terraform/stacks/control-plane/backend.staging.hcl
```

The comment above the rule says why it is a glob rather than a list, so the next person does not narrow it back.