### PR TITLE
infra: the certificate alert that would be switched off, and the rest of ff893073

### DIFF
--- a/docs/src/content/docs/self-hosting/azure.md
+++ b/docs/src/content/docs/self-hosting/azure.md
@@ -23,8 +23,8 @@ can run is worse than a short one.
 | CI identity, federated, no secret | **applied**, `af-infra-ci` |
 | Control plane on Kubernetes instead | **works**, the Helm chart, installed on a real cluster in CI |
 | Goldens storage | **off by default**, see below |
-| Alerting, an action group and eleven rules | **written**, `infra/terraform/modules/alerting`, off unless `alerting_enabled` |
-| Production, `app.antifailure.dev` | **written**, `production.tfvars`, not applied. [Standing up production](/docs/self-hosting/production) |
+| Alerting, an action group and eleven rules | **applied** in production, `infra/terraform/modules/alerting`, off unless `alerting_enabled`. Staging runs without it on purpose |
+| Production, `app.antifailure.dev` | **applied**, `af-cp-prod-centralus`, serving on a managed certificate. [Standing up production](/docs/self-hosting/production) |
 | Environment pool on AKS | **does not exist** |
 
 The goldens storage account is `goldens_enabled = false` on purpose. Nothing in

--- a/infra/terraform/modules/alerting/availability.tf
+++ b/infra/terraform/modules/alerting/availability.tf
@@ -139,6 +139,21 @@ resource "azurerm_application_insights_standard_web_test" "certificate" {
   timeout       = 30
   retry_enabled = false
 
+  # NOT A DEFAULT, AND LEAVING IT OUT IS WHY THIS TEST RAN ZERO TIMES.
+  #
+  # azurerm defaults `enabled` on a standard web test to FALSE. The readyz test
+  # above says `enabled = true` and this one said nothing, so the apply created
+  # it, reported success, and produced a test that never ran. The
+  # certificate-expiring rule was created enabled, wired to the action group,
+  # and reported healthy the whole time, because a rule over a test with no
+  # results has nothing to be unhealthy about. Checked in the portal rather than
+  # inferred: `Enabled: False` on afcpprod-certificate against `Enabled: True`
+  # on afcpprod-readyz, from the same apply.
+  #
+  # This is the alert that guards the one failure that is otherwise silent, a
+  # managed certificate that stops renewing itself.
+  enabled = true
+
   description = "Fails when the certificate on ${var.probe_url} has fewer than ${var.certificate_warning_days} days left."
 
   request {

--- a/infra/terraform/modules/control-plane/database.tf
+++ b/infra/terraform/modules/control-plane/database.tf
@@ -175,7 +175,20 @@ resource "azurerm_postgresql_flexible_server" "this" {
     }
     # The password is generated and stored in Key Vault. Changing it here would
     # silently break the running application, which reads the old one.
-    ignore_changes = [administrator_password, zone]
+    #
+    # The two zones are ignored for the same reason as each other: Azure picks
+    # them and this configuration deliberately does not. `zone` was already here
+    # for the primary. standby_availability_zone is the same value for the HA
+    # replica, and without it every plan after the first apply reads
+    #
+    #   high_availability[0].standby_availability_zone: "2" -> null
+    #
+    # forever, because Azure assigned 2 and nothing here ever will. It is one
+    # in-place change on a plan that should be empty, and a plan that is never
+    # empty is one people stop reading, which is how a real change gets waved
+    # through. Pinning a zone instead would be worse: it would tie the standby
+    # to a zone that may not be the one Azure can actually place it in.
+    ignore_changes = [administrator_password, zone, high_availability[0].standby_availability_zone]
   }
 
   depends_on = [azurerm_private_dns_zone_virtual_network_link.postgres]


### PR DESCRIPTION
## The whole of ff893073, accounted for

`ff893073` has a subject and a body entirely about a Postgres test port. Its
diff changed that test file and **twelve others**, reverting them. Outside the
test file: **70 lines added, 317 removed, 12 files.** Three defects have already
shipped from it and been fixed one at a time by three separate lanes, each of
whom could see only their own piece.

This restores the two live regressions nobody had claimed, and closes the table
so the next person can see there is nothing left to find.

The App id restoration is deliberately **not** here. It is PR #210, on its own,
because it is the only piece that cannot pass CI without a decision about
permissions. Everything in this pull request needs no Key Vault read and goes
green.

## The table

Every file `ff893073` touched. Completeness is mechanical rather than anecdotal:
`git diff --numstat ff893073^ origin/main` per file, where any removal count is
content that existed before the revert and is still absent.

| File | What is missing | Verdict |
| --- | --- | --- |
| `modules/alerting/availability.tf` | `enabled = true` on the certificate web test | **RESTORED HERE, first commit.** Live. Never been back to since the revert. |
| `modules/control-plane/database.tf` | `standby_availability_zone` from `ignore_changes` | **RESTORED HERE.** Live. |
| `self-hosting/azure.md` | two status rows, applied downgraded to written | **RESTORED HERE.** False against the live plane. |
| `stacks/control-plane/production.tfvars` | `github_app_id` | **PR #210**, split out, blocked on a permissions decision |
| `stacks/control-plane/production.tfvars` | `cd_principal_id` | PR 208, in flight |
| `stacks/control-plane/ci.tf` | the CD Contributor grant | PR 208, in flight |
| `stacks/control-plane/variables.tf` | `variable "cd_principal_id"` | PR 208, in flight |
| `.gitignore` | nothing | **restored by 203.** Both `backend*.hcl` and `plan.txt` verified present. |
| `modules/control-plane/domain.tf` | nothing | **restored by 205.** `git diff ff893073^ origin/main` on that path is empty. |
| `stacks/control-plane/outputs.tf` | nothing that matters | **settled, not a regression.** All 23 removed lines are comment. `sensitive = true` survives, and main carries its own shorter explanation. |
| `stacks/control-plane/variables.tf` | nothing that matters | **settled, examined.** Only three non blank removals: an image tag `default`, one comment line, and the old `signin_allowlist` description. All three were superseded by later work, not reverted by this commit. |
| `engine/internal/env/fidelity_postgres_test.go` | n/a | **legitimate.** The change the commit message describes, and it is correct. |
| `docs/plan/STATUS.md` | three rows downgraded from proven to written | **UNOWNED.** Documentation. |
| `self-hosting/production.md` | 84 of 90 lines, including the entire **Bind the certificate** step, and 15 steps renumbered to 14 | **UNOWNED.** Documentation, and the most consequential of the four. |
| `infra/ISOLATION.md` | the fifth resource group, why production is a separate group, both state keys, both cost figures | **UNOWNED.** Documentation. |

Three unowned rows, all documentation, none of them changing what an apply does.
There is nothing else. The runbook is the one to take next: on main it no longer
contains the step that binds the managed certificate to the custom domain, so
somebody standing up a new production gets a hostname and a certificate with
nothing joining them, and the removed text says in as many words that this
failure "looks like a network problem".

## Which of these a plan review could have caught

The lead asked, and the answer is the interesting part of this whole exercise.

| Regression | Visible in a plan? |
| --- | --- |
| `standby_availability_zone` | **Yes, loudly.** `"2" -> null` on every single production plan, forever. |
| `github_app_id` | **Technically, barely.** It is in the diff, but rendered as positional churn in an `env` list, and **both plans print the identical summary line**, `2 to add, 6 to change, 1 to destroy`. |
| **certificate web test** | **No. Not in any plan, ever.** |

The third one is the point. `enabled` defaulting to false is a **create time**
attribute. On the apply that first created the test there was no prior state to
diff against, so the plan showed a resource being created with the attributes
written down and nothing looked wrong. The test was created disabled, the alert
rule was created enabled and wired to the pager, and the rule reported **healthy**
ever after, because a rule over a probe with no results has nothing to be
unhealthy about.

That is monitoring reporting green while measuring nothing, and no plan review
would ever have caught it. Only an apply followed by somebody opening the portal
did, which is what the restored comment records in capitals.

## The two restorations

**`availability.tf`, first commit, and the most serious of the three.** This
defect has **already shipped once**. The comment `ff893073` deleted opens
"NOT A DEFAULT, AND LEAVING IT OUT IS WHY THIS TEST RAN ZERO TIMES", so somebody
hit it, an apply was the only thing that could find it, they fixed it and wrote
down why, and the revert put the defect back and took the explanation with it.
On main today `readyz` carries `enabled = true` at line 54 and the certificate
test at 129 carries nothing, which is exactly the asymmetry that comment exists
to prevent.

The production plan proposes `enabled = true` to `null` today, and both live web
tests currently report `Enabled: true`, read back from Azure. So the next apply
takes a running probe and stops it.

`app.antifailure.dev` is a `.dev` domain, which is **HSTS preloaded**. A lapsed
certificate there is an `ERR_SSL_PROTOCOL_ERROR` with no way to click through,
on a dashboard that says fine.

**`database.tf`.** `high_availability[0].standby_availability_zone` was dropped
from `ignore_changes`. Production runs ZoneRedundant HA with the standby in zone
2, so every plan carries `"2" -> null` forever for a value Azure assigns. The
restored comment already rejects the obvious alternative and says why: pinning a
zone would tie the standby to one Azure may not be able to place it in. That is
worth reading before reaching for it.

**Both comments are restored from the commit that had them right, not rewritten
from memory.** `git diff ff893073^ HEAD` on `availability.tf` is empty. They are
the argument somebody wrote while looking at the failure, and a reconstruction
would be a weaker artifact.

## The general lesson, and the honest answer is no gate

Three findings, one common cause: a commit message that described something else.

**No gate catches that class, and I am not proposing one.** `tools/planguard`
refuses an unacknowledged DESTROY; every regression here is an in place update,
so it is correct to miss them. The two catchable commit shapes both fail:
"removes far more than it adds" trips on this commit and on every honest
deletion; "touches files unrelated to the message" trips on every legitimate
code plus doc change. A heuristic that fires on every large refactor gets
disabled in a week, and a disabled gate is worse than none because it looks like
coverage.

Every instrument this repository has passed, and each was right to. Git merged
it, the compiler took it, the tests passed, and the one file the message was
about was genuinely fixed.

**The check belongs in review, and the sentence is: read the file list before
the diff.** A subject about one test file over a thirteen file diff is visible
in one line of `git show --stat`, before a single hunk. That belongs in
`CONTRIBUTING` beside the commit message conventions, and I would rather have
that one true sentence than a heuristic on a commit gate.

**One more pattern worth recording while it is in front of us.** This stack has
now produced **two separate failures whose signature is a complete looking plan
with a non zero exit**: the sensitive output that `205` fixed, raised while
evaluating outputs *after* the whole diff and its summary line are printed, and
the managed certificate ordering. Both read like a plan that worked. Anyone
reviewing a plan for this stack should check the exit status and not the last
line of output.

**Postscript, and it is not a joke.** While preparing this work my first commit
swept in another lane's staged engine changes, because I ran `git add` against
an index that already held them. Same failure, same night. I caught it by
running `git show --stat` on my own commit before pushing, rebuilt the branch,
and returned their work to the tree untouched. The practice, demonstrating both
directions in one sitting.

## Checks

`terraform fmt -recursive -check` clean, `terraform validate` valid,
`tools/inputcheck` 284 values unrenamed and unretyped. Neither file adds a
resource or changes a security attribute. Nothing here reads a Key Vault secret,
which is precisely why it can be green while #210 cannot.
