### PR TITLE
deploy: the scheduled maintenance job kept running an old release

### DIFF
--- a/.changes/the-maintenance-job-ran-an-old-image.md
+++ b/.changes/the-maintenance-job-ran-an-old-image.md
@@ -7,3 +7,6 @@ the job back before reporting success.
 Previously only the application and bootstrap job moved. The scheduled process
 that creates event partitions stayed on the image from the last Terraform
 apply, so production served v1.1.0 while maintenance still ran v1.0.0.
+
+A revision whose private address cannot be read now refuses promotion instead
+of skipping the candidate health check and asking customers to test it first.

--- a/.changes/the-maintenance-job-ran-an-old-image.md
+++ b/.changes/the-maintenance-job-ran-an-old-image.md
@@ -7,6 +7,8 @@ the job back before reporting success.
 Previously only the application and bootstrap job moved. The scheduled process
 that creates event partitions stayed on the image from the last Terraform
 apply, so production served v1.1.0 while maintenance still ran v1.0.0.
+Both Terraform defaults now name the published v1.1.1 image, so an apply repairs
+that existing job rather than keeping its old release.
 
 A revision whose private address cannot be read now refuses promotion instead
 of skipping the candidate health check and asking customers to test it first.

--- a/.changes/the-maintenance-job-ran-an-old-image.md
+++ b/.changes/the-maintenance-job-ran-an-old-image.md
@@ -1,0 +1,9 @@
+# fixed
+
+Continuous deployment now moves the maintenance job to the same tested image
+digest as the serving control plane, after both health checks pass, and reads
+the job back before reporting success.
+
+Previously only the application and bootstrap job moved. The scheduled process
+that creates event partitions stayed on the image from the last Terraform
+apply, so production served v1.1.0 while maintenance still ran v1.0.0.

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -67,6 +67,7 @@ env:
   RESOURCE_GROUP: af-cp-centralus
   APP: afcp-app
   BOOTSTRAP_JOB: afcp-bootstrap
+  MAINTENANCE_JOB: afcp-maintenance
   STAGING_URL: https://app.dev.antifailure.dev
   # Production, in its own resource group with its own everything. The names
   # come from `name = "afcpprod"` in production.tfvars, and the group is
@@ -75,6 +76,7 @@ env:
   PRODUCTION_RESOURCE_GROUP: af-cp-prod-centralus
   PRODUCTION_APP: afcpprod-app
   PRODUCTION_BOOTSTRAP_JOB: afcpprod-bootstrap
+  PRODUCTION_MAINTENANCE_JOB: afcpprod-maintenance
   PRODUCTION_URL: https://app.antifailure.dev
 
 jobs:
@@ -280,7 +282,7 @@ jobs:
           IMAGE_DIGEST: ${{ needs.build.outputs.digest }}
         run: |
           deploy/cd/deploy.sh \
-            "${RESOURCE_GROUP}" "${APP}" "${BOOTSTRAP_JOB}" \
+            "${RESOURCE_GROUP}" "${APP}" "${BOOTSTRAP_JOB}" "${MAINTENANCE_JOB}" \
             "${IMAGE_DIGEST}" "${GITHUB_SHA}" "${STAGING_URL}"
 
       - name: What is serving
@@ -393,7 +395,8 @@ jobs:
           IMAGE_DIGEST: ${{ needs.build.outputs.digest }}
         run: |
           deploy/cd/deploy.sh \
-            "${PRODUCTION_RESOURCE_GROUP}" "${PRODUCTION_APP}" "${PRODUCTION_BOOTSTRAP_JOB}" \
+            "${PRODUCTION_RESOURCE_GROUP}" "${PRODUCTION_APP}" \
+            "${PRODUCTION_BOOTSTRAP_JOB}" "${PRODUCTION_MAINTENANCE_JOB}" \
             "${IMAGE_DIGEST}" "${GITHUB_SHA}" "${PRODUCTION_URL}"
 
       - name: What is serving

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,12 @@ jobs:
         # tree that runs the script and a commit that does not.
         run: go run ./tools/execcheck .
 
+      - name: The serving app and its maintenance job use one tested image
+        # A failed candidate, a failed public health gate and a failed job
+        # update have different safe end states. This runs the real deploy
+        # script against fake Azure and health endpoints and proves all three.
+        run: ./deploy/cd/deploy_test.sh
+
       - name: No YAML key is defined twice in one mapping
         # examples/github-workflow.yml declared `seed` and `concurrency` twice
         # each in its workflow_dispatch inputs. YAML keeps the last definition,

--- a/deploy/cd/deploy.sh
+++ b/deploy/cd/deploy.sh
@@ -333,7 +333,9 @@ if [ -n "$REV_FQDN" ] && [ "$REV_FQDN" != "None" ]; then
     exit 1
   fi
 else
-  say "no per-revision address available; skipping the pre-promotion smoke test"
+  say "NO CANDIDATE ADDRESS. Cannot prove the revision is healthy. Traffic never moved; $PREVIOUS is still serving."
+  az containerapp revision deactivate -n "$APP" -g "$RG" --revision "$NEW" -o none || true
+  exit 1
 fi
 
 # ---------------------------------------------------------------------------

--- a/deploy/cd/deploy.sh
+++ b/deploy/cd/deploy.sh
@@ -28,16 +28,17 @@
 # backward compatible with the previous release. That constraint is real and is
 # stated in docs/plan/notes/cd.md rather than pretended away here.
 #
-#   deploy.sh <resource-group> <app> <bootstrap-job> <image> <commit> <base-url>
+#   deploy.sh <resource-group> <app> <bootstrap-job> <maintenance-job> <image> <commit> <base-url>
 
 set -euo pipefail
 
 RG="${1:?resource group}"
 APP="${2:?container app}"
-JOB="${3:?bootstrap job}"
-IMAGE="${4:?image reference, digest-pinned}"
-COMMIT="${5:?commit being deployed}"
-BASE_URL="${6:?public origin}"
+BOOTSTRAP_JOB="${3:?bootstrap job}"
+MAINTENANCE_JOB="${4:?maintenance job}"
+IMAGE="${5:?image reference, digest-pinned}"
+COMMIT="${6:?commit being deployed}"
+BASE_URL="${7:?public origin}"
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -242,17 +243,17 @@ say "currently serving: $PREVIOUS"
 # ---------------------------------------------------------------------------
 # 1. Migrations, before traffic.
 # ---------------------------------------------------------------------------
-say "migration pre-check: running $JOB on the new image"
+say "migration pre-check: running $BOOTSTRAP_JOB on the new image"
 
-az containerapp job update -n "$JOB" -g "$RG" --image "$IMAGE" -o none
+az containerapp job update -n "$BOOTSTRAP_JOB" -g "$RG" --image "$IMAGE" -o none
 
-EXEC="$(az containerapp job start -n "$JOB" -g "$RG" --query name -o tsv)"
+EXEC="$(az containerapp job start -n "$BOOTSTRAP_JOB" -g "$RG" --query name -o tsv)"
 say "bootstrap execution: $EXEC"
 
 # Poll rather than trusting a single read: the execution is Running for a while
 # and its terminal state is the only one worth acting on.
 for _ in $(seq 1 60); do
-  STATUS="$(az containerapp job execution show -n "$JOB" -g "$RG" --job-execution-name "$EXEC" \
+  STATUS="$(az containerapp job execution show -n "$BOOTSTRAP_JOB" -g "$RG" --job-execution-name "$EXEC" \
     --query "properties.status" -o tsv 2>/dev/null || echo Unknown)"
   case "$STATUS" in
     Succeeded) break ;;
@@ -345,7 +346,40 @@ say "post-deploy health gate on $BASE_URL"
 if "$HERE/health-gate.sh" "$BASE_URL" "$COMMIT" 40 3; then
   say "DEPLOYED: $BASE_URL is serving $COMMIT from $NEW"
   reap_superseded "$NEW" "$PREVIOUS"
+
+  # The scheduled job must run the same code that is serving. Terraform creates
+  # it from a release tag, but continuous deployment moves the application by
+  # digest. Before this update, every app deploy left maintenance on the tag
+  # Terraform last applied. Production reached v1.1.0 while the partition job
+  # still ran v1.0.0.
+  #
+  # This is after both health gates. Moving the job before the candidate proves
+  # itself would let a failed release change the process that runs DDL later.
+  # A failure here does not roll back a healthy application. It makes the run
+  # fail with the app serving and the scheduled job unchanged, which is the
+  # exact state an operator has to repair.
+  maintenance_updated=true
+  say "updating scheduled maintenance job $MAINTENANCE_JOB to the tested image"
+  if az containerapp job update -n "$MAINTENANCE_JOB" -g "$RG" --image "$IMAGE" -o none; then
+    maintenance_image="$(az containerapp job show -n "$MAINTENANCE_JOB" -g "$RG" \
+      --query "properties.template.containers[0].image" -o tsv 2>/dev/null || true)"
+    if [ "$maintenance_image" = "$IMAGE" ]; then
+      say "maintenance job now uses $IMAGE"
+    else
+      maintenance_updated=false
+      echo "maintenance image read back as ${maintenance_image:-nothing}; expected $IMAGE"
+    fi
+  else
+    maintenance_updated=false
+  fi
+  if [ "$maintenance_updated" != true ]; then
+    echo "::error title=Maintenance image stayed behind::$APP is healthy on $COMMIT, but $MAINTENANCE_JOB is not on $IMAGE. The application remains on the healthy revision."
+  fi
+
   assert_connection_budget
+  if [ "$maintenance_updated" != true ]; then
+    exit 1
+  fi
   exit 0
 fi
 

--- a/deploy/cd/deploy.sh
+++ b/deploy/cd/deploy.sh
@@ -12,10 +12,11 @@
 #      one. A revision that cannot start never reaches a user.
 #   3. Shift traffic.
 #   4. Check the public origin, including which commit answers.
-#   5. Deactivate every revision this deploy superseded except one, and prove
-#      what is left fits in the database's connection budget.
-#   6. On any failure after step 2, put traffic back on the revision that was
-#      serving before and deactivate the new one.
+#   5. Deactivate every revision this deploy superseded except one, update the
+#      scheduled job, and prove the database's connection budget still fits.
+#   6. On a failed public health check, restore the previous revision. Candidate
+#      failures never move traffic. Maintenance and budget failures report the
+#      unhealthy operational state while leaving the healthy app serving.
 #
 # Step 6 is only fast because the app runs in Multiple revision mode: the old
 # revision is still up with no traffic, so the way back is one API call rather

--- a/deploy/cd/deploy_test.sh
+++ b/deploy/cd/deploy_test.sh
@@ -69,7 +69,11 @@ case "$command" in
           printf 'Running\n'
         fi
         ;;
-      properties.fqdn) printf 'candidate.example\n' ;;
+      properties.fqdn)
+        if [ "${AF_DEPLOY_TEST_ADDRESS:-present}" != missing ]; then
+          printf 'candidate.example\n'
+        fi
+        ;;
       properties.createdTime) printf '2026-09-04T00:00:00Z\n' ;;
     esac
     ;;
@@ -96,8 +100,10 @@ log="${AF_DEPLOY_TEST_LOG:?}"
 url="${!#}"
 printf 'health %s\n' "$url" >> "$log"
 
-if [[ "$url" == https://public.example/* ]] &&
-   [ "${AF_DEPLOY_TEST_PUBLIC:-ok}" = fail ]; then
+if { [[ "$url" == https://public.example/* ]] &&
+     [ "${AF_DEPLOY_TEST_PUBLIC:-ok}" = fail ]; } ||
+   { [[ "$url" == https://candidate.example/* ]] &&
+     [ "${AF_DEPLOY_TEST_CANDIDATE_HEALTH:-ok}" = fail ]; }; then
   case " $* " in
     *" -f"*) exit 22 ;;
     *" -w "*) printf '503' ;;
@@ -139,6 +145,9 @@ line_of() {
 expect() {
   local name="$1"
   shift
+  if [ -n "${AF_DEPLOY_TEST_ASSERT:-}" ] && [ "$AF_DEPLOY_TEST_ASSERT" != "$name" ]; then
+    return 0
+  fi
   if "$@"; then
     printf 'ok  %s\n' "$name"
   else
@@ -176,6 +185,22 @@ expect "maintenance receives the tested digest" has_line \
   "job-update maintenance ghcr.io/example/control-plane@sha256:tested" "$CASE_LOG"
 expect "maintenance moves after public health" later_than \
   "job-update maintenance" "health https://public.example/readyz" "$CASE_LOG"
+expect "maintenance moves after candidate health" later_than \
+  "job-update maintenance" "health https://candidate.example/readyz" "$CASE_LOG"
+
+run_deploy address-missing AF_DEPLOY_TEST_ADDRESS=missing
+expect "a missing candidate address refuses the deploy" is_nonzero "$CASE_RC"
+expect "a missing candidate address leaves maintenance alone" omits \
+  "job-update maintenance" "$CASE_LOG"
+expect "a missing candidate address is never promoted" omits \
+  "containerapp ingress traffic set" "$CASE_LOG"
+
+run_deploy candidate-unhealthy AF_DEPLOY_TEST_CANDIDATE_HEALTH=fail
+expect "an unhealthy candidate refuses the deploy" is_nonzero "$CASE_RC"
+expect "an unhealthy candidate leaves maintenance alone" omits \
+  "job-update maintenance" "$CASE_LOG"
+expect "an unhealthy candidate is never promoted" omits \
+  "containerapp ingress traffic set" "$CASE_LOG"
 
 run_deploy revision-failed AF_DEPLOY_TEST_REVISION=fail
 expect "a failed candidate refuses the deploy" is_nonzero "$CASE_RC"

--- a/deploy/cd/deploy_test.sh
+++ b/deploy/cd/deploy_test.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+
+# The application and its scheduled DDL job move as one release.
+#
+# This runs the real deploy script against a fake Azure command and a fake
+# readiness origin. It checks the ordering rather than searching source text:
+# the maintenance image moves only after the candidate revision and public
+# origin are healthy, and every failure before that point leaves it alone.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/bin"
+
+cat > "$TMP/bin/az" <<'FAKE_AZ'
+#!/usr/bin/env bash
+set -euo pipefail
+
+log="${AF_DEPLOY_TEST_LOG:?}"
+command="$*"
+printf 'az %s\n' "$command" >> "$log"
+
+name=""
+image=""
+query=""
+args=("$@")
+for ((i = 0; i < ${#args[@]}; i++)); do
+  case "${args[$i]}" in
+    -n) name="${args[$((i + 1))]}" ;;
+    --image) image="${args[$((i + 1))]}" ;;
+    --query) query="${args[$((i + 1))]}" ;;
+  esac
+done
+
+case "$command" in
+  "containerapp ingress traffic show"*)
+    printf 'old-revision\n'
+    ;;
+  "containerapp job update"*)
+    printf 'job-update %s %s\n' "$name" "$image" >> "$log"
+    if [ "$name" = maintenance ] && [ "${AF_DEPLOY_TEST_MAINTENANCE:-ok}" = fail ]; then
+      exit 41
+    fi
+    ;;
+  "containerapp job show"*)
+    if [ "${AF_DEPLOY_TEST_MAINTENANCE_READBACK:-current}" = stale ]; then
+      printf 'ghcr.io/example/control-plane@sha256:old\n'
+    else
+      printf 'ghcr.io/example/control-plane@sha256:tested\n'
+    fi
+    ;;
+  "containerapp job start"*)
+    printf 'bootstrap-execution\n'
+    ;;
+  "containerapp job execution show"*)
+    printf 'Succeeded\n'
+    ;;
+  "containerapp update"*)
+    printf 'app-update %s\n' "$image" >> "$log"
+    ;;
+  "containerapp revision show"*)
+    case "$query" in
+      properties.runningState)
+        if [ "${AF_DEPLOY_TEST_REVISION:-ok}" = fail ]; then
+          printf 'Failed\n'
+        else
+          printf 'Running\n'
+        fi
+        ;;
+      properties.fqdn) printf 'candidate.example\n' ;;
+      properties.createdTime) printf '2026-09-04T00:00:00Z\n' ;;
+    esac
+    ;;
+  "containerapp ingress traffic set"*)
+    printf 'traffic %s\n' "$command" >> "$log"
+    ;;
+  "containerapp revision deactivate"*)
+    printf 'deactivate %s\n' "$command" >> "$log"
+    ;;
+  "postgres flexible-server list"*)
+    # No server makes the connection-budget check report itself unchecked. The
+    # ordering under test is complete before that independent check.
+    ;;
+  "containerapp revision list"*)
+    ;;
+esac
+FAKE_AZ
+
+cat > "$TMP/bin/curl" <<'FAKE_CURL'
+#!/usr/bin/env bash
+set -euo pipefail
+
+log="${AF_DEPLOY_TEST_LOG:?}"
+url="${!#}"
+printf 'health %s\n' "$url" >> "$log"
+
+if [[ "$url" == https://public.example/* ]] &&
+   [ "${AF_DEPLOY_TEST_PUBLIC:-ok}" = fail ]; then
+  case " $* " in
+    *" -f"*) exit 22 ;;
+    *" -w "*) printf '503' ;;
+    *) printf '{"ready":false,"commit":"old"}' ;;
+  esac
+  exit 0
+fi
+
+printf '{"ready":true,"commit":"abcdef123456"}'
+FAKE_CURL
+
+cat > "$TMP/bin/sleep" <<'FAKE_SLEEP'
+#!/usr/bin/env bash
+exit 0
+FAKE_SLEEP
+
+chmod +x "$TMP/bin/az" "$TMP/bin/curl" "$TMP/bin/sleep"
+
+run_deploy() {
+  local case_name="$1"
+  shift
+  CASE_LOG="$TMP/$case_name.events"
+  CASE_OUT="$TMP/$case_name.out"
+  : > "$CASE_LOG"
+  if env PATH="$TMP/bin:$PATH" AF_DEPLOY_TEST_LOG="$CASE_LOG" "$@" \
+      "$ROOT/deploy/cd/deploy.sh" group app bootstrap maintenance \
+      ghcr.io/example/control-plane@sha256:tested abcdef123456 https://public.example \
+      > "$CASE_OUT" 2>&1; then
+    CASE_RC=0
+  else
+    CASE_RC=$?
+  fi
+}
+
+line_of() {
+  grep -nF "$1" "$2" | head -1 | cut -d: -f1
+}
+
+expect() {
+  local name="$1"
+  shift
+  if "$@"; then
+    printf 'ok  %s\n' "$name"
+  else
+    printf 'FAIL  %s\n' "$name" >&2
+    if [ -n "${CASE_LOG:-}" ] && [ -f "$CASE_LOG" ]; then
+      printf 'events:\n' >&2
+      sed 's/^/  /' "$CASE_LOG" >&2
+    fi
+    if [ -n "${CASE_OUT:-}" ] && [ -f "$CASE_OUT" ]; then
+      printf 'output:\n' >&2
+      sed 's/^/  /' "$CASE_OUT" >&2
+    fi
+    exit 1
+  fi
+}
+
+is_zero() { [ "$1" -eq 0 ]; }
+is_nonzero() { [ "$1" -ne 0 ]; }
+contains() { grep -Fq "$1" "$2"; }
+has_line() { grep -Fxq "$1" "$2"; }
+omits() { ! grep -Fq "$1" "$2"; }
+later_than() { [ "$(line_of "$1" "$3")" -gt "$(line_of "$2" "$3")" ]; }
+count_is() { [ "$(grep -Fc "$1" "$3")" -eq "$2" ]; }
+
+expect "staging passes its maintenance job to the deploy" count_is \
+  '"${MAINTENANCE_JOB}"' 1 "$ROOT/.github/workflows/cd.yml"
+expect "production passes its maintenance job to the deploy" count_is \
+  '"${PRODUCTION_MAINTENANCE_JOB}"' 1 "$ROOT/.github/workflows/cd.yml"
+
+run_deploy healthy
+expect "a healthy release succeeds" is_zero "$CASE_RC"
+expect "bootstrap receives the tested digest" has_line \
+  "job-update bootstrap ghcr.io/example/control-plane@sha256:tested" "$CASE_LOG"
+expect "maintenance receives the tested digest" has_line \
+  "job-update maintenance ghcr.io/example/control-plane@sha256:tested" "$CASE_LOG"
+expect "maintenance moves after public health" later_than \
+  "job-update maintenance" "health https://public.example/readyz" "$CASE_LOG"
+
+run_deploy revision-failed AF_DEPLOY_TEST_REVISION=fail
+expect "a failed candidate refuses the deploy" is_nonzero "$CASE_RC"
+expect "a failed candidate leaves maintenance alone" omits "job-update maintenance" "$CASE_LOG"
+expect "a failed candidate is never promoted" omits "containerapp ingress traffic set" "$CASE_LOG"
+
+run_deploy public-failed AF_DEPLOY_TEST_PUBLIC=fail
+expect "a failed public health gate refuses the deploy" is_nonzero "$CASE_RC"
+expect "a failed public health gate leaves maintenance alone" omits \
+  "job-update maintenance" "$CASE_LOG"
+expect "a failed public health gate restores the old revision" contains \
+  "revision-weight old-revision=100" "$CASE_LOG"
+
+run_deploy maintenance-failed AF_DEPLOY_TEST_MAINTENANCE=fail
+expect "a refused maintenance update fails the run" is_nonzero "$CASE_RC"
+expect "a refused maintenance update does not roll back a healthy app" omits \
+  "revision-weight old-revision=100" "$CASE_LOG"
+expect "a refused maintenance update names the live state" contains \
+  "The application remains on the healthy revision" "$CASE_OUT"
+
+run_deploy maintenance-stale AF_DEPLOY_TEST_MAINTENANCE_READBACK=stale
+expect "a stale maintenance read back fails the run" is_nonzero "$CASE_RC"
+expect "a stale maintenance read back names both images" contains \
+  "maintenance image read back as ghcr.io/example/control-plane@sha256:old; expected ghcr.io/example/control-plane@sha256:tested" \
+  "$CASE_OUT"
+
+printf 'deploy ordering: all cases passed\n'

--- a/deploy/cd/deploy_test.sh
+++ b/deploy/cd/deploy_test.sh
@@ -142,12 +142,14 @@ line_of() {
   grep -nF "$1" "$2" | head -1 | cut -d: -f1
 }
 
+CHECKED=0
 expect() {
   local name="$1"
   shift
   if [ -n "${AF_DEPLOY_TEST_ASSERT:-}" ] && [ "$AF_DEPLOY_TEST_ASSERT" != "$name" ]; then
     return 0
   fi
+  CHECKED=$((CHECKED + 1))
   if "$@"; then
     printf 'ok  %s\n' "$name"
   else
@@ -227,4 +229,8 @@ expect "a stale maintenance read back names both images" contains \
   "maintenance image read back as ghcr.io/example/control-plane@sha256:old; expected ghcr.io/example/control-plane@sha256:tested" \
   "$CASE_OUT"
 
-printf 'deploy ordering: all cases passed\n'
+if [ "$CHECKED" -eq 0 ]; then
+  printf 'FAIL  no deployment assertions matched the selection\n' >&2
+  exit 1
+fi
+printf 'deploy ordering: %s assertions passed\n' "$CHECKED"

--- a/docs/src/content/docs/self-hosting/production.md
+++ b/docs/src/content/docs/self-hosting/production.md
@@ -74,6 +74,7 @@ resource_group_name  = "af-tfstate-eastus"
 storage_account_name = "<the state account>"
 container_name       = "tfstate"
 key                  = "control-plane-production.tfstate"
+use_azuread_auth     = true
 EOF
 terraform init -backend-config=backend.production.hcl -reconfigure
 ```

--- a/docs/src/content/docs/self-hosting/releasing.md
+++ b/docs/src/content/docs/self-hosting/releasing.md
@@ -327,6 +327,9 @@ in the workflow, so it cannot be edited in the same pull request that deploys.
    migrations first in the `afcpprod-bootstrap` job**, creates the new revision
    at zero traffic, health checks it on its own address, shifts traffic, health
    checks the public origin, and rolls traffic back if that last check fails.
+4. After both health checks pass, points `afcpprod-maintenance` at the exact
+   image digest staging tested and reads the job back. A failed candidate cannot
+   change the scheduled process that runs DDL later.
 
 The migration runs before any traffic moves. If it fails, nothing has changed
 and the previous revision is still serving. That ordering is the reason a

--- a/infra/terraform/modules/control-plane/variables.tf
+++ b/infra/terraform/modules/control-plane/variables.tf
@@ -154,7 +154,7 @@ variable "image_repository" {
 }
 variable "image_tag" {
   type    = string
-  default = "v1.0.0"
+  default = "v1.1.1"
 }
 variable "image_digest" {
   type        = string

--- a/infra/terraform/stacks/control-plane/variables.tf
+++ b/infra/terraform/stacks/control-plane/variables.tf
@@ -89,7 +89,7 @@ variable "image_repository" {
 
 variable "image_tag" {
   type    = string
-  default = "v1.0.0"
+  default = "v1.1.1"
 }
 
 variable "image_digest" {

--- a/justfile
+++ b/justfile
@@ -99,6 +99,7 @@ gate: _reports
     run "the examples still compile"     just examples
     run "gate matches CI"                just gatecheck
     run "every script can be executed"   just execcheck
+    run "deploy keeps jobs on one image" just deploycheck
     run "no yaml key is shadowed"        just keycheck
     run "vet"                            just vet
     run "typecheck"                      just typecheck
@@ -974,6 +975,12 @@ gatecheck:
 # pull request.
 execcheck:
     go run ./tools/execcheck .
+
+# The serving application and the scheduled DDL job stay on one tested image.
+# The test runs the real deploy script against fake Azure and health endpoints,
+# including every failure ordering that must leave maintenance unchanged.
+deploycheck:
+    ./deploy/cd/deploy_test.sh
 
 # No YAML key is defined twice in one mapping.
 #


### PR DESCRIPTION
## The failure

The control plane and bootstrap job moved with every release, but scheduled
maintenance still used the image from the last Terraform apply. Production
served v1.1.0 while the daily partition job ran v1.0.0.

Both Terraform image defaults now name v1.1.1, after that tag was published at
59486b63. This is intentionally a separate commit from the release itself.

## The repair

Both deployment entry points pass their maintenance job explicitly. The deploy
script updates that job to the tested digest only after candidate and public
health checks pass, then reads the image back. A failed maintenance update fails
the workflow while preserving the healthy application.

Independent review also found that an absent candidate address skipped its
health check. That path now refuses promotion. The production backend example
now includes the Azure AD authentication setting required by its storage account.

## Verification

The real deploy script runs against controlled Azure and HTTP endpoints. All
24 assertions pass. Each has isolated production mutation evidence, with the
intended assertion failing and passing after restoration. The original 17
mutation results were preserved from preparation and their tests rerun here;
the seven candidate-health assertions were added and individually mutated in
this pass. Selecting an unknown assertion also fails rather than passing an
empty suite.

| Assertion | Mutation outcome |
| --- | --- |
| Staging passes the maintenance job | Red, restored green |
| Production passes the maintenance job | Red, restored green |
| A healthy release succeeds | Red, restored green |
| Bootstrap receives the tested digest | Red, restored green |
| Maintenance receives the tested digest | Red, restored green |
| Maintenance follows public health | Red, restored green |
| Maintenance follows candidate health | Red, restored green |
| Missing candidate address refuses deployment | Red, restored green |
| Missing candidate address leaves maintenance alone | Red, restored green |
| Missing candidate address never promotes | Red, restored green |
| Unhealthy candidate refuses deployment | Red, restored green |
| Unhealthy candidate leaves maintenance alone | Red, restored green |
| Unhealthy candidate never promotes | Red, restored green |
| Failed candidate refuses deployment | Red, restored green |
| Failed candidate leaves maintenance alone | Red, restored green |
| Failed candidate never promotes | Red, restored green |
| Failed public health refuses deployment | Red, restored green |
| Failed public health leaves maintenance alone | Red, restored green |
| Failed public health restores the old revision | Red, restored green |
| Refused maintenance update fails the workflow | Red, restored green |
| Refused maintenance update preserves the healthy app | Red, restored green |
| Refused maintenance update names the live state | Red, restored green |
| Stale maintenance readback fails the workflow | Red, restored green |
| Stale maintenance readback names both images | Red, restored green |

Bash syntax, Terraform format and validation, tagsync, gatecheck, execcheck,
prosecheck, changecheck and claimcheck pass. The production read-only
plan before the image-default bump had two analytics-secret creates, one app
update, and zero destroys, preserving existing credentials and alert receivers.
That plan is not an apply and will be regenerated after the tagged production
deployment completes. Live maintenance repair is not yet claimed.
