### PR TITLE
operator: first sign-in needed a hand-built job and a visible database URL

### DIFF
--- a/.changes/operator-first-command.md
+++ b/.changes/operator-first-command.md
@@ -1,0 +1,6 @@
+# fixed
+
+The first operator required a hand-built container job and a database URL on
+the command line. `just operator-init production` now opens secure interactive
+setup in the exact running deployment, using its existing credential. An
+existing root operator is never replaced.

--- a/.dockerignore
+++ b/.dockerignore
@@ -31,6 +31,7 @@ deploy
 !deploy/docker/control-plane.Dockerfile
 !deploy/docker/bootstrap.mjs
 !deploy/docker/maintenance.mjs
+!deploy/docker/af-operator
 !deploy/docker/personas.mjs
 ee
 web/node_modules

--- a/.github/workflows/control-plane-image.yml
+++ b/.github/workflows/control-plane-image.yml
@@ -14,6 +14,7 @@ on:
     paths:
       - 'web/**'
       - 'deploy/**'
+      - '.dockerignore'
       - '.github/workflows/control-plane-image.yml'
 
   # NO `paths:` FILTER HERE, AND THAT IS THE POINT.
@@ -149,6 +150,16 @@ jobs:
           }
           check_refusal maintenance.mjs AF_MAINTENANCE_DATABASE_URL
           check_refusal bootstrap.mjs AF_MIGRATION_DATABASE_URL
+
+          # Exercise the packaged command, not only the source file it wraps.
+          out=$(docker run --rm --entrypoint af-operator "$img" init 2>&1) && rc=0 || rc=$?
+          if [ "$rc" -eq 0 ]; then
+            echo "FAIL: operator setup exited 0 without its runtime credential"; exit 1
+          fi
+          case "$out" in
+            *AF_ADMIN_DATABASE_URL*) echo "operator setup refuses and names its runtime credential" ;;
+            *) echo "FAIL: operator setup did not reach its credential guard. It said: $out"; exit 1 ;;
+          esac
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/deploy/cd/operator-init.mjs
+++ b/deploy/cd/operator-init.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawn, spawnSync } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+
+/** Read only the two exact literal identifiers the deployment already uses. */
+export function deploymentTarget(environment, source) {
+  if (!['production', 'staging'].includes(environment)) throw new Error('Choose production or staging explicitly.')
+  const literal = (name) => {
+    const matches = [...source.matchAll(new RegExp(`^${name}\\s*=\\s*"([a-z0-9-]+)"\\s*$`, 'gm'))]
+    if (matches.length !== 1) throw new Error(`The deployment must declare one literal ${name}.`)
+    return matches[0][1]
+  }
+  const group = literal('resource_group_name')
+  const name = literal('name')
+  if (!group.startsWith('af-')) throw new Error('Refusing a resource group outside Antifailure.')
+  return { group, app: `${name}-app` }
+}
+
+export async function remoteOperatorInit(target, execute = spawnSync, connect = connectOperator) {
+  const inspect = (args) => {
+    const result = execute('az', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] })
+    if (result.status !== 0) {
+      const detail = result.stderr?.trim() || result.error?.message || `exit status ${result.status}`
+      throw new Error(`Azure could not verify the deployment: ${detail}`)
+    }
+    try { return JSON.parse(result.stdout) } catch { throw new Error('Azure returned an unreadable deployment response.') }
+  }
+  const group = inspect(['group', 'show', '--name', target.group, '--query', '{name:name,project:tags.project}', '--output', 'json'])
+  if (group.name !== target.group || group.project !== 'antifailure') {
+    throw new Error('The resource group is not the exact tagged Antifailure deployment. Nothing was changed.')
+  }
+  const app = inspect(['containerapp', 'show', '--resource-group', target.group, '--name', target.app,
+    '--query', '{name:name,resourceGroup:resourceGroup,state:properties.runningStatus,traffic:properties.configuration.ingress.traffic,latest:properties.latestRevisionName}', '--output', 'json'])
+  if (app.name !== target.app || app.resourceGroup !== target.group || app.state !== 'Running') {
+    throw new Error('The exact application is not running. Nothing was changed.')
+  }
+  const serving = Array.isArray(app.traffic) ? app.traffic.filter((entry) => entry && entry.weight > 0) : []
+  if (serving.length !== 1 || serving[0].weight !== 100) {
+    throw new Error('The application does not have one revision serving all traffic. Resolve the deployment split before operator setup.')
+  }
+  const revision = serving[0].latestRevision ? app.latest : serving[0].revisionName
+  if (typeof revision !== 'string' || !/^[a-z0-9-]+$/.test(revision)) throw new Error('Azure did not identify the serving revision.')
+  await connect({ ...target, revision })
+}
+
+/** A successful Azure websocket exit is not proof the remote command succeeded. */
+export async function connectOperator(target, execute = spawn, output = process.stdout, token = randomUUID(), restoreTerminal = saveTerminal()) {
+  const marker = `operator-init-complete:${token}`
+  const child = execute('az', ['containerapp', 'exec', '--resource-group', target.group, '--name', target.app, '--revision', target.revision,
+    '--command', `af-operator init --completion-token ${token}`], { stdio: ['inherit', 'pipe', 'inherit'] })
+  let cancelled = false
+  let forceStop
+  const signals = ['SIGINT', 'SIGTERM', 'SIGHUP']
+  const forwarders = new Map(signals.map((signal) => [signal, () => {
+    cancelled = true
+    child.kill(signal)
+    forceStop ??= setTimeout(() => child.kill('SIGKILL'), 2000)
+    forceStop.unref()
+  }]))
+  for (const [signal, forward] of forwarders) process.on(signal, forward)
+  try { await new Promise((resolve, reject) => {
+    let tail = ''
+    let completed = false
+    child.stdout.on('data', (chunk) => {
+      output.write(chunk)
+      tail = (tail + chunk.toString()).slice(-4096)
+      completed ||= tail.includes(marker)
+    })
+    child.on('error', () => reject(new Error('Azure could not open the setup terminal. Check that the Azure CLI is installed and signed in.')))
+    child.on('close', (status) => {
+      if (status !== 0 || !completed || cancelled) {
+        reject(new Error('The remote setup did not confirm completion. No password reset was attempted. Read the setup refusal above.'))
+      } else resolve()
+    })
+  }) } finally {
+    for (const [signal, forward] of forwarders) process.removeListener(signal, forward)
+    clearTimeout(forceStop)
+    restoreTerminal()
+  }
+}
+
+function saveTerminal() {
+  if (!process.stdin.isTTY || process.platform === 'win32') return () => {}
+  const state = spawnSync('stty', ['-g'], { encoding: 'utf8', stdio: ['inherit', 'pipe', 'ignore'] })
+  if (state.status !== 0) throw new Error('Could not save terminal settings. Setup has not started.')
+  return () => {
+    const restored = spawnSync('stty', [state.stdout.trim()], { stdio: ['inherit', 'ignore', 'inherit'] })
+    if (restored.status !== 0) throw new Error('Could not restore the terminal. Run stty sane before continuing.')
+  }
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    const environment = process.argv[2]
+    if (process.argv.length !== 3 || !['production', 'staging'].includes(environment)) {
+      throw new Error('Run just operator-init production or just operator-init staging.')
+    }
+    if (!process.stdin.isTTY) throw new Error('Open an interactive terminal to run operator setup. Password entry happens inside the runtime.')
+    const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+    const target = deploymentTarget(environment, readFileSync(resolve(root, `infra/terraform/stacks/control-plane/${environment}.tfvars`), 'utf8'))
+    console.log(`Creating the first operator on ${environment}: ${target.group}/${target.app}.`)
+    console.log('An existing root operator is never replaced. Password entry happens in the remote runtime.')
+    await remoteOperatorInit(target)
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : 'Operator setup failed.')
+    process.exitCode = 1
+  }
+}

--- a/deploy/docker/af-operator
+++ b/deploy/docker/af-operator
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec node /app/apps/api/src/operator-cli.ts "$@"

--- a/deploy/docker/control-plane.Dockerfile
+++ b/deploy/docker/control-plane.Dockerfile
@@ -121,7 +121,8 @@ COPY web/packages/policy ./packages/policy
 # how a schema arrives that the running code does not understand.
 COPY deploy/docker/bootstrap.mjs ./bootstrap.mjs
 COPY deploy/docker/maintenance.mjs ./maintenance.mjs
-COPY --chmod=755 deploy/docker/af-operator /usr/local/bin/af-operator
+COPY deploy/docker/af-operator /usr/local/bin/af-operator
+RUN chmod 755 /usr/local/bin/af-operator
 # The preview identities. Refuses to run outside an environment the engine
 # created; see the file for why that check is not a formality.
 COPY deploy/docker/personas.mjs ./personas.mjs

--- a/deploy/docker/control-plane.Dockerfile
+++ b/deploy/docker/control-plane.Dockerfile
@@ -121,6 +121,7 @@ COPY web/packages/policy ./packages/policy
 # how a schema arrives that the running code does not understand.
 COPY deploy/docker/bootstrap.mjs ./bootstrap.mjs
 COPY deploy/docker/maintenance.mjs ./maintenance.mjs
+COPY --chmod=755 deploy/docker/af-operator /usr/local/bin/af-operator
 # The preview identities. Refuses to run outside an environment the engine
 # created; see the file for why that check is not a formality.
 COPY deploy/docker/personas.mjs ./personas.mjs

--- a/docs/src/content/docs/self-hosting/operations.md
+++ b/docs/src/content/docs/self-hosting/operations.md
@@ -15,6 +15,39 @@ acknowledgement means, and what to do first for each class of page. The
 [status page](/docs/self-hosting/status-page) is what a customer reads while
 you read this one; it is not the pager and does not substitute for it.
 
+## Create the first operator
+
+From this repository, with the Azure CLI signed into the deployment's
+subscription, run one command:
+
+```sh
+just operator-init production
+```
+
+Use `staging` instead to target staging. The command reads that environment's
+checked-in deployment identifiers, verifies the exact resource group carries
+the Antifailure project tag, and opens setup in the running application. It
+does not create a container job or fetch the database password to your machine.
+The application image must include `af-operator`; an older image refuses the
+command rather than falling back to another account-creation path.
+
+Enter the operator email, display name and password. Password entry and its
+confirmation are hidden. The runtime uses its existing `AF_ADMIN_DATABASE_URL`,
+and the account can sign in at `/admin`. This is separate from GitHub customer
+sign-in. Setup refuses an existing root operator and never resets its password.
+
+For another container host, open a terminal in the serving container and run:
+
+```sh
+af-operator init
+```
+
+Automation may supply the email and display name as arguments and pipe the
+password on standard input. A password or database URL is never a command
+argument. A successful Azure connection alone is not a successful setup: the
+wrapper also requires the runtime's completion acknowledgement. Always finish
+by signing in and opening an operator-only page.
+
 ## The first thirty seconds
 
 Three questions, in this order, because the answer to each changes which of the

--- a/justfile
+++ b/justfile
@@ -878,6 +878,10 @@ sidebarcheck:
 runbookcheck:
     go run ./tools/runbookcheck .
 
+# Create the first operator using the deployment's existing database credential.
+operator-init environment:
+    node deploy/cd/operator-init.mjs {{quote(environment)}}
+
 # STATUS.md keeps the rule it states about itself.
 #
 # That file opens by saying every component carries one of a fixed set of

--- a/tools/gatecheck/main.go
+++ b/tools/gatecheck/main.go
@@ -576,6 +576,10 @@ func uncalledByGate(recipes []recipe, reachable map[string]bool) []string {
 		// property it helps with -- every commit carrying a sign-off -- is
 		// already a gate in CI that does not depend on anybody having run it.
 		"hooks": true,
+		// Creates the first privileged operator in a chosen live deployment.
+		// Running account creation as part of a source check would be a write
+		// to production, not verification. Its tests run inside test-web.
+		"operator-init": true,
 	}
 
 	var uncalled []string

--- a/tools/gatecheck/main_test.go
+++ b/tools/gatecheck/main_test.go
@@ -479,6 +479,22 @@ _generated:
 	}
 }
 
+func TestOperatorInitializationIsNotRunByTheSourceGate(t *testing.T) {
+	got := uncalled(`
+gate:
+    run "errors" just errcheck
+
+errcheck:
+    go run ./tools/errcheck .
+
+operator-init environment:
+    node deploy/cd/operator-init.mjs production
+`)
+	if len(got) != 0 {
+		t.Fatalf("operator creation was required in the source gate: %v", got)
+	}
+}
+
 func TestAConvenienceRecipeIsNotReported(t *testing.T) {
 	// `just fmt` writes files and `just db` starts a container. Neither
 	// belongs in a gate, and reporting them would teach people to ignore this.

--- a/web/apps/api/package.json
+++ b/web/apps/api/package.json
@@ -9,7 +9,8 @@
   },
   "bin": {
     "af-control-plane": "./src/main.ts",
-    "af-control-plane-backup": "./src/backup-cli.ts"
+    "af-control-plane-backup": "./src/backup-cli.ts",
+    "af-operator": "./src/operator-cli.ts"
   },
   "scripts": {
     "start": "node src/main.ts",

--- a/web/apps/api/src/admin/operator-command.ts
+++ b/web/apps/api/src/admin/operator-command.ts
@@ -1,0 +1,45 @@
+import { bootstrapOperator, type BootstrapOperatorInput, type BootstrapOperatorResult } from './bootstrap.ts'
+import { operatorInput } from './operator-input.ts'
+
+export interface OperatorCommandOptions {
+  adminUrl?: string
+  publicUrl?: string
+  email?: string
+  name?: string
+  password?: string
+  prompt?: typeof operatorInput
+  bootstrap?: (input: BootstrapOperatorInput) => Promise<BootstrapOperatorResult>
+}
+
+/** Uses the credential already present in the runtime, never a URL argument. */
+export async function initializeOperator(options: OperatorCommandOptions): Promise<string> {
+  if (!options.adminUrl) {
+    throw new Error('This runtime has no AF_ADMIN_DATABASE_URL. Enable its operator database credential before creating an operator.')
+  }
+  let destination = '/admin'
+  if (options.publicUrl) {
+    try {
+      const url = new URL(options.publicUrl)
+      if (!['http:', 'https:'].includes(url.protocol) || url.username || url.password) throw new Error()
+      destination = new URL('/admin', url).href
+    } catch {
+      throw new Error('AF_PUBLIC_URL must be an HTTP or HTTPS address without credentials. Nothing was written.')
+    }
+  }
+  const prompt = options.prompt ?? operatorInput
+  const email = options.email ?? await prompt('Operator email: ', false)
+  const name = options.name ?? await prompt('Display name: ', false)
+  const password = options.password ?? await prompt('Password, at least 12 characters: ', true)
+  if (options.password === undefined) {
+    const confirmation = await prompt('Confirm password: ', true)
+    if (password !== confirmation) throw new Error('The passwords did not match. Nothing was written.')
+  }
+  await (options.bootstrap ?? bootstrapOperator)({
+    adminUrl: options.adminUrl,
+    email,
+    name,
+    password,
+    operator: 'operator init',
+  })
+  return `The first operator is ready. Sign in at ${destination}`
+}

--- a/web/apps/api/src/admin/operator-input.ts
+++ b/web/apps/api/src/admin/operator-input.ts
@@ -1,0 +1,53 @@
+import { emitKeypressEvents } from 'node:readline'
+import type { ReadStream, WriteStream } from 'node:tty'
+
+/** Read from the terminal without ever echoing a password, including on paste. */
+export async function operatorInput(
+  label: string,
+  secret: boolean,
+  input: ReadStream = process.stdin,
+  output: WriteStream = process.stderr,
+): Promise<string> {
+  if (!input.isTTY || !output.isTTY) {
+    throw new Error('Interactive setup needs a terminal. For automation, pass email and name and pipe the password on standard input.')
+  }
+  emitKeypressEvents(input)
+  const wasRaw = input.isRaw
+  input.setRawMode(true)
+  input.resume()
+  output.write(label)
+  return await new Promise<string>((resolve, reject) => {
+    let value = ''
+    const finish = (error?: Error) => {
+      input.removeListener('keypress', keypress)
+      input.removeListener('end', ended)
+      input.setRawMode(wasRaw)
+      input.pause()
+      output.write('\n')
+      if (error) reject(error)
+      else resolve(value)
+    }
+    const ended = () => finish(new Error('Setup cancelled before the answer was complete.'))
+    const keypress = (text: string | undefined, key: { name?: string; ctrl?: boolean; meta?: boolean }) => {
+      if (key.ctrl && (key.name === 'c' || key.name === 'd')) {
+        finish(new Error('Setup cancelled.'))
+      } else if (key.name === 'return' || key.name === 'enter') {
+        finish()
+      } else if (key.name === 'backspace') {
+        if (value) {
+          value = Array.from(value).slice(0, -1).join('')
+          if (!secret) output.write('\b \b')
+        }
+      } else if (text && !key.ctrl && !key.meta && !/[\u0000-\u001f\u007f]/.test(text)) {
+        if (value.length + text.length > 512) {
+          finish(new Error('That answer is too long. Setup accepts at most 512 characters.'))
+          return
+        }
+        value += text
+        if (!secret) output.write(text)
+      }
+    }
+    input.on('keypress', keypress)
+    input.once('end', ended)
+  })
+}

--- a/web/apps/api/src/operator-cli.ts
+++ b/web/apps/api/src/operator-cli.ts
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+import { parseArgs } from 'node:util'
+import { initializeOperator } from './admin/operator-command.ts'
+
+try {
+  const { values, positionals } = parseArgs({
+    allowPositionals: true,
+    options: { email: { type: 'string' }, name: { type: 'string' }, 'completion-token': { type: 'string' } },
+  })
+  if (positionals.length !== 1 || positionals[0] !== 'init' || Boolean(values.email) !== Boolean(values.name)) {
+    throw new Error('Run af-operator init. For automation, supply both email and name and pipe the password on standard input.')
+  }
+  if (values['completion-token'] && !/^[0-9a-f-]{36}$/.test(values['completion-token'])) {
+    throw new Error('The completion token is not a valid setup token.')
+  }
+  let password: string | undefined
+  if (values.email !== undefined) {
+    if (process.stdin.isTTY) throw new Error('Automation reads the password from standard input, never an argument. Omit email and name for interactive setup.')
+    const chunks: Buffer[] = []
+    let size = 0
+    for await (const chunk of process.stdin) {
+      const bytes = Buffer.from(chunk)
+      size += bytes.length
+      if (size > 2048) throw new Error('The password input exceeds the 2048 byte limit.')
+      chunks.push(bytes)
+    }
+    password = Buffer.concat(chunks).toString('utf8').replace(/\r?\n$/, '')
+  }
+  console.log(await initializeOperator({
+    adminUrl: process.env.AF_ADMIN_DATABASE_URL,
+    publicUrl: process.env.AF_PUBLIC_URL,
+    email: values.email,
+    name: values.name,
+    password,
+  }))
+  if (values['completion-token']) console.log(`operator-init-complete:${values['completion-token']}`)
+} catch (error) {
+  // Argument errors may contain the supplied value. Do not echo them.
+  if (error instanceof TypeError && 'code' in error && String(error.code).startsWith('ERR_PARSE_ARGS')) {
+    console.error('Unrecognized arguments. Run af-operator init; a password is never a command argument.')
+  } else {
+    console.error(error instanceof Error ? error.message : 'Operator setup failed.')
+  }
+  process.exitCode = 1
+}

--- a/web/apps/api/test/operator-azure.test.ts
+++ b/web/apps/api/test/operator-azure.test.ts
@@ -1,0 +1,104 @@
+import { it } from 'node:test'
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+import { PassThrough } from 'node:stream'
+const { deploymentTarget, remoteOperatorInit, connectOperator } = await import('../../../../deploy/cd/operator-init.mjs' as string)
+
+const source = 'resource_group_name = "af-test"\nname = "afproof"\n'
+const target = { group: 'af-test', app: 'afproof-app' }
+const servingTarget = { ...target, revision: 'afproof-app-r1' }
+function azure(overrides: Record<string, unknown> = {}) {
+  const calls: unknown[][] = []
+  const execute = (_: string, args: string[], options: unknown) => {
+    calls.push([args, options])
+    if (args[0] === 'group') return { status: 0, stdout: JSON.stringify({ name: target.group, project: 'antifailure', ...overrides }) }
+    if (args[1] === 'show') return { status: 0, stdout: JSON.stringify({ name: target.app, resourceGroup: target.group, state: 'Running', traffic: [{ revisionName: servingTarget.revision, weight: 100 }] }) }
+    return { status: 0 }
+  }
+  return { calls, execute }
+}
+
+it('resolves the exact deployment instead of selecting the first matching app', () => {
+  assert.deepEqual(deploymentTarget('production', source), target)
+})
+it('requires an explicit known environment', () => {
+  assert.throws(() => deploymentTarget('prod', source), /Choose production or staging/)
+})
+it('refuses foreign resource groups before Azure runs', () => {
+  assert.throws(() => deploymentTarget('staging', source.replace('af-test', 'postiz-rg')), /outside Antifailure/)
+})
+it('refuses duplicate deployment identifiers', () => {
+  assert.throws(() => deploymentTarget('staging', source + 'name = "second"\n'), /one literal name/)
+})
+it('requires the live project tag before opening the operator terminal', async () => {
+  await assert.rejects(remoteOperatorInit(target, azure({ project: 'another-project' }).execute), /exact tagged Antifailure/)
+})
+it('opens the verified exact runtime after both Azure checks', async () => {
+  const fake = azure()
+  let connected
+  await remoteOperatorInit(target, fake.execute, async (value: unknown) => { connected = value })
+  assert.deepEqual(connected, servingTarget)
+})
+it('fails closed when Azure cannot verify the target', async () => {
+  await assert.rejects(remoteOperatorInit(target, () => ({ status: 1, stderr: 'provider diagnostic' })), /could not verify/)
+})
+it('preserves the Azure refusal instead of hiding the reason behind a generic error', async () => {
+  await assert.rejects(remoteOperatorInit(target, () => ({ status: 1, stderr: 'AuthorizationFailed: missing Reader permission' })), /AuthorizationFailed: missing Reader permission/)
+})
+
+function connection() {
+  const child = Object.assign(new EventEmitter(), { stdout: new PassThrough() })
+  let args: unknown
+  const execute = (_: unknown, supplied: unknown) => { args = supplied; return child }
+  return { child, execute, args: () => args }
+}
+const token = '00000000-0000-4000-8000-000000000001'
+it('never sends a password or database URL in the Azure command arguments', async () => {
+  const fake = connection()
+  const pending = connectOperator(servingTarget, fake.execute, new PassThrough(), token)
+  fake.child.stdout.write(`operator-init-complete:${token}\n`)
+  fake.child.emit('close', 0)
+  await pending
+  assert.deepEqual(fake.args(), ['containerapp', 'exec', '--resource-group', 'af-test', '--name', 'afproof-app', '--revision', servingTarget.revision, '--command', `af-operator init --completion-token ${token}`])
+})
+it('does not confuse a clean Azure exit with a successful operator setup', async () => {
+  const fake = connection()
+  const pending = connectOperator(servingTarget, fake.execute, new PassThrough(), token)
+  fake.child.stdout.write('The control plane already has a root operator.\n')
+  fake.child.emit('close', 0)
+  await assert.rejects(pending, /did not confirm completion/)
+})
+
+it('restores the local terminal even when remote setup is refused', async () => {
+  const fake = connection()
+  let restored = false
+  const pending = connectOperator(servingTarget, fake.execute, new PassThrough(), token, () => { restored = true })
+  fake.child.emit('close', 0)
+  await pending.catch(() => {})
+  assert.equal(restored, true)
+})
+
+for (const signal of ['SIGTERM', 'SIGHUP'] as const) {
+  it(`terminates the Azure child when the wrapper receives ${signal}`, async () => {
+    const fake = connection()
+    let forwarded
+    Object.assign(fake.child, { kill(value: string) { forwarded = value } })
+    const pending = connectOperator(servingTarget, fake.execute, new PassThrough(), token)
+    process.emit(signal)
+    fake.child.emit('close', 1)
+    await pending.catch(() => {})
+    assert.equal(forwarded, signal)
+  })
+}
+
+it('refuses split traffic instead of choosing an arbitrary running revision', async () => {
+  const fake = azure()
+  const execute = (command: string, args: string[], options: unknown) => {
+    const result = fake.execute(command, args, options)
+    if (args[0] === 'containerapp') {
+      result.stdout = JSON.stringify({ name: target.app, resourceGroup: target.group, state: 'Running', traffic: [{ revisionName: 'first', weight: 50 }, { revisionName: 'second', weight: 50 }] })
+    }
+    return result
+  }
+  await assert.rejects(remoteOperatorInit(target, execute, async () => { throw new Error('connected') }), /one revision serving all traffic/)
+})

--- a/web/apps/api/test/operator-command-live.test.ts
+++ b/web/apps/api/test/operator-command-live.test.ts
@@ -1,0 +1,40 @@
+import { after, before, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { adminUrl, available, startApi, type ApiHarness } from './harness.ts'
+
+const hasDb = await available()
+let api: ApiHarness
+let ownsRootSlot = false
+const email = 'operator-command-proof@example.test'
+const password = 'test-only-command-passphrase'
+const completionToken = '00000000-0000-4000-8000-000000000002'
+before(async () => {
+  if (!hasDb) return
+  api = await startApi()
+  api.clock.advance(Date.now() - api.clock.now().getTime())
+  const roots = await api.admin`SELECT id FROM admin_users WHERE is_root`
+  if (roots.length) throw new Error('This test requires an isolated database with no root operator. It never resets an existing root.')
+  ownsRootSlot = true
+})
+after(async () => {
+  if (api && ownsRootSlot) {
+    await api.admin`ALTER TABLE admin_users DISABLE TRIGGER admin_root_is_permanent_del`
+    try { await api.admin`DELETE FROM admin_users WHERE email = ${email}` }
+    finally { await api.admin`ALTER TABLE admin_users ENABLE TRIGGER admin_root_is_permanent_del` }
+  }
+  if (api) await api.close()
+})
+
+it('the actual command creates a credential that reaches a protected operator endpoint', { skip: !hasDb }, async () => {
+  const run = spawnSync(process.execPath, [fileURLToPath(new URL('../src/operator-cli.ts', import.meta.url)), 'init', '--email', email, '--name', 'Command Proof', '--completion-token', completionToken], {
+    env: { ...process.env, AF_ADMIN_DATABASE_URL: adminUrl, AF_PUBLIC_URL: 'https://example.test' },
+    input: `${password}\n`, encoding: 'utf8',
+  })
+  const signedIn = await api.fetch('/v1/admin/signin', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ email, password }) })
+  const cookie = signedIn.headers.get('set-cookie')?.split(';')[0] ?? ''
+  const me = await api.fetch('/trpc/admin.me', { headers: { cookie } })
+  assert.deepEqual({ exit: run.status, signin: signedIn.status, protected: me.status, identity: (await me.text()).includes(email), passwordLeaked: `${run.stdout}${run.stderr}`.includes(password), completion: run.stdout.includes(`operator-init-complete:${completionToken}`) },
+    { exit: 0, signin: 200, protected: 200, identity: true, passwordLeaked: false, completion: true })
+})

--- a/web/apps/api/test/operator-command.test.ts
+++ b/web/apps/api/test/operator-command.test.ts
@@ -1,0 +1,107 @@
+import { it } from 'node:test'
+import assert from 'node:assert/strict'
+import { PassThrough } from 'node:stream'
+import type { ReadStream, WriteStream } from 'node:tty'
+import { initializeOperator } from '../src/admin/operator-command.ts'
+import { operatorInput } from '../src/admin/operator-input.ts'
+import type { BootstrapOperatorInput, BootstrapOperatorResult } from '../src/admin/bootstrap.ts'
+
+const result: BootstrapOperatorResult = { adminUserId: 'test', email: 'operator@example.test', name: 'Operator', role: 'owner', applied: true, auditSeq: 1 }
+const base = { adminUrl: 'postgres://runtime-only', email: result.email, name: result.name, password: 'test-only-operator-password' }
+
+it('uses the runtime credential and the existing bootstrap guard', async () => {
+  let received: BootstrapOperatorInput | undefined
+  await initializeOperator({ ...base, bootstrap: async (input) => { received = input; return result } })
+  assert.deepEqual(received, { ...base, operator: 'operator init' })
+})
+
+it('refuses a runtime with no privileged credential before asking for a password', async () => {
+  await assert.rejects(initializeOperator({ prompt: async () => { throw new Error('prompted') } }), /no AF_ADMIN_DATABASE_URL/)
+})
+
+it('keeps the first-operator refusal instead of resetting an existing account', async () => {
+  await assert.rejects(initializeOperator({ ...base, bootstrap: async () => { throw new Error('already has a root operator') } }), /already has a root operator/)
+})
+
+it('confirms an interactive password before any write', async () => {
+  await assert.rejects(initializeOperator({ ...base, password: undefined,
+    prompt: async (label) => label.startsWith('Confirm') ? 'different' : 'test-only-operator-password',
+    bootstrap: async () => { throw new Error('wrote') },
+  }), /passwords did not match/)
+})
+
+it('prompts for both identity fields and hides both password entries', async () => {
+  const calls: boolean[] = []
+  const answers = [result.email, result.name, base.password, base.password]
+  await initializeOperator({ adminUrl: base.adminUrl, prompt: async (_, secret) => { calls.push(secret); return answers.shift()! }, bootstrap: async () => result })
+  assert.deepEqual(calls, [false, false, true, true])
+})
+
+it('points the completed setup at the real operator route', async () => {
+  assert.equal(await initializeOperator({ ...base, publicUrl: 'https://control.example.test/console', bootstrap: async () => result }), 'The first operator is ready. Sign in at https://control.example.test/admin')
+})
+
+it('rejects a malformed public URL before writing the first operator', async () => {
+  await assert.rejects(initializeOperator({ ...base, publicUrl: 'not-a-url', bootstrap: async () => { throw new Error('wrote') } }), /AF_PUBLIC_URL must/)
+})
+
+it('rejects credentials embedded in the public URL without printing them', async () => {
+  await assert.rejects(initializeOperator({ ...base, publicUrl: 'https://name:sensitive@example.test', bootstrap: async () => { throw new Error('wrote') } }), { message: 'AF_PUBLIC_URL must be an HTTP or HTTPS address without credentials. Nothing was written.' })
+})
+
+function terminal() {
+  const input = new PassThrough() as unknown as ReadStream
+  const output = new PassThrough() as unknown as WriteStream
+  let written = ''
+  Object.assign(input, { isTTY: true, isRaw: false, setRawMode(value: boolean) { input.isRaw = value; return input } })
+  Object.assign(output, { isTTY: true })
+  output.on('data', (value) => { written += String(value) })
+  return { input, output, written: () => written }
+}
+
+it('does not echo a pasted password into terminal output', async () => {
+  const t = terminal()
+  const answer = operatorInput('Password: ', true, t.input, t.output)
+  for (const value of 'test-only-secret') t.input.emit('keypress', value, {})
+  t.input.emit('keypress', '\r', { name: 'return' })
+  await answer
+  assert.equal(t.written(), 'Password: \n')
+})
+
+it('returns the actual secret rather than masking the value passed to bootstrap', async () => {
+  const t = terminal()
+  const answer = operatorInput('Password: ', true, t.input, t.output)
+  t.input.emit('keypress', 'passphrase', {})
+  t.input.emit('keypress', '\r', { name: 'return' })
+  assert.equal(await answer, 'passphrase')
+})
+
+it('restores terminal echo after successful password entry', async () => {
+  const t = terminal()
+  const answer = operatorInput('Password: ', true, t.input, t.output)
+  t.input.emit('keypress', '\r', { name: 'return' })
+  await answer
+  assert.equal(t.input.isRaw, false)
+})
+
+it('cancels on interrupt instead of submitting a partial password', async () => {
+  const t = terminal()
+  const answer = operatorInput('Password: ', true, t.input, t.output)
+  t.input.emit('keypress', '\u0003', { name: 'c', ctrl: true })
+  await assert.rejects(answer, /Setup cancelled/)
+})
+
+it('refuses nonterminal interactive input', async () => {
+  const t = terminal()
+  Object.assign(t.input, { isTTY: false })
+  await assert.rejects(operatorInput('Password: ', true, t.input, t.output), /needs a terminal/)
+})
+
+it('handles backspace without placing a secret character on screen', async () => {
+  const t = terminal()
+  const answer = operatorInput('Password: ', true, t.input, t.output)
+  t.input.emit('keypress', 'ab', {})
+  t.input.emit('keypress', '\u007f', { name: 'backspace' })
+  t.input.emit('keypress', '\r', { name: 'return' })
+  assert.equal(await answer, 'a')
+})

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -20,7 +20,7 @@
     },
     "apps/api": {
       "name": "@antifailure/api",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@antifailure/db": "*",
@@ -34,7 +34,8 @@
       },
       "bin": {
         "af-control-plane": "src/main.ts",
-        "af-control-plane-backup": "src/backup-cli.ts"
+        "af-control-plane-backup": "src/backup-cli.ts",
+        "af-operator": "src/operator-cli.ts"
       },
       "devDependencies": {
         "@types/node": "^24.0.0",
@@ -285,7 +286,7 @@
     },
     "packages/db": {
       "name": "@antifailure/db",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "drizzle-orm": "^0.45.2",
@@ -301,7 +302,7 @@
     },
     "packages/policy": {
       "name": "@antifailure/policy",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.0.0",


### PR DESCRIPTION
## The missing step

The bootstrap routine existed, but a first operator still needed a manually
assembled remote shell or container job, a privileged database URL in command
arguments, and password input prepared outside the product.

`just operator-init production` now resolves the checked-in deployment, verifies
its exact tagged resource group and application, and opens `af-operator init`
inside the revision serving all traffic. Staging must be named explicitly.
Split traffic is refused rather than selecting an arbitrary revision.

The runtime reads its existing administrative credential and prompts for email,
name and a hidden password with confirmation. The existing first-root guard is
unchanged. It never resets a root account. No temporary Azure job is created.

Azure websocket exit zero is not proof the remote command succeeded. The helper
requires a per-invocation completion acknowledgement and restores the caller's
terminal settings on completion or refusal. Azure inspection failures retain
their diagnostic rather than claiming only that verification failed.

The new executable is packaged in the API workspace and copied into the control
plane image. Operations documents both the Azure command and direct container
entry point. Source gates explicitly exclude live account creation while still
running its tests.

## Verified locally

* The real command created a disposable local operator, signed in through the
  actual HTTP route and reached the protected operator identity procedure.
* Interactive terminal entry echoed identity fields and neither password entry.
* API typecheck, prosecheck, changecheck, varcheck, gatecheck and the gatecheck
  package tests passed.
* Documentation built 89 pages. The new section was inspected at desktop and
  phone widths with light and dark preferences; 320 pixels had no horizontal
  overflow. The existing site keeps its light palette for both preferences.
* The production app inspection shape was checked read-only. No production
  operator was created, reset or removed.

The complete local API rerun is still pending under measured host load. The
previous run completed 1898 tests with one failure: the completion marker used
the environment-variable naming prefix, so the configuration documentation
check treated it as an undocumented setting. The marker is now an ordinary
protocol message, not an invented configuration variable. Focused configuration
documentation, command and Azure tests pass after that fix.

CI found two separate image defects and both are fixed here. The ordinary
image build found that the new executable was excluded by the build context.
Dogfood then found that the engine's legacy builder cannot use the BuildKit
COPY permission option. The exact wrapper is now admitted to the context and
its permission is set with a portable RUN instruction. A tiny context-copy
probe and legacy-builder image passed locally. The image workflow now watches
ignore-file changes and invokes the packaged operator command before publish.
Its exit-code and missing-credential diagnostic assertions each went red under
an independent mutation and green after restoration.

## Independent mutation proofs

Every row below went red with its production line broken, then green after
restoration. Each test contains one assertion, including the combined live
result so an earlier assertion cannot hide the later protected-route proof.

| Test | Broken behavior observed |
| --- | --- |
| Runtime credential | Bootstrap received a different connection |
| Missing privileged credential | A prompt happened before configuration refusal |
| Existing root refusal | The refusal was swallowed |
| Password confirmation | A mismatched confirmation reached the write |
| Prompt privacy | Confirmation was marked visible |
| Final route | Setup pointed to the obsolete console-prefixed route |
| Invalid public URL | Invalid configuration was accepted |
| Embedded URL credentials | A credential-bearing public URL was accepted |
| Hidden terminal output | A password character was echoed |
| Password value | A masked value replaced the actual answer |
| Terminal restoration | Raw input mode remained enabled |
| Interrupt | Cancellation submitted a partial answer |
| Nonterminal input | Interactive setup accepted a pipe |
| Backspace | The erased character remained in the password |
| Exact deployment | An incorrect application name was selected |
| Explicit environment | An unknown environment was accepted |
| Resource boundary | A foreign resource group was accepted |
| Duplicate configuration | Multiple deployment names were accepted |
| Live ownership | A group with another project tag was accepted |
| Serving revision | The selected revision was replaced |
| Azure read failure | A failed inspection was treated as readable data |
| Azure diagnostic | The actual authorization refusal disappeared |
| Remote arguments | A password argument was added to the remote command |
| Completion proof | A clean transport exit counted as completed setup |
| Local terminal cleanup | Refusal skipped restoration |
| Split traffic | An arbitrary serving revision was chosen |
| Real command and sign-in | A different password caused both protected requests to return 401; separately, a wrong completion marker failed while both requests still returned 200 |
| Source gate boundary | Live operator creation became a required source gate |
| Termination signal | SIGTERM stopped reaching the Azure child |
| Terminal hangup | SIGHUP stopped reaching the Azure child |

An independent review also exercised real disposable child processes for
SIGINT, SIGTERM and SIGHUP, including repeated signals against a child that
ignored them. Forced termination occurred after approximately two seconds,
cleanup ran and the wrapper exited nonzero. No child remained running.

## Remaining deployment proof

The new Azure command has not yet been executed against a deployed image
containing this executable. The local database and terminal paths are proven;
the Azure boundaries are tested with controlled responses. A release still has
to deliver the executable before that final cloud verification can run.
