### PR TITLE
test: an assertion that failed on a coin toss

### DIFF
--- a/web/apps/api/test/billing.test.ts
+++ b/web/apps/api/test/billing.test.ts
@@ -1286,7 +1286,24 @@ describe('billing', { skip: hasDatabase ? false : 'no Postgres at AF_TEST_DATABA
       form.has('line_items[0][quantity]'), false,
       'a seat count in the input reached Stripe as a quantity',
     )
-    assert.equal(sent.body.includes('200'), false, `200 reached Stripe: ${sent.body}`)
+    // Every VALUE, rather than a substring of the whole body.
+    //
+    // This was `sent.body.includes('200')`, and it went red on a pull request
+    // that changed one line of .gitignore. The body it printed carried no
+    // quantity at all and was exactly right; what it matched was the
+    // organization's own identifier, `1338f347-4154-445c-bac5-606e5200be24`,
+    // which happens to contain those three digits. The test generates that id
+    // and does not control it, so the assertion failed on a coin toss and would
+    // have gone on doing it forever.
+    //
+    // A check that fails for a reason no diff can explain is worse than one
+    // that is missing, because it teaches everybody to rerun a red job without
+    // reading it, and that habit is what lets a real failure through. Reading
+    // the values keeps everything the substring version was for: a 200 sent as
+    // any field's value still fails, including one nobody thought to name.
+    for (const [field, value] of form.entries()) {
+      assert.notEqual(value, '200', `the seat count reached Stripe as ${field}`)
+    }
 
     // And the audit entry does not record a seat count either, because there
     // is no longer any such thing to record.


### PR DESCRIPTION
## It went red on a diff of one gitignore line

`a caller that asks for two hundred seats is billed for none of them` failed on PR #203, whose entire change is one line in `.gitignore`. The body it printed was correct:

```
mode=subscription&customer=cus_mock00000000000005
&line_items%5B0%5D%5Bprice%5D=price_team_afmock
&client_reference_id=1338f347-4154-445c-bac5-606e5200be24
&metadata%5Borg_id%5D=1338f347-4154-445c-bac5-606e5200be24
```

No quantity anywhere. The assertion was a substring search over the whole form body:

```js
assert.equal(sent.body.includes('200'), false, `200 reached Stripe: ${sent.body}`)
```

and the organization id that run generated was `1338f347-4154-445c-bac5-606e5200be24`, which carries those three digits at position 29. The test generates that id and does not control it, so this failed on a coin toss and would have gone on doing it at whatever rate a random identifier happens to contain `200`.

## Why it is worth a commit rather than a rerun

A check that fails for a reason no diff can explain is worse than one that is missing. It teaches everybody to rerun a red job without reading it, and that habit is what lets a real failure through. The same argument is already written into the rehearsal timing test, and the `tfsec` installer earned it again this week.

## The change keeps everything the old check was for

Every **value**, rather than a substring of the whole body. A `200` sent as any field's value still fails, including a field nobody thought to name, and the message now says which field it was instead of printing the entire body.

The precise assertion above it, that `line_items[0][quantity]` is absent, is untouched. That one states the property; this one is the belt-and-braces pass, and it should not be the reason main goes red.

## Proved rather than argued

| Case | Should pass | Old | New |
| --- | --- | --- | --- |
| correct code, id happens to carry 200 | yes | **no** | yes |
| correct code, ordinary id | yes | yes | yes |
| the defect: 200 as the quantity | no | no | no |
| the defect, with an unlucky id too | no | no | no |

The old check is wrong on the first row. The new one is right on all four, so it did not get weaker to stop being flaky.