### PR TITLE
A worked example that threw half of itself away

### DIFF
--- a/.changes/a-worked-example-that-threw-half-of-itself-away.md
+++ b/.changes/a-worked-example-that-threw-half-of-itself-away.md
@@ -1,0 +1,23 @@
+# fixed
+
+The worked GitHub Actions example silently discarded half its inputs.
+
+`examples/github-workflow.yml` declared `seed` and `concurrency` twice each in
+its `workflow_dispatch` inputs. YAML keeps the last definition, so the first
+pair's descriptions were text nobody would ever see, in the one file this
+product hands a new user as the example of how to wire it into CI. Nothing
+failed. The workflow parsed, GitHub accepted it, the example rendered, and two
+descriptions were simply gone.
+
+`tools/keycheck` now refuses any YAML file in the repository that defines the
+same key twice in one mapping, and `just keycheck` runs it locally.
+
+Helm charts are rendered before they are read rather than skipped. A chart
+template is Go template source that no YAML parser can take, so the first
+version of the gate reported twelve unreadable files, checked the other forty
+three, and printed a summary naming fifty five. Nothing else covers them
+either: `helm lint`, pointed at a chart whose `service.yaml` defined `type`
+twice, returned "0 chart(s) failed". A duplicate survives rendering intact, so
+`helm template` output is what the gate parses. With helm missing the command
+fails rather than skipping, because skipping would restore the same silence one
+step further away.

--- a/.changes/a-worked-example-that-threw-half-of-itself-away.md
+++ b/.changes/a-worked-example-that-threw-half-of-itself-away.md
@@ -12,8 +12,8 @@ descriptions were simply gone.
 `tools/keycheck` now refuses any YAML file in the repository that defines the
 same key twice in one mapping, and `just keycheck` runs it locally.
 
-Helm charts are rendered before they are read rather than skipped. A chart
-template is Go template source that no YAML parser can take, so the first
+Helm charts are rendered through three valid profiles before they are read. A
+chart template is Go template source that no YAML parser can take, so the first
 version of the gate reported twelve unreadable files, checked the other forty
 three, and printed a summary naming fifty five. Nothing else covers them
 either: `helm lint`, pointed at a chart whose `service.yaml` defined `type`
@@ -21,3 +21,8 @@ twice, returned "0 chart(s) failed". A duplicate survives rendering intact, so
 `helm template` output is what the gate parses. With helm missing the command
 fails rather than skipping, because skipping would restore the same silence one
 step further away.
+
+The inline, external secret and sparse profiles reach every conditional
+resource and optional body. Helm's source markers must account for every
+authored YAML template, so a resource disabled by the defaults cannot disappear
+from the gate.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,11 +221,12 @@ jobs:
         # failed: the workflow parsed, GitHub accepted it, and half the block
         # was simply gone.
         #
-        # The chart templates are rendered rather than skipped, because they
-        # are Go template source that no YAML parser can read and because
-        # `helm lint` was pointed at a chart whose service.yaml defined `type`
-        # twice and returned "0 chart(s) failed". Rendering is the only way
-        # anything looks inside them.
+        # The chart templates are rendered in three valid profiles rather than
+        # skipped, because they are Go template source that no YAML parser can
+        # read. `helm lint` was pointed at a chart whose service.yaml defined
+        # `type` twice and returned "0 chart(s) failed". Rendering is the only
+        # way anything looks inside them. Helm's source markers prove that the
+        # profiles reached every authored YAML template.
         run: go run ./tools/keycheck .
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,21 @@ jobs:
         # tree that runs the script and a commit that does not.
         run: go run ./tools/execcheck .
 
+      - name: No YAML key is defined twice in one mapping
+        # examples/github-workflow.yml declared `seed` and `concurrency` twice
+        # each in its workflow_dispatch inputs. YAML keeps the last definition,
+        # so the first pair's descriptions were text nobody would ever see, in
+        # the file this product hands a new user as the worked example. Nothing
+        # failed: the workflow parsed, GitHub accepted it, and half the block
+        # was simply gone.
+        #
+        # The chart templates are rendered rather than skipped, because they
+        # are Go template source that no YAML parser can read and because
+        # `helm lint` was pointed at a chart whose service.yaml defined `type`
+        # twice and returned "0 chart(s) failed". Rendering is the only way
+        # anything looks inside them.
+        run: go run ./tools/keycheck .
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         # For the examples that are not Go. Pinned to the same major the
         # runtime images use, so the version that builds an example here is the

--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,7 @@ runner/artifacts/
 /gatecheck
 /installcheck
 /installsh
+/keycheck
 /ldcheck
 /licensecheck
 /licensegen

--- a/examples/github-workflow.yml
+++ b/examples/github-workflow.yml
@@ -94,9 +94,8 @@ on:
         default: ''
       seed:
         description: >-
-          Replays the same schedule or the same wander. A whole number for
-          scenario and any string for explore, because that is what each
-          command's own --seed takes.
+          Makes load, scenario and explore repeat the same choices. Use a whole
+          number for load or scenario, and any string for explore.
         required: false
         default: ''
       concurrency:

--- a/examples/github-workflow.yml
+++ b/examples/github-workflow.yml
@@ -88,14 +88,6 @@ on:
         description: Multiplier on production's rate. observed_load only.
         required: false
         default: ''
-      seed:
-        description: Makes two runs do the same thing. A number for load, free text for exploration.
-        required: false
-        default: ''
-      concurrency:
-        description: Ceiling on requests in flight. http_scenario only.
-        required: false
-        default: ''
       run_id:
         description: The control plane's identifier for this run. Leave it empty; the engine asks.
         required: false

--- a/justfile
+++ b/justfile
@@ -99,6 +99,7 @@ gate: _reports
     run "the examples still compile"     just examples
     run "gate matches CI"                just gatecheck
     run "every script can be executed"   just execcheck
+    run "no yaml key is shadowed"        just keycheck
     run "vet"                            just vet
     run "typecheck"                      just typecheck
     run "format"                         just fmt-check
@@ -972,6 +973,14 @@ gatecheck:
 # pull request.
 execcheck:
     go run ./tools/execcheck .
+
+# No YAML key is defined twice in one mapping.
+#
+# Charts are rendered before they are read: a template is Go template source
+# that no YAML parser can take, and helm lint returns clean on a chart whose
+# service.yaml defines `type` twice.
+keycheck:
+    go run ./tools/keycheck .
 
 # The TypeScript that ships: the control plane packages, the agent runner, and
 # the console.

--- a/justfile
+++ b/justfile
@@ -169,6 +169,7 @@ setup:
     need npm    ""        "ships with node"                                    npm --version
     need docker ""        "https://docs.docker.com/get-docker/"                docker --version
     need git    ""        "brew install git"                                   git --version
+    need helm   ""        "https://helm.sh/docs/intro/install/ , or: brew install helm" helm version
 
     echo
     echo "Documentation gates"
@@ -976,9 +977,10 @@ execcheck:
 
 # No YAML key is defined twice in one mapping.
 #
-# Charts are rendered before they are read: a template is Go template source
-# that no YAML parser can take, and helm lint returns clean on a chart whose
-# service.yaml defines `type` twice.
+# Charts are rendered through three valid profiles before they are read: a
+# template is Go template source that no YAML parser can take, and helm lint
+# returns clean on a chart whose service.yaml defines `type` twice. Helm's
+# source markers prove that every authored YAML template was reached.
 keycheck:
     go run ./tools/keycheck .
 

--- a/tools/keycheck/main.go
+++ b/tools/keycheck/main.go
@@ -1,0 +1,315 @@
+// Command keycheck proves that no YAML file in this repository defines the
+// same key twice in one mapping.
+//
+// The failure that earned it: examples/github-workflow.yml declared `seed` and
+// `concurrency` twice each in its workflow_dispatch inputs. YAML resolves that
+// by keeping the last definition, so the first pair's descriptions were text
+// nobody would ever see, sitting in the file this product hands a new user as
+// the worked example of how to wire it into CI. Nothing failed. The workflow
+// parsed, GitHub accepted it, the example rendered, and the two descriptions
+// were simply gone. A defect that produces no error and no wrong answer, only
+// a quietly discarded half of a file, is the kind that survives every review.
+//
+// It is not a cosmetic class. The same shape in a workflow silently drops a
+// `permissions` block, an `env` entry or an `if` guard, and the run that
+// results looks exactly like the run somebody intended.
+//
+// WHY THIS WALKS THE NODE TREE RATHER THAN DECODING.
+//
+// gopkg.in/yaml.v3 does report a duplicate when a document is decoded into a
+// Go map, and that is the obvious implementation. It is the wrong one here for
+// two reasons, and both are the difference between a check that answers this
+// question and one that answers a nearby question.
+//
+// The first is that decoding stops. An unmarshal error carries the first
+// duplicate it met and abandons the rest of the document, so a file with four
+// of these reports one, gets fixed once, and comes back. This walk reports
+// every one of them in every file in a single pass.
+//
+// The second is that decoding fails for reasons that have nothing to do with
+// duplicate keys. Half the YAML here is a Helm template or a GitHub expression,
+// and a decode that errors on a type mismatch or an unknown tag is
+// indistinguishable, from the caller's side, from a decode that errored on a
+// duplicate. A check that cannot tell its own finding from an unrelated parse
+// failure is a check that will one day be silenced wholesale. Parsing to a
+// yaml.Node succeeds on anything syntactically well formed and leaves the
+// judgement here.
+//
+// WHAT IS DELIBERATELY OUT OF SCOPE. Keys that repeat across sibling documents
+// in a multi document file are not duplicates; each document is its own
+// mapping and each is walked separately. A merge key is a key like any other
+// and repeating it in one mapping is the same defect, so it is not special
+// cased.
+//
+// HELM TEMPLATES ARE RENDERED RATHER THAN SKIPPED, and this is the half of the
+// gate that took the longest to get right. A chart template is Go template
+// source, not YAML: gopkg.in/yaml.v3 cannot parse one, so the first version of
+// this command reported twelve unparseable files, checked the other forty
+// three, and printed a summary that named fifty five. That summary is the
+// defect this repository keeps finding in its own instruments. A check that
+// silently covers four fifths of what it claims is worse than one that covers
+// none, because the number reads as coverage.
+//
+// Nothing else catches it either. `helm lint` was pointed at a chart whose
+// service.yaml defined `type` twice and it returned "1 chart(s) linted, 0
+// chart(s) failed". A duplicate key survives rendering intact, so `helm
+// template` output holds it and can be parsed. That is what this does.
+//
+// If helm is not installed this command FAILS rather than skipping the charts.
+// Skipping would restore exactly the silence above, one environment variable
+// further away.
+//
+// There are no exemptions and there is no exemption file, because unlike a
+// naming rule or a prose rule this has no defensible exception: a mapping that
+// defines a key twice has thrown one of them away, and no reason makes that
+// intended.
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// finding is one key that a later key in the same mapping shadowed.
+type finding struct {
+	File  string
+	Line  int
+	Key   string
+	First int
+}
+
+func (f finding) String() string {
+	return fmt.Sprintf("%s:%d: %q was already defined at line %d. YAML keeps this one, so the earlier definition has no effect.",
+		f.File, f.Line, f.Key, f.First)
+}
+
+// skipped names directories that hold code this repository did not write.
+var skipped = map[string]bool{
+	".git": true, "node_modules": true, "dist": true, "build": true,
+	".next": true, "vendor": true, "testdata": true,
+}
+
+func main() {
+	root := flag.String("root", ".", "directory to scan")
+	flag.Parse()
+
+	charts, err := findCharts(*root)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "keycheck:", err)
+		os.Exit(2)
+	}
+
+	files, err := collect(*root, charts)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "keycheck:", err)
+		os.Exit(2)
+	}
+
+	var found []finding
+	var unread []string
+	for _, f := range files {
+		hits, scanErr := scan(*root, f)
+		if scanErr != nil {
+			// A file this could not read is not a clean file. It is recorded
+			// and it fails the run, because "no duplicates" said about
+			// something nothing parsed is the silence this gate exists to
+			// remove.
+			fmt.Fprintf(os.Stderr, "keycheck: %s could not be parsed: %v\n", f, scanErr)
+			unread = append(unread, f)
+			continue
+		}
+		found = append(found, hits...)
+	}
+
+	for _, c := range charts {
+		hits, renderErr := scanChart(*root, c)
+		if renderErr != nil {
+			fmt.Fprintf(os.Stderr, "keycheck: the chart at %s could not be rendered: %v\n", c, renderErr)
+			unread = append(unread, c)
+			continue
+		}
+		found = append(found, hits...)
+	}
+
+	if len(found) == 0 && len(unread) == 0 {
+		fmt.Printf("keycheck: %d YAML files and %d rendered chart(s), no key defined twice in one mapping\n",
+			len(files), len(charts))
+		return
+	}
+
+	sort.Slice(found, func(i, j int) bool {
+		if found[i].File != found[j].File {
+			return found[i].File < found[j].File
+		}
+		return found[i].Line < found[j].Line
+	})
+	for _, f := range found {
+		fmt.Println(f)
+	}
+	if len(found) > 0 {
+		fmt.Fprintf(os.Stderr, "\nkeycheck: %d key(s) silently discarded. YAML keeps the LAST definition, so the earlier one has no effect.\n", len(found))
+	}
+	if len(unread) > 0 {
+		fmt.Fprintf(os.Stderr, "keycheck: %d file(s) or chart(s) were not checked at all, listed above. That is a failure, not a pass.\n", len(unread))
+	}
+	os.Exit(1)
+}
+
+// chartValues are the minimum a render needs. They are values the chart
+// REQUIRES and nothing more: every one of them is enforced by a `fail` in the
+// chart's own templates, so a render without them stops before producing
+// anything. Rendering with placeholders is safe because nothing here is
+// deployed; the output is parsed and thrown away.
+//
+// A new required value breaks this loudly, with helm's own message naming it,
+// which is the failure mode to want.
+var chartValues = []string{
+	"database.url=keycheck",
+	"database.migrationUrl=keycheck",
+	"github.clientId=keycheck",
+	"github.clientSecret=keycheck",
+	"github.redirectUri=https://keycheck.invalid/cb",
+}
+
+// findCharts returns the directory of every Helm chart under root.
+func findCharts(root string) ([]string, error) {
+	var out []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if skipped[d.Name()] {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if d.Name() != "Chart.yaml" {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, filepath.Dir(path))
+		if relErr != nil {
+			return relErr
+		}
+		out = append(out, rel)
+		return nil
+	})
+	sort.Strings(out)
+	return out, err
+}
+
+// scanChart renders one chart and reports every shadowed key in the result.
+//
+// The templates themselves are unparseable Go template source, so this is the
+// only way to look inside them at all.
+func scanChart(root, chart string) ([]finding, error) {
+	if _, err := exec.LookPath("helm"); err != nil {
+		return nil, fmt.Errorf("helm is not installed, so this chart's templates cannot be read: %w", err)
+	}
+	args := []string{"template", "keycheck", chart}
+	for _, v := range chartValues {
+		args = append(args, "--set", v)
+	}
+	cmd := exec.Command("helm", args...)
+	cmd.Dir = root
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	return parse(filepath.Join(chart, "(rendered)"), out)
+}
+
+// collect returns every YAML file under root that this repository wrote,
+// except the template directories of the charts, which are rendered instead.
+func collect(root string, charts []string) ([]string, error) {
+	templates := map[string]bool{}
+	for _, c := range charts {
+		templates[filepath.Join(c, "templates")] = true
+	}
+	var out []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if skipped[d.Name()] {
+				return fs.SkipDir
+			}
+			if rel, relErr := filepath.Rel(root, path); relErr == nil && templates[rel] {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		switch strings.ToLower(filepath.Ext(path)) {
+		case ".yml", ".yaml":
+			rel, relErr := filepath.Rel(root, path)
+			if relErr != nil {
+				rel = path
+			}
+			out = append(out, rel)
+		}
+		return nil
+	})
+	sort.Strings(out)
+	return out, err
+}
+
+// scan reads one file and returns every shadowed key in it.
+func scan(root, rel string) ([]finding, error) {
+	b, err := os.ReadFile(filepath.Join(root, rel))
+	if err != nil {
+		return nil, err
+	}
+	return parse(rel, b)
+}
+
+// parse walks every document in one YAML stream.
+func parse(rel string, b []byte) ([]finding, error) {
+	dec := yaml.NewDecoder(strings.NewReader(string(b)))
+	var out []finding
+	for {
+		var doc yaml.Node
+		if err := dec.Decode(&doc); err != nil {
+			if errors.Is(err, io.EOF) {
+				return out, nil
+			}
+			return nil, err
+		}
+		out = append(out, walk(rel, &doc)...)
+	}
+}
+
+// walk descends one document, reporting duplicates in every mapping it holds.
+func walk(rel string, n *yaml.Node) []finding {
+	var out []finding
+	if n.Kind == yaml.MappingNode {
+		// A mapping's Content alternates key, value, key, value. Stepping by
+		// two over pairs rather than iterating every child is what keeps a
+		// value that happens to equal a key's name from being mistaken for one.
+		first := map[string]int{}
+		for i := 0; i+1 < len(n.Content); i += 2 {
+			k := n.Content[i]
+			if at, seen := first[k.Value]; seen {
+				out = append(out, finding{File: rel, Line: k.Line, Key: k.Value, First: at})
+				continue
+			}
+			first[k.Value] = k.Line
+		}
+	}
+	for _, c := range n.Content {
+		out = append(out, walk(rel, c)...)
+	}
+	return out
+}

--- a/tools/keycheck/main.go
+++ b/tools/keycheck/main.go
@@ -59,6 +59,12 @@
 // Skipping would restore exactly the silence above, one environment variable
 // further away.
 //
+// One default render is not coverage either. Optional resources disappear
+// from it, so three valid profiles exercise inline and external credentials,
+// every maintenance mode, autoscaling, ingress and sparse configuration. Helm
+// names the source template above every rendered document. The union of those
+// names must contain every authored YAML template before this gate may pass.
+//
 // There are no exemptions and there is no exemption file, because unlike a
 // naming rule or a prose rule this has no defensible exception: a mapping that
 // defines a key twice has thrown one of them away, and no reason makes that
@@ -82,16 +88,58 @@ import (
 
 // finding is one key that a later key in the same mapping shadowed.
 type finding struct {
-	File  string
-	Line  int
-	Key   string
-	First int
+	File       string
+	Line       int
+	Key        string
+	First      int
+	Document   string
+	Path       string
+	Occurrence int
+	Profiles   []string
 }
 
 func (f finding) String() string {
-	return fmt.Sprintf("%s:%d: %q was already defined at line %d. YAML keeps this one, so the earlier definition has no effect.",
-		f.File, f.Line, f.Key, f.First)
+	line := fmt.Sprintf("%s:%d", f.File, f.Line)
+	first := fmt.Sprintf("line %d", f.First)
+	if len(f.Profiles) > 0 {
+		line = fmt.Sprintf("%s: rendered line %d", f.File, f.Line)
+		first = fmt.Sprintf("rendered line %d", f.First)
+	}
+	where := ""
+	if f.Document != "" {
+		where = " in " + f.Document
+	}
+	if f.Path != "" {
+		where += " at " + f.Path
+	}
+	profiles := ""
+	if len(f.Profiles) > 0 {
+		profiles = " Profiles: " + strings.Join(f.Profiles, ", ") + "."
+	}
+	return fmt.Sprintf("%s: %q was already defined at %s%s. YAML keeps this one, so the earlier definition has no effect.%s",
+		line, f.Key, first, where, profiles)
 }
+
+type findingIdentity struct {
+	File       string
+	Document   string
+	Path       string
+	Key        string
+	Occurrence int
+}
+
+type chartScan struct {
+	Findings  []finding
+	Templates []string
+}
+
+type helmProfile struct {
+	Name    string
+	Release string
+	Values  string
+}
+
+type chartRenderer func(root, chart string, profile helmProfile) ([]byte, error)
 
 // skipped names directories that hold code this repository did not write.
 var skipped = map[string]bool{
@@ -132,18 +180,19 @@ func main() {
 	}
 
 	for _, c := range charts {
-		hits, renderErr := scanChart(*root, c)
+		result, renderErr := scanChart(*root, c)
+		found = append(found, result.Findings...)
 		if renderErr != nil {
-			fmt.Fprintf(os.Stderr, "keycheck: the chart at %s could not be rendered: %v\n", c, renderErr)
+			fmt.Fprintf(os.Stderr, "keycheck: the chart at %s could not be checked: %v\n", c, renderErr)
 			unread = append(unread, c)
 			continue
 		}
-		found = append(found, hits...)
 	}
+	found = mergeFindings(found)
 
 	if len(found) == 0 && len(unread) == 0 {
-		fmt.Printf("keycheck: %d YAML files and %d rendered chart(s), no key defined twice in one mapping\n",
-			len(files), len(charts))
+		fmt.Printf("keycheck: %d YAML files and %d chart render(s), no key defined twice in one mapping\n",
+			len(files), len(charts)*len(chartProfiles))
 		return
 	}
 
@@ -151,7 +200,16 @@ func main() {
 		if found[i].File != found[j].File {
 			return found[i].File < found[j].File
 		}
-		return found[i].Line < found[j].Line
+		if found[i].Document != found[j].Document {
+			return found[i].Document < found[j].Document
+		}
+		if found[i].Path != found[j].Path {
+			return found[i].Path < found[j].Path
+		}
+		if found[i].Key != found[j].Key {
+			return found[i].Key < found[j].Key
+		}
+		return found[i].Occurrence < found[j].Occurrence
 	})
 	for _, f := range found {
 		fmt.Println(f)
@@ -160,25 +218,158 @@ func main() {
 		fmt.Fprintf(os.Stderr, "\nkeycheck: %d key(s) silently discarded. YAML keeps the LAST definition, so the earlier one has no effect.\n", len(found))
 	}
 	if len(unread) > 0 {
-		fmt.Fprintf(os.Stderr, "keycheck: %d file(s) or chart(s) were not checked at all, listed above. That is a failure, not a pass.\n", len(unread))
+		fmt.Fprintf(os.Stderr, "keycheck: %d file(s) or chart(s) were not checked completely, listed above. That is a failure, not a pass.\n", len(unread))
 	}
 	os.Exit(1)
 }
 
-// chartValues are the minimum a render needs. They are values the chart
-// REQUIRES and nothing more: every one of them is enforced by a `fail` in the
-// chart's own templates, so a render without them stops before producing
-// anything. Rendering with placeholders is safe because nothing here is
-// deployed; the output is parsed and thrown away.
-//
-// A new required value breaks this loudly, with helm's own message naming it,
-// which is the failure mode to want.
-var chartValues = []string{
-	"database.url=keycheck",
-	"database.migrationUrl=keycheck",
-	"github.clientId=keycheck",
-	"github.clientSecret=keycheck",
-	"github.redirectUri=https://keycheck.invalid/cb",
+// chartProfiles reach the three materially different shapes of the chart.
+// Each profile is valid on its own. Their union renders every authored YAML
+// template, including resources that the defaults deliberately leave off.
+var chartProfiles = []helmProfile{
+	{
+		Name:    "rich inline cronjob",
+		Release: "keycheck-inline",
+		Values: `database:
+  url: keycheck
+  migrationUrl: keycheck
+github:
+  clientId: keycheck
+  clientSecret: keycheck
+  redirectUri: https://keycheck.invalid/cb
+nameOverride: profile
+image:
+  digest: ""
+  pullSecrets:
+    - name: keycheck-pull
+bootstrap:
+  enabled: true
+maintenance:
+  mode: cronjob
+config:
+  appBaseUrl: http://keycheck.invalid
+  insecureCookies: true
+  operatorSetsPlan: true
+  signinAllowlist: [keycheck]
+  eventRetentionMonths: "2"
+  eventArchiveDir: /archive
+service:
+  annotations:
+    keycheck.service: covered
+ingress:
+  enabled: false
+autoscaling:
+  enabled: false
+podDisruptionBudget:
+  enabled: true
+networkPolicy:
+  enabled: true
+  ingressFrom: []
+serviceAccount:
+  create: true
+  name: ""
+  annotations:
+    keycheck.service-account: covered
+podAnnotations:
+  keycheck.pod-annotation: covered
+podLabels:
+  keycheck.pod-label: covered
+nodeSelector:
+  kubernetes.io/os: linux
+tolerations:
+  - key: keycheck
+    operator: Exists
+affinity:
+  nodeAffinity: {}
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector: {}
+`,
+	},
+	{
+		Name:    "external secret autoscaled inProcess with ingress",
+		Release: "keycheck-external",
+		Values: `database:
+  existingSecret: keycheck-database
+github:
+  existingSecret: keycheck-github
+fullnameOverride: keycheck-fullname
+image:
+  digest: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+bootstrap:
+  enabled: true
+maintenance:
+  mode: inProcess
+config:
+  signinAllowlist: []
+autoscaling:
+  enabled: true
+ingress:
+  enabled: true
+  className: keycheck
+  annotations:
+    keycheck.ingress: covered
+  tls:
+    - secretName: keycheck-tls
+      hosts: [cp.example.com]
+networkPolicy:
+  enabled: true
+  ingressFrom:
+    - namespaceSelector:
+        matchLabels:
+          keycheck.network: allowed
+serviceAccount:
+  create: false
+  name: keycheck-external
+`,
+	},
+	{
+		Name:    "sparse maintenance off",
+		Release: "antifailure-control-plane",
+		Values: `database:
+  url: keycheck
+  migrationUrl: ""
+github:
+  clientId: keycheck
+  clientSecret: keycheck
+  redirectUri: https://keycheck.invalid/cb
+nameOverride: ""
+fullnameOverride: ""
+image:
+  tag: v1.1.1-keycheck
+bootstrap:
+  enabled: false
+maintenance:
+  mode: "off"
+config:
+  signinAllowlist: null
+replicaCount: 1
+podDisruptionBudget:
+  enabled: true
+ingress:
+  enabled: true
+  className: ""
+  annotations: {}
+  tls: []
+networkPolicy:
+  enabled: false
+  ingressFrom: []
+serviceAccount:
+  create: false
+  name: ""
+  annotations: {}
+service:
+  annotations: {}
+podAnnotations: {}
+podLabels: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}
+topologySpreadConstraints: []
+`,
+	},
 }
 
 // findCharts returns the directory of every Helm chart under root.
@@ -208,27 +399,127 @@ func findCharts(root string) ([]string, error) {
 	return out, err
 }
 
-// scanChart renders one chart and reports every shadowed key in the result.
-//
-// The templates themselves are unparseable Go template source, so this is the
-// only way to look inside them at all.
-func scanChart(root, chart string) ([]finding, error) {
+// scanChart renders every profile and reports each authored duplicate once.
+func scanChart(root, chart string) (chartScan, error) {
 	if _, err := exec.LookPath("helm"); err != nil {
-		return nil, fmt.Errorf("helm is not installed, so this chart's templates cannot be read: %w", err)
+		return chartScan{}, fmt.Errorf("helm is not installed, so this chart's templates cannot be read: %w", err)
 	}
-	args := []string{"template", "keycheck", chart}
-	for _, v := range chartValues {
-		args = append(args, "--set", v)
+	return scanChartWith(root, chart, renderChartProfile)
+}
+
+func scanChartWith(root, chart string, render chartRenderer) (chartScan, error) {
+	return scanChartProfilesWith(root, chart, chartProfiles, render)
+}
+
+func scanChartProfilesWith(root, chart string, profiles []helmProfile, render chartRenderer) (chartScan, error) {
+	expected, err := chartTemplates(root, chart)
+	if err != nil {
+		return chartScan{}, err
 	}
-	cmd := exec.Command("helm", args...)
+
+	result := chartScan{}
+	reached := map[string]bool{}
+	var failures []error
+	for _, profile := range profiles {
+		if profileErr := validateProfile(profile); profileErr != nil {
+			failures = append(failures, fmt.Errorf("profile %q has invalid values: %w", profile.Name, profileErr))
+			continue
+		}
+		out, renderErr := render(root, chart, profile)
+		if renderErr != nil {
+			failures = append(failures, fmt.Errorf("profile %q could not be rendered: %w", profile.Name, renderErr))
+			continue
+		}
+		hits, templates, parseErr := parseRendered(chart, profile.Name, out)
+		if parseErr != nil {
+			failures = append(failures, fmt.Errorf("profile %q produced unreadable YAML: %w", profile.Name, parseErr))
+			continue
+		}
+		result.Findings = append(result.Findings, hits...)
+		for _, template := range templates {
+			reached[template] = true
+		}
+	}
+
+	result.Findings = mergeFindings(result.Findings)
+	for template := range reached {
+		result.Templates = append(result.Templates, template)
+	}
+	sort.Strings(result.Templates)
+
+	var missing []string
+	for _, template := range expected {
+		if !reached[template] {
+			missing = append(missing, template)
+		}
+	}
+	if len(missing) > 0 {
+		failures = append(failures, fmt.Errorf("the render profiles reached no document from %s", strings.Join(missing, ", ")))
+	}
+	return result, errors.Join(failures...)
+}
+
+func validateProfile(profile helmProfile) error {
+	hits, err := parse("profile values", []byte(profile.Values))
+	if err != nil {
+		return err
+	}
+	if len(hits) == 0 {
+		return nil
+	}
+	var messages []string
+	for _, hit := range hits {
+		messages = append(messages, hit.String())
+	}
+	return fmt.Errorf("%d key(s) are defined more than once: %s", len(hits), strings.Join(messages, "; "))
+}
+
+func renderChartProfile(root, chart string, profile helmProfile) ([]byte, error) {
+	cmd := exec.Command("helm", "template", profile.Release, chart, "-f", "-")
 	cmd.Dir = root
+	cmd.Stdin = strings.NewReader(profile.Values)
 	var stderr strings.Builder
 	cmd.Stderr = &stderr
 	out, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", err, strings.TrimSpace(stderr.String()))
+		detail := strings.TrimSpace(stderr.String())
+		if detail == "" {
+			detail = "helm returned no diagnostic"
+		}
+		return nil, fmt.Errorf("%w: %s", err, detail)
 	}
-	return parse(filepath.Join(chart, "(rendered)"), out)
+	return out, nil
+}
+
+// chartTemplates returns every authored YAML template. NOTES.txt and helper
+// templates are not YAML documents and are outside this gate's claim.
+func chartTemplates(root, chart string) ([]string, error) {
+	chartRoot := filepath.Join(root, chart)
+	templateRoot := filepath.Join(chartRoot, "templates")
+	var out []string
+	err := filepath.WalkDir(templateRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		ext := strings.ToLower(filepath.Ext(path))
+		if ext != ".yaml" && ext != ".yml" {
+			return nil
+		}
+		rel, relErr := filepath.Rel(chartRoot, path)
+		if relErr != nil {
+			return relErr
+		}
+		out = append(out, filepath.ToSlash(rel))
+		return nil
+	})
+	sort.Strings(out)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // collect returns every YAML file under root that this repository wrote,
@@ -279,6 +570,7 @@ func scan(root, rel string) ([]finding, error) {
 func parse(rel string, b []byte) ([]finding, error) {
 	dec := yaml.NewDecoder(strings.NewReader(string(b)))
 	var out []finding
+	document := 0
 	for {
 		var doc yaml.Node
 		if err := dec.Decode(&doc); err != nil {
@@ -287,29 +579,242 @@ func parse(rel string, b []byte) ([]finding, error) {
 			}
 			return nil, err
 		}
-		out = append(out, walk(rel, &doc)...)
+		if len(doc.Content) == 0 {
+			continue
+		}
+		document++
+		hits := walk(rel, &doc)
+		identity := documentIdentity(doc.Content[0], document)
+		for i := range hits {
+			hits[i].Document = identity
+		}
+		out = append(out, hits...)
 	}
+}
+
+// parseRendered reads Helm's source markers as well as the YAML. Those markers
+// let findings survive line movement between profiles and prove which authored
+// templates produced at least one document.
+func parseRendered(chart, profile string, b []byte) ([]finding, []string, error) {
+	dec := yaml.NewDecoder(strings.NewReader(string(b)))
+	sources := renderedSources(b)
+	var found []finding
+	var templates []string
+	document := 0
+	for {
+		var doc yaml.Node
+		if err := dec.Decode(&doc); err != nil {
+			if errors.Is(err, io.EOF) {
+				return found, uniqueStrings(templates), nil
+			}
+			return nil, nil, err
+		}
+		if len(doc.Content) == 0 {
+			continue
+		}
+		document++
+		source := sourceFromNode(&doc)
+		if source == "" && document <= len(sources) {
+			source = sources[document-1]
+		}
+		template, err := normalizeTemplateSource(source)
+		if err != nil {
+			return nil, nil, fmt.Errorf("document %d: %w", document, err)
+		}
+		templates = append(templates, template)
+
+		hits := walk(filepath.ToSlash(filepath.Join(chart, template)), &doc)
+		identity := documentIdentity(doc.Content[0], document)
+		for i := range hits {
+			hits[i].Document = identity
+			hits[i].Profiles = []string{profile}
+		}
+		found = append(found, hits...)
+	}
+}
+
+func renderedSources(b []byte) []string {
+	var out []string
+	for _, line := range strings.Split(string(b), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "# Source:") {
+			out = append(out, strings.TrimSpace(strings.TrimPrefix(line, "# Source:")))
+		}
+	}
+	return out
+}
+
+func sourceFromNode(n *yaml.Node) string {
+	comments := []string{n.HeadComment}
+	if len(n.Content) > 0 {
+		comments = append(comments, n.Content[0].HeadComment)
+	}
+	for _, comment := range comments {
+		for _, line := range strings.Split(comment, "\n") {
+			line = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), "#"))
+			if strings.HasPrefix(line, "Source:") {
+				return strings.TrimSpace(strings.TrimPrefix(line, "Source:"))
+			}
+		}
+	}
+	return ""
+}
+
+func normalizeTemplateSource(source string) (string, error) {
+	source = filepath.ToSlash(strings.TrimSpace(source))
+	at := strings.Index(source, "templates/")
+	if at < 0 {
+		if source == "" {
+			return "", errors.New("the rendered document has no Helm source marker")
+		}
+		return "", fmt.Errorf("the Helm source marker %q names no template", source)
+	}
+	return source[at:], nil
+}
+
+func uniqueStrings(in []string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, value := range in {
+		if !seen[value] {
+			seen[value] = true
+			out = append(out, value)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func mergeFindings(in []finding) []finding {
+	byIdentity := map[findingIdentity]int{}
+	var out []finding
+	for _, hit := range in {
+		identity := findingIdentity{
+			File: hit.File, Document: hit.Document, Path: hit.Path,
+			Key: hit.Key, Occurrence: hit.Occurrence,
+		}
+		if at, ok := byIdentity[identity]; ok {
+			out[at].Profiles = appendUnique(out[at].Profiles, hit.Profiles...)
+			continue
+		}
+		byIdentity[identity] = len(out)
+		hit.Profiles = appendUnique(nil, hit.Profiles...)
+		out = append(out, hit)
+	}
+	return out
+}
+
+func appendUnique(current []string, values ...string) []string {
+	for _, value := range values {
+		seen := false
+		for _, existing := range current {
+			if existing == value {
+				seen = true
+				break
+			}
+		}
+		if !seen {
+			current = append(current, value)
+		}
+	}
+	return current
+}
+
+func documentIdentity(root *yaml.Node, ordinal int) string {
+	if root.Kind != yaml.MappingNode {
+		return fmt.Sprintf("document %d", ordinal)
+	}
+	apiVersion := mappingScalar(root, "apiVersion")
+	kind := mappingScalar(root, "kind")
+	metadata := mappingNode(root, "metadata")
+	name := mappingScalar(metadata, "name")
+	namespace := mappingScalar(metadata, "namespace")
+	if kind == "" || name == "" {
+		return fmt.Sprintf("document %d", ordinal)
+	}
+	identity := kind + " " + name
+	if namespace != "" {
+		identity = kind + " " + namespace + "/" + name
+	}
+	if apiVersion != "" {
+		identity = apiVersion + " " + identity
+	}
+	return identity
+}
+
+func mappingNode(n *yaml.Node, key string) *yaml.Node {
+	if n == nil || n.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(n.Content); i += 2 {
+		if n.Content[i].Value == key {
+			return n.Content[i+1]
+		}
+	}
+	return nil
+}
+
+func mappingScalar(n *yaml.Node, key string) string {
+	value := mappingNode(n, key)
+	if value == nil || value.Kind != yaml.ScalarNode {
+		return ""
+	}
+	return value.Value
 }
 
 // walk descends one document, reporting duplicates in every mapping it holds.
 func walk(rel string, n *yaml.Node) []finding {
+	return walkAt(rel, n, "$")
+}
+
+func walkAt(rel string, n *yaml.Node, path string) []finding {
 	var out []finding
-	if n.Kind == yaml.MappingNode {
+	switch n.Kind {
+	case yaml.MappingNode:
 		// A mapping's Content alternates key, value, key, value. Stepping by
 		// two over pairs rather than iterating every child is what keeps a
 		// value that happens to equal a key's name from being mistaken for one.
-		first := map[string]int{}
+		type seenKey struct {
+			line  int
+			count int
+		}
+		seen := map[string]seenKey{}
 		for i := 0; i+1 < len(n.Content); i += 2 {
 			k := n.Content[i]
-			if at, seen := first[k.Value]; seen {
-				out = append(out, finding{File: rel, Line: k.Line, Key: k.Value, First: at})
-				continue
+			prior := seen[k.Value]
+			prior.count++
+			if prior.line == 0 {
+				prior.line = k.Line
+			} else {
+				out = append(out, finding{
+					File: rel, Line: k.Line, Key: k.Value, First: prior.line,
+					Path: path, Occurrence: prior.count,
+				})
 			}
-			first[k.Value] = k.Line
+			seen[k.Value] = prior
+			out = append(out, walkAt(rel, n.Content[i+1], mappingPath(path, k.Value))...)
+		}
+	case yaml.SequenceNode:
+		for i, child := range n.Content {
+			out = append(out, walkAt(rel, child, path+sequenceSegment(child, i))...)
+		}
+	default:
+		for _, child := range n.Content {
+			out = append(out, walkAt(rel, child, path)...)
 		}
 	}
-	for _, c := range n.Content {
-		out = append(out, walk(rel, c)...)
-	}
 	return out
+}
+
+func mappingPath(parent, key string) string {
+	return fmt.Sprintf("%s[%q]", parent, key)
+}
+
+func sequenceSegment(n *yaml.Node, index int) string {
+	for _, key := range []string{"name", "host", "path", "kind", "port", "type"} {
+		if value := mappingScalar(n, key); value != "" {
+			return fmt.Sprintf("[%s=%q]", key, value)
+		}
+	}
+	return fmt.Sprintf("[%d]", index)
 }

--- a/tools/keycheck/main_test.go
+++ b/tools/keycheck/main_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -206,6 +205,30 @@ func TestTheMessageNamesBothLines(t *testing.T) {
 	}
 }
 
+// A chart finding carries rendered offsets, not source offsets. The label must
+// make that distinction explicit so the source template never appears to name
+// a line that belongs to the combined Helm output.
+func TestAProfiledMessageLabelsRenderedLines(t *testing.T) {
+	f := finding{
+		File: "chart/templates/service.yaml", Line: 11, Key: "type", First: 5,
+		Profiles: []string{"rich inline cronjob"},
+	}
+	s := f.String()
+	var failures []string
+	if !strings.Contains(s, "rendered line 11") {
+		failures = append(failures, "the surviving offset is not labeled as rendered: "+s)
+	}
+	if !strings.Contains(s, "rendered line 5") {
+		failures = append(failures, "the discarded offset is not labeled as rendered: "+s)
+	}
+	if strings.Contains(s, "service.yaml:11") {
+		failures = append(failures, "the rendered offset is formatted as a source line: "+s)
+	}
+	if len(failures) > 0 {
+		t.Fatalf("profiled finding:\n%s", strings.Join(failures, "\n"))
+	}
+}
+
 // A chart's templates are not read as YAML. They are Go template source, which
 // no YAML parser can read, so collect must leave them to the render path
 // rather than reporting twelve files it could not check.
@@ -243,43 +266,303 @@ func TestCollectLeavesChartTemplatesToTheRenderPath(t *testing.T) {
 	}
 }
 
-// A duplicate key inside a Helm template is found through the render. This is
-// the case helm lint returns clean on, so without it the twelve chart
-// templates are covered by nothing at all.
-func TestADuplicateInsideAChartTemplateIsFound(t *testing.T) {
-	if _, err := exec.LookPath("helm"); err != nil {
-		t.Skip("helm is not installed")
-	}
-	dir := t.TempDir()
-	chart := filepath.Join(dir, "chart")
-	if err := os.MkdirAll(filepath.Join(chart, "templates"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	files := map[string]string{
-		"Chart.yaml":  "apiVersion: v2\nname: k\nversion: 0.1.0\n",
-		"values.yaml": "kind: Service\n",
-		"templates/service.yaml": `apiVersion: v1
-kind: {{ .Values.kind }}
+// A branch that defaults off still has to be read. The external profile is the
+// only one that enables autoscaling, so a default render would miss this
+// duplicate.
+func TestADuplicateInABranchDisabledByDefaultsIsFound(t *testing.T) {
+	root, chart := testChart(t, "autoscaling:\n  enabled: false\n", map[string]string{
+		"templates/hpa.yaml": `{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
 metadata:
   name: k
+spec:
+  maxReplicas: 3
+  maxReplicas: 4
+{{- end }}
+`,
+	})
+	result, err := scanChart(root, chart)
+	if err != nil {
+		t.Fatalf("scanChart: %v", err)
+	}
+	if len(result.Findings) != 1 {
+		t.Fatalf("want 1 finding, got %v", result.Findings)
+	}
+	hit := result.Findings[0]
+	if hit.Key != "maxReplicas" {
+		t.Errorf("key = %q, want maxReplicas", hit.Key)
+	}
+	if strings.Join(hit.Profiles, ",") != "external secret autoscaled inProcess with ingress" {
+		t.Errorf("profiles = %v, want only the external autoscaling profile", hit.Profiles)
+	}
+}
+
+// The chart has twelve authored YAML templates. Reaching each one is the proof
+// behind the gate's chart coverage claim, so the expected list is deliberate.
+func TestEveryAuthoredChartTemplateIsReached(t *testing.T) {
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := scanChart(root, "deploy/helm/antifailure-control-plane")
+	if err != nil {
+		t.Fatalf("scanChart: %v", err)
+	}
+	want := []string{
+		"templates/cronjob-maintenance.yaml",
+		"templates/deployment.yaml",
+		"templates/hpa.yaml",
+		"templates/ingress.yaml",
+		"templates/job-bootstrap.yaml",
+		"templates/networkpolicy.yaml",
+		"templates/pdb.yaml",
+		"templates/secret-bootstrap.yaml",
+		"templates/secret.yaml",
+		"templates/service.yaml",
+		"templates/serviceaccount.yaml",
+		"templates/tests/test-connection.yaml",
+	}
+	if strings.Join(result.Templates, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("reached templates:\n%s\nwant:\n%s", strings.Join(result.Templates, "\n"), strings.Join(want, "\n"))
+	}
+}
+
+// Template names prove breadth, and these markers prove the conditional
+// bodies rendered with the values each profile is meant to exercise.
+func TestChartProfilesReachTheirOptionalBranches(t *testing.T) {
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		profile  helmProfile
+		contains []string
+		omits    []string
+	}{
+		{
+			profile: chartProfiles[0],
+			contains: []string{
+				"name: keycheck-inline-profile", "kind: CronJob", "kind: Job",
+				"kind: NetworkPolicy", "- from:\n        []", "kind: PodDisruptionBudget",
+				"kind: ServiceAccount", "kind: Secret", "imagePullSecrets:",
+				"keycheck.service: covered", "keycheck.service-account: covered",
+				"keycheck.pod-label: covered", "keycheck.pod-annotation: covered",
+				"name: AF_APP_BASE_URL", "name: AF_INSECURE_COOKIES",
+				"name: AF_OPERATOR_SETS_PLAN", "name: AF_SIGNIN_ALLOWLIST",
+				"name: AF_EVENT_RETENTION_MONTHS", "name: AF_EVENT_ARCHIVE_DIR",
+				"mountPath: /archive", "replicas: 2", "topologySpreadConstraints:",
+				"nodeSelector:", "tolerations:", "affinity:",
+				"image: ghcr.io/antifailure/control-plane:",
+			},
+			omits: []string{"kind: HorizontalPodAutoscaler", "kind: Ingress", "@sha256:"},
+		},
+		{
+			profile: chartProfiles[1],
+			contains: []string{
+				"name: keycheck-fullname", "kind: HorizontalPodAutoscaler",
+				"kind: Ingress", "kind: Job", "kind: NetworkPolicy",
+				"kind: PodDisruptionBudget", "serviceAccountName: keycheck-external",
+				"name: keycheck-database", "name: keycheck-github",
+				"image: ghcr.io/antifailure/control-plane@sha256:aaaaaaaa",
+				"name: AF_MAINTENANCE_DATABASE_URL", "name: AF_SIGNIN_ALLOWLIST\n              value: \"\"",
+				"keycheck.ingress: covered", "ingressClassName: keycheck",
+				"secretName: keycheck-tls", "namespaceSelector:",
+				"keycheck.network: allowed",
+			},
+			omits: []string{
+				"kind: Secret", "kind: ServiceAccount", "kind: CronJob",
+				"\n  replicas:", "imagePullSecrets:",
+			},
+		},
+		{
+			profile: chartProfiles[2],
+			contains: []string{
+				"name: antifailure-control-plane", "kind: Secret", "kind: Ingress",
+				"replicas: 1", "serviceAccountName: default",
+				"image: ghcr.io/antifailure/control-plane:v1.1.1-keycheck",
+				"AF_DATABASE_URL: \"keycheck\"",
+			},
+			omits: []string{
+				"AF_MIGRATION_DATABASE_URL", "name: AF_SIGNIN_ALLOWLIST",
+				"name: AF_MAINTENANCE_DATABASE_URL", "kind: Job", "kind: CronJob",
+				"kind: HorizontalPodAutoscaler", "kind: PodDisruptionBudget",
+				"kind: NetworkPolicy", "kind: ServiceAccount", "ingressClassName:",
+				"imagePullSecrets:", "topologySpreadConstraints:", "nodeSelector:",
+				"tolerations:", "affinity:", "keycheck.ingress:", "secretName:", "@sha256:",
+			},
+		},
+	}
+
+	var failures []string
+	for _, test := range tests {
+		out, renderErr := renderChartProfile(root, "deploy/helm/antifailure-control-plane", test.profile)
+		if renderErr != nil {
+			failures = append(failures, test.profile.Name+": "+renderErr.Error())
+			continue
+		}
+		rendered := string(out)
+		for _, marker := range test.contains {
+			if !strings.Contains(rendered, marker) {
+				failures = append(failures, test.profile.Name+": missing "+marker)
+			}
+		}
+		for _, marker := range test.omits {
+			if strings.Contains(rendered, marker) {
+				failures = append(failures, test.profile.Name+": unexpectedly rendered "+marker)
+			}
+		}
+	}
+	if len(failures) > 0 {
+		t.Fatalf("profile branch coverage:\n%s", strings.Join(failures, "\n"))
+	}
+}
+
+// The same authored duplicate renders in all three profiles. It is one defect,
+// so rendered line movement must not make the report repeat it three times.
+func TestADuplicateAcrossProfilesIsReportedOnce(t *testing.T) {
+	root, chart := testChart(t, "ingress:\n  enabled: false\n", map[string]string{
+		"templates/service.yaml": `apiVersion: v1
+kind: Service
+metadata:
+  name: k
+{{- if .Values.ingress.enabled }}
+  labels:
+    profile: external
+{{- end }}
 spec:
   type: ClusterIP
   type: NodePort
 `,
-	}
-	for name, body := range files {
-		if err := os.WriteFile(filepath.Join(chart, name), []byte(body), 0o644); err != nil {
-			t.Fatal(err)
-		}
-	}
-	found, err := scanChart(dir, "chart")
+	})
+	result, err := scanChart(root, chart)
 	if err != nil {
 		t.Fatalf("scanChart: %v", err)
 	}
-	if len(found) != 1 {
-		t.Fatalf("want 1 finding, got %v", found)
+	if len(result.Findings) != 1 {
+		t.Fatalf("want 1 finding, got %v", result.Findings)
 	}
-	if found[0].Key != "type" {
-		t.Errorf("key = %q, want type", found[0].Key)
+	var wantProfiles []string
+	for _, profile := range chartProfiles {
+		wantProfiles = append(wantProfiles, profile.Name)
 	}
+	if strings.Join(result.Findings[0].Profiles, "\n") != strings.Join(wantProfiles, "\n") {
+		t.Fatalf("profiles = %v, want %v", result.Findings[0].Profiles, wantProfiles)
+	}
+}
+
+// Every part of the identity prevents two distinct authored defects from
+// collapsing into one. Only the second profile for the exact same identity is
+// evidence for the existing finding.
+func TestFindingIdentityKeepsDistinctDefects(t *testing.T) {
+	base := finding{
+		File: "chart/templates/service.yaml", Document: "v1 Service k",
+		Path: `$["spec"]`, Key: "type", Occurrence: 2,
+		Profiles: []string{"rich inline cronjob"},
+	}
+	found := mergeFindings([]finding{
+		base,
+		{
+			File: base.File, Document: base.Document, Path: base.Path,
+			Key: base.Key, Occurrence: base.Occurrence,
+			Profiles: []string{"external secret autoscaled inProcess with ingress"},
+		},
+		{File: "chart/templates/other.yaml", Document: base.Document, Path: base.Path, Key: base.Key, Occurrence: base.Occurrence},
+		{File: base.File, Document: "v1 Service other", Path: base.Path, Key: base.Key, Occurrence: base.Occurrence},
+		{File: base.File, Document: base.Document, Path: `$["metadata"]`, Key: base.Key, Occurrence: base.Occurrence},
+		{File: base.File, Document: base.Document, Path: base.Path, Key: "port", Occurrence: base.Occurrence},
+		{File: base.File, Document: base.Document, Path: base.Path, Key: base.Key, Occurrence: 3},
+	})
+	if len(found) != 6 {
+		t.Fatalf("want 6 distinct findings, got %d: %v", len(found), found)
+	}
+}
+
+// One bad profile cannot hide behind two successful renders. The error names
+// the profile that failed and keeps Helm's reason.
+func TestASingleProfileRenderFailureIsFatalAndNamed(t *testing.T) {
+	root, chart := testChart(t, "autoscaling:\n  enabled: false\n", map[string]string{
+		"templates/service.yaml": `{{- if .Values.autoscaling.enabled }}
+{{- fail "the autoscaled branch is broken" }}
+{{- end }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: k
+`,
+	})
+	result, err := scanChart(root, chart)
+	if err == nil {
+		t.Fatal("want the external profile render failure, got nil")
+	}
+	if !strings.Contains(err.Error(), `profile "external secret autoscaled inProcess with ingress"`) {
+		t.Fatalf("error does not name the failed profile: %v", err)
+	}
+	if !strings.Contains(err.Error(), "the autoscaled branch is broken") {
+		t.Fatalf("error lost Helm's diagnostic: %v", err)
+	}
+	if strings.Join(result.Templates, ",") != "templates/service.yaml" {
+		t.Fatalf("successful profiles were discarded: %v", result.Templates)
+	}
+}
+
+// Helm accepts duplicate values and keeps the last one. The profiles are part
+// of this gate, so they pass through the same duplicate check before Helm can
+// silently change what the matrix covers.
+func TestADuplicateInProfileValuesStopsBeforeHelm(t *testing.T) {
+	root, chart := testChart(t, "", map[string]string{
+		"templates/service.yaml": "apiVersion: v1\nkind: Service\nmetadata:\n  name: k\n",
+	})
+	profile := helmProfile{
+		Name:    "duplicate values",
+		Release: "keycheck",
+		Values:  "config:\n  port: 1\nconfig:\n  port: 2\n",
+	}
+	called := false
+	render := func(_, _ string, _ helmProfile) ([]byte, error) {
+		called = true
+		separator := strings.Repeat("-", 3)
+		return []byte(separator + "\n# Source: keycheck-test/templates/service.yaml\napiVersion: v1\nkind: Service\nmetadata:\n  name: k\n"), nil
+	}
+	_, err := scanChartProfilesWith(root, chart, []helmProfile{profile}, render)
+	var failures []string
+	if err == nil {
+		failures = append(failures, "duplicate profile values returned no error")
+	} else {
+		if !strings.Contains(err.Error(), `profile "duplicate values" has invalid values`) {
+			failures = append(failures, "error did not name the profile: "+err.Error())
+		}
+		if !strings.Contains(err.Error(), `"config" was already defined`) {
+			failures = append(failures, "error did not name the duplicate: "+err.Error())
+		}
+	}
+	if called {
+		failures = append(failures, "Helm was called with ambiguous profile values")
+	}
+	if len(failures) > 0 {
+		t.Fatalf("profile validation:\n%s", strings.Join(failures, "\n"))
+	}
+}
+
+func testChart(t *testing.T, values string, templates map[string]string) (string, string) {
+	t.Helper()
+	root := t.TempDir()
+	chart := "chart"
+	files := map[string]string{
+		"Chart.yaml":  "apiVersion: v2\nname: keycheck-test\nversion: 0.1.0\n",
+		"values.yaml": values,
+	}
+	for name, body := range templates {
+		files[name] = body
+	}
+	for name, body := range files {
+		path := filepath.Join(root, chart, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root, chart
 }

--- a/tools/keycheck/main_test.go
+++ b/tools/keycheck/main_test.go
@@ -1,0 +1,285 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// write puts one file under a fresh directory and returns the directory.
+func write(t *testing.T, name, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// The defect this gate was written for, in the shape it actually had: two
+// pairs of workflow_dispatch inputs, the first of each pair discarded.
+func TestTheWorkedExampleDefectIsFound(t *testing.T) {
+	dir := write(t, "github-workflow.yml", `on:
+  workflow_dispatch:
+    inputs:
+      seed:
+        description: Makes two runs do the same thing.
+      concurrency:
+        description: Ceiling on requests in flight.
+      run_id:
+        description: The control plane's identifier.
+      seed:
+        description: Replays the same schedule.
+      concurrency:
+        description: Ceiling on requests in flight, for scenario.
+`)
+	found, err := scan(dir, "github-workflow.yml")
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(found) != 2 {
+		t.Fatalf("want 2 findings, got %d: %v", len(found), found)
+	}
+	if found[0].Key != "seed" {
+		t.Errorf("first finding key = %q, want seed", found[0].Key)
+	}
+	if found[1].Key != "concurrency" {
+		t.Errorf("second finding key = %q, want concurrency", found[1].Key)
+	}
+	if found[0].First != 4 {
+		t.Errorf("first finding points at line %d as the discarded one, want 4", found[0].First)
+	}
+	if found[0].Line != 10 {
+		t.Errorf("first finding reports line %d as the survivor, want 10", found[0].Line)
+	}
+}
+
+// A file with no duplicate must produce no finding. Without this the gate
+// could report every key and still pass the test above.
+func TestACleanFileReportsNothing(t *testing.T) {
+	dir := write(t, "clean.yml", `on:
+  workflow_dispatch:
+    inputs:
+      seed:
+        description: one
+      concurrency:
+        description: two
+`)
+	found, err := scan(dir, "clean.yml")
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(found) != 0 {
+		t.Fatalf("want no findings, got %v", found)
+	}
+}
+
+// A value that happens to equal a sibling key's name is not a duplicate. This
+// is what the step-by-two over pairs buys, and a walk over every child would
+// fail it.
+func TestAValueEqualToAKeyNameIsNotADuplicate(t *testing.T) {
+	dir := write(t, "values.yml", `seed: seed
+concurrency: seed
+`)
+	found, err := scan(dir, "values.yml")
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(found) != 0 {
+		t.Fatalf("want no findings, got %v", found)
+	}
+}
+
+// Nested mappings are walked. A duplicate three levels down is the same defect
+// as one at the root and the workflow case is always nested.
+func TestADuplicateNestedDeeplyIsFound(t *testing.T) {
+	dir := write(t, "nested.yml", `jobs:
+  build:
+    steps:
+      - env:
+          A: one
+          A: two
+`)
+	found, err := scan(dir, "nested.yml")
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(found) != 1 {
+		t.Fatalf("want 1 finding, got %v", found)
+	}
+	if found[0].Key != "A" {
+		t.Errorf("key = %q, want A", found[0].Key)
+	}
+}
+
+// The same key in two documents of one file is not a duplicate. Helm output
+// and Kubernetes manifests are full of this and reporting it would make the
+// gate unusable on exactly the files that most need it.
+func TestSiblingDocumentsDoNotCollide(t *testing.T) {
+	dir := write(t, "multi.yml", `kind: Service
+---
+kind: Deployment
+`)
+	found, err := scan(dir, "multi.yml")
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(found) != 0 {
+		t.Fatalf("want no findings, got %v", found)
+	}
+}
+
+// Every duplicate in a file is reported, not just the first. This is the whole
+// reason the gate walks the tree instead of decoding into a map, and without
+// this assertion the decoding implementation would pass the suite.
+func TestEveryDuplicateIsReportedNotJustTheFirst(t *testing.T) {
+	dir := write(t, "many.yml", `a: 1
+a: 2
+b: 3
+b: 4
+c: 5
+c: 6
+`)
+	found, err := scan(dir, "many.yml")
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(found) != 3 {
+		t.Fatalf("want 3 findings, got %d: %v", len(found), found)
+	}
+}
+
+// collect finds YAML by extension and does not descend into code this
+// repository did not write.
+func TestCollectSkipsVendoredDirectories(t *testing.T) {
+	dir := t.TempDir()
+	for _, p := range []string{"a.yml", "sub/b.yaml", "node_modules/c.yml", "x.txt"} {
+		full := filepath.Join(dir, p)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte("k: v\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	files, err := collect(dir, nil)
+	if err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	got := strings.Join(files, ",")
+	want := "a.yml,sub/b.yaml"
+	if got != want {
+		t.Fatalf("collect = %q, want %q", got, want)
+	}
+}
+
+// A file this cannot parse must be an error rather than a clean result,
+// because "no duplicates" about a file nothing read is the silence the gate
+// exists to remove.
+func TestAnUnparseableFileIsAnErrorNotACleanPass(t *testing.T) {
+	dir := write(t, "broken.yml", "a: [1, 2\nb: :\n")
+	found, err := scan(dir, "broken.yml")
+	if err == nil {
+		t.Fatalf("want a parse error, got %d findings and no error", len(found))
+	}
+}
+
+// The message names the surviving line and the discarded one, because a
+// finding a reader cannot act on is a finding they will silence.
+func TestTheMessageNamesBothLines(t *testing.T) {
+	f := finding{File: "x.yml", Line: 11, Key: "seed", First: 5}
+	s := f.String()
+	if !strings.Contains(s, "x.yml:11") {
+		t.Errorf("message does not name the surviving line: %s", s)
+	}
+	if !strings.Contains(s, "line 5") {
+		t.Errorf("message does not name the discarded line: %s", s)
+	}
+	if !strings.Contains(s, `"seed"`) {
+		t.Errorf("message does not name the key: %s", s)
+	}
+}
+
+// A chart's templates are not read as YAML. They are Go template source, which
+// no YAML parser can read, so collect must leave them to the render path
+// rather than reporting twelve files it could not check.
+func TestCollectLeavesChartTemplatesToTheRenderPath(t *testing.T) {
+	dir := t.TempDir()
+	for _, p := range []string{
+		"deploy/chart/Chart.yaml",
+		"deploy/chart/values.yaml",
+		"deploy/chart/templates/service.yaml",
+		"other.yml",
+	} {
+		full := filepath.Join(dir, p)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte("k: v\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	charts, err := findCharts(dir)
+	if err != nil {
+		t.Fatalf("findCharts: %v", err)
+	}
+	if strings.Join(charts, ",") != "deploy/chart" {
+		t.Fatalf("findCharts = %v, want [deploy/chart]", charts)
+	}
+	files, err := collect(dir, charts)
+	if err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	got := strings.Join(files, ",")
+	want := "deploy/chart/Chart.yaml,deploy/chart/values.yaml,other.yml"
+	if got != want {
+		t.Fatalf("collect = %q, want %q", got, want)
+	}
+}
+
+// A duplicate key inside a Helm template is found through the render. This is
+// the case helm lint returns clean on, so without it the twelve chart
+// templates are covered by nothing at all.
+func TestADuplicateInsideAChartTemplateIsFound(t *testing.T) {
+	if _, err := exec.LookPath("helm"); err != nil {
+		t.Skip("helm is not installed")
+	}
+	dir := t.TempDir()
+	chart := filepath.Join(dir, "chart")
+	if err := os.MkdirAll(filepath.Join(chart, "templates"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	files := map[string]string{
+		"Chart.yaml":  "apiVersion: v2\nname: k\nversion: 0.1.0\n",
+		"values.yaml": "kind: Service\n",
+		"templates/service.yaml": `apiVersion: v1
+kind: {{ .Values.kind }}
+metadata:
+  name: k
+spec:
+  type: ClusterIP
+  type: NodePort
+`,
+	}
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(chart, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	found, err := scanChart(dir, "chart")
+	if err != nil {
+		t.Fatalf("scanChart: %v", err)
+	}
+	if len(found) != 1 {
+		t.Fatalf("want 1 finding, got %v", found)
+	}
+	if found[0].Key != "type" {
+		t.Errorf("key = %q, want type", found[0].Key)
+	}
+}


### PR DESCRIPTION
`examples/github-workflow.yml` declared `seed` and `concurrency` twice in its
dispatch inputs. YAML keeps the last definition, so GitHub accepted the file
while silently discarding the first descriptions.

## What changed

The example now defines each input once, and the seed description covers load,
scenario, and exploration without losing any of the original guidance.

`tools/keycheck` walks YAML mapping nodes and reports every duplicate, rather
than stopping at the first one. It is part of CI and `just gate`.

Helm templates are rendered through three valid profiles. Together they cover
all twelve authored YAML templates, every maintenance mode, inline and external
credentials, tag and digest images, generated and named service accounts,
autoscaling, ingress, network policy, archive mounts, and sparse configuration.
The gate validates its own profile YAML before Helm can discard a duplicate.
Helm source markers give findings a stable template, document, mapping path,
key, and occurrence identity, so one authored defect is reported once even when
several profiles render it.

`just setup` now names Helm because the repository gate requires it, and the
compiled `keycheck` binary is ignored at the repository root.

## Verification

```text
go test -count=1 ./tools/...
ok for every tools package

go run ./tools/gatecheck .
78 gates in 9 pull request workflows, 68 paired and 8 documented exemptions

go run ./tools/keycheck .
43 YAML files and 3 chart renders, no key defined twice in one mapping

go run ./tools/prosecheck .
718 files, 0 violations
```

Twenty three independent mutations were applied one at a time. They covered
the disabled-template path, every profile group, every deduplication identity
field, profile validation, rendered-line labeling, render errors, retained
successful coverage, and profile-specific diagnostics. Every mutation failed
its named assertion, and the restored suite passed uncached.

CI attempt 3 concluded `success` for every required context on commit
`baa4925999a16d9077137f437c098a0dad97c85e`.
