### PR TITLE
engine: a manifest in a subdirectory could never find the runner at the top of its own checkout

### DIFF
--- a/.changes/runner-search-from-a-subdirectory.md
+++ b/.changes/runner-search-from-a-subdirectory.md
@@ -1,0 +1,17 @@
+# fixed
+
+`af ci` could not find the agent runner unless the manifest sat at the top of
+the checkout or one directory below it. A project kept in a subdirectory, which
+is the ordinary shape rather than the exotic one, got AF-AGT-004 naming four
+paths, none of which was the runner at the top of the checkout the command was
+running inside. `af runner install` already walked up to the top of the checkout
+and the search `af ci` uses was a second copy that never learned to. There is
+one search now, so the two cannot disagree again, and a run also looks beside
+the binary under `share/antifailure` the way the installer already did.
+
+A run that reached no verdict used to give the same reason whether the manifest
+declared no workflows or the run died before it reached the workflows it does
+declare. The first is true, the second is false, and a false reason sends a
+reader to edit a manifest that was never the problem. The report now says which
+of the two happened, and when workflows were declared it points at what stopped
+the run instead of at the manifest.

--- a/engine/internal/cli/ci.go
+++ b/engine/internal/cli/ci.go
@@ -93,6 +93,11 @@ change.`),
 			run := report.Run{
 				Environment: o.EnvID(), Branch: branchName(e, branch),
 				Commit: commitSHA(e), DocsBase: docsBase,
+				// Read from the manifest here, before anything can fail, so
+				// that a run which dies before the workflows still knows how
+				// many it was supposed to run. Reading it later would put it
+				// behind exactly the failures it exists to describe.
+				Declared: len(m.Workflows),
 			}
 			started := e.Clock.Now()
 			var migration []report.Finding

--- a/engine/internal/cli/gate.go
+++ b/engine/internal/cli/gate.go
@@ -73,6 +73,21 @@ func egressFinding(e *report.Egress, p report.Policy) *report.Finding {
 // Counted from the workflows rather than from the count of results, so a
 // manifest that declares none lands here too. That is the same failure wearing
 // a different hat: nothing was tested either way.
+//
+// Three states reach here and they used to be described by two sentences, one
+// of which was a guess. A manifest with no workflows and a run that never
+// reached the workflows it does declare both arrive with no results, and the
+// detail told both of them "the manifest declares no workflows". For the
+// second that is false, and a false reason is worse than a vague one: it sends
+// somebody to add workflows to a manifest that already has them while the real
+// cause, an environment or a runner that never came up, goes unread. It sent
+// somebody there. Three legs of this repository's own nightly reported it,
+// each of the three manifests declares a workflow, and the cause in all three
+// was AF-AGT-004 warned about earlier in the same output.
+//
+// So the manifest's own count is carried on the run and the two are told
+// apart by it rather than by the absence of results, which is evidence for
+// neither.
 func workflowsUnverifiedFinding(run report.Run, p report.Policy) *report.Finding {
 	if p.WorkflowsUnverified == report.LevelIgnore {
 		return nil
@@ -83,17 +98,33 @@ func workflowsUnverifiedFinding(run report.Run, p report.Policy) *report.Finding
 	title := "No workflow reached a verdict about the application."
 	detail := "Every workflow was blocked or proved nothing either way, so this run " +
 		"says nothing about whether the application works."
+	fix := "Read the workflow rows for what stopped each one. If the project has no " +
+		"workflows yet, set policy.workflows_unverified to warn so the choice is " +
+		"recorded rather than assumed."
 	if len(run.Workflows) == 0 {
 		title = "No workflows ran, so nothing about the application was checked."
-		detail = "The manifest declares no workflows, so there was nothing to carry through."
+		switch {
+		case run.Declared > 0:
+			detail = fmt.Sprintf(
+				"The manifest declares %s and none of them produced a result, so the "+
+					"run stopped before the application was reached. The manifest is "+
+					"not the thing to change.",
+				plural(run.Declared, "workflow", "workflows"))
+			fix = "Read the errors above this line for what stopped the run before the " +
+				"workflows. An environment that did not come up and a runner that " +
+				"could not be found both land here."
+		default:
+			detail = "The manifest declares no workflows, so there was nothing to carry through."
+			fix = "Add a workflow to the manifest. If the project has no workflows yet, " +
+				"set policy.workflows_unverified to warn so the choice is recorded " +
+				"rather than assumed."
+		}
 	}
 	return &report.Finding{
 		Rule: ruleWorkflowsUnverified, Level: p.WorkflowsUnverified,
 		Count: len(run.Workflows), Where: "the workflows",
 		Title: title, Detail: detail,
-		Fix: "Read the workflow rows for what stopped each one. If the project has no " +
-			"workflows yet, set policy.workflows_unverified to warn so the choice is " +
-			"recorded rather than assumed.",
+		Fix: fix,
 	}
 }
 

--- a/engine/internal/cli/gate_test.go
+++ b/engine/internal/cli/gate_test.go
@@ -392,6 +392,65 @@ func TestWorkflowsUnverified_NoWorkflowsAtAllIsAlsoAFinding(t *testing.T) {
 	f := workflowsUnverifiedFinding(report.Run{}, defaultGate())
 	require.NotNil(t, f)
 	require.Contains(t, f.Title, "No workflows ran")
+	require.Contains(t, f.Detail, "declares no workflows",
+		"a manifest with no workflows is the one case where saying so is true")
+}
+
+// A run that never reached the workflows it does declare is told a different
+// reason from a manifest that declares none.
+//
+// The two states arrived here identically, because both have no results, and
+// both were told "the manifest declares no workflows". For the second that is
+// false. Three legs of this repository's own nightly reported it, each of the
+// three manifests declares a workflow, and the cause in all three was a runner
+// the engine could not find. The verdict was right and the reason sent a
+// reader to edit a manifest that was never the problem.
+//
+// Asserted as two separate requires because one assertion could not tell which
+// half broke: a detail that says both things, or a detail that says neither,
+// are different defects.
+func TestWorkflowsUnverified_DeclaredButNoneRanIsNotAMissingManifest(t *testing.T) {
+	f := workflowsUnverifiedFinding(report.Run{Declared: 3}, defaultGate())
+	require.NotNil(t, f)
+	require.NotContains(t, f.Detail, "declares no workflows",
+		"the manifest declares three, and saying it declares none sends the reader "+
+			"to edit the one file that is not the problem")
+	require.Contains(t, f.Detail, "declares 3 workflows",
+		"the reason has to say what the manifest actually asked for")
+}
+
+// The reason names the run rather than the manifest, and so does the fix.
+//
+// A reader who is told the manifest is not the thing to change and then given
+// a fix that says "add a workflow to the manifest" has been told both things
+// at once, which is the original defect with an extra step.
+func TestWorkflowsUnverified_DeclaredButNoneRanPointsAwayFromTheManifest(t *testing.T) {
+	f := workflowsUnverifiedFinding(report.Run{Declared: 1}, defaultGate())
+	require.NotNil(t, f)
+	require.Contains(t, f.Detail, "not the thing to change")
+	require.NotContains(t, f.Fix, "Add a workflow",
+		"the fix must not send the reader to the manifest either")
+}
+
+// One declared workflow reads as one, not as "1 workflows".
+func TestWorkflowsUnverified_DeclaredCountReadsAsProse(t *testing.T) {
+	f := workflowsUnverifiedFinding(report.Run{Declared: 1}, defaultGate())
+	require.NotNil(t, f)
+	require.Contains(t, f.Detail, "declares 1 workflow and")
+}
+
+// Results that exist but reached no verdict are a third state, and keep the
+// wording they had. The run did reach the application and proved nothing about
+// it, which is neither of the two above.
+func TestWorkflowsUnverified_BlockedResultsKeepTheirOwnReason(t *testing.T) {
+	run := report.Run{Declared: 2, Workflows: []report.Workflow{
+		{Name: "sign-in", Verdict: report.VerdictBlocked},
+		{Name: "place-an-order", Verdict: report.VerdictBlocked},
+	}}
+	f := workflowsUnverifiedFinding(run, defaultGate())
+	require.NotNil(t, f)
+	require.Contains(t, f.Detail, "Every workflow was blocked")
+	require.NotContains(t, f.Detail, "declares no workflows")
 }
 
 // One verdict about the application is enough to clear it.

--- a/engine/internal/cli/runner.go
+++ b/engine/internal/cli/runner.go
@@ -18,6 +18,7 @@ import (
 	"github.com/spf13/cobra"
 
 	aferrors "github.com/antifailure/antifailure/engine/internal/errors"
+	"github.com/antifailure/antifailure/engine/internal/runnerpath"
 )
 
 // The runner is a separate program in a separate language, and installing it
@@ -29,12 +30,12 @@ import (
 // speaks to it is a failure nobody can read.
 
 // RunnerHome is where the runner is installed.
+//
+// The target and the search that has to find it afterwards are one fact, so
+// they are kept in one place. This used to be spelled out here and again in
+// the orchestrator, which is how the two searches came to disagree.
 func RunnerHome() (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(home, ".antifailure", "runner"), nil
+	return runnerpath.Home()
 }
 
 // RunnerCheckJSON is the machine readable result of af runner check.
@@ -567,20 +568,13 @@ func checksJSON(results []runnerCheck) []RunnerCheckItemJSON {
 }
 
 // runnerSource finds the runner to copy.
+//
+// The candidate list is shared with the one `af ci` uses, minus this command's
+// own target. See engine/internal/runnerpath for why they are one list.
 func runnerSource(e *Env, from string) (string, error) {
 	candidates := []string{from}
 	if from == "" {
-		candidates = nil
-		// At and above the working directory, for a checkout.
-		candidates = append(candidates, checkoutRunners(e.WorkDir)...)
-		// Beside the binary, for an installed release, which ships the runner
-		// next to it rather than fetching it.
-		if self, err := os.Executable(); err == nil {
-			dir := filepath.Dir(self)
-			candidates = append(candidates,
-				filepath.Join(dir, "runner"),
-				filepath.Join(dir, "..", "share", "antifailure", "runner"))
-		}
+		candidates = runnerpath.ToInstallFrom(e.WorkDir)
 	}
 	for _, c := range candidates {
 		if c == "" {
@@ -592,50 +586,6 @@ func runnerSource(e *Env, from string) (string, error) {
 	}
 	return "", aferrors.Coded(aferrors.AFAGT004,
 		"detail", "no runner source was found; looked in "+strings.Join(candidates, ", "))
-}
-
-// checkoutRunners lists the runner directories at and above dir, stopping at
-// the checkout dir sits in.
-//
-// This ascends because the working directory is not reliably the root of the
-// checkout, and looking exactly one level up quietly assumed it was. Running
-// `af runner install` from examples/go-api searched examples/go-api/runner and
-// examples/runner, then reported that no runner source existed, while the
-// runner it wanted sat at the top of the very checkout it was running inside.
-// Anyone who keeps a project in a subdirectory met the same wall, and the
-// error told them to install a runner they already had.
-//
-// The ascent stops at the directory holding .git rather than walking to the
-// filesystem root. A walk to the root would eventually find an unrelated
-// ~/runner belonging to something else and copy that, which is a worse failure
-// than the one this fixes: it succeeds, and the wrong runner is only visible
-// later as a test that will not run.
-//
-// Outside any checkout there is no root to stop at, so only the two nearest
-// directories are offered. That is exactly the pair this searched before, so
-// the case that already worked still works, and the error message does not
-// list every directory up to / and bury the two that matter.
-func checkoutRunners(dir string) []string {
-	abs, err := filepath.Abs(dir)
-	if err != nil {
-		abs = dir
-	}
-	var found []string
-	for d := abs; ; {
-		found = append(found, filepath.Join(d, "runner"))
-		if _, err := os.Stat(filepath.Join(d, ".git")); err == nil {
-			return found
-		}
-		parent := filepath.Dir(d)
-		if parent == d {
-			break
-		}
-		d = parent
-	}
-	if len(found) > 2 {
-		found = found[:2]
-	}
-	return found
 }
 
 // copyTree copies the runner's source, and nothing it can rebuild.

--- a/engine/internal/cli/runner_source_test.go
+++ b/engine/internal/cli/runner_source_test.go
@@ -101,27 +101,3 @@ func TestRunnerSourceHonoursAnExplicitFrom(t *testing.T) {
 		t.Errorf("got %q, want the explicit %q, not the checkout at %q", got, other, root)
 	}
 }
-
-// Outside a checkout the search is the pair it always was, so the error names
-// the two directories that could plausibly hold a runner rather than every
-// directory between here and the filesystem root.
-func TestCheckoutRunnersStopsAtTwoWithoutACheckout(t *testing.T) {
-	work := filepath.Join(t.TempDir(), "a", "b", "c")
-	if err := os.MkdirAll(work, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	got := checkoutRunners(work)
-	want := []string{
-		filepath.Join(work, "runner"),
-		filepath.Join(filepath.Dir(work), "runner"),
-	}
-	if len(got) != len(want) {
-		t.Fatalf("got %v, want %v", got, want)
-	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Errorf("got %v, want %v", got, want)
-			break
-		}
-	}
-}

--- a/engine/internal/env/find_runner_test.go
+++ b/engine/internal/env/find_runner_test.go
@@ -1,0 +1,148 @@
+package env
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// emptyHome gives a test a home directory of its own.
+//
+// The search legitimately looks in ~/.antifailure/runner for an installed
+// runner, and on the machine of anyone who has run `af runner install` there
+// is one there. Without this, these tests would pass or fail on whether the
+// person running them had ever installed a runner, which is a test that
+// answers a question about the developer rather than about the code.
+func emptyHome(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+}
+
+// A checkout with one runner at its top and a project some directories down
+// inside it, which is the shape every example in this repository has and the
+// shape a customer has whenever their manifest is not at the root.
+func runnerCheckout(t *testing.T, depth int) (root, project string) {
+	t.Helper()
+	emptyHome(t)
+	root = t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	src := filepath.Join(root, "runner", "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte("//\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	project = root
+	for i := 0; i < depth; i++ {
+		project = filepath.Join(project, "d")
+	}
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return root, project
+}
+
+// The runner is found from a manifest that is not at the top of the checkout.
+//
+// This is the failure itself. Root is the directory holding the manifest, and
+// the search looked there and exactly one directory above it, so a manifest at
+// examples/django-api never reached the runner at the top of the very checkout
+// it was running inside. Every example leg of the nightly failed here with
+// AF-AGT-004, naming four paths and not the one the runner was in, and so did
+// any customer keeping their project in a subdirectory.
+//
+// Depth 2 is examples/<name>, which is the corpus. Depth 4 is there because
+// the number of levels was never the rule, and a fix that counted them would
+// pass this at 2 and fail at 4.
+func TestFindRunnerFindsTheCheckoutRunnerFromASubdirectory(t *testing.T) {
+	for _, depth := range []int{0, 1, 2, 4} {
+		root, project := runnerCheckout(t, depth)
+		o := &Orchestrator{opts: Options{Root: project}}
+		got, err := o.findRunner("")
+		if err != nil {
+			t.Fatalf("depth %d: %v", depth, err)
+		}
+		want := filepath.Join(root, "runner", "src", "main.ts")
+		if got != want {
+			t.Errorf("depth %d: got %q, want %q", depth, got, want)
+		}
+	}
+}
+
+// The ascent stops at the checkout rather than at the filesystem root.
+//
+// A runner outside the checkout belongs to something else. Running it would
+// succeed, which is worse than refusing: the wrong runner is only visible
+// later, as a workflow that will not start for a reason nobody can read.
+func TestFindRunnerDoesNotClimbOutOfTheCheckout(t *testing.T) {
+	emptyHome(t)
+	outside := t.TempDir()
+	src := filepath.Join(outside, "runner", "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "main.ts"), []byte("//\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	root := filepath.Join(outside, "checkout")
+	if err := os.MkdirAll(filepath.Join(root, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	project := filepath.Join(root, "examples", "go-api")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	o := &Orchestrator{opts: Options{Root: project}}
+	got, err := o.findRunner("")
+	if err == nil {
+		t.Fatalf("ran %q from outside the checkout, and should have found nothing", got)
+	}
+	if strings.Contains(err.Error(), filepath.Join(outside, "runner")) {
+		t.Errorf("the runner outside the checkout was searched: %v", err)
+	}
+}
+
+// An explicit --runner is still the only thing searched, so a wider search
+// cannot quietly substitute a different runner for the one asked for.
+func TestFindRunnerHonoursAnExplicitOverride(t *testing.T) {
+	root, project := runnerCheckout(t, 2)
+	other := filepath.Join(t.TempDir(), "main.ts")
+	if err := os.WriteFile(other, []byte("//\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	o := &Orchestrator{opts: Options{Root: project}}
+	got, err := o.findRunner(other)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != other {
+		t.Errorf("got %q, want the explicit %q, not the checkout at %q", got, other, root)
+	}
+}
+
+// An override that is not there is refused by name.
+//
+// It used to fall through to the search, so `--runner /a/typo` ran whatever
+// the checkout happened to hold and reported nothing about the path the
+// caller actually named.
+func TestFindRunnerRefusesAnOverrideThatIsNotThere(t *testing.T) {
+	_, project := runnerCheckout(t, 2)
+	missing := filepath.Join(t.TempDir(), "nowhere", "main.ts")
+
+	o := &Orchestrator{opts: Options{Root: project}}
+	got, err := o.findRunner(missing)
+	if err == nil {
+		t.Fatalf("got %q, and an override that does not exist must be refused", got)
+	}
+	if !strings.Contains(err.Error(), missing) {
+		t.Errorf("the refusal does not name the path that was asked for: %v", err)
+	}
+}

--- a/engine/internal/env/test.go
+++ b/engine/internal/env/test.go
@@ -13,6 +13,7 @@ import (
 	aferrors "github.com/antifailure/antifailure/engine/internal/errors"
 	"github.com/antifailure/antifailure/engine/internal/load"
 	"github.com/antifailure/antifailure/engine/internal/personas"
+	"github.com/antifailure/antifailure/engine/internal/runnerpath"
 	"github.com/antifailure/antifailure/engine/internal/runtime/local"
 	"github.com/antifailure/antifailure/engine/pkg/schema"
 )
@@ -498,31 +499,32 @@ func (o *Orchestrator) driveRunner(ctx context.Context, job runnerJob) (*TestRep
 
 // findRunner locates the runner's entry point.
 //
-// Looked for beside the repository first, so a checkout works with no
-// installation, then on PATH, so an installed engine finds an installed
-// runner. A clear refusal beats a mysterious exec failure.
+// Looked for inside the checkout first, so a checkout works with no
+// installation, then where an install put one, then beside the binary, so an
+// installed engine finds an installed runner. A clear refusal beats a
+// mysterious exec failure.
+//
+// The candidate list is shared with `af runner install`, which is the whole
+// point of it living in runnerpath. This function used to keep its own copy:
+// o.opts.Root and one level above it, and nothing else. o.opts.Root is the
+// directory holding the manifest, so a project one directory further down than
+// that never reached the runner at the top of its own checkout. Every nightly
+// leg that ran an example under examples/ failed here, naming four paths and
+// not the one the runner was in, and so did any customer whose manifest is not
+// at the top of their repository.
 func (o *Orchestrator) findRunner(override string) (string, error) {
-	candidates := []string{override}
-	if override == "" {
-		candidates = []string{
-			filepath.Join(o.opts.Root, "runner", "src", "main.ts"),
-			filepath.Join(o.opts.Root, "..", "runner", "src", "main.ts"),
+	if override != "" {
+		if _, err := os.Stat(override); err == nil {
+			return override, nil
 		}
-		if home, err := os.UserHomeDir(); err == nil {
-			candidates = append(candidates,
-				filepath.Join(home, ".antifailure", "runner", "src", "main.ts"))
-		}
-		if self, err := os.Executable(); err == nil {
-			// Beside the binary, for an installed release that ships the
-			// runner next to it rather than fetching it separately.
-			candidates = append(candidates,
-				filepath.Join(filepath.Dir(self), "runner", "src", "main.ts"))
-		}
+		return "", aferrors.Coded(aferrors.AFAGT004, "detail", "looked in "+override)
+	}
+	dirs := runnerpath.ToRun(o.opts.Root)
+	candidates := make([]string, 0, len(dirs))
+	for _, d := range dirs {
+		candidates = append(candidates, filepath.Join(d, "src", "main.ts"))
 	}
 	for _, c := range candidates {
-		if c == "" {
-			continue
-		}
 		if _, err := os.Stat(c); err == nil {
 			return c, nil
 		}

--- a/engine/internal/report/report.go
+++ b/engine/internal/report/report.go
@@ -23,7 +23,19 @@ type Run struct {
 	Commit      string
 	Golden      string
 	Workflows   []Workflow
-	Invariants  []Invariant
+	// Declared is how many workflows the manifest asked for, which is not the
+	// same number as len(Workflows) and was being read as though it were.
+	//
+	// Workflows holds results. A run whose environment died before the
+	// workflows were reached has none, and so does a manifest that declares
+	// none, and the gate told both of them "the manifest declares no
+	// workflows". The verdict was right in both cases and the reason was false
+	// in one, which sends somebody to edit a manifest that was never the
+	// problem. It sent somebody there: three example legs of this repository's
+	// own nightly were read as declaring no workflows when each declares one,
+	// and the runner they could not find was the actual cause.
+	Declared   int
+	Invariants []Invariant
 	// Findings are what the run noticed about the change that is not a
 	// workflow or an invariant: migration locks, rewrites, lint, plans, query
 	// counts, an unknown destination, unmasked data, a resource left behind.

--- a/engine/internal/runnerpath/runnerpath.go
+++ b/engine/internal/runnerpath/runnerpath.go
@@ -1,0 +1,115 @@
+// Package runnerpath answers one question in one place: where the agent runner
+// might be.
+//
+// It exists because that question was answered twice, and the two answers
+// drifted. `af runner install` learned to walk up to the top of the checkout,
+// because anyone keeping a project in a subdirectory was told to install a
+// runner the checkout already had. `af ci` kept its own copy of the search,
+// which looked in the manifest's directory and exactly one level above it, and
+// nobody moved the fix across. So `af runner install` worked from
+// examples/django-api and `af ci` from the same directory reported AF-AGT-004
+// naming four paths, none of which was the runner sitting at the top of the
+// checkout it was running inside.
+//
+// Two copies of a search is the defect. One list, with the one difference
+// between the callers named out loud, is the fix.
+package runnerpath
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Home is where `af runner install` puts its copy, and where a run looks for
+// an installed one.
+func Home() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".antifailure", "runner"), nil
+}
+
+// ToRun lists the runner directories a run may use, nearest first.
+//
+// dir is the directory holding the manifest, which is not reliably the top of
+// the checkout: a customer whose manifest sits three directories down is the
+// ordinary case, not the exotic one.
+func ToRun(dir string) []string {
+	candidates := inCheckout(dir)
+	if home, err := Home(); err == nil {
+		candidates = append(candidates, home)
+	}
+	return append(candidates, besideTheBinary()...)
+}
+
+// ToInstallFrom lists the runner directories `af runner install` may copy
+// from, nearest first.
+//
+// The same list as ToRun with Home left out, and that omission is the only
+// difference between the two. Home is this command's target. Offering it as a
+// source would let an install copy a directory onto itself, and a stale runner
+// left there by an older engine would become the source of the fresh one,
+// which is how a release ships against a runner it was never tested with.
+func ToInstallFrom(dir string) []string {
+	return append(inCheckout(dir), besideTheBinary()...)
+}
+
+// inCheckout lists the runner directories at and above dir, stopping at the
+// checkout dir sits in.
+//
+// This ascends because the working directory is not reliably the root of the
+// checkout, and looking exactly one level up quietly assumed it was.
+//
+// The ascent stops at the directory holding .git rather than walking to the
+// filesystem root. A walk to the root would eventually find an unrelated
+// ~/runner belonging to something else and use that, which is a worse failure
+// than the one this fixes: it succeeds, and the wrong runner is only visible
+// later as a test that will not run.
+//
+// Outside any checkout there is no root to stop at, so only the two nearest
+// directories are offered. That is exactly the pair this searched before, so
+// the case that already worked still works, and the error does not list every
+// directory up to / and bury the two that matter.
+func inCheckout(dir string) []string {
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		abs = dir
+	}
+	var found []string
+	for d := abs; ; {
+		found = append(found, filepath.Join(d, "runner"))
+		if _, err := os.Stat(filepath.Join(d, ".git")); err == nil {
+			return found
+		}
+		parent := filepath.Dir(d)
+		if parent == d {
+			break
+		}
+		d = parent
+	}
+	if len(found) > 2 {
+		found = found[:2]
+	}
+	return found
+}
+
+// besideTheBinary is where an installed release keeps the runner it shipped
+// with, rather than fetching one.
+//
+// Both layouts, because both exist: next to the binary for an archive somebody
+// unpacked, and under ../share/antifailure for a package that follows the
+// filesystem hierarchy. The run path used to know only the first, so on a
+// packaged install `af runner install` could find the shipped runner and
+// `af ci` could not.
+func besideTheBinary() []string {
+	self, err := os.Executable()
+	if err != nil {
+		return nil
+	}
+	dir := filepath.Dir(self)
+	return []string{
+		filepath.Join(dir, "runner"),
+		filepath.Join(dir, "..", "share", "antifailure", "runner"),
+	}
+}

--- a/engine/internal/runnerpath/runnerpath_test.go
+++ b/engine/internal/runnerpath/runnerpath_test.go
@@ -1,0 +1,88 @@
+package runnerpath
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+func emptyHome(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+}
+
+// The two callers search the same places, and differ in exactly one.
+//
+// This is the guard against the defect that made this package. The search was
+// written twice, `af runner install` learned to walk up to the top of the
+// checkout, `af ci` did not, and nothing anywhere could tell that the two had
+// stopped agreeing. Now there is one list, and this fails if a candidate is
+// ever added to one caller and not the other, or if the one deliberate
+// difference stops being the only one.
+func TestTheRunAndInstallSearchesDifferOnlyByTheInstallTarget(t *testing.T) {
+	emptyHome(t)
+	dir := t.TempDir()
+
+	home, err := Home()
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, install := ToRun(dir), ToInstallFrom(dir)
+
+	if !slices.Contains(run, home) {
+		t.Errorf("a run cannot see an installed runner: %v does not contain %q", run, home)
+	}
+	if slices.Contains(install, home) {
+		t.Errorf("install offers its own target as a source, so it can copy a stale "+
+			"runner onto itself: %v contains %q", install, home)
+	}
+
+	withoutHome := slices.DeleteFunc(slices.Clone(run), func(c string) bool { return c == home })
+	if !slices.Equal(withoutHome, install) {
+		t.Errorf("the two searches have drifted apart.\n  run, without the install target: %v\n  install:                         %v",
+			withoutHome, install)
+	}
+}
+
+// The ascent reaches the top of the checkout and stops there.
+//
+// Outside a checkout there is no top to stop at, so only the two nearest
+// directories are offered rather than every directory up to the filesystem
+// root, which would bury the two that matter and could find an unrelated
+// runner belonging to something else.
+func TestTheCheckoutSearchAscendsToTheTopAndNoFurther(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	deep := filepath.Join(root, "examples", "django-api")
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got := inCheckout(deep)
+	want := []string{
+		filepath.Join(deep, "runner"),
+		filepath.Join(root, "examples", "runner"),
+		filepath.Join(root, "runner"),
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	loose := filepath.Join(t.TempDir(), "a", "b", "c")
+	if err := os.MkdirAll(loose, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	got = inCheckout(loose)
+	want = []string{
+		filepath.Join(loose, "runner"),
+		filepath.Join(filepath.Dir(loose), "runner"),
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("outside a checkout: got %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
The nightly is red on three legs. All three fail for one cause, and it is not the one the finding was filed under.

## The product bug

The runner search is written twice. `af runner install` learned to walk up to the top of the checkout, because anyone keeping a project in a subdirectory was being told to install a runner the checkout already had. The orchestrator kept its own copy, which looks in the manifest's own directory and exactly one directory above it. Nobody moved the fix across.

`af ci` from `examples/django-api` searches four paths and none of them is the runner at the top of the checkout it is running inside:

```
examples/django-api/runner/src/main.ts
examples/runner/src/main.ts
~/.antifailure/runner/src/main.ts
bin/runner/src/main.ts
```

That is AF-AGT-004 on all three example legs of run 33737585154, and it is what a customer gets whenever their manifest is not at the top of their repository.

**Why the search and not the installer or the error.** The installer would have worked, because `~/.antifailure/runner` is one of those four paths, so running `af runner install` in the nightly would have turned the legs green while leaving the engine unable to find a runner in the checkout it is standing in. It would also leave a stale copy under the home directory silently shadowing the checkout's. The error message is already accurate about where it looked; making it name the checkout root as a suggestion tells somebody to do by hand a thing the engine can do in three lines, and an error is the right fix only when the tool genuinely cannot know.

There is one list now, in `engine/internal/runnerpath`, with the one real difference between the callers named out loud: install must not offer its own target as a source, or a stale runner becomes the source of a fresh one. The run path also gained `../share/antifailure/runner`, which install already had.

## The judgement call, which dissolved

The finding said the three example manifests declare no workflows, and asked whether to write three sets of workflows or to delete the legs from the matrix.

Each of the three declares one, and `examples/go-api` declares invariants besides. No manifest needed changing and no leg needed removing. The report said otherwise, and the report was wrong, which is the third item below.

## The reporting bug

`workflowsUnverifiedFinding` picked its wording from `len(run.Workflows) == 0`. `Workflows` holds results. A manifest that declares none and a run that died before it reached the workflows it does declare both arrive with no results, and both were told "The manifest declares no workflows, so there was nothing to carry through."

The verdict was right in both cases and the reason was false in one. A false reason is worse than a vague one: it sends a reader to edit the one file that is not the problem while the real cause, four lines above in the same output, goes unread. It sent a reader there, which is how this arrived as a question about writing workflows.

The manifest's own count is now carried on the run and read before anything can fail, so the two states are told apart by evidence rather than by the absence of it.

## Proof

`TestFindRunnerFindsTheCheckoutRunnerFromASubdirectory` drives the orchestrator's own search from a manifest zero, one, two and four directories down a checkout. Pointed at the search as it stood, it fails at depth two with the same four paths the nightly printed. Depth four is there because the number of levels was never the rule, and a fix that counted them would pass at two.

`TestTheRunAndInstallSearchesDifferOnlyByTheInstallTarget` is the guard against the drift itself. It fails if a candidate is ever added to one caller and not the other.

The three new gate tests fail against the old wording, checked by reverting it.

The structural test that could be written here and should not be is one asking whether each nightly leg has a runner above it on disk. Every leg did. It would have passed for the whole period the nightly was red, which is the shape of the golden test that 207 replaced.