### PR TITLE
infra: the App production actually serves, configured as not existing

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -463,12 +463,25 @@ jobs:
       # no role is added for this step. -lock=false for the same reason the
       # staging plan does not lock: a lease is a write, and stacks/tfstate
       # deliberately grants this identity no write on the state.
-      # -refresh=false, and with that flag the only
-      # Azure call this plan makes is azurerm_client_config, which reads the
-      # caller's own identity and needs no role at all: every
-      # azurerm_key_vault_secret data source in the module is counted to zero
-      # under production.tfvars, so no secret is read and no role on
-      # af-cp-prod-centralus is required.
+      # -refresh=false, and the only Azure call this plan makes is
+      # azurerm_client_config, which reads the caller's own identity and needs
+      # no role at all. No secret is read and no role on af-cp-prod-centralus
+      # is required.
+      #
+      # THE REASON FOR THAT CHANGED, AND THE OLD REASON WAS LOAD BEARING BY
+      # ACCIDENT. This used to hold because every azurerm_key_vault_secret data
+      # source was counted to zero under production.tfvars, which was true only
+      # because github_app_id had been emptied by a revert. The moment it was
+      # restored this step failed, on a vault read this identity is not granted
+      # and should not be: it is reachable from a pull_request federated
+      # credential, and the App private key signs as the installation on every
+      # customer repository. It holds now because the module CONSTRUCTS those
+      # secret ids instead of reading them. See modules/control-plane/keyvault.tf.
+      #
+      # -refresh=false does NOT suppress a data source. Terraform evaluates it
+      # on every plan, which is why the staging plan above still reads staging's
+      # vault, where this identity does hold Secrets Officer. Do not reintroduce
+      # a data source here believing the flag covers it.
       #
       # LAST IN THE JOB ON PURPOSE. It re-initialises the backend against the
       # production state, and every step above reads files the staging plan

--- a/infra/terraform/modules/control-plane/app.tf
+++ b/infra/terraform/modules/control-plane/app.tf
@@ -293,10 +293,7 @@ resource "azurerm_container_app" "this" {
   # will one day set it to the empty string.
   dynamic "secret" {
     for_each = merge(
-      var.github_app_id == "" ? {} : {
-        "github-app-private-key"    = data.azurerm_key_vault_secret.github_app_private_key[0].versionless_id
-        "github-app-webhook-secret" = data.azurerm_key_vault_secret.github_app_webhook_secret[0].versionless_id
-      },
+      local.github_app_secret_ids,
       var.stripe_price_team == "" ? {} : {
         "stripe-secret-key"     = data.azurerm_key_vault_secret.stripe_secret_key[0].versionless_id
         "stripe-webhook-secret" = data.azurerm_key_vault_secret.stripe_webhook_secret[0].versionless_id

--- a/infra/terraform/modules/control-plane/keyvault.tf
+++ b/infra/terraform/modules/control-plane/keyvault.tf
@@ -286,25 +286,48 @@ resource "azurerm_key_vault_secret" "owned" {
   depends_on = [azurerm_role_assignment.deployer_writes_secrets]
 }
 
-# The GitHub App's two secrets, read rather than written.
+# The GitHub App's two secrets, ADDRESSED RATHER THAN READ.
 #
 # See the variable comments: GitHub mints the private key and shows it once, so
 # Terraform cannot create it and must not manage it. A person puts both in the
-# vault; this reads them so the container app can reference them by id.
+# vault and the container app references them by id.
 #
-# count on github_app_id rather than on the secrets existing, so that a stack
-# with no App plans clean instead of failing on a data source for a secret that
-# is deliberately absent.
-data "azurerm_key_vault_secret" "github_app_private_key" {
-  count        = var.github_app_id == "" ? 0 : 1
-  name         = var.github_app_private_key_secret_name
-  key_vault_id = azurerm_key_vault.this.id
-}
-
-data "azurerm_key_vault_secret" "github_app_webhook_secret" {
-  count        = var.github_app_id == "" ? 0 : 1
-  name         = var.github_app_webhook_secret_name
-  key_vault_id = azurerm_key_vault.this.id
+# THESE WERE `data "azurerm_key_vault_secret"` AND THAT MADE EVERY PLAN A
+# PRIVILEGED READ. The container app never wants the secret's VALUE, only its
+# versionless id, which is a URI built from the vault's own uri and the secret's
+# name. Both are already here, so a data source was spending a Key Vault data
+# plane read to obtain a string that is a function of two things in this
+# configuration. Reading a secret to learn its address is the wrong shape.
+#
+# What that cost, measured rather than argued. `terraform plan -refresh=false`
+# does NOT serve a data source from state; it evaluates it, so the read happened
+# on every plan. On staging that passed, because the plan identity holds Key
+# Vault Secrets Officer there. On production it holds Contributor on the group
+# and nothing on the vault, so the moment `github_app_id` was set the production
+# plan check failed and could only have been fixed by granting a pull request
+# identity read access to production's App private key. That key signs as the
+# installation on every customer repository this product is installed on, and a
+# pull request can edit the workflow that uses the identity in the same commit.
+# Constructing the id needs no role at all.
+#
+# WHAT THIS GIVES UP, and it is a real trade rather than a free win. The data
+# source also asserted the secret EXISTS, so a missing secret failed at plan.
+# Now it fails at apply, with Azure naming the secret it could not find. That
+# check was only ever load bearing on staging: on production the identity that
+# runs the plan cannot read the vault, so the plan could not assert it there
+# either. An apply that stops with "secret not found" beats a plan that only
+# verifies the environment where it does not matter.
+#
+# Empty on no App, so a stack without one renders no secret block at all, which
+# is what the count on the old data sources was for.
+#
+# Addressed, not read: the trailing slash on vault_uri is trimmed rather than
+# assumed, so this cannot depend on how the provider spells it.
+locals {
+  github_app_secret_ids = var.github_app_id == "" ? {} : {
+    "github-app-private-key"    = "${trimsuffix(azurerm_key_vault.this.vault_uri, "/")}/secrets/${var.github_app_private_key_secret_name}"
+    "github-app-webhook-secret" = "${trimsuffix(azurerm_key_vault.this.vault_uri, "/")}/secrets/${var.github_app_webhook_secret_name}"
+  }
 }
 
 # Stripe's two credentials and Resend's one, read rather than written, and the

--- a/infra/terraform/stacks/control-plane/production.tfvars
+++ b/infra/terraform/stacks/control-plane/production.tfvars
@@ -210,11 +210,18 @@ signup_url = "https://antifailure.dev/contact"
 # them means a staging compromise writes into production's tenants. Installation
 # ids differ per App and github_installations keys on them.
 #
-# The module reads the App's two secrets from Key Vault with a data source,
-# because GitHub mints the private key once and Terraform can neither create nor
-# recreate it. So setting this id before those secrets are in the production
-# vault fails at PLAN, which is the correct order and not a bug. The checklist
-# in the production guide has the steps in the order that works.
+# GitHub mints the private key once and shows it once, so Terraform can neither
+# create the App's two secrets nor recreate them. A person puts both in the
+# vault and the module addresses them by id.
+#
+# SETTING THIS BEFORE THOSE SECRETS EXIST NOW FAILS AT APPLY RATHER THAN AT
+# PLAN, and that changed deliberately. The module used to read both with a
+# `data "azurerm_key_vault_secret"`, which asserted they existed and made the
+# order enforceable at plan time. It also made every plan a privileged Key Vault
+# read, which the pull request plan identity cannot perform on this vault, so
+# the plan time check only ever worked on staging. See keyvault.tf for the whole
+# argument. The apply names the secret it could not find. The checklist in the
+# production guide still has the steps in the order that works.
 #
 # App 4775259, slug `antifailure`, installed on the antifailure organization as
 # installation 157834739. The OAuth App that signs people in is a separate

--- a/infra/terraform/stacks/control-plane/production.tfvars
+++ b/infra/terraform/stacks/control-plane/production.tfvars
@@ -203,7 +203,7 @@ self_serve_signup = true
 # somebody turned away actually needs.
 signup_url = "https://antifailure.dev/contact"
 
-# EMPTY UNTIL THE PRODUCTION GITHUB APP EXISTS, AND SETTING IT EARLY FAILS.
+# SET ONLY AFTER THE PRODUCTION GITHUB APP EXISTS. SETTING IT EARLY FAILS.
 #
 # Production needs its OWN App, not staging's: the webhook secret and the
 # private key are the credentials that let a delivery write rows, so sharing
@@ -215,7 +215,23 @@ signup_url = "https://antifailure.dev/contact"
 # recreate it. So setting this id before those secrets are in the production
 # vault fails at PLAN, which is the correct order and not a bug. The checklist
 # in the production guide has the steps in the order that works.
-github_app_id = ""
+#
+# App 4775259, slug `antifailure`, installed on the antifailure organization as
+# installation 157834739. The OAuth App that signs people in is a separate
+# registration and its client id and secret are the seeded vault entries, not
+# this value: an App id is not a credential and unlocks nothing, which is why it
+# sits here rather than arriving as a TF_VAR_.
+#
+# The App this names is CONFIGURED AND SERVING. Read off the running container
+# rather than remembered: afcpprod-app carries AF_GITHUB_APP_ID=4775259 and both
+# vault secrets exist. Emptying this line does not remove the App; it removes
+# all three environment variables from the container app on the next apply, and
+# with them the installation webhook, which is the only path by which an
+# organization comes into being. That failure presents as a customer signing in
+# to an empty screen, so it reads as a product bug rather than a configuration
+# one. See ci.tf for the commit that emptied it and for what a plan gate can and
+# cannot catch.
+github_app_id = "4775259"
 
 # One identity applies this stack, and it is the same person as staging, so the
 # grant is pinned rather than following whoever is calling. See staging.tfvars

--- a/infra/terraform/stacks/control-plane/production.tfvars
+++ b/infra/terraform/stacks/control-plane/production.tfvars
@@ -215,13 +215,33 @@ signup_url = "https://antifailure.dev/contact"
 # vault and the module addresses them by id.
 #
 # SETTING THIS BEFORE THOSE SECRETS EXIST NOW FAILS AT APPLY RATHER THAN AT
-# PLAN, and that changed deliberately. The module used to read both with a
-# `data "azurerm_key_vault_secret"`, which asserted they existed and made the
-# order enforceable at plan time. It also made every plan a privileged Key Vault
-# read, which the pull request plan identity cannot perform on this vault, so
-# the plan time check only ever worked on staging. See keyvault.tf for the whole
-# argument. The apply names the secret it could not find. The checklist in the
-# production guide still has the steps in the order that works.
+# PLAN. That is a deliberate trade, and on THIS plane it costs nothing, because
+# the check it replaces has never once run here.
+#
+# The module used to read both secrets with a `data "azurerm_key_vault_secret"`,
+# which asserted they existed. Asserting existence requires READING, and the
+# identity that runs the production plan holds Contributor on the resource group
+# and nothing at all on this vault. So the read failed on PERMISSION before it
+# could ever report on EXISTENCE. What was given up on production is an
+# intention this deployment's own permission model has never permitted, not a
+# check that worked.
+#
+# DO NOT RESTORE THE DATA SOURCE TO GET THE CHECK BACK. It does not come back.
+# The wall is the grant, and the grant has no per secret scope: it would open
+# every secret in this vault, this one included, to an identity that a pull
+# request can reach and whose workflow a pull request can edit in the same
+# commit. keyvault.tf carries the whole argument.
+#
+# STAGING IS THE HONEST COST, and it is worth stating because it is easy to
+# assume otherwise. staging.tfvars sets github_app_id too, both environments
+# share this module, and staging's plan identity CAN read staging's vault. So
+# staging did have a working plan time existence check and this removes it. A
+# missing secret there now surfaces at apply with Azure naming the secret, which
+# is a later moment than plan and not a dangerous one, on the environment where
+# somebody is experimenting anyway.
+#
+# The checklist in the production guide still has the steps in the order that
+# works.
 #
 # App 4775259, slug `antifailure`, installed on the antifailure organization as
 # installation 157834739. The OAuth App that signs people in is a separate


### PR DESCRIPTION
## Scope changed: this is now the App id alone

This pull request was three restorations from `ff893073`. The other two, the
certificate probe and the standby zone, moved to **#211**, which is green and
also carries the full file by file accounting of the commit. They need no Key
Vault read; this one does, and that is the whole story below.

Two green pull requests beat one that had to loosen a gate.

## The finding

`github_app_id = ""` in `production.tfvars`, and production is serving App
**4775259** right now. Read off the deployment, not remembered:

```
az containerapp show -n afcpprod-app -g af-cp-prod-centralus
  AF_GITHUB_APP_ID = 4775259
az keyvault secret list --vault-name afcpprod-kv-centralus
  github-app-private-key, github-app-webhook-secret
```

`app.tf` gates `AF_GITHUB_APP_ID`, `AF_GITHUB_APP_PRIVATE_KEY` and
`AF_GITHUB_APP_WEBHOOK_SECRET` on that variable being non empty, in three
`dynamic "env"` blocks. The next apply removes all three from the running
container. The installation webhook is how an organization comes into being, so
that takes out the path by which a customer gets a tenant, and the symptom is a
person signing in to an empty screen. It has happened once already: the
`installation.created` delivery arrived six minutes before the App was
configured, was answered 503, and `github_installations` stayed empty.

### Proof, and why the diff is the wrong instrument

Terraform renders a container's `env` list positionally, so removing three
variables reads as a cascade of renames. Worse, **both plans print the identical
summary line**: `2 to add, 6 to change, 1 to destroy`. A reviewer reading the
summary sees no difference between a production that serves its GitHub App and
one that has it stripped.

So the check is `terraform show -json` on the plan, asking the planned container
for its env names. It can say no, and did:

| `github_app_id` | `AF_GITHUB_APP_*` in the planned container |
| --- | --- |
| `""`, main | none, 13 variables |
| `"4775259"`, here | all three, 16 variables |

## Why CI is red, confirmed rather than assumed

The `production can still be planned` step fails. **This is the gate working.
Do not route around it.**

Confirmed by controlled comparison, which is better evidence than the error
text I could not extract from the step summary:

| Branch | `github_app_id` | `plan` job |
| --- | --- | --- |
| PR 208 | `""` | **pass**, 55s |
| this one | `"4775259"` | **fail**, 57s |

Same workflow, same federated identity, same production state, same day, one
variable different.

The staging plan **in that same job** shows the mechanism:

```
data.azurerm_key_vault_secret.github_app_private_key[0]: Read complete after 1s
  [id=https://afcp-kv-centralus.vault.azure.net/secrets/github-app-private-key/...]
```

`afcp-kv-centralus` is **staging**, where `af-infra-ci` holds Key Vault Secrets
Officer. On production's vault that principal holds exactly one thing,
`Contributor` at resource group scope, and the vault is
`enableRbacAuthorization: true` with **zero** access policies. Contributor grants
nothing on the Key Vault data plane.

**Correcting the brief I was given, as asked.** `-refresh=false` does *not*
serve these from state. The data sources are evaluated on every plan. Staging's
`github_app_id` has always been set, so this read has always happened on every
plan; production's being empty is the only reason nobody noticed. `infra.yml`
carries a comment asserting the opposite, and that assertion was true only
because of the very defect this pull request fixes:

> every `azurerm_key_vault_secret` data source in the module is counted to zero
> under `production.tfvars`, so no secret is read and no role on
> `af-cp-prod-centralus` is required.

That comment needs updating by whichever fix lands.

## The three shapes, with the argument

**1. Grant the plan identity read on production's vault.** Smallest change:
Key Vault Secrets User for `f99916dc-1e11-4305-8e03-1e116a1e93e1` scoped to
`afcpprod-kv-centralus`.

```sh
az role assignment create \
  --assignee-object-id f99916dc-1e11-4305-8e03-1e116a1e93e1 \
  --assignee-principal-type ServicePrincipal \
  --role "Key Vault Secrets User" \
  --scope "$(az keyvault show -n afcpprod-kv-centralus \
              -g af-cp-prod-centralus --query id -o tsv)"
```

**What else that identity could then read: every secret in the production
vault.** Key Vault Secrets User is vault wide; there is no per secret scope
here. That is `github-app-private-key`, `github-app-webhook-secret`,
`database-url`, `migration-database-url`, `admin-database-url`,
`provider-key-secret`, `github-client-secret`, and the Stripe and Resend
credentials as they land. The identity is the one a **pull request** plan job
federates into, and a pull request can edit the workflow that uses it in the same
commit. This is the same class of decision as the two hand made grants recorded
tonight, and it is a real widening for the sake of a check.

**2. Make the data source unnecessary. I think this is the right one, and it is
smaller than it sounds.** The module never uses the secret's *value*. It uses
only `.versionless_id`, which is a URI:

```
https://afcpprod-kv-centralus.vault.azure.net/secrets/github-app-private-key
```

That is `azurerm_key_vault.this.vault_uri` plus the name, both already known
from the managed vault resource with no data plane call at all. And **the module
already does exactly this for the secrets it owns**: `local.secret_by_name`
(`keyvault.tf:430`) merges the owned and seeded secrets and `app.tf:286` reads
`.versionless_id` off them, no data source involved. So 196 did solve this once,
for a different set of secrets.

**The cost, stated plainly, because it is not free.** The data source is also a
plan time existence check. `production.tfvars` documents that as deliberate:
setting the App id before the secrets are in the vault "fails at PLAN, which is
the correct order and not a bug". A constructed URI would move that failure to
apply, or to a container that starts against a secret that is not there. If we
take this shape we should say so in that comment rather than let it silently
become wrong. The same reshape applies to the Stripe and Resend secrets, which
use the identical pattern.

**3. Narrow what the check asserts.** I like this least and am not proposing it.
The check exists to prove the stack is applyable, and one that excludes the
resources it cannot see is the nearby question again, which is the failure mode
this entire night has been about.

## RESOLVED: shape 2, and the gate is green

Decision taken: **construct the id, do not grant the read.** The commit
`address the App's secrets instead of reading them` does it.

The container app never wanted either secret's value, only `.versionless_id`,
which is the vault uri plus the name. Both were already in the configuration, so
the data sources were spending a privileged read to obtain a string Terraform
already knew.

**`plan` now passes on this branch: 1m5s, production check included.** That is
the verification that counts, because it ran as the CI identity rather than as
mine, and mine would have passed either way.

Verified three ways before pushing, because a subtly wrong id would deploy a
container app pointing at nothing:

| Check | Result |
| --- | --- |
| `TF_LOG=DEBUG` over a production plan | **zero** requests to `vault.azure.net`; only `azurerm_client_config`, which needs no role |
| the plan itself | **no change proposed** to either `key_vault_secret_id`, so the constructed value equals what the last apply wrote |
| the running container app | carries `https://afcpprod-kv-centralus.vault.azure.net/secrets/github-app-private-key`, exactly `vault_uri` trimmed, `/secrets/`, and the name |

The third is read from Azure rather than from Terraform, and it also settles the
concern about whether a versionless URI is acceptable: production has been
serving on versionless URIs this whole time, and so are `database-url` and the
other owned secrets through `local.secret_by_name`.

The trailing slash is trimmed rather than assumed, so this does not depend on
how the provider spells `vault_uri`.

### What it gives up, recorded rather than buried

The data source also asserted the secret existed, so a missing secret failed at
plan and now fails at apply with Azure naming the secret. That check was only
ever load bearing on staging, since on production the plan identity cannot read
the vault at all. `production.tfvars` said the opposite and now says this, and
the `infra.yml` comment that claimed no vault read is required now explains why
that is true for a reason which does not depend on a revert.

### One thing left for another lane

Stripe's two credentials and Resend's one still use data sources of the same
shape. Both are empty on both environments today so nothing is broken, but the
identical plan failure is waiting for whoever sets `stripe_price_team` or
`mail_from` on production. Same fix, deliberately not folded in here.

## What I did not do

I did not weaken the check, did not grant anything, did not merge, did not
apply, and did not touch `local.key_vault_name`. No role assignment was created
or requested anywhere in this pull request.

## Base

`main` at 5484857a, which is 208 merged. The `Antifailure` check
is also red here and is red identically on 208, 207 and 205 including the two
already merged; it is pre existing and untouched by this.
