### PR TITLE
A refusal that named no cause

### DIFF
--- a/.changes/a-refusal-that-named-no-cause.md
+++ b/.changes/a-refusal-that-named-no-cause.md
@@ -1,0 +1,19 @@
+# fixed
+
+The npm advisory gate refused and would not say why.
+
+`npm advisories` went red on main and on every open pull request, and the whole
+output was `npmaudit: api: npm audit refused:` with nothing after the colon. npm
+had returned a report whose `error` object was present and whose code, summary
+and detail were all empty, and the format string printed the three empty strings
+faithfully. The step had run for exactly five minutes first, twice, which is
+npm's own default fetch timeout and the shape of a registry that never answered.
+None of that reached anybody, because this is the one error path that fires when
+the registry is unreachable and it was the one path of the three that did not
+carry stderr.
+
+A refusal now carries npm's exit error and its stderr, and an empty refusal
+reports itself as empty rather than trailing off after a colon. An empty stderr
+is stated out loud, because npm printing nothing and this tool discarding what
+npm printed look identical in a log, and the second of those is what was
+happening.

--- a/tools/npmaudit/main.go
+++ b/tools/npmaudit/main.go
@@ -321,7 +321,7 @@ func parse(stdout []byte, project string, runErr error, stderr string) ([]*findi
 		return nil, fmt.Errorf("%s: npm audit printed something that is not a report: %w\n%s", project, err, trim(stderr))
 	}
 	if rep.Error != nil {
-		return nil, fmt.Errorf("%s: npm audit refused: %s %s\n%s", project, rep.Error.Code, rep.Error.Summary, rep.Error.Detail)
+		return nil, refusal(project, rep.Error, runErr, stderr)
 	}
 	if rep.AuditReportVersion == nil {
 		if runErr != nil {
@@ -370,6 +370,53 @@ func identifier(url string, source int) string {
 		}
 	}
 	return fmt.Sprintf("npm-%d", source)
+}
+
+// refusal turns npm's error object into a sentence that names a cause.
+//
+// THE FAILURE THAT EARNED IT. `npm advisories` went red on main and on every
+// open pull request, and the entire output was:
+//
+//	npmaudit: api: npm audit refused:
+//	exit status 1
+//
+// Nothing after the colon. npm had returned a report whose `error` object was
+// present and whose code, summary and detail were all empty, and the format
+// string printed the three empty strings faithfully. The step had run for
+// exactly five minutes first, which is the shape of a registry that never
+// answered, and none of that reached anybody: this is the ONE error path that
+// fires when the registry is unreachable and it was the one path of the three
+// here that did not carry stderr.
+//
+// So the rule this encodes is the one the repository already applies to the
+// error catalogue. A message that cannot name a cause has to say that it
+// cannot, rather than trailing off and leaving a reader to assume the tool
+// found nothing worth printing. An empty refusal now reports itself as empty,
+// and every refusal carries the process's own diagnostics.
+func refusal(project string, e *npmError, runErr error, stderr string) error {
+	said := strings.TrimSpace(strings.Join([]string{e.Code, e.Summary, e.Detail}, " "))
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s: npm audit refused", project)
+	if said == "" {
+		// The case that produced this function. npm said it was refusing and
+		// then said nothing about why, so that fact is the finding.
+		b.WriteString(" and gave no code, summary or detail")
+	} else {
+		fmt.Fprintf(&b, ": %s", said)
+	}
+	if runErr != nil {
+		fmt.Fprintf(&b, "\nnpm exited: %v", runErr)
+	}
+	if out := trim(stderr); out != "" {
+		fmt.Fprintf(&b, "\nnpm wrote to stderr:\n%s", out)
+	} else {
+		// Said out loud, because "the tool printed nothing more" and "the tool
+		// discarded what was printed" look identical from a log, and the second
+		// of those is the defect this function replaces.
+		b.WriteString("\nnpm wrote nothing to stderr.")
+	}
+	return errors.New(b.String())
 }
 
 func trim(s string) string {

--- a/tools/npmaudit/main_test.go
+++ b/tools/npmaudit/main_test.go
@@ -298,3 +298,72 @@ func TestTheFixtureIsShapedLikeNpmsOutput(t *testing.T) {
 		t.Fatal("the request entry is the union case and needs all five elements")
 	}
 }
+
+// The exact shape that took main red: npm returns an error object and fills in
+// none of it. The old format string printed three empty strings, so the whole
+// output was "npmaudit: api: npm audit refused:" with nothing after the colon.
+func TestAnEmptyRefusalSaysThatItIsEmpty(t *testing.T) {
+	const blank = `{"error":{"code":"","summary":"","detail":""}}`
+	_, err := parse([]byte(blank), "api", nil, "")
+	if err == nil {
+		t.Fatal("an empty refusal was read as a clean tree")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "gave no code, summary or detail") {
+		t.Errorf("an empty refusal must say it is empty: %q", msg)
+	}
+	if strings.HasSuffix(strings.SplitN(msg, "\n", 2)[0], ":") {
+		t.Errorf("the first line trails off after a colon: %q", msg)
+	}
+}
+
+// The one path that fires when the registry is unreachable is the one that used
+// to discard the diagnostics. Both the process's exit error and its stderr have
+// to reach the reader.
+func TestARefusalCarriesStderrAndTheExitError(t *testing.T) {
+	const blank = `{"error":{"code":"","summary":"","detail":""}}`
+	_, err := parse([]byte(blank), "api", os.ErrDeadlineExceeded, "npm ERR! network request to https://registry.npmjs.org failed")
+	if err == nil {
+		t.Fatal("an empty refusal was read as a clean tree")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "registry.npmjs.org") {
+		t.Errorf("stderr did not reach the reader: %q", msg)
+	}
+	if !strings.Contains(msg, os.ErrDeadlineExceeded.Error()) {
+		t.Errorf("the exit error did not reach the reader: %q", msg)
+	}
+}
+
+// Silence from npm and silence from this tool look identical in a log, and the
+// second one is the defect being fixed, so an empty stderr is stated rather
+// than left out.
+func TestAnEmptyStderrIsStatedRatherThanOmitted(t *testing.T) {
+	const blank = `{"error":{"code":"","summary":"","detail":""}}`
+	_, err := parse([]byte(blank), "api", nil, "   ")
+	if err == nil {
+		t.Fatal("an empty refusal was read as a clean tree")
+	}
+	if !strings.Contains(err.Error(), "npm wrote nothing to stderr") {
+		t.Errorf("an empty stderr must be stated: %q", err.Error())
+	}
+}
+
+// A refusal that DOES say why keeps saying it. Fixing the empty case must not
+// bury the populated one.
+func TestAPopulatedRefusalStillNamesItsCause(t *testing.T) {
+	const enolock = `{"error":{"code":"ENOLOCK","summary":"This command requires an existing lockfile.","detail":"Try creating one first"}}`
+	_, err := parse([]byte(enolock), "runner", nil, "")
+	if err == nil {
+		t.Fatal("npm refusing to run was read as a clean tree")
+	}
+	msg := err.Error()
+	for _, want := range []string{"ENOLOCK", "existing lockfile", "Try creating one first", "runner"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("the refusal dropped %q: %s", want, msg)
+		}
+	}
+	if strings.Contains(msg, "gave no code") {
+		t.Errorf("a populated refusal was reported as empty: %s", msg)
+	}
+}


### PR DESCRIPTION
`npm advisories` is red on main and on every open pull request. The entire output is:

```
npmaudit: api: npm audit refused:
exit status 1
```

Nothing after the colon. npm returned a report whose `error` object was present and whose code, summary and detail were all empty, and the format string at `tools/npmaudit/main.go:324` printed the three empty strings faithfully.

## What the timing says

The step ran for exactly five minutes before failing, in both failing runs:

| Run | Started | Failed | Duration |
| --- | --- | --- | --- |
| 33815005859 | 22:51:54 | 22:56:55 | 5m01s |
| 33825232140 | 01:18:20 | 01:23:21 | 5m01s |

That is npm's own default `fetch-timeout` of 300000ms, and it is the shape of a registry that never answered rather than of a real advisory. None of that evidence reached anybody.

## Why this one path

`parse` has three error paths. The two that fire on a malformed report both call `trim(stderr)`. This one, the only one that fires when the registry is unreachable, was the one that threw the diagnostics away. So the gate that exists to say what is wrong with the dependency tree could not say what was wrong with itself, and there is no way to tell a real advisory from an unreachable registry without reading the source.

## What changed

A refusal now carries npm's exit error and its stderr. An empty refusal says it is empty rather than trailing off after a colon. An empty stderr is stated out loud, because npm printing nothing and this tool discarding what npm printed look identical in a log, and the second of those is the defect being fixed.

**This does not by itself make the gate pass.** It makes the next failure legible, which is the prerequisite for fixing the cause rather than guessing at it. If the registry is the problem, the next run will say so in npm's own words.

## Verification

Every test was mutation tested, one break per assertion:

| Mutation | Caught by |
| --- | --- |
| Restore the original format string, the exact bug | `TestAnEmptyRefusalSaysThatItIsEmpty` and two others |
| Drop stderr from the refusal | `TestARefusalCarriesStderrAndTheExitError`, `TestAnEmptyStderrIsStatedRatherThanOmitted` |
| Drop the exit error | `TestARefusalCarriesStderrAndTheExitError` |
| Treat every refusal as empty, dropping populated fields | `TestAPopulatedRefusalStillNamesItsCause`, `TestNpmRefusingIsAnErrorAndNotAnEmptyReport` |
| Keep the trailing colon on an empty refusal | `TestAnEmptyRefusalSaysThatItIsEmpty` |

The pre-existing `TestNpmRefusingIsAnErrorAndNotAnEmptyReport` still passes, and a new test asserts a populated refusal is not reported as empty, so the fix to the blank case cannot bury the case that already worked.