### PR TITLE
github: the check on our own pull requests was listening to the wrong run

### DIFF
--- a/.changes/check-hears-the-run-that-ran-it.md
+++ b/.changes/check-hears-the-run-that-ran-it.md
@@ -1,0 +1,29 @@
+# fixed
+
+The `Antifailure` check on this repository's own pull requests said "Nothing was
+verified" on every one of them, and it was right. Two things were wrong and each
+alone was enough for silence.
+
+A GitHub App is delivered a `workflow_run` event for every workflow in a
+repository. The control plane bound the first one it saw for a commit and let
+that run's completion decide the check. One workflow per repository gets away
+with that; this repository has seventeen. On commit `ada5644` the run that ended
+the generation was `Security`, green fifty seconds in, while the job running
+`af ci` was still building its database. The check was completed and amber
+before the check had run. A workflow run now has no standing until it says which
+run it is, by trading a workflow identity GitHub signed for a callback
+credential, and that identity's `run_id` is GitHub's own claim rather than
+anything a job asserts.
+
+And the dogfood workflow never reported at all. It had no `id-token: write`, so
+the runner set no identity variables and nothing could prove what the job was;
+it named no control plane, so the engine's event sink did not try; it never
+asked `af ci` for `--report-json`; and it posted to `/v1/pr/report` nowhere. It
+wrote a comment and exited zero, which is the shape of failure this repository
+names most often, with the product itself doing the naming on every pull request
+and nobody reading it.
+
+Both workflows now ask for the credential in their second step rather than
+beside the report at the end, so the check reads as running while a runner is
+working, a job that dies is a run the control plane can name and cancel, and a
+dead run is reported in seconds rather than at the deadline.

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -26,9 +26,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# Read, and only read, for everything that runs untrusted code. The one job
-# that needs to write a comment declares it for itself and does nothing else,
-# which is narrower than granting it here and hoping.
+# Read, and only read, for everything that runs untrusted code. The two jobs
+# that need more declare it for themselves and nothing else, which is narrower
+# than granting it here and hoping: the comment job takes
+# `pull-requests: write`, and the job below takes `id-token: write`, which is
+# not a write to this repository at all. It lets the job ask GitHub to sign a
+# statement about itself, which is what it trades for a credential good for
+# this one commit on the control plane.
 permissions:
   contents: read
 
@@ -43,6 +47,21 @@ jobs:
     # apart. They run on the schedule below.
     name: control plane
     runs-on: ubuntu-latest
+
+    # `id-token: write` is the whole reason this check reported nothing for as
+    # long as it has existed. Without it the runner sets neither
+    # ACTIONS_ID_TOKEN_REQUEST_URL nor _TOKEN, the job cannot prove what it is,
+    # and every route to the control plane is closed: the two steps below skip
+    # and the engine's own event sink finds no identity to exchange. The job
+    # then exits zero having posted a comment, and the App, hearing nothing,
+    # says "Nothing was verified" on every pull request this repository has.
+    #
+    # It is not a write to the repository. GitHub mints a short lived signed
+    # statement about this job, and it withholds it from a fork's pull request,
+    # which is the fork case working rather than failing.
+    permissions:
+      contents: read
+      id-token: write
     # Larger than the budgets inside it, deliberately. The harness fails a step
     # that runs over its budget and writes a report saying which one and by how
     # much; a runner timeout kills the job and writes nothing, so a budget that
@@ -69,6 +88,17 @@ jobs:
           --health-retries 10
 
     env:
+      # The hosted control plane this repository is connected to, and the one
+      # whose App posts the `Antifailure` check on every pull request here.
+      #
+      # A literal rather than `vars.AF_CONTROL_PLANE`, which is what
+      # examples/github-workflow.yml tells a customer to set. A customer's
+      # address is their own and belongs in a variable; this repository's is
+      # this repository's own product at its published address, and a variable
+      # that has to be set by hand before the check can work is a variable
+      # somebody will not set. It was not set here, which is the second of the
+      # two reasons nothing was ever reported.
+      AF_CONTROL_PLANE: https://app.antifailure.dev
       # The source the masking rules are written against. Synthesised rather
       # than restored from production: a control plane that copies a real
       # customer's database into a public CI runner would be the single worst
@@ -78,6 +108,61 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # BEFORE THE WORK, NOT AFTER IT, AND THE ORDER IS THE POINT.
+      #
+      # This tells the control plane which of this repository's workflow runs
+      # is the one checking this commit. Until a run says so the control plane
+      # is guessing, and it used to guess by binding the first `workflow_run`
+      # delivery it saw for the commit, which on this repository is whichever
+      # of seventeen workflows GitHub happened to start first. On ada5644 that
+      # was `Security`, green in fifty seconds, and its completion ended the
+      # generation as "Nothing was verified" while this job was still building
+      # its database. That guess is gone from the control plane now, and this
+      # step is the half that replaces it.
+      #
+      # Claiming here rather than beside the report below also means the check
+      # reads "Building the environment and running the agents" for the twenty
+      # minutes that is true, and that a job which dies at minute ten is a run
+      # the control plane can name, cancel, and tear the environment down for.
+      #
+      # The credential is good for one hour and for this commit alone. It is
+      # not a secret in the repository: there is nothing here to steal when the
+      # job is not running.
+      - name: Tell the control plane this run is the one checking this commit
+        id: claim
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          # The audience matters. Without one GitHub mints an identity for the
+          # repository owner's URL, which every workflow in the organization
+          # can obtain, and a credential any workflow can get is not a
+          # credential.
+          identity=$(curl -sS -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=antifailure-control-plane" |
+            jq -r '.value // empty')
+          if [ -z "$identity" ]; then
+            echo "GitHub would not mint a workflow identity for this job."
+            echo "On a pull request from a fork it never will, which is deliberate."
+            exit 0
+          fi
+          token=$(curl -sS -X POST "${AF_CONTROL_PLANE}/v1/pr/callback-token" \
+            -H "Authorization: Bearer ${identity}" \
+            -H 'content-type: application/json' \
+            -d "{\"head_sha\":\"${HEAD_SHA}\"}" |
+            jq -r '.token // empty')
+          if [ -z "$token" ]; then
+            echo "The control plane issued no callback credential for ${HEAD_SHA}."
+            echo "That is not a failure of this run: it reports through the comment below."
+            exit 0
+          fi
+          # Masked so that no later step can print it into a public log, and
+          # written to the step output rather than to a file the artifact
+          # upload would then publish.
+          echo "::add-mask::$token"
+          echo "token=$token" >> "$GITHUB_OUTPUT"
+          echo "The control plane is expecting a report from this run."
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
@@ -182,13 +267,83 @@ jobs:
         # adds is a budget per step, taken from the environment's own event
         # stream, and a JSON record of the run, which is what a ten green
         # streak is a claim about.
+        env:
+          # What the engine's own event sink reports to, which is a different
+          # thing from the report below and needs saying. The report is one
+          # verdict about one commit, posted by the step at the end; this is
+          # forty event types streamed while the run happens, and the console's
+          # run view is built out of them. `attachControlPlane` reads this
+          # variable and this variable only, and mints its own credential from
+          # the same workflow identity the claim above used. Unset, it does not
+          # even try, which is right for a laptop and was wrong here.
+          AF_CONTROL_PLANE_URL: ${{ env.AF_CONTROL_PLANE }}
         run: |
           go run ./tools/dogfood \
             -C . \
             --af "$GITHUB_WORKSPACE/bin/af" \
             --mode pr \
             --report "$GITHUB_WORKSPACE/dogfood-report.md" \
+            --report-json "$GITHUB_WORKSPACE/dogfood-report.json" \
             --record "$GITHUB_WORKSPACE/dogfood-record.json"
+
+      # The verdict, to the check the App posts on this pull request.
+      #
+      # `always()`, because the report of a failing run is the one worth
+      # reading, and because a run that fails is exactly the run whose check
+      # must not stay amber.
+      #
+      # Skipped without a credential, which is the fork case and the case where
+      # the control plane refused the claim, and in both of those the comment
+      # below is the whole answer. It is NOT skipped when the report is
+      # missing: a run that produced no report still has to say so, because a
+      # check that hears nothing is the state this whole change is about.
+      - name: Tell the control plane what this commit did
+        if: always() && steps.claim.outputs.token != ''
+        env:
+          TOKEN: ${{ steps.claim.outputs.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          # jq rather than a hand built string. A report carries quotes,
+          # newlines and backslashes, and a body pasted together in the shell
+          # is malformed on the first interesting run.
+          if [ -f "$GITHUB_WORKSPACE/dogfood-report.json" ]; then
+            markdown="$GITHUB_WORKSPACE/dogfood-report.md"
+            [ -f "$markdown" ] || printf '' > "$markdown"
+            jq -n --arg sha "$HEAD_SHA" \
+                  --rawfile markdown "$markdown" \
+                  --slurpfile report "$GITHUB_WORKSPACE/dogfood-report.json" \
+                  '{head_sha: $sha, markdown: $markdown, report: $report[0]}' > payload.json
+          else
+            # No report at all. Sent rather than skipped, and sent as a report
+            # with no workflows in it, which the control plane reads as
+            # unverified because a run that evaluated nothing verified nothing.
+            # Saying it here rather than leaving the check to the deadline is
+            # the difference between a reader learning this in ten seconds and
+            # learning it in forty five minutes.
+            jq -n --arg sha "$HEAD_SHA" \
+                  --arg url "$RUN_URL" \
+                  '{head_sha: $sha,
+                    markdown: ("## Dogfood\n\nThis run produced no report, so nothing about the change itself was checked. That is a failure of the pipeline rather than a verdict on the diff.\n\n[What happened](" + $url + ")"),
+                    report: {Workflows: [], Invariants: []}}' > payload.json
+          fi
+
+          code=$(curl -sS -o response.json -w '%{http_code}' \
+            -X POST "${AF_CONTROL_PLANE}/v1/pr/report" \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H 'content-type: application/json' \
+            --data-binary @payload.json)
+          cat response.json
+          echo
+          # A refused report is a red step. The reason this defect lived so
+          # long is that every route to the control plane failed quietly, and a
+          # publish step that swallows its own answer is that same failure
+          # rebuilt one layer up.
+          if [ "$code" != "200" ]; then
+            echo "::error::the control plane refused this run's report with HTTP $code"
+            exit 1
+          fi
 
       # There was a step here called "What the database noticed about this
       # change", running `af insights || true`. It was removed rather than
@@ -227,6 +382,7 @@ jobs:
           name: dogfood-report
           path: |
             dogfood-report.md
+            dogfood-report.json
             dogfood-record.json
             .antifailure/logs
           retention-days: 30

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -135,23 +135,42 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           set -euo pipefail
+          # EVERY FAILURE HERE IS SURVIVED, AND THAT IS THE SHAPE OF THIS
+          # SCRIPT. The observability of a run is not the run: a control plane
+          # that is down, or a repository nobody has connected, must not turn a
+          # working check into a red job.
+          #
+          # `:-` on both runner variables rather than a bare read. Under
+          # `set -u` a bare read of an unset one ends the step, and on a pull
+          # request from a FORK GitHub sets NEITHER of them. That would make the
+          # one case this has to handle gracefully, an outside contributor who
+          # can fix nothing, the one case that goes red.
+          request_token="${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}"
+          request_url="${ACTIONS_ID_TOKEN_REQUEST_URL:-}"
+          if [ -z "$request_token" ] || [ -z "$request_url" ]; then
+            echo "This job was granted no workflow identity, so it cannot introduce itself."
+            echo "On a pull request from a fork GitHub withholds one, which is deliberate."
+            exit 0
+          fi
+
           # The audience matters. Without one GitHub mints an identity for the
           # repository owner's URL, which every workflow in the organization
           # can obtain, and a credential any workflow can get is not a
           # credential.
-          identity=$(curl -sS -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=antifailure-control-plane" |
-            jq -r '.value // empty')
+          # `|| true` on the pipeline, because `set -o pipefail` would
+          # otherwise end the job on a curl that could not connect.
+          identity=$(curl -sS -H "Authorization: Bearer $request_token" \
+            "${request_url}&audience=antifailure-control-plane" |
+            jq -r '.value // empty' || true)
           if [ -z "$identity" ]; then
             echo "GitHub would not mint a workflow identity for this job."
-            echo "On a pull request from a fork it never will, which is deliberate."
             exit 0
           fi
           token=$(curl -sS -X POST "${AF_CONTROL_PLANE}/v1/pr/callback-token" \
             -H "Authorization: Bearer ${identity}" \
             -H 'content-type: application/json' \
             -d "{\"head_sha\":\"${HEAD_SHA}\"}" |
-            jq -r '.token // empty')
+            jq -r '.token // empty' || true)
           if [ -z "$token" ]; then
             echo "The control plane issued no callback credential for ${HEAD_SHA}."
             echo "That is not a failure of this run: it reports through the comment below."

--- a/docs/src/content/docs/guides/github.md
+++ b/docs/src/content/docs/guides/github.md
@@ -90,6 +90,44 @@ GitHub's conclusion vocabulary is smaller than ours, so two of ours share
 `action_required`. They stay apart in the check's title, which is the first line
 anybody reads, and in the comment.
 
+## Which of your workflow runs is the check
+
+A GitHub App is delivered a `workflow_run` event for **every** workflow in your
+repository, not only the one that runs Antifailure. A repository with one
+workflow never notices. A repository with seventeen does, and this one did: a
+lint job that finishes green in fifty seconds looks, from the outside, exactly
+like the check finishing without reporting, and the check on this repository's
+own pull requests read "Nothing was verified" for its entire life because a
+security scan kept crossing the line first.
+
+So a workflow run has no standing here until it says which run it is, and it
+says so by asking for a callback credential:
+
+```
+POST /v1/pr/callback-token
+Authorization: Bearer <the workflow identity GitHub signed>
+{"head_sha": "<the commit>"}
+```
+
+The `run_id` inside that identity is GitHub's own claim about the job, not
+something the workflow asserts, so no job can introduce itself as another one.
+From then on that run is the check: its completion decides the verdict when it
+did not report, and cancelling it is how an environment gets torn down.
+
+**Ask for it before the work, not beside the report.** The example workflow does
+this in its second step, and the three things it buys are all lost by asking at
+the end:
+
+- the check reads "Building the environment and running the agents" for the
+  minutes that is true, rather than "Waiting for a runner" while one is working;
+- a job that dies halfway is a run this control plane can name and cancel, which
+  is its only route into the runtime holding your environment;
+- a run that dies is reported in seconds rather than at the deadline.
+
+A commit where no run ever introduces itself is not passed and not failed. It
+sits until the deadline and then reads "Nothing was verified: the run never
+reported back", which is `timed_out` and true: nothing came back at all.
+
 ## One comment, about one commit
 
 The comment's first line carries the commit it is about. That is not decoration:

--- a/examples/github-workflow.yml
+++ b/examples/github-workflow.yml
@@ -209,22 +209,41 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           set -euo pipefail
+          # EVERY FAILURE HERE IS SURVIVED, AND THAT IS THE SHAPE OF THIS
+          # SCRIPT. The observability of a run is not the run: a control plane
+          # that is down, or a repository nobody has connected, must not turn a
+          # working check into a red job.
+          #
+          # `:-` on both runner variables rather than a bare read. Under
+          # `set -u` a bare read of an unset one ends the step, and on a pull
+          # request from a FORK GitHub sets NEITHER of them. That would make the
+          # one case this has to handle gracefully, an outside contributor who
+          # can fix nothing, the one case that goes red.
+          request_token="${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}"
+          request_url="${ACTIONS_ID_TOKEN_REQUEST_URL:-}"
+          if [ -z "$request_token" ] || [ -z "$request_url" ]; then
+            echo "This job was granted no workflow identity, so it cannot introduce itself."
+            echo "On a pull request from a fork GitHub withholds one, which is deliberate."
+            exit 0
+          fi
+
           # The audience matters. Without one GitHub mints an identity for your
           # organization's URL, which every workflow in it can obtain, and a
           # credential any workflow can get is not a credential.
-          identity=$(curl -sS -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=antifailure-control-plane" |
-            jq -r '.value // empty')
+          # `|| true` on the pipeline, because `set -o pipefail` would
+          # otherwise end the job on a curl that could not connect.
+          identity=$(curl -sS -H "Authorization: Bearer $request_token" \
+            "${request_url}&audience=antifailure-control-plane" |
+            jq -r '.value // empty' || true)
           if [ -z "$identity" ]; then
             echo "GitHub would not mint a workflow identity for this job."
-            echo "On a pull request from a fork it never will, which is deliberate."
             exit 0
           fi
           token=$(curl -sS -X POST "${AF_CONTROL_PLANE}/v1/pr/callback-token" \
             -H "Authorization: Bearer ${identity}" \
             -H 'content-type: application/json' \
             -d "{\"head_sha\":\"${HEAD_SHA}\"}" |
-            jq -r '.token // empty')
+            jq -r '.token // empty' || true)
           if [ -z "$token" ]; then
             echo "The control plane issued no callback credential for ${HEAD_SHA}."
             echo "This run reports through the comment below instead."

--- a/examples/github-workflow.yml
+++ b/examples/github-workflow.yml
@@ -180,6 +180,59 @@ jobs:
           # merge base to find. Without this the analysis fails with AF-DET-010.
           fetch-depth: 0
 
+      # BEFORE THE WORK, so the control plane knows which run this is while it
+      # still matters.
+      #
+      # A GitHub App is delivered a `workflow_run` event for EVERY workflow in
+      # your repository, and it cannot tell yours apart from your linter's
+      # until one of them says so. This step is a run saying so, and it proves
+      # it: the credential comes back only for an identity GitHub signed, whose
+      # `run_id` claim is GitHub's own rather than anything this file asserts.
+      #
+      # Claiming here rather than beside the report at the end buys three
+      # things. The check reads "Building the environment and running the
+      # agents" for the minutes that is true rather than "Waiting for a runner".
+      # A job that dies halfway is a run the control plane can name and cancel,
+      # which is its only route into the runtime holding your environment. And
+      # a run that dies is reported in seconds rather than at the deadline.
+      #
+      # AF_CONTROL_PLANE unset skips it, and this job comments for itself
+      # below. That is the self-hosted and no-account path and it stays working.
+      - name: Tell the control plane this run is the one checking this commit
+        id: claim
+        if: env.AF_CONTROL_PLANE != ''
+        env:
+          # ACTIONS_ID_TOKEN_REQUEST_URL and _TOKEN are put in the environment
+          # by the runner itself for any job with id-token: write, so they are
+          # used below without being declared here. Declaring them would read
+          # them at expression time, which is before the runner sets them.
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          # The audience matters. Without one GitHub mints an identity for your
+          # organization's URL, which every workflow in it can obtain, and a
+          # credential any workflow can get is not a credential.
+          identity=$(curl -sS -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=antifailure-control-plane" |
+            jq -r '.value // empty')
+          if [ -z "$identity" ]; then
+            echo "GitHub would not mint a workflow identity for this job."
+            echo "On a pull request from a fork it never will, which is deliberate."
+            exit 0
+          fi
+          token=$(curl -sS -X POST "${AF_CONTROL_PLANE}/v1/pr/callback-token" \
+            -H "Authorization: Bearer ${identity}" \
+            -H 'content-type: application/json' \
+            -d "{\"head_sha\":\"${HEAD_SHA}\"}" |
+            jq -r '.token // empty')
+          if [ -z "$token" ]; then
+            echo "The control plane issued no callback credential for ${HEAD_SHA}."
+            echo "This run reports through the comment below instead."
+            exit 0
+          fi
+          echo "::add-mask::$token"
+          echo "token=$token" >> "$GITHUB_OUTPUT"
+
       - name: Install Antifailure
         # Every step gets a fresh process and a fresh PATH, so the step that
         # runs af is not the one that installed it. The installer writes its
@@ -359,37 +412,19 @@ jobs:
       # below. That is the self-hosted and no-account path and it stays working.
       - name: Tell the control plane what this commit did
         id: publish
-        if: always() && env.AF_CONTROL_PLANE != '' && hashFiles('report.json') != ''
+        if: >-
+          always() && steps.claim.outputs.token != ''
+          && hashFiles('report.json') != ''
         env:
-          # ACTIONS_ID_TOKEN_REQUEST_URL and _TOKEN are put in the environment by
-          # the runner itself for any job with id-token: write, so they are used
-          # below without being declared here. Declaring them would read them at
-          # expression time, which is before the runner sets them.
+          TOKEN: ${{ steps.claim.outputs.token }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           set -euo pipefail
-          # The identity token, asked for with the audience the control plane
-          # expects. Without an audience GitHub mints one for the repository
-          # owner's URL, which every workflow in the organization can get, and a
-          # credential that any workflow can obtain is not a credential.
-          identity=$(curl -sS -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=antifailure-control-plane" |
-            sed -n 's/.*"value":"\([^"]*\)".*/\1/p')
-          if [ -z "$identity" ]; then
-            echo "GitHub would not mint a workflow identity token."
-            echo "On a pull request from a fork it never will, which is deliberate."
-            exit 0
-          fi
-
-          token=$(curl -sS -X POST "${AF_CONTROL_PLANE}/v1/pr/callback-token" \
-            -H "Authorization: Bearer ${identity}" \
-            -H 'content-type: application/json' \
-            -d "{\"head_sha\":\"${HEAD_SHA}\"}" |
-            sed -n 's/.*"token":"\([^"]*\)".*/\1/p')
-          if [ -z "$token" ]; then
-            echo "The control plane did not issue a callback credential for ${HEAD_SHA}."
-            exit 0
-          fi
+          # The credential the claim step already holds, rather than a second
+          # identity exchange. One run has one credential, it is good for an
+          # hour against this commit alone, and asking for another here would
+          # be the run introducing itself twice.
+          token="$TOKEN"
 
           # jq is on every GitHub-hosted runner. The report and the Markdown go
           # in as JSON values rather than being pasted into a string, because a

--- a/tools/dogfood/main.go
+++ b/tools/dogfood/main.go
@@ -49,11 +49,23 @@ import (
 
 func main() {
 	var (
-		root    = flag.String("C", ".", "Repository root to run in")
-		af      = flag.String("af", "", "Path to the af binary, defaulting to ./bin/af under the root")
-		mode    = flag.String("mode", "pr", "pr or nightly")
-		record  = flag.String("record", "", "Write the run record here as JSON")
-		report  = flag.String("report", "", "Where af ci writes the pull request comment")
+		root   = flag.String("C", ".", "Repository root to run in")
+		af     = flag.String("af", "", "Path to the af binary, defaulting to ./bin/af under the root")
+		mode   = flag.String("mode", "pr", "pr or nightly")
+		record = flag.String("record", "", "Write the run record here as JSON")
+		report = flag.String("report", "", "Where af ci writes the pull request comment")
+		// The same report as JSON, and it exists for one caller: the step that
+		// posts this run's result to the hosted control plane's pull request
+		// check. The check needs counts and an environment name, and reading
+		// them back out of the Markdown would be a parser for prose.
+		//
+		// Without it the harness ran `af ci` with no --report-json, so the
+		// workflow had no report.json, so the publish step had nothing to
+		// send, so the check said "Nothing was verified" about a run that had
+		// just verified everything. A flag the engine has had since it was
+		// written, with no caller.
+		reportJSON = flag.String("report-json", "",
+			"Where af ci writes the same report as JSON, for the control plane")
 		scale   = flag.Float64("budget-scale", 1, "Multiply every budget, for a slower machine")
 		refresh = flag.Bool("refresh-golden", false, "Refresh the golden first, as the nightly does")
 		keep    = flag.Bool("keep", false, "Leave the environment up, for debugging")
@@ -77,7 +89,7 @@ func main() {
 
 	r := &runner{
 		root: abs, af: binary, mode: *mode, scale: *scale,
-		keep: *keep, refresh: *refresh, reportPath: *report,
+		keep: *keep, refresh: *refresh, reportPath: *report, reportJSONPath: *reportJSON,
 	}
 	run := r.do()
 
@@ -167,6 +179,10 @@ type runner struct {
 	keep       bool
 	refresh    bool
 	reportPath string
+	// Where `af ci` writes the machine readable copy. Separate from
+	// reportPath because the Markdown is read by a person on the pull request
+	// and this one is read by the control plane's check.
+	reportJSONPath string
 }
 
 // Step is one command, timed and judged.
@@ -246,6 +262,9 @@ func (r *runner) do() *Run {
 	args := []string{"ci", "--no-color"}
 	if r.reportPath != "" {
 		args = append(args, "--report", r.reportPath)
+	}
+	if r.reportJSONPath != "" {
+		args = append(args, "--report-json", r.reportJSONPath)
 	}
 	if r.mode == "nightly" {
 		args = append(args, "--load")

--- a/tools/dogfood/main_test.go
+++ b/tools/dogfood/main_test.go
@@ -788,6 +788,35 @@ func TestAJobThatRunsTheCheckCanReportIt(t *testing.T) {
 			t.Errorf("job %q runs the whole product and posts to /v1/pr/report nowhere, so the "+
 				"result reaches a comment and the check hears nothing", name)
 		}
+
+		// AND THE FORK CASE, WHICH IS THE ONE THAT MUST NOT GO RED.
+		//
+		// GitHub withholds the workflow identity from a pull request opened
+		// from a fork, on purpose, and sets neither runner variable. A step
+		// under `set -u` that reads one of them bare aborts with "unbound
+		// variable" and exit 1, so the single case that has to degrade
+		// gracefully, an outside contributor who can fix nothing, would be the
+		// one case that fails. The step reads them through `:-` and says so
+		// instead. Proved rather than assumed: bash exits 1 on the bare read
+		// and 0 on the guarded one.
+		for _, st := range job.Steps {
+			if !strings.Contains(st.Run, "/v1/pr/callback-token") {
+				continue
+			}
+			if !strings.Contains(st.Run, "set -u") && !strings.Contains(st.Run, "set -euo") {
+				continue
+			}
+			for _, v := range []string{
+				"ACTIONS_ID_TOKEN_REQUEST_TOKEN", "ACTIONS_ID_TOKEN_REQUEST_URL",
+			} {
+				if strings.Contains(st.Run, "${"+v+"}") {
+					t.Errorf("job %q reads ${%s} bare under set -u, so a pull request from a "+
+						"fork, where GitHub sets neither, ends the step with an unbound "+
+						"variable and a red check nobody outside this repository can fix. "+
+						"Read it as ${%s:-} and say what happened", name, v, v)
+				}
+			}
+		}
 	}
 	if checked == 0 {
 		t.Error("no job in dogfood.yml runs the harness in pull request mode, so this test " +

--- a/tools/dogfood/main_test.go
+++ b/tools/dogfood/main_test.go
@@ -679,3 +679,169 @@ func hostPort(value string) (string, string) {
 	}
 	return rest, ""
 }
+
+// A job that runs the check can report the check.
+//
+// THE DEFECT THIS IS THE INSTRUMENT FOR, and it is the most visible one this
+// repository has ever carried, because every contributor who opened a pull
+// request saw it. The hosted App posts a check named `Antifailure` on every
+// commit here, and on every commit it said:
+//
+//	Nothing was verified
+//	The workflow run finished successfully and Antifailure never reported a
+//	result, so nothing was verified.
+//
+// It was telling the truth. This job ran the whole product against the control
+// plane's own schema for twenty minutes and then reported the result to a pull
+// request comment and to nowhere else. There was no `id-token: write`, so the
+// runner set no ACTIONS_ID_TOKEN_REQUEST_URL and the job could not prove what
+// it was; there was no control plane address, so the engine's event sink did
+// not try; and there was no step that posted a report, so nothing arrived. The
+// job exited zero, the comment appeared, and the pipeline looked fine, which is
+// the exact shape of failure this repository names most often: a gate that
+// passes while checking nothing. Here the product itself was the thing saying
+// so on every pull request, and it went unread for the life of the check.
+//
+// So this asserts the four things that together make a run reportable, because
+// any one of them missing is silence and three of the four were missing:
+//
+//   - `id-token: write` on the job, which is what lets it prove what it is;
+//   - an address for the control plane, without which every route is off;
+//   - `--report-json`, because the check needs counts and the Markdown is
+//     prose;
+//   - a step that posts to /v1/pr/report, because a report written to a file
+//     is a report nobody receives.
+//
+// It reads the workflow rather than trusting the comments in it, and it is
+// keyed on the job that runs the harness rather than on a job name, so a job
+// that starts running `af ci` tomorrow is covered without anybody remembering
+// this file.
+func TestAJobThatRunsTheCheckCanReportIt(t *testing.T) {
+	type step struct {
+		Name string            `yaml:"name"`
+		If   string            `yaml:"if"`
+		Run  string            `yaml:"run"`
+		Env  map[string]string `yaml:"env"`
+	}
+	var workflow struct {
+		Jobs map[string]struct {
+			Permissions map[string]string `yaml:"permissions"`
+			Env         map[string]string `yaml:"env"`
+			Steps       []step            `yaml:"steps"`
+		} `yaml:"jobs"`
+	}
+	body, err := os.ReadFile(filepath.Join("..", "..", ".github", "workflows", "dogfood.yml"))
+	if err != nil {
+		t.Fatalf("could not read the workflow: %v", err)
+	}
+	if err := yaml.Unmarshal(body, &workflow); err != nil {
+		t.Fatalf("could not parse the workflow: %v", err)
+	}
+
+	// Only the pull request job. The nightly runs on a schedule, where there is
+	// no pull request and so no check to report to, and demanding a credential
+	// of it would be a check enforcing a habit rather than a requirement.
+	checked := 0
+	for name, job := range workflow.Jobs {
+		runsTheCheck := false
+		for _, s := range job.Steps {
+			if strings.Contains(s.Run, "tools/dogfood") && strings.Contains(s.Run, "--mode pr") {
+				runsTheCheck = true
+			}
+		}
+		if !runsTheCheck {
+			continue
+		}
+		checked++
+
+		if job.Permissions["id-token"] != "write" {
+			t.Errorf("job %q runs the check and has no `id-token: write`, so the runner sets no "+
+				"identity variables, the job cannot prove what it is, and the check on every pull "+
+				"request says nothing was verified", name)
+		}
+		if job.Env["AF_CONTROL_PLANE"] == "" {
+			t.Errorf("job %q runs the check and names no AF_CONTROL_PLANE, so there is nowhere "+
+				"to report to and every route to the control plane is skipped", name)
+		}
+
+		wantsJSON, claims, publishes := false, false, false
+		for _, s := range job.Steps {
+			if strings.Contains(s.Run, "--report-json") {
+				wantsJSON = true
+			}
+			if strings.Contains(s.Run, "/v1/pr/callback-token") {
+				claims = true
+			}
+			if strings.Contains(s.Run, "/v1/pr/report") {
+				publishes = true
+			}
+		}
+		if !wantsJSON {
+			t.Errorf("job %q never asks for --report-json, so there are no counts to send and "+
+				"the only report is Markdown, which reading would be a parser for prose", name)
+		}
+		if !claims {
+			t.Errorf("job %q never asks for a callback credential, so the control plane is never "+
+				"told which of this repository's workflow runs is the one checking the commit", name)
+		}
+		if !publishes {
+			t.Errorf("job %q runs the whole product and posts to /v1/pr/report nowhere, so the "+
+				"result reaches a comment and the check hears nothing", name)
+		}
+	}
+	if checked == 0 {
+		t.Error("no job in dogfood.yml runs the harness in pull request mode, so this test " +
+			"checked nothing. Either the job was renamed out from under it or the check is gone")
+	}
+}
+
+// The claim comes before the work, not beside the report.
+//
+// A run that introduces itself only at the end is a run the control plane
+// cannot name while it matters. For the whole twenty minutes the check would
+// read "Waiting for a runner" when a runner is plainly working, and a job that
+// dies at minute ten leaves an environment the control plane has no run id to
+// cancel, because the only route it has into the runtime holding that
+// environment is cancelling the workflow run.
+//
+// It is also what makes the control plane's side safe to tighten. A workflow
+// run that has not claimed cannot end a generation any more, so a late claim
+// would trade one silence for another.
+func TestTheClaimComesBeforeTheWork(t *testing.T) {
+	type step struct {
+		Run string `yaml:"run"`
+	}
+	var workflow struct {
+		Jobs map[string]struct {
+			Steps []step `yaml:"steps"`
+		} `yaml:"jobs"`
+	}
+	body, err := os.ReadFile(filepath.Join("..", "..", ".github", "workflows", "dogfood.yml"))
+	if err != nil {
+		t.Fatalf("could not read the workflow: %v", err)
+	}
+	if err := yaml.Unmarshal(body, &workflow); err != nil {
+		t.Fatalf("could not parse the workflow: %v", err)
+	}
+
+	for name, job := range workflow.Jobs {
+		claimed, ran := -1, -1
+		for i, s := range job.Steps {
+			if claimed < 0 && strings.Contains(s.Run, "/v1/pr/callback-token") {
+				claimed = i
+			}
+			if ran < 0 && strings.Contains(s.Run, "tools/dogfood") &&
+				strings.Contains(s.Run, "--mode pr") {
+				ran = i
+			}
+		}
+		if claimed < 0 || ran < 0 {
+			continue
+		}
+		if claimed > ran {
+			t.Errorf("job %q claims its callback credential at step %d and runs the check at "+
+				"step %d, so the check reads as waiting for a runner while one is working and a "+
+				"run that dies leaves an environment nothing can name", name, claimed, ran)
+		}
+	}
+}

--- a/web/apps/api/src/github/lifecycle.ts
+++ b/web/apps/api/src/github/lifecycle.ts
@@ -675,20 +675,17 @@ async function handleWorkflowRun(
   const found = await deps.pool.withGitHubAccount(login, async (db) => {
     const repo = await repositoryByName(db, repository)
     if (!repo) return null
-    const rows = await db.execute<{ id: string; state: GenerationState }>(sql`
-      SELECT g.id, g.state::text AS state
+    const rows = await db.execute<{
+      id: string
+      state: GenerationState
+      workflow_run_id: string | null
+    }>(sql`
+      SELECT g.id, g.state::text AS state, g.workflow_run_id::text AS workflow_run_id
       FROM pr_generations g JOIN pull_requests p ON p.id = g.pull_request_id
       WHERE p.repository_id = ${repo.id}::uuid AND g.head_sha = ${headSha}
       ORDER BY g.queued_at DESC LIMIT 1`)
     const generation = rows[0]
     if (!generation) return { orgId: repo.org_id, generation: null }
-
-    // The run id is bound to the generation the first time it is seen, and it
-    // is what makes teardown possible: cancelling this run is the only route
-    // this control plane has into the runtime holding the environment.
-    await db.execute(sql`
-      UPDATE pr_generations SET workflow_run_id = ${run.id}, updated_at = ${deps.clock.now().toISOString()}
-      WHERE id = ${generation.id}::uuid AND workflow_run_id IS NULL`)
     return { orgId: repo.org_id, generation }
   })
 
@@ -710,6 +707,41 @@ async function handleWorkflowRun(
     }
   }
   const generationId = found.generation.id
+
+  // A RUN THIS CONTROL PLANE WAS NEVER TOLD ABOUT HAS NO STANDING TO SAY
+  // ANYTHING ABOUT THE COMMIT, AND THIS IS THE DEFECT THIS GUARD EXISTS FOR.
+  //
+  // A GitHub App is delivered `workflow_run` for EVERY workflow in the
+  // repository, and this handler used to bind the first one it saw and then
+  // let it end the generation. A repository with one workflow gets away with
+  // that. This one has seventeen, and on commit ada5644 the run that ended the
+  // generation was `Security`, which finished green fifty seconds in, while
+  // the job that actually runs `af ci` was still building its database. The
+  // check therefore said "Nothing was verified" about a check that was at that
+  // moment running, which is the same class of lie as a green gate that
+  // checked nothing: the state was correct about its own knowledge and wrong
+  // about the world, because it had bound itself to a stranger.
+  //
+  // The only party that knows which run is the check is the run itself, and it
+  // says so by asking for a callback credential, which proves through a
+  // workflow identity token that it is a job on this commit. `issueCallback`
+  // records the run id it names, so from here a bound run is the check and an
+  // unbound one is somebody else's workflow.
+  //
+  // The cost is deliberate and is not silence. A check whose job dies before
+  // it ever introduces itself is left to the deadline sweeper, which writes
+  // `timed_out` and "Nothing reported before the deadline", and that sentence
+  // is true. The sentence this replaces was not.
+  const bound = found.generation.workflow_run_id
+  if (bound !== String(run.id)) {
+    return {
+      handled: true,
+      detail: bound
+        ? `run ${run.id} is not the run reporting on ${shortSha(headSha)}`
+        : `no run has claimed ${shortSha(headSha)} yet, so run ${run.id} is not it`,
+      orgId: found.orgId,
+    }
+  }
 
   if (payload.action === 'in_progress' || payload.action === 'requested') {
     await markRunning(deps, login, generationId)
@@ -1566,6 +1598,15 @@ export async function issueCallback(
   )
 
   if ('refused' in result) return result
+
+  // Published here, and it has to be. The transaction above moved the
+  // generation from queued to running and bound it to the run that just proved
+  // which run it is, and neither of those is a fact until GitHub has been told.
+  // Without this the check reads "Waiting for a runner" for the whole twenty
+  // minutes a runner is plainly working, which is the same complaint this
+  // whole change is about one size smaller: a state that is correct about its
+  // own knowledge and stale about the world.
+  await publish(deps, login, result.generationId)
   return { token, generationId: result.generationId }
 }
 

--- a/web/apps/api/test/prlifecycle.test.ts
+++ b/web/apps/api/test/prlifecycle.test.ts
@@ -380,11 +380,27 @@ describe(
       assert.ok(commentFor(11), 'a pull request with a queued check has no comment')
       assert.match(commentFor(11)!.body, new RegExp(`sha=${head}`))
 
+      // A run event alone moves nothing, and that is the fix for the defect
+      // that made this repository's own check say "Nothing was verified" on
+      // every pull request. Seventeen workflows run on a commit here and the
+      // App is delivered an event for all of them, so a handler that acts on
+      // the first one it sees is a handler acting on a stranger.
       await deliver('workflow_run', workflowRunPayload('in_progress', head, 5001))
+      assert.equal((await generation(head))?.state, 'queued')
+
+      // The run that is the check says so, by trading a workflow identity
+      // GitHub signed for a credential good for this commit. `run_id` in that
+      // identity is GitHub's own, so the binding cannot be claimed by a job
+      // that is not the job it says it is.
+      assert.ok(await callbackFor(head, 5001), 'a running check was issued no credential')
       assert.equal((await generation(head))?.state, 'running')
       assert.equal(checkFor(head)?.status, 'in_progress')
       // Bound, because cancelling this run is the only route into the runtime.
       assert.equal((await generation(head))?.workflow_run_id, '5001')
+
+      // And from here its own run events are heard, because it is now the run.
+      await deliver('workflow_run', workflowRunPayload('in_progress', head, 5001))
+      assert.equal((await generation(head))?.state, 'running')
     })
 
     // -----------------------------------------------------------------------
@@ -404,9 +420,14 @@ describe(
       await deliver('pull_request', pullRequestPayload('opened', 12, head))
       assert.equal((await generation(head))?.state, 'queued')
 
-      // And the run event that follows still binds, so nothing is lost by the
-      // early one having arrived first.
+      // And nothing is lost by the early one having arrived first: the run
+      // introduces itself when it reaches the step that does so, and binds
+      // then. It is the claim rather than the run event that binds, because
+      // the claim is the only one of the two that proves which run it is.
       await deliver('workflow_run', workflowRunPayload('in_progress', head, 5002))
+      assert.equal((await generation(head))?.state, 'queued')
+
+      assert.ok(await callbackFor(head, 5002))
       const now = await generation(head)
       assert.equal(now?.state, 'running')
       assert.equal(now?.workflow_run_id, '5002')
@@ -761,6 +782,11 @@ describe(
         conclusion: null,
         headSha: head,
       })
+      // The run introduces itself, which is what gives the control plane a run
+      // id to cancel. Cancelling that run is the only route it has into the
+      // runtime holding the environment, so a run that never said which run it
+      // was is a run whose environment nothing can reach.
+      assert.ok(await callbackFor(head, 5009))
       await deliver('workflow_run', workflowRunPayload('in_progress', head, 5009))
 
       await deliver('pull_request', pullRequestPayload('closed', 20, head, { state: 'closed' }))
@@ -810,6 +836,7 @@ describe(
         conclusion: null,
         headSha: head,
       })
+      assert.ok(await callbackFor(head, 5010))
       await deliver('workflow_run', workflowRunPayload('in_progress', head, 5010))
       await deliver('pull_request', pullRequestPayload('closed', 21, head, { state: 'closed' }))
 
@@ -843,8 +870,16 @@ describe(
       // run means the job exited zero, and `af ci` exits zero on a run that
       // verified nothing. Pull request 49 demonstrated six blocked workflows
       // inside a successful job.
+      //
+      // The run here is the check: it introduced itself, so this control plane
+      // knows whose silence this is. That distinction is the whole of the
+      // guard above it. A run that never introduced itself and exits green
+      // says nothing about the commit and is left to the deadline; THIS run
+      // said it was the check, ran, and came back with nothing, and that is a
+      // finding rather than a gap.
       const head = sha('missing-callback')
       await deliver('pull_request', pullRequestPayload('opened', 22, head))
+      assert.ok(await callbackFor(head, 5011))
       await deliver('workflow_run', workflowRunPayload('in_progress', head, 5011))
       await deliver('workflow_run', workflowRunPayload('completed', head, 5011, 'success'))
 
@@ -855,12 +890,69 @@ describe(
       assert.match(commentFor(22)!.body, /nothing was verified/i)
     })
 
+    it('a stranger\u2019s workflow run cannot end a check it never ran', async () => {
+      // THE DEFECT THAT MADE THIS REPOSITORY'S OWN CHECK SAY "Nothing was
+      // verified" ON EVERY PULL REQUEST IT HAS EVER HAD.
+      //
+      // A GitHub App is delivered `workflow_run` for EVERY workflow in the
+      // repository. This control plane used to bind the first delivery it saw
+      // for a commit and then let that run's completion decide the check. One
+      // workflow per repository gets away with it. On commit ada5644 of this
+      // repository, which has seventeen, the run that ended the generation was
+      // `Security`, green fifty seconds in, while the job running `af ci` was
+      // still building its database twenty minutes from an answer.
+      //
+      // So the check was completed and amber before the check had run, and it
+      // was amber for the honest reason that nothing had reported, which is
+      // why it read as true and went unfixed. The lie was not in the sentence.
+      // It was in having listened to a stranger.
+      const head = sha('stranger-run')
+      await deliver('pull_request', pullRequestPayload('opened', 60, head))
+
+      // Somebody else's workflow, start to finish, green. It is not the check.
+      await deliver('workflow_run', workflowRunPayload('in_progress', head, 7001))
+      await deliver('workflow_run', workflowRunPayload('completed', head, 7001, 'success'))
+
+      const afterStranger = await generation(head)
+      assert.equal(
+        afterStranger?.state,
+        'queued',
+        'a workflow run that never claimed this commit ended the check anyway',
+      )
+      assert.equal(afterStranger?.workflow_run_id, null, 'a stranger\u2019s run was bound')
+      assert.notEqual(checkFor(head)?.status, 'completed')
+
+      // The run that IS the check says so, the way a job says so: by trading a
+      // workflow identity for a credential good for this commit.
+      const token = (await callbackFor(head, 7002))!
+      assert.equal((await generation(head))?.workflow_run_id, '7002')
+      assert.equal((await generation(head))?.state, 'running')
+
+      // And now its own completion means something.
+      assert.equal((await report(token, head, ['pass'])).status, 200)
+      assert.equal((await generation(head))?.state, 'passed')
+      assert.equal(checkFor(head)?.conclusion, 'success')
+    })
+
+    it('a stranger\u2019s run that fails cannot block a check either', async () => {
+      // The same guard from the other side, because the failure direction is
+      // the one an outside contributor would see: a lint workflow that goes
+      // red on somebody's branch would have reported the change as blocked
+      // before Antifailure had looked at a line of it.
+      const head = sha('stranger-run-red')
+      await deliver('pull_request', pullRequestPayload('opened', 61, head))
+      await deliver('workflow_run', workflowRunPayload('completed', head, 7003, 'failure'))
+      assert.equal((await generation(head))?.state, 'queued')
+      assert.notEqual(checkFor(head)?.status, 'completed')
+    })
+
     it('a run that failed before reporting is blocked, not failed', async () => {
       // Blocked and failed are different claims. A job that died before the
       // check ran has found nothing about the change, and reporting it as a
       // failure of the change blames the author for our own gap.
       const head = sha('run-failed-early')
       await deliver('pull_request', pullRequestPayload('opened', 23, head))
+      assert.ok(await callbackFor(head, 5012))
       await deliver('workflow_run', workflowRunPayload('completed', head, 5012, 'failure'))
       assert.equal((await generation(head))?.state, 'blocked')
       assert.equal(checkFor(head)?.conclusion, 'action_required')
@@ -896,6 +988,7 @@ describe(
         const runId = shape === 'check_run' ? 5030 : 5031
         await deliver('pull_request', pullRequestPayload('opened', number, head))
         api.addWorkflowRun({ id: runId, repository, status: 'in_progress', conclusion: null, headSha: head })
+        assert.ok(await callbackFor(head, runId))
         await deliver('workflow_run', workflowRunPayload('in_progress', head, runId))
         await deliver('workflow_run', workflowRunPayload('completed', head, runId, 'failure'))
         assert.equal((await generation(head))?.state, 'blocked')
@@ -930,6 +1023,7 @@ describe(
     it('ordering: timeout, and the check says so rather than spinning', async () => {
       const head = sha('timeout')
       await deliver('pull_request', pullRequestPayload('opened', 25, head))
+      assert.ok(await callbackFor(head, 5014))
       await deliver('workflow_run', workflowRunPayload('in_progress', head, 5014))
       assert.equal((await generation(head))?.state, 'running')
 


### PR DESCRIPTION
## What is wrong

The `Antifailure` check on this repository's own pull requests says this on
every one of them, open and merged:

> **Nothing was verified**
> Commit `ada5644`. The workflow run finished successfully and Antifailure never
> reported a result, so nothing was verified.

It is right, and it has been right for the life of the feature. Two independent
faults, either one enough for silence.

## Fault one, and it is a product defect rather than a permission

A GitHub App is delivered `workflow_run` for **every** workflow in a repository.
`handleWorkflowRun` bound the first delivery it saw for a commit and then let
that run's completion decide the check. One workflow per repository never
notices. This repository has seventeen.

The timing on `ada5644` says it outright:

| event | time |
| --- | --- |
| check created | 09:40:38Z |
| `Security` finished, green | 09:41:38Z |
| check completed, "Nothing was verified" | 09:43:21Z |
| `Dogfood`, the job that runs `af ci` | still running |

A security scan crossed the line and the control plane read it as the check
coming home empty. So the check was completed and amber before the check had
run, and it was amber for the honest reason that nothing had reported, which is
exactly why it read as true and went unread. The lie was not in the sentence. It
was in having listened to a stranger.

**This matters beyond us.** Any customer with more than one workflow has the
same defect, and the more workflows they have the more reliably their check is
decided by whichever one is fastest.

**The fix.** A workflow run has no standing until it says which run it is, and
it says so by trading a workflow identity GitHub signed for a callback
credential. `run_id` inside that identity is GitHub's own claim about the job,
not something the workflow asserts, so no job can introduce itself as another
one. `issueCallback` already recorded that run id and moved the generation to
running; it just never published, so the check sat on "Waiting for a runner"
while the control plane knew better. It publishes now.

A commit no run ever claims is not passed and not failed. It falls to the
deadline sweeper that already exists, which writes `timed_out` and "the run
never reported back". That sentence is true. The one it replaces was not.

## Fault two, the workflow

Confirming and correcting the hypothesis in the brief: `id-token: write` is
necessary and nowhere near sufficient. `dogfood.yml` was missing four things and
any one of them alone is silence.

- **No `id-token: write`**, so the runner set neither `ACTIONS_ID_TOKEN_REQUEST_URL`
  nor `_TOKEN` and the job could not prove what it was.
- **No control plane address.** `attachControlPlane` mints only when
  `baseURL != ""`, deliberately, so that a laptop never trades an identity
  against a service its user has never heard of. `AF_CONTROL_PLANE` was unset
  and the repository variable `vars.AF_CONTROL_PLANE` does not exist either.
- **No `--report-json`.** `tools/dogfood` never passed it, so `af ci` wrote only
  Markdown and there were no counts to send. The engine has had the flag since
  it was written, with no caller.
- **No post to `/v1/pr/report` anywhere.** `examples/github-workflow.yml`, the
  file customers copy, has always carried those steps. This repository's own
  workflow never did.

Note what the engine's event sink is and is not. It reports events over
`/v1/engine/token`, which is a different credential and a different endpoint
from the check's report. Granting `id-token: write` alone would have started the
event stream and still left the check saying nothing was verified.

## The claim comes before the work

Both this workflow and the example now ask for the credential in their second
step rather than beside the report at the end. Three things, all lost by asking
late:

- the check reads "Building the environment and running the agents" for the
  twenty minutes that is true;
- a job that dies halfway is a run this control plane can name and cancel, which
  is its only route into the runtime holding the environment;
- a dead run is reported in seconds rather than at the deadline.

**Compatibility.** A copy of the old example still works: it claims late, binds
late, and reports. Only the crash path is slower, and it lands on `timed_out`
with a true sentence rather than a wrong one.

## The comment stays

Unconditional, as asked. A fork's pull request gets no identity and no
credential, and the check and the comment are different audiences.

## The fork case, on purpose

Already designed, and I verified it rather than assuming. GitHub withholds the
identity from a fork's pull request job, so the claim step prints why and exits
zero. No red step for an outside contributor. On the control plane side a fork's
generation is `blocked` at creation with:

> This pull request is from a fork, and `<sha>` has not been approved. A
> maintainer who has read this exact commit adds the `antifailure:allow` label.

That is `action_required` with an instruction naming the person who can act and
the exact thing they do. It is not an unfixable red. Two tests already cover it
and both still pass. **So no product change is needed here**, and the App
creating a check it cannot yet receive a report for is correct: the check is how
the contributor learns a maintainer has to approve the commit.

## What this will actually say once it reports

**I do not know, and I am not going to pretend otherwise.** `af ci` on this
repository needs Docker, a Postgres 17 service and roughly twenty minutes, and I
have not run one. It may come back red. If it does, that is an accurate red
replacing a misleading amber, which is progress and is not the same as green. I
have tuned nothing to make it pass. The first run on this pull request is the
answer.

## One step a human has to take

None on the hosted plane, and I changed no live setting. The address is a
literal in the workflow rather than `vars.AF_CONTROL_PLANE`, because a variable
that must be set by hand before the check can work is a variable somebody will
not set, and it was not set here. That is the whole configuration.

If you would rather it came from a variable:

```bash
gh variable set AF_CONTROL_PLANE --repo antifailure/antifailure --body https://app.antifailure.dev
```

and change the one `env:` line back to `${{ vars.AF_CONTROL_PLANE }}`.

**The repository is already bound.** It has to be: a check run only exists for a
generation, a generation only exists for a row in `repositories`, and the check
is being posted. The binding is not the finding.

## Whatever would have caught it

Three tests, and each fails on the tree as it was. That is the point, so here is
the proof.

`TestAJobThatRunsTheCheckCanReportIt`, keyed on the job that runs the harness in
pull request mode rather than on a job name, against `origin/main`:

```
--- FAIL: TestAJobThatRunsTheCheckCanReportIt
  job "dogfood" runs the check and has no `id-token: write` ...
  job "dogfood" runs the check and names no AF_CONTROL_PLANE ...
  job "dogfood" never asks for --report-json ...
  job "dogfood" never asks for a callback credential ...
  job "dogfood" runs the whole product and posts to /v1/pr/report nowhere ...
```

It also refuses to pass silently if the job is renamed out from under it.
`TestTheClaimComesBeforeTheWork` fails on a claim that drifts back to the end.

And the two in `prlifecycle.test.ts`, against the unfixed control plane, which
reproduce the production symptom rather than a nearby question:

```
not ok - a stranger's workflow run cannot end a check it never ran
    expected: 'queued'   actual: 'unverified'
not ok - a stranger's run that fails cannot block a check either
    expected: 'queued'   actual: 'blocked'
```

## Verified

| what | result |
| --- | --- |
| `go test ./tools/dogfood/` | pass |
| `prlifecycle.test.ts` | 39 pass, 0 fail |
| `githubapi` + `reportseam` + `hosted` | 64 pass, 0 fail |
| `tsc --noEmit` on the API | clean |
| both workflow files parse | yes |
| a real `af ci` on this branch | **not run**, see above |

The API tests were run against a Postgres I started for this branch. The shared
`af-cp-test` container carries other lanes' unmerged migrations and fails at the
hook with `relation "oidc_repository_bindings" already exists`, which is not
this change.

## One thing I found and did not fix

`examples/github-workflow.yml` defines `seed` and `concurrency` twice each in
its `workflow_dispatch.inputs`, on `main`, before this branch. GitHub takes the
last, so the first description of each is dead text. Out of scope here and worth
somebody's lane.
