### PR TITLE
infra: production could not be planned, and only staging was ever planned

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -430,10 +430,15 @@ jobs:
       # credential alone, and it is why "plan production from empty state too"
       # would have been a check that could not say no.
       #
-      # WHAT IT COSTS IN PERMISSION: nothing new. The same federated credential,
-      # the same storage account and container, one more blob key. -lock=false
-      # because the identity is Storage Blob Data READER and cannot take a
-      # lease, exactly as above. -refresh=false, and with that flag the only
+      # WHAT IT COSTS IN PERMISSION: nothing new, and that was checked against
+      # Azure rather than inferred. The same federated credential, the same
+      # storage account and container, one more blob key. The Storage Blob Data
+      # Reader that stacks/tfstate grants this identity is scoped to the whole
+      # ACCOUNT, so the second blob is already readable by a grant that exists;
+      # no role is added for this step. -lock=false for the same reason the
+      # staging plan does not lock: a lease is a write, and stacks/tfstate
+      # deliberately grants this identity no write on the state.
+      # -refresh=false, and with that flag the only
       # Azure call this plan makes is azurerm_client_config, which reads the
       # caller's own identity and needs no role at all: every
       # azurerm_key_vault_secret data source in the module is counted to zero

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -206,6 +206,11 @@ jobs:
           else
             echo "remote_state=false" >> "$GITHUB_OUTPUT"
             echo "::warning title=Planning from empty state::AZURE_TFSTATE_RG and AZURE_TFSTATE_ACCOUNT are not both set, so this plan started from an empty state. Every resource reads as a create and THIS PLAN CANNOT REPORT A DESTROY."
+            # And the other half of what an empty state cannot see, said here
+            # rather than left as a step that quietly did not run. The
+            # production check needs a known value to reject and an empty state
+            # has none, so it is skipped rather than reporting a false pass.
+            echo "::warning title=Production not checked::The production plan is skipped without a state backend, so nothing here checked whether production can be planned at all."
           fi
 
       - uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -397,3 +397,105 @@ jobs:
             cat "$GITHUB_WORKSPACE/cost.txt"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # THE FOURTH MODE, AND THE ONE THIS JOB DID NOT HAVE.
+      #
+      # Every step above plans STAGING. Production is a second var-file against
+      # a second state blob and nothing planned it, so the one environment
+      # Terraform could not manage was the one nothing checked. That gap is
+      # quiet by construction: deploys go out through `az containerapp update`
+      # in deploy/cd/deploy.sh rather than through Terraform, so production kept
+      # shipping normally for days while its stack could not be planned at all.
+      # A stack that cannot be planned is a stack nobody can change, and the
+      # settings that were merged and could not be applied were the ones that
+      # turn the operator portal on.
+      #
+      # IT LOOKS AT THE EXIT STATUS AND AT NOTHING ELSE. It does not review the
+      # diff and must not be read as reviewing it, because the inputs here are
+      # not the inputs an apply would use: alert_emails is a placeholder, so
+      # this plan always proposes an in-place change to the action group's
+      # receiver that no apply would ever make. A plan run with different inputs
+      # is a plan about a different desired state, which is the same reason the
+      # staging block pins ci_principal_id. Whether the plan SUCCEEDS is the one
+      # thing that does not depend on those inputs, and it is the whole question
+      # being asked.
+      #
+      # WHY IT NEEDS THE REAL STATE, measured rather than assumed. The failure
+      # this catches is a provider argument validator refusing a value it can
+      # never accept. Terraform SKIPS a validator whose value is unknown, and
+      # from an empty state every id in the plan is unknown, so the empty-state
+      # mode above plans the identical broken configuration clean and exits
+      # zero. Only a plan holding the recorded state has a known value to
+      # refuse. That is why this is gated on remote_state and not on a
+      # credential alone, and it is why "plan production from empty state too"
+      # would have been a check that could not say no.
+      #
+      # WHAT IT COSTS IN PERMISSION: nothing new. The same federated credential,
+      # the same storage account and container, one more blob key. -lock=false
+      # because the identity is Storage Blob Data READER and cannot take a
+      # lease, exactly as above. -refresh=false, and with that flag the only
+      # Azure call this plan makes is azurerm_client_config, which reads the
+      # caller's own identity and needs no role at all: every
+      # azurerm_key_vault_secret data source in the module is counted to zero
+      # under production.tfvars, so no secret is read and no role on
+      # af-cp-prod-centralus is required.
+      #
+      # LAST IN THE JOB ON PURPOSE. It re-initialises the backend against the
+      # production state, and every step above reads files the staging plan
+      # wrote. Running it earlier would leave those steps describing one
+      # environment from a directory pointed at the other, which is the exact
+      # confusion infra/ISOLATION.md warns about in this shared stack directory.
+      - name: production can still be planned
+        if: steps.azure.outputs.ready == 'true' && steps.azure.outputs.remote_state == 'true'
+        working-directory: infra/terraform/stacks/control-plane
+        env:
+          ARM_USE_OIDC: "true"
+          ARM_USE_AZUREAD: "true"
+          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          TF_VAR_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          TF_VAR_github_client_id: plan-only
+          TF_VAR_github_client_secret: plan-only
+          TF_VAR_github_redirect_uri: https://example.invalid/auth/callback
+          TF_VAR_ci_principal_id: ${{ vars.AZURE_CI_PRINCIPAL_ID }}
+          # Production refuses to plan with alerting on and no receiver, which
+          # is a deliberate validation and not something to work around: an
+          # action group with no receivers creates cleanly, attaches to every
+          # rule, reports healthy and tells nobody. A placeholder satisfies it
+          # so the check can reach the configuration behind it. Nothing is
+          # delivered to this address because nothing is applied from here.
+          TF_VAR_alert_emails: '["plan-only@example.invalid"]'
+        run: |
+          set -euo pipefail
+          terraform init -reconfigure -input=false \
+            -backend-config="resource_group_name=${{ secrets.AZURE_TFSTATE_RG }}" \
+            -backend-config="storage_account_name=${{ secrets.AZURE_TFSTATE_ACCOUNT }}" \
+            -backend-config="container_name=tfstate" \
+            -backend-config="key=control-plane-production.tfstate" \
+            -backend-config="use_azuread_auth=true" \
+            -backend-config="use_oidc=true"
+          # No -out, and the log goes to the runner's temp directory rather
+          # than into the stack. `terraform show -json` on a plan file includes
+          # the values of sensitive input variables and this plan has no reader,
+          # and a log written beside staging.tfvars is one more untracked file
+          # in a directory an operator also works in by hand.
+          log="$RUNNER_TEMP/production-plan.txt"
+          if terraform plan -input=false -lock=false -refresh=false \
+            -var-file=production.tfvars -no-color > "$log" 2>&1; then
+            echo "Production planned successfully. The diff above is staging's; this step read only the exit status." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::error title=Production cannot be planned::terraform plan against production.tfvars and control-plane-production.tfstate failed. Until it passes, no change to this stack can be applied to production, including changes already merged. The failure is below."
+            {
+              echo
+              echo "### Production cannot be planned"
+              echo
+              echo 'This is not about the diff. `terraform plan -var-file=production.tfvars`'
+              echo 'exited non-zero, so production has no applyable plan at all.'
+              echo
+              echo '```'
+              tail -c 20000 "$log"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi

--- a/infra/terraform/modules/control-plane/domain.tf
+++ b/infra/terraform/modules/control-plane/domain.tf
@@ -1,15 +1,24 @@
 # app.antifailure.dev, and everything Terraform can own of it.
 #
-# Four resources in one order that works and several that do not. Azure will not
-# issue a managed certificate for a name it cannot prove you control, and it
-# proves control by resolving DNS, so the records have to exist and be correct
-# before the certificate is asked for, and the certificate has to exist before
-# the binding can reference it.
+# Four resources in one order that works and several that do not, and THE ORDER
+# HERE IS NOT THE OBVIOUS ONE. Azure will not issue a managed certificate for a
+# name it cannot prove you control, and it proves control by resolving DNS, so
+# the records have to exist and be correct first. What is not obvious, and what
+# cost this an apply, is that Azure ALSO refuses to issue the certificate until
+# the hostname is already bound to an app in the environment:
+#
+#   RequireCustomHostnameInEnvironment: Creating managed certificate requires
+#   hostname 'app.antifailure.dev' added as a custom hostname to a container
+#   app or route in environment 'afcpprod-env'
+#
+# So the binding cannot reference the certificate, because the certificate
+# cannot exist until the binding does. Expressing it the other way round is a
+# dependency cycle, not a fix.
 #
 #   CNAME <sub>        ->  the container app's default FQDN
 #   TXT   asuid.<sub>  ->  the app's custom_domain_verification_id
-#   managed certificate for the full name
-#   custom domain binding on the app, referencing that certificate
+#   custom domain binding on the app, with NO certificate
+#   managed certificate for the full name, which Azure then binds ITSELF
 #
 # THE TXT RECORD IS NOT OPTIONAL AND IS THE PART PEOPLE MISS. A CNAME alone
 # proves that a name points at an Azure endpoint, not that it points at YOUR
@@ -75,7 +84,47 @@ resource "azurerm_dns_txt_record" "asuid" {
   tags = var.tags
 }
 
-# The certificate Azure issues and renews for free.
+# The binding, as a separate resource rather than an ingress block, and it comes
+# BEFORE the certificate.
+#
+# azurerm_container_app's ingress carries a custom_domain list, and using both
+# it and this resource makes the two fight: every apply would see the binding
+# this resource created as an unexpected value inside the app's ingress and
+# propose to remove it. app.tf therefore ignores that attribute, and this is the
+# one place a custom domain is declared.
+#
+# NO CERTIFICATE HERE, AND THAT IS THE WHOLE POINT. The provider documents it:
+# "Omit this value if you wish to use an Azure Managed certificate." The
+# hostname is added first with no TLS, the certificate is requested against a
+# hostname that now exists, and Azure attaches it to this binding itself once it
+# has issued. Naming the certificate here instead is what produced
+# RequireCustomHostnameInEnvironment at the top of this file.
+resource "azurerm_container_app_custom_domain" "app" {
+  count = local.custom_domain_enabled ? 1 : 0
+
+  name             = var.custom_domain
+  container_app_id = azurerm_container_app.this.id
+
+  # Azure validates ownership when the hostname is ADDED, not only when the
+  # certificate is issued, so both records have to be in place before this. The
+  # CNAME alone is not enough; asuid carries the verification id that ties the
+  # name to this specific app.
+  depends_on = [
+    azurerm_dns_cname_record.app,
+    azurerm_dns_txt_record.asuid,
+  ]
+
+  lifecycle {
+    # Azure writes both of these when the managed certificate below is issued,
+    # asynchronously and outside any apply. Both are ForceNew, so without this a
+    # plan run after issuance proposes to REPLACE the binding, and replacing it
+    # takes the name off the app for as long as the recreate takes. The provider
+    # says to do exactly this for an Azure managed certificate.
+    ignore_changes = [certificate_binding_type, container_app_environment_certificate_id]
+  }
+}
+
+# The certificate Azure issues, renews and binds for free.
 #
 # Not a certificate this repository holds. There is no private key here, nothing
 # to rotate, and nothing that expires because somebody left. What can go wrong
@@ -95,27 +144,8 @@ resource "azurerm_container_app_environment_managed_certificate" "app" {
 
   tags = var.tags
 
-  # Both records, not just the CNAME. Azure reads them in the same validation
-  # and a certificate request that arrives before the TXT record exists fails
-  # with a message about domain ownership rather than about DNS.
-  depends_on = [
-    azurerm_dns_cname_record.app,
-    azurerm_dns_txt_record.asuid,
-  ]
-}
-
-# The binding, as a separate resource rather than an ingress block.
-#
-# azurerm_container_app's ingress carries a custom_domain list, and using both
-# it and this resource makes the two fight: every apply would see the binding
-# this resource created as an unexpected value inside the app's ingress and
-# propose to remove it. app.tf therefore ignores that attribute, and this is the
-# one place a custom domain is declared.
-resource "azurerm_container_app_custom_domain" "app" {
-  count = local.custom_domain_enabled ? 1 : 0
-
-  name                                     = var.custom_domain
-  container_app_id                         = azurerm_container_app.this.id
-  container_app_environment_certificate_id = azurerm_container_app_environment_managed_certificate.app[0].id
-  certificate_binding_type                 = "SniEnabled"
+  # The binding, not the DNS records. It depends on them in turn, so the records
+  # are still ordered ahead of this, and naming the binding is what encodes the
+  # requirement Azure actually enforces.
+  depends_on = [azurerm_container_app_custom_domain.app]
 }


### PR DESCRIPTION
`terraform plan -var-file=production.tfvars` has exited non-zero on every commit
since the custom domain certificate was created on 30 August. Not a diff nobody
liked: no plan at all, so nothing merged could be applied to production. PR 201
turned `operator_portal_enabled` on and set `site_origin`. Those are what make
`app.antifailure.dev/admin` show data rather than say it has no operator
database credential, and they are what the twenty two operator sections in
v1.1.0 are waiting behind.

## The diagnosis, corrected in three places

I reproduced it before trusting the report, and the report is wrong in ways that
change the fix.

**It is not a refresh failure.** It survives `-refresh=false`, which is the flag
CI already plans with. No Azure read is involved.

**It is not the certificate resource.** It is
`azurerm_container_app_custom_domain.app[0]`, at `domain.tf` line 119, whose
`container_app_environment_certificate_id` carries
`managedenvironments.ValidateCertificateID`. That validator accepts a **static**
certificate id, `.../managedEnvironments/<env>/certificates/<name>`. The
configuration hands it a **managed** one, `.../managedCertificates/<name>`. The
segment at position 8 does not match, and the error names the certificate rather
than the resource that rejected it.

**A plan is produced.** Terraform renders the full diff and the
`Plan: 2 to add, 6 to change, 1 to destroy` summary, then exits 1. There is a
diff to read; what there is not is a plan file or an apply.

## Moving the provider pin does not fix it

The schema is byte for byte identical in 4.30.0, 4.55.0, 4.81.0 and **5.3.0**:

| version | `container_app_environment_certificate_id` | `container_app_environment_managed_certificate_id` |
| --- | --- | --- |
| 4.30.0 | Optional, `ValidateCertificateID` | Computed only |
| 4.55.0 | Optional, `ValidateCertificateID` | Computed only |
| 4.81.0 | Optional, `ValidateCertificateID` | Computed only |
| 5.3.0 | Optional, `ValidateCertificateID` | Computed only |

There is no version in which that argument accepts a managed certificate id, and
none in which the managed id can be assigned instead. A 5.x bump would cost a
re-verification of every resource in the stack and buy nothing here.

Upstream [issue 25788](https://github.com/hashicorp/terraform-provider-azurerm/issues/25788)
is this exact error. The fix in
[PR 25972](https://github.com/hashicorp/terraform-provider-azurerm/pull/25972)
taught the **Read** to accept both shapes, which is why production's state
records the binding correctly, and left the argument validator alone.

## It is a revert, not a new bug

The correct version was written in `7d23ae1c` after a real apply hit
`RequireCustomHostnameInEnvironment`. Commit `ff893073`, whose subject and entire
message are about a Postgres test port, reverted it, along with 124 lines of
`self-hosting/production.md`, `ISOLATION.md`, `azure.md`, and the `.gitignore`
rule that PR 203 is restoring separately. This restores the `domain.tf` slice
unchanged from `7d23ae1c`.

## Why this shape is right and not a workaround

It is the provider's own documented example, quoted from the 4.81.0 docs:

> Omit this value if you wish to use an Azure Managed certificate.

> If using an Azure Managed Certificate `container_app_environment_certificate_id`
> and `certificate_binding_type` should be added to `ignore_changes` to prevent
> resource recreation due to these values being modified asynchronously outside
> of Terraform.

Azure writes both fields itself when the certificate issues. Both are ForceNew,
so without the `ignore_changes` a later plan proposes to **replace** the binding,
and replacing it takes the name off the app for as long as the recreate takes.
The order is inverted because Azure enforces it: it refuses to issue a
certificate for a hostname no app in the environment claims, so the binding is
created first with no certificate and the certificate second.

## What the other two candidates would have cost

**State surgery, `terraform state rm` plus `terraform import`.** The problem is
not in the state. Production's state already reads exactly as this configuration
now asks:

```
container_app_environment_certificate_id          = ""
container_app_environment_managed_certificate_id  = ".../managedCertificates/app-antifailure-dev"
certificate_binding_type                          = "SniEnabled"
```

There is nothing to re-import. It would be a write against production state, in
the shared stack directory the runbook warns about, to correct something that is
already correct.

**Taking the certificate out of Terraform.** The module would stop creating it,
so a fresh install gets a custom domain with no TLS and a manual step nobody
remembers. It also gives up the thing this file exists for: production's DNS
pair was created by Terraform precisely so it is not another thing somebody
remembers to do.

Neither buys anything the config change does not, and both cost more.

## Verified against real production state

**No apply was run.** Every command below is read only.

| | exit | result |
| --- | --- | --- |
| production, before | 1 | the parse error |
| production, after | 0 | `2 to add, 6 to change, 1 to destroy` |
| staging, after | 0 | `No changes. Your infrastructure matches the configuration.` |

Neither the binding nor the certificate appears in the fixed production diff.
They refresh and are not proposed for change, so applying this changes nothing
about the domain. The `1 to destroy` is `azurerm_role_assignment.cd_deploys_the_group`,
which is in production state and in no `.tf` file; it is present before and after
this change and is **not** mine. See the notes at the bottom.

## The check

This survived because the plan job plans staging and only staging, and
`staging.tfvars` sets no `custom_domain`, so all four resources in `domain.tf`
count to zero and nothing has ever planned them. Production is a second var-file
against a second state blob that nothing read. Deploys go out through
`az containerapp update` in `deploy/cd/deploy.sh` rather than through Terraform,
so production kept shipping while its stack could not be planned. That is why
days passed with no symptom.

The job now plans production too, as a fourth mode alongside the three it already
names, and asks **one** question: does it exit zero. It does not review the diff
and the step says so, because `alert_emails` is a placeholder here and the plan
therefore always proposes an action group change no apply would make. The exit
status is the part that does not depend on the inputs.

**It needs the real state, and that was measured rather than assumed.** Terraform
skips a validator whose value is unknown. From an empty state every id in the
plan is unknown, so I ran the existing empty-state mode against `production.tfvars`
on the broken tree and it planned clean: `Plan: 51 to add, 0 to change, 0 to destroy`,
exit 0. **"Just plan production from empty state too" would have been a check
that could not say no.** That is why the step is gated on `remote_state` and not
on a credential alone.

**It costs no new permission.** This was the report's main worry and it does not
hold:

- Same federated credential, same storage account, same container, one more blob
  key. Checked against Azure rather than inferred: the Storage Blob Data Reader
  grant is scoped to the whole **account**, not to a blob, so the second state
  key is already readable by a grant that exists. No role is added.
- `-lock=false`, for the same reason the staging plan does not lock: a lease is a
  write and `stacks/tfstate` deliberately grants this identity none. See the
  correction below, though: the live grant is not what the repository says.
- `-refresh=false`, and with that flag the only Azure call the plan makes is
  `azurerm_client_config`, which reads the caller's own identity and needs no
  role. Measured: 1 read with refresh off, versus 50 with it on.
- No secret is read. Every `azurerm_key_vault_secret` data source in the module
  is gated on `github_app_id`, `stripe_price_team` or `mail_from`, and all three
  are empty under `production.tfvars`, so all five count to zero.
- No role on `af-cp-prod-centralus` is required.

It runs last in the job because it re-initialises the backend against production
state, and every step above reads files the staging plan wrote.

**Proved in both directions**, running the step's own logic:

```
=== FIXED TREE ===
GATE SAYS: yes, production can be planned
exit=0

=== BROKEN TREE (domain.tf reverted to main) ===
GATE SAYS: NO. Production cannot be planned. Failure text:
Error: parsing ".../managedCertificates/app-antifailure-dev": parsing segment
"staticCertificates": parsing the Certificate ID: the segment at position 8
didn't match
exit=1
```

## No state operations are needed, but DO NOT APPLY THIS YET

Nothing here requires anyone to run a state command. Production state is already
in the shape this configuration expects.

**An apply is not safe yet, and not because of this branch.** The same commit
`ff893073` also deleted `azurerm_role_assignment.cd_deploys_the_group` from
`stacks/control-plane/ci.tf`, along with its `cd_principal_id` variable. That
resource is the **Contributor** grant on `af-cp-prod-centralus`, and its own
deleted comment says what it is for: without it "the production job fails at its
first `az containerapp` call, so continuous deployment cannot reach production at
all."

The grant is live in Azure, held by `f99916dc-1e11-4305-8e03-1e116a1e93e1`, and
recorded in production state. The configuration no longer declares it. So every
production plan reports `1 to destroy`, and **the first apply would remove the
grant that lets `cd.yml` deploy to production.** That is the `1 to destroy` in
both plans above. It is present before and after this branch and is not caused
by it, but this branch is what makes an apply reachable, so it has to be fixed
first.

The order that works:

1. Restore `cd_deploys_the_group` and `cd_principal_id` in `ci.tf` from
   `c27447d5`, and set `cd_principal_id` in `production.tfvars`. Confirm the
   production plan then reports **0 to destroy**.
2. Only then `terraform apply -var-file=production.tfvars` with the real
   `TF_VAR_alert_emails`, from a directory initialised with
   `-reconfigure -backend-config=backend.production.hcl`, reading the first line
   of the plan before answering yes.

I have not done step 1 here. It is a change to production's permission model and
a second finding, and folding it into this branch would put a role grant inside a
pull request about a plan. It should be its own PR and it should land before this
one is applied.

## Four things I found and did not fix, because they are not this finding

1. **`ff893073` reverted more than `domain.tf`.** `azure.md`'s status table now
   says production is "**written**, `production.tfvars`, not applied" when it is
   applied and serving. `production.md` lost 124 lines. PR 203 took the
   `.gitignore` slice. Somebody should take the docs slice.
2. **`ff893073` also deleted the production deploy grant.** See the apply
   warning above. `azurerm_role_assignment.cd_deploys_the_group` and its
   `cd_principal_id` variable were removed from `ci.tf` by the same revert, the
   grant is live in Azure and recorded in state, and every production plan now
   proposes to destroy it. This is the highest priority of the four.
3. **The plan identity holds `Storage Blob Data Contributor` on the state
   account.** `stacks/tfstate` grants it Reader and spends a paragraph on why
   Contributor "would give every pull request in this repository the ability to
   corrupt or delete the record of everything the project owns". The Contributor
   assignment was created by hand on 2026-08-28T03:20:32Z, an hour and a half
   after the Reader grant, and appears in no `.tf` file. So the `-lock=false`
   pair is currently a convention rather than an enforced boundary. The second
   commit on this branch stops the workflow asserting the false half; removing
   the grant is a production permission change and is not this branch's to make.
4. **`plan.txt` is not gitignored.** The plan step writes `plan.tfplan`,
   `plan.json` and `plan.txt` into the stack directory. `*.tfplan` covers the
   first and a `plan.json` rule at `.gitignore:63` covers the second; `plan.txt`
   is covered by nothing. It is `terraform show -no-color` output, so it carries
   the plan body rather than the raw sensitive variable values, which makes it
   the smaller of the two risks and still an untracked file nobody meant to
   offer to `git add -A`. It belongs in PR 203's file, so I left it alone rather
   than conflict. This is a correction: an earlier revision of this description
   said `plan.json` was unignored too, and it is not.

Do not merge without a look at the fourth mode's first real run: if the CI
identity cannot read the production state blob, this step is where that shows up,
and the fix is a grant rather than a revert of this branch.




