### PR TITLE
console: Plan refused an owner after their role changed

### DIFF
--- a/.changes/analytics-was-in-every-customers-sidebar.md
+++ b/.changes/analytics-was-in-every-customers-sidebar.md
@@ -1,32 +1,30 @@
 # fixed
 
-The operator's analytics dashboard was in every customer's sidebar, and an
-owner could be told their role could not see the plan.
+The Plan page no longer refuses an owner because its shared browser session
+still holds the role they had before a promotion.
 
-Two defects with one shape: a screen decided what to show from a question it
-had not finished asking.
+The production ordering was exact. On 2026-09-03 an active session began at
+04:50:45 UTC. The membership changed to owner at 12:22:59 UTC. The shared layout
+correctly preserved its already ready session state across navigation. When the
+Plan page opened, `billing.get`, `subscriptions.current` and
+`subscriptions.invoices` each read the current owner role from the database and
+succeeded. The page then replaced those results with a refusal based on the old
+client role.
 
-**Analytics.** The page counts arrivals across the WHOLE installation, and its
-own docstring calls it the operator's dashboard. The console gated it on
-`analytics.read`, which owners and admins of every organization hold, because
-it describes a kind of reading rather than a right over the installation. So it
-appeared in every tenant's navigation, and clicking it produced a refusal
-written for somebody else. On an installation that had never set
-`AF_ANALYTICS_OPERATOR_ORG`, which is every installation by default, it refused
-the operator too, so the entry led nowhere for anybody.
+The Plan page now leaves access to those three server procedures. The shared
+session refreshes after a successful role change, GitHub membership sync or
+member removal, and when the window regains focus or a hidden tab becomes
+visible. Only the newest response wins when those refreshes overlap. The
+session response cannot be stored in a browser or intermediary cache. If a
+refresh fails, the live shell keeps the last good answer and says that its
+controls may be out of date, with a retry beside it.
 
-The session now reports whether this organization operates the installation,
-and the entry appears only then. A boolean rather than the slug, because
-naming the operator to a tenant is a fact about somebody else.
+The mobile shell also returns keyboard focus to the menu button after its
+drawer closes, rather than leaving focus on a control that no longer exists.
 
-**The plan page, and two others.** `may()` answers "does this role hold this
-permission", and a role that has not loaded is not a role that holds nothing.
-Three pages called it before the session resolved and rendered a REFUSAL, so an
-owner opening the plan page was told their role could not see it, about a
-permission owners are the only holders of. A refusal is the worst thing to show
-while waiting, because it is the one message somebody acts on rather than waits
-through: they go looking for whoever can change their role.
-
-`permissionVerdict` returns four answers instead of two, and separates a
-session that failed to load from a role that was refused, because those send
-the reader to different places.
+The operator analytics dashboard is also absent from customer navigation. Its
+page and navigation now share one check that requires both the operator
+organization marker and the `analytics.read` permission. Owners and admins of
+the operator organization can open it. Members, viewers, customer owners and
+installations with no operator configured cannot. The session reports only the
+boolean marker, never another organization's slug.

--- a/.changes/analytics-was-in-every-customers-sidebar.md
+++ b/.changes/analytics-was-in-every-customers-sidebar.md
@@ -1,0 +1,32 @@
+# fixed
+
+The operator's analytics dashboard was in every customer's sidebar, and an
+owner could be told their role could not see the plan.
+
+Two defects with one shape: a screen decided what to show from a question it
+had not finished asking.
+
+**Analytics.** The page counts arrivals across the WHOLE installation, and its
+own docstring calls it the operator's dashboard. The console gated it on
+`analytics.read`, which owners and admins of every organization hold, because
+it describes a kind of reading rather than a right over the installation. So it
+appeared in every tenant's navigation, and clicking it produced a refusal
+written for somebody else. On an installation that had never set
+`AF_ANALYTICS_OPERATOR_ORG`, which is every installation by default, it refused
+the operator too, so the entry led nowhere for anybody.
+
+The session now reports whether this organization operates the installation,
+and the entry appears only then. A boolean rather than the slug, because
+naming the operator to a tenant is a fact about somebody else.
+
+**The plan page, and two others.** `may()` answers "does this role hold this
+permission", and a role that has not loaded is not a role that holds nothing.
+Three pages called it before the session resolved and rendered a REFUSAL, so an
+owner opening the plan page was told their role could not see it, about a
+permission owners are the only holders of. A refusal is the worst thing to show
+while waiting, because it is the one message somebody acts on rather than waits
+through: they go looking for whoever can change their role.
+
+`permissionVerdict` returns four answers instead of two, and separates a
+session that failed to load from a role that was refused, because those send
+the reader to different places.

--- a/console/app/(app)/analytics/page.tsx
+++ b/console/app/(app)/analytics/page.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useState } from "react";
 import { useSessionContext } from "@/components/session";
 import { query, useApi } from "@/lib/api";
+import { mayReadAnalytics } from "@/lib/roles";
 import { DayColumns, Meter } from "@/components/Meter";
 import {
   Card,
@@ -159,30 +160,35 @@ function Analytics() {
   const overview = useApi<Overview>(() => query("analytics.overview", { days }), [days]);
   const catalog = useApi<CatalogAnswer>(() => query("analytics.catalog"), []);
 
-  // Two questions, and the old code asked only the weaker one.
-  //
-  // analytics.read is held by owners and admins of EVERY organization, so
-  // asking it alone let any owner reach this page and meet a server refusal
-  // written for somebody else. The question that decides it is whether this
-  // organization operates the installation, which the session answers and
-  // routers/analytics.ts enforces. Hiding the page is still a convenience and
-  // never the boundary; the server refuses regardless of what is rendered.
-  if (session.status === "loading") {
-    return (
-      <Page title="Analytics">
-        <CardSkeleton count={2} />
-      </Page>
-    );
-  }
-  if (!session.data?.analyticsOperator) {
+  // The shared helper asks both questions: whether this organization operates
+  // the installation and whether this role holds analytics.read. The server
+  // enforces both again, so this branch is a useful screen rather than the
+  // boundary.
+  if (!mayReadAnalytics(session.data)) {
+    const operator = session.data?.analyticsOperator === true;
     return (
       <Page title="Analytics">
         <Card title="Analytics">
-          <Empty title="This dashboard is not about your organization">
-            It counts arrivals across the whole installation, so it belongs to
-            whoever operates this control plane rather than to any one tenant on
-            it. Your own runs, environments and usage are on the pages in the
-            menu.
+          <Empty
+            title={
+              operator
+                ? "Your role cannot see this"
+                : "This dashboard is not about your organization"
+            }
+          >
+            {operator ? (
+              <>
+                The dashboard covers the whole installation, so it needs the
+                analytics.read permission, which owners and admins have.
+              </>
+            ) : (
+              <>
+                It counts arrivals across the whole installation, so it belongs
+                to whoever operates this control plane rather than to any one
+                tenant on it. Your own runs, environments and usage are on the
+                pages in the menu.
+              </>
+            )}
           </Empty>
         </Card>
       </Page>

--- a/console/app/(app)/analytics/page.tsx
+++ b/console/app/(app)/analytics/page.tsx
@@ -3,7 +3,6 @@
 import { Suspense, useState } from "react";
 import { useSessionContext } from "@/components/session";
 import { query, useApi } from "@/lib/api";
-import { may } from "@/lib/roles";
 import { DayColumns, Meter } from "@/components/Meter";
 import {
   Card,
@@ -160,18 +159,30 @@ function Analytics() {
   const overview = useApi<Overview>(() => query("analytics.overview", { days }), [days]);
   const catalog = useApi<CatalogAnswer>(() => query("analytics.catalog"), []);
 
-  // The permission the console knows about. The server checks it again and then
-  // checks something this copy cannot express: that the caller belongs to the
-  // organization operating this installation. So hiding the page here is a
-  // convenience and never the boundary, and the server's refusal is what the
-  // Loaded branch below renders when it disagrees.
-  if (!may(session.data?.role, "analytics.read")) {
+  // Two questions, and the old code asked only the weaker one.
+  //
+  // analytics.read is held by owners and admins of EVERY organization, so
+  // asking it alone let any owner reach this page and meet a server refusal
+  // written for somebody else. The question that decides it is whether this
+  // organization operates the installation, which the session answers and
+  // routers/analytics.ts enforces. Hiding the page is still a convenience and
+  // never the boundary; the server refuses regardless of what is rendered.
+  if (session.status === "loading") {
+    return (
+      <Page title="Analytics">
+        <CardSkeleton count={2} />
+      </Page>
+    );
+  }
+  if (!session.data?.analyticsOperator) {
     return (
       <Page title="Analytics">
         <Card title="Analytics">
-          <Empty title="Your role cannot see this">
-            The dashboard covers the whole installation rather than one organization, so it needs
-            the analytics.read permission, which owners and admins have.
+          <Empty title="This dashboard is not about your organization">
+            It counts arrivals across the whole installation, so it belongs to
+            whoever operates this control plane rather than to any one tenant on
+            it. Your own runs, environments and usage are on the pages in the
+            menu.
           </Empty>
         </Card>
       </Page>

--- a/console/app/(app)/cli/page.tsx
+++ b/console/app/(app)/cli/page.tsx
@@ -3,12 +3,13 @@
 import { useEffect, useState } from "react";
 import { mutate, query, useApi } from "@/lib/api";
 import { useSessionContext } from "@/components/session";
-import { may } from "@/lib/roles";
+import { permissionVerdict, type PermissionVerdict } from "@/lib/roles";
 import {
   Badge,
   Bar,
   Button,
   Card,
+  CardSkeleton,
   CommandBlock,
   Empty,
   LinkButton,
@@ -285,12 +286,29 @@ function ForCI({ origin }: { origin: string | null }) {
  * engine token is a secret somebody pasted into a build machine. Revoking
  * either takes effect on the next request, since every route re-reads the row.
  */
-function Tokens({ mayManage, csrf }: { mayManage: boolean; csrf: string }) {
+function Tokens({ verdict, csrf }: { verdict: PermissionVerdict; csrf: string }) {
   const state = useApi<TokenRow[]>(() => query<TokenRow[]>("tokens.list"), []);
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  if (!mayManage) {
+  // Only a resolved session decides this. While it is loading, a refusal here
+  // reads as "your role was checked and found wanting", which is a sentence
+  // about a role nobody has read yet.
+  if (verdict === "loading") {
+    return <CardSkeleton count={1} />;
+  }
+  if (verdict === "unavailable") {
+    return (
+      <Card title="Terminals and tokens">
+        <p className="max-w-[74ch] px-4 py-4 text-[13px] leading-6 text-muted">
+          This session could not be read, so which machines can act as this
+          organization is not known here. Signing your own terminal in above
+          still works.
+        </p>
+      </Card>
+    );
+  }
+  if (verdict === "refused") {
     return (
       <Card title="Terminals and tokens">
         <p className="max-w-[74ch] px-4 py-4 text-[13px] leading-6 text-muted">
@@ -430,7 +448,7 @@ export default function CliPage() {
         <SignIn origin={origin} />
         <FirstRun />
         <ForCI origin={origin} />
-        <Tokens mayManage={may(role, "tokens.manage")} csrf={csrf} />
+        <Tokens verdict={permissionVerdict(session.status, role, "tokens.manage")} csrf={csrf} />
       </div>
     </Page>
   );

--- a/console/app/(app)/cli/page.tsx
+++ b/console/app/(app)/cli/page.tsx
@@ -3,13 +3,12 @@
 import { useEffect, useState } from "react";
 import { mutate, query, useApi } from "@/lib/api";
 import { useSessionContext } from "@/components/session";
-import { permissionVerdict, type PermissionVerdict } from "@/lib/roles";
+import { may } from "@/lib/roles";
 import {
   Badge,
   Bar,
   Button,
   Card,
-  CardSkeleton,
   CommandBlock,
   Empty,
   LinkButton,
@@ -286,29 +285,12 @@ function ForCI({ origin }: { origin: string | null }) {
  * engine token is a secret somebody pasted into a build machine. Revoking
  * either takes effect on the next request, since every route re-reads the row.
  */
-function Tokens({ verdict, csrf }: { verdict: PermissionVerdict; csrf: string }) {
+function Tokens({ mayManage, csrf }: { mayManage: boolean; csrf: string }) {
   const state = useApi<TokenRow[]>(() => query<TokenRow[]>("tokens.list"), []);
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  // Only a resolved session decides this. While it is loading, a refusal here
-  // reads as "your role was checked and found wanting", which is a sentence
-  // about a role nobody has read yet.
-  if (verdict === "loading") {
-    return <CardSkeleton count={1} />;
-  }
-  if (verdict === "unavailable") {
-    return (
-      <Card title="Terminals and tokens">
-        <p className="max-w-[74ch] px-4 py-4 text-[13px] leading-6 text-muted">
-          This session could not be read, so which machines can act as this
-          organization is not known here. Signing your own terminal in above
-          still works.
-        </p>
-      </Card>
-    );
-  }
-  if (verdict === "refused") {
+  if (!mayManage) {
     return (
       <Card title="Terminals and tokens">
         <p className="max-w-[74ch] px-4 py-4 text-[13px] leading-6 text-muted">
@@ -448,7 +430,7 @@ export default function CliPage() {
         <SignIn origin={origin} />
         <FirstRun />
         <ForCI origin={origin} />
-        <Tokens verdict={permissionVerdict(session.status, role, "tokens.manage")} csrf={csrf} />
+        <Tokens mayManage={may(role, "tokens.manage")} csrf={csrf} />
       </div>
     </Page>
   );

--- a/console/app/(app)/members/page.tsx
+++ b/console/app/(app)/members/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { mutate, query, useApi } from "@/lib/api";
 import { useSessionContext } from "@/components/session";
 import { may } from "@/lib/roles";
@@ -492,6 +492,10 @@ function Members() {
   const state = useApi<Member[]>(() => query("members.list"), []);
   const csrf = session.data?.csrfToken ?? "";
   const mayManage = may(session.data?.role, "members.manage");
+  const reloadMembership = useCallback(() => {
+    state.reload();
+    session.reload();
+  }, [session.reload, state.reload]);
 
   const [removing, setRemoving] = useState<Member | null>(null);
   const [busy, setBusy] = useState(false);
@@ -510,7 +514,7 @@ function Members() {
       <div className="space-y-6">
         <Card
           title="People"
-          actions={mayManage ? <SyncFromGitHub csrf={csrf} onSynced={state.reload} /> : null}
+          actions={mayManage ? <SyncFromGitHub csrf={csrf} onSynced={reloadMembership} /> : null}
         >
           <Loaded state={state} skeleton={<TableSkeleton rows={4} cols={5} />}>
             {(rows) => {
@@ -567,7 +571,7 @@ function Members() {
                           </Td>
                           <Td label="Role">
                             {mayManage ? (
-                              <RolePicker member={m} csrf={csrf} onChanged={state.reload} />
+                              <RolePicker member={m} csrf={csrf} onChanged={reloadMembership} />
                             ) : (
                               <Badge>{m.role}</Badge>
                             )}
@@ -615,7 +619,7 @@ function Members() {
           try {
             await mutate("members.remove", { githubLogin: m.github_login }, csrf);
             setRemoving(null);
-            state.reload();
+            reloadMembership();
           } catch (err) {
             setRemoved((r) => {
               const next = new Set(r);

--- a/console/app/(app)/plan/page.tsx
+++ b/console/app/(app)/plan/page.tsx
@@ -2,12 +2,13 @@
 
 import { useState } from "react";
 import { mutate, query, useApi } from "@/lib/api";
-import { may } from "@/lib/roles";
+import { permissionVerdict } from "@/lib/roles";
 import { useSessionContext } from "@/components/session";
 import {
   Badge,
   Button,
   Card,
+  CardSkeleton,
   Empty,
   Loaded,
   Page,
@@ -135,11 +136,32 @@ function Billing() {
     return { quota, billing, invoices: invoicePage.invoices };
   }, []);
   const csrf = session.data?.csrfToken ?? "";
-  const mayManage = may(session.data?.role, "billing.manage");
+  const verdict = permissionVerdict(session.status, session.data?.role, "billing.manage");
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  if (!mayManage) {
+  // Three answers, not two. An owner opening this page used to be told their
+  // role could not see it, because the session had not arrived and an absent
+  // role read as a role that does not hold billing.manage. A refusal is the
+  // worst thing to render while waiting: it is the one message somebody acts
+  // on rather than waits through.
+  if (verdict === "loading") {
+    return <CardSkeleton count={2} />;
+  }
+  if (verdict === "unavailable") {
+    return (
+      <Card title="Plan">
+        <Empty
+          title="That did not load"
+          action={<Button onClick={session.reload}>Try again</Button>}
+        >
+          The plan needs your role, and this session could not be read. Nothing
+          here says anything about what you may do.
+        </Empty>
+      </Card>
+    );
+  }
+  if (verdict === "refused") {
     return (
       <Card title="Plan">
         <Empty title="Your role cannot see this">

--- a/console/app/(app)/plan/page.tsx
+++ b/console/app/(app)/plan/page.tsx
@@ -2,13 +2,11 @@
 
 import { useState } from "react";
 import { mutate, query, useApi } from "@/lib/api";
-import { permissionVerdict } from "@/lib/roles";
 import { useSessionContext } from "@/components/session";
 import {
   Badge,
   Button,
   Card,
-  CardSkeleton,
   Empty,
   Loaded,
   Page,
@@ -127,6 +125,10 @@ function money(amount: string | number, currency: string): string {
 
 function Billing() {
   const session = useSessionContext();
+  // These procedures each enforce billing.manage after reading the current
+  // role from the database. The shared browser session can hold an older role
+  // until its refresh returns, so it must not decide whether their data gets
+  // rendered. A server refusal still reaches Loaded as the page error.
   const state = useApi<PageState>(async () => {
     const [quota, billing, invoicePage] = await Promise.all([
       query<PlanState>("billing.get"),
@@ -136,41 +138,8 @@ function Billing() {
     return { quota, billing, invoices: invoicePage.invoices };
   }, []);
   const csrf = session.data?.csrfToken ?? "";
-  const verdict = permissionVerdict(session.status, session.data?.role, "billing.manage");
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-
-  // Three answers, not two. An owner opening this page used to be told their
-  // role could not see it, because the session had not arrived and an absent
-  // role read as a role that does not hold billing.manage. A refusal is the
-  // worst thing to render while waiting: it is the one message somebody acts
-  // on rather than waits through.
-  if (verdict === "loading") {
-    return <CardSkeleton count={2} />;
-  }
-  if (verdict === "unavailable") {
-    return (
-      <Card title="Plan">
-        <Empty
-          title="That did not load"
-          action={<Button onClick={session.reload}>Try again</Button>}
-        >
-          The plan needs your role, and this session could not be read. Nothing
-          here says anything about what you may do.
-        </Empty>
-      </Card>
-    );
-  }
-  if (verdict === "refused") {
-    return (
-      <Card title="Plan">
-        <Empty title="Your role cannot see this">
-          The plan decides this organization&rsquo;s quotas, and changing it needs
-          the billing.manage permission, which only an owner holds.
-        </Empty>
-      </Card>
-    );
-  }
 
   async function act(name: string, action: () => Promise<void>) {
     setBusy(name);

--- a/console/components/Shell.tsx
+++ b/console/components/Shell.tsx
@@ -22,7 +22,7 @@ import {
 } from "@/components/icons";
 import { rest, type Session } from "@/lib/api";
 import { useSessionContext } from "@/components/session";
-import { may } from "@/lib/roles";
+import { may, mayReadAnalytics } from "@/lib/roles";
 import { Button, Field, Lede, LinkButton, Standalone, inputClass } from "@/components/ui";
 
 /**
@@ -75,10 +75,9 @@ const NAV = [
  * variable unset, so did the operator. A navigation entry that always leads to
  * a refusal is worse than no entry.
  *
- * It is not gated on analytics.read. That permission is held by owners and
- * admins of every organization, because it describes a kind of reading rather
- * than a right over this installation. The session's `analyticsOperator` is
- * the only field that answers the question the menu is actually asking.
+ * `analyticsOperator` identifies the right organization, then analytics.read
+ * keeps members and viewers of that organization out. The same helper asks
+ * both questions here and on the page.
  */
 const OPERATOR_NAV = [
   { href: "/analytics", label: "Analytics", Icon: IconAnalytics },
@@ -339,7 +338,7 @@ function NavList({ onNavigate }: { onNavigate?: () => void }) {
   const session = useSessionContext();
   // Appended rather than merged into NAV, so the operator's one extra entry
   // sits at the end and the order every customer sees never moves.
-  const items = session.data?.analyticsOperator ? [...NAV, ...OPERATOR_NAV] : NAV;
+  const items = mayReadAnalytics(session.data) ? [...NAV, ...OPERATOR_NAV] : NAV;
   return (
     <ul className="space-y-0.5">
       {items.map(({ href, label, Icon }) => {
@@ -380,14 +379,36 @@ function Who({ session }: { session: Session }) {
   );
 }
 
+function SessionRefreshNotice({ page = false }: { page?: boolean }) {
+  const session = useSessionContext();
+  if (!session.refreshError) return null;
+  const notice = (
+    <div
+      role="status"
+      className="flex flex-wrap items-center gap-x-3 gap-y-2 rounded-lg border border-rule bg-[rgba(138,90,0,0.12)] px-4 py-3"
+    >
+      <p className="text-[12.5px] leading-5 text-ink">
+        Could not refresh your session. Controls may be out of date.
+      </p>
+      <Button onClick={session.reload}>Try again</Button>
+    </div>
+  );
+  return page ? (
+    <div className="mx-auto w-full max-w-[1120px] px-5 pt-5 sm:px-8 lg:px-10">
+      {notice}
+    </div>
+  ) : notice;
+}
+
 export function Shell({ children }: { children: ReactNode }) {
   const session = useSessionContext();
   const pathname = usePathname();
   const [menu, setMenu] = useState(false);
+  const opener = useRef<HTMLButtonElement>(null);
   const closer = useRef<HTMLButtonElement>(null);
 
-  // Escape closes the drawer, and while it is open the page behind it does not
-  // scroll. Both are the parts of a mobile menu that usually get skipped.
+  // Escape closes the drawer, the page behind it does not scroll, and focus
+  // returns to the control that opened it. All three belong to one interaction.
   useEffect(() => {
     if (!menu) return;
     const onKey = (e: KeyboardEvent) => {
@@ -400,6 +421,7 @@ export function Shell({ children }: { children: ReactNode }) {
     return () => {
       document.removeEventListener("keydown", onKey);
       document.body.style.overflow = previous;
+      opener.current?.focus();
     };
   }, [menu]);
 
@@ -450,6 +472,11 @@ export function Shell({ children }: { children: ReactNode }) {
           you leave rather than what you bought: take a copy of everything,
           sign a session out, delete the organization, and close your account.
         </Lede>
+        {session.refreshError ? (
+          <div className="mt-5">
+            <SessionRefreshNotice />
+          </div>
+        ) : null}
         <div className="mt-6 space-y-3">
           {mayBill ? (
             <LinkButton href="/plan" full>
@@ -530,7 +557,10 @@ export function Shell({ children }: { children: ReactNode }) {
             </span>
           </div>
         </header>
-        <main>{children}</main>
+        <main>
+          <SessionRefreshNotice page />
+          {children}
+        </main>
       </div>
     );
   }
@@ -560,6 +590,7 @@ export function Shell({ children }: { children: ReactNode }) {
           </span>
         </Link>
         <button
+          ref={opener}
           type="button"
           onClick={() => setMenu(true)}
           aria-expanded={menu}
@@ -605,7 +636,10 @@ export function Shell({ children }: { children: ReactNode }) {
         </div>
       ) : null}
 
-      <main className="min-w-0">{children}</main>
+      <main className="min-w-0">
+        <SessionRefreshNotice page />
+        {children}
+      </main>
     </div>
   );
 }

--- a/console/components/Shell.tsx
+++ b/console/components/Shell.tsx
@@ -62,8 +62,26 @@ const NAV = [
   { href: "/plan", label: "Plan", Icon: IconPlan },
   { href: "/keys", label: "Provider keys", Icon: IconKeys },
   { href: "/cli", label: "Command line", Icon: IconTerminal },
-  { href: "/analytics", label: "Analytics", Icon: IconAnalytics },
   { href: "/settings", label: "Settings", Icon: IconSettings },
+];
+
+/**
+ * Analytics is not a customer's page and was in every customer's sidebar.
+ *
+ * The dashboard behind it covers the WHOLE installation: where people came
+ * from, where they landed, how far they got. `routers/analytics.ts` refuses
+ * anybody outside the organization named by AF_ANALYTICS_OPERATOR_ORG, so
+ * every tenant who clicked it got an error, and on an installation with that
+ * variable unset, so did the operator. A navigation entry that always leads to
+ * a refusal is worse than no entry.
+ *
+ * It is not gated on analytics.read. That permission is held by owners and
+ * admins of every organization, because it describes a kind of reading rather
+ * than a right over this installation. The session's `analyticsOperator` is
+ * the only field that answers the question the menu is actually asking.
+ */
+const OPERATOR_NAV = [
+  { href: "/analytics", label: "Analytics", Icon: IconAnalytics },
 ];
 
 /**
@@ -318,9 +336,13 @@ function SignOutButton() {
 
 function NavList({ onNavigate }: { onNavigate?: () => void }) {
   const pathname = usePathname();
+  const session = useSessionContext();
+  // Appended rather than merged into NAV, so the operator's one extra entry
+  // sits at the end and the order every customer sees never moves.
+  const items = session.data?.analyticsOperator ? [...NAV, ...OPERATOR_NAV] : NAV;
   return (
     <ul className="space-y-0.5">
-      {NAV.map(({ href, label, Icon }) => {
+      {items.map(({ href, label, Icon }) => {
         const active = pathname === href;
         return (
           <li key={href}>

--- a/console/components/session.tsx
+++ b/console/components/session.tsx
@@ -1,14 +1,10 @@
 "use client";
 
-import { createContext, useContext, type ReactNode } from "react";
-import { useSession, type ApiError, type Session } from "@/lib/api";
+import { createContext, useContext, useEffect, type ReactNode } from "react";
+import { useSession } from "@/lib/api";
+import { shouldRefreshSession } from "@/lib/session-freshness";
 
-interface SessionState {
-  status: "loading" | "ready" | "error";
-  data: Session | null;
-  error: ApiError | null;
-  reload: () => void;
-}
+type SessionState = ReturnType<typeof useSession>;
 
 const Ctx = createContext<SessionState | null>(null);
 
@@ -23,7 +19,25 @@ const Ctx = createContext<SessionState | null>(null);
  */
 export function SessionProvider({ children }: { children: ReactNode }) {
   const state = useSession();
-  return <Ctx.Provider value={state as SessionState}>{children}</Ctx.Provider>;
+  const reload = state.reload;
+
+  useEffect(() => {
+    const onFocus = () => {
+      if (shouldRefreshSession("focus", document.visibilityState)) reload();
+    };
+    const onVisibilityChange = () => {
+      if (shouldRefreshSession("visibilitychange", document.visibilityState)) reload();
+    };
+
+    window.addEventListener("focus", onFocus);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => {
+      window.removeEventListener("focus", onFocus);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, [reload]);
+
+  return <Ctx.Provider value={state}>{children}</Ctx.Provider>;
 }
 
 /** The session, from the provider. Throws rather than silently refetching if a

--- a/console/lib/api.ts
+++ b/console/lib/api.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { trpcData } from "@/lib/wire";
+import { isCurrentResponse } from "@/lib/session-freshness";
 
 /**
  * Where the API is.
@@ -136,6 +137,8 @@ export async function rest<T>(
   init: {
     method?: string;
     body?: unknown;
+    /** Browser cache policy for endpoints whose answer is identity or access. */
+    cache?: RequestCache;
     /** The TENANT token, sent as x-antifailure-csrf. */
     csrf?: string;
     /**
@@ -164,6 +167,7 @@ export async function rest<T>(
   const res = await fetch(`${BASE}${path}`, {
     method,
     credentials: "same-origin",
+    cache: init.cache,
     headers,
     body: init.body === undefined ? undefined : JSON.stringify(init.body),
   });
@@ -254,12 +258,12 @@ export function useApi<T>(fn: () => Promise<T>, deps: unknown[] = []) {
     run
       .current()
       .then((data) => {
-        if (!alive.current || mine !== seq.current) return;
+        if (!isCurrentResponse(alive.current, mine, seq.current)) return;
         setState({ status: "ready", data, error: null });
         setRefreshing(false);
       })
       .catch((error: unknown) => {
-        if (!alive.current || mine !== seq.current) return;
+        if (!isCurrentResponse(alive.current, mine, seq.current)) return;
         setRefreshing(false);
         // The held rows are still the last thing the control plane actually
         // said. Throwing them away because the next question went unanswered
@@ -279,7 +283,7 @@ export function useApi<T>(fn: () => Promise<T>, deps: unknown[] = []) {
 
 /** The signed-in session, or the absence of one. */
 export function useSession() {
-  return useApi<Session>(() => rest<Session>("/auth/session"), []);
+  return useApi<Session>(() => rest<Session>("/auth/session", { cache: "no-store" }), []);
 }
 
 /**

--- a/console/lib/api.ts
+++ b/console/lib/api.ts
@@ -38,6 +38,11 @@ export interface Session {
   selfServeSignup?: boolean;
   githubAppInstallUrl?: string;
   plan?: string | null;
+  /** Whether this organization is the one operating this installation. Absent
+   *  from an older control plane, which is read as false: showing an
+   *  installation-wide dashboard to a tenant is the failure this field exists
+   *  to end, so an unknown answer hides it rather than showing it. */
+  analyticsOperator?: boolean;
   hostedRequiredPlan?: string | null;
   hostedAccess?: boolean;
 }

--- a/console/lib/plan-access.test.ts
+++ b/console/lib/plan-access.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const source = readFileSync(new URL("../app/(app)/plan/page.tsx", import.meta.url), "utf8");
+
+test("the Plan page does not decide access from the cached client role", () => {
+  // The behavioral half is in the API auth suite: all three procedures return
+  // owner data to a session whose browser snapshot still says member. This
+  // guard keeps the page from putting that older answer back in front of the
+  // live procedure results.
+  assert.equal(
+    source.includes("session.data?.role") || source.includes("Your role cannot see this"),
+    false,
+  );
+});

--- a/console/lib/roles.test.ts
+++ b/console/lib/roles.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { ROLE_PERMISSIONS, may, permissionVerdict } from "./roles.ts";
+import { ROLE_PERMISSIONS, may, mayReadAnalytics } from "./roles.ts";
 
 /*
  * The invariants the lapsed-exits screen is built on.
@@ -53,39 +53,16 @@ test("an unknown or absent role is refused rather than defaulted", () => {
   assert.equal(may("superuser", "billing.manage"), false);
 });
 
-test("a permission that gates a whole screen never reads loading as refused", () => {
-  // The defect this exists for, in one line: an OWNER opened /plan and was
-  // told "your role cannot see this" about billing.manage, which owners are
-  // the only holders of. The page called may() before the session resolved,
-  // read undefined as "does not hold it", and rendered a refusal.
-  assert.equal(permissionVerdict("loading", undefined, "billing.manage"), "loading");
-  assert.equal(permissionVerdict("loading", "owner", "billing.manage"), "loading");
-  // Even a role that genuinely lacks it is still "loading" while loading. The
-  // session in hand at that moment is not the one the answer must come from.
-  assert.equal(permissionVerdict("loading", "viewer", "billing.manage"), "loading");
-});
-
-test("a session that failed to load is unavailable rather than refused", () => {
-  // Separate answers because they send the reader to different places. A
-  // permission error tells somebody to find whoever can change their role; an
-  // unreachable control plane tells them to retry. Rendering the first when
-  // the second is true is the more expensive mistake.
-  assert.equal(permissionVerdict("error", undefined, "billing.manage"), "unavailable");
-  assert.equal(permissionVerdict("error", "owner", "billing.manage"), "unavailable");
-  // Ready and roleless is signed out, or signed in with no organization.
-  // Neither says anything about this permission.
-  assert.equal(permissionVerdict("ready", null, "billing.manage"), "unavailable");
-  assert.equal(permissionVerdict("ready", "", "billing.manage"), "unavailable");
-});
-
-test("a resolved session still decides the permission, both ways", () => {
-  // The positive control. A verdict function that never returns "allowed"
-  // would pass both tests above and break every gated screen.
-  assert.equal(permissionVerdict("ready", "owner", "billing.manage"), "allowed");
-  assert.equal(permissionVerdict("ready", "admin", "billing.manage"), "refused");
-  assert.equal(permissionVerdict("ready", "member", "billing.manage"), "refused");
-  assert.equal(permissionVerdict("ready", "owner", "analytics.read"), "allowed");
-  assert.equal(permissionVerdict("ready", "member", "analytics.read"), "refused");
-  // An unknown role is refused rather than defaulted, same as may().
-  assert.equal(permissionVerdict("ready", "superuser", "billing.manage"), "refused");
+test("analytics needs both the operator organization and a permitted role", () => {
+  assert.deepEqual(
+    [
+      mayReadAnalytics({ analyticsOperator: true, role: "owner" }),
+      mayReadAnalytics({ analyticsOperator: true, role: "admin" }),
+      mayReadAnalytics({ analyticsOperator: true, role: "member" }),
+      mayReadAnalytics({ analyticsOperator: true, role: "viewer" }),
+      mayReadAnalytics({ analyticsOperator: false, role: "owner" }),
+      mayReadAnalytics({ role: "owner" }),
+    ],
+    [true, true, false, false, false, false],
+  );
 });

--- a/console/lib/roles.test.ts
+++ b/console/lib/roles.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { ROLE_PERMISSIONS, may } from "./roles.ts";
+import { ROLE_PERMISSIONS, may, permissionVerdict } from "./roles.ts";
 
 /*
  * The invariants the lapsed-exits screen is built on.
@@ -51,4 +51,41 @@ test("an unknown or absent role is refused rather than defaulted", () => {
   assert.equal(may(undefined, "data.export"), false);
   assert.equal(may("", "organization.delete"), false);
   assert.equal(may("superuser", "billing.manage"), false);
+});
+
+test("a permission that gates a whole screen never reads loading as refused", () => {
+  // The defect this exists for, in one line: an OWNER opened /plan and was
+  // told "your role cannot see this" about billing.manage, which owners are
+  // the only holders of. The page called may() before the session resolved,
+  // read undefined as "does not hold it", and rendered a refusal.
+  assert.equal(permissionVerdict("loading", undefined, "billing.manage"), "loading");
+  assert.equal(permissionVerdict("loading", "owner", "billing.manage"), "loading");
+  // Even a role that genuinely lacks it is still "loading" while loading. The
+  // session in hand at that moment is not the one the answer must come from.
+  assert.equal(permissionVerdict("loading", "viewer", "billing.manage"), "loading");
+});
+
+test("a session that failed to load is unavailable rather than refused", () => {
+  // Separate answers because they send the reader to different places. A
+  // permission error tells somebody to find whoever can change their role; an
+  // unreachable control plane tells them to retry. Rendering the first when
+  // the second is true is the more expensive mistake.
+  assert.equal(permissionVerdict("error", undefined, "billing.manage"), "unavailable");
+  assert.equal(permissionVerdict("error", "owner", "billing.manage"), "unavailable");
+  // Ready and roleless is signed out, or signed in with no organization.
+  // Neither says anything about this permission.
+  assert.equal(permissionVerdict("ready", null, "billing.manage"), "unavailable");
+  assert.equal(permissionVerdict("ready", "", "billing.manage"), "unavailable");
+});
+
+test("a resolved session still decides the permission, both ways", () => {
+  // The positive control. A verdict function that never returns "allowed"
+  // would pass both tests above and break every gated screen.
+  assert.equal(permissionVerdict("ready", "owner", "billing.manage"), "allowed");
+  assert.equal(permissionVerdict("ready", "admin", "billing.manage"), "refused");
+  assert.equal(permissionVerdict("ready", "member", "billing.manage"), "refused");
+  assert.equal(permissionVerdict("ready", "owner", "analytics.read"), "allowed");
+  assert.equal(permissionVerdict("ready", "member", "analytics.read"), "refused");
+  // An unknown role is refused rather than defaulted, same as may().
+  assert.equal(permissionVerdict("ready", "superuser", "billing.manage"), "refused");
 });

--- a/console/lib/roles.ts
+++ b/console/lib/roles.ts
@@ -49,3 +49,38 @@ export const ROLE_PERMISSIONS: Record<string, readonly string[]> = {
 export function may(role: string | null | undefined, permission: string): boolean {
   return (ROLE_PERMISSIONS[role ?? ""] ?? []).includes(permission);
 }
+
+/**
+ * What a screen should render when a permission decides the whole screen.
+ *
+ * WHY THIS IS NOT `may()` WITH AN `if`. `may()` answers one question, "does
+ * this role hold this permission", and a role that has not arrived yet is not
+ * a role that holds nothing: it is not known. Three pages asked `may()` before
+ * the session resolved and rendered a REFUSAL, so an owner loading /plan was
+ * told "your role cannot see this" about a permission owners are the only
+ * holders of. The screenshot of that is what this function exists to prevent.
+ *
+ * A refusal is also the worst possible thing to render while loading, because
+ * it is the one message a person acts on rather than waits through. Somebody
+ * reads it and goes looking for who can change their role.
+ *
+ * The four answers are deliberately four. "unavailable" is separate from
+ * "refused" because a session that failed to load says nothing about the role,
+ * and a page that shows a permission error when the control plane is
+ * unreachable sends the reader after the wrong problem.
+ */
+export type PermissionVerdict = "loading" | "unavailable" | "allowed" | "refused";
+
+export function permissionVerdict(
+  status: "loading" | "ready" | "error",
+  role: string | null | undefined,
+  permission: string,
+): PermissionVerdict {
+  if (status === "loading") return "loading";
+  if (status === "error") return "unavailable";
+  // Ready, and still no role: signed out, or signed in with no organization.
+  // Neither is a refusal about this permission, and both are states the shell
+  // already renders around this page.
+  if (!role) return "unavailable";
+  return may(role, permission) ? "allowed" : "refused";
+}

--- a/console/lib/roles.ts
+++ b/console/lib/roles.ts
@@ -51,36 +51,15 @@ export function may(role: string | null | undefined, permission: string): boolea
 }
 
 /**
- * What a screen should render when a permission decides the whole screen.
+ * Whether the installation analytics link belongs in this session.
  *
- * WHY THIS IS NOT `may()` WITH AN `if`. `may()` answers one question, "does
- * this role hold this permission", and a role that has not arrived yet is not
- * a role that holds nothing: it is not known. Three pages asked `may()` before
- * the session resolved and rendered a REFUSAL, so an owner loading /plan was
- * told "your role cannot see this" about a permission owners are the only
- * holders of. The screenshot of that is what this function exists to prevent.
- *
- * A refusal is also the worst possible thing to render while loading, because
- * it is the one message a person acts on rather than waits through. Somebody
- * reads it and goes looking for who can change their role.
- *
- * The four answers are deliberately four. "unavailable" is separate from
- * "refused" because a session that failed to load says nothing about the role,
- * and a page that shows a permission error when the control plane is
- * unreachable sends the reader after the wrong problem.
+ * Both facts matter. `analyticsOperator` identifies the one organization that
+ * operates this installation, while `analytics.read` keeps members and viewers
+ * of that organization out. The server enforces both again. This helper keeps
+ * the page and both navigation rails from drifting into different questions.
  */
-export type PermissionVerdict = "loading" | "unavailable" | "allowed" | "refused";
-
-export function permissionVerdict(
-  status: "loading" | "ready" | "error",
-  role: string | null | undefined,
-  permission: string,
-): PermissionVerdict {
-  if (status === "loading") return "loading";
-  if (status === "error") return "unavailable";
-  // Ready, and still no role: signed out, or signed in with no organization.
-  // Neither is a refusal about this permission, and both are states the shell
-  // already renders around this page.
-  if (!role) return "unavailable";
-  return may(role, permission) ? "allowed" : "refused";
+export function mayReadAnalytics(
+  session: { analyticsOperator?: boolean; role?: string | null } | null | undefined,
+): boolean {
+  return session?.analyticsOperator === true && may(session.role, "analytics.read");
 }

--- a/console/lib/session-freshness.test.ts
+++ b/console/lib/session-freshness.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { isCurrentResponse, shouldRefreshSession } from "./session-freshness.ts";
+
+const apiSource = readFileSync(new URL("api.ts", import.meta.url), "utf8");
+
+test("window focus refreshes the shared session", () => {
+  assert.equal(shouldRefreshSession("focus", "hidden"), true);
+});
+
+test("only a visible document restoration refreshes the shared session", () => {
+  assert.deepEqual(
+    [
+      shouldRefreshSession("visibilitychange", "visible"),
+      shouldRefreshSession("visibilitychange", "hidden"),
+    ],
+    [true, false],
+  );
+});
+
+test("only the newest response from a mounted provider is current", () => {
+  assert.deepEqual(
+    [
+      isCurrentResponse(true, 4, 4),
+      isCurrentResponse(true, 3, 4),
+      isCurrentResponse(false, 4, 4),
+    ],
+    [true, false, false],
+  );
+});
+
+test("the session request bypasses the browser cache", () => {
+  // The API integration suite checks the matching response header. This side
+  // makes the browser revalidate even if an older deployment omitted it.
+  assert.match(
+    apiSource,
+    /rest<Session>\("\/auth\/session", \{ cache: "no-store" \}\)/,
+  );
+});

--- a/console/lib/session-freshness.ts
+++ b/console/lib/session-freshness.ts
@@ -1,0 +1,30 @@
+export type SessionRefreshTrigger = "focus" | "visibilitychange";
+
+/**
+ * Whether a browser event means the shared session may have changed.
+ *
+ * Focus always asks again. A visibility change asks only when the document is
+ * visible, since refreshing while it is being hidden cannot update a control
+ * anybody can see and the matching visible event follows when they return.
+ */
+export function shouldRefreshSession(
+  trigger: SessionRefreshTrigger,
+  visibilityState: DocumentVisibilityState,
+): boolean {
+  return trigger === "focus" || visibilityState === "visible";
+}
+
+/**
+ * Only the newest session response may replace the shared answer.
+ *
+ * Focus and visibility restoration can happen close together, and member
+ * changes can overlap either one. An older response arriving last must not put
+ * the old role or a session that has since been revoked back on screen.
+ */
+export function isCurrentResponse(
+  mounted: boolean,
+  responseSequence: number,
+  latestSequence: number,
+): boolean {
+  return mounted && responseSequence === latestSequence;
+}

--- a/console/lib/shell-focus.test.ts
+++ b/console/lib/shell-focus.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const source = readFileSync(new URL("../components/Shell.tsx", import.meta.url), "utf8");
+
+test("the mobile drawer returns focus to the control that opened it", () => {
+  // The browser check proves the interaction. This guard keeps both ends of
+  // the focus handoff on the same ref when the drawer is edited later.
+  assert.deepEqual(
+    [source.includes("ref={opener}"), source.includes("opener.current?.focus()")],
+    [true, true],
+  );
+});

--- a/infra/terraform/stacks/control-plane/production.tfvars
+++ b/infra/terraform/stacks/control-plane/production.tfvars
@@ -347,3 +347,31 @@ operator_portal_enabled = true
 # that antifailure.dev actually talks to. Unset here presents to a visitor as a
 # network error on the contact form with no explanation anywhere.
 site_origin = "https://antifailure.dev"
+
+# ---------------------------------------------------------------------------
+# The acquisition dashboard, and who it belongs to.
+# ---------------------------------------------------------------------------
+
+# WITHOUT THIS, THE PAGE CAN ONLY REFUSE. routers/analytics.ts compares the
+# caller's organization slug against this value, and an empty value refuses
+# EVERYBODY with PRECONDITION_FAILED naming the variable. That is the state
+# this plane was in while the console showed the page to every customer, so the
+# only thing anybody ever saw there was an error about a variable they could
+# not set.
+#
+# The slug rather than the identifier, because a slug is what an operator can
+# write here without first querying their own database. It is compared against
+# the row rather than against the session, so renaming the organization takes
+# effect on the next request rather than at a sign-in that may never come.
+#
+# `antifailure` is the organization operating this control plane. It is the
+# same row every tenant here is a peer of, which is why the console never
+# receives this value: naming the operator to a customer is a fact about
+# somebody else. The session carries a boolean instead.
+analytics_operator_org = "antifailure"
+
+# Recording, which is a separate question from reading. Off means the page
+# still renders and says, in the provenance line, that every number on it is
+# zero because nothing is being counted, rather than presenting an empty funnel
+# as a bad week.
+analytics_enabled = true

--- a/web/apps/api/src/server.ts
+++ b/web/apps/api/src/server.ts
@@ -1219,6 +1219,10 @@ export function createServer(options: ServerOptions) {
   const signInMethods = ['github', ...(options.emailSignIn ? ['email'] : [])]
 
   app.get('/auth/session', async (c) => {
+    // Identity, membership, role and revocation are all read live here. A
+    // cached response can restore a permission that was removed or hide one
+    // that was granted, so neither a browser nor an intermediary may retain it.
+    c.header('cache-control', 'no-store')
     const token = readCookie(c.req.header('cookie'), SESSION_COOKIE)
     const publicSignIn = {
       methods: signInMethods,
@@ -1248,14 +1252,14 @@ export function createServer(options: ServerOptions) {
       // cannot know at build time which organization that is, and the slug
       // itself is not the console's business: naming it would tell every
       // customer who operates the plane they are a tenant of. A boolean
-      // answers the only question a navigation menu has.
+      // answers the installation relationship without disclosing the slug.
       //
       // Not a permission, deliberately. analytics.read is held by owners and
       // admins of EVERY organization, because it describes a kind of reading
-      // rather than a right over this installation, and routers/analytics.ts
-      // refuses on the organization regardless of it. Without this field the
-      // console showed an installation-wide dashboard in every customer's
-      // sidebar and let them click through to a refusal.
+      // rather than a right over this installation. The console combines that
+      // permission with this field, and routers/analytics.ts enforces both.
+      // Without the field, the console showed an installation-wide dashboard
+      // in every customer's sidebar and let them click through to a refusal.
       analyticsOperator:
         options.analyticsOperatorOrgSlug != null &&
         session.orgSlug === options.analyticsOperatorOrgSlug,

--- a/web/apps/api/src/server.ts
+++ b/web/apps/api/src/server.ts
@@ -1242,6 +1242,23 @@ export function createServer(options: ServerOptions) {
       orgSlug: session.orgSlug,
       role: session.role,
       plan: session.plan,
+      // Whether THIS organization is the one operating this installation.
+      //
+      // The console is one static export served by every installation, so it
+      // cannot know at build time which organization that is, and the slug
+      // itself is not the console's business: naming it would tell every
+      // customer who operates the plane they are a tenant of. A boolean
+      // answers the only question a navigation menu has.
+      //
+      // Not a permission, deliberately. analytics.read is held by owners and
+      // admins of EVERY organization, because it describes a kind of reading
+      // rather than a right over this installation, and routers/analytics.ts
+      // refuses on the organization regardless of it. Without this field the
+      // console showed an installation-wide dashboard in every customer's
+      // sidebar and let them click through to a refusal.
+      analyticsOperator:
+        options.analyticsOperatorOrgSlug != null &&
+        session.orgSlug === options.analyticsOperatorOrgSlug,
       hostedRequiredPlan,
       hostedAccess: hasHostedAccess(session.plan, hostedRequiredPlan),
       githubAppInstallUrl: options.githubAppInstallUrl,

--- a/web/apps/api/test/analytics-dashboard.test.ts
+++ b/web/apps/api/test/analytics-dashboard.test.ts
@@ -79,6 +79,55 @@ describe(
       assert.equal(errorCode(res.body), 'FORBIDDEN')
     })
 
+    it('tells the console whether THIS organization operates the installation', async () => {
+      // The field the navigation menu reads, and the defect it ends.
+      //
+      // /analytics sat in every customer's sidebar because the console gated
+      // it on analytics.read, which owners and admins of EVERY organization
+      // hold. So a customer clicked an installation-wide dashboard and met a
+      // refusal written for somebody else, and the console had no field that
+      // could have told it otherwise: the slug is deliberately not sent, since
+      // naming the operator to every tenant is a fact about somebody else.
+      const asOperator = await signInAs(h, operator, 'owner')
+      const mine = await h.fetch('/auth/session', { headers: { cookie: asOperator.cookie } })
+      const mineBody = (await mine.json()) as { role: string; analyticsOperator?: boolean }
+      assert.equal(mineBody.role, 'owner')
+      assert.equal(mineBody.analyticsOperator, true)
+
+      // The positive control above is what makes this line mean something: an
+      // owner of another organization holds the same permission and the same
+      // role, and differs only in the one thing the field reports.
+      const asCustomer = await signInAs(h, customer, 'owner')
+      const theirs = await h.fetch('/auth/session', { headers: { cookie: asCustomer.cookie } })
+      const theirsBody = (await theirs.json()) as { role: string; analyticsOperator?: boolean }
+      assert.equal(theirsBody.role, 'owner')
+      assert.equal(theirsBody.analyticsOperator, false)
+
+      // And the slug itself never leaves the control plane.
+      assert.ok(
+        !JSON.stringify(theirsBody).includes(operator.slug),
+        'the session named the operating organization to a tenant',
+      )
+    })
+
+    it('reports no analytics operator at all when the variable is unset', async () => {
+      // The state every self-hosted installation starts in, and the one this
+      // repository's own production plane was in: with nothing configured the
+      // entry must be hidden from EVERYBODY, including the operator, because
+      // the page behind it can only refuse.
+      const unset = await startApi()
+      try {
+        const org = await seedOrg(unset.admin, 'noopsorg')
+        const session = await signInAs(unset, org, 'owner')
+        const res = await unset.fetch('/auth/session', { headers: { cookie: session.cookie } })
+        const body = (await res.json()) as { analyticsOperator?: boolean }
+        assert.equal(body.analyticsOperator, false)
+        await dropOrg(unset.admin, org.orgId)
+      } finally {
+        await unset.close()
+      }
+    })
+
     it('refuses everyone, and says which variable to set, when none is configured', async () => {
       // The default. A dashboard that renders zeros because it is switched off
       // is indistinguishable from one that renders zeros because nobody came,

--- a/web/apps/api/test/analytics-dashboard.test.ts
+++ b/web/apps/api/test/analytics-dashboard.test.ts
@@ -56,6 +56,12 @@ describe(
       assert.equal(body.result.data.provenance.recording, true)
     })
 
+    it('lets an admin of the operator organization read it', async () => {
+      const session = await signInAs(h, operator, 'admin')
+      const res = await callProcedure(h, session, 'analytics.overview', 'query', { days: 28 })
+      assert.equal(res.status, 200, JSON.stringify(res.body))
+    })
+
     it('refuses the OWNER of another organization, who holds every permission in their own', async () => {
       // The case the permission matrix cannot see, and the reason this file
       // exists. A permission check alone answers yes here.
@@ -79,8 +85,15 @@ describe(
       assert.equal(errorCode(res.body), 'FORBIDDEN')
     })
 
+    it('refuses a viewer of the operator organization, who lacks the permission', async () => {
+      const session = await signInAs(h, operator, 'viewer')
+      const res = await callProcedure(h, session, 'analytics.overview', 'query', { days: 28 })
+      assert.equal(errorCode(res.body), 'FORBIDDEN')
+    })
+
     it('tells the console whether THIS organization operates the installation', async () => {
-      // The field the navigation menu reads, and the defect it ends.
+      // One of the two fields the shared console helper reads. The other is
+      // role, because only owners and admins hold analytics.read.
       //
       // /analytics sat in every customer's sidebar because the console gated
       // it on analytics.read, which owners and admins of EVERY organization
@@ -96,7 +109,8 @@ describe(
 
       // The positive control above is what makes this line mean something: an
       // owner of another organization holds the same permission and the same
-      // role, and differs only in the one thing the field reports.
+      // role, and differs only in the installation relationship this field
+      // reports.
       const asCustomer = await signInAs(h, customer, 'owner')
       const theirs = await h.fetch('/auth/session', { headers: { cookie: asCustomer.cookie } })
       const theirsBody = (await theirs.json()) as { role: string; analyticsOperator?: boolean }

--- a/web/apps/api/test/auth.test.ts
+++ b/web/apps/api/test/auth.test.ts
@@ -12,7 +12,9 @@ import {
   ABSOLUTE_LIFETIME_MS, IDLE_TIMEOUT_MS, hashToken, issueSession, resolveSession,
   sessionCookie, readCookie, csrfTokenFor, csrfMatches, sweepSessions,
 } from '../src/auth/session.ts'
-import { safeRedirect, beginSignIn, completeSignIn, syncMembership, SignInError } from '../src/auth/signin.ts'
+import {
+  safeRedirect, beginSignIn, completeSignIn, syncMembership, SignInError, type SyncReport,
+} from '../src/auth/signin.ts'
 import { FakeClock } from '../src/clock.ts'
 import { FakeGitHub } from '../src/auth/fakegithub.ts'
 import { GitHubError } from '../src/auth/github.ts'
@@ -122,6 +124,18 @@ describe('the OAuth exchange', { skip: hasDatabase ? false : 'no Postgres' }, ()
     assert.equal(body.signedIn, true)
     assert.equal(body.orgId, org.orgId)
     assert.equal(body.role, 'member')
+  })
+
+  it('does not let a browser cache a signed in or signed out session', async () => {
+    const signedIn = await signInAs(h, org, 'member', 'uncached')
+    const [withSession, withoutSession] = await Promise.all([
+      h.fetch('/auth/session', { headers: { cookie: signedIn.cookie } }),
+      h.fetch('/auth/session'),
+    ])
+    assert.deepEqual(
+      [withSession.headers.get('cache-control'), withoutSession.headers.get('cache-control')],
+      ['no-store', 'no-store'],
+    )
   })
 
   it('signs in behind a chain of proxies, where the forwarded header is a list', async () => {
@@ -810,6 +824,42 @@ describe('sessions', { skip: hasDatabase ? false : 'no Postgres' }, () => {
     }
   })
 
+  it('billing reads a promotion made after the browser cached its session', async () => {
+    // This is the production ordering. The browser had a ready member session
+    // before the role changed, then the shared layout kept that answer while
+    // the Plan page mounted. Every billing procedure read the new owner role
+    // from the database and succeeded. A client gate over the older answer was
+    // the only refusal in the path.
+    const owner = await signInAs(h, org, 'owner', 'promoter')
+    const promoted = await signInAs(h, org, 'member', 'promoted')
+    const [person] = await h.admin<{ github_login: string }[]>`
+      SELECT github_login FROM users WHERE id = ${promoted.userId}`
+
+    const cached = await h.fetch('/auth/session', { headers: { cookie: promoted.cookie } })
+    const cachedSession = (await cached.json()) as { role: string }
+    const changed = await callProcedure(h, owner, 'members.setRole', 'mutation', {
+      githubLogin: person!.github_login,
+      role: 'owner',
+    })
+    const procedureStatuses: number[] = []
+    for (const [path, input] of [
+      ['billing.get', {}],
+      ['subscriptions.current', {}],
+      ['subscriptions.invoices', { limit: 20 }],
+    ] as const) {
+      const response = await callProcedure(h, promoted, path, 'query', input)
+      procedureStatuses.push(response.status)
+    }
+
+    const refreshed = await h.fetch('/auth/session', { headers: { cookie: promoted.cookie } })
+    const refreshedSession = (await refreshed.json()) as { role: string }
+    assert.deepEqual(
+      [cachedSession.role, changed.status, ...procedureStatuses, refreshedSession.role],
+      ['member', 200, 200, 200, 200, 'owner'],
+      JSON.stringify(changed.body),
+    )
+  })
+
   // -------------------------------------------------------------------------
   // The sweeper, and the two clocks it has to satisfy at once.
   // -------------------------------------------------------------------------
@@ -1158,6 +1208,53 @@ describe('members.sync over the route', { skip: hasDatabase ? false : 'no Postgr
       (m) => m.github_login,
     )
     assert.ok(!logins2.includes(arrives.login), 'a member GitHub no longer reports is still listed')
+  })
+
+  it('a sync that removes its caller makes the next session read signed out', async () => {
+    const ownOrg = await seedOrg(h.admin, 'syncself')
+    try {
+      await installFor(ownOrg.orgId, ownOrg.slug)
+      await signInAs(h, ownOrg, 'owner', 'staysowner')
+      const actor = await signInAs(h, ownOrg, 'admin', 'syncedout')
+      const upstream = await signInAs(h, ownOrg, 'member', 'upstream')
+      const [person] = await h.admin<{ github_login: string }[]>`
+        SELECT github_login FROM users WHERE id = ${actor.userId}`
+      const [kept] = await h.admin<{
+        github_id: string
+        github_login: string
+        email: string
+        name: string | null
+        avatar_url: string | null
+      }[]>`
+        SELECT github_id, github_login, email, name, avatar_url
+        FROM users WHERE id = ${upstream.userId}`
+      await h.admin`
+        UPDATE members SET source = 'github'
+        WHERE org_id = ${ownOrg.orgId} AND user_id = ${actor.userId}`
+
+      h.github.setMembers(ownOrg.slug, [{
+        user: {
+          id: Number(kept!.github_id),
+          login: kept!.github_login,
+          email: kept!.email,
+          name: kept!.name,
+          avatarUrl: kept!.avatar_url,
+        },
+        role: 'member',
+      }])
+      const result = await callProcedure(h, actor, 'members.sync', 'mutation', {})
+      const report = (result.body as { result: { data: SyncReport } }).result.data
+
+      const refreshed = await h.fetch('/auth/session', { headers: { cookie: actor.cookie } })
+      const session = (await refreshed.json()) as { signedIn: boolean }
+      assert.deepEqual(
+        [result.status, report.removed.includes(person!.github_login), session.signedIn],
+        [200, true, false],
+        JSON.stringify(result.body),
+      )
+    } finally {
+      await dropOrg(h.admin, ownOrg.orgId)
+    }
   })
 
   it('an empty answer from GitHub is a refusal with a reason, not a 500', async () => {

--- a/web/apps/api/test/enterprise.test.ts
+++ b/web/apps/api/test/enterprise.test.ts
@@ -575,6 +575,22 @@ describe(
         assert.equal(errorCode(after.body), 'UNAUTHORIZED')
       })
 
+      it('an administrator who removes themself gets a signed out session answer', async () => {
+        const admin = await signInAs(h, org, 'admin', 'selfremove')
+        const [row] = await h.admin<{ github_login: string }[]>`
+          SELECT github_login FROM users WHERE id = ${admin.userId}`
+
+        const removed = await callProcedure(h, admin, 'members.remove', 'mutation', {
+          githubLogin: row!.github_login,
+        })
+        const refreshed = await h.fetch('/auth/session', { headers: { cookie: admin.cookie } })
+        const session = (await refreshed.json()) as { signedIn: boolean }
+        assert.deepEqual(
+          [data<{ removed: boolean }>(removed.body).removed, session.signedIn],
+          [true, false],
+        )
+      })
+
       it('the last owner cannot be removed or demoted', async () => {
         const [row] = await h.admin<{ github_login: string }[]>`
           SELECT github_login FROM users WHERE id = ${owner.userId}`


### PR DESCRIPTION
The Plan page could refuse an owner whose shared browser session still carried their role before promotion. The three billing procedures read the current database role and succeeded, but the page replaced their results with its older local answer.

Plan now renders the server authorization result. The shared session refreshes after role changes, membership sync, removal, window focus and visible-tab return. Overlapping responses keep the newest answer. Session requests and responses use no-store. A failed refresh preserves usable content and presents a retry. Self removal and sync removal reach the signed-out screen.

Analytics navigation and the page now use the same check: the configured operator organization plus analytics.read. Operator owners and admins can read it; operator members, viewers and customer owners cannot. The session exposes a boolean relationship without disclosing another organization's slug. Production variables enable collection and name the operator organization, requiring a separate production Terraform apply.

The mobile drawer also restores focus to its opener when closed.

Validation on the final local tree:

* Console: 144 tests, TypeScript and production build passed.
* Isolated UTC database: 142 database, 43 policy and 1,871 API tests passed with zero failures or skips. Web typecheck and OpenAPI check passed.
* Twelve new assertion mutation cells failed their intended assertion and passed after restoration.
* Browser checks covered stale role, initial loading and failure, refresh failure and recovery, overlapping responses, focus and visibility, membership changes, self removal and analytics roles. Desktop and mobile screenshots were reviewed. Light and dark preferences were exercised; the console currently has one authored light palette. The preserved browser report records zero overflow, zero axe violations and no console or page errors, with table contrast also inspected manually.

The original page-loading diagnosis was corrected during source and live-state tracing: Shell already handles initial session loading before mounting its children. No unused permissionVerdict abstraction remains.
