### PR TITLE
infra: restore the grant that lets deployment reach production

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -365,6 +365,26 @@ jobs:
             --pricing infra/pricing.yaml \
             --budget 300 | tee cost.txt
 
+      # WHAT THE SUMMARY BELOW SAYS, SAID IN AN EXIT CODE INSTEAD.
+      #
+      # The Summarise step already counts destroys and already bolds the count.
+      # That instinct was right and it could not fail: it writes a sentence into
+      # a job summary and asks a person to read it. Commit ff893073 deleted the
+      # Contributor grant that lets continuous deployment reach production, and
+      # every plan afterwards said "1 to destroy" into a green check.
+      #
+      # GATED ON remote_state, not on the credential. A plan from an empty
+      # state shows every resource as a create and cannot contain a destroy, so
+      # running this against one would be a green check that examined nothing.
+      # planguard refuses such a plan outright rather than passing it, and this
+      # condition keeps it from being asked in the first place.
+      - name: staging destroys nothing unacknowledged
+        if: steps.azure.outputs.ready == 'true' && steps.azure.outputs.remote_state == 'true'
+        run: |
+          GOTOOLCHAIN=local go run ./tools/planguard \
+            -plan infra/terraform/stacks/control-plane/plan.json \
+            -environment staging
+
       # The destroy count, called out on its own. A plan buried in a log is a
       # plan nobody reads; "3 to destroy" in the summary is one somebody asks
       # about.
@@ -485,14 +505,22 @@ jobs:
             -backend-config="key=control-plane-production.tfstate" \
             -backend-config="use_azuread_auth=true" \
             -backend-config="use_oidc=true"
-          # No -out, and the log goes to the runner's temp directory rather
-          # than into the stack. `terraform show -json` on a plan file includes
-          # the values of sensitive input variables and this plan has no reader,
-          # and a log written beside staging.tfvars is one more untracked file
-          # in a directory an operator also works in by hand.
+          # THE PLAN IS WRITTEN OUT NOW, AND IT WAS NOT BEFORE. The reason
+          # given for not writing one was that `terraform show -json` on a plan
+          # file includes the values of sensitive input variables and this plan
+          # had no reader. It has one: tools/planguard, in the step below, and a
+          # plan with a reader is worth the file. Everything else about the
+          # original reasoning still holds and is kept, so both the plan and its
+          # JSON go to the runner's temp directory rather than into the stack,
+          # where they would be two more untracked files in a directory an
+          # operator also works in by hand. Neither is ever printed: planguard
+          # reads resource_changes and prior_state and deliberately does not
+          # touch the variables block.
           log="$RUNNER_TEMP/production-plan.txt"
           if terraform plan -input=false -lock=false -refresh=false \
-            -var-file=production.tfvars -no-color > "$log" 2>&1; then
+            -var-file=production.tfvars -no-color \
+            -out="$RUNNER_TEMP/production.tfplan" > "$log" 2>&1; then
+            terraform show -json "$RUNNER_TEMP/production.tfplan" > "$RUNNER_TEMP/production-plan.json"
             echo "Production planned successfully. The diff above is staging's; this step read only the exit status." >> "$GITHUB_STEP_SUMMARY"
           else
             echo "::error title=Production cannot be planned::terraform plan against production.tfvars and control-plane-production.tfstate failed. Until it passes, no change to this stack can be applied to production, including changes already merged. The failure is below."
@@ -509,3 +537,35 @@ jobs:
             } >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
+
+      # THE SAME QUESTION, ASKED WHERE IT WAS NEVER ASKED AT ALL.
+      #
+      # The step above reads the exit status and says so: a plan that SUCCEEDS
+      # can still be a plan that removes something nobody meant to remove, and
+      # that is not a hypothetical here. This is the environment where it
+      # happened, and it went unseen for days for two compounding reasons:
+      # production could not be planned at all, and the destroy counter that
+      # does exist runs against staging and reports rather than fails.
+      #
+      # IT IS SAFE TO READ THIS DIFF EVEN THOUGH THE STEP ABOVE SAYS THE DIFF
+      # CANNOT BE TRUSTED, and the distinction is the reason this step is
+      # allowed to exist. The inputs here are not the inputs an apply would use:
+      # alert_emails is a placeholder and ci_principal_id arrives from a
+      # repository variable, so the ADDS and the IN PLACE CHANGES in this plan
+      # describe a desired state nobody will ever apply. Neither placeholder can
+      # manufacture a DESTROY. A destroy appears when state holds a managed
+      # resource that no configuration declares, and no value passed on the
+      # command line makes a resource stop being declared. Verified rather than
+      # assumed: the pull request that added this planned production both ways
+      # and the destroy set was identical.
+      #
+      # It is a separate step from the plan on purpose. "Production cannot be
+      # planned" and "production plans, and the plan removes something" are
+      # different failures with different fixes, and a reader should not have to
+      # work out which one a red check meant.
+      - name: production destroys nothing unacknowledged
+        if: steps.azure.outputs.ready == 'true' && steps.azure.outputs.remote_state == 'true'
+        run: |
+          GOTOOLCHAIN=local go run ./tools/planguard \
+            -plan "$RUNNER_TEMP/production-plan.json" \
+            -environment production

--- a/.gitignore
+++ b/.gitignore
@@ -155,6 +155,7 @@ runner/artifacts/
 /motioncheck
 /notices
 /npmaudit
+/planguard
 /prosecheck
 /proxysrc
 /readability

--- a/docs/src/content/docs/self-hosting/production.md
+++ b/docs/src/content/docs/self-hosting/production.md
@@ -354,13 +354,30 @@ az ad app federated-credential list --id "$APP_ID" \
 
 **What is missing is the role assignment**, because the production group does
 not exist until step 5 and a grant cannot precede its scope. The identity needs
-on the production group what it already has on staging's:
+on the production group what it already has on staging's: Contributor, scoped to
+that group and nothing wider.
+
+**Terraform owns it. Do not create it by hand.** This page used to print an
+`az role assignment create` here and that instruction outlived the code that
+replaced it, which is worse than either alone: a grant made by hand is absent
+from the stack's state, cannot survive a rebuild, and reads to the next person
+as a resource Terraform does not manage. The grant is
+`azurerm_role_assignment.cd_deploys_the_group` in
+`stacks/control-plane/ci.tf`, and it is switched on by `cd_principal_id` in
+`production.tfvars`, which is already set. Step 5 creates it along with
+everything else.
+
+Confirm it after the apply, rather than trusting this page:
 
 ```sh
-az role assignment create --role Contributor \
+az role assignment list \
   --assignee "$(az ad app list --display-name af-infra-ci --query '[0].appId' -o tsv)" \
-  --scope "$(az group show -n af-cp-prod-centralus --query id -o tsv)"
+  --scope "$(az group show -n af-cp-prod-centralus --query id -o tsv)" \
+  --query "[].roleDefinitionName" -o tsv
 ```
+
+If that prints nothing, `cd.yml`'s production job fails at its first
+`az containerapp` call and continuous deployment cannot reach production at all.
 
 ### 13. Set the approval rule on the production environment
 

--- a/infra/terraform/stacks/control-plane/ci.tf
+++ b/infra/terraform/stacks/control-plane/ci.tf
@@ -20,3 +20,49 @@ resource "azurerm_role_assignment" "ci_reads_the_group" {
   role_definition_name = "Reader"
   principal_id         = var.ci_principal_id
 }
+
+# What the DEPLOY job is allowed to do, which is a great deal more.
+#
+# CONTRIBUTOR, at this resource group and nowhere else. cd.yml updates the
+# container app's image, starts the bootstrap job and shifts ingress traffic, and
+# none of that is possible with the Reader above. Without this assignment the
+# production job fails at its first `az containerapp` call, so continuous
+# deployment cannot reach production at all.
+#
+# THIS IS THE SAME PRINCIPAL AS THE READER ABOVE, AND THAT IS THE UNCOMFORTABLE
+# PART, stated here rather than left for somebody to discover from a role
+# listing. One identity both plans pull requests and deploys, so the sentence in
+# the comment above about a credential being worthless to anybody who steals it
+# does not hold on a stack that sets this: a pull request can edit the workflow
+# that uses the credential in the same commit that runs it. Splitting the two
+# identities is the real fix and it breaks continuous deployment until the
+# second one is federated, so it is a decision somebody has to make rather than
+# something to slip into this file.
+#
+# Contributor supersedes Reader, so setting both variables to the same object id
+# creates two assignments where one would do. Production sets only this one.
+#
+# WHY THIS IS HERE AND NOT AN `az role assignment create`. Staging's equivalent
+# grant was made by hand and is therefore invisible to anybody reading this
+# stack, absent from its state, and unable to survive a rebuild. It is also the
+# reason `az role assignment list` on staging's group returns Contributor while
+# this file describes Reader. A grant that decides whether deployment works
+# belongs in the code that everything else about the environment lives in.
+#
+# THIS BLOCK HAS BEEN DELETED ONCE ALREADY AND THAT IS WHY THE PARAGRAPH BELOW
+# EXISTS. ff893073, whose subject and whole message are about a Postgres test
+# port, carried a stale checkout of twelve unrelated files and took this
+# resource, its variable and its production value with it. Nothing failed:
+# production kept serving, because deploys run through `az containerapp update`
+# rather than through Terraform, and the stack could not be planned at all until
+# the step added in this same branch. The grant simply became a live assignment
+# in Azure and in state that no configuration declared, which is to say a
+# pending `1 to destroy` sitting in front of whoever applied next. The gate in
+# tools/planguard exists to make that specific silence audible, and it reads the
+# acknowledgement file beside it rather than this comment.
+resource "azurerm_role_assignment" "cd_deploys_the_group" {
+  count                = var.cd_principal_id == "" ? 0 : 1
+  scope                = module.foundation.resource_group_id
+  role_definition_name = "Contributor"
+  principal_id         = var.cd_principal_id
+}

--- a/infra/terraform/stacks/control-plane/production.tfvars
+++ b/infra/terraform/stacks/control-plane/production.tfvars
@@ -223,6 +223,28 @@ github_app_id = ""
 assign_deployer_secret_officer = true
 deployer_principal_id          = "3537595b-8059-4839-9cd8-04325c824291"
 
+# WITHOUT THIS, CONTINUOUS DEPLOYMENT CANNOT REACH PRODUCTION AT ALL.
+#
+# The object id of af-infra-ci, the Entra application GitHub Actions federates
+# into. cd.yml's production job updates the container app's image, starts the
+# bootstrap job and shifts ingress traffic; every one of those is a write and
+# the identity holds nothing on this group until this line grants it.
+#
+# An object id is not a secret. It identifies a principal and unlocks nothing,
+# which is why it sits here beside deployer_principal_id rather than arriving as
+# an environment variable. That placement is deliberate and is the difference
+# between this grant and staging's: a value passed as TF_VAR_ by the plan job
+# and NOT by the person who runs apply produces a plan that says "1 to add" on
+# every pull request forever, for a resource nobody ever creates. That is
+# exactly what ci_principal_id does today, and a plan that is never empty is one
+# people stop reading.
+#
+# The grant this line describes is live in Azure and recorded in
+# control-plane-production.tfstate. Deleting the line does not revoke it; it
+# turns it into an orphan that the next apply removes. See ci.tf for the commit
+# that did exactly that and for the gate that now refuses it.
+cd_principal_id = "f99916dc-1e11-4305-8e03-1e116a1e93e1"
+
 # ---------------------------------------------------------------------------
 # Alerting.
 # ---------------------------------------------------------------------------

--- a/infra/terraform/stacks/control-plane/variables.tf
+++ b/infra/terraform/stacks/control-plane/variables.tf
@@ -239,6 +239,12 @@ variable "ci_principal_id" {
   description = "Object id of the service principal GitHub Actions federates into. Gets Reader on this resource group and nothing else. Empty disables the grant."
 }
 
+variable "cd_principal_id" {
+  type        = string
+  default     = ""
+  description = "Object id of the identity cd.yml deploys with. Gets Contributor on this resource group and nothing else, which is what updating the container app and shifting traffic needs. Empty disables the grant, and with it continuous deployment into this environment."
+}
+
 variable "geo_redundant_backup" {
   type        = bool
   default     = false

--- a/tools/gatecheck/main.go
+++ b/tools/gatecheck/main.go
@@ -728,6 +728,27 @@ var exemptFromGate = map[string]string{
 		"than silently costed at zero. " +
 		"It runs on every pull request touching infra/ in infra.yml, against the " +
 		"plan produced there, with --budget so an over-budget plan fails.",
+
+	"tool planguard": "" +
+		"Its input is not in the tree, for the same reason tools/cost's is not. " +
+		"planguard reads a Terraform plan and the whole of its question is about " +
+		"what the RECORDED STATE holds that the configuration no longer declares, " +
+		"so it needs the real state blob and not merely a cloud account. It " +
+		"refuses a plan made without one rather than passing it, which is the " +
+		"point: a plan from an empty state shows every resource as a create and " +
+		"cannot contain a destroy, so a green result from a laptop would be a " +
+		"check that examined nothing. " +
+		"What IS a function of the tree is every rule it applies, and `go test " +
+		"./tools/planguard` covers each one inside `gate`: an unacknowledged " +
+		"destroy is refused, a replace counts as a destroy, an acknowledged one " +
+		"passes, an acknowledgement with no expiry or no reason is not a " +
+		"decision, an expired one has lapsed, one that matched nothing is stale, " +
+		"a plan with no managed resources in its prior state is refused rather " +
+		"than passed, and a plan it cannot parse is an error rather than an empty " +
+		"result. " +
+		"It runs on every pull request touching infra/ in infra.yml, against both " +
+		"the staging and the production plan produced there, and only when those " +
+		"plans were made against the real state.",
 }
 
 // workflowSet is the workflows that run on a pull request, kept with their

--- a/tools/inputcheck/surface-v1.tsv
+++ b/tools/inputcheck/surface-v1.tsv
@@ -247,6 +247,7 @@ terraform:stacks/control-plane	variable	app_base_url	string	optional
 terraform:stacks/control-plane	variable	assign_deployer_secret_officer	bool	optional
 terraform:stacks/control-plane	variable	backup_retention_days	number	optional
 terraform:stacks/control-plane	variable	budget_contact_emails	list(string)	optional
+terraform:stacks/control-plane	variable	cd_principal_id	string	optional
 terraform:stacks/control-plane	variable	ci_principal_id	string	optional
 terraform:stacks/control-plane	variable	custom_domain	string	optional
 terraform:stacks/control-plane	variable	database_extensions	list(string)	optional

--- a/tools/planguard/destroys-acknowledged.tsv
+++ b/tools/planguard/destroys-acknowledged.tsv
@@ -1,0 +1,11 @@
+# Destroys somebody decided to make, one per line, tab separated:
+#
+#   <terraform address>	<expiry YYYY-MM-DD>	<why it is intended>
+#
+# An address listed here is a destroy `terraform plan` is allowed to propose
+# without failing tools/planguard. Read that tool's package comment for why the
+# mechanism is a written line rather than a flag, and why an entry that
+# acknowledges nothing is an error rather than a harmless leftover.
+#
+# THE STEADY STATE OF THIS FILE IS EMPTY. A line here should be added in the
+# pull request that causes the destroy and removed in the one after it lands.

--- a/tools/planguard/main.go
+++ b/tools/planguard/main.go
@@ -1,0 +1,391 @@
+// Command planguard refuses a Terraform plan that destroys a resource nobody
+// said they wanted destroyed.
+//
+// THE DEFECT THIS EXISTS FOR, because it is a defect with no symptom. Commit
+// ff893073, whose subject and whole message are about a Postgres test port,
+// carried a stale checkout of twelve unrelated files. Among them it deleted
+// `azurerm_role_assignment.cd_deploys_the_group`, which is the Contributor
+// grant on af-cp-prod-centralus that lets cd.yml deploy production at all.
+//
+// Nothing failed. Nothing could have. The grant stayed live in Azure and stayed
+// recorded in control-plane-production.tfstate; only the configuration that
+// declared it went away. Deploys kept working because they run through
+// `az containerapp update` rather than through Terraform. The whole of the
+// damage was that every production plan from then on said "1 to destroy", and
+// the first `terraform apply` would have revoked the grant that lets deployment
+// reach production, after which the next deploy fails at its first
+// `az containerapp` call and production cannot be shipped to.
+//
+// So the shape of the bug is: a resource that exists in Azure, exists in state,
+// and exists in no configuration. Terraform is not confused by that and does
+// not need to be told about it. Terraform reports it correctly, as a destroy,
+// and the report goes into a plan log that a green check invites nobody to
+// read.
+//
+// WHAT THIS REPOSITORY ALREADY HAD, and why it was not enough. infra.yml
+// already counts destroys and already bolds the count into the job summary:
+// "**This plan DESTROYS 1 resource(s).** Read it before approving." That is the
+// right instinct and it failed twice over. It ran only against STAGING, and
+// production was the environment that could not be planned at all until the
+// step this branch adds. And it is a sentence rather than an exit code, so even
+// pointed at the right plan it asks a person to notice. A check whose failure
+// mode is "somebody did not read the summary" is documentation.
+//
+// WHY THE RULE IS "NO DESTROY", AND NOT SOMETHING NARROWER. The tempting
+// narrowing is to gate only the resources that look important, role assignments
+// say, or only production. Both require this tool to know which destroys matter,
+// and it cannot: the grant that started this was three lines of HCL and the
+// least imposing thing in the file. The honest rule is that no destroy is
+// routine, because a destroy is Terraform reporting that the configuration and
+// the world disagree, and the whole question is whether a person decided that.
+//
+// AND WHY IT IS NOT A BLANKET REFUSAL EITHER. A gate with no way through it
+// gets deleted the first time somebody legitimately needs to remove a resource,
+// and then the protection is gone permanently for the sake of one afternoon.
+// That is close to how the grant was lost in the first place: something with no
+// owner got swept along. So a destroy is allowed when it is WRITTEN DOWN, in
+// tools/planguard/destroys-acknowledged.tsv, naming the exact address, an
+// expiry and a reason. The price of an intended destroy is one line and the
+// review that line gets. The price of an unintended one is a red check.
+//
+// THE THREE RULES ARE tools/tfsecignores' THREE RULES, deliberately, because
+// this repository already made that decision about suppressions and a second
+// mechanism with different manners would be one more thing to learn:
+//
+//  1. An entry with no expiry or no reason is not a decision.
+//  2. An entry past its expiry has lapsed, and it says so rather than quietly
+//     continuing to hold the gate open.
+//  3. An entry that acknowledged NOTHING is stale and is an error. This is the
+//     rule that keeps the file honest. Somebody acknowledges a destroy, the
+//     destroy happens, and the line stays behind reading as permission that is
+//     no longer scoped to anything. From then on it would wave through a future
+//     destroy of the same address that nobody agreed to.
+//
+// IT REFUSES TO PASS A PLAN THAT COULD NOT HAVE FAILED. This is the part worth
+// being careful about, and infra.yml already learned it the hard way in the
+// empty-state warning it prints: a plan made with no remote state shows every
+// resource as a create, so it CANNOT contain a destroy, and running this tool
+// against one would produce a green check that examined nothing. That is worse
+// than no check, because it looks like evidence. So a plan whose prior state
+// holds no managed resources at all is an ERROR here and never a pass. The same
+// reasoning is why a plan file this tool cannot parse is an error rather than
+// an empty set of changes: tfsec failing to run and tfsec finding nothing look
+// identical in an exit code, and eight findings once sat behind a green check in
+// this repository for exactly that reason.
+//
+// WHAT IT DOES NOT CATCH, said here so the check is not read as more than it
+// is. It sees destroys and it sees nothing else. The same commit that deleted
+// the grant also reverted `github_app_id` to empty, which strips the GitHub App
+// id and its two secret references out of the running production container app.
+// That is an in-place UPDATE, not a destroy, and this tool passes it. A gate on
+// updates would have to know which updates are wanted, and almost all of them
+// are; that is a different check, if it is a check at all.
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+)
+
+// dateLayout matches tools/tfsecignores. One spelling of a date across the
+// repository is worth more than any argument for a different one.
+const dateLayout = "2006-01-02"
+
+// reasonFloor is how much prose an acknowledgement needs before it counts as a
+// stated reason, and it is tfsecignores' number for the same reason: the bar is
+// "somebody wrote something" rather than a word count nobody can defend.
+const reasonFloor = 40
+
+// planChange is the subset of `terraform show -json` this tool decides on.
+//
+// It reads resource_changes and prior_state and nothing else. Notably it does
+// NOT read the `variables` block, which carries the values of sensitive input
+// variables: this tool is run in a pipeline where a plan holding production
+// credentials passes through it, and the less of that it touches the smaller
+// the chance a future edit prints one.
+type planFile struct {
+	FormatVersion   string           `json:"format_version"`
+	ResourceChanges []resourceChange `json:"resource_changes"`
+	PriorState      *struct {
+		Values *struct {
+			RootModule module `json:"root_module"`
+		} `json:"values"`
+	} `json:"prior_state"`
+}
+
+type module struct {
+	Resources []struct {
+		Mode string `json:"mode"`
+	} `json:"resources"`
+	ChildModules []module `json:"child_modules"`
+}
+
+// managed is every MANAGED resource the prior state knows about, at any depth.
+//
+// BOTH HALVES OF THAT SENTENCE WERE LEARNED FROM A REAL PLAN RATHER THAN
+// REASONED, and the tool was wrong about each of them first.
+//
+// At any depth, because the control plane stack keeps almost everything inside
+// module.control_plane; counting only the root module would call a perfectly
+// good plan empty and refuse it.
+//
+// MANAGED, because a plan built with no state at all is not empty. Terraform
+// reads data sources during the plan and records them in prior_state, so the
+// genuinely stateless production plan carries exactly one entry,
+// module.control_plane.data.azurerm_client_config.current, and an earlier
+// version of this function counted it and passed the plan. That is the precise
+// failure this guard exists to prevent, reproduced by the guard itself. Only a
+// managed resource can be destroyed, so only a managed resource is evidence
+// that a destroy was possible.
+func (m module) managed() int {
+	n := 0
+	for _, r := range m.Resources {
+		if r.Mode == "managed" {
+			n++
+		}
+	}
+	for _, c := range m.ChildModules {
+		n += c.managed()
+	}
+	return n
+}
+
+type resourceChange struct {
+	Address string `json:"address"`
+	Type    string `json:"type"`
+	Mode    string `json:"mode"`
+	Change  struct {
+		Actions []string `json:"actions"`
+	} `json:"change"`
+}
+
+// destroys reports whether this change removes the real resource.
+//
+// "delete" appearing anywhere in actions is the test, which means a REPLACE
+// counts. That is deliberate and is not over-reach: replacing a role assignment
+// revokes it and grants it again, and a deploy that runs in that window fails
+// exactly as it would against a plain destroy. infra.yml's existing destroy
+// counter asks the same question the same way.
+func (c resourceChange) destroys() bool {
+	for _, a := range c.Change.Actions {
+		if a == "delete" {
+			return true
+		}
+	}
+	return false
+}
+
+// acknowledgement is one line of destroys-acknowledged.tsv.
+type acknowledgement struct {
+	Address string
+	Expires string
+	Reason  string
+	Line    int
+
+	expires time.Time
+	matched bool
+}
+
+func main() {
+	plan := flag.String("plan", "", "Path to the output of `terraform show -json <planfile>`.")
+	ackPath := flag.String("acknowledged", "tools/planguard/destroys-acknowledged.tsv", "Path to the acknowledgement file.")
+	label := flag.String("environment", "", "Which environment this plan is for, used only in messages.")
+	now := flag.String("now", "", "Override today's date, as YYYY-MM-DD. For tests.")
+	flag.Parse()
+
+	if err := run(*plan, *ackPath, *label, *now); err != nil {
+		fmt.Fprintf(os.Stderr, "planguard: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(planPath, ackPath, label, nowOverride string) error {
+	if planPath == "" {
+		return errors.New("-plan is required")
+	}
+
+	today := time.Now().UTC()
+	if nowOverride != "" {
+		t, err := time.Parse(dateLayout, nowOverride)
+		if err != nil {
+			return fmt.Errorf("-now: %w", err)
+		}
+		today = t
+	}
+
+	p, err := readPlan(planPath)
+	if err != nil {
+		return err
+	}
+
+	// The check that keeps this check honest. See the package comment: a plan
+	// with no prior state cannot contain a destroy, so passing one is not
+	// evidence of anything.
+	if p.PriorState == nil || p.PriorState.Values == nil || p.PriorState.Values.RootModule.managed() == 0 {
+		return fmt.Errorf(`this plan has NO PRIOR STATE, so it cannot contain a destroy and this check cannot say no.
+
+A plan made without a state backend reads every resource as a create. Passing it
+would be a green check that examined nothing, which is worse than no check.
+Point this at a plan made against the real state, or do not run it at all.
+
+  plan: %s`, planPath)
+	}
+
+	acks, err := readAcknowledgements(ackPath)
+	if err != nil {
+		return err
+	}
+
+	var problems []string
+
+	// Rule 1 and rule 2, on the file itself, before any plan is consulted. A
+	// malformed acknowledgement is a problem whether or not it is load bearing
+	// today.
+	for i := range acks {
+		a := &acks[i]
+		switch {
+		case a.Expires == "":
+			problems = append(problems, fmt.Sprintf(
+				"%s:%d: %s has no expiry. An acknowledgement with no shelf life is a policy change wearing a temporary hat.",
+				ackPath, a.Line, a.Address))
+		case len(strings.TrimSpace(a.Reason)) < reasonFloor:
+			problems = append(problems, fmt.Sprintf(
+				"%s:%d: %s has no stated reason (needs at least %d characters saying why this destroy is intended).",
+				ackPath, a.Line, a.Address, reasonFloor))
+		case a.expires.Before(today):
+			problems = append(problems, fmt.Sprintf(
+				"%s:%d: %s expired on %s. The decision to allow this destroy has lapsed; renew it deliberately or remove the line.",
+				ackPath, a.Line, a.Address, a.Expires))
+		}
+	}
+
+	byAddress := map[string]*acknowledgement{}
+	for i := range acks {
+		byAddress[acks[i].Address] = &acks[i]
+	}
+
+	var unacknowledged []resourceChange
+	for _, c := range p.ResourceChanges {
+		if !c.destroys() {
+			continue
+		}
+		if a, ok := byAddress[c.Address]; ok && a.Expires != "" && !a.expires.Before(today) {
+			a.matched = true
+			continue
+		}
+		unacknowledged = append(unacknowledged, c)
+	}
+
+	// Rule 3. An acknowledgement that matched nothing is stale, and a stale one
+	// is permission sitting in the tree for a destroy nobody is proposing.
+	for i := range acks {
+		a := &acks[i]
+		if !a.matched && a.Expires != "" && !a.expires.Before(today) {
+			problems = append(problems, fmt.Sprintf(
+				"%s:%d: %s acknowledges a destroy this plan does not propose. Either the destroy already happened and this line should go, or the address changed and this line no longer protects what somebody thought it did.",
+				ackPath, a.Line, a.Address))
+		}
+	}
+
+	sort.Slice(unacknowledged, func(i, j int) bool { return unacknowledged[i].Address < unacknowledged[j].Address })
+
+	where := "this plan"
+	if label != "" {
+		where = label
+	}
+
+	if len(unacknowledged) > 0 {
+		var b strings.Builder
+		fmt.Fprintf(&b, "%s proposes %d destroy(s) that nobody acknowledged.\n\n", where, len(unacknowledged))
+		for _, c := range unacknowledged {
+			fmt.Fprintf(&b, "  %s  (%s, actions: %s)\n", c.Address, c.Type, strings.Join(c.Change.Actions, ","))
+		}
+		b.WriteString(`
+A destroy here means the resource exists in state and in the cloud, and no
+configuration in this repository declares it any more. That is either a removal
+somebody intended, or a removal nobody noticed, and the two are indistinguishable
+from the outside. This gate exists because they were indistinguishable once and
+the resource was the grant that lets continuous deployment reach production.
+
+IF THIS DESTROY IS INTENDED, say so and this passes. Add a line to
+` + ackPath + `, tab separated:
+
+  <address>	<expiry YYYY-MM-DD>	<why it is intended>
+
+IF IT IS NOT, the fix is in the configuration, not here. Find what stopped
+declaring the resource. ` + "`git log -S <resource name>`" + ` on the stack usually names
+the commit in one go.`)
+		problems = append(problems, b.String())
+	}
+
+	if len(problems) > 0 {
+		return errors.New(strings.Join(problems, "\n\n"))
+	}
+
+	fmt.Printf("planguard: %s destroys nothing that is not acknowledged (%d change(s) examined, %d acknowledgement(s) live).\n",
+		where, len(p.ResourceChanges), len(acks))
+	return nil
+}
+
+// readPlan refuses anything it cannot understand rather than reporting an empty
+// set of changes. See the package comment: "could not read it" and "found
+// nothing" must not share an exit code.
+func readPlan(path string) (*planFile, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading plan: %w", err)
+	}
+	var p planFile
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w\n\nThis wants the output of `terraform show -json <planfile>`, not the plan file itself and not the human readable plan.", path, err)
+	}
+	if p.FormatVersion == "" {
+		return nil, fmt.Errorf("%s has no format_version, so it is not a `terraform show -json` document. Refusing to report zero destroys from a file this tool did not understand.", path)
+	}
+	return &p, nil
+}
+
+// readAcknowledgements parses the TSV. A file that is absent is not an error:
+// the expected steady state of this repository is that no destroy is
+// acknowledged, and requiring an empty file to exist would be ceremony.
+func readAcknowledgements(path string) ([]acknowledgement, error) {
+	raw, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading acknowledgements: %w", err)
+	}
+
+	var out []acknowledgement
+	for i, line := range strings.Split(string(raw), "\n") {
+		n := i + 1
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		fields := strings.Split(line, "\t")
+		a := acknowledgement{Line: n, Address: strings.TrimSpace(fields[0])}
+		if len(fields) > 1 {
+			a.Expires = strings.TrimSpace(fields[1])
+		}
+		if len(fields) > 2 {
+			a.Reason = strings.TrimSpace(strings.Join(fields[2:], " "))
+		}
+		if a.Expires != "" {
+			t, err := time.Parse(dateLayout, a.Expires)
+			if err != nil {
+				return nil, fmt.Errorf("%s:%d: expiry %q is not %s", path, n, a.Expires, dateLayout)
+			}
+			a.expires = t
+		}
+		out = append(out, a)
+	}
+	return out, nil
+}

--- a/tools/planguard/main_test.go
+++ b/tools/planguard/main_test.go
@@ -1,0 +1,237 @@
+// Every test here is written the way this repository asks for: one break per
+// assertion, and each case names the specific wrong behaviour it would catch.
+// A test that only proves the happy path passes is a test that cannot say no.
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// planJSON builds a `terraform show -json` document with a non-empty prior
+// state, because a plan with an empty prior state is rejected before any of
+// these rules are reached and would make every case below vacuous.
+func planJSON(changes string) string {
+	return `{
+	  "format_version": "1.2",
+	  "prior_state": {"values": {"root_module": {"resources": [{"mode": "managed"}]}}},
+	  "resource_changes": [` + changes + `]
+	}`
+}
+
+const destroyOfTheGrant = `{
+  "address": "azurerm_role_assignment.cd_deploys_the_group[0]",
+  "type": "azurerm_role_assignment",
+  "mode": "managed",
+  "change": {"actions": ["delete"]}
+}`
+
+func write(t *testing.T, name, body string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// The case this tool was built for. If this passes, the tool is decoration.
+func TestUnacknowledgedDestroyFails(t *testing.T) {
+	plan := write(t, "plan.json", planJSON(destroyOfTheGrant))
+	err := run(plan, filepath.Join(t.TempDir(), "absent.tsv"), "production", "2026-09-03")
+	if err == nil {
+		t.Fatal("an unacknowledged destroy passed, which is the whole defect this exists to catch")
+	}
+	if !strings.Contains(err.Error(), "cd_deploys_the_group") {
+		t.Fatalf("the failure does not name the resource being destroyed: %v", err)
+	}
+}
+
+// A plan with nothing to destroy passes, or the gate is a permanent red and
+// gets removed.
+func TestCleanPlanPasses(t *testing.T) {
+	plan := write(t, "plan.json", planJSON(`{
+	  "address": "azurerm_container_app.this",
+	  "type": "azurerm_container_app",
+	  "mode": "managed",
+	  "change": {"actions": ["update"]}
+	}`))
+	if err := run(plan, filepath.Join(t.TempDir(), "absent.tsv"), "production", "2026-09-03"); err != nil {
+		t.Fatalf("a plan that destroys nothing was refused: %v", err)
+	}
+}
+
+// A REPLACE destroys the resource and is caught. Catching only ["delete"] on
+// its own would wave through a role assignment being revoked and regranted.
+func TestReplaceCountsAsDestroy(t *testing.T) {
+	plan := write(t, "plan.json", planJSON(`{
+	  "address": "azurerm_role_assignment.cd_deploys_the_group[0]",
+	  "type": "azurerm_role_assignment",
+	  "mode": "managed",
+	  "change": {"actions": ["delete", "create"]}
+	}`))
+	if err := run(plan, filepath.Join(t.TempDir(), "absent.tsv"), "production", "2026-09-03"); err == nil {
+		t.Fatal("a replace passed; a replace revokes the grant and grants it again, and a deploy in that window fails")
+	}
+}
+
+// The way through the gate has to actually work, or the gate gets deleted the
+// first time somebody legitimately needs a destroy.
+func TestAcknowledgedDestroyPasses(t *testing.T) {
+	plan := write(t, "plan.json", planJSON(destroyOfTheGrant))
+	ack := write(t, "ack.tsv", "azurerm_role_assignment.cd_deploys_the_group[0]\t2026-12-31\tThe second identity is federated now, so this grant is being removed on purpose.\n")
+	if err := run(plan, ack, "production", "2026-09-03"); err != nil {
+		t.Fatalf("an acknowledged destroy was still refused: %v", err)
+	}
+}
+
+// Rule 2. An expired acknowledgement stops holding the gate open, and says so.
+func TestExpiredAcknowledgementFails(t *testing.T) {
+	plan := write(t, "plan.json", planJSON(destroyOfTheGrant))
+	ack := write(t, "ack.tsv", "azurerm_role_assignment.cd_deploys_the_group[0]\t2026-08-01\tThe second identity is federated now, so this grant is being removed on purpose.\n")
+	err := run(plan, ack, "production", "2026-09-03")
+	if err == nil {
+		t.Fatal("an expired acknowledgement still waved the destroy through")
+	}
+	if !strings.Contains(err.Error(), "expired on 2026-08-01") {
+		t.Fatalf("the failure does not say the acknowledgement lapsed: %v", err)
+	}
+}
+
+// Rule 1. A bare address with no expiry is not a decision.
+func TestAcknowledgementWithoutExpiryFails(t *testing.T) {
+	plan := write(t, "plan.json", planJSON(destroyOfTheGrant))
+	ack := write(t, "ack.tsv", "azurerm_role_assignment.cd_deploys_the_group[0]\n")
+	err := run(plan, ack, "production", "2026-09-03")
+	if err == nil || !strings.Contains(err.Error(), "no expiry") {
+		t.Fatalf("a bare address with no expiry was accepted as a decision: %v", err)
+	}
+}
+
+// Rule 1, the other half. An expiry with no prose is not a reason.
+func TestAcknowledgementWithoutReasonFails(t *testing.T) {
+	plan := write(t, "plan.json", planJSON(destroyOfTheGrant))
+	ack := write(t, "ack.tsv", "azurerm_role_assignment.cd_deploys_the_group[0]\t2026-12-31\ttidy up\n")
+	err := run(plan, ack, "production", "2026-09-03")
+	if err == nil || !strings.Contains(err.Error(), "no stated reason") {
+		t.Fatalf("an acknowledgement with no stated reason was accepted: %v", err)
+	}
+}
+
+// Rule 3. This is the rule that keeps the file honest: permission left behind
+// after the destroy happened would wave through a future destroy of the same
+// address that nobody agreed to.
+func TestStaleAcknowledgementFails(t *testing.T) {
+	plan := write(t, "plan.json", planJSON(`{
+	  "address": "azurerm_container_app.this",
+	  "type": "azurerm_container_app",
+	  "mode": "managed",
+	  "change": {"actions": ["update"]}
+	}`))
+	ack := write(t, "ack.tsv", "azurerm_role_assignment.cd_deploys_the_group[0]\t2026-12-31\tThe second identity is federated now, so this grant is being removed on purpose.\n")
+	err := run(plan, ack, "production", "2026-09-03")
+	if err == nil || !strings.Contains(err.Error(), "does not propose") {
+		t.Fatalf("an acknowledgement that matched nothing was left in place: %v", err)
+	}
+}
+
+// The check that keeps this check honest. A plan built with no state backend
+// reads every resource as a create and CANNOT contain a destroy, so passing one
+// would be a green check that examined nothing.
+func TestEmptyStatePlanIsRefusedRatherThanPassed(t *testing.T) {
+	plan := write(t, "plan.json", `{
+	  "format_version": "1.2",
+	  "prior_state": {"values": {"root_module": {}}},
+	  "resource_changes": [{
+	    "address": "azurerm_role_assignment.cd_deploys_the_group[0]",
+	    "type": "azurerm_role_assignment",
+	    "mode": "managed",
+	    "change": {"actions": ["create"]}
+	  }]
+	}`)
+	err := run(plan, filepath.Join(t.TempDir(), "absent.tsv"), "production", "2026-09-03")
+	if err == nil {
+		t.Fatal("an empty-state plan PASSED; that is a green check that examined nothing")
+	}
+	if !strings.Contains(err.Error(), "NO PRIOR STATE") {
+		t.Fatalf("refused for the wrong reason: %v", err)
+	}
+}
+
+// THE REGRESSION THIS TOOL SHIPPED WITH AND THEN CAUGHT IN ITSELF.
+//
+// The shape below is copied from a real `terraform plan -var-file=production.tfvars`
+// run with no state backend at all. It is not empty: Terraform reads data
+// sources during the plan and records them in prior_state, so a stateless plan
+// still carries module.control_plane.data.azurerm_client_config.current. The
+// first version of this guard counted prior-state resources without looking at
+// their mode, found one, concluded the plan had real state, and PASSED a plan
+// in which a destroy was impossible. The synthetic empty-state test above did
+// not catch it because it was written from what an empty plan ought to look
+// like rather than from one.
+func TestPlanWithOnlyDataSourcesInPriorStateIsRefused(t *testing.T) {
+	plan := write(t, "plan.json", `{
+	  "format_version": "1.2",
+	  "prior_state": {"values": {"root_module": {"child_modules": [{
+	    "address": "module.control_plane",
+	    "resources": [{"mode": "data", "address": "module.control_plane.data.azurerm_client_config.current"}]
+	  }]}}},
+	  "resource_changes": []
+	}`)
+	err := run(plan, filepath.Join(t.TempDir(), "absent.tsv"), "production", "2026-09-03")
+	if err == nil {
+		t.Fatal("a stateless plan whose prior state holds only a data source was accepted as having real state")
+	}
+	if !strings.Contains(err.Error(), "NO PRIOR STATE") {
+		t.Fatalf("refused for the wrong reason: %v", err)
+	}
+}
+
+// Resources nested in modules count as prior state. Counting only the root
+// module would call every real control-plane plan empty, because almost
+// everything in that stack lives inside module.control_plane.
+func TestPriorStateCountsNestedModules(t *testing.T) {
+	plan := write(t, "plan.json", `{
+	  "format_version": "1.2",
+	  "prior_state": {"values": {"root_module": {
+	    "child_modules": [{"resources": [{"mode": "managed"}, {"mode": "managed"}]}]
+	  }}},
+	  "resource_changes": []
+	}`)
+	if err := run(plan, filepath.Join(t.TempDir(), "absent.tsv"), "production", "2026-09-03"); err != nil {
+		t.Fatalf("a plan whose state lives in a child module was called empty: %v", err)
+	}
+}
+
+// "Could not read it" and "found nothing" must not share an exit code. Eight
+// tfsec findings once sat behind a green check in this repository for exactly
+// this reason.
+func TestUnparseablePlanIsAnErrorNotAnEmptyResult(t *testing.T) {
+	plan := write(t, "plan.json", "this is the human readable plan, not JSON")
+	if err := run(plan, filepath.Join(t.TempDir(), "absent.tsv"), "production", "2026-09-03"); err == nil {
+		t.Fatal("a plan this tool could not parse was reported as destroying nothing")
+	}
+}
+
+// JSON that parses but is not a plan document must not report zero destroys.
+func TestJSONWithoutFormatVersionIsRefused(t *testing.T) {
+	plan := write(t, "plan.json", `{"resource_changes": []}`)
+	err := run(plan, filepath.Join(t.TempDir(), "absent.tsv"), "production", "2026-09-03")
+	if err == nil || !strings.Contains(err.Error(), "format_version") {
+		t.Fatalf("a JSON document that is not a plan was accepted: %v", err)
+	}
+}
+
+// The acknowledgement file shipped in this repository has to parse, and its
+// steady state is that it acknowledges nothing.
+func TestShippedAcknowledgementFileIsWellFormedAndEmpty(t *testing.T) {
+	acks, err := readAcknowledgements("destroys-acknowledged.tsv")
+	if err != nil {
+		t.Fatalf("the acknowledgement file in this repository does not parse: %v", err)
+	}
+	if len(acks) != 0 {
+		t.Fatalf("this repository acknowledges %d destroy(s); the steady state is none: %v", len(acks), acks)
+	}
+}


### PR DESCRIPTION
Restores `azurerm_role_assignment.cd_deploys_the_group`, the Contributor grant on `af-cp-prod-centralus` that continuous deployment needs, and adds the gate that would have caught its removal.

**Rebased onto `main` at `0de7655a`.** This was originally branched from `w-tf-managed-cert` because the production planguard step needs the production plan step that #205 introduced. #205 and #203 have since landed, as the squash commits `3b9a129c` and `da33ac74`.

`git rebase origin/main` was the wrong instrument here and I did not use it. Because #205 landed squashed, git does not know its three commits are already in `main` and began replaying all three, conflicting on `infra.yml` against content identical to what it was trying to apply. I reset to `origin/main` and cherry-picked my single commit instead, which applied with no conflict at all.

**A clean cherry-pick is exactly the dangerous case here,** so I checked rather than trusted it. `main` already carries the production plan step, and a second copy would be invisible to git and to YAML parsing and would run the plan twice. Counted in the merged file: `production can still be planned` appears once, `terraform plan` twice (staging and production, as before), the production plan is written once and read once, and there are exactly two planguard steps. My diff against `main` is byte identical to the pre-rebase commit, and `domain.tf` is untouched, since it was never in my commit.

On `.gitignore` I kept one line rather than taking `main`'s side entirely: `/planguard`, which is mine, not #203's. Without it `go build ./tools/planguard` drops a platform specific binary in the repository root, and `tools/gatecheck`'s own test fails for exactly that reason. #203's `backend*.hcl` and `plan.txt` entries are untouched, and I confirmed `backend*.hcl` works by watching `git status` stay clean with a real `backend.production.hcl` in the stack.

## Every claim, checked

All confirmed. Two corrections at the end.

| Claim | Verdict |
| --- | --- |
| `ff893073` deleted the resource, its variable and its production value | Confirmed |
| The grant is live in Azure | Confirmed. Contributor, scope `af-cp-prod-centralus`, created 2026-08-30T23:28:57Z |
| Held by `f99916dc-1e11-4305-8e03-1e116a1e93e1` | Confirmed. `az ad sp show` returns `af-infra-ci` |
| Recorded in production state | Confirmed. `control-plane-production.tfstate` serial 22, root address `azurerm_role_assignment.cd_deploys_the_group` |
| No configuration declares it | Confirmed. Zero matches for `cd_principal_id` anywhere in the tree |
| Production plans report `1 to destroy` | Confirmed, and it is the only destroy |

The production job's first `az containerapp` call is real: `cd.yml` line 371 runs `az containerapp show` against `PRODUCTION_RESOURCE_GROUP` before doing anything else.

## The proof it worked

Planned against the real production state, `-refresh=false -lock=false`, with the alert receiver read out of the deployed action group rather than invented.

Re-measured after the rebase, against `main` at `0de7655a`, because the base moved and the old numbers were taken against a different tree.

Before, on pristine `main`:

```
Plan: 2 to add, 6 to change, 1 to destroy.

['delete']  azurerm_role_assignment.cd_deploys_the_group[0]
```

After:

```
Plan: 2 to add, 6 to change, 0 to destroy.

['no-op']   azurerm_role_assignment.cd_deploys_the_group[0]
```

The `no-op` is the part worth reading. A recreate would have meant the restored address or arguments did not match what Azure and the state already hold; a no-op says they do.

**One correction to how I measured it the first time.** To plan the pre-fix tree I reached for `git stash push` on the three files. My changes are committed rather than working tree edits, so it silently saved nothing and I planned the fixed tree while believing it was the unfixed one. It reported `0 to destroy` and I nearly recorded that as the "before". The numbers above come from `git checkout origin/main -- <the three files>`, verified by grepping that the resource and the variable were actually absent before the plan ran.

## The gate, and why this shape

This repository **already counts destroys.** `infra.yml` computes the count from staging's plan and bolds it into the job summary. That instinct was right and it failed twice over: it runs against staging, and production was the environment that could not be planned at all; and it is a sentence rather than an exit code, so even aimed correctly it asks a person to notice.

So the new thing is not the count. It is that the count can fail, and that it is asked of production.

`tools/planguard` refuses any plan proposing a destroy that is not written down in `tools/planguard/destroys-acknowledged.tsv` with an expiry and a reason.

I considered the narrower framings you asked about and rejected them. Gating only role assignments, or only certain resources, requires the tool to know which destroys matter; the one that started this was three lines of HCL and the least imposing thing in the file. A blanket refusal with no way through it gets deleted the first time a destroy is legitimate, and something with no owner getting swept along is close to how the grant was lost in the first place. **The cost when a destroy is intended is one line and the review that line gets.** The three rules on the acknowledgement file are `tools/tfsecignores`' three, deliberately, so there is one mechanism to learn rather than two.

### It can say no, against real plans

| Plan | Result |
| --- | --- |
| Production, tree before the fix | exit 1, names `azurerm_role_assignment.cd_deploys_the_group[0]` |
| Production, tree after the fix | exit 0 |
| Production, no state backend | exit 1, refused as unable to say no |
| Staging, current | exit 0, clean today, so gating it costs nothing |

Thirteen unit tests cover each rule with one break per assertion.

### The bug the real plan found in the guard

Worth reporting because it is the exact failure the guard exists to prevent, committed by the guard.

planguard refuses a plan built with no state, since every resource reads as a create and a destroy cannot appear. My synthetic test for that passed. Pointed at a **real** stateless production plan, it passed the plan instead of refusing it: a stateless plan is not empty, because Terraform records data sources in `prior_state`, so it carried `module.control_plane.data.azurerm_client_config.current` and the guard concluded the state was real.

It counts managed resources now. The regression test is built from the real shape. Mutating the fix back leaves the synthetic test green and turns the real-shape test red, which is the point.

## A second regression in the same apply, which I did not fix here

`ff893073` also reverted `github_app_id` to `""`, and that has not been restored either. The pending production apply would strip these from the running container app:

```
AF_GITHUB_APP_ID:             '4775259' -> None
AF_GITHUB_APP_PRIVATE_KEY:    secret:github-app-private-key -> None
AF_GITHUB_APP_WEBHOOK_SECRET: secret:github-app-webhook-secret -> None
```

Both secrets are present in `afcpprod-kv-centralus`, so the value is restorable. **planguard does not catch this and cannot:** it is an in place update, not a destroy, and a gate on updates would have to know which updates are wanted.

I left it out deliberately. Restoring the grant is a no-op against reality; restoring this changes what production actually runs. It also interacts with a permission I could not exercise from here: on production's vault the plan identity `af-infra-ci` holds **nothing**, while on staging's it holds Key Vault Secrets Officer. That is why staging plans fine with an App id set. Setting `github_app_id` in `production.tfvars` may therefore break #205's new production plan check in CI, depending on whether the two `azurerm_key_vault_secret` data sources are served from state under `-refresh=false` or re-read. Someone should settle that against the CI identity before changing the value.

## On the state account grant

Already found and documented, in `a3b31ebb` on #205, which stopped asserting the false half and said removing it is not that branch's to make. I verified it independently rather than duplicating the work: `Storage Blob Data Contributor`, principal `f99916dc`, account scope, created 2026-08-28T03:20:32Z, in no `.tf` file.

**Splitting it out.** Removing a live grant is a production permission change and belongs in a step somebody runs, not in a PR that also restores a different grant. What that step is:

```sh
az role assignment delete \
  --assignee f99916dc-1e11-4305-8e03-1e116a1e93e1 \
  --role "Storage Blob Data Contributor" \
  --scope "/subscriptions/efb6886a-85df-4439-addd-2863a1e0a22e/resourceGroups/af-tfstate-eastus/providers/Microsoft.Storage/storageAccounts/aftfstateefb6886a"
```

Check before running it that no workflow writes state as this identity. Every plan in `infra.yml` is `-lock=false` and `-refresh=false`, which is consistent with an identity meant to hold no write, but the check is worth making rather than assuming. The `Reader` and `Storage Blob Data Reader` grants stay.

While verifying it I found a **third** hand made grant of the same class: `af-infra-ci` holds **Key Vault Secrets Officer on the staging vault** `afcp-kv-centralus`, which is in no `.tf` file and is a good deal more than `stacks/tfstate` describes this identity as having. That is the grant letting the plan job read staging's secrets, and it is worth a decision of its own.

## Two corrections

- **The count.** "124 lines" is the churn in `docs/self-hosting/production.md` alone. Outside the one test file the commit describes, it is 70 lines added and 317 removed across twelve files.
- **`main` is at `d8be4f3f`, not `6f8d327e`.** `6f8d327e` is the tip of `fix/nightly-golden-source` in another worktree.

Also minor: the Contributor on the state account was created 3h07m after the `Storage Blob Data Reader` grant. The "hour and a half" gap is to the plain `Reader` grant at 01:46:37Z.

## Also in here

`docs/self-hosting/production.md` step 12 still told an operator to create this grant by hand with `az role assignment create`, an instruction that outlived the code replacing it. Following it now produces exactly the hand made grant `ci.tf` explains at length is the thing to avoid. It now says Terraform owns it, and gives a command to confirm it after the apply.

`tools/gatecheck` refused the new steps until the exemption beside `tools/cost`'s recorded why a tool whose input is a cloud plan cannot run inside `just gate`. `tools/inputcheck` records `cd_principal_id` as a new optional input; it postdates the deletion by three days, could not have caught it, and its snapshot had frozen the absence as correct.

## Gates run

`terraform fmt`, `terraform validate`, `go test ./tools/...`, `gatecheck`, `inputcheck`, `claimcheck`, `prosecheck`, `forbidden`, `readability`. All green. No apply was run and no `terraform apply` is proposed by this PR.

