### PR TITLE
build: a failure before the build log named a log that did not exist

### DIFF
--- a/.changes/a-build-that-never-started-named-a-log-that-was-never-written.md
+++ b/.changes/a-build-that-never-started-named-a-log-that-was-never-written.md
@@ -1,0 +1,18 @@
+# fixed
+
+A build the Docker daemon refused told you to read a log that does not exist.
+
+`af up` on a service whose Dockerfile the build context does not carry printed
+AF-BLD-001, "The build for service api failed after 0s", and next to it "Read
+the build log above; the first error line names the step that failed." There
+was no build log above. The daemon rejected the request before opening a
+stream, so nothing was built and nothing was printed, and the only sentence
+that identified the problem, "Cannot locate specified Dockerfile:
+deploy/docker/control-plane.Dockerfile", was reachable only by running the
+command again with `-v`.
+
+That path is now AF-BLD-006, which carries the daemon's own sentence in the
+message where it prints by default, and whose next step says nothing was built
+and points at build.context and .dockerignore. AF-BLD-001 keeps the case it was
+right for, a build that ran, produced output and lost, where the log really is
+above.

--- a/.changes/a-build-that-never-started-named-a-log-that-was-never-written.md
+++ b/.changes/a-build-that-never-started-named-a-log-that-was-never-written.md
@@ -1,18 +1,16 @@
 # fixed
 
-A build the Docker daemon refused told you to read a log that does not exist.
+A build request that ended before Docker opened a log told you to read a log
+that did not exist.
 
-`af up` on a service whose Dockerfile the build context does not carry printed
-AF-BLD-001, "The build for service api failed after 0s", and next to it "Read
-the build log above; the first error line names the step that failed." There
-was no build log above. The daemon rejected the request before opening a
-stream, so nothing was built and nothing was printed, and the only sentence
-that identified the problem, "Cannot locate specified Dockerfile:
-deploy/docker/control-plane.Dockerfile", was reachable only by running the
-command again with `-v`.
+`af up` used AF-BLD-001 for every immediate endpoint failure, including a
+permanent refusal, a lost Docker connection, a cancellation, and a temporary
+capacity failure. AF-BLD-001 says to read the build log above, but Docker had
+not opened the stream that could carry one.
 
-That path is now AF-BLD-006, which carries the daemon's own sentence in the
-message where it prints by default, and whose next step says nothing was built
-and points at build.context and .dockerignore. AF-BLD-001 keeps the case it was
-right for, a build that ran, produced output and lost, where the log really is
-above.
+Permanent endpoint refusals now use AF-BLD-006 and say to correct Docker's
+redacted message. Cancellation, connection, capacity, and other immediate
+failures use retryable AF-BLD-007 with guidance to run `af doctor` or try
+`af up` again. Both say that no build log exists. A secret Antifailure has
+loaded is removed before the detail reaches normal output, the wrapped cause,
+JSON output, or an event.

--- a/docs/src/content/docs/reference/errors.md
+++ b/docs/src/content/docs/reference/errors.md
@@ -240,14 +240,26 @@ The build for service {service} failed after {duration}, and its Dockerfile is {
 
 ### AF-BLD-006
 
-The build for service {service} never started: {detail}
+The Docker endpoint refused the build request for service {service} before opening a build log: {detail}
 
-**What to do.** That sentence is the daemon's own and it is the whole account of the failure. Nothing was built and nothing was printed, because the request was refused before the first step ran. If it names a Dockerfile, the path is resolved inside the build context, so check that the file is under build.context and is not excluded by .dockerignore.
+**What to do.** Nothing was built and no build log exists. Correct what the message names, then run 'af up' again. If it names a Dockerfile, its path is resolved inside build.context, and .dockerignore can exclude it.
 
 | | |
 | --- | --- |
 | Exit code | `1` |
 | Retryable | No. Retrying the same operation unchanged will fail the same way. |
+| More | [guides/build](/docs/guides/build) |
+
+### AF-BLD-007
+
+The build request for service {service} ended before a build log opened: {detail}
+
+**What to do.** Nothing was built and no build log exists. If Docker is unreachable, run 'af doctor'. For a cancellation or temporary Docker failure, run 'af up' again.
+
+| | |
+| --- | --- |
+| Exit code | `1` |
+| Retryable | Yes. The engine retries automatically where it can. |
 | More | [guides/build](/docs/guides/build) |
 
 ### AF-BLD-010

--- a/docs/src/content/docs/reference/errors.md
+++ b/docs/src/content/docs/reference/errors.md
@@ -238,6 +238,18 @@ The build for service {service} failed after {duration}, and its Dockerfile is {
 | Retryable | No. Retrying the same operation unchanged will fail the same way. |
 | More | [reference/manifest](/docs/reference/manifest) |
 
+### AF-BLD-006
+
+The build for service {service} never started: {detail}
+
+**What to do.** That sentence is the daemon's own and it is the whole account of the failure. Nothing was built and nothing was printed, because the request was refused before the first step ran. If it names a Dockerfile, the path is resolved inside the build context, so check that the file is under build.context and is not excluded by .dockerignore.
+
+| | |
+| --- | --- |
+| Exit code | `1` |
+| Retryable | No. Retrying the same operation unchanged will fail the same way. |
+| More | [guides/build](/docs/guides/build) |
+
 ### AF-BLD-010
 
 No build strategy could be detected for {service}.

--- a/engine/internal/build/docker.go
+++ b/engine/internal/build/docker.go
@@ -281,8 +281,7 @@ func (b *DockerBuilder) Build(ctx context.Context, req Request) (Result, error) 
 		log, buildErr, err = b.attempt(ctx, req, opts, extra, false)
 	}
 	if err != nil {
-		return res, aferrors.Wrap(err, aferrors.AFBLD001,
-			"service", req.Service, "duration", b.clock.Since(started).Round(time.Second).String())
+		return res, startFailure(err, req)
 	}
 
 	res.Log = log
@@ -291,6 +290,20 @@ func (b *DockerBuilder) Build(ctx context.Context, req Request) (Result, error) 
 		return res, buildFailure(buildErr, req, res.Duration.Round(time.Second).String())
 	}
 	return res, nil
+}
+
+// startFailure reports a build that never started, which is not the same
+// failure as a build that ran and lost.
+//
+// The daemon refused the request, so there is no stream, no log, and nothing
+// in Result to show. AF-BLD-001 says to read the build log above; on this path
+// there is no build log above, and the sentence sends the reader looking for
+// output that was never produced. The daemon's own message is the entire
+// diagnosis, and until this it was reachable only under -v, so the code that
+// carries it puts it in the message where it is read by default.
+func startFailure(err error, req Request) error {
+	return aferrors.Wrap(err, aferrors.AFBLD006,
+		"service", req.Service, "detail", err.Error())
 }
 
 // buildFailure names build.context when the build ran from the repository root

--- a/engine/internal/build/docker.go
+++ b/engine/internal/build/docker.go
@@ -303,27 +303,13 @@ func (b *DockerBuilder) Build(ctx context.Context, req Request) (Result, error) 
 func (b *DockerBuilder) startFailure(err error, req Request) error {
 	raw := err.Error()
 	code := aferrors.AFBLD007
-	switch {
-	case cerrdefs.IsInvalidArgument(err),
-		cerrdefs.IsNotFound(err),
-		cerrdefs.IsUnauthorized(err),
-		cerrdefs.IsPermissionDenied(err),
-		cerrdefs.IsNotImplemented(err),
-		strings.Contains(raw, "Cannot locate specified Dockerfile"):
+	if cerrdefs.IsInvalidArgument(err) ||
+		cerrdefs.IsNotFound(err) ||
+		cerrdefs.IsUnauthorized(err) ||
+		cerrdefs.IsPermissionDenied(err) ||
+		cerrdefs.IsNotImplemented(err) ||
+		strings.Contains(raw, "Cannot locate specified Dockerfile") {
 		code = aferrors.AFBLD006
-	case cerrdefs.IsCanceled(err),
-		cerrdefs.IsDeadlineExceeded(err),
-		client.IsErrConnectionFailed(err),
-		cerrdefs.IsUnavailable(err),
-		cerrdefs.IsResourceExhausted(err),
-		cerrdefs.IsInternal(err),
-		cerrdefs.IsUnknown(err),
-		cerrdefs.IsConflict(err):
-		code = aferrors.AFBLD007
-	default:
-		// An unknown failure before the response stream opened may be
-		// temporary. It is safer to permit a retry than to call it permanent.
-		code = aferrors.AFBLD007
 	}
 
 	detail := b.redactor.String(raw)

--- a/engine/internal/build/docker.go
+++ b/engine/internal/build/docker.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	cerrdefs "github.com/containerd/errdefs"
 	dockerbuild "github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/client"
 
@@ -281,7 +282,7 @@ func (b *DockerBuilder) Build(ctx context.Context, req Request) (Result, error) 
 		log, buildErr, err = b.attempt(ctx, req, opts, extra, false)
 	}
 	if err != nil {
-		return res, startFailure(err, req)
+		return res, b.startFailure(err, req)
 	}
 
 	res.Log = log
@@ -292,18 +293,57 @@ func (b *DockerBuilder) Build(ctx context.Context, req Request) (Result, error) 
 	return res, nil
 }
 
-// startFailure reports a build that never started, which is not the same
-// failure as a build that ran and lost.
+// startFailure reports an error returned before Docker opened the response
+// stream. Result has no log on this path, so AF-BLD-001 cannot tell the reader
+// to inspect one. A permanent endpoint refusal and a request that was
+// cancelled or interrupted need different retry guidance.
 //
-// The daemon refused the request, so there is no stream, no log, and nothing
-// in Result to show. AF-BLD-001 says to read the build log above; on this path
-// there is no build log above, and the sentence sends the reader looking for
-// output that was never produced. The daemon's own message is the entire
-// diagnosis, and until this it was reachable only under -v, so the code that
-// carries it puts it in the message where it is read by default.
-func startFailure(err error, req Request) error {
-	return aferrors.Wrap(err, aferrors.AFBLD006,
-		"service", req.Service, "detail", err.Error())
+// The endpoint's text can contain a credential. Redact it once here, before it
+// reaches the normal message, the wrapped error, JSON output, or an event.
+func (b *DockerBuilder) startFailure(err error, req Request) error {
+	raw := err.Error()
+	code := aferrors.AFBLD007
+	switch {
+	case cerrdefs.IsInvalidArgument(err),
+		cerrdefs.IsNotFound(err),
+		cerrdefs.IsUnauthorized(err),
+		cerrdefs.IsPermissionDenied(err),
+		cerrdefs.IsNotImplemented(err),
+		strings.Contains(raw, "Cannot locate specified Dockerfile"):
+		code = aferrors.AFBLD006
+	case cerrdefs.IsCanceled(err),
+		cerrdefs.IsDeadlineExceeded(err),
+		client.IsErrConnectionFailed(err),
+		cerrdefs.IsUnavailable(err),
+		cerrdefs.IsResourceExhausted(err),
+		cerrdefs.IsInternal(err),
+		cerrdefs.IsUnknown(err),
+		cerrdefs.IsConflict(err):
+		code = aferrors.AFBLD007
+	default:
+		// An unknown failure before the response stream opened may be
+		// temporary. It is safer to permit a retry than to call it permanent.
+		code = aferrors.AFBLD007
+	}
+
+	detail := b.redactor.String(raw)
+	cause := sanitizedBuildCause{message: detail, original: err}
+	return aferrors.Wrap(cause, code, "service", req.Service, "detail", detail)
+}
+
+// sanitizedBuildCause keeps cancellation identity without making the
+// original text reachable through the error chain. It deliberately does not
+// implement Unwrap. Verbose and JSON output both render Error, which returns
+// only the redacted message.
+type sanitizedBuildCause struct {
+	message  string
+	original error
+}
+
+func (e sanitizedBuildCause) Error() string { return e.message }
+
+func (e sanitizedBuildCause) Is(target error) bool {
+	return errors.Is(e.original, target)
 }
 
 // buildFailure names build.context when the build ran from the repository root
@@ -331,11 +371,10 @@ func buildFailure(err error, req Request, duration string) error {
 
 // attempt runs one build and reads its stream.
 //
-// Two errors come back and they are different things. The first is whether the
-// build could be STARTED, which is a fault of this process or the daemon. The
-// second is whether the build SUCCEEDED, which is a fault of the Dockerfile
-// and arrives inside the stream rather than from the call. Only the second is
-// worth showing somebody a log for, and only the first is worth retrying.
+// Two errors come back and they are different things. The first means Docker
+// did not open a response stream, so there is no build log. It may be a
+// permanent refusal or a temporary interruption. The second arrives inside
+// the stream after the build ran, so the log is the evidence to read.
 func (b *DockerBuilder) attempt(
 	ctx context.Context,
 	req Request,

--- a/engine/internal/build/docker_test.go
+++ b/engine/internal/build/docker_test.go
@@ -3,6 +3,7 @@ package build
 import (
 	"context"
 	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -192,9 +193,38 @@ func coded(t *testing.T, err error) *aferrors.Error {
 	return e
 }
 
+type refusedRoundTripper struct{}
+
+func (refusedRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, refusedConnectionError()
+}
+
+func refusedConnectionError() net.Error {
+	return &net.OpError{
+		Op: "dial", Net: "tcp", Err: errors.New("connection refused"),
+	}
+}
+
+func dockerConnectionFailure(t *testing.T) error {
+	t.Helper()
+	cli, err := dockerclient.NewClientWithOpts(
+		dockerclient.WithHost("http://docker.invalid"),
+		dockerclient.WithHTTPClient(&http.Client{Transport: refusedRoundTripper{}}),
+		dockerclient.WithVersion("1.48"),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cli.Close() })
+
+	_, err = cli.Ping(context.Background())
+	require.True(t, dockerclient.IsErrConnectionFailed(err),
+		"the fixture must exercise Docker's typed connection failure")
+	return err
+}
+
 func TestStartFailure_ClassifiesEveryImmediateDockerFailure(t *testing.T) {
 	t.Parallel()
 	b := &DockerBuilder{redactor: redact.New()}
+	connectionFailure := dockerConnectionFailure(t)
 	cases := []struct {
 		name      string
 		err       error
@@ -248,7 +278,7 @@ func TestStartFailure_ClassifiesEveryImmediateDockerFailure(t *testing.T) {
 		},
 		{
 			name:      "connection failed",
-			err:       dockerclient.ErrorConnectionFailed("unix:///var/run/docker.sock"),
+			err:       connectionFailure,
 			wantCode:  aferrors.AFBLD007,
 			retryable: true,
 		},

--- a/engine/internal/build/docker_test.go
+++ b/engine/internal/build/docker_test.go
@@ -180,6 +180,101 @@ func TestBuildFailure_NamesTheContextWhenTheDockerfileIsNotAtItsRoot(t *testing.
 	}
 }
 
+// A build the daemon refused outright and a build that ran and failed are two
+// different failures, and until this they returned the same code and the same
+// instruction. "Read the build log above" is true of the second and false of
+// the first: nothing ran, so nothing was written, and the reader is sent to
+// look for output that does not exist while the daemon's own sentence, which
+// is the whole diagnosis, sits under -v where they will not see it.
+//
+// Asserted on the next step rather than on the code, because the code is only
+// the mechanism. What was wrong was the sentence a stuck user reads.
+func TestStartAndBuildFailures_OnlyTheOneWithALogSendsTheReaderToIt(t *testing.T) {
+	t.Parallel()
+	req := Request{Service: "api", DockerfilePath: "Dockerfile"}
+	daemon := errors.New("Error response from daemon: Cannot locate specified " +
+		"Dockerfile: deploy/docker/control-plane.Dockerfile")
+
+	started := coded(t, buildFailure(daemon, req, "12s"))
+	require.Equal(t, aferrors.AFBLD001, started.Code())
+	require.Contains(t, started.NextStep(), "build log above",
+		"this build ran, so there is a log and the reader should read it")
+
+	never := coded(t, startFailure(daemon, req))
+	require.Equal(t, aferrors.AFBLD006, never.Code())
+	require.NotContains(t, never.NextStep(), "build log above",
+		"nothing ran, so there is no log; naming one is the dead end this closes")
+	require.Contains(t, never.Message(), "Cannot locate specified Dockerfile",
+		"the daemon's sentence is the only account of the failure, so it is in "+
+			"the message, which prints without -v, and not only in the cause, "+
+			"which does not")
+	require.Contains(t, never.Message(), "api", "the message names the service")
+}
+
+func coded(t *testing.T, err error) *aferrors.Error {
+	t.Helper()
+	var e *aferrors.Error
+	require.True(t, aferrors.As(err, &e))
+	return e
+}
+
+// The end to end form of the case above, against a real daemon.
+//
+// On the legacy builder a Dockerfile the context does not carry is refused by
+// the daemon before the build begins, which is the failure reported from
+// 'af up': the call returns an error, no stream is opened, and Result.Log
+// stays empty. Forced onto that builder rather than left to the daemon's
+// preference, because BuildKit reports the same input through the stream
+// instead, where a log genuinely exists and AF-BLD-001 is honest. Which of the
+// two a machine takes is what this is separating, so it cannot be left to the
+// machine.
+func TestDockerBuilder_ARefusedBuildCarriesTheDaemonsReasonAndNoLog(t *testing.T) {
+	b := requireLegacyBuilder(t)
+	c := contextFor(t, map[string]string{
+		"Dockerfile": "FROM alpine:3.20\nCMD [\"true\"]\n",
+	})
+
+	res, err := buildAndClean(t, b, Request{
+		Service: "api", Context: c, EnvID: "env-build-13",
+		DockerfilePath: "deploy/docker/control-plane.Dockerfile",
+	})
+	require.Error(t, err)
+
+	e := coded(t, err)
+	require.Equal(t, aferrors.AFBLD006, e.Code())
+	require.Empty(t, res.Log,
+		"nothing ran, which is exactly why the reader cannot be sent to a log")
+	require.Contains(t, e.Message(), "Cannot locate specified Dockerfile",
+		"the daemon named the file it could not find, and that is the diagnosis")
+	require.NotContains(t, e.NextStep(), "build log above")
+}
+
+// requireLegacyBuilder is requireBuilder against the pre BuildKit builder.
+// DOCKER_BUILDKIT=0 is the documented escape hatch and wantsBuildKit reads it
+// through the injected Getenv, so nothing in the process environment changes.
+func requireLegacyBuilder(t *testing.T) *DockerBuilder {
+	t.Helper()
+	if os.Getenv("AF_SKIP_DOCKER") != "" {
+		t.Skip("skipped: AF_SKIP_DOCKER is set")
+	}
+	b, err := NewDockerBuilder(DockerOptions{
+		Clock:  clock.New(),
+		Getenv: func(string) string { return "0" },
+	})
+	if err != nil {
+		t.Skipf("skipped: no Docker daemon is reachable: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if _, err := b.cli.Ping(ctx); err != nil {
+		_ = b.Close()
+		t.Skipf("skipped: the Docker daemon did not respond: %v", err)
+	}
+	require.False(t, b.buildKit, "DOCKER_BUILDKIT=0 selects the legacy builder")
+	t.Cleanup(func() { _ = b.Close() })
+	return b
+}
+
 func TestDockerBuilder_ReportsAnUnusableDockerfile(t *testing.T) {
 	b := requireBuilder(t)
 	c := contextFor(t, map[string]string{"Dockerfile": "THIS IS NOT A DOCKERFILE\n"})

--- a/engine/internal/build/docker_test.go
+++ b/engine/internal/build/docker_test.go
@@ -3,17 +3,22 @@ package build
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
 	"time"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types/image"
+	dockerclient "github.com/docker/docker/client"
 	"github.com/stretchr/testify/require"
 
 	"github.com/antifailure/antifailure/engine/internal/clock"
 	"github.com/antifailure/antifailure/engine/internal/dockerutil"
 	aferrors "github.com/antifailure/antifailure/engine/internal/errors"
+	"github.com/antifailure/antifailure/engine/internal/redact"
 )
 
 func requireBuilder(t *testing.T) *DockerBuilder {
@@ -180,37 +185,6 @@ func TestBuildFailure_NamesTheContextWhenTheDockerfileIsNotAtItsRoot(t *testing.
 	}
 }
 
-// A build the daemon refused outright and a build that ran and failed are two
-// different failures, and until this they returned the same code and the same
-// instruction. "Read the build log above" is true of the second and false of
-// the first: nothing ran, so nothing was written, and the reader is sent to
-// look for output that does not exist while the daemon's own sentence, which
-// is the whole diagnosis, sits under -v where they will not see it.
-//
-// Asserted on the next step rather than on the code, because the code is only
-// the mechanism. What was wrong was the sentence a stuck user reads.
-func TestStartAndBuildFailures_OnlyTheOneWithALogSendsTheReaderToIt(t *testing.T) {
-	t.Parallel()
-	req := Request{Service: "api", DockerfilePath: "Dockerfile"}
-	daemon := errors.New("Error response from daemon: Cannot locate specified " +
-		"Dockerfile: deploy/docker/control-plane.Dockerfile")
-
-	started := coded(t, buildFailure(daemon, req, "12s"))
-	require.Equal(t, aferrors.AFBLD001, started.Code())
-	require.Contains(t, started.NextStep(), "build log above",
-		"this build ran, so there is a log and the reader should read it")
-
-	never := coded(t, startFailure(daemon, req))
-	require.Equal(t, aferrors.AFBLD006, never.Code())
-	require.NotContains(t, never.NextStep(), "build log above",
-		"nothing ran, so there is no log; naming one is the dead end this closes")
-	require.Contains(t, never.Message(), "Cannot locate specified Dockerfile",
-		"the daemon's sentence is the only account of the failure, so it is in "+
-			"the message, which prints without -v, and not only in the cause, "+
-			"which does not")
-	require.Contains(t, never.Message(), "api", "the message names the service")
-}
-
 func coded(t *testing.T, err error) *aferrors.Error {
 	t.Helper()
 	var e *aferrors.Error
@@ -218,61 +192,234 @@ func coded(t *testing.T, err error) *aferrors.Error {
 	return e
 }
 
-// The end to end form of the case above, against a real daemon.
-//
-// On the legacy builder a Dockerfile the context does not carry is refused by
-// the daemon before the build begins, which is the failure reported from
-// 'af up': the call returns an error, no stream is opened, and Result.Log
-// stays empty. Forced onto that builder rather than left to the daemon's
-// preference, because BuildKit reports the same input through the stream
-// instead, where a log genuinely exists and AF-BLD-001 is honest. Which of the
-// two a machine takes is what this is separating, so it cannot be left to the
-// machine.
-func TestDockerBuilder_ARefusedBuildCarriesTheDaemonsReasonAndNoLog(t *testing.T) {
-	b := requireLegacyBuilder(t)
-	c := contextFor(t, map[string]string{
-		"Dockerfile": "FROM alpine:3.20\nCMD [\"true\"]\n",
-	})
+func TestStartFailure_ClassifiesEveryImmediateDockerFailure(t *testing.T) {
+	t.Parallel()
+	b := &DockerBuilder{redactor: redact.New()}
+	cases := []struct {
+		name      string
+		err       error
+		wantCode  aferrors.Code
+		retryable bool
+		is        error
+	}{
+		{
+			name:     "invalid argument",
+			err:      cerrdefs.ErrInvalidArgument.WithMessage("the request is invalid"),
+			wantCode: aferrors.AFBLD006,
+		},
+		{
+			name:     "not found",
+			err:      cerrdefs.ErrNotFound.WithMessage("the endpoint was not found"),
+			wantCode: aferrors.AFBLD006,
+		},
+		{
+			name:     "unauthorized",
+			err:      cerrdefs.ErrUnauthenticated.WithMessage("the endpoint refused the credential"),
+			wantCode: aferrors.AFBLD006,
+		},
+		{
+			name:     "permission denied",
+			err:      cerrdefs.ErrPermissionDenied.WithMessage("the endpoint refused this operation"),
+			wantCode: aferrors.AFBLD006,
+		},
+		{
+			name:     "not implemented",
+			err:      cerrdefs.ErrNotImplemented.WithMessage("the endpoint does not implement builds"),
+			wantCode: aferrors.AFBLD006,
+		},
+		{
+			name:     "observed missing Dockerfile response",
+			err:      errors.New("Error response from daemon: Cannot locate specified Dockerfile: Dockerfile"),
+			wantCode: aferrors.AFBLD006,
+		},
+		{
+			name:      "cancelled",
+			err:       context.Canceled,
+			wantCode:  aferrors.AFBLD007,
+			retryable: true,
+			is:        context.Canceled,
+		},
+		{
+			name:      "deadline exceeded",
+			err:       context.DeadlineExceeded,
+			wantCode:  aferrors.AFBLD007,
+			retryable: true,
+			is:        context.DeadlineExceeded,
+		},
+		{
+			name:      "connection failed",
+			err:       dockerclient.ErrorConnectionFailed("unix:///var/run/docker.sock"),
+			wantCode:  aferrors.AFBLD007,
+			retryable: true,
+		},
+		{
+			name:      "unavailable",
+			err:       cerrdefs.ErrUnavailable.WithMessage("the endpoint is unavailable"),
+			wantCode:  aferrors.AFBLD007,
+			retryable: true,
+		},
+		{
+			name:      "resource exhausted",
+			err:       cerrdefs.ErrResourceExhausted.WithMessage("the builder is at capacity"),
+			wantCode:  aferrors.AFBLD007,
+			retryable: true,
+		},
+		{
+			name:      "internal",
+			err:       cerrdefs.ErrInternal.WithMessage("the endpoint failed internally"),
+			wantCode:  aferrors.AFBLD007,
+			retryable: true,
+		},
+		{
+			name:      "unknown",
+			err:       cerrdefs.ErrUnknown.WithMessage("the endpoint returned an unknown response"),
+			wantCode:  aferrors.AFBLD007,
+			retryable: true,
+		},
+		{
+			name:      "conflict",
+			err:       cerrdefs.ErrConflict.WithMessage("the builder is changing state"),
+			wantCode:  aferrors.AFBLD007,
+			retryable: true,
+		},
+		{
+			name:      "unclassified",
+			err:       errors.New("the response stream did not open"),
+			wantCode:  aferrors.AFBLD007,
+			retryable: true,
+		},
+		{
+			name: "permanent classification wins",
+			err: errors.Join(
+				cerrdefs.ErrInvalidArgument.WithMessage("the request is invalid"),
+				context.Canceled,
+			),
+			wantCode: aferrors.AFBLD006,
+		},
+	}
 
-	res, err := buildAndClean(t, b, Request{
-		Service: "api", Context: c, EnvID: "env-build-13",
-		DockerfilePath: "deploy/docker/control-plane.Dockerfile",
-	})
-	require.Error(t, err)
-
-	e := coded(t, err)
-	require.Equal(t, aferrors.AFBLD006, e.Code())
-	require.Empty(t, res.Log,
-		"nothing ran, which is exactly why the reader cannot be sent to a log")
-	require.Contains(t, e.Message(), "Cannot locate specified Dockerfile",
-		"the daemon named the file it could not find, and that is the diagnosis")
-	require.NotContains(t, e.NextStep(), "build log above")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := b.startFailure(tc.err, Request{Service: "api"})
+			e := coded(t, got)
+			require.Equal(t, tc.wantCode, e.Code())
+			require.Equal(t, tc.retryable, e.Retryable())
+			require.Contains(t, e.NextStep(), "no build log exists")
+			require.NotContains(t, strings.ToLower(e.NextStep()), "read the build log")
+			if tc.is != nil {
+				require.ErrorIs(t, got, tc.is,
+					"sanitizing the cause must preserve cancellation identity")
+			}
+		})
+	}
 }
 
-// requireLegacyBuilder is requireBuilder against the pre BuildKit builder.
-// DOCKER_BUILDKIT=0 is the documented escape hatch and wantsBuildKit reads it
-// through the injected Getenv, so nothing in the process environment changes.
-func requireLegacyBuilder(t *testing.T) *DockerBuilder {
-	t.Helper()
-	if os.Getenv("AF_SKIP_DOCKER") != "" {
-		t.Skip("skipped: AF_SKIP_DOCKER is set")
+func TestStartFailure_RedactsEveryExposedCopyOfTheCause(t *testing.T) {
+	t.Parallel()
+	const secret = "opaque-lilac-cabinet-94173"
+	r := redact.New()
+	require.True(t, r.Register(secret))
+	b := &DockerBuilder{redactor: r}
+
+	cases := []struct {
+		name string
+		err  error
+		code aferrors.Code
+	}{
+		{
+			name: "permanent refusal",
+			err: cerrdefs.ErrInvalidArgument.WithMessage(
+				"the invalid request carried " + secret,
+			),
+			code: aferrors.AFBLD006,
+		},
+		{
+			name: "temporary interruption",
+			err:  errors.New("the connection ended around " + secret),
+			code: aferrors.AFBLD007,
+		},
 	}
-	b, err := NewDockerBuilder(DockerOptions{
-		Clock:  clock.New(),
-		Getenv: func(string) string { return "0" },
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := b.startFailure(tc.err, Request{Service: "api"})
+			e := coded(t, got)
+			require.Equal(t, tc.code, e.Code())
+
+			cause := aferrors.Unwrap(e)
+			require.NotNil(t, cause)
+			surfaces := map[string]string{
+				"normal message":            e.Message(),
+				"full error and event text": e.Error(),
+				"verbose and JSON cause":    cause.Error(),
+			}
+			for name, rendered := range surfaces {
+				t.Run(name, func(t *testing.T) {
+					require.NotContains(t, rendered, secret, "%s exposed the original", name)
+				})
+			}
+
+			t.Run("cause cannot be unwrapped", func(t *testing.T) {
+				_, unwraps := cause.(interface{ Unwrap() error })
+				require.False(t, unwraps,
+					"the sanitized cause must not expose the original through Unwrap")
+			})
+		})
+	}
+}
+
+func TestDockerBuilder_AnImmediateHTTPRefusalHasNoBuildLog(t *testing.T) {
+	t.Parallel()
+	const detail = "the requested target stage does not exist"
+	requests := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- r.Method + " " + r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"message":"` + detail + `"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	cli, err := dockerclient.NewClientWithOpts(
+		dockerclient.WithHost(srv.URL),
+		dockerclient.WithHTTPClient(srv.Client()),
+		dockerclient.WithVersion("1.48"),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cli.Close() })
+
+	b := &DockerBuilder{
+		cli: cli, clock: clock.New(), redactor: redact.New(), noCache: true,
+	}
+	res, err := b.Build(context.Background(), Request{
+		Service: "api",
+		Context: contextFor(t, map[string]string{
+			"Dockerfile": "FROM scratch\n",
+		}),
+		EnvID: "env-build-refused",
 	})
-	if err != nil {
-		t.Skipf("skipped: no Docker daemon is reachable: %v", err)
+	require.Error(t, err)
+	select {
+	case request := <-requests:
+		require.Equal(t, "POST /v1.48/build", request,
+			"Build must reach Docker's build endpoint for this to cover the live call site")
+	default:
+		t.Fatal("Build did not reach Docker's build endpoint")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	if _, err := b.cli.Ping(ctx); err != nil {
-		_ = b.Close()
-		t.Skipf("skipped: the Docker daemon did not respond: %v", err)
-	}
-	require.False(t, b.buildKit, "DOCKER_BUILDKIT=0 selects the legacy builder")
-	t.Cleanup(func() { _ = b.Close() })
-	return b
+
+	e := coded(t, err)
+	t.Run("uses the immediate refusal code", func(t *testing.T) {
+		require.Equal(t, aferrors.AFBLD006, e.Code(),
+			"an error before the stream opens must not use AF-BLD-001")
+	})
+	t.Run("keeps useful endpoint detail", func(t *testing.T) {
+		require.Contains(t, e.Message(), detail,
+			"the endpoint's useful detail must print without verbose output")
+	})
+	t.Run("has no build log", func(t *testing.T) {
+		require.Empty(t, res.Log,
+			"Docker refused the request before opening the stream that carries a log")
+	})
 }
 
 func TestDockerBuilder_ReportsAnUnusableDockerfile(t *testing.T) {

--- a/engine/internal/errors/catalog.yaml
+++ b/engine/internal/errors/catalog.yaml
@@ -429,6 +429,13 @@ errors:
     docs: reference/manifest
     retryable: false
     exit_code: 1
+  - code: AF-BLD-006
+    area: BLD
+    message: "The build for service {service} never started: {detail}"
+    next_step: "That sentence is the daemon's own and it is the whole account of the failure. Nothing was built and nothing was printed, because the request was refused before the first step ran. If it names a Dockerfile, the path is resolved inside the build context, so check that the file is under build.context and is not excluded by .dockerignore."
+    docs: guides/build
+    retryable: false
+    exit_code: 1
   - code: AF-BLD-002
     area: BLD
     message: "The Dockerfile for {service} is not valid at line {line}: {detail}"

--- a/engine/internal/errors/catalog.yaml
+++ b/engine/internal/errors/catalog.yaml
@@ -431,10 +431,17 @@ errors:
     exit_code: 1
   - code: AF-BLD-006
     area: BLD
-    message: "The build for service {service} never started: {detail}"
-    next_step: "That sentence is the daemon's own and it is the whole account of the failure. Nothing was built and nothing was printed, because the request was refused before the first step ran. If it names a Dockerfile, the path is resolved inside the build context, so check that the file is under build.context and is not excluded by .dockerignore."
+    message: "The Docker endpoint refused the build request for service {service} before opening a build log: {detail}"
+    next_step: "Nothing was built and no build log exists. Correct what the message names, then run 'af up' again. If it names a Dockerfile, its path is resolved inside build.context, and .dockerignore can exclude it."
     docs: guides/build
     retryable: false
+    exit_code: 1
+  - code: AF-BLD-007
+    area: BLD
+    message: "The build request for service {service} ended before a build log opened: {detail}"
+    next_step: "Nothing was built and no build log exists. If Docker is unreachable, run 'af doctor'. For a cancellation or temporary Docker failure, run 'af up' again."
+    docs: guides/build
+    retryable: true
     exit_code: 1
   - code: AF-BLD-002
     area: BLD

--- a/engine/internal/errors/codes.gen.go
+++ b/engine/internal/errors/codes.gen.go
@@ -45,8 +45,12 @@ const (
 	// Dockerfile is {dockerfile} inside a build context rooted at the
 	// repository.
 	AFBLD005 Code = "AF-BLD-005"
-	// The build for service {service} never started: {detail}
+	// The Docker endpoint refused the build request for service {service}
+	// before opening a build log: {detail}
 	AFBLD006 Code = "AF-BLD-006"
+	// The build request for service {service} ended before a build log
+	// opened: {detail}
+	AFBLD007 Code = "AF-BLD-007"
 	// No build strategy could be detected for {service}.
 	AFBLD010 Code = "AF-BLD-010"
 	// The Dockerfile {dockerfile} for {service} is excluded from the build
@@ -562,10 +566,19 @@ var catalog = map[Code]Entry{
 	AFBLD006: {
 		Code:      AFBLD006,
 		Area:      "BLD",
-		Message:   "The build for service {service} never started: {detail}",
-		NextStep:  "That sentence is the daemon's own and it is the whole account of the failure. Nothing was built and nothing was printed, because the request was refused before the first step ran. If it names a Dockerfile, the path is resolved inside the build context, so check that the file is under build.context and is not excluded by .dockerignore.",
+		Message:   "The Docker endpoint refused the build request for service {service} before opening a build log: {detail}",
+		NextStep:  "Nothing was built and no build log exists. Correct what the message names, then run 'af up' again. If it names a Dockerfile, its path is resolved inside build.context, and .dockerignore can exclude it.",
 		Docs:      "guides/build",
 		Retryable: false,
+		ExitCode:  ExitFailure,
+	},
+	AFBLD007: {
+		Code:      AFBLD007,
+		Area:      "BLD",
+		Message:   "The build request for service {service} ended before a build log opened: {detail}",
+		NextStep:  "Nothing was built and no build log exists. If Docker is unreachable, run 'af doctor'. For a cancellation or temporary Docker failure, run 'af up' again.",
+		Docs:      "guides/build",
+		Retryable: true,
 		ExitCode:  ExitFailure,
 	},
 	AFBLD010: {

--- a/engine/internal/errors/codes.gen.go
+++ b/engine/internal/errors/codes.gen.go
@@ -45,6 +45,8 @@ const (
 	// Dockerfile is {dockerfile} inside a build context rooted at the
 	// repository.
 	AFBLD005 Code = "AF-BLD-005"
+	// The build for service {service} never started: {detail}
+	AFBLD006 Code = "AF-BLD-006"
 	// No build strategy could be detected for {service}.
 	AFBLD010 Code = "AF-BLD-010"
 	// The Dockerfile {dockerfile} for {service} is excluded from the build
@@ -554,6 +556,15 @@ var catalog = map[Code]Entry{
 		Message:   "The build for service {service} failed after {duration}, and its Dockerfile is {dockerfile} inside a build context rooted at the repository.",
 		NextStep:  "If the Dockerfile expects to be built from its own directory, which is what 'docker build {dir}' does, set build.context to {dir} for this service. Otherwise read the build log above; the first error line names the step that failed.",
 		Docs:      "reference/manifest",
+		Retryable: false,
+		ExitCode:  ExitFailure,
+	},
+	AFBLD006: {
+		Code:      AFBLD006,
+		Area:      "BLD",
+		Message:   "The build for service {service} never started: {detail}",
+		NextStep:  "That sentence is the daemon's own and it is the whole account of the failure. Nothing was built and nothing was printed, because the request was refused before the first step ran. If it names a Dockerfile, the path is resolved inside the build context, so check that the file is under build.context and is not excluded by .dockerignore.",
+		Docs:      "guides/build",
 		Retryable: false,
 		ExitCode:  ExitFailure,
 	},

--- a/www/public/errors.v1.json
+++ b/www/public/errors.v1.json
@@ -193,10 +193,21 @@
       "code": "AF-BLD-006",
       "area": "BLD",
       "areaName": "Build",
-      "message": "The build for service {service} never started: {detail}",
-      "resolution": "That sentence is the daemon's own and it is the whole account of the failure. Nothing was built and nothing was printed, because the request was refused before the first step ran. If it names a Dockerfile, the path is resolved inside the build context, so check that the file is under build.context and is not excluded by .dockerignore.",
+      "message": "The Docker endpoint refused the build request for service {service} before opening a build log: {detail}",
+      "resolution": "Nothing was built and no build log exists. Correct what the message names, then run 'af up' again. If it names a Dockerfile, its path is resolved inside build.context, and .dockerignore can exclude it.",
       "docs": "https://antifailure.dev/docs/guides/build",
       "retryable": false,
+      "exitCode": 1,
+      "planned": false
+    },
+    {
+      "code": "AF-BLD-007",
+      "area": "BLD",
+      "areaName": "Build",
+      "message": "The build request for service {service} ended before a build log opened: {detail}",
+      "resolution": "Nothing was built and no build log exists. If Docker is unreachable, run 'af doctor'. For a cancellation or temporary Docker failure, run 'af up' again.",
+      "docs": "https://antifailure.dev/docs/guides/build",
+      "retryable": true,
       "exitCode": 1,
       "planned": false
     },

--- a/www/public/errors.v1.json
+++ b/www/public/errors.v1.json
@@ -190,6 +190,17 @@
       "planned": false
     },
     {
+      "code": "AF-BLD-006",
+      "area": "BLD",
+      "areaName": "Build",
+      "message": "The build for service {service} never started: {detail}",
+      "resolution": "That sentence is the daemon's own and it is the whole account of the failure. Nothing was built and nothing was printed, because the request was refused before the first step ran. If it names a Dockerfile, the path is resolved inside the build context, so check that the file is under build.context and is not excluded by .dockerignore.",
+      "docs": "https://antifailure.dev/docs/guides/build",
+      "retryable": false,
+      "exitCode": 1,
+      "planned": false
+    },
+    {
       "code": "AF-BLD-010",
       "area": "BLD",
       "areaName": "Build",


### PR DESCRIPTION
Every error returned before Docker opens its build response stream used
AF-BLD-001. That code tells the reader to inspect the build log, but no stream
means no log exists.

## What changed

Immediate endpoint refusals now use AF-BLD-006. The normal message includes
Docker's useful reason, and the next step says nothing was built and no log
exists.

Cancellation, deadline, connection, capacity, internal, unknown, conflict, and
unclassified pre-stream failures use retryable AF-BLD-007. Its next step names
`af doctor` for an unreachable daemon and `af up` for a new attempt.

The missing-Dockerfile sentence remains a lower-level deterministic refusal,
but current `af up` catches missing, excluded, or out-of-context Dockerfiles
earlier as AF-BLD-011 or AF-BLD-012. This change does not claim otherwise.

Docker's error text is passed through the shared redactor before it reaches the
normal message, full error, event text, verbose cause, or JSON cause. The
sanitized cause preserves cancellation identity for `errors.Is` and does not
unwrap to the original text.

## Verification

The error generator reports 154 codes across 19 areas. Build and error tests
pass uncached, vet passes, errcheck finds all 154 documented and reachable,
prosecheck reports 718 files and zero violations, and generated artifacts are
idempotent.

Fifty three independent mutations were applied and restored. They cover all 16
classification paths, 16 retryability assertions, cancellation and deadline
identity, both next steps, every redaction surface for both codes, the no-unwrap
boundary, and the fake HTTP build path's code, useful detail, and empty log.
Every mutation failed its named assertion before the restored suite passed.
