### PR TITLE
analytics: cleanup erased usage and its history

### DIFF
--- a/.changes/durable-environment-usage.md
+++ b/.changes/durable-environment-usage.md
@@ -1,0 +1,8 @@
+# fixed
+
+- Removing an environment or repository erased its consumption from operator
+  analytics and could reset the rolling cost cap. Usage now retains each
+  environment's recorded interval through cleanup, while organization deletion
+  still erases its history. Scheduled maintenance saves daily UTC totals, and
+  Analytics & Usage displays those measurements as a chart and accessible table.
+  Already deleted history cannot be recovered.

--- a/console/app/admin/administration/analytics/page.tsx
+++ b/console/app/admin/administration/analytics/page.tsx
@@ -25,30 +25,7 @@ import {
   type UsageWindow,
 } from "@/lib/admin-administration";
 
-/**
- * What the platform is being used for, measured rather than estimated.
- *
- * THE UNIT IS THE ENVIRONMENT-HOUR, and it is not a unit invented for this
- * page. src/costs.ts defines it as the one thing this system can both measure
- * and charge for: one environment held for one hour. Every plan cap is
- * expressed in it, every run is refused against it, and the arithmetic is two
- * columns on the environments table. A page here reporting "runs" or "activity"
- * would be reporting something no cap is enforced on and no invoice derives
- * from.
- *
- * WHAT THIS PAGE CANNOT SHOW, AND SAYS SO. There is no rollup, aggregate,
- * metric or daily-usage table anywhere in this schema. Every figure below is
- * computed at the moment the page loads, over the rows that still exist. That
- * has three honest consequences and the page states all three at the bottom
- * rather than hiding them: there is no history older than the underlying table,
- * there is no trend line, and the query costs something.
- *
- * The alternative was a growth chart over a series nobody stores. This
- * repository has a check called figurecheck precisely because an invented
- * fidelity score shipped once, drawn client side so that curl found nothing and
- * every cheap audit came back clean. A dashboard over invented numbers is worse
- * than a page that admits a gap.
- */
+/** Recorded environment consumption and scheduled UTC history. */
 export default function AdministrationAnalyticsPage() {
   const [window, setWindow] = useState<UsageWindow>("24h");
   const usage = useAdminUsage(window);
@@ -57,12 +34,12 @@ export default function AdministrationAnalyticsPage() {
   return (
     <AdminPage
       href="/admin/administration/analytics"
-      lede="Measured in environment-hours, the unit every plan cap is enforced in. One environment held for one hour is one."
+      lede="See which organizations use the platform, how their usage changes, and what they spend on models."
     >
       <div className="grid gap-5">
         <Card
           title="Consumption by organization"
-          note="The overlap of each environment with the window, counting one still running up to now. Computed live: there is no rollup table behind this."
+          note="One environment kept for an hour uses one environment-hour. Completed environments remain counted after cleanup."
           actions={
             <div className="min-w-0">
               <Field label="Window">
@@ -80,20 +57,27 @@ export default function AdministrationAnalyticsPage() {
           }
         >
           <Loaded state={usage} skeleton={<TableSkeleton rows={6} cols={6} />}>
-            {(data) => <UsageTable usage={data} />}
+            {(data) => <><UsageTrend usage={data} /><UsageTable usage={data} /></>}
           </Loaded>
         </Card>
 
         <Card
           title="Model spend against budget"
-          note="provider_budgets, which is the one thing in this schema that is genuinely a rollup: one row per organization, provider and period."
+          note="Recorded model spend compared with each organization's budget for that period."
         >
           <Loaded state={spend} skeleton={<TableSkeleton rows={4} cols={5} />}>
             {(data) => <SpendTable spend={data} />}
           </Loaded>
         </Card>
 
-        <NotWired />
+        <Card title="How usage is counted">
+          <p className="max-w-[72ch] px-4 py-4 text-[13px] leading-6 text-muted">
+            Totals include active and completed environments. Cleanup preserves their recorded
+            hours. The daily chart uses saved UTC totals from scheduled maintenance; today's
+            bar is partial. Deleting an organization removes its usage history. Records removed
+            before usage history was introduced cannot be recovered.
+          </p>
+        </Card>
       </div>
     </AdminPage>
   );
@@ -246,51 +230,40 @@ function SpendTable({ spend }: { spend: AdminSpend }) {
   );
 }
 
-/* -------------------------------------------------------------------------
- * The gap, said out loud
- * ---------------------------------------------------------------------- */
-
-/**
- * What this section is not, and what would make it more.
- *
- * On the page rather than in a comment, because the reader is the person who
- * would otherwise assume a trend line is coming or that these numbers reach
- * back further than they do. A section that quietly omits its limits is how a
- * measurement gets used for something it cannot support.
- */
-function NotWired() {
+function UsageTrend({ usage }: { usage: AdminUsage }) {
+  if (!usage.series?.length) return (
+    <p className="border-b border-rule px-4 py-4 text-[13px] text-muted">
+      No saved daily measurements in this window. Current totals, if any, are below.
+    </p>
+  );
+  const maximum = Math.max(...usage.series.map((point) => point.hours), 1);
   return (
-    <Card title="What this page cannot show yet">
-      <div className="px-4 py-4">
-        <p className="max-w-[72ch] text-[13px] leading-6 text-muted">
-          There is no usage rollup in this schema. No aggregate table, no daily metric, no stored
-          series. Every figure above is computed when the page loads, over the rows that still
-          exist, which has three consequences worth naming.
-        </p>
-        <ul className="mt-3 grid max-w-[72ch] gap-2.5 text-[13px] leading-6 text-muted">
-          <li>
-            <span className="font-medium text-ink">No history.</span> Consumption reaches back only
-            as far as the environments table still holds rows. A torn down environment that was
-            pruned took its hours with it.
-          </li>
-          <li>
-            <span className="font-medium text-ink">No trend.</span> There is no series to draw a
-            line through, so this page draws none. A chart here would be describing numbers nobody
-            stored.
-          </li>
-          <li>
-            <span className="font-medium text-ink">A real cost.</span> The consumption query is an
-            aggregate across every tenant, so the window is capped at thirty days and the list at
-            twenty five organizations.
-          </li>
-        </ul>
-        <p className="mt-3 max-w-[72ch] text-[13px] leading-6 text-muted">
-          Making it more would mean a rollup table and a write path that actually runs, on the
-          schedule that already keeps the events partitions ahead of the writes. Model spend is the
-          one place a period series does exist, which is why it is the only thing here with a past.
-        </p>
+    <figure className="border-b border-rule px-4 py-4">
+      <figcaption className="text-[13px] font-medium text-ink">Recorded environment-hours · UTC</figcaption>
+      <p className="mt-1 mb-4 text-[12px] leading-5 text-muted">
+        Calendar days intersecting this window. Partial boundary days differ from the rolling totals below.
+      </p>
+      <p className="mb-2 text-[12px] text-muted">Scale: 0 to {maximum.toLocaleString()} hours</p>
+      <div className="flex h-36 items-end gap-1" aria-hidden="true">
+        {usage.series.map((point) => (
+          <div key={point.day} className="flex h-full min-w-0 flex-1 items-end" title={`${point.day}: ${point.hours} hours`}>
+            <div className="w-full rounded-t bg-ink" style={{ height: `${point.hours / maximum * 100}%` }} />
+          </div>
+        ))}
       </div>
-    </Card>
+      <div className="mt-2 flex justify-between text-[12px] text-muted">
+        <span>{usage.series[0].day}</span><span>{usage.series[usage.series.length - 1].day}</span>
+      </div>
+      <details className="mt-3 text-[13px] text-muted">
+        <summary className="min-h-11 cursor-pointer py-3">Read daily measurements</summary>
+        <TableWrap><Table><thead><tr><Th>Day (UTC)</Th><Th numeric>Hours</Th><Th>Measured</Th></tr></thead>
+          <tbody>{usage.series.map((point) => <tr key={point.day}>
+            <Td>{point.day}</Td><Td numeric label="Hours">{point.hours}</Td>
+            <Td label="Measured">{point.measuredAt ? <When value={point.measuredAt} /> : 'No recorded usage'}</Td>
+          </tr>)}</tbody>
+        </Table></TableWrap>
+      </details>
+    </figure>
   );
 }
 

--- a/console/lib/admin-administration.ts
+++ b/console/lib/admin-administration.ts
@@ -139,6 +139,7 @@ export interface AdminUsage {
   windowHours: number;
   since: string;
   rows: UsageRow[];
+  series: { day: string; hours: number; measuredAt: string | null }[];
 }
 
 export interface SpendRow {

--- a/docs/plans/2026-09-04-durable-usage-design.md
+++ b/docs/plans/2026-09-04-durable-usage-design.md
@@ -1,0 +1,77 @@
+# Usage that survives cleanup
+
+## Contract
+
+The lifetime recorded by the environment projection is the unit already used
+by cost caps. Cleanup must not erase it. An organization deletion must erase
+both its intervals and its daily totals. No backfill claims to reconstruct
+environments that were removed before this migration.
+
+This records the lifetime the existing environment projection reports. A
+deleted projection recreated under the same environment name gets a distinct
+interval. An in-place engine restart that reuses the same projection UUID is
+still limited by the existing ingestion protocol: sequence numbers are local
+to an engine state directory, and teardown events carry no lifetime identity.
+Fixing that requires a persistent lifetime identifier on all lifecycle events,
+including fresh runners. This change does not claim to solve that protocol gap.
+
+## Data and writers
+
+`environment_usage` retains the projection UUID, display identifier, tenant,
+creation time and teardown time. Its primary key is the projection UUID, not
+the reusable environment name. It has no foreign key to the disposable
+environment or repository. Its organization foreign key cascades on deletion.
+
+A database trigger runs on every environment insert, timestamp update and
+delete, including repository cascades. This covers ingestion, direct teardown
+and future cleanup callers without depending on each caller remembering a
+second write. A deletion of an open projection closes its recorded interval at
+the deletion time. Metadata already removed from cost attribution is labelled
+as removed rather than reconstructed.
+
+The trigger marks the organization's earliest affected time dirty before
+writing the interval. The scheduled rollup takes that same checkpoint row lock,
+replaces affected UTC days and advances its checkpoint in one transaction.
+Unchanged closed history is not recomputed on every pass. Open intervals are
+revisited from the previous checkpoint, and a late timestamp correction marks
+earlier days for replacement. Retried and concurrent calls replace totals,
+rather than adding them. An older maintenance clock cannot move the checkpoint
+backward; future timestamps remain eligible until their recorded time arrives.
+
+The existing maintenance entry points invoke the rollup after partition upkeep
+and product-event aggregation. Product events and environment usage remain
+distinct measurements. The operator reads saved calendar days for the chart
+and current intervals for exact rolling totals. The daily chart preserves idle
+day spacing and explains why calendar boundary days differ from rolling totals.
+
+## Access and retention
+
+Application connections can only select their own organization's records.
+They cannot directly insert, update or delete ledger or aggregate rows. The
+operator pool has its existing separate credential and tenant-read permission.
+The privileged migration and maintenance role owns the scheduled writer.
+Both SQL functions place the temporary schema last in their explicit search
+path. A tenant-created temporary table cannot redirect the privileged trigger.
+Organization deletion removes all three usage tables through foreign keys.
+No email address, IP address, database row or application payload is copied
+into usage history.
+
+## Alternatives considered
+
+An event-only writer misses direct teardown and cascade paths. A daily total
+without its source intervals cannot correct late events or compute a rolling
+24-hour cap. Keeping the disposable environment rows forever would retain
+unneeded operational metadata and make cleanup depend on billing retention.
+The interval ledger separates those lifetimes while preserving the current
+metering definition.
+
+## Verification
+
+Behavioral tests use real PostgreSQL and cover cleanup before and after rollup,
+concurrent retries, repository removal, organization erasure, reused names,
+late corrections, out-of-order maintenance clocks, future teardown times,
+ongoing accrual through the actual maintenance function, durable cost caps,
+cost attribution, tenant isolation and the operator route's recorded series.
+Each new assertion receives a production mutation and restored green run.
+Browser review checks populated data, loading failures and recovery, narrow
+and desktop layouts, the daily measurement table, and keyboard accessibility.

--- a/web/apps/api/src/admin/administration.ts
+++ b/web/apps/api/src/admin/administration.ts
@@ -17,9 +17,8 @@
 // estimated, defaulted, or filled in to make a card look complete. Where a
 // measurement does not exist the field is absent and the page says so, because
 // the failure this portal cannot afford is an operator during an incident
-// reading a placeholder as an answer. That is also why there is no rollup
-// table behind `usage`: there is none in this schema, and inventing a series
-// would be worse than admitting there is no history.
+// reading a placeholder as an answer. Usage history comes from scheduled
+// persisted measurements, with their measurement time carried to the reader.
 //
 // WHY THE OVERVIEW IS TWO ROUTES AND NOT ONE. `standing` reads organizations
 // and environments; `activity` reads the operator audit chain. They are two
@@ -282,12 +281,10 @@ export const administrationRouter = router({
    * asking who is using the platform is asking the same question the cap asks,
    * about everybody at once.
    *
-   * THERE IS NO ROLLUP TABLE IN THIS SCHEMA, and this route does not pretend
-   * otherwise. Every figure is computed at the moment of the call, over
-   * environments, so there is no series before what that table still holds and
-   * nothing here can draw a trend. The response carries the window and the
-   * fact that it was computed live, so the page states it rather than
-   * implying a warehouse that does not exist.
+   * The durable interval ledger survives environment and repository cleanup.
+   * Scheduled daily UTC aggregates provide the historical series. Rolling
+   * totals include live intervals up to the request clock, while every daily
+   * point carries its measurement time so stale maintenance is visible.
    *
    * Two windows per row on purpose. The selected window answers "who is using
    * this", and the rolling twenty four hours answers "who is about to be
@@ -342,10 +339,10 @@ export const administrationRouter = router({
                      - GREATEST(e.created_at, ${day.toISOString()}::timestamptz)
                    )) / 3600.0
                  )), 0) AS day_hours,
-                 count(e.id) AS environments,
-                 count(e.id) FILTER (WHERE e.state <> 'torn_down') AS live
+                 count(e.env_id) AS environments,
+                 count(e.env_id) FILTER (WHERE e.torn_down_at IS NULL) AS live
           FROM organizations o
-          JOIN environments e ON e.org_id = o.id
+          JOIN environment_usage e ON e.org_id = o.id
           -- The overlap, which is what makes every duration above positive.
           WHERE e.created_at < ${now.toISOString()}::timestamptz
             AND COALESCE(e.torn_down_at, ${now.toISOString()}::timestamptz)
@@ -354,11 +351,27 @@ export const administrationRouter = router({
           ORDER BY window_hours DESC
           LIMIT ${input.limit}`)
 
+        const series = await db.execute<{ day: string; hours: string; measured_at: Date | string | null }>(sql`
+          WITH coverage AS (
+            SELECT min(day) AS first, max(measured_at) AS latest FROM environment_usage_daily
+          ), days AS (
+            SELECT generate_series(
+              GREATEST(coverage.first, (${since.toISOString()}::timestamptz AT TIME ZONE 'UTC')::date)::timestamp,
+              LEAST((coverage.latest AT TIME ZONE 'UTC')::date,
+                (${now.toISOString()}::timestamptz AT TIME ZONE 'UTC')::date)::timestamp,
+              interval '1 day')::date AS day
+            FROM coverage WHERE first IS NOT NULL
+          )
+          SELECT days.day::text, COALESCE(SUM(d.hours), 0)::text AS hours,
+            min(d.measured_at) AS measured_at
+          FROM days LEFT JOIN environment_usage_daily d ON d.day = days.day
+          GROUP BY days.day ORDER BY days.day`)
         return {
           at: now.toISOString(),
           window: input.window,
           windowHours,
           since: since.toISOString(),
+          series: series.map((r) => ({ day: r.day, hours: round(num(r.hours)), measuredAt: r.measured_at === null ? null : iso(r.measured_at) })),
           rows: rows.map((r) => {
             const dayHours = round(num(r.day_hours))
             const dayCapHours = capsFor(r.plan).perDayHours

--- a/web/apps/api/src/costs.ts
+++ b/web/apps/api/src/costs.ts
@@ -198,8 +198,9 @@ export async function environmentHoursSince(
         - GREATEST(created_at, ${since.toISOString()}::timestamptz)
       )) / 3600.0
     ), 0) AS hours
-    FROM environments
+    FROM environment_usage
     WHERE org_id = ${orgId}
+      AND created_at < ${now.toISOString()}::timestamptz
       AND COALESCE(torn_down_at, ${now.toISOString()}::timestamptz) > ${since.toISOString()}::timestamptz`)
 
   // COALESCE guarantees a row and a number, but the driver hands back numeric
@@ -253,19 +254,22 @@ export async function costAttribution(
     hours: string | number | null
     runs: string | number | null
   }>(sql`
-    SELECT e.env_id, r.full_name AS repository, e.branch,
-           e.created_at, e.torn_down_at,
+    SELECT u.env_id, COALESCE(r.full_name, 'Removed repository') AS repository,
+           COALESCE(e.branch, 'Removed environment') AS branch,
+           u.created_at, u.torn_down_at,
            EXTRACT(EPOCH FROM (
-             LEAST(COALESCE(e.torn_down_at, ${now.toISOString()}::timestamptz),
+             LEAST(COALESCE(u.torn_down_at, ${now.toISOString()}::timestamptz),
                    ${now.toISOString()}::timestamptz)
-             - GREATEST(e.created_at, ${since.toISOString()}::timestamptz)
+             - GREATEST(u.created_at, ${since.toISOString()}::timestamptz)
            )) / 3600.0 AS hours,
            (SELECT count(*) FROM runs ru WHERE ru.environment_id = e.id) AS runs
-    FROM environments e
-    JOIN repositories r ON r.id = e.repository_id
-    WHERE e.org_id = ${orgId}
-      AND COALESCE(e.torn_down_at, ${now.toISOString()}::timestamptz) > ${since.toISOString()}::timestamptz
-    ORDER BY hours DESC, e.env_id
+    FROM environment_usage u
+    LEFT JOIN environments e ON e.id = u.environment_id
+    LEFT JOIN repositories r ON r.id = e.repository_id
+    WHERE u.org_id = ${orgId}
+      AND u.created_at < ${now.toISOString()}::timestamptz
+      AND COALESCE(u.torn_down_at, ${now.toISOString()}::timestamptz) > ${since.toISOString()}::timestamptz
+    ORDER BY hours DESC, u.env_id
     LIMIT ${limit}`)
 
   return rows.map((row) => ({

--- a/web/apps/api/src/maintenance.ts
+++ b/web/apps/api/src/maintenance.ts
@@ -66,6 +66,7 @@ export interface MaintenanceRun {
   rolledUp: string[]
   /** Raw analytics events deleted by retention. */
   analyticsPruned: number
+  usageOrganizations: number
 }
 
 const DAY_MS = 24 * 60 * 60 * 1000
@@ -161,6 +162,9 @@ export async function runMaintenance(
         : { retentionDays: config.analyticsRetentionDays }),
     })
 
+    const usage = await admin<{ count: string }[]>`
+      SELECT roll_up_environment_usage(${now.toISOString()}::timestamptz) AS count`
+
     return {
       created: [...made.created, ...analyticsPartitions.created],
       dropped,
@@ -168,6 +172,7 @@ export async function runMaintenance(
       pruned,
       rolledUp: rolled.days,
       analyticsPruned: rolled.pruned,
+      usageOrganizations: Number(usage[0]?.count ?? 0),
     }
   } finally {
     await admin.end({ timeout: 10 })
@@ -205,6 +210,7 @@ export function startMaintenance(
       if (run.analyticsPruned) {
         log(`pruned ${run.analyticsPruned} raw analytics events past the retention`)
       }
+      if (run.usageOrganizations) log(`rolled up usage for ${run.usageOrganizations} organizations`)
     } catch (err) {
       onError(err)
     }

--- a/web/apps/api/test/admin-administration.test.ts
+++ b/web/apps/api/test/admin-administration.test.ts
@@ -284,6 +284,32 @@ describe('the administration routes', { skip: hasDb ? false : 'no database' }, (
    * ------------------------------------------------------------------ */
 
   describe('usage, measured in environment-hours', () => {
+    test('recorded daily history reaches the operator route after environment cleanup', async () => {
+      const caller = await callerFor('analytics')
+      const now = h.clock.now()
+      await h.admin`SELECT roll_up_environment_usage(${now.toISOString()}::timestamptz)`
+      const before = await caller.admin.administration.usage({ window: '7d', limit: 100 })
+      const org = await seedOrg(h.admin, 'history')
+      const envId = `history-${randomUUID()}`
+      await h.admin`
+        INSERT INTO environments(org_id, repository_id, env_id, branch, state, created_at, torn_down_at)
+        VALUES (${org.orgId}, ${org.repoId}, ${envId}, 'main', 'torn_down',
+          ${new Date(now.getTime() - 2 * 3600_000).toISOString()},
+          ${new Date(now.getTime() - 3600_000).toISOString()})`
+      await h.admin`DELETE FROM environments WHERE org_id = ${org.orgId}`
+      await h.admin`SELECT roll_up_environment_usage(${now.toISOString()}::timestamptz)`
+      const after = await caller.admin.administration.usage({ window: '7d', limit: 100 })
+      const sum = (data: typeof after) => data.series.reduce((total, point) => total + point.hours, 0)
+      assert.deepEqual({
+        retained: after.rows.find((row) => row.id === org.orgId)?.hours,
+        dailyIncrease: Math.round((sum(after) - sum(before)) * 100) / 100,
+      }, { retained: 1, dailyIncrease: 1 })
+      assert.deepEqual(after.series.slice(-2).map((point) => point.day), [
+        new Date(now.getTime() - 86400_000).toISOString().slice(0, 10),
+        now.toISOString().slice(0, 10),
+      ], 'the empty current UTC day remains a dated slot rather than compressing time')
+    })
+
     test('an environment held for a known time is measured as that time', async () => {
       const caller = await callerFor('analytics')
       // Timestamps derived from h.clock, NOT from the database's now().

--- a/web/apps/api/test/usage-history.test.ts
+++ b/web/apps/api/test/usage-history.test.ts
@@ -1,0 +1,176 @@
+import { after, before, describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { randomUUID } from 'node:crypto'
+import { sql } from 'drizzle-orm'
+import { available, setup, type Harness } from '../../../packages/db/test/harness.ts'
+import { costAttribution, environmentHoursSince } from '../src/costs.ts'
+import { runMaintenance } from '../src/maintenance.ts'
+import { FakeClock } from '../src/clock.ts'
+import { adminUrl } from './harness.ts'
+
+const has = await available()
+const start = '2026-09-01T23:00:00Z'
+const end = '2026-09-02T02:00:00Z'
+const now = '2026-09-02T04:00:00Z'
+
+describe('usage survives disposable environments', { skip: has ? false : 'no database' }, () => {
+  let h: Harness
+  const orgs: string[] = []
+  before(async () => { h = await setup() })
+  after(async () => {
+    for (const org of orgs) await h.admin`DELETE FROM organizations WHERE id = ${org}`
+    await h.close()
+  })
+  async function fixture(closed = true) {
+    const slug = `usage-${randomUUID()}`
+    const [org] = await h.admin<{ id: string }[]>`
+      INSERT INTO organizations(slug, name) VALUES (${slug}, 'Usage') RETURNING id`
+    const id = org!.id
+    orgs.push(id)
+    const [repo] = await h.admin<{ id: string }[]>`
+      INSERT INTO repositories(org_id, full_name) VALUES (${id}, ${slug + '/app'}) RETURNING id`
+    const [env] = await h.admin<{ id: string }[]>`
+      INSERT INTO environments(org_id, repository_id, env_id, branch, created_at, torn_down_at, state)
+      VALUES (${id}, ${repo!.id}, 'env', 'main', ${start}, ${closed ? end : null},
+        ${closed ? 'torn_down' : 'running'}) RETURNING id`
+    return { org: id, repo: repo!.id, env: env!.id }
+  }
+  async function roll(at = now) { await h.admin`SELECT roll_up_environment_usage(${at}::timestamptz)` }
+  async function hours(org: string) {
+    const rows = await h.admin<{ day: string; hours: number }[]>`
+      SELECT day::text, hours::float8 AS hours FROM environment_usage_daily
+      WHERE org_id = ${org} ORDER BY day`
+    return Array.from(rows)
+  }
+  const expected = [{ day: '2026-09-01', hours: 1 }, { day: '2026-09-02', hours: 2 }]
+
+  for (const ordering of ['delete then rollup', 'rollup then delete', 'concurrent rollups'] as const) {
+    it(ordering, async () => {
+      const f = await fixture()
+      if (ordering === 'rollup then delete') await roll()
+      await h.admin`DELETE FROM environments WHERE id = ${f.env}`
+      if (ordering === 'concurrent rollups') await Promise.all([roll(), roll()])
+      else await roll()
+      assert.deepEqual(await hours(f.org), expected)
+    })
+  }
+  it('repository cascade retains its completed interval', async () => {
+    const f = await fixture()
+    await h.admin`DELETE FROM repositories WHERE id = ${f.repo}`
+    await roll()
+    assert.deepEqual(await hours(f.org), expected)
+  })
+  it('recreating the same environment name starts a new interval without billing the gap', async () => {
+    const f = await fixture()
+    await h.admin`DELETE FROM environments WHERE id = ${f.env}`
+    await h.admin`INSERT INTO environments(org_id, repository_id, env_id, branch, state, created_at, torn_down_at)
+      VALUES (${f.org}, ${f.repo}, 'env', 'main', 'torn_down', '2026-09-03T00:00:00Z', '2026-09-03T01:00:00Z')`
+    await roll('2026-09-03T02:00:00Z')
+    assert.deepEqual(await hours(f.org), [...expected, { day: '2026-09-03', hours: 1 }])
+  })
+  it('late earlier creation repairs prior UTC days after a completed rollup', async () => {
+    const f = await fixture()
+    await roll()
+    await h.admin`UPDATE environments SET created_at = '2026-09-01T22:00:00Z' WHERE id = ${f.env}`
+    await roll()
+    assert.deepEqual(await hours(f.org), [{ day: '2026-09-01', hours: 2 }, expected[1]])
+  })
+  it('close after rollup replaces the open measurement without double counting', async () => {
+    const f = await fixture(false)
+    await roll()
+    await h.admin`UPDATE environments SET torn_down_at = ${end}, state = 'torn_down' WHERE id = ${f.env}`
+    await roll()
+    assert.deepEqual(await hours(f.org), expected)
+  })
+  it('an open environment accrues through maintenance with no close event', async () => {
+    const f = await fixture(false)
+    await roll('2026-09-02T01:00:00Z')
+    await runMaintenance({ adminUrl }, new FakeClock(new Date(now)))
+    assert.deepEqual(await hours(f.org), [expected[0], { day: '2026-09-02', hours: 4 }])
+  })
+  it('an older maintenance call cannot move a newer open measurement backwards', async () => {
+    const f = await fixture(false)
+    await roll()
+    await roll('2026-09-02T01:00:00Z')
+    assert.deepEqual(await hours(f.org), [expected[0], { day: '2026-09-02', hours: 4 }])
+  })
+  it('an older maintenance call still repairs a late earlier creation', async () => {
+    const f = await fixture(false)
+    await roll()
+    await h.admin`UPDATE environments SET created_at = '2026-09-01T22:00:00Z' WHERE id = ${f.env}`
+    await roll('2026-09-02T01:00:00Z')
+    assert.deepEqual(await hours(f.org), [{ day: '2026-09-01', hours: 2 }, { day: '2026-09-02', hours: 4 }])
+  })
+  it('a future close remains eligible when its first rollup runs before that close', async () => {
+    const f = await fixture()
+    await roll('2026-09-02T01:00:00Z')
+    await roll()
+    assert.deepEqual(await hours(f.org), expected)
+  })
+  it('a teardown clock behind creation cannot block deletion or create negative credit', async () => {
+    const f = await fixture(false)
+    await h.admin`UPDATE environments SET torn_down_at = '2026-09-01T22:00:00Z', state = 'torn_down'
+      WHERE id = ${f.env}`
+    const used = await h.pool.withTenant({ orgId: f.org }, (db) =>
+      environmentHoursSince(db, f.org, new Date('2026-09-01T00:00:00Z'), new Date(now)))
+    assert.equal(used, 0)
+  })
+  it('deleting an organization erases intervals, daily history and checkpoints', async () => {
+    const f = await fixture()
+    await roll()
+    await h.admin`DELETE FROM organizations WHERE id = ${f.org}`
+    const rows = await h.admin<{ count: number }[]>`
+      SELECT (SELECT count(*) FROM environment_usage WHERE org_id = ${f.org})::int
+        + (SELECT count(*) FROM environment_usage_daily WHERE org_id = ${f.org})::int
+        + (SELECT count(*) FROM usage_rollup_state WHERE org_id = ${f.org})::int AS count`
+    assert.equal(rows[0]!.count, 0)
+  })
+  it('cleanup cannot reset the rolling cost cap', async () => {
+    const f = await fixture()
+    await h.admin`DELETE FROM environments WHERE id = ${f.env}`
+    const used = await h.pool.withTenant({ orgId: f.org }, (db) =>
+      environmentHoursSince(db, f.org, new Date('2026-09-01T00:00:00Z'), new Date(now)))
+    assert.equal(used, 3)
+  })
+  it('a future creation cannot cancel another interval with negative hours', async () => {
+    const f = await fixture()
+    await h.admin`INSERT INTO environments(org_id, repository_id, env_id, branch, created_at)
+      VALUES (${f.org}, ${f.repo}, 'future-start', 'main', '2026-09-03T00:00:00Z')`
+    const used = await h.pool.withTenant({ orgId: f.org }, (db) =>
+      environmentHoursSince(db, f.org, new Date('2026-09-01T00:00:00Z'), new Date(now)))
+    assert.equal(used, 3)
+  })
+  it('attribution still explains consumption after repository removal', async () => {
+    const f = await fixture()
+    await h.admin`DELETE FROM repositories WHERE id = ${f.repo}`
+    const rows = await h.pool.withTenant({ orgId: f.org }, (db) =>
+      costAttribution(db, f.org, new Date('2026-09-01T00:00:00Z'), new Date(now)))
+    assert.deepEqual(rows.map((row) => ({ hours: row.hours, repository: row.repository })),
+      [{ hours: 3, repository: 'Removed repository' }])
+  })
+  it('a tenant reads only its own daily history', async () => {
+    const a = await fixture()
+    const b = await fixture()
+    await roll()
+    const rows = await h.pool.withTenant({ orgId: a.org }, (db) =>
+      db.execute<{ org_id: string }>(sql`SELECT DISTINCT org_id FROM environment_usage_daily
+        WHERE org_id IN (${a.org}::uuid, ${b.org}::uuid)`))
+    assert.deepEqual(rows.map((r) => r.org_id), [a.org])
+  })
+  it('a tenant temporary table cannot shadow the privileged ledger writer', async () => {
+    const f = await fixture()
+    const id = randomUUID()
+    const rows = await h.pool.withTenant({ orgId: f.org }, async (db) => {
+      await db.execute(sql`CREATE TEMP TABLE environment_usage
+        (LIKE public.environment_usage INCLUDING ALL) ON COMMIT DROP`)
+      await db.execute(sql`INSERT INTO public.environments
+        (id, org_id, repository_id, env_id, branch, created_at, torn_down_at, state)
+        VALUES (${id}::uuid, ${f.org}::uuid, ${f.repo}::uuid, 'shadow-control', 'main',
+          ${start}::timestamptz, ${end}::timestamptz, 'torn_down')`)
+      return db.execute<{ retained: number; shadowed: number }>(sql`
+        SELECT (SELECT count(*) FROM public.environment_usage WHERE environment_id = ${id}::uuid)::int AS retained,
+          (SELECT count(*) FROM pg_temp.environment_usage)::int AS shadowed`)
+    })
+    assert.deepEqual(Array.from(rows), [{ retained: 1, shadowed: 0 }])
+  })
+})

--- a/web/packages/db/migrations/0037_usage_survives_environment_cleanup.sql
+++ b/web/packages/db/migrations/0037_usage_survives_environment_cleanup.sql
@@ -1,0 +1,137 @@
+/* Environment cleanup used to erase consumption. Keep only the interval and
+ * tenant key, without a foreign key to the disposable environment. Deleting
+ * the organization still erases its ledger and aggregates. Existing rows are
+ * backfilled; already deleted history cannot be reconstructed. */
+BEGIN;
+
+CREATE TABLE environment_usage (
+  environment_id uuid PRIMARY KEY,
+  org_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  env_id text NOT NULL,
+  created_at timestamptz NOT NULL,
+  torn_down_at timestamptz,
+  CHECK (torn_down_at IS NULL OR torn_down_at >= created_at)
+);
+CREATE INDEX environment_usage_org_idx ON environment_usage(org_id, created_at);
+CREATE INDEX environment_usage_open_idx ON environment_usage(org_id, created_at)
+  WHERE torn_down_at IS NULL;
+
+CREATE TABLE usage_rollup_state (
+  org_id uuid PRIMARY KEY REFERENCES organizations(id) ON DELETE CASCADE,
+  dirty_from timestamptz,
+  rolled_through timestamptz
+);
+
+CREATE TABLE environment_usage_daily (
+  org_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  day date NOT NULL,
+  hours numeric NOT NULL CHECK (hours >= 0),
+  environments bigint NOT NULL CHECK (environments >= 0),
+  measured_at timestamptz NOT NULL,
+  PRIMARY KEY (org_id, day)
+);
+CREATE INDEX environment_usage_daily_day_idx ON environment_usage_daily(day, org_id);
+
+CREATE FUNCTION retain_environment_usage() RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, public, pg_temp AS $$
+DECLARE
+  source environments;
+  ended timestamptz;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    source := OLD;
+    /* An ordinary deletion closes a still-open interval. The enclosing
+     * organization deletion must not recreate a child of a missing parent. */
+    IF NOT EXISTS (SELECT 1 FROM organizations WHERE id = source.org_id) THEN
+      RETURN OLD;
+    END IF;
+    ended := GREATEST(source.created_at, COALESCE(source.torn_down_at, statement_timestamp()));
+  ELSE
+    source := NEW;
+    ended := CASE WHEN source.torn_down_at IS NULL THEN NULL
+      ELSE GREATEST(source.created_at, source.torn_down_at) END;
+    IF TG_OP = 'UPDATE' AND NEW.created_at = OLD.created_at
+      AND NEW.torn_down_at IS NOT DISTINCT FROM OLD.torn_down_at THEN
+      RETURN NEW;
+    END IF;
+  END IF;
+  /* Queue first: the rollup takes the same row lock before reading intervals.
+   * A concurrent close either precedes the snapshot or remains dirty. */
+  INSERT INTO usage_rollup_state(org_id, dirty_from)
+    VALUES (source.org_id, source.created_at)
+    ON CONFLICT (org_id) DO UPDATE
+      SET dirty_from = LEAST(usage_rollup_state.dirty_from, EXCLUDED.dirty_from);
+  INSERT INTO environment_usage(environment_id, org_id, env_id, created_at, torn_down_at)
+    VALUES (source.id, source.org_id, source.env_id, source.created_at, ended)
+    ON CONFLICT (environment_id) DO UPDATE
+      SET created_at = LEAST(environment_usage.created_at, EXCLUDED.created_at),
+          torn_down_at = COALESCE(EXCLUDED.torn_down_at, environment_usage.torn_down_at);
+  RETURN source;
+END
+$$;
+REVOKE ALL ON FUNCTION retain_environment_usage() FROM PUBLIC;
+CREATE TRIGGER retain_environment_usage
+  AFTER INSERT OR UPDATE OR DELETE ON environments
+  FOR EACH ROW EXECUTE FUNCTION retain_environment_usage();
+
+INSERT INTO environment_usage(environment_id, org_id, env_id, created_at, torn_down_at)
+  SELECT id, org_id, env_id, created_at,
+    CASE WHEN torn_down_at IS NULL THEN NULL ELSE GREATEST(created_at, torn_down_at) END
+  FROM environments;
+INSERT INTO usage_rollup_state(org_id, dirty_from)
+  SELECT org_id, min(created_at) FROM environment_usage GROUP BY org_id;
+
+CREATE FUNCTION roll_up_environment_usage(as_of timestamptz) RETURNS bigint
+LANGUAGE plpgsql SET search_path = pg_catalog, public, pg_temp SET timezone = 'UTC' AS $$
+DECLARE
+  target record;
+  first_day timestamptz;
+  measured_to timestamptz;
+  written bigint := 0;
+BEGIN
+  FOR target IN SELECT * FROM usage_rollup_state
+    WHERE dirty_from IS NOT NULL OR EXISTS (
+      SELECT 1 FROM environment_usage u
+      WHERE u.org_id = usage_rollup_state.org_id AND u.torn_down_at IS NULL)
+    ORDER BY org_id FOR UPDATE
+  LOOP
+    measured_to := GREATEST(as_of, target.rolled_through);
+    first_day := date_trunc('day', LEAST(target.dirty_from, target.rolled_through), 'UTC');
+    IF first_day IS NULL OR first_day > measured_to THEN CONTINUE; END IF;
+    DELETE FROM environment_usage_daily
+      WHERE org_id = target.org_id AND day >= (first_day AT TIME ZONE 'UTC')::date;
+    INSERT INTO environment_usage_daily(org_id, day, hours, environments, measured_at)
+      SELECT target.org_id, (d AT TIME ZONE 'UTC')::date,
+        SUM(EXTRACT(EPOCH FROM (
+          LEAST(COALESCE(u.torn_down_at, measured_to), d + interval '1 day', measured_to)
+          - GREATEST(u.created_at, d))) / 3600.0), count(*), measured_to
+      FROM generate_series(first_day, measured_to, interval '1 day') d
+      JOIN environment_usage u ON u.org_id = target.org_id
+        AND u.created_at < LEAST(d + interval '1 day', measured_to)
+        AND COALESCE(u.torn_down_at, measured_to) > d
+      GROUP BY d;
+    UPDATE usage_rollup_state SET dirty_from = (
+      SELECT min(created_at) FROM environment_usage
+      WHERE org_id = target.org_id AND (created_at >= measured_to OR torn_down_at > measured_to)
+    ), rolled_through = measured_to
+      WHERE org_id = target.org_id;
+    written := written + 1;
+  END LOOP;
+  RETURN written;
+END
+$$;
+REVOKE ALL ON FUNCTION roll_up_environment_usage(timestamptz) FROM PUBLIC;
+
+DO $$
+DECLARE t text;
+BEGIN
+  FOREACH t IN ARRAY ARRAY['environment_usage', 'environment_usage_daily', 'usage_rollup_state']
+  LOOP
+    EXECUTE format('ALTER TABLE %I ENABLE ROW LEVEL SECURITY', t);
+    EXECUTE format('ALTER TABLE %I FORCE ROW LEVEL SECURITY', t);
+    EXECUTE format('GRANT SELECT ON %I TO antifailure_app, antifailure_admin', t);
+    EXECUTE format('CREATE POLICY tenant_reads ON %I FOR SELECT TO antifailure_app USING (org_id = current_org())', t);
+  END LOOP;
+END
+$$;
+COMMIT;

--- a/web/packages/db/src/schema.ts
+++ b/web/packages/db/src/schema.ts
@@ -1460,7 +1460,30 @@ export const adminOperations = pgTable('admin_operations', {
 /** Every table the application writes to, for the cross-tenant suite. A table
  *  added to the schema and forgotten here is a table nobody proved is
  *  isolated, so the suite asserts this list covers the database. */
+export const environmentUsage = pgTable('environment_usage', {
+  environmentId: uuid('environment_id').primaryKey(),
+  orgId: uuid('org_id').notNull().references(() => organizations.id, { onDelete: 'cascade' }),
+  envId: text('env_id').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
+  tornDownAt: timestamp('torn_down_at', { withTimezone: true }),
+})
+
+export const usageRollupState = pgTable('usage_rollup_state', {
+  orgId: uuid('org_id').primaryKey().references(() => organizations.id, { onDelete: 'cascade' }),
+  dirtyFrom: timestamp('dirty_from', { withTimezone: true }),
+  rolledThrough: timestamp('rolled_through', { withTimezone: true }),
+})
+
+export const environmentUsageDaily = pgTable('environment_usage_daily', {
+  orgId: uuid('org_id').notNull().references(() => organizations.id, { onDelete: 'cascade' }),
+  day: date('day').notNull(),
+  hours: numeric('hours').notNull(),
+  environments: bigint('environments', { mode: 'number' }).notNull(),
+  measuredAt: timestamp('measured_at', { withTimezone: true }).notNull(),
+}, (t) => [primaryKey({ columns: [t.orgId, t.day] })])
+
 export const tenantScopedTables = [
+  environmentUsage, environmentUsageDaily, usageRollupState,
   members, githubInstallations, repositories, environments, goldenVersions,
   runs, verdicts, artifacts, maskingRules, networkRules, runtimes, engineTokens,
   events, auditEntries, providerKeys, providerBudgets,

--- a/web/packages/db/test/harness.ts
+++ b/web/packages/db/test/harness.ts
@@ -425,6 +425,8 @@ export async function seedTenant(admin: postgres.Sql, label: string): Promise<Fi
     INSERT INTO github_deliveries (delivery_id, org_id, account_login, event, action)
     VALUES (${`delivery-${slug}`}, ${orgId}, ${slug}, 'pull_request', 'opened')`
 
+  await admin`SELECT roll_up_environment_usage(clock_timestamp())`
+
   return {
     orgId, userId, repoId, envId, runId, slug, connectionId, customerId,
     workloadId, workloadVersionId, workloadRunId,

--- a/web/packages/db/test/writers.test.ts
+++ b/web/packages/db/test/writers.test.ts
@@ -137,6 +137,29 @@ function sitesFor(table: string, verb: 'INSERT INTO' | 'FROM' | 'UPDATE'): Site[
   return found
 }
 
+/** A function installed by a migration keeps running after the migration.
+ * A bare backfill does not. Count a body only when a production call or a
+ * trigger on a production-written table reaches that exact function. */
+function recurringSqlWriter(site: Site): boolean {
+  if (!isMigration(site.file)) return false
+  const source = contents.get(path.join(repo, site.file))?.join('\n') ?? ''
+  const routines = /CREATE(?: OR REPLACE)? FUNCTION\s+(\w+)\s*\([\s\S]*?\$\$([\s\S]*?)\$\$;/gi
+  for (const match of source.matchAll(routines)) {
+    const first = source.slice(0, match.index).split('\n').length
+    const last = first + match[0].split('\n').length - 1
+    if (site.line < first || site.line > last) continue
+    const name = match[1]!
+    const called = new RegExp(`\\b(?:SELECT|CALL)\\s+${name}\\s*\\(`, 'i')
+    for (const [file, lines] of contents) {
+      if (!isMigration(file) && !isFixture(file) && lines.some((line) => called.test(line))) return true
+    }
+    const trigger = new RegExp(`CREATE TRIGGER\\s+\\w+[\\s\\S]*?\\bON\\s+(\\w+)\\s+FOR EACH ROW EXECUTE FUNCTION\\s+${name}\\s*\\(`, 'i')
+    const table = trigger.exec(source)?.[1]
+    if (table && sitesFor(table, 'INSERT INTO').some((s) => !isMigration(s.file) && !isFixture(s.file))) return true
+  }
+  return false
+}
+
 /** Where a customer meets the table: the console's API, or the compliance pack. */
 function isCustomerFacingReader(file: string): boolean {
   const p = file.split(path.sep).join('/')
@@ -280,7 +303,7 @@ describe('every table a screen reads is written by something that is not a fixtu
     for (const table of tables) {
       const readers = sitesFor(table, 'FROM').filter((s) => isCustomerFacingReader(s.file))
       const writers = sitesFor(table, 'INSERT INTO')
-      const inserted = writers.filter((s) => !isFixture(s.file) && !isMigration(s.file))
+      const inserted = writers.filter((s) => !isFixture(s.file) && (!isMigration(s.file) || recurringSqlWriter(s)))
       const fixtures = writers.filter((s) => isFixture(s.file))
 
       // A SINGLETON SEEDED BY ITS MIGRATION AND MAINTAINED BY UPDATE.


### PR DESCRIPTION
Removing an environment or its repository erased the interval that operator analytics and cost caps counted. Usage could disappear after cleanup, and Analytics & Usage had no saved daily history to show.

Retain each projection's recorded interval independently of the disposable environment. Scheduled maintenance writes idempotent UTC daily totals; the operator page reads them into a chart and an accessible measurement table. Rolling totals and cost attribution continue to include removed environments. Organization deletion still removes all usage records. The trigger covers ingestion, direct teardown and repository cascades, and its trusted search path prevents a tenant's temporary table from redirecting the write.

The retained identity is the projection UUID, so deleting and recreating the same environment name preserves separate lifetimes without billing the gap. This does not claim to fix the existing in-place restart protocol: fresh runners can reset local sequence numbers, and teardown events carry no lifetime identity. That separate generation-wire work remains necessary and is documented in the design.

Validation:

- Full API suite: 1,890 passed, zero failed or skipped.
- Full database package suite: 142 passed, zero failed or skipped.
- Console suite: 140 passed; production static build and API typecheck succeeded.
- Real local API and PostgreSQL browser review at 320 and 1440 pixels, under light and dark preferences. The console deliberately retains its documented light palette. Inspected populated and empty states, daily table expansion by keyboard, exact recorded values, organization erasure, and retry recovery after the API stopped. No horizontal overflow at either width.
- Axe reported zero violations; existing shared navigation IDs and the common time component require the separate accessibility follow-up already in progress.

Mutation evidence, each changed independently and then restored to green:

1. Delete before rollup: wrong hour divisor failed the retained daily totals.
2. Rollup before delete: wrong hour divisor failed the retained daily totals.
3. Concurrent rollups: wrong hour divisor failed the resulting daily totals.
4. Repository cascade: wrong hour divisor failed the retained daily totals.
5. Recreated environment name: wrong hour divisor failed the separated daily totals.
6. Late earlier creation: wrong hour divisor failed the corrected prior day.
7. Close after rollup: wrong hour divisor failed the replacement measurement.
8. Open interval through maintenance: wrong hour divisor failed ongoing accrual.
9. Older maintenance call: removing the monotonic checkpoint failed current usage.
10. Older call with a late correction: removing the monotonic checkpoint failed the corrected series.
11. Future teardown: clearing its dirty checkpoint early failed eventual accrual.
12. Tenant isolation: widening the read policy exposed another tenant and failed.
13. Organization erasure, interval ledger: removing its cascade left data and failed.
14. Organization erasure, daily totals: removing its cascade left data and failed.
15. Organization erasure, checkpoint: removing its cascade left data and failed.
16. Temporary table shadowing: removing the explicit temporary-schema position redirected the write; retained count became zero and shadow count one.
17. Cost cap after cleanup: reading disposable environments returned zero instead of three hours.
18. Cost attribution after cleanup: requiring the removed projection dropped the explanatory row.
19. Scheduled writer: removing its maintenance call left one hour instead of four.
20. Operator series: replacing measured hours with zero failed the one-hour increase.
21. Calendar spacing: dropping empty day slots failed the later assertion after the consumption assertion passed.
22. Writer gate, scheduled SQL function: removing its caller reported the daily table as unwritten.
23. Writer gate, installed trigger: disconnecting its function reported the interval ledger as unwritten.
24. Teardown clock before creation: assigning a positive interval instead of clamping failed the zero-credit result.
25. Future creation: removing the start-time filter subtracted twenty hours from another interval.
26. Reused-name identity: replacing UUID separation with name reuse charged twenty-four hours instead of two on the stopped day.

No production deployment or production migration is claimed by this PR. Existing history already deleted before this migration cannot be reconstructed.
