### PR TITLE
dogfood: the nightly leg that dogfoods this repo had no database to copy

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -343,6 +343,47 @@ jobs:
       matrix:
         manifest: ['.', examples/django-api, examples/go-api, examples/next-app]
 
+    # The database the '.' leg copies its golden from.
+    #
+    # The same service the control plane job above carries, for the same
+    # reason and with the same limit on what it may hold. Synthesised rather
+    # than restored from production: a control plane that copies a real
+    # customer's database into a public CI runner would be the single worst
+    # thing this repository could do, and what the masking rules are about is
+    # the shape rather than the rows.
+    #
+    # It is here and not only there because a job level `env:` does not reach
+    # another job. The nightly had neither the service nor the variable, so its
+    # '.' leg ran the repository's own manifest, which names
+    # AF_STAGING_DATABASE_URL as its source, against nothing at all: the golden
+    # refresh refused with AF-DB-016 and `af ci` then had no golden to branch,
+    # so the one leg that exists to prove this control plane dogfoods itself
+    # had never once done it.
+    #
+    # The three example legs need none of this. Not one of them sets
+    # database.source_url_env, so their goldens are built with no source, which
+    # the engine does without complaint and reports as "from no production
+    # database, so it holds no rows". Giving them a source they never ask for
+    # would be cargo cult. Kept honest by
+    # TestEveryLegCanReachTheSourceItsManifestNames in tools/dogfood, which
+    # reads the manifests rather than this list and so narrows or widens with
+    # them.
+    services:
+      staging:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_PASSWORD: staging
+          POSTGRES_DB: antifailure
+        ports: ['5433:5432']
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      AF_STAGING_DATABASE_URL: postgres://postgres:staging@127.0.0.1:5433/antifailure
+
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -354,6 +395,8 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
+          cache: npm
+          cache-dependency-path: web/package-lock.json
 
       - run: go build -o bin/af ./engine/cmd/af
 
@@ -409,6 +452,50 @@ jobs:
             echo "::error::$MANIFEST/antifailure.yaml does not exist, so this leg has nothing to run"
             exit 1
           fi
+
+      - name: Does this leg copy a source database
+        # Asked of the manifest rather than of the matrix, so that the two
+        # steps below narrow and widen with the corpus instead of with a name
+        # somebody remembered to update. Today exactly one leg answers yes.
+        #
+        # A leg that names a source and never seeds it is the quiet version of
+        # the failure this whole change is about: the refresh would find the
+        # service, copy an empty schema, publish a golden with nothing in it
+        # and exit 0, and the workflows that read the golden would fail with no
+        # sign of why. So the answer here decides both the install and the
+        # seed, and neither is keyed on a manifest path.
+        id: source
+        env:
+          MANIFEST: ${{ matrix.manifest }}
+        run: |
+          set -euo pipefail
+          if grep -qE '^[[:space:]]*source_url_env:' "$MANIFEST/antifailure.yaml"; then
+            echo 'needed=true' >> "$GITHUB_OUTPUT"
+            echo "$MANIFEST names a source database, so it gets one"
+          else
+            echo 'needed=false' >> "$GITHUB_OUTPUT"
+            echo "$MANIFEST names no source, so its golden is built from nothing and holds no rows"
+          fi
+
+      - name: Install what shapes the staging database
+        if: steps.source.outputs.needed == 'true'
+        run: npm ci --no-audit --no-fund
+        working-directory: web
+
+      - name: Shape the staging database
+        # The same script the control plane job runs, for the same reason:
+        # migrations and then a deterministic seed, both from one script,
+        # because a seed against a schema it did not create fails on the first
+        # column somebody added.
+        #
+        # Without it the service is an empty Postgres and the golden copied
+        # from it is an empty golden, which is worse than the AF-DB-016 this
+        # replaces: that one at least said so.
+        if: steps.source.outputs.needed == 'true'
+        run: npm run seed --workspace @antifailure/db
+        working-directory: web
+        env:
+          AF_MIGRATION_DATABASE_URL: ${{ env.AF_STAGING_DATABASE_URL }}
 
       - name: The pipeline, with load
         # --refresh-golden, because there is no golden here to find otherwise.

--- a/tools/dogfood/main_test.go
+++ b/tools/dogfood/main_test.go
@@ -498,3 +498,184 @@ func TestTheNightlyMakesAGoldenBeforeItRunsThePipeline(t *testing.T) {
 	t.Error("no step in the nightly job refreshes a golden, so every leg reaches " +
 		"af ci with none and fails with AF-DB-012")
 }
+
+// Every leg can reach the source database its own manifest names.
+//
+// This is the question TestTheNightlyMakesAGoldenBeforeItRunsThePipeline above
+// is one step away from asking, and the gap between the two is a red nightly
+// that ran for its whole history. That test asks whether some step refreshes a
+// golden. A step that refreshes a golden and a step that can refresh a golden
+// are different claims, and the nightly satisfied the first while failing the
+// second on its most important leg: the job carried the `--refresh-golden`
+// flag, so the test passed, and carried neither the Postgres service nor the
+// AF_STAGING_DATABASE_URL that the repository's own manifest names, so the
+// refresh refused with AF-DB-016 before it copied a byte. `af ci` then had no
+// golden and reported that it had checked nothing, honestly, which is the only
+// reason anybody noticed.
+//
+// So this reads the manifests instead of the workflow's own vocabulary, and
+// asserts three things per leg:
+//
+//   - a manifest that names database.source_url_env has that variable set by
+//     the job that runs it, because job level env does not cross jobs and that
+//     is precisely how the nightly lost it;
+//   - the value names a loopback address, because the alternative is a public
+//     runner holding a route to a database that somebody's rows are in, and
+//     that is the single worst thing this repository could do;
+//   - a service container in the same job publishes the port the value names,
+//     because a variable pointing at nothing fails at connect time instead of
+//     with AF-DB-016 and is just as red.
+//
+// A manifest that names no source asserts nothing at all. Three of the four
+// legs are in that case today and need no Postgres, so widening this to "every
+// leg has a database" would be a check that enforces a habit rather than a
+// requirement.
+func TestEveryLegCanReachTheSourceItsManifestNames(t *testing.T) {
+	root := filepath.Join("..", "..")
+
+	type service struct {
+		Ports []string `yaml:"ports"`
+	}
+	var workflow struct {
+		Jobs map[string]struct {
+			Env      map[string]string  `yaml:"env"`
+			Services map[string]service `yaml:"services"`
+			Strategy struct {
+				Matrix struct {
+					Manifest []string `yaml:"manifest"`
+				} `yaml:"matrix"`
+			} `yaml:"strategy"`
+			Steps []struct {
+				Run string `yaml:"run"`
+			} `yaml:"steps"`
+		} `yaml:"jobs"`
+	}
+	body, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "dogfood.yml"))
+	if err != nil {
+		t.Fatalf("could not read the workflow: %v", err)
+	}
+	if err := yaml.Unmarshal(body, &workflow); err != nil {
+		t.Fatalf("could not parse the workflow: %v", err)
+	}
+
+	// Which manifests a job runs, taken from the -C it passes rather than from
+	// a list here. A job that grew a leg without this test noticing would be
+	// the same defect one level up.
+	dashC := regexp.MustCompile(`-C\s+"?([^\s"\\]+)"?`)
+
+	checked := 0
+	for name, job := range workflow.Jobs {
+		var legs []string
+		for _, step := range job.Steps {
+			for _, m := range dashC.FindAllStringSubmatch(step.Run, -1) {
+				arg := m[1]
+				// The matrix value, however this job spells it.
+				if strings.Contains(arg, "matrix.manifest") || arg == "$MANIFEST" {
+					legs = append(legs, job.Strategy.Matrix.Manifest...)
+					continue
+				}
+				legs = append(legs, arg)
+			}
+		}
+
+		seen := map[string]bool{}
+		for _, leg := range legs {
+			if seen[leg] {
+				continue
+			}
+			seen[leg] = true
+
+			var m struct {
+				Database struct {
+					SourceURLEnv string `yaml:"source_url_env"`
+				} `yaml:"database"`
+			}
+			raw, err := os.ReadFile(filepath.Join(root, leg, "antifailure.yaml"))
+			if err != nil {
+				// Covered by TestTheNightlyCorpusIsEveryExample, which names
+				// the defect better than this test would.
+				continue
+			}
+			if err := yaml.Unmarshal(raw, &m); err != nil {
+				t.Errorf("%s: could not parse %s/antifailure.yaml: %v", name, leg, err)
+				continue
+			}
+			if m.Database.SourceURLEnv == "" {
+				// Builds its golden from nothing, which the engine does
+				// deliberately and reports. Nothing to supply.
+				continue
+			}
+			checked++
+
+			value, ok := job.Env[m.Database.SourceURLEnv]
+			if !ok || strings.TrimSpace(value) == "" {
+				t.Errorf("job %q runs %s, whose manifest names %s as the database to copy, "+
+					"and the job sets no value for it. The refresh will refuse with AF-DB-016 "+
+					"and af ci will then have no golden to branch, so this leg checks nothing. "+
+					"A job level env: block in another job does not reach this one.",
+					name, leg, m.Database.SourceURLEnv)
+				continue
+			}
+
+			host, port := hostPort(value)
+			if host != "127.0.0.1" && host != "localhost" && host != "::1" {
+				t.Errorf("job %q points %s at host %q. Every leg of this workflow runs on a "+
+					"public runner, so the only database it may reach is one this job stood "+
+					"up itself. Copying a real customer's database here is the single worst "+
+					"thing this repository could do.", name, m.Database.SourceURLEnv, host)
+				continue
+			}
+			if port == "" {
+				t.Errorf("job %q sets %s to %q, which names no port, so nothing here can say "+
+					"what it reaches", name, m.Database.SourceURLEnv, value)
+				continue
+			}
+
+			published := false
+			for _, svc := range job.Services {
+				for _, p := range svc.Ports {
+					if strings.HasPrefix(p, port+":") || p == port {
+						published = true
+					}
+				}
+			}
+			if !published {
+				t.Errorf("job %q points %s at port %s and no service container in that job "+
+					"publishes it, so the refresh fails on connect rather than on AF-DB-016 "+
+					"and the leg is red either way", name, m.Database.SourceURLEnv, port)
+			}
+		}
+	}
+
+	// The assertion that keeps this test from passing by looking at nothing.
+	//
+	// Every branch above is a continue on a leg that needs no source, so a
+	// tree in which no manifest names one, or in which the -C parsing stopped
+	// matching the workflow's shape, would run zero comparisons and report
+	// success. That is the failure this whole file exists to argue against.
+	if checked == 0 {
+		t.Error("no leg of any job was found to name a source database, so this test " +
+			"compared nothing. Either every manifest dropped database.source_url_env, " +
+			"or the -C arguments in dogfood.yml stopped being readable here.")
+	}
+}
+
+// hostPort pulls the host and port out of a Postgres connection string without
+// requiring it to parse as a URL, because a workflow expression in the middle
+// of one is still a value this test has to be able to talk about.
+func hostPort(value string) (string, string) {
+	rest := value
+	if i := strings.Index(rest, "://"); i >= 0 {
+		rest = rest[i+3:]
+	}
+	if i := strings.LastIndex(rest, "@"); i >= 0 {
+		rest = rest[i+1:]
+	}
+	if i := strings.IndexAny(rest, "/?"); i >= 0 {
+		rest = rest[:i]
+	}
+	if i := strings.LastIndex(rest, ":"); i >= 0 {
+		return rest[:i], rest[i+1:]
+	}
+	return rest, ""
+}


### PR DESCRIPTION
## What was wrong

The nightly Dogfood job's `.` leg runs the repository's own manifest, which
names `AF_STAGING_DATABASE_URL` as the database to build a golden from. The
`nightly` job carried neither the Postgres service container nor the variable.
The `dogfood` job has both, and a job level `env:` block does not cross jobs,
so that bought the nightly nothing.

From run [33735986446](https://github.com/antifailure/antifailure/actions/runs/33735986446), job `nightly, the whole corpus (.)`:

```
dogfood: golden refresh
  AF-DB-016 database.source_url_env names AF_STAGING_DATABASE_URL, and no
            configured source has a value for it.
...
  golden refresh         0s  FAILED (3)
  ci                     0s  FAILED (3)
```

The leg that exists to prove this control plane dogfoods itself has never once
done it.

## Scope, checked per leg rather than assumed

The matrix is `['.', examples/django-api, examples/go-api, examples/next-app]`.
Only the first needs a source database. This is from the manifests and from
what the four legs actually did in that run, not from reasoning about them:

| leg | `database.source_url_env` | golden refresh in run 33735986446 |
| --- | --- | --- |
| `.` | `AF_STAGING_DATABASE_URL` | `FAILED (3)`, AF-DB-016 |
| `examples/django-api` | not set | `ok`, 9s |
| `examples/go-api` | not set | `ok`, 9s |
| `examples/next-app` | not set | `ok`, 9s |

The three examples set no source and no `database.seed` either. They build
their schema from `services[].migrate`, and the engine builds a golden with no
source without complaint, reporting it in the branch line:

```
branching the database from gv_20260903085731_98d4ac56, made for django-orders,
from no production database, so it holds no rows
```

So giving them a Postgres would be cargo cult, and the fix is narrower than
adding a service to the job and letting every leg use it.

## The fix

`services:` and `env:` on the `nightly` job, mirroring the `dogfood` job. The
source is synthesised and seeded on the runner, never restored from anything
real. The comment above the pull request job's env block argues that copying a
customer's database onto a public runner would be the worst thing this
repository could do, and that argument applies here unchanged, so it is
restated rather than referenced.

Two steps shape that database, and they are gated on
`steps.source.outputs.needed`, which is decided by reading the leg's manifest
for `source_url_env` rather than by matching a path. A leg that named a source
and skipped the seed would copy an empty schema, publish a golden with nothing
in it and exit 0, which is quieter than the AF-DB-016 this replaces.

## What notices next time

`TestEveryLegCanReachTheSourceItsManifestNames` in `tools/dogfood`.

The existing `TestTheNightlyMakesAGoldenBeforeItRunsThePipeline` sits one line
above it and asks whether some step refreshes a golden. The nightly carried
`--refresh-golden`, so that test passed for the entire period the job was red.
A step that refreshes a golden and a step that *can* refresh one are different
claims.

The new test reads the manifests instead of the workflow's own vocabulary. It
derives each job's legs from the `-C` arguments in its run scripts, resolves
the matrix, and for any leg whose manifest names a source asserts that the job
running it sets that variable, that the value is loopback, and that a service
in the same job publishes the port. A leg naming no source asserts nothing.

### It was made to say no, on each assertion separately

A passing test says nothing about which of its assertions can fire, so each was
broken on purpose against this tree:

| mutation | result |
| --- | --- |
| tree as it was, before this fix | fails, naming `nightly` and leg `.` |
| env value pointed at `staging.internal.example` | fails on both jobs, on the loopback rule |
| service removed, env kept | fails on the port not being published |
| `source_url_env` removed from the root manifest | fails on having compared nothing |
| tree with this fix | passes |

The last row of that list is the one I would have missed. Every branch in the
test is a `continue` on a leg that needs no source, so a tree where no manifest
named one, or where the `-C` parsing stopped matching the workflow's shape,
would compare zero legs and report success. The explicit `checked == 0` guard
is what stops it becoming the thing it was written to catch.

### What it still cannot catch

It is static. It reads YAML and manifests, so it proves the variable is set,
local, and backed by a published port. It cannot prove the database behind that
port has anything in it, that the seed script succeeded, or that the golden
built from it is one the workflows can use. Only a real run shows that, which
is why this pull request drove one.

## The judgement call on `policy.workflows_unverified`

**No change, and the premise it was raised on is wrong.** It already fails.

`workflows_unverified` defaults to `LevelFail` in two places that agree,
`engine/internal/manifest/normalize.go` and `engine/internal/report/policy.go`,
and none of the four manifests declares a `policy:` block to soften it. The
comment on the default already makes the argument: "the default has to be the
one that does not lie."

The evidence is in the same run. The three example legs got a golden, brought
an environment up, and then exited **9** on exactly this rule:

```
  golden refresh         9s  ok
  ci                  3m34s  FAILED (9)
```

So a nightly that passes while checking nothing is not a thing this repository
currently ships, on this rule. There is nothing stricter than fail to move it
to, and moving it the other way is what the finding warns against. The honest
answer is that the gate was already right and the golden underneath it was not.

Two things follow that are worth writing down rather than acting on here.

**The three example legs are still red, for a different reason, and this pull
request does not fix them.** Their goldens build fine. They fail because those
three manifests declare no workflows at all, so `af ci` correctly reports that
nothing was checked. They also hit `AF-AGT-004`: the runner is installed at the
repository root and the engine looks for it relative to the manifest, so it
searches `examples/django-api/runner/src/main.ts` and three other paths but
never the root. Making those legs green means giving three example apps real
workflows and making the runner reachable from a subdirectory. That is a
separate finding of real size and I have not touched it, so **the nightly as a
whole will still be red after this merges, with one leg green instead of none.**

**A product bug, found on the way and not fixed here.** In the `.` leg the
report said "The manifest declares no workflows, so there was nothing to carry
through." The root manifest declares six. `workflowsUnverifiedFinding` in
`engine/internal/cli/gate.go` picks that wording from `len(run.Workflows) == 0`,
which is also true when the environment died before the workflows were ever
loaded. The verdict is right and the reason given for it is false, which is the
kind of detail that sends somebody to edit a manifest that was never the
problem.

## The run I drove

`workflow_dispatch` on this branch, run
[33737585154](https://github.com/antifailure/antifailure/actions/runs/33737585154).
Driven by hand rather than waited for, as asked.

**The `.` leg is green for the first time.** It went from a refresh that
refused before copying a byte to this:

```
    ok    gv_20260903091542_d1c46d45   1390 rows across 63 tables masked in 9s
    Verified 357 columns across 80 tables, 6024 rows sampled.
...
  ### Antifailure: All 6 workflows passed, and 4 invariants held.
...
  golden refresh         9s  ok
  ci                  2m08s  ok
green
```

The golden now holds what the workflows need: 60 audit entries, 30 network
rules, 30 environments, 12 members, 3 organizations. The network policy
workflow depends on the golden carrying at least one proposed rule, which the
manifest calls out as a deliberate dependency, and it now does.

**The three example legs are still red**, on `workflows_unverified`, exactly as
they were before this change and for the reason set out above. The run is
`failure` overall because of them.

**The gating did what it says.** On `examples/go-api` the two seed steps report
`skipped`, after a step that explains itself:

```
examples/go-api names no source, so its golden is built from nothing and holds no rows
```

### Two things the leg surfaced by running at all

Neither is touched here. Both were invisible while the leg could not build a
golden, which is the argument for fixing it.

- `AF-LOD-010: Load could not be generated: every route in the shape is unsafe
  to send; add safe_routes to the manifest`. This repository's manifest already
  declares four `load.safe_routes`. Either they are not reaching the load
  shape or the message is wrong about why.
- `the migrations were not rehearsed: no migration tool was recognised in this
  repository`, on a repository whose manifest runs `node bootstrap.mjs` as its
  migrate command.

## Checks

Everything on this pull request passes except two, and neither is this change:

- `Antifailure` fails. It fails on every open pull request (#207, #205, #203)
  and on #204, which merged anyway, so it is a repository wide condition that
  predates this branch.
- `nightly, the whole corpus` shows `skipping`, which is correct: the job is
  gated to `schedule` and `workflow_dispatch`, so a `pull_request` event does
  not run it. That is why it was dispatched by hand instead.

The `engine` job, which is where `cd tools && go test ./...` runs, passes with
the new test in it.
