### PR TITLE
DO NOT MERGE: negative control for the production plan gate in PR 205

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -430,10 +430,15 @@ jobs:
       # credential alone, and it is why "plan production from empty state too"
       # would have been a check that could not say no.
       #
-      # WHAT IT COSTS IN PERMISSION: nothing new. The same federated credential,
-      # the same storage account and container, one more blob key. -lock=false
-      # because the identity is Storage Blob Data READER and cannot take a
-      # lease, exactly as above. -refresh=false, and with that flag the only
+      # WHAT IT COSTS IN PERMISSION: nothing new, and that was checked against
+      # Azure rather than inferred. The same federated credential, the same
+      # storage account and container, one more blob key. The Storage Blob Data
+      # Reader that stacks/tfstate grants this identity is scoped to the whole
+      # ACCOUNT, so the second blob is already readable by a grant that exists;
+      # no role is added for this step. -lock=false for the same reason the
+      # staging plan does not lock: a lease is a write, and stacks/tfstate
+      # deliberately grants this identity no write on the state.
+      # -refresh=false, and with that flag the only
       # Azure call this plan makes is azurerm_client_config, which reads the
       # caller's own identity and needs no role at all: every
       # azurerm_key_vault_secret data source in the module is counted to zero

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -397,3 +397,105 @@ jobs:
             cat "$GITHUB_WORKSPACE/cost.txt"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # THE FOURTH MODE, AND THE ONE THIS JOB DID NOT HAVE.
+      #
+      # Every step above plans STAGING. Production is a second var-file against
+      # a second state blob and nothing planned it, so the one environment
+      # Terraform could not manage was the one nothing checked. That gap is
+      # quiet by construction: deploys go out through `az containerapp update`
+      # in deploy/cd/deploy.sh rather than through Terraform, so production kept
+      # shipping normally for days while its stack could not be planned at all.
+      # A stack that cannot be planned is a stack nobody can change, and the
+      # settings that were merged and could not be applied were the ones that
+      # turn the operator portal on.
+      #
+      # IT LOOKS AT THE EXIT STATUS AND AT NOTHING ELSE. It does not review the
+      # diff and must not be read as reviewing it, because the inputs here are
+      # not the inputs an apply would use: alert_emails is a placeholder, so
+      # this plan always proposes an in-place change to the action group's
+      # receiver that no apply would ever make. A plan run with different inputs
+      # is a plan about a different desired state, which is the same reason the
+      # staging block pins ci_principal_id. Whether the plan SUCCEEDS is the one
+      # thing that does not depend on those inputs, and it is the whole question
+      # being asked.
+      #
+      # WHY IT NEEDS THE REAL STATE, measured rather than assumed. The failure
+      # this catches is a provider argument validator refusing a value it can
+      # never accept. Terraform SKIPS a validator whose value is unknown, and
+      # from an empty state every id in the plan is unknown, so the empty-state
+      # mode above plans the identical broken configuration clean and exits
+      # zero. Only a plan holding the recorded state has a known value to
+      # refuse. That is why this is gated on remote_state and not on a
+      # credential alone, and it is why "plan production from empty state too"
+      # would have been a check that could not say no.
+      #
+      # WHAT IT COSTS IN PERMISSION: nothing new. The same federated credential,
+      # the same storage account and container, one more blob key. -lock=false
+      # because the identity is Storage Blob Data READER and cannot take a
+      # lease, exactly as above. -refresh=false, and with that flag the only
+      # Azure call this plan makes is azurerm_client_config, which reads the
+      # caller's own identity and needs no role at all: every
+      # azurerm_key_vault_secret data source in the module is counted to zero
+      # under production.tfvars, so no secret is read and no role on
+      # af-cp-prod-centralus is required.
+      #
+      # LAST IN THE JOB ON PURPOSE. It re-initialises the backend against the
+      # production state, and every step above reads files the staging plan
+      # wrote. Running it earlier would leave those steps describing one
+      # environment from a directory pointed at the other, which is the exact
+      # confusion infra/ISOLATION.md warns about in this shared stack directory.
+      - name: production can still be planned
+        if: steps.azure.outputs.ready == 'true' && steps.azure.outputs.remote_state == 'true'
+        working-directory: infra/terraform/stacks/control-plane
+        env:
+          ARM_USE_OIDC: "true"
+          ARM_USE_AZUREAD: "true"
+          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          TF_VAR_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          TF_VAR_github_client_id: plan-only
+          TF_VAR_github_client_secret: plan-only
+          TF_VAR_github_redirect_uri: https://example.invalid/auth/callback
+          TF_VAR_ci_principal_id: ${{ vars.AZURE_CI_PRINCIPAL_ID }}
+          # Production refuses to plan with alerting on and no receiver, which
+          # is a deliberate validation and not something to work around: an
+          # action group with no receivers creates cleanly, attaches to every
+          # rule, reports healthy and tells nobody. A placeholder satisfies it
+          # so the check can reach the configuration behind it. Nothing is
+          # delivered to this address because nothing is applied from here.
+          TF_VAR_alert_emails: '["plan-only@example.invalid"]'
+        run: |
+          set -euo pipefail
+          terraform init -reconfigure -input=false \
+            -backend-config="resource_group_name=${{ secrets.AZURE_TFSTATE_RG }}" \
+            -backend-config="storage_account_name=${{ secrets.AZURE_TFSTATE_ACCOUNT }}" \
+            -backend-config="container_name=tfstate" \
+            -backend-config="key=control-plane-production.tfstate" \
+            -backend-config="use_azuread_auth=true" \
+            -backend-config="use_oidc=true"
+          # No -out, and the log goes to the runner's temp directory rather
+          # than into the stack. `terraform show -json` on a plan file includes
+          # the values of sensitive input variables and this plan has no reader,
+          # and a log written beside staging.tfvars is one more untracked file
+          # in a directory an operator also works in by hand.
+          log="$RUNNER_TEMP/production-plan.txt"
+          if terraform plan -input=false -lock=false -refresh=false \
+            -var-file=production.tfvars -no-color > "$log" 2>&1; then
+            echo "Production planned successfully. The diff above is staging's; this step read only the exit status." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::error title=Production cannot be planned::terraform plan against production.tfvars and control-plane-production.tfstate failed. Until it passes, no change to this stack can be applied to production, including changes already merged. The failure is below."
+            {
+              echo
+              echo "### Production cannot be planned"
+              echo
+              echo 'This is not about the diff. `terraform plan -var-file=production.tfvars`'
+              echo 'exited non-zero, so production has no applyable plan at all.'
+              echo
+              echo '```'
+              tail -c 20000 "$log"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi

--- a/infra/terraform/modules/control-plane/domain.tf
+++ b/infra/terraform/modules/control-plane/domain.tf
@@ -1,24 +1,15 @@
 # app.antifailure.dev, and everything Terraform can own of it.
 #
-# Four resources in one order that works and several that do not, and THE ORDER
-# HERE IS NOT THE OBVIOUS ONE. Azure will not issue a managed certificate for a
-# name it cannot prove you control, and it proves control by resolving DNS, so
-# the records have to exist and be correct first. What is not obvious, and what
-# cost this an apply, is that Azure ALSO refuses to issue the certificate until
-# the hostname is already bound to an app in the environment:
-#
-#   RequireCustomHostnameInEnvironment: Creating managed certificate requires
-#   hostname 'app.antifailure.dev' added as a custom hostname to a container
-#   app or route in environment 'afcpprod-env'
-#
-# So the binding cannot reference the certificate, because the certificate
-# cannot exist until the binding does. Expressing it the other way round is a
-# dependency cycle, not a fix.
+# Four resources in one order that works and several that do not. Azure will not
+# issue a managed certificate for a name it cannot prove you control, and it
+# proves control by resolving DNS, so the records have to exist and be correct
+# before the certificate is asked for, and the certificate has to exist before
+# the binding can reference it.
 #
 #   CNAME <sub>        ->  the container app's default FQDN
 #   TXT   asuid.<sub>  ->  the app's custom_domain_verification_id
-#   custom domain binding on the app, with NO certificate
-#   managed certificate for the full name, which Azure then binds ITSELF
+#   managed certificate for the full name
+#   custom domain binding on the app, referencing that certificate
 #
 # THE TXT RECORD IS NOT OPTIONAL AND IS THE PART PEOPLE MISS. A CNAME alone
 # proves that a name points at an Azure endpoint, not that it points at YOUR
@@ -84,47 +75,7 @@ resource "azurerm_dns_txt_record" "asuid" {
   tags = var.tags
 }
 
-# The binding, as a separate resource rather than an ingress block, and it comes
-# BEFORE the certificate.
-#
-# azurerm_container_app's ingress carries a custom_domain list, and using both
-# it and this resource makes the two fight: every apply would see the binding
-# this resource created as an unexpected value inside the app's ingress and
-# propose to remove it. app.tf therefore ignores that attribute, and this is the
-# one place a custom domain is declared.
-#
-# NO CERTIFICATE HERE, AND THAT IS THE WHOLE POINT. The provider documents it:
-# "Omit this value if you wish to use an Azure Managed certificate." The
-# hostname is added first with no TLS, the certificate is requested against a
-# hostname that now exists, and Azure attaches it to this binding itself once it
-# has issued. Naming the certificate here instead is what produced
-# RequireCustomHostnameInEnvironment at the top of this file.
-resource "azurerm_container_app_custom_domain" "app" {
-  count = local.custom_domain_enabled ? 1 : 0
-
-  name             = var.custom_domain
-  container_app_id = azurerm_container_app.this.id
-
-  # Azure validates ownership when the hostname is ADDED, not only when the
-  # certificate is issued, so both records have to be in place before this. The
-  # CNAME alone is not enough; asuid carries the verification id that ties the
-  # name to this specific app.
-  depends_on = [
-    azurerm_dns_cname_record.app,
-    azurerm_dns_txt_record.asuid,
-  ]
-
-  lifecycle {
-    # Azure writes both of these when the managed certificate below is issued,
-    # asynchronously and outside any apply. Both are ForceNew, so without this a
-    # plan run after issuance proposes to REPLACE the binding, and replacing it
-    # takes the name off the app for as long as the recreate takes. The provider
-    # says to do exactly this for an Azure managed certificate.
-    ignore_changes = [certificate_binding_type, container_app_environment_certificate_id]
-  }
-}
-
-# The certificate Azure issues, renews and binds for free.
+# The certificate Azure issues and renews for free.
 #
 # Not a certificate this repository holds. There is no private key here, nothing
 # to rotate, and nothing that expires because somebody left. What can go wrong
@@ -144,8 +95,27 @@ resource "azurerm_container_app_environment_managed_certificate" "app" {
 
   tags = var.tags
 
-  # The binding, not the DNS records. It depends on them in turn, so the records
-  # are still ordered ahead of this, and naming the binding is what encodes the
-  # requirement Azure actually enforces.
-  depends_on = [azurerm_container_app_custom_domain.app]
+  # Both records, not just the CNAME. Azure reads them in the same validation
+  # and a certificate request that arrives before the TXT record exists fails
+  # with a message about domain ownership rather than about DNS.
+  depends_on = [
+    azurerm_dns_cname_record.app,
+    azurerm_dns_txt_record.asuid,
+  ]
+}
+
+# The binding, as a separate resource rather than an ingress block.
+#
+# azurerm_container_app's ingress carries a custom_domain list, and using both
+# it and this resource makes the two fight: every apply would see the binding
+# this resource created as an unexpected value inside the app's ingress and
+# propose to remove it. app.tf therefore ignores that attribute, and this is the
+# one place a custom domain is declared.
+resource "azurerm_container_app_custom_domain" "app" {
+  count = local.custom_domain_enabled ? 1 : 0
+
+  name                                     = var.custom_domain
+  container_app_id                         = azurerm_container_app.this.id
+  container_app_environment_certificate_id = azurerm_container_app_environment_managed_certificate.app[0].id
+  certificate_binding_type                 = "SniEnabled"
 }

--- a/infra/terraform/modules/control-plane/domain.tf
+++ b/infra/terraform/modules/control-plane/domain.tf
@@ -1,15 +1,24 @@
 # app.antifailure.dev, and everything Terraform can own of it.
 #
-# Four resources in one order that works and several that do not. Azure will not
-# issue a managed certificate for a name it cannot prove you control, and it
-# proves control by resolving DNS, so the records have to exist and be correct
-# before the certificate is asked for, and the certificate has to exist before
-# the binding can reference it.
+# Four resources in one order that works and several that do not, and THE ORDER
+# HERE IS NOT THE OBVIOUS ONE. Azure will not issue a managed certificate for a
+# name it cannot prove you control, and it proves control by resolving DNS, so
+# the records have to exist and be correct first. What is not obvious, and what
+# cost this an apply, is that Azure ALSO refuses to issue the certificate until
+# the hostname is already bound to an app in the environment:
+#
+#   RequireCustomHostnameInEnvironment: Creating managed certificate requires
+#   hostname 'app.antifailure.dev' added as a custom hostname to a container
+#   app or route in environment 'afcpprod-env'
+#
+# So the binding cannot reference the certificate, because the certificate
+# cannot exist until the binding does. Expressing it the other way round is a
+# dependency cycle, not a fix.
 #
 #   CNAME <sub>        ->  the container app's default FQDN
 #   TXT   asuid.<sub>  ->  the app's custom_domain_verification_id
-#   managed certificate for the full name
-#   custom domain binding on the app, referencing that certificate
+#   custom domain binding on the app, with NO certificate
+#   managed certificate for the full name, which Azure then binds ITSELF
 #
 # THE TXT RECORD IS NOT OPTIONAL AND IS THE PART PEOPLE MISS. A CNAME alone
 # proves that a name points at an Azure endpoint, not that it points at YOUR
@@ -75,7 +84,47 @@ resource "azurerm_dns_txt_record" "asuid" {
   tags = var.tags
 }
 
-# The certificate Azure issues and renews for free.
+# The binding, as a separate resource rather than an ingress block, and it comes
+# BEFORE the certificate.
+#
+# azurerm_container_app's ingress carries a custom_domain list, and using both
+# it and this resource makes the two fight: every apply would see the binding
+# this resource created as an unexpected value inside the app's ingress and
+# propose to remove it. app.tf therefore ignores that attribute, and this is the
+# one place a custom domain is declared.
+#
+# NO CERTIFICATE HERE, AND THAT IS THE WHOLE POINT. The provider documents it:
+# "Omit this value if you wish to use an Azure Managed certificate." The
+# hostname is added first with no TLS, the certificate is requested against a
+# hostname that now exists, and Azure attaches it to this binding itself once it
+# has issued. Naming the certificate here instead is what produced
+# RequireCustomHostnameInEnvironment at the top of this file.
+resource "azurerm_container_app_custom_domain" "app" {
+  count = local.custom_domain_enabled ? 1 : 0
+
+  name             = var.custom_domain
+  container_app_id = azurerm_container_app.this.id
+
+  # Azure validates ownership when the hostname is ADDED, not only when the
+  # certificate is issued, so both records have to be in place before this. The
+  # CNAME alone is not enough; asuid carries the verification id that ties the
+  # name to this specific app.
+  depends_on = [
+    azurerm_dns_cname_record.app,
+    azurerm_dns_txt_record.asuid,
+  ]
+
+  lifecycle {
+    # Azure writes both of these when the managed certificate below is issued,
+    # asynchronously and outside any apply. Both are ForceNew, so without this a
+    # plan run after issuance proposes to REPLACE the binding, and replacing it
+    # takes the name off the app for as long as the recreate takes. The provider
+    # says to do exactly this for an Azure managed certificate.
+    ignore_changes = [certificate_binding_type, container_app_environment_certificate_id]
+  }
+}
+
+# The certificate Azure issues, renews and binds for free.
 #
 # Not a certificate this repository holds. There is no private key here, nothing
 # to rotate, and nothing that expires because somebody left. What can go wrong
@@ -95,27 +144,8 @@ resource "azurerm_container_app_environment_managed_certificate" "app" {
 
   tags = var.tags
 
-  # Both records, not just the CNAME. Azure reads them in the same validation
-  # and a certificate request that arrives before the TXT record exists fails
-  # with a message about domain ownership rather than about DNS.
-  depends_on = [
-    azurerm_dns_cname_record.app,
-    azurerm_dns_txt_record.asuid,
-  ]
-}
-
-# The binding, as a separate resource rather than an ingress block.
-#
-# azurerm_container_app's ingress carries a custom_domain list, and using both
-# it and this resource makes the two fight: every apply would see the binding
-# this resource created as an unexpected value inside the app's ingress and
-# propose to remove it. app.tf therefore ignores that attribute, and this is the
-# one place a custom domain is declared.
-resource "azurerm_container_app_custom_domain" "app" {
-  count = local.custom_domain_enabled ? 1 : 0
-
-  name                                     = var.custom_domain
-  container_app_id                         = azurerm_container_app.this.id
-  container_app_environment_certificate_id = azurerm_container_app_environment_managed_certificate.app[0].id
-  certificate_binding_type                 = "SniEnabled"
+  # The binding, not the DNS records. It depends on them in turn, so the records
+  # are still ordered ahead of this, and naming the binding is what encodes the
+  # requirement Azure actually enforces.
+  depends_on = [azurerm_container_app_custom_domain.app]
 }


### PR DESCRIPTION
Temporary and disposable. It exists to make the new step in PR 205 fail in CI, not on a laptop, and it will be closed and its branch deleted as soon as the infra run lands.

It carries PR 205's `.github/workflows/infra.yml` and main's `infra/terraform/modules/control-plane/domain.tf`. If the gate works, the `production can still be planned` step goes red with the certificate id parse error. If it goes green, the gate cannot say no and PR 205 needs rethinking rather than merging.

See PR 205. Close this without merging.