### PR TITLE
init: a helper image was made to run migrations it never contained

### DIFF
--- a/.changes/init-runtime-ownership.md
+++ b/.changes/init-runtime-ownership.md
@@ -1,3 +1,5 @@
+# fixed
+
 An image used only to execute isolated snippets was detected as a web server,
 and a repository's Alembic migration was assigned to it even though the image
 contained neither Alembic nor the application's schema. Initialization now

--- a/.changes/init-runtime-ownership.md
+++ b/.changes/init-runtime-ownership.md
@@ -1,0 +1,9 @@
+An image used only to execute isolated snippets was detected as a web server,
+and a repository's Alembic migration was assigned to it even though the image
+contained neither Alembic nor the application's schema. Initialization now
+requires runtime evidence before treating a Dockerfile as a service. A
+framework or Compose command can supply that evidence.
+
+Migration commands outside a unique service directory now require an explicit
+image owner. An unattended run refuses to guess. Choosing manual setup reports
+that migrations remain unconfigured; it does not claim the database is ready.

--- a/.changes/init-runtime-ownership.md
+++ b/.changes/init-runtime-ownership.md
@@ -5,6 +5,8 @@ and a repository's Alembic migration was assigned to it even though the image
 contained neither Alembic nor the application's schema. Initialization now
 requires runtime evidence before treating a Dockerfile as a service. A
 framework or Compose command can supply that evidence.
+Images without an established runtime are named in both the summary and JSON
+report, because a base image can inherit a command detection did not see.
 
 Migration commands outside a unique service directory now require an explicit
 image owner. An unattended run refuses to guess. Choosing manual setup reports

--- a/docs/plans/2026-09-04-init-runtime-ownership-design.md
+++ b/docs/plans/2026-09-04-init-runtime-ownership-design.md
@@ -1,0 +1,48 @@
+# Initialization must identify the process that owns a migration
+
+The reported repository contains a Next.js dashboard, a Python dependency
+project with Alembic, and a minimal Python image used by an isolated snippet
+executor. The snippet image declares no command or port. Its caller supplies
+the command when it creates a disposable container. Starting that image as a
+web service invents a process; attaching root Alembic migrations to it invents
+dependencies that were never installed.
+
+Keep Docker build evidence available to framework and Compose detection, but
+do not declare a service from a Dockerfile with no command or exposed port.
+After evidence is folded by directory, omit candidates no analyzer declared
+as a service. Compose or a framework may still identify the runtime.
+
+Only transfer an orphan migration automatically when exactly one declared
+service shares its directory. Otherwise ask which image contains the tool and
+migration files. There is no default. An unattended caller must answer the
+question explicitly. A manual choice must disclose missing migration setup.
+Unknown owners are errors, and named owners must receive the command in the
+written manifest.
+
+This correction does not provide a dedicated migration image. The existing
+runtime runs each migration in its service image before starting that service.
+A complete automatic solution for a Python schema beside a Node dashboard
+needs an independent migration build and execution contract across the local
+and Kubernetes runtimes. The application's trading image is not an acceptable
+substitute: its entrypoint runs trading logic and its build does not copy the
+migration files. No trading or broker path belongs in an onboarding test.
+
+Verification uses a minimal credential-free repository fixture, exercises the
+real initialization command, and mutates each assertion's production path.
+
+The ten regression behaviors all passed their isolated production mutations:
+helper image exclusion, orphan owner question, no sort-order assignment,
+Compose-supplied runtime, unique local owner, unattended refusal, written owner
+command, manual disclosure, unknown owner refusal, and persistent manual note.
+Twelve mutation cells covered those assertions, including separate declaration
+and merge filters and separate migration-directory and transfer lines. Every
+mutation failed the named test and passed again after restoration. The complete
+detection and CLI packages passed uncached, focused lint reported zero issues,
+and prosecheck reported zero violations.
+
+Further source tracing found that the dashboard ignores DATABASE_URL. It reads
+separate POSTGRES_HOST and POSTGRES_PASSWORD values, hardcodes its database and
+user, and requires SSL. It also refuses every login when DASHBOARD_ACCESS_KEY
+is absent. Therefore a listening HTTP port, or even successful Alembic, does
+not establish that this application's onboarding is complete. Component
+database configuration and real sign-in remain observable acceptance work.

--- a/docs/plans/2026-09-04-init-runtime-ownership-design.md
+++ b/docs/plans/2026-09-04-init-runtime-ownership-design.md
@@ -10,7 +10,10 @@ dependencies that were never installed.
 Keep Docker build evidence available to framework and Compose detection, but
 do not declare a service from a Dockerfile with no command or exposed port.
 After evidence is folded by directory, omit candidates no analyzer declared
-as a service. Compose or a framework may still identify the runtime.
+as a service. Compose or a framework may still identify the runtime. Name
+unassigned images in the human summary and JSON report: inherited base-image
+commands cannot be established from the Dockerfile alone, and omission must
+not silently imply that all application components were identified.
 
 Only transfer an orphan migration automatically when exactly one declared
 service shares its directory. Otherwise ask which image contains the tool and
@@ -30,11 +33,13 @@ migration files. No trading or broker path belongs in an onboarding test.
 Verification uses a minimal credential-free repository fixture, exercises the
 real initialization command, and mutates each assertion's production path.
 
-The ten regression behaviors all passed their isolated production mutations:
+The fourteen regression behaviors all passed their isolated production mutations:
 helper image exclusion, orphan owner question, no sort-order assignment,
 Compose-supplied runtime, unique local owner, unattended refusal, written owner
-command, manual disclosure, unknown owner refusal, and persistent manual note.
-Twelve mutation cells covered those assertions, including separate declaration
+command, manual disclosure, unknown owner refusal, persistent manual note,
+inherited runtime disclosure, assigned-image exclusion from that disclosure,
+and both human and JSON image reports.
+Sixteen mutation cells covered those assertions, including separate declaration
 and merge filters and separate migration-directory and transfer lines. Every
 mutation failed the named test and passed again after restoration. The complete
 detection and CLI packages passed uncached, focused lint reported zero issues,

--- a/engine/internal/cli/init.go
+++ b/engine/internal/cli/init.go
@@ -99,14 +99,15 @@ func parseAnswers(raw []string) map[string]string {
 
 // InitReport is the JSON form of af init.
 type InitReport struct {
-	ManifestPath string            `json:"manifest_path"`
-	Created      bool              `json:"created"`
-	Services     []string          `json:"services"`
-	EgressRules  int               `json:"egress_rules"`
-	Questions    []detect.Question `json:"questions,omitempty"`
-	Assumed      map[string]string `json:"assumed,omitempty"`
-	Findings     int               `json:"findings"`
-	Partial      bool              `json:"partial"`
+	ManifestPath     string            `json:"manifest_path"`
+	Created          bool              `json:"created"`
+	Services         []string          `json:"services"`
+	EgressRules      int               `json:"egress_rules"`
+	Questions        []detect.Question `json:"questions,omitempty"`
+	Assumed          map[string]string `json:"assumed,omitempty"`
+	Findings         int               `json:"findings"`
+	Partial          bool              `json:"partial"`
+	UnassignedImages []string          `json:"unassigned_images,omitempty"`
 }
 
 func runInit(ctx context.Context, env *Env, opts initOptions) error {
@@ -186,7 +187,8 @@ func runInit(ctx context.Context, env *Env, opts initOptions) error {
 	report := InitReport{
 		ManifestPath: manifestPath, Created: true, Services: names,
 		EgressRules: len(res.Draft.Egress.Rules), Questions: res.Questions,
-		Assumed: assumed, Findings: len(res.Findings), Partial: res.Partial,
+		UnassignedImages: res.UnassignedImages,
+		Assumed:          assumed, Findings: len(res.Findings), Partial: res.Partial,
 	}
 	if env.Out.Format == FormatJSON {
 		return env.Out.JSON(report)
@@ -451,6 +453,13 @@ func renderInitSummary(env *Env, res *detect.Result, assumed map[string]string, 
 	env.Out.Table([]Column{
 		Col("SERVICE"), Col("KIND"), Num("PORT"), Col("PATH"), Flex("COMMAND"),
 	}, rows)
+	if len(res.UnassignedImages) > 0 {
+		env.Out.Section("Images without a detected service")
+		for _, dockerfile := range res.UnassignedImages {
+			env.Out.Printf("  %s\n", dockerfile)
+		}
+		env.Out.Note(StyleWarn, "These images were not added. No command or port established their runtime; a base image may supply one. If an image runs part of your application, declare that service and its command in Compose or in this manifest before af up.")
+	}
 
 	if len(res.Draft.Egress.Rules) > 0 {
 		env.Out.Section("Network policy")

--- a/engine/internal/cli/init.go
+++ b/engine/internal/cli/init.go
@@ -152,6 +152,11 @@ func runInit(ctx context.Context, env *Env, opts initOptions) error {
 	if err != nil {
 		return err
 	}
+	for _, q := range res.Questions {
+		if q.Migration != "" && assumed[q.ID] != "" {
+			body = append([]byte("# "+strings.ReplaceAll(assumed[q.ID], "\n", "\n# ")+"\n"), body...)
+		}
+	}
 	if _, err := manifest.Parse(body, manifestPath, env.WorkDir); err != nil {
 		// The refusal has to say that nothing was written. Wrapping the
 		// validator's own error let AF-MAN-002 reach the user unchanged, and
@@ -269,6 +274,23 @@ func resolveQuestions(env *Env, res *detect.Result, opts initOptions, assumed ma
 			return aferrors.Coded(aferrors.AFDET004,
 				"question", q.Prompt,
 				"id", q.ID)
+		}
+		if q.Migration != "" {
+			if answer == "manual:configure" {
+				assumed[q.ID] = "Not configured: " + q.Migration + ". Configure migrations before af up."
+				continue
+			}
+			applied := false
+			for j := range res.Draft.Services {
+				if res.Draft.Services[j].Name == answer && res.Draft.Services[j].Migrate == "" {
+					res.Draft.Services[j].Migrate = q.Migration
+					applied = true
+				}
+			}
+			if !applied {
+				return aferrors.Coded(aferrors.AFDET006, "id", q.ID+"="+answer, "known", strings.Join(q.Options, ", "))
+			}
+			continue
 		}
 		_ = applyAnswer(res.Draft, q.ID, answer)
 	}

--- a/engine/internal/cli/migration_owner_test.go
+++ b/engine/internal/cli/migration_owner_test.go
@@ -1,12 +1,55 @@
 package cli_test
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func unassignedImageFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	for name, content := range map[string]string{
+		"package.json":     `{"name":"dashboard","dependencies":{"next":"15"}}`,
+		"proxy/Dockerfile": "FROM nginx:stable\n",
+	} {
+		filename := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(filename), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filename, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func TestUnassignedImage_SummaryNamesExcludedImage(t *testing.T) {
+	dir := unassignedImageFixture(t)
+	got := runCLI(t, dir, nil, "init", "--non-interactive")
+	if got.code != 0 {
+		t.Fatal(got.stderr)
+	}
+	require.Contains(t, got.stdout, "proxy/Dockerfile")
+}
+
+func TestUnassignedImage_JSONNamesExcludedImage(t *testing.T) {
+	dir := unassignedImageFixture(t)
+	got := runCLI(t, dir, nil, "init", "--non-interactive", "--output", "json")
+	if got.code != 0 {
+		t.Fatal(got.stderr)
+	}
+	var report struct {
+		UnassignedImages []string `json:"unassigned_images"`
+	}
+	if err := json.Unmarshal([]byte(got.stdout), &report); err != nil {
+		t.Fatal(err)
+	}
+	require.Equal(t, []string{"proxy/Dockerfile"}, report.UnassignedImages)
+}
 
 func migrationOwnerFixture(t *testing.T) string {
 	t.Helper()

--- a/engine/internal/cli/migration_owner_test.go
+++ b/engine/internal/cli/migration_owner_test.go
@@ -1,0 +1,73 @@
+package cli_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func migrationOwnerFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, "dashboard"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for name, content := range map[string]string{
+		"dashboard/package.json": `{"name":"dashboard","dependencies":{"next":"15"}}`,
+		"alembic.ini":            "[alembic]\n",
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func TestMigrationOwner_UnattendedRunRefusesToGuess(t *testing.T) {
+	dir := migrationOwnerFixture(t)
+	got := runCLI(t, dir, nil, "init", "--non-interactive")
+	require.Contains(t, got.stderr, "AF-DET-004")
+}
+
+func TestMigrationOwner_AnswerReachesWrittenManifest(t *testing.T) {
+	dir := migrationOwnerFixture(t)
+	got := runCLI(t, dir, nil, "init", "--non-interactive", "--answer", "migration."+filepath.Base(dir)+".service=dashboard")
+	if got.code != 0 {
+		t.Fatal(got.stderr)
+	}
+	body, err := os.ReadFile(filepath.Join(dir, "antifailure.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	require.Contains(t, string(body), "migrate: alembic upgrade head")
+}
+
+func TestMigrationOwner_ManualChoiceDisclosesMissingSetup(t *testing.T) {
+	dir := migrationOwnerFixture(t)
+	got := runCLI(t, dir, nil, "init", "--non-interactive", "--answer", "migration."+filepath.Base(dir)+".service=manual:configure")
+	if got.code != 0 {
+		t.Fatal(got.stderr)
+	}
+	require.Contains(t, got.stdout, "Not configured: alembic upgrade head")
+}
+
+func TestMigrationOwner_UnknownOwnerIsRefused(t *testing.T) {
+	dir := migrationOwnerFixture(t)
+	got := runCLI(t, dir, nil, "init", "--non-interactive", "--answer", "migration."+filepath.Base(dir)+".service=absent")
+	require.Contains(t, got.stderr, "AF-DET-006")
+}
+
+func TestMigrationOwner_ManualChoiceRemainsInTheManifest(t *testing.T) {
+	dir := migrationOwnerFixture(t)
+	got := runCLI(t, dir, nil, "init", "--non-interactive", "--answer", "migration."+filepath.Base(dir)+".service=manual:configure")
+	if got.code != 0 {
+		t.Fatal(got.stderr)
+	}
+	body, err := os.ReadFile(filepath.Join(dir, "antifailure.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	require.Contains(t, string(body), "# Not configured: alembic upgrade head")
+}

--- a/engine/internal/detect/container.go
+++ b/engine/internal/detect/container.go
@@ -74,13 +74,15 @@ func (a *DockerAnalyzer) Analyze(_ context.Context, r *Repo) ([]Finding, error) 
 			Detail: fmt.Sprintf("%s builds this service.", p),
 			Extra:  extra,
 		})
-		out = append(out, Finding{
-			Kind: KindService, Subject: name, Value: "web",
-			Confidence: Medium, Evidence: p,
-			// A Dockerfile carries no name of its own, so this one is the
-			// directory, which the merger treats as the weakest identity.
-			Extra: map[string]string{"dir": dir, "name_from": "dir"},
-		})
+		if df.command != "" || len(df.ports) > 0 {
+			out = append(out, Finding{
+				Kind: KindService, Subject: name, Value: "web",
+				Confidence: Medium, Evidence: p,
+				// A Dockerfile carries no name of its own, so this one is the
+				// directory, which the merger treats as the weakest identity.
+				Extra: map[string]string{"dir": dir, "name_from": "dir"},
+			})
+		}
 		if len(df.stages) > 1 {
 			out = append(out, Finding{
 				Kind: KindNote, Subject: name + ".stages", Value: strings.Join(df.stages, ","),

--- a/engine/internal/detect/detect.go
+++ b/engine/internal/detect/detect.go
@@ -304,6 +304,10 @@ type Result struct {
 	// Questions are the things af init has to ask, because a finding was below
 	// the confidence threshold or two analyzers disagreed.
 	Questions []Question
+	// UnassignedImages names Dockerfiles whose runtime was not established by
+	// a command, port, framework or Compose declaration. Their base image may
+	// inherit a process, so omission must be visible rather than called unused.
+	UnassignedImages []string
 	// Partial reports that the time or size budget ran out before the walk
 	// finished, so the draft may be incomplete.
 	Partial bool
@@ -428,6 +432,20 @@ func Run(ctx context.Context, fsys fs.FS, root string, opts Options) (*Result, e
 
 	sortFindings(res.Findings)
 	res.Draft, res.Questions = Merge(res.Findings, root)
+	assigned := map[string]bool{}
+	for _, svc := range res.Draft.Services {
+		if svc.Build != nil {
+			assigned[svc.Build.Dockerfile] = true
+		}
+	}
+	for _, f := range res.Findings {
+		if f.Kind == KindBuild && f.Value == "dockerfile" {
+			dockerfile := f.Extra["dockerfile"]
+			if dockerfile != "" && !assigned[dockerfile] {
+				res.UnassignedImages = appendUnique(res.UnassignedImages, dockerfile)
+			}
+		}
+	}
 	res.Duration = opts.Clock.Since(start)
 	return res, nil
 }

--- a/engine/internal/detect/detect.go
+++ b/engine/internal/detect/detect.go
@@ -315,6 +315,8 @@ type Result struct {
 
 // Question is something detection could not decide.
 type Question struct {
+	// Migration is the command awaiting an explicit runtime owner.
+	Migration string `json:",omitempty"`
 	// ID is stable, so that a non interactive run can answer it by flag.
 	ID string
 	// Prompt is the question, in the second person.

--- a/engine/internal/detect/merge.go
+++ b/engine/internal/detect/merge.go
@@ -210,6 +210,9 @@ func mergeServices(findings []Finding, questions *[]Question) []schema.Service {
 
 		case KindMigration:
 			c := get(f.Subject)
+			if c.dir == "" {
+				c.dir = f.Extra["dir"]
+			}
 			if c.migrate == "" {
 				c.migrate = f.Value
 			}
@@ -248,13 +251,16 @@ func mergeServices(findings []Finding, questions *[]Question) []schema.Service {
 	// Two sources describing one service are still one service.
 	order = coalesceServices(byName, order)
 
-	// A migration command found for the repository as a whole belongs to the
-	// web service that will run it, not to a phantom service of its own.
-	reassignRepoWideMigration(byName, order)
+	// A migration needs an owner with evidence, not the first service in a
+	// sorted list. An orphan with no unique local owner becomes a question.
+	reassignRepoWideMigration(byName, order, questions)
 
 	out := make([]schema.Service, 0, len(order))
 	for _, name := range order {
 		c := byName[name]
+		if len(c.declaredBy) == 0 {
+			continue
+		}
 		// A candidate with nothing but a migration command is not a service.
 		if c.kind == schema.ServiceWeb && c.port == 0 && c.command == "" && c.build == nil && c.framework == "" {
 			continue
@@ -411,9 +417,9 @@ func coalesceServices(byName map[string]*candidate, order []string) []string {
 	var groupOrder []string
 	for _, name := range order {
 		c := byName[name]
-		// A candidate nothing declared is not a service yet. The repository
-		// wide migration is the case, and reassignRepoWideMigration owns it.
-		if len(c.declaredBy) == 0 {
+		// An image may borrow runtime evidence from another source in its
+		// directory. Orphan migrations are resolved separately below.
+		if len(c.declaredBy) == 0 && c.build == nil {
 			continue
 		}
 		key := normalizeDir(c.dir) + "\x00" + string(c.kind)
@@ -570,28 +576,37 @@ func normalizeDir(dir string) string {
 	return strings.TrimPrefix(cleaned, "./")
 }
 
-// reassignRepoWideMigration moves a migration command that was attributed to
-// the repository onto the service most likely to own it.
-func reassignRepoWideMigration(byName map[string]*candidate, order []string) {
-	var orphan *candidate
+// reassignRepoWideMigration transfers a migration only to a unique local
+// service. A command found elsewhere needs the user's explicit image choice.
+func reassignRepoWideMigration(byName map[string]*candidate, order []string, questions *[]Question) {
 	for _, name := range order {
-		c := byName[name]
-		if c.migrate != "" && c.port == 0 && c.command == "" && c.framework == "" && c.build == nil {
-			orphan = c
-			break
-		}
-	}
-	if orphan == nil {
-		return
-	}
-	for _, name := range order {
-		c := byName[name]
-		if c == orphan || c.kind != schema.ServiceWeb || c.migrate != "" {
+		orphan := byName[name]
+		if orphan.migrate == "" || len(orphan.declaredBy) != 0 {
 			continue
 		}
-		c.migrate = orphan.migrate
+		var owners []*candidate
+		var options []string
+		for _, other := range order {
+			c := byName[other]
+			if len(c.declaredBy) == 0 || c.migrate != "" {
+				continue
+			}
+			options = append(options, c.name)
+			if normalizeDir(c.dir) == normalizeDir(orphan.dir) {
+				owners = append(owners, c)
+			}
+		}
+		if len(owners) == 1 {
+			owners[0].migrate = orphan.migrate
+		} else {
+			*questions = append(*questions, Question{
+				ID: "migration." + name + ".service", Migration: orphan.migrate,
+				Prompt:  fmt.Sprintf("Which service image can run %s?", orphan.migrate),
+				Options: append(options, "manual:configure"),
+				Why:     "The migration was found outside a unique service directory. Its image must contain the migration tool and files. Choose manual only if you will configure migrations separately before af up.",
+			})
+		}
 		orphan.migrate = ""
-		return
 	}
 }
 

--- a/engine/internal/detect/runtime_ownership_test.go
+++ b/engine/internal/detect/runtime_ownership_test.go
@@ -1,0 +1,61 @@
+package detect_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// This is the Bonfire layout with no credentials or trading implementation.
+func TestRuntimeOwnership_HelperImageIsNotAWebService(t *testing.T) {
+	res := run(t, "research", map[string]string{
+		"dashboard/package.json":           `{"name":"research-dashboard","dependencies":{"next":"15"},"scripts":{"start":"next start -p 3100"}}`,
+		"dashboard/Dockerfile":             "FROM node:22\nEXPOSE 3100\nCMD [\"node\",\"server.js\"]\n",
+		"engine/agents/sandbox/Dockerfile": "FROM python:3.12-slim\nWORKDIR /sandbox\nUSER nobody\n",
+		"alembic.ini":                      "[alembic]\nscript_location = migrations\n",
+	})
+	require.Len(t, res.Draft.Services, 1)
+}
+
+func TestRuntimeOwnership_OrphanMigrationRequiresAnOwner(t *testing.T) {
+	res := run(t, "research", map[string]string{
+		"dashboard/package.json": `{"name":"dashboard","dependencies":{"next":"15"}}`,
+		"alembic.ini":            "[alembic]\n",
+	})
+	var migration string
+	for _, q := range res.Questions {
+		if q.ID == "migration.research.service" {
+			migration = q.Migration
+		}
+	}
+	require.Equal(t, "alembic upgrade head", migration)
+}
+
+func TestRuntimeOwnership_OrphanMigrationIsNotAssignedBySortOrder(t *testing.T) {
+	res := run(t, "research", map[string]string{
+		"dashboard/package.json": `{"name":"dashboard","dependencies":{"next":"15"}}`,
+		"alembic.ini":            "[alembic]\n",
+	})
+	require.Empty(t, serviceNamed(t, res.Draft, "dashboard").Migrate)
+}
+
+func TestRuntimeOwnership_ComposeCanSupplyTheImageCommand(t *testing.T) {
+	res := run(t, "research", map[string]string{
+		"compose.yaml":       "services:\n  api:\n    build: ./runtime\n    command: python app.py\n    ports:\n      - '8080:8080'\n",
+		"runtime/Dockerfile": "FROM python:3.12-slim\nWORKDIR /app\n",
+	})
+	svc := serviceNamed(t, res.Draft, "api")
+	var dockerfile string
+	if svc.Build != nil {
+		dockerfile = svc.Build.Dockerfile
+	}
+	require.Equal(t, "runtime/Dockerfile", dockerfile)
+}
+
+func TestRuntimeOwnership_UniqueLocalMigrationKeepsItsOwner(t *testing.T) {
+	res := run(t, "research", map[string]string{
+		"dashboard/package.json": `{"name":"ui","dependencies":{"next":"15"}}`,
+		"dashboard/alembic.ini":  "[alembic]\n",
+	})
+	require.Equal(t, "alembic upgrade head", serviceNamed(t, res.Draft, "ui").Migrate)
+}

--- a/engine/internal/detect/runtime_ownership_test.go
+++ b/engine/internal/detect/runtime_ownership_test.go
@@ -59,3 +59,19 @@ func TestRuntimeOwnership_UniqueLocalMigrationKeepsItsOwner(t *testing.T) {
 	})
 	require.Equal(t, "alembic upgrade head", serviceNamed(t, res.Draft, "ui").Migrate)
 }
+
+func TestRuntimeOwnership_InheritedRuntimeIsReportedAsUnassigned(t *testing.T) {
+	res := run(t, "research", map[string]string{
+		"dashboard/package.json": `{"name":"dashboard","dependencies":{"next":"15"}}`,
+		"proxy/Dockerfile":       "FROM nginx:stable\n",
+	})
+	require.Equal(t, []string{"proxy/Dockerfile"}, res.UnassignedImages)
+}
+
+func TestRuntimeOwnership_AssignedImageIsNotReportedMissing(t *testing.T) {
+	res := run(t, "research", map[string]string{
+		"compose.yaml":       "services:\n  api:\n    build: ./runtime\n    command: python app.py\n    ports:\n      - '8080:8080'\n",
+		"runtime/Dockerfile": "FROM python:3.12-slim\nWORKDIR /app\n",
+	})
+	require.Empty(t, res.UnassignedImages)
+}


### PR DESCRIPTION
## What went wrong

An isolated Python snippet image containing only a base image, working directory
and user was detected as a web server. Initialization asked for an invented
port, then assigned root Alembic migrations to that image even though it
contained neither Alembic nor the migration files. Startup failed after the
application had already spent minutes building.

## What changes

Docker build evidence remains available to real framework and Compose service
declarations. A Dockerfile without a command or exposed port no longer creates
a service by itself. Orphan migrations transfer automatically only to a unique
service in the same directory. Otherwise initialization requires an explicit
image owner. Invalid owners fail. Choosing manual setup discloses the missing
migration configuration both in the summary and in the written manifest.
Unassigned Dockerfiles are named in the human summary and JSON report because
a base image may provide runtime metadata that source detection cannot see.

This is a bounded correction, not a claim that the reported application's full
onboarding works. Its Python migrations need an independent migration image;
its Node dashboard uses separate database variables and requires an access key.
Those remaining blockers and the relevant runtime paths are recorded in the
design document. No trading process, broker request or production database
mutation was run during this work.

## Failure paths covered

- Helper image: TestRuntimeOwnership_HelperImageIsNotAWebService.
- Missing migration owner: TestRuntimeOwnership_OrphanMigrationRequiresAnOwner.
- Wrong migration owner: TestRuntimeOwnership_OrphanMigrationIsNotAssignedBySortOrder.
- Compose image linkage: TestRuntimeOwnership_ComposeCanSupplyTheImageCommand.
- Local migration linkage: TestRuntimeOwnership_UniqueLocalMigrationKeepsItsOwner.
- Unattended guess: TestMigrationOwner_UnattendedRunRefusesToGuess.
- Discarded answer: TestMigrationOwner_AnswerReachesWrittenManifest.
- Hidden manual work: TestMigrationOwner_ManualChoiceDisclosesMissingSetup.
- Invalid owner: TestMigrationOwner_UnknownOwnerIsRefused.
- Forgotten manual work: TestMigrationOwner_ManualChoiceRemainsInTheManifest.
- Inherited runtime gap: TestRuntimeOwnership_InheritedRuntimeIsReportedAsUnassigned.
- Assigned image false warning: TestRuntimeOwnership_AssignedImageIsNotReportedMissing.
- Missing human disclosure: TestUnassignedImage_SummaryNamesExcludedImage.
- Missing machine disclosure: TestUnassignedImage_JSONNamesExcludedImage.

## Security considerations

No secret handling, masked data, proxy or journal changes. No outbound
connection, stored data class or dependency is added. The change does not widen
what an untrusted repository can reach. Detection remains a bounded read of
repository files. Initialization writes only its existing manifest and state
metadata, with an additional comment when manual migration setup was chosen.

## Exit criteria evidence

```text
go test ./internal/detect ./internal/cli -count=1
ok github.com/antifailure/antifailure/engine/internal/detect 0.024s
ok github.com/antifailure/antifailure/engine/internal/cli 19.498s
golangci-lint run ./internal/detect/... ./internal/cli/...
0 issues.
go run ./tools/prosecheck .
prosecheck: 720 files, 0 places where the punctuation gives it away
```

The complete just gate command was not run locally. CI must answer the
remaining gates, and a passing focused suite is not presented as their result.

Full detection and CLI packages passed uncached. Focused Go lint reported zero
issues. Prosecheck reported 720 files and zero violations on the final tree.
Changecheck reports four user-visible changes covered by the fragment.
Git diff whitespace check passed.

Each new behavior was mutation tested, with an intended failure followed by a
restored pass: helper image exclusion, orphan owner question, no sort-order
assignment, Compose-supplied runtime, unique local owner, unattended refusal,
written owner command, manual disclosure, unknown owner refusal, and persistent
manual note, inherited runtime disclosure, assigned-image exclusion, and human
and JSON image reports. Sixteen isolated mutations cover these fourteen tests because image
declaration and merging, and migration directory and transfer, are separate
production decisions.

The helper fixture contains no credentials or trading implementation. CI is
still pending and will be inspected before merge. Release coordination owns
merge ordering.

## Checklist

- [x] Commit is signed off.
- [x] A changelog fragment exists.
- [x] Design and remaining limitations are documented.
- [x] Existing error codes are reused.
- [x] No secret or real customer record is included.
