### PR TITLE
console: align the operator overview and repair accessible labels

### DIFF
--- a/.changes/operator-labels-and-contrast.md
+++ b/.changes/operator-labels-and-contrast.md
@@ -1,0 +1,8 @@
+# fixed
+
+The operator sidebar and mobile menu now label their sections with distinct
+identifiers. Both navigations are mounted together, so their shared identifiers
+previously made accessible labels ambiguous.
+
+Success badges use the card background. Their previous translucent green fill
+reduced text contrast below 4.5:1 on the overview page background.

--- a/.changes/operator-labels-and-contrast.md
+++ b/.changes/operator-labels-and-contrast.md
@@ -6,3 +6,7 @@ previously made accessible labels ambiguous.
 
 Success badges use the card background. Their previous translucent green fill
 reduced text contrast below 4.5:1 on the overview page background.
+
+The overview now aligns its attention and installation panels in one row,
+places recent actions across the full width, and gives each directory-card row
+a shared bottom edge. Narrow screens keep a natural single-column layout.

--- a/console/app/admin/page.tsx
+++ b/console/app/admin/page.tsx
@@ -5,7 +5,6 @@ import {
   Badge,
   Bar,
   Card,
-  CardSkeleton,
   Empty,
   Loaded,
   Table,
@@ -130,11 +129,11 @@ export default function AdminOverviewPage() {
         </Loaded>
       ) : null}
 
-      <div className="mt-7 grid items-start gap-5 lg:grid-cols-[minmax(0,1fr)_300px]">
-        <div className="grid min-w-0 gap-5">
-          {mayReadTenants ? (
-            <Card title="What needs an operator">
-              <Loaded state={standing} skeleton={<CardSkeleton count={2} />}>
+      <div className="mt-7 grid gap-5 lg:grid-cols-[minmax(0,1fr)_300px]">
+        {mayReadTenants ? (
+          <Card title="What needs an operator" className="flex flex-col">
+            <div className="flex flex-1 flex-col justify-center">
+              <Loaded state={standing} skeleton={<AttentionSkeleton />}>
                 {(data) => (
                   <Attention
                     standing={data}
@@ -145,45 +144,44 @@ export default function AdminOverviewPage() {
                   />
                 )}
               </Loaded>
-            </Card>
-          ) : null}
+            </div>
+          </Card>
+        ) : null}
 
-          {mayReadAudit ? (
-            <Card
-              title="Recent operator actions"
-              note="Writes only. Reads are counted and left out."
-              actions={
-                <Link
-                  href="/admin/security/audit"
-                  className="inline-flex min-h-11 items-center text-[13px] text-muted underline decoration-transparent underline-offset-4 hover:text-ink hover:decoration-[rgba(16,16,16,0.35)] sm:min-h-0"
-                >
-                  Full chain
-                </Link>
-              }
-            >
-              <Loaded state={activity} skeleton={<TableSkeleton rows={4} cols={4} />}>
-                {(data) => <RecentActions activity={data} />}
-              </Loaded>
-            </Card>
-          ) : null}
-        </div>
-
-        <div className="grid min-w-0 gap-5">
-          {mayReadTenants ? (
-            <Card title="The installation">
-              <Loaded state={standing} skeleton={<FiguresSkeleton />}>
-                {(data) => (
-                  <Figures
-                    standing={data}
-                    activity={mayReadAudit ? activity.data : null}
-                    installation={mayReadInfra ? installation.data : null}
-                  />
-                )}
-              </Loaded>
-            </Card>
-          ) : null}
-        </div>
+        {mayReadTenants ? (
+          <Card title="The installation">
+            <Loaded state={standing} skeleton={<FiguresSkeleton />}>
+              {(data) => (
+                <Figures
+                  standing={data}
+                  activity={mayReadAudit ? activity.data : null}
+                  installation={mayReadInfra ? installation.data : null}
+                />
+              )}
+            </Loaded>
+          </Card>
+        ) : null}
       </div>
+
+      {mayReadAudit ? (
+        <Card
+          className="mt-5"
+          title="Recent operator actions"
+          note="Writes only. Reads are counted and left out."
+          actions={
+            <Link
+              href="/admin/security/audit"
+              className="inline-flex min-h-11 items-center text-[13px] text-muted underline decoration-transparent underline-offset-4 hover:text-ink hover:decoration-[rgba(16,16,16,0.35)] sm:min-h-0"
+            >
+              Full chain
+            </Link>
+          }
+        >
+          <Loaded state={activity} skeleton={<TableSkeleton rows={4} cols={4} />}>
+            {(data) => <RecentActions activity={data} />}
+          </Loaded>
+        </Card>
+      ) : null}
 
       <h2 className="mt-9 text-[13px] font-medium uppercase tracking-[0.08em] text-dim">
         Everything this role can reach
@@ -199,18 +197,12 @@ export default function AdminOverviewPage() {
           </div>
         </Card>
       ) : (
-        // items-start, so a card ends where its content ends. Grid items
-        // stretch to the tallest in their row by default, and the groups have
-        // three entries and five, so Customers was drawn as tall as Product
-        // with two hundred pixels of nothing inside it. That reads as a
-        // section that failed to load rather than as a short one.
-        //
-        // mt-3 is the administration lane's, separating the directory from the
-        // statement above it that this page now leads with.
-        <div className="mt-3 grid items-start gap-5 lg:grid-cols-2">
+        // Each row shares a bottom edge even when its groups contain different
+        // numbers of links. Mobile keeps the natural single-column height.
+        <div className="mt-3 grid gap-5 lg:grid-cols-2">
           {groups.map((group) => (
-            <Card key={group.slug} title={group.label}>
-              <ul>
+            <Card key={group.slug} title={group.label} className="flex flex-col">
+              <ul className="lg:grid lg:flex-1 lg:auto-rows-fr">
                 {group.items.map((item) => (
                   <SectionLink key={item.href} item={item} />
                 ))}
@@ -364,6 +356,20 @@ interface Item {
   href: string;
   action: string;
   tone: "fail" | "warn";
+}
+
+function AttentionSkeleton() {
+  return (
+    <div className="grid gap-6 px-4 py-6" aria-label="Loading operator tasks">
+      {[0, 1].map((row) => (
+        <div key={row} className="grid gap-2">
+          <Bar className="h-3.5 w-40 max-w-full" />
+          <Bar className="h-3 w-full" />
+          <Bar className="h-3 w-2/3" />
+        </div>
+      ))}
+    </div>
+  );
 }
 
 /**
@@ -661,7 +667,7 @@ function SectionLink({ item }: { item: AdminNavItem }) {
     <li className="border-b border-rule last:border-b-0">
       <Link
         href={item.href}
-        className="flex min-h-11 items-start gap-3 px-4 py-3 transition-colors hover:bg-[rgba(16,16,16,0.035)]"
+        className="flex min-h-11 items-start gap-3 px-4 py-3 transition-colors hover:bg-[rgba(16,16,16,0.035)] lg:h-full lg:items-center"
       >
         <Icon className="mt-0.5 h-4 w-4 shrink-0 text-muted" />
         <span className="min-w-0">

--- a/console/components/AdminShell.tsx
+++ b/console/components/AdminShell.tsx
@@ -17,7 +17,7 @@
  * where they are; it has to be legible at a glance and then get out of the way.
  */
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { usePathname } from "next/navigation";
 import Link from "next/link";
 import { IconSignOut, LogoMark } from "@/components/icons";
@@ -234,6 +234,7 @@ function NavLink({ item, onNavigate }: { item: AdminNavItem; onNavigate?: () => 
  * nothing reads as a section that failed to load.
  */
 function NavList({ me, onNavigate }: { me: AdminMe | null; onNavigate?: () => void }) {
+  const labelPrefix = useId();
   const groups = ADMIN_NAV.map((group) => ({
     ...group,
     items: group.items.filter((item) => operatorMay(me, item.permission)),
@@ -248,9 +249,9 @@ function NavList({ me, onNavigate }: { me: AdminMe | null; onNavigate?: () => vo
       ) : null}
 
       {groups.map((group) => (
-        <section key={group.slug} aria-labelledby={`nav-${group.slug}`}>
+        <section key={group.slug} aria-labelledby={`${labelPrefix}-${group.slug}`}>
           <h2
-            id={`nav-${group.slug}`}
+            id={`${labelPrefix}-${group.slug}`}
             className="px-2.5 pb-1.5 text-[11px] font-medium uppercase tracking-[0.1em] text-[rgba(255,255,255,0.55)]"
           >
             {group.label}

--- a/console/components/ui.tsx
+++ b/console/components/ui.tsx
@@ -317,7 +317,7 @@ export type Tone = "pass" | "fail" | "warn" | "neutral";
  */
 export function Badge({ tone = "neutral", children }: { tone?: Tone; children: ReactNode }) {
   const styles: Record<Tone, string> = {
-    pass: "text-pass bg-[rgba(30,122,58,0.1)]",
+    pass: "text-pass bg-card",
     fail: "text-fail bg-[rgba(179,38,30,0.1)]",
     warn: "text-warn bg-[rgba(138,90,0,0.12)]",
     neutral: "text-muted bg-[rgba(16,16,16,0.06)]",


### PR DESCRIPTION
The operator overview placed cards in independent columns, so related panels ended at different heights. It also mounted the sidebar and mobile menu with the same section IDs, and its All clear badge measured 4.4:1 text contrast.

Align the attention and installation panels in one row, put recent actions across the full width, and give each directory-card pair a shared bottom edge. Link rows fill their cards on desktop while mobile keeps natural heights. The loading state uses task-shaped rows instead of nested cards. Give each navigation instance stable React IDs and put success text on the existing card background, which measures 5.38:1.

Validation: after rebasing onto PR 218's merge, all 140 console tests passed without skips. Console and site production builds passed, classcheck and motioncheck passed, prosecheck reported zero violations. Inspected the rendered operator overview at 1440 and 320 pixels, with light and dark system preferences. The product intentionally uses one light theme. Both the closed sidebar and open mobile menu have zero duplicate IDs. No horizontal overflow at 320. Measured equal bottom edges for all four paired panel rows. Checked populated, empty, loading and network-error layouts; removing the failed-request fixture and pressing Try again recovered the panels. Axe reports zero definite violations; timestamp labeling and gradient-backed table text still require manual review. The All clear state was exercised using only this worktree's disposable seeded database.

Production login itself was separately restored by provisioning the root operator through the existing bootstrap command, then verifying browser sign-in, a protected page, reload, and sign-out. This PR contains no credentials or account provisioning changes.
