### PR TITLE
infra: put the do not restore instruction in the file it applies to

### DIFF
--- a/infra/terraform/modules/control-plane/keyvault.tf
+++ b/infra/terraform/modules/control-plane/keyvault.tf
@@ -318,6 +318,14 @@ resource "azurerm_key_vault_secret" "owned" {
 # either. An apply that stops with "secret not found" beats a plan that only
 # verifies the environment where it does not matter.
 #
+# DO NOT RESTORE THE DATA SOURCE. This is the file somebody edits when they see
+# a constructed id where a read used to be, so the instruction belongs here and
+# not only in production.tfvars. Restoring it does not give the existence check
+# back: it gives back a plan that fails on permission, on production, for every
+# pull request, and the only way through is the grant refused above. If the
+# check is what you want, the honest place for it is the apply, which already
+# names the secret it could not find.
+#
 # Empty on no App, so a stack without one renders no secret block at all, which
 # is what the count on the old data sources was for.
 #


### PR DESCRIPTION
One comment, in the one place it was missing.

## What is already on main, verified rather than assumed

Checking `origin/main` at 2f8a8a97 before writing this, the comment work from 210 **did land**. All three pieces are there:

| Piece | Where | On main |
| --- | --- | --- |
| `DO NOT RESTORE THE DATA SOURCE TO GET THE CHECK BACK` | `production.tfvars` | yes |
| `STAGING IS THE HONEST COST`, and that staging loses its check | `production.tfvars` | yes |
| do not reintroduce a data source believing the flag covers it | `infra.yml` | yes |
| the constructed ids themselves | `keyvault.tf` | yes |

So no follow up was needed for those, and this pull request does not restate them.

## What actually was missing

`keyvault.tf` carried the reasoning but not the instruction. That is the file somebody opens when they notice a constructed id where a data source used to be, so it is where the imperative has to be. A reader who skims reasoning still obeys an instruction.

It also now says what restoring the data source would produce, because the mistake is not obviously wrong when you make it. It does not fail on the author's machine. It fails on permission, on production, for every pull request, and the only apparent way through is the grant that was deliberately refused. That is the path by which a reverted decision quietly becomes a widened one.

Comment only, one file, no behaviour change.