### PR TITLE
console: the first-result guide never ran a check

### DIFF
--- a/.changes/a-response-that-never-finished-loading.md
+++ b/.changes/a-response-that-never-finished-loading.md
@@ -1,4 +1,4 @@
-## Fixed
+# fixed
 
 A successful HTTP response with a missing tRPC result left console cards
 loading forever. Queries and mutations now reject malformed or incomplete

--- a/.changes/a-response-that-never-finished-loading.md
+++ b/.changes/a-response-that-never-finished-loading.md
@@ -1,0 +1,6 @@
+## Fixed
+
+A successful HTTP response with a missing tRPC result left console cards
+loading forever. Queries and mutations now reject malformed or incomplete
+responses with a human error and the existing retry action. Valid empty and
+nullable results are preserved, as are the server's permission refusals.

--- a/.changes/first-check-has-an-execution.md
+++ b/.changes/first-check-has-an-execution.md
@@ -1,4 +1,4 @@
-## Fixed
+# fixed
 
 The console's first-result guide stopped at commands that prepare a manifest
 and inspect the machine, without executing a test. It now walks through runner

--- a/.changes/first-check-has-an-execution.md
+++ b/.changes/first-check-has-an-execution.md
@@ -1,0 +1,11 @@
+## Fixed
+
+The console's first-result guide stopped at commands that prepare a manifest
+and inspect the machine, without executing a test. It now walks through runner
+setup, an isolated environment, a workflow run, its result and cleanup. Empty
+Runs and Masking pages link to the next useful step, and the environment page
+offers the configured GitHub App installation link when one is available.
+The pages explain masking, environments and runs in plain language.
+Optional runtime registration and CI credentials stay available behind labeled
+disclosures. Long commands can now be focused and scrolled with the keyboard
+on a narrow screen.

--- a/console/app/(app)/cli/page.tsx
+++ b/console/app/(app)/cli/page.tsx
@@ -91,18 +91,20 @@ function Install() {
   return (
     <Card
       title="Install the engine"
-      note="One command, on the machine the work happens on."
+      note="Install the command line and prepare its browser runner."
     >
       <div className="space-y-3 px-4 py-4">
         <CommandBlock command={INSTALL} said="Install command copied to the clipboard" />
         <p className="max-w-[74ch] text-[13px] leading-6 text-muted">
-          Downloads the release for your platform, checks it against the
-          published checksum, and puts <code className="font-mono">af</code> and
-          its runner under <code className="font-mono">~/.antifailure</code>,
-          with that directory added to the file your login shell reads. It is
-          POSIX <code className="font-mono">sh</code> rather than bash, so it
-          works in a container as well as on a laptop, and it is the same file
-          served at that address if you would rather read it first.
+          Downloads and verifies the release for your machine, then installs
+          <code className="font-mono"> af</code> and its runner under
+          <code className="font-mono"> ~/.antifailure</code>. Run this in a
+          terminal on the machine where you will test your application.
+        </p>
+        <CommandBlock command="af runner install" said="Runner setup command copied to the clipboard" />
+        <p className="max-w-[74ch] text-[13px] leading-6 text-muted">
+          With Node.js installed, this prepares the browser runner that executes
+          your workflows. Docker runs the isolated environment.
         </p>
       </div>
     </Card>
@@ -119,7 +121,7 @@ function SignIn({ origin }: { origin: string | null }) {
   return (
     <Card
       title="Sign this terminal in"
-      note="The device authorization grant. Nothing is pasted and nothing is copied through a clipboard."
+      note="Connect your terminal to the account you are using here."
     >
       <div className="space-y-3 px-4 py-4">
         {command === null ? (
@@ -134,18 +136,14 @@ function SignIn({ origin }: { origin: string | null }) {
           <CommandBlock command={command} said="Sign-in command copied to the clipboard" />
         )}
         <p className="max-w-[74ch] text-[13px] leading-6 text-muted">
-          It prints an eight character code and opens this control plane in a
-          browser. Check that the code on the screen is the code in your
-          terminal, approve it, and the token goes from here straight into the
-          operating system&rsquo;s credential store. Nobody is ever shown it, no
-          clipboard carries it, and it never reaches a shell history file.
+          Your terminal opens an approval page. Match its code to the one in
+          your terminal, then approve. The credential is stored securely on
+          your machine, so you do not need to copy a secret.
         </p>
         <p className="max-w-[74ch] text-[13px] leading-6 text-muted">
-          The token can read environments and runs and write events, and nothing
-          else. It cannot manage members, change policy, or touch a provider
-          key. <code className="font-mono">af login --scope providers.write</code>{" "}
-          asks for more, and what was asked for is on the approval screen, so a
-          capability cannot be granted without being read.
+          This lets the terminal report environments and results to your
+          organization. Managing members, policy and provider keys requires
+          separate permissions.
         </p>
         <div className="flex flex-wrap gap-2 pt-1">
           <LinkButton href="/device" variant="secondary">
@@ -163,30 +161,70 @@ function SignIn({ origin }: { origin: string | null }) {
 }
 
 function FirstRun() {
+  // The signed-in content appears after the document's initial hash lookup.
+  // Complete a direct link once this target exists, without smooth motion.
+  useEffect(() => {
+    if (window.location.hash === "#first-run") {
+      document.getElementById("first-run")?.scrollIntoView();
+    }
+  }, []);
   return (
+    <div id="first-run" className="scroll-mt-6">
     <Card
-      title="Get a first result"
-      note="Neither of these needs an account. Both run entirely on your machine."
+      title="Run your first check"
+      note="Run these in your application checkout. The environment runs on your machine; a signed-in terminal reports its results here."
     >
       <div className="space-y-5 px-4 py-4">
         <div className="space-y-2">
+          <h3 className="text-[14px] font-medium text-ink">1. Describe your app</h3>
           <CommandBlock command="af init" said="af init copied to the clipboard" />
           <p className="max-w-[74ch] text-[13px] leading-6 text-muted">
-            Reads the repository and writes{" "}
-            <code className="font-mono">antifailure.yaml</code>: the services it
-            found, the port each listens on, the migration command, and a
-            network policy derived from the SDKs you depend on. It runs nothing
-            from the repository, and everything it reports names the file it
-            came from.
+            Reads your repository and writes{" "}
+            <code className="font-mono">antifailure.yaml</code>. Review the
+            services, database setup and network rules it detects, plus the test
+            accounts and workflows it proposes. A workflow describes something
+            a user should be able to do in your app.
           </p>
         </div>
         <div className="space-y-2">
+          <h3 className="text-[14px] font-medium text-ink">2. Check what is ready</h3>
           <CommandBlock command="af start" said="af start copied to the clipboard" />
           <p className="max-w-[74ch] text-[13px] leading-6 text-muted">
-            Says where you are and what the single next command is, read off
-            that machine as it is right now rather than off a record of what it
-            last did. It is the one command worth remembering, and it is safe to
-            run at any point because it writes nothing.
+            Checks your machine and configuration, then names the next step.
+            Resolve the prerequisites it reports before continuing. You can
+            run this again whenever you are unsure what to do next.
+          </p>
+        </div>
+        <div className="space-y-2">
+          <h3 className="text-[14px] font-medium text-ink">3. Create an isolated environment</h3>
+          <CommandBlock command="af up" said="af up copied to the clipboard" />
+          <p className="max-w-[74ch] text-[13px] leading-6 text-muted">
+            Builds and starts a copy of your app with its own database and
+            network policy. If you use production data, review the masking
+            rules first: masking replaces sensitive values in the copy before
+            tests use it. The source database is read, not rewritten.
+          </p>
+          <LinkButton href="https://antifailure.dev/docs/concepts/masking" variant="secondary">
+            Understand masking
+          </LinkButton>
+        </div>
+        <div className="space-y-2">
+          <h3 className="text-[14px] font-medium text-ink">4. Execute your workflows</h3>
+          <CommandBlock command="af test" said="af test copied to the clipboard" />
+          <p className="max-w-[74ch] text-[13px] leading-6 text-muted">
+            A run is one execution of the workflows in your manifest. The runner
+            uses your app in a browser and reports each verdict with evidence.
+            Open Runs to inspect the result. A blocked or unverified workflow
+            needs attention; it is not a successful test.
+          </p>
+          <LinkButton href="/runs" variant="secondary">View run results</LinkButton>
+        </div>
+        <div className="space-y-2">
+          <h3 className="text-[14px] font-medium text-ink">5. Remove the environment</h3>
+          <CommandBlock command="af down" said="af down copied to the clipboard" />
+          <p className="max-w-[74ch] text-[13px] leading-6 text-muted">
+            Stops and removes the resources created for this environment. Use
+            this after inspecting a result, including after a failed startup.
           </p>
         </div>
         <p className="max-w-[74ch] text-[13px] leading-6 text-muted">
@@ -197,6 +235,7 @@ function FirstRun() {
         </p>
       </div>
     </Card>
+    </div>
   );
 }
 
@@ -423,13 +462,18 @@ export default function CliPage() {
   return (
     <Page
       title="Command line"
-      lede="The engine runs on your machine and in your CI, never on this control plane. Install it, sign this terminal in, and run it: three commands, and the runs appear here. What CI needs is a different credential and it comes last."
+      lede="Install the engine, connect your terminal to this account, then create an isolated environment and run your workflows. The steps below take you through a result and cleanup."
     >
       <div className="space-y-6">
         <Install />
         <SignIn origin={origin} />
         <FirstRun />
-        <ForCI origin={origin} />
+        <details>
+          <summary className="cursor-pointer rounded-md px-1 py-3 text-[13px] font-medium text-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ink">
+            Next: run checks in CI
+          </summary>
+          <div className="mt-3"><ForCI origin={origin} /></div>
+        </details>
         <Tokens mayManage={may(role, "tokens.manage")} csrf={csrf} />
       </div>
     </Page>

--- a/console/app/(app)/environments/page.tsx
+++ b/console/app/(app)/environments/page.tsx
@@ -227,14 +227,22 @@ function Create({ onRequested }: { onRequested: () => void }) {
             <Empty
               title="No repositories connected"
               action={
-                <LinkButton href="/cli" variant="secondary">
-                  Bring one up from a terminal
-                </LinkButton>
+                <div className="flex flex-wrap justify-center gap-2">
+                  {session.data?.githubAppInstallUrl ? (
+                    <LinkButton href={session.data.githubAppInstallUrl} variant="secondary">
+                      Connect a GitHub repository
+                    </LinkButton>
+                  ) : null}
+                  <LinkButton href="/cli" variant="secondary">
+                    Start from your terminal
+                  </LinkButton>
+                </div>
               }
             >
-              One appears here once the GitHub App reports an installation that
-              includes it. That is not the only way in: the engine brings an
-              environment up from the checkout you already have.
+              For checks in GitHub, install the App on your repository and
+              configure its Antifailure workflow. For a first local check, use
+              the application checkout you already have. Connecting a repository
+              alone does not start an environment.
             </Empty>
           ) : (
             <form
@@ -500,7 +508,7 @@ function Environments() {
   return (
     <Page
       title="Environments"
-      lede="Every environment this organization has, newest first. State is what the engine last reported, not what was asked for."
+      lede="An environment is an isolated copy of your app where workflows can run safely. This list shows what the engine last reported, newest first."
     >
       {selected ? (
         <div className="mb-6">
@@ -522,13 +530,13 @@ function Environments() {
                 title="No environments yet"
                 action={
                   <LinkButton href="/cli" variant="secondary">
-                    Start with the command line
+                    Run your first check
                   </LinkButton>
                 }
               >
-                An environment appears here the first time an engine reports
-                one. Nothing has yet, which is what an organization looks like
-                before its first run, not something being wrong.
+                Create a copy of your app, execute a workflow against it, then
+                inspect the result under Runs. The command-line guide walks
+                through setup, execution and cleanup.
               </Empty>
             ) : (
               <>
@@ -587,7 +595,14 @@ function Environments() {
       </Card>
 
       <div className="mt-6">
-        <Runtimes />
+        {state.status === "ready" && state.data.length === 0 ? (
+          <details>
+            <summary className="cursor-pointer rounded-md px-1 py-3 text-[13px] font-medium text-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ink">
+              Optional: name where environments run
+            </summary>
+            <div className="mt-3"><Runtimes /></div>
+          </details>
+        ) : <Runtimes />}
       </div>
     </Page>
   );

--- a/console/app/(app)/masking/page.tsx
+++ b/console/app/(app)/masking/page.tsx
@@ -165,7 +165,7 @@ export default function MaskingPage() {
     >
       <Page
         title="Masking"
-        lede="Which columns are transformed on the way out, and what each golden attests it did."
+        lede="Masking replaces sensitive values in copied data before tests use it. Review the rules here and the verification recorded for each reusable database snapshot, called a golden."
       >
         <WithRepository>{(repository) => <Masking repository={repository} />}</WithRepository>
       </Page>

--- a/console/app/(app)/runs/page.tsx
+++ b/console/app/(app)/runs/page.tsx
@@ -14,6 +14,7 @@ import {
   CellLink,
   Empty,
   Field,
+  LinkButton,
   Loaded,
   Page,
   Row,
@@ -245,9 +246,10 @@ function Start({ onStarted }: { onStarted: () => void }) {
           const live = data.environments.filter((e) => e.state !== "torn_down");
           if (live.length === 0) {
             return (
-              <Empty title="No environment to run against">
-                A run needs an environment that is up. Ask for one on the
-                Environments page, and this fills when the engine reports it.
+              <Empty title="Create an environment first" action={<LinkButton href="/environments" variant="secondary">Set up an environment</LinkButton>}>
+                A run executes workflows against an isolated copy of your app.
+                Create that environment first, then return here to start a run
+                from its configured GitHub workflow.
               </Empty>
             );
           }
@@ -404,10 +406,9 @@ function Runs() {
         <Loaded state={state} skeleton={<TableSkeleton rows={6} cols={5} />}>
           {(data) =>
             data.length === 0 ? (
-              <Empty title="No runs yet">
-                A run appears the first time the engine exercises an
-                environment. Nothing here means nothing has run, not that
-                something is broken.
+              <Empty title="No runs yet" action={<LinkButton href="/cli#first-run" variant="secondary">Run your first workflow</LinkButton>}>
+                Creating an environment does not test it. Execute the workflows
+                in your manifest to get verdicts and evidence here.
               </Empty>
             ) : (
               <>

--- a/console/components/RepositoryPicker.tsx
+++ b/console/components/RepositoryPicker.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter, useSearchParams } from "next/navigation";
 import { query, useApi } from "@/lib/api";
-import { Bar, Empty, ErrorState, selectClass } from "@/components/ui";
+import { Bar, Empty, ErrorState, LinkButton, selectClass } from "@/components/ui";
 import type { ReactNode } from "react";
 
 export interface Repository {
@@ -49,9 +49,10 @@ export function WithRepository({
   const repos = state.data ?? [];
   if (repos.length === 0) {
     return (
-      <Empty title="No repositories connected">
-        Masking rules and network policy belong to a repository. One appears
-        here when the GitHub App reports an installation that includes it.
+      <Empty title="Choose an application first" action={<LinkButton href="/environments" variant="secondary">Set up an environment</LinkButton>}>
+        Masking rules and network policy belong to your application repository.
+        Start with an environment to connect a repository or run its checkout
+        from your terminal, then return here to review its policy.
       </Empty>
     );
   }

--- a/console/components/ui.tsx
+++ b/console/components/ui.tsx
@@ -547,7 +547,7 @@ export function CommandBlock({
 }) {
   return (
     <div className="flex flex-wrap items-start justify-between gap-3">
-      <pre className="min-w-0 flex-1 overflow-x-auto rounded-md border border-rule bg-[rgba(16,16,16,0.03)] px-3 py-2.5 font-mono text-[12.5px] leading-6 text-ink">
+      <pre tabIndex={0} className="min-w-0 flex-1 overflow-x-auto rounded-md border border-rule bg-[rgba(16,16,16,0.03)] px-3 py-2.5 font-mono text-[12.5px] leading-6 text-ink focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ink">
         <code>{command}</code>
       </pre>
       <CopyButton

--- a/console/lib/api.ts
+++ b/console/lib/api.ts
@@ -1,8 +1,10 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { trpcData } from "@/lib/wire";
+import { ApiError, trpcResponse } from "@/lib/wire";
 import { isCurrentResponse } from "@/lib/session-freshness";
+
+export { ApiError } from "@/lib/wire";
 
 /**
  * Where the API is.
@@ -48,17 +50,6 @@ export interface Session {
   hostedAccess?: boolean;
 }
 
-export class ApiError extends Error {
-  readonly status: number;
-  readonly code: string;
-  constructor(message: string, status: number, code: string) {
-    super(message);
-    this.name = "ApiError";
-    this.status = status;
-    this.code = code;
-  }
-}
-
 async function readError(res: Response): Promise<ApiError> {
   let message = `The control plane answered ${res.status}.`;
   let code = "UNKNOWN";
@@ -99,7 +90,7 @@ export async function query<T>(path: string, input?: unknown): Promise<T> {
     headers: { accept: "application/json" },
   });
   if (!res.ok) throw await readError(res);
-  return trpcData<T>(await res.json());
+  return trpcResponse<T>(res);
 }
 
 /**
@@ -127,7 +118,7 @@ export async function mutate<T>(
     body: JSON.stringify(input),
   });
   if (!res.ok) throw await readError(res);
-  return trpcData<T>(await res.json());
+  return trpcResponse<T>(res);
 }
 
 /** A plain JSON endpoint on the control plane, for the few things that are not

--- a/console/lib/wire.test.ts
+++ b/console/lib/wire.test.ts
@@ -1,28 +1,34 @@
-// The tRPC envelope, and the unwrap that was missing from it.
-//
-// The token half of this suite moved to lib/admin-csrf.test.ts, which asserts
-// the same properties and several more. What is left here is the half that
-// module does not cover: `mutate` answers the body the control plane sent, and
-// a caller reading a field off it is reading the field it asked for rather than
-// a field of the envelope around it.
-
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 
-import { trpcData } from "./wire.ts";
+import { ApiError, trpcData, trpcResponse } from "./wire.ts";
 
-describe("the envelope", () => {
-  test("the data is what comes out, not the envelope", () => {
-    assert.deepEqual(trpcData({ result: { data: { suspended: true } } }), { suspended: true });
-    assert.equal(trpcData<number>({ result: { data: 0 } }), 0);
+describe("the tRPC response boundary", () => {
+  for (const [name, value] of Object.entries({ object: { suspended: true }, zero: 0, false: false, null: null, empty: "", collection: [] })) {
+    test(`preserves valid ${name} data`, () => {
+      assert.deepEqual(trpcData({ result: { data: value } }), value);
+    });
+  }
+
+  for (const [name, body] of Object.entries({ empty: {}, missingData: { result: {} }, null: null, undefined: undefined, array: [], invalidResult: { result: "not data" }, undefinedData: { result: { data: undefined } } })) {
+    test(`rejects ${name} envelope as an actionable error`, () => {
+      assert.throws(() => trpcData(body), { name: "ApiError", code: "INVALID_RESPONSE", status: 200, message: "The control plane returned an incomplete response. Try again." });
+    });
+  }
+
+  test("preserves the server's semantic error even on HTTP success", () => {
+    assert.throws(() => trpcData({ error: { message: "Only an owner can change this.", data: { code: "FORBIDDEN" } } }), { message: "Only an owner can change this.", code: "FORBIDDEN" });
   });
 
-  test("a body that is not an envelope yields undefined rather than throwing", () => {
-    // The control plane has already said something went wrong by this point,
-    // and a TypeError here would replace its message with a stack trace.
-    assert.equal(trpcData({}), undefined);
-    assert.equal(trpcData({ result: {} }), undefined);
-    assert.equal(trpcData(null), undefined);
-    assert.equal(trpcData(undefined), undefined);
+  test("does not read a contradictory error envelope as success", () => {
+    assert.throws(() => trpcData({ error: {}, result: { data: { saved: true } } }), ApiError);
+  });
+
+  test("a truncated JSON response fails with a retryable protocol error", async () => {
+    await assert.rejects(trpcResponse(new Response('{"result":', { status: 200 })), { name: "ApiError", code: "INVALID_RESPONSE", status: 200 });
+  });
+
+  test("the HTTP reader returns the data inside the envelope", async () => {
+    assert.deepEqual(await trpcResponse(Response.json({ result: { data: { changed: true } } })), { changed: true });
   });
 });

--- a/console/lib/wire.ts
+++ b/console/lib/wire.ts
@@ -28,10 +28,53 @@
  * this gets the envelope with the right TypeScript type on it, which is the
  * shape of bug that survives a compiler and a review.
  *
- * Optional all the way down rather than asserted, because a body that is not
- * the expected shape has already failed and throwing a TypeError here would
- * replace whatever the control plane said with a stack trace.
+ * HTTP success does not prove that this envelope exists. Returning undefined
+ * made the hook report ready while Loaded kept a skeleton on screen forever.
+ * Refuse a missing envelope with the error the existing retry UI understands.
+ * Null, false, zero and empty collections remain valid endpoint results.
  */
-export function trpcData<T>(body: unknown): T {
-  return (body as { result?: { data?: T } } | null)?.result?.data as T;
+export function trpcData<T>(body: unknown, status = 200): T {
+  if (record(body) && Object.hasOwn(body, "error")) {
+    const error = body.error;
+    const message = typeof error === "string" ? error : record(error) ? error.message : undefined;
+    const code = record(error) && record(error.data) ? error.data.code : undefined;
+    if (typeof message === "string" && message.trim()) {
+      throw new ApiError(message, status, typeof code === "string" ? code : "UNKNOWN");
+    }
+    throw incompleteResponse(status);
+  }
+  if (!record(body) || !record(body.result) || !Object.hasOwn(body.result, "data") || body.result.data === undefined) {
+    throw incompleteResponse(status);
+  }
+  return body.result.data as T;
+}
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export class ApiError extends Error {
+  readonly status: number;
+  readonly code: string;
+  constructor(message: string, status: number, code: string) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.code = code;
+  }
+}
+
+function incompleteResponse(status: number): ApiError {
+  return new ApiError("The control plane returned an incomplete response. Try again.", status, "INVALID_RESPONSE");
+}
+
+/** Parsing and envelope validation are shared by queries and mutations. */
+export async function trpcResponse<T>(response: Response): Promise<T> {
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    throw incompleteResponse(response.status);
+  }
+  return trpcData<T>(body, response.status);
 }


### PR DESCRIPTION
## The failure

The console called a card a first result, but its commands only wrote a
manifest and inspected the machine. A new account had no instruction to run
the workflows. Empty Runs and Masking pages offered no next action.

The guide now continues through runner setup, an isolated environment,
workflow execution, results and cleanup. It explains environments, runs and
masking where they first matter. Optional CI and runtime setup remain
available behind labeled disclosures. A configured GitHub installation link
appears in the empty repository state.

During browser verification, an incomplete HTTP200 response left a card
loading forever. Queries and mutations now reject missing tRPC envelopes with
an actionable error. Valid empty and nullable results remain valid, and a
server refusal stays a refusal. Long copyable commands are also keyboard
focusable and scrollable on narrow screens.

## Evidence

All 155 console tests pass with zero skips; TypeScript and production export
pass. Seventeen separate boundary mutation cells failed their intended test,
with the production file restored after each, then all seventeen passed.
Prosecheck checked 727 files with zero findings.

The real built console was inspected at 1440, 390 and 320 pixels with light
and dark preferences, keeping the project's intentional light palette.
Owner, administrator, member and viewer states were exercised. An incomplete
query response showed Try again and recovered to the table. An incomplete
revoke response left the token live and displayed the error; a valid retry
showed REVOKED and removed the action. The first-workflow link reaches the
instructions after hydration, and both optional disclosures open.

The narrow command audit initially found two keyboard overflow violations.
After the focus fix, WCAG A/AA found zero; ArrowRight scrolled the focused
command 40 pixels with a visible outline. No page overflow at 320 or 390.

Browser tests use explicit HTTP fixtures and the production console build.
They verify rendering and recovery, not OAuth, GitHub installation, real
engine execution, payment or production deployment.
