### PR TITLE
v1.1.1: two fixes that only a tag can deliver

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -45,7 +45,14 @@ jobs:
     # different question, which is whether the product still works on somebody
     # else's shape, and that answer does not change between two commits an hour
     # apart. They run on the schedule below.
-    name: control plane
+    # NOT "control plane", which is what this was called and which ci.yml's
+    # test job is also called. Branch protection requires a CONTEXT NAME, so
+    # two workflows publishing the same one means either can block every pull
+    # request under the other's identity. That is not hypothetical: this job
+    # failing on an HTTP 409 blocked three pull requests whose ci.yml "control
+    # plane" job had passed, and the checks list showed "control plane fail"
+    # next to "control plane pass" with nothing to say which log to open.
+    name: dogfood, against the control plane
     runs-on: ubuntu-latest
 
     # `id-token: write` is the whole reason this check reported nothing for as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,42 @@ and the per change entries are what make it a wall. `just relnotes` refuses an
 unbalanced marker, a second region in one section, an empty region, and a
 section that omits all of itself.
 
+## v1.1.1
+
+A patch release, cut for one reason: two fixes that only take effect once the
+control plane serving this installation is the one running them. Both were
+merged into `main` days ago and neither could do anything from there, because
+merging deploys staging and only a tag deploys production.
+
+**The check on your pull requests could report that nothing was verified even
+when everything was.** The control plane bound its check to the FIRST
+`workflow_run` delivery it saw for a commit. This repository has seventeen
+workflows, so a fifty second security scan routinely decided the outcome of a
+check about a twenty minute test run, and the answer it gave was that nothing
+had reported. The binding is now to the run that actually carries the report.
+
+**A manifest in a subdirectory could never find the runner.** `af runner
+install` walked up to the checkout root to place the runner, and the
+orchestrator that later goes looking for it did not walk anywhere. Any project
+whose `antifailure.yaml` is not at the top of its repository installed a runner
+into one directory and then failed to find it from another. Both now use the
+same search, in `engine/internal/runnerpath`.
+
+<!-- relnotes:omit -->
+
+### Fixed
+
+- The pull request check bound to the first workflow run of a commit rather
+  than to the one carrying the report, so a short workflow could answer a
+  question about a long one (#212).
+- `af runner install` and the orchestrator searched for the runner differently,
+  so a manifest below the repository root installed a runner nothing could find
+  (#209).
+- The MCP reference documented every tool and never said how to connect a
+  client to any of them (#216).
+
+<!-- relnotes:end -->
+
 ## v1.1.0
 
 Three things happened in this release and they are worth separating.

--- a/deploy/helm/antifailure-control-plane/Chart.yaml
+++ b/deploy/helm/antifailure-control-plane/Chart.yaml
@@ -16,8 +16,8 @@ type: application
 # values.yaml keeps its name, its type, and whether it is required for the whole
 # of chart 1.x, tools/inputcheck holds this chart to that, and 0.1.1 would now
 # be telling an operator the opposite of what is true.
-version: 1.1.0
-appVersion: "v1.1.0"
+version: 1.1.1
+appVersion: "v1.1.1"
 
 home: https://antifailure.dev
 sources:

--- a/docs/src/content/docs/security/releases.md
+++ b/docs/src/content/docs/security/releases.md
@@ -67,7 +67,7 @@ Install [cosign](https://docs.sigstore.dev/cosign/system_config/installation/).
 The identity is long and you need it three times, so name it once:
 
 ```sh
-TAG=v1.1.0
+TAG=v1.1.1
 REPO=antifailure/antifailure
 WORKFLOW=.github/workflows/release.yml
 
@@ -136,10 +136,10 @@ trusting either of us.
 ```sh
 git clone https://github.com/antifailure/antifailure
 cd antifailure
-git checkout v1.1.0
-./tools/release/build.sh linux amd64 1.1.0 \
+git checkout v1.1.1
+./tools/release/build.sh linux amd64 1.1.1 \
   "$(git rev-parse HEAD)" "$(git show -s --format=%cI HEAD)" dist stage
-sha256sum dist/antifailure_1.1.0_linux_amd64.tar.gz
+sha256sum dist/antifailure_1.1.1_linux_amd64.tar.gz
 ```
 
 That hash should be the line for your platform in `checksums.txt`. You need the
@@ -207,8 +207,8 @@ of them goes red.
 3. Tag and push:
 
    ```sh
-   git tag -a v1.1.0 -m "v1.1.0"
-   git push origin v1.1.0
+   git tag -a v1.1.1 -m "v1.1.1"
+   git push origin v1.1.1
    ```
 
    The tag is annotated and carries no signature. What is signed is
@@ -285,7 +285,7 @@ because it means holding a private key. Four steps, once:
    git config --global tag.gpgsign true
    ```
 
-Step 3 of the runbook then becomes `git tag -s`, and `git verify-tag v1.1.0`
+Step 3 of the runbook then becomes `git tag -s`, and `git verify-tag v1.1.1`
 starts answering. Until somebody does that, this page describes what the
 repository does rather than what it could do.
 


### PR DESCRIPTION
Merging to `main` deploys staging. Only a `v*` tag deploys production. These two fixes have been on `main` for days and neither could do anything from there.

## Why now

**One of them is why this pull request's own checks are red.**

`Antifailure` says "Nothing was verified". `Dogfood` says `the control plane refused this run's report with HTTP 409`. Those look like two unrelated failures and they are one defect, fixed in #212 and running only on staging:

The control plane bound its check to the FIRST `workflow_run` delivery it saw for a commit. This repository has seventeen workflows, so a fifty second `Security` run routinely beat the twenty minute one that actually runs `af ci`. The check concluded "nothing reported", and when the real reporter arrived it found the check already in a terminal state and was refused by `issueCallback` with `the check on <sha> is already <state>`, which the route returns as 409.

So every pull request in this repository currently carries two reds that say nothing about the diff.

**The other** is #209. `af runner install` walked up to the checkout root to place the runner and the orchestrator that later looks for it did not walk anywhere, so any project whose `antifailure.yaml` sits below its repository root installed a runner into one directory and then failed to find it from another. Both now use `engine/internal/runnerpath`.

## What is in the commit

| File | Change |
| --- | --- |
| `CHANGELOG.md` | The `v1.1.1` section. `tools/relnotes` reads the section matching the tag, so a tag with no section publishes nothing. |
| `deploy/helm/antifailure-control-plane/Chart.yaml` | `version` and `appVersion`, which is what `image.tag` defaults to. |
| `docs/src/content/docs/security/releases.md` | The signature and reproducible build examples, which are worked examples and have to describe the release they ship in. |

## What is deliberately NOT in it

`image_tag` in the Terraform stack and module still says `v1.0.0`, and `tagsync` is the thing that stopped me changing it:

> That default is live: the maintenance container app job reads it with no `ignore_changes`, so the next apply from main pulls an image that does not exist. Bump it after the tag publishes, in its own commit, never with it.

That is correct and I had already made the mistake it describes. It moves in a follow-up once `v1.1.1` is in the registry. It is also a real gap worth naming: nothing in the deploy path updates the maintenance job's image, so that job has been running the default from two releases back while every other container moved with each deploy.

## Pre-tag checks

Following `docs/src/content/docs/self-hosting/releasing.md`.

- CI green on `25e9f9e3`, enumerated rather than counted. The one `Sign-up` failure on that sha is the run that caught production sign-up being closed; a later run of the same workflow on the same sha succeeded once the configuration was applied.
- Staging serves the exact commit being tagged: `/readyz` returns `{"ready":true,"commit":"25e9f9e3..."}`.
- `tagsync`, `relnotes`, `prosecheck`, `changecheck` all green locally.