### PR TITLE
billing: delivery order could remove paid access

### DIFF
--- a/.changes/analytics-utc-boundaries.md
+++ b/.changes/analytics-utc-boundaries.md
@@ -1,0 +1,6 @@
+# fixed
+
+Analytics could omit midnight events and assign funnels to the wrong week when
+PostgreSQL used a local timezone. Daily counts, active-subject aggregation and
+funnel computation now use UTC inside their transactions, including across
+daylight-saving changes, without changing the caller's connection setting.

--- a/.changes/billing-event-ordering.md
+++ b/.changes/billing-event-ordering.md
@@ -1,0 +1,9 @@
+# fixed
+
+Billing could remove a paid plan when a newer canceled subscription arrived,
+choose a plan according to webhook arrival time, or overwrite a newer payment
+with a delayed reconciliation response. Plan selection now uses the provider's
+creation time and the newest known entitling subscription, serializes concurrent
+writes before reading the deciding rows, and keeps newer deliveries ahead of
+older reconciliation snapshots. The current subscription shown on Plan prefers
+a live purchase over a newer ended one.

--- a/.changes/billing-event-ordering.md
+++ b/.changes/billing-event-ordering.md
@@ -1,9 +1,10 @@
 # fixed
 
 Billing could remove a paid plan when a newer canceled subscription arrived,
-choose a plan according to webhook arrival time, or overwrite a newer payment
-with a delayed reconciliation response. Plan selection now uses the provider's
+choose a plan according to webhook arrival time, or miss a payment event while
+its customer was being attached. Plan selection now uses the provider's
 creation time and the newest known entitling subscription, serializes concurrent
-writes before reading the deciding rows, and keeps newer deliveries ahead of
-older reconciliation snapshots. The current subscription shown on Plan prefers
+writes before reading the deciding rows, and serializes customer attachment
+with its deliveries. Invoice and payment-method writes follow the same lock
+order as subscription repair. The current subscription shown on Plan prefers
 a live purchase over a newer ended one.

--- a/docs/plans/2026-09-04-billing-event-ordering-design.md
+++ b/docs/plans/2026-09-04-billing-event-ordering-design.md
@@ -1,0 +1,56 @@
+# Billing outcomes must not depend on delivery order
+
+The existing contract is newest entitling subscription, not newest subscription
+of any status. Stripe's creation timestamp decides age. Receipt time cannot:
+webhooks may arrive in any order. Equal timestamps use the provider identifier
+as a stable tie break, not a claim about which purchase happened first.
+
+Three approaches were considered. Keeping the current newest-row query breaks
+the contract for canceled rows. Choosing the largest plan invents a commercial
+policy rather than implementing the existing one. This repair keeps the promised
+newest known entitling subscription policy and changes its actual reader.
+
+## Data and concurrency
+
+The decoder retains the subscription's `created` timestamp. The existing
+creation column stores it on insert and repairs older receipt-time values on
+the next accepted delivery or reconciliation. When a payload omits creation,
+an existing value is retained; a new row uses its event timestamp. No synthetic
+history is backfilled without provider evidence.
+
+Subscription writers lock their organization before writing a subscription.
+Recomputation takes that same lock before selecting. This both serializes
+different subscription writers and prevents a subscription-first lock ordering
+from deadlocking with organization-first writers. Public callers are the live
+webhook, pending-event replay during customer attachment, and reconciliation.
+
+A known paid subscription in an entitling status wins over an ended subscription
+or one whose price grants no known plan. When the only deciding active row has
+an unknown price, the organization plan is left alone as documented. An unknown
+status retains the existing conservative behavior instead of guessing a plan.
+The billing screen independently prefers a live subscription so cancellation
+and checkout do not act on a newer ended purchase.
+
+Reconciliation records its observation time before starting the provider
+requests. A newer webhook arriving during those requests must not be overwritten
+by a response that was already in flight. This applies to invoices as well as
+subscriptions. Provider requests remain outside database transactions.
+
+## Verification and boundary
+
+Real PostgreSQL tests cover both subscription arrival orders, canceled and
+unknown-price competitors, stable ties, correction of old creation values,
+missing creation fields, and both lock boundaries. Controlled provider responses
+prove that a subscription cancellation and an invoice payment delivered during
+reconciliation survive its completion. Every new assertion is independently
+mutation-tested. Existing signed webhook, replay, missing-webhook recovery,
+tenant isolation and entitlement enforcement suites remain required.
+
+This repair does not claim to prevent a second Stripe checkout session. That
+requires a separate durable reservation and provider idempotency lifecycle.
+It makes no live charges and does not change Stripe account settings.
+
+Provider references:
+
+- [Subscription object](https://docs.stripe.com/api/subscriptions/object)
+- [Webhook delivery behavior](https://docs.stripe.com/webhooks)

--- a/docs/plans/2026-09-04-billing-event-ordering-design.md
+++ b/docs/plans/2026-09-04-billing-event-ordering-design.md
@@ -31,18 +31,31 @@ status retains the existing conservative behavior instead of guessing a plan.
 The billing screen independently prefers a live subscription so cancellation
 and checkout do not act on a newer ended purchase.
 
-Reconciliation records its observation time before starting the provider
-requests. A newer webhook arriving during those requests must not be overwritten
-by a response that was already in flight. This applies to invoices as well as
-subscriptions. Provider requests remain outside database transactions.
+Customer attachment and live delivery take the same customer-keyed transaction
+advisory lock before either inserts a row. This closes the concurrent ordering
+where the customer lookup and pending-event lookup each missed an uncommitted
+row, then neither side retried. The complete lock order is customer,
+organization, then billing entity. Invoice repair takes the organization lock
+before the invoice, and every known-customer delivery takes it before applying
+an event, so its final organization foreign-key check cannot invert that order.
+
+Reconciliation snapshot ordering remains a separate required repair. Independent
+review rejected a request-start timestamp change: a fresh canceled response
+could then be overwritten by an older webhook delivered after the response.
+Request-end timestamps have the opposite ambiguity, masking a newer event whose
+change occurred after the response snapshot was taken. A local clock value is
+not a provider object version. The safe follow-up is a persisted per-object
+dirty generation and refresh lease: events schedule canonical provider reads,
+reads run outside transactions, and only the current lease and generation may
+apply the response. Periodic reconciliation reaches the same writer.
 
 ## Verification and boundary
 
 Real PostgreSQL tests cover both subscription arrival orders, canceled and
 unknown-price competitors, stable ties, correction of old creation values,
-missing creation fields, and both lock boundaries. Controlled provider responses
-prove that a subscription cancellation and an invoice payment delivered during
-reconciliation survive its completion. Every new assertion is independently
+missing creation fields, and the lock boundaries. Forced overlap pauses actual
+database statements so attachment and webhook delivery reach the precise race
+that previously left a paid purchase unresolved. Every new assertion is independently
 mutation-tested. Existing signed webhook, replay, missing-webhook recovery,
 tenant isolation and entitlement enforcement suites remain required.
 

--- a/web/apps/api/src/analytics/insights.ts
+++ b/web/apps/api/src/analytics/insights.ts
@@ -108,6 +108,7 @@ export interface InsightResult {
  */
 export async function recomputeSubjectDays(admin: postgres.Sql, day: string): Promise<number> {
   return admin.begin(async (tx) => {
+    await tx`SELECT set_config('TimeZone', 'UTC', true)`
     // One writer at a time, for the reason in lock.ts.
     await tx.unsafe(TAKE_ROLLUP_LOCK)
     await tx`DELETE FROM analytics_subject_days WHERE day = ${day}::date`
@@ -342,6 +343,8 @@ async function recomputeOneFunnel(
     GROUP BY 2, 3`
 
   return admin.begin(async (tx) => {
+    // The entry week and the elapsed-day window are both defined in UTC.
+    await tx`SELECT set_config('TimeZone', 'UTC', true)`
     // One writer at a time, for the reason in lock.ts.
     await tx.unsafe(TAKE_ROLLUP_LOCK)
     await tx`

--- a/web/apps/api/src/analytics/rollup.ts
+++ b/web/apps/api/src/analytics/rollup.ts
@@ -170,6 +170,9 @@ async function recomputeDay(admin: postgres.Sql, day: string, name: EventName): 
   const dimB = dimensionExpression(name, 1)
 
   return admin.begin(async (tx) => {
+    // JavaScript chose a UTC day. Date casts must use that same boundary,
+    // independent of the database host's local timezone or daylight saving.
+    await tx`SELECT set_config('TimeZone', 'UTC', true)`
     // The lock first, so two replicas recomputing the same day queue rather
     // than colliding on the primary key. See lock.ts for why it is transaction
     // scoped rather than held across the run.

--- a/web/apps/api/src/billing/store.ts
+++ b/web/apps/api/src/billing/store.ts
@@ -18,7 +18,7 @@ import type { Clock } from '../clock.ts'
 import type { Analytics } from '../analytics/record.ts'
 import type { StripeClient } from './stripe.ts'
 import { LIVE_STATUSES, type StripeConfig } from './plans.ts'
-import { recomputePlan, resolvePending, writeInvoice, writeSubscription } from './webhook.ts'
+import { lockBillingCustomer, recomputePlan, resolvePending, writeInvoice, writeSubscription } from './webhook.ts'
 
 export interface BillingCustomer {
   orgId: string
@@ -72,6 +72,7 @@ export async function attachCustomer(
   customer: { id: string; email: string | null },
   analytics: Analytics,
 ): Promise<{ customerId: string; created: boolean; resolved: number }> {
+  await lockBillingCustomer(db, customer.id)
   const now = clock.now().toISOString()
   const inserted = await db.execute<{ stripe_customer_id: string }>(sql`
     INSERT INTO billing_customers (org_id, stripe_customer_id, email, created_at, updated_at)
@@ -215,10 +216,6 @@ export async function reconcile(
   // missing customer.subscription.created webhook leaves no local id to query,
   // which made the old reconciliation unable to recover the exact outage it
   // claimed to handle.
-  // A response can have been read before a newer webhook arrives. Giving that
-  // snapshot the response-completion time would let the older answer overwrite
-  // the delivery that landed while the network call was in flight.
-  const observedAt = clock.now()
   const [subscriptions, invoices] = await Promise.all([
     client
       .listSubscriptions(customerId, 50)
@@ -243,9 +240,12 @@ export async function reconcile(
       notes.push(`subscriptions could not be read from Stripe (${subscriptions.error})`)
     }
     for (const subscription of subscriptions.list) {
-      // The observation began before the request, not after its response.
+      // This legacy watermark is a local observation time, not a provider
+      // version. Moving it to request start fixes one ordering and breaks the
+      // reverse. Snapshot/event ambiguity needs a persisted canonical refresh
+      // protocol; this plan-selection repair does not claim to solve it.
       const written = await writeSubscription(
-        db, clock, config, orgId, subscription, observedAt, analytics,
+        db, clock, config, orgId, subscription, clock.now(), analytics,
       )
       if (written.outcome === 'applied') changed += 1
       notes.push(`${subscription.id}: ${subscription.status}, ${written.detail}`)
@@ -258,7 +258,7 @@ export async function reconcile(
       notes.push(`invoices could not be read from Stripe (${invoices.error})`)
     } else {
       for (const invoice of invoices.list) {
-        const written = await writeInvoice(db, clock, orgId, invoice, observedAt)
+        const written = await writeInvoice(db, clock, orgId, invoice, clock.now())
         if (written.outcome === 'applied') changed += 1
       }
       notes.push(`${invoices.list.length} invoices read from Stripe`)

--- a/web/apps/api/src/billing/store.ts
+++ b/web/apps/api/src/billing/store.ts
@@ -100,17 +100,17 @@ export async function readBillingState(db: Db, orgId: string): Promise<BillingSt
   const customer = await db.execute<{ stripe_customer_id: string; email: string | null }>(sql`
     SELECT stripe_customer_id, email FROM billing_customers WHERE org_id = ${orgId}::uuid`)
 
+  const liveStatuses = sql.join(LIVE_STATUSES.map((status) => sql`${status}`), sql`, `)
   const subscription = await db.execute<SubscriptionRow>(sql`
     SELECT stripe_subscription_id, plan, status, price_id, quantity,
            current_period_start, current_period_end, cancel_at_period_end, canceled_at
     FROM subscriptions WHERE org_id = ${orgId}::uuid
-    ORDER BY created_at DESC LIMIT 1`)
+    ORDER BY (status IN (${liveStatuses})) DESC, created_at DESC, stripe_subscription_id DESC LIMIT 1`)
 
   // Each status as its own bind parameter. Interpolating a JavaScript array
   // into `= ANY(...)` produces a row expression rather than an array, which
   // Postgres refuses, and the refusal reaches the caller as a 500 on the
   // billing screen.
-  const liveStatuses = sql.join(LIVE_STATUSES.map((status) => sql`${status}`), sql`, `)
   const live = await db.execute<{ n: string }>(sql`
     SELECT count(*) AS n FROM subscriptions
     WHERE org_id = ${orgId}::uuid AND status IN (${liveStatuses})`)
@@ -215,6 +215,10 @@ export async function reconcile(
   // missing customer.subscription.created webhook leaves no local id to query,
   // which made the old reconciliation unable to recover the exact outage it
   // claimed to handle.
+  // A response can have been read before a newer webhook arrives. Giving that
+  // snapshot the response-completion time would let the older answer overwrite
+  // the delivery that landed while the network call was in flight.
+  const observedAt = clock.now()
   const [subscriptions, invoices] = await Promise.all([
     client
       .listSubscriptions(customerId, 50)
@@ -239,11 +243,9 @@ export async function reconcile(
       notes.push(`subscriptions could not be read from Stripe (${subscriptions.error})`)
     }
     for (const subscription of subscriptions.list) {
-      // The event time is now, because this is what Stripe believes now. That
-      // advances the watermark past any delivery still in flight, which is
-      // correct: a webhook describing an older state must not undo this.
+      // The observation began before the request, not after its response.
       const written = await writeSubscription(
-        db, clock, config, orgId, subscription, clock.now(), analytics,
+        db, clock, config, orgId, subscription, observedAt, analytics,
       )
       if (written.outcome === 'applied') changed += 1
       notes.push(`${subscription.id}: ${subscription.status}, ${written.detail}`)
@@ -256,7 +258,7 @@ export async function reconcile(
       notes.push(`invoices could not be read from Stripe (${invoices.error})`)
     } else {
       for (const invoice of invoices.list) {
-        const written = await writeInvoice(db, clock, orgId, invoice, clock.now())
+        const written = await writeInvoice(db, clock, orgId, invoice, observedAt)
         if (written.outcome === 'applied') changed += 1
       }
       notes.push(`${invoices.list.length} invoices read from Stripe`)

--- a/web/apps/api/src/billing/stripe.ts
+++ b/web/apps/api/src/billing/stripe.ts
@@ -65,6 +65,8 @@ export interface StripeCustomer {
 export interface StripeSubscription {
   id: string
   customerId: string
+  /** Provider creation time, never the time a webhook happened to arrive. */
+  createdAt?: Date | null
   /** The subscription item the price hangs off.
    *
    *  Carried because changing a plan means REPLACING that item's price, and an
@@ -756,6 +758,7 @@ export function subscriptionOf(body: Record<string, unknown>): StripeSubscriptio
   return {
     id,
     customerId,
+    createdAt: instant(body.created),
     itemId: item ? text(item.id) : null,
     status: text(body.status) ?? 'incomplete',
     priceId: item ? idOf(item.price) : null,

--- a/web/apps/api/src/billing/webhook.ts
+++ b/web/apps/api/src/billing/webhook.ts
@@ -225,6 +225,7 @@ export async function handleStripeDelivery(
   }
 
   return pool.withStripeCustomer(customerId, async (db) => {
+    await lockBillingCustomer(db, customerId)
     // The insert is the claim on the work. A retry inserts nothing, so the
     // handler below runs once for one event id however many times Stripe sends
     // it. Doing this first, before any decision, is what makes that true even
@@ -258,6 +259,10 @@ export async function handleStripeDelivery(
       }
     }
 
+    // Invoice and payment-method writes eventually attach their event to this
+    // organization too. Take its lock before any entity lock, including the
+    // event update's foreign-key check, to match reconciliation's order.
+    await db.execute(sql`SELECT id FROM organizations WHERE id = ${orgId}::uuid FOR UPDATE`)
     const applied = await apply(db, clock, config, orgId, event, analytics)
     await db.execute(sql`
       UPDATE billing_events
@@ -318,6 +323,16 @@ export async function resolvePending(
     details.push(`${event.type}: ${applied.detail}`)
   }
   return { resolved: pending.length, details }
+}
+
+/** A customer can be named before its local row exists, so row locks alone
+ * cannot serialize attachment with a delivery. Both paths take this lock before
+ * inserting, then use fresh statement snapshots after any contender commits.
+ * The order is customer, organization, then billing entity. No network call is
+ * made while this transaction-scoped lock is held. */
+export async function lockBillingCustomer(db: Db, customerId: string): Promise<void> {
+  await db.execute(sql`
+    SELECT pg_advisory_xact_lock(hashtextextended(${'antifailure.billing.customer:' + customerId}, 0))`)
 }
 
 // ---------------------------------------------------------------------------
@@ -482,7 +497,7 @@ export async function recomputePlan(
     SELECT plan, status FROM subscriptions
     WHERE org_id = ${orgId}::uuid
     ORDER BY (status IN (${entitling}) AND plan <> ${DEFAULT_PLAN}) DESC,
-             created_at DESC, stripe_subscription_id DESC
+             (status IN (${entitling})) DESC, created_at DESC, stripe_subscription_id DESC
     LIMIT 1`)
   const newest = live[0]
   if (!newest) return 'no subscription; the plan was left alone'
@@ -535,6 +550,7 @@ export async function writeInvoice(
   invoice: StripeInvoice,
   eventCreated: Date,
 ): Promise<Outcome> {
+  await db.execute(sql`SELECT id FROM organizations WHERE id = ${orgId}::uuid FOR UPDATE`)
   const now = clock.now().toISOString()
   const paidAt = invoice.status === 'paid' ? eventCreated.toISOString() : null
 

--- a/web/apps/api/src/billing/webhook.ts
+++ b/web/apps/api/src/billing/webhook.ts
@@ -396,6 +396,10 @@ export async function writeSubscription(
   eventCreated: Date,
   analytics: Analytics,
 ): Promise<Outcome> {
+  // Serialize before taking a subscription lock. Different subscription rows
+  // still decide one organization plan, so locking only the final update lets
+  // concurrent writers each compute from a snapshot missing the other's row.
+  await db.execute(sql`SELECT id FROM organizations WHERE id = ${orgId}::uuid FOR UPDATE`)
   const entitled = planForPrice(config, subscription.priceId)
   const now = clock.now().toISOString()
 
@@ -415,7 +419,8 @@ export async function writeSubscription(
       ${entitled ?? DEFAULT_PLAN}, ${subscription.priceId}, ${subscription.quantity},
       ${subscription.status}, ${iso(subscription.currentPeriodStart)},
       ${iso(subscription.currentPeriodEnd)}, ${subscription.cancelAtPeriodEnd},
-      ${iso(subscription.canceledAt)}, ${eventCreated.toISOString()}, ${now}, ${now})
+      ${iso(subscription.canceledAt)}, ${eventCreated.toISOString()},
+      ${(subscription.createdAt ?? eventCreated).toISOString()}, ${now})
     ON CONFLICT (stripe_subscription_id) DO UPDATE SET
       plan = coalesce(${entitled}, subscriptions.plan),
       price_id = excluded.price_id,
@@ -426,6 +431,7 @@ export async function writeSubscription(
       cancel_at_period_end = excluded.cancel_at_period_end,
       canceled_at = excluded.canceled_at,
       last_event_at = excluded.last_event_at,
+      created_at = coalesce(${iso(subscription.createdAt ?? null)}::timestamptz, subscriptions.created_at),
       updated_at = ${now}
     -- The watermark. An event created before the one this row was last written
     -- from updates nothing, so a late delivery cannot resurrect a cancelled
@@ -470,13 +476,19 @@ export async function recomputePlan(
   orgId: string,
   analytics: Analytics,
 ): Promise<string> {
+  await db.execute(sql`SELECT id FROM organizations WHERE id = ${orgId}::uuid FOR UPDATE`)
+  const entitling = sql.join(ENTITLING_STATUSES.map((status) => sql`${status}`), sql`, `)
   const live = await db.execute<{ plan: string; status: string }>(sql`
     SELECT plan, status FROM subscriptions
     WHERE org_id = ${orgId}::uuid
-    ORDER BY created_at DESC
+    ORDER BY (status IN (${entitling}) AND plan <> ${DEFAULT_PLAN}) DESC,
+             created_at DESC, stripe_subscription_id DESC
     LIMIT 1`)
   const newest = live[0]
   if (!newest) return 'no subscription; the plan was left alone'
+  if (ENTITLING_STATUSES.includes(newest.status) && newest.plan === DEFAULT_PLAN) {
+    return 'the subscription price grants no known plan; the plan was left alone'
+  }
 
   const wanted = planForStatus(newest.status, null)
   if (wanted === null) {

--- a/web/apps/api/test/analytics-orderings.test.ts
+++ b/web/apps/api/test/analytics-orderings.test.ts
@@ -53,7 +53,8 @@ describe(
       const day = today()
       await h.admin`
         DELETE FROM analytics_events
-        WHERE occurred_at >= ${day}::date AND occurred_at < (${day}::date + interval '2 days')`
+        WHERE occurred_at >= (${day}::date::timestamp AT TIME ZONE 'UTC')
+          AND occurred_at < ((${day}::date + interval '2 days') AT TIME ZONE 'UTC')`
       await h.admin`DELETE FROM analytics_daily WHERE day >= ${day}::date`
       await h.close()
     })

--- a/web/apps/api/test/analytics-timezone.test.ts
+++ b/web/apps/api/test/analytics-timezone.test.ts
@@ -1,0 +1,67 @@
+import { after, before, describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { randomUUID } from 'node:crypto'
+import postgres from 'postgres'
+import { available, adminUrl, startApi, type ApiHarness } from './harness.ts'
+import { FakeClock } from '../src/clock.ts'
+import { rollUp } from '../src/analytics/rollup.ts'
+import { CATALOG } from '../src/analytics/catalog.ts'
+
+const hasDatabase = await available()
+
+describe('analytics uses UTC boundaries on a local-time database', { skip: !hasDatabase }, () => {
+  let h: ApiHarness
+  let local: postgres.Sql
+  before(async () => {
+    h = await startApi()
+    local = postgres(adminUrl, { max: 1, connection: { TimeZone: 'America/Chicago' }, onnotice: () => {} })
+  })
+  after(async () => {
+    await local.end()
+    await h.close()
+  })
+
+  for (const day of ['2040-03-12', '2040-11-05']) {
+    describe(`the Monday after daylight saving changes, ${day}`, () => {
+      before(async () => {
+        const subject = randomUUID().replaceAll('-', '')
+        for (const [name, minute, payload] of [
+          ['site.page_viewed', '00', { route: 'home', source: 'search', entry: true }],
+          ['site.cta_engaged', '01', { cta: 'waitlist_open', route: 'home' }],
+          ['site.lead_submitted', '02', { source: 'search', landing: 'home', outcome: 'recorded' }],
+        ] as const) {
+          const spec = CATALOG[name]
+          await local`
+            INSERT INTO analytics_events (event_id, name, version, occurred_at, source,
+              session_surrogate, actor_kind, privacy_basis, payload)
+            VALUES (${randomUUID()}, ${name}, ${spec.version}, ${`${day}T00:${minute}:00Z`}::timestamptz,
+              ${spec.source}, ${subject}, ${spec.actorKind}, ${spec.privacyBasis}, ${local.json(payload)})`
+        }
+        await rollUp(local, new FakeClock(`${day}T23:00:00Z`), { lookbackDays: 1 })
+      })
+      after(async () => {
+        await local`DELETE FROM analytics_events WHERE occurred_at >= ${`${day}T00:00:00Z`}::timestamptz AND occurred_at < ${`${day}T23:59:59Z`}::timestamptz`
+        await local`DELETE FROM analytics_daily WHERE day = ${day}::date`
+        await local`DELETE FROM analytics_subject_days WHERE day = ${day}::date`
+        await local`DELETE FROM analytics_actives WHERE day = ${day}::date`
+        await local`DELETE FROM analytics_funnel_weeks WHERE entered_week = ${day}::date`
+      })
+      it('counts midnight events on their UTC day', async () => {
+        const [row] = await local`SELECT sum(events)::int AS n FROM analytics_daily WHERE day = ${day}::date AND name = 'site.page_viewed'`
+        assert.equal(row!.n, 1)
+      })
+      it('includes the midnight subject in the active working set', async () => {
+        const [row] = await local`SELECT count(*)::int AS n FROM analytics_subject_days WHERE day = ${day}::date AND name = 'site.page_viewed'`
+        assert.equal(row!.n, 1)
+      })
+      it('assigns a completed midnight funnel to its UTC entry week', async () => {
+        const [row] = await local`SELECT sum(subjects)::int AS n FROM analytics_funnel_weeks WHERE entered_week = ${day}::date AND funnel = 'acquisition' AND steps_completed = 3`
+        assert.equal(row!.n, 1)
+      })
+      it('restores the caller connection timezone after aggregation', async () => {
+        const [row] = await local`SHOW TimeZone`
+        assert.equal(row!.TimeZone, 'America/Chicago')
+      })
+    })
+  }
+})

--- a/web/apps/api/test/billing-ordering.test.ts
+++ b/web/apps/api/test/billing-ordering.test.ts
@@ -1,0 +1,215 @@
+import { after, before, describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { randomUUID } from 'node:crypto'
+import { handleStripeDelivery, recomputePlan, writeSubscription } from '../src/billing/webhook.ts'
+import { readBillingState, reconcile } from '../src/billing/store.ts'
+import { RealStripeClient, subscriptionOf } from '../src/billing/stripe.ts'
+import { available, startApi, seedOrg, dropOrg, stripeAgainstMockPack, type ApiHarness } from './harness.ts'
+import type { StripeConfig } from '../src/billing/plans.ts'
+
+const hasDatabase = await available()
+
+describe('billing across subscription arrival orders', { skip: !hasDatabase }, () => {
+  let h: ApiHarness
+  let config: StripeConfig
+  const orgIds: string[] = []
+  before(async () => {
+    const stripe = await stripeAgainstMockPack()
+    config = stripe.config
+    h = await startApi({ stripe: stripe.billing })
+  })
+  after(async () => {
+    for (const orgId of orgIds) await dropOrg(h.admin, orgId)
+    await h.close()
+  })
+
+  async function fixture() {
+    const org = await seedOrg(h.admin, 'billing-order')
+    orgIds.push(org.orgId)
+    const customer = `cus_${randomUUID()}`
+    await h.admin`INSERT INTO billing_customers (org_id, stripe_customer_id) VALUES (${org.orgId}, ${customer})`
+    return { orgId: org.orgId, customer }
+  }
+
+  function object(customer: string, id: string, created: number, plan = 'team', status = 'active') {
+    return {
+      id, customer, created, status,
+      items: { data: [{ id: 'si_order', price: `price_${plan}_afmock`, quantity: 1 }] },
+    }
+  }
+
+  async function deliver(body: ReturnType<typeof object>) {
+    await handleStripeDelivery(h.pool, h.clock, config, {
+      id: `evt_${randomUUID()}`, type: 'customer.subscription.updated',
+      created: h.clock.now(), object: body,
+    }, h.analytics)
+  }
+
+  async function plan(orgId: string) {
+    const [row] = await h.admin`SELECT plan FROM organizations WHERE id = ${orgId}`
+    return row!.plan
+  }
+
+  for (const reverse of [false, true]) {
+    it(`keeps the newest entitling subscription when arrival is ${reverse ? 'new then old' : 'old then new'}`, async () => {
+      const f = await fixture()
+      const bodies = [object(f.customer, `sub_${randomUUID()}`, 100, 'team'), object(f.customer, `sub_${randomUUID()}`, 200, 'enterprise')]
+      for (const body of reverse ? bodies.reverse() : bodies) await deliver(body)
+      assert.equal(await plan(f.orgId), 'enterprise')
+    })
+  }
+
+  it('a newer canceled subscription cannot remove an older active entitlement', async () => {
+    const f = await fixture()
+    await deliver(object(f.customer, `sub_${randomUUID()}`, 100, 'enterprise'))
+    await deliver(object(f.customer, `sub_${randomUUID()}`, 200, 'team', 'canceled'))
+    assert.equal(await plan(f.orgId), 'enterprise')
+  })
+
+  it('the current subscription is the live one rather than a newer ended purchase', async () => {
+    const f = await fixture()
+    const live = `sub_${randomUUID()}`
+    await deliver(object(f.customer, live, 100))
+    await deliver(object(f.customer, `sub_${randomUUID()}`, 200, 'enterprise', 'canceled'))
+    const state = await h.pool.withTenant({ orgId: f.orgId }, db => readBillingState(db, f.orgId))
+    assert.equal(state.subscription?.id, live)
+  })
+
+  it('equal provider creation times have a stable provider identifier tie break', async () => {
+    const f = await fixture()
+    const prefix = randomUUID()
+    await deliver(object(f.customer, `sub_z_${prefix}`, 100, 'enterprise'))
+    await deliver(object(f.customer, `sub_a_${prefix}`, 100, 'team'))
+    assert.equal(await plan(f.orgId), 'enterprise')
+  })
+
+  it('a newly observed unknown price does not downgrade an existing paid organization', async () => {
+    const f = await fixture()
+    await h.admin`UPDATE organizations SET plan = 'enterprise' WHERE id = ${f.orgId}`
+    await deliver(object(f.customer, `sub_${randomUUID()}`, 100, 'unknown'))
+    assert.equal(await plan(f.orgId), 'enterprise')
+  })
+
+  it('a newer unknown price cannot hide an older known active plan', async () => {
+    const f = await fixture()
+    await deliver(object(f.customer, `sub_${randomUUID()}`, 200, 'unknown'))
+    await deliver(object(f.customer, `sub_${randomUUID()}`, 100, 'enterprise'))
+    assert.equal(await plan(f.orgId), 'enterprise')
+  })
+
+  it('a reconciliation response cannot undo a newer webhook delivered while its request was in flight', async () => {
+    const f = await fixture()
+    const body = object(f.customer, `sub_${randomUUID()}`, 100)
+    await deliver(body)
+    h.clock.advance(1000)
+    const client = new RealStripeClient({ ...config, fetch: async input => {
+      const url = new URL(String(input))
+      if (url.pathname === '/v1/subscriptions') {
+        h.clock.advance(1000)
+        await deliver({ ...body, status: 'canceled' })
+        h.clock.advance(1000)
+        return Response.json({ data: [body] })
+      }
+      return Response.json({ data: [] })
+    } })
+    await reconcile(h.pool, h.clock, config, client, f.orgId, h.analytics)
+    assert.equal(await plan(f.orgId), 'free')
+  })
+
+  it('an invoice reconciliation snapshot cannot undo payment delivered during its request', async () => {
+    const f = await fixture()
+    const invoice = { id: `in_${randomUUID()}`, customer: f.customer, status: 'open', amount_paid: 0 }
+    const client = new RealStripeClient({ ...config, fetch: async input => {
+      const url = new URL(String(input))
+      if (url.pathname === '/v1/invoices') {
+        h.clock.advance(1000)
+        await handleStripeDelivery(h.pool, h.clock, config, {
+          id: `evt_${randomUUID()}`, type: 'invoice.paid', created: h.clock.now(),
+          object: { ...invoice, status: 'paid', amount_paid: 50000 },
+        }, h.analytics)
+        h.clock.advance(1000)
+        return Response.json({ data: [invoice] })
+      }
+      return Response.json({ data: [] })
+    } })
+    await reconcile(h.pool, h.clock, config, client, f.orgId, h.analytics)
+    const [row] = await h.admin`SELECT amount_paid FROM invoices WHERE stripe_invoice_id = ${invoice.id}`
+    assert.equal(Number(row!.amount_paid), 50000)
+  })
+
+  it('a later delivery repairs the creation time stored by older application code', async () => {
+    const f = await fixture()
+    const body = object(f.customer, `sub_${randomUUID()}`, 100)
+    await deliver(body)
+    await h.admin`UPDATE subscriptions SET created_at = '2026-01-01', last_event_at = '2025-01-01' WHERE stripe_subscription_id = ${body.id}`
+    await deliver(body)
+    const [row] = await h.admin`SELECT extract(epoch FROM created_at)::int AS seconds FROM subscriptions WHERE stripe_subscription_id = ${body.id}`
+    assert.equal(row!.seconds, 100)
+  })
+
+  it('a payload without provider creation preserves the previously known creation time', async () => {
+    const f = await fixture()
+    const body = object(f.customer, `sub_${randomUUID()}`, 100)
+    await deliver(body)
+    await h.admin`UPDATE subscriptions SET last_event_at = '2025-01-01' WHERE stripe_subscription_id = ${body.id}`
+    await deliver({ ...body, created: undefined } as unknown as ReturnType<typeof object>)
+    const [row] = await h.admin`SELECT extract(epoch FROM created_at)::int AS seconds FROM subscriptions WHERE stripe_subscription_id = ${body.id}`
+    assert.equal(row!.seconds, 100)
+  })
+
+  it('recomputing waits for the organization lock before reading the deciding subscription', async () => {
+    const f = await fixture()
+    const body = object(f.customer, `sub_${randomUUID()}`, 100)
+    await deliver(body)
+    let release!: () => void
+    let locked!: () => void
+    const lockReady = new Promise<void>(resolve => { locked = resolve })
+    const mayCommit = new Promise<void>(resolve => { release = resolve })
+    const writer = h.admin.begin(async tx => {
+      await tx`SELECT id FROM organizations WHERE id = ${f.orgId} FOR UPDATE`
+      await tx`UPDATE subscriptions SET plan = 'enterprise' WHERE stripe_subscription_id = ${body.id}`
+      locked()
+      await mayCommit
+    })
+    await lockReady
+    const reader = h.pool.withTenant({ orgId: f.orgId }, db => recomputePlan(db, h.clock, f.orgId, h.analytics))
+    try {
+      await waitForBlockedQuery()
+    } finally { release() }
+    await Promise.all([writer, reader])
+    assert.equal(await plan(f.orgId), 'enterprise')
+  })
+
+  it('subscription writes wait for the organization before holding any subscription row lock', async () => {
+    const f = await fixture()
+    const body = object(f.customer, `sub_${randomUUID()}`, 100)
+    await deliver(body)
+    await h.admin`UPDATE subscriptions SET last_event_at = '2025-01-01' WHERE stripe_subscription_id = ${body.id}`
+    let release!: () => void
+    let locked!: () => void
+    const lockReady = new Promise<void>(resolve => { locked = resolve })
+    const mayInspect = new Promise<void>(resolve => { release = resolve })
+    const holder = h.admin.begin(async tx => {
+      await tx`SELECT id FROM organizations WHERE id = ${f.orgId} FOR UPDATE`
+      locked()
+      await mayInspect
+      await tx`SELECT id FROM subscriptions WHERE stripe_subscription_id = ${body.id} FOR UPDATE NOWAIT`
+    })
+    await lockReady
+    const writer = h.pool.withTenant({ orgId: f.orgId }, async db => {
+      await writeSubscription(db, h.clock, config, f.orgId, subscriptionOf(body), h.clock.now(), h.analytics)
+      await recomputePlan(db, h.clock, f.orgId, h.analytics)
+    })
+    try { await waitForBlockedQuery() } finally { release() }
+    await assert.doesNotReject(Promise.all([holder, writer]))
+  })
+
+  async function waitForBlockedQuery() {
+    for (let attempt = 0; attempt < 200; attempt++) {
+      const rows = await h.admin`SELECT pid FROM pg_stat_activity WHERE datname = current_database() AND usename = 'antifailure_app' AND wait_event_type = 'Lock'`
+      if (rows.length) return
+      await new Promise(resolve => setTimeout(resolve, 5))
+    }
+    throw new Error('The contender never reached the real PostgreSQL lock')
+  }
+})

--- a/web/apps/api/test/billing-ordering.test.ts
+++ b/web/apps/api/test/billing-ordering.test.ts
@@ -1,9 +1,13 @@
 import { after, before, describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { randomUUID } from 'node:crypto'
-import { handleStripeDelivery, recomputePlan, writeSubscription } from '../src/billing/webhook.ts'
-import { readBillingState, reconcile } from '../src/billing/store.ts'
-import { RealStripeClient, subscriptionOf } from '../src/billing/stripe.ts'
+import type postgres from 'postgres'
+import type { SQL } from 'drizzle-orm'
+import { PgDialect } from 'drizzle-orm/pg-core'
+import type { Db, Pool } from '@antifailure/db'
+import { handleStripeDelivery, recomputePlan, writeInvoice, writeSubscription } from '../src/billing/webhook.ts'
+import { attachCustomer, readBillingState } from '../src/billing/store.ts'
+import { invoiceOf, subscriptionOf } from '../src/billing/stripe.ts'
 import { available, startApi, seedOrg, dropOrg, stripeAgainstMockPack, type ApiHarness } from './harness.ts'
 import type { StripeConfig } from '../src/billing/plans.ts'
 
@@ -23,11 +27,11 @@ describe('billing across subscription arrival orders', { skip: !hasDatabase }, (
     await h.close()
   })
 
-  async function fixture() {
+  async function fixture(attached = true) {
     const org = await seedOrg(h.admin, 'billing-order')
     orgIds.push(org.orgId)
     const customer = `cus_${randomUUID()}`
-    await h.admin`INSERT INTO billing_customers (org_id, stripe_customer_id) VALUES (${org.orgId}, ${customer})`
+    if (attached) await h.admin`INSERT INTO billing_customers (org_id, stripe_customer_id) VALUES (${org.orgId}, ${customer})`
     return { orgId: org.orgId, customer }
   }
 
@@ -97,44 +101,60 @@ describe('billing across subscription arrival orders', { skip: !hasDatabase }, (
     assert.equal(await plan(f.orgId), 'enterprise')
   })
 
-  it('a reconciliation response cannot undo a newer webhook delivered while its request was in flight', async () => {
+  it('an older unknown active purchase is preserved behind a newer ended purchase', async () => {
     const f = await fixture()
-    const body = object(f.customer, `sub_${randomUUID()}`, 100)
-    await deliver(body)
-    h.clock.advance(1000)
-    const client = new RealStripeClient({ ...config, fetch: async input => {
-      const url = new URL(String(input))
-      if (url.pathname === '/v1/subscriptions') {
-        h.clock.advance(1000)
-        await deliver({ ...body, status: 'canceled' })
-        h.clock.advance(1000)
-        return Response.json({ data: [body] })
-      }
-      return Response.json({ data: [] })
-    } })
-    await reconcile(h.pool, h.clock, config, client, f.orgId, h.analytics)
-    assert.equal(await plan(f.orgId), 'free')
+    await h.admin`UPDATE organizations SET plan = 'enterprise' WHERE id = ${f.orgId}`
+    await deliver(object(f.customer, `sub_${randomUUID()}`, 100, 'unknown'))
+    await deliver(object(f.customer, `sub_${randomUUID()}`, 200, 'team', 'canceled'))
+    assert.equal(await plan(f.orgId), 'enterprise')
   })
 
-  it('an invoice reconciliation snapshot cannot undo payment delivered during its request', async () => {
-    const f = await fixture()
-    const invoice = { id: `in_${randomUUID()}`, customer: f.customer, status: 'open', amount_paid: 0 }
-    const client = new RealStripeClient({ ...config, fetch: async input => {
-      const url = new URL(String(input))
-      if (url.pathname === '/v1/invoices') {
-        h.clock.advance(1000)
-        await handleStripeDelivery(h.pool, h.clock, config, {
-          id: `evt_${randomUUID()}`, type: 'invoice.paid', created: h.clock.now(),
-          object: { ...invoice, status: 'paid', amount_paid: 50000 },
-        }, h.analytics)
-        h.clock.advance(1000)
-        return Response.json({ data: [invoice] })
+  it('forced overlap of initial attachment and webhook resolves the paid purchase', async () => {
+    const f = await fixture(false)
+    const inserted = barrier()
+    const continueWebhook = barrier()
+    const continueAttach = barrier()
+    let pendingRead = false
+    const watched: Pool = {
+      ...h.pool,
+      withStripeCustomer: (customer, fn) => h.pool.withStripeCustomer(customer, db =>
+        fn(afterQuery(db, async statement => {
+          if (statement.includes('INSERT INTO billing_events')) {
+            inserted.release()
+            await continueWebhook.promise
+          }
+        }))),
+    }
+    const webhook = handleStripeDelivery(watched, h.clock, config, {
+      id: `evt_${randomUUID()}`, type: 'customer.subscription.created', created: h.clock.now(),
+      object: object(f.customer, `sub_${randomUUID()}`, 100, 'enterprise'),
+    }, h.analytics)
+    await inserted.promise
+    const attachment = h.pool.withTenant({ orgId: f.orgId }, db => attachCustomer(
+      afterQuery(db, async statement => {
+        if (statement.includes('FROM billing_events')) {
+          pendingRead = true
+          await continueAttach.promise
+        }
+      }), h.clock, config, f.orgId, { id: f.customer, email: null }, h.analytics,
+    ))
+    try {
+      // With serialization, attachment waits on the customer lock. Without
+      // either call site, its pending SELECT sees no committed webhook row.
+      for (let i = 0; i < 200 && !pendingRead; i++) {
+        const waits = await h.admin`SELECT pid FROM pg_stat_activity WHERE datname = current_database() AND usename = 'antifailure_app' AND wait_event = 'advisory'`
+        if (waits.length) break
+        await new Promise(resolve => setTimeout(resolve, 5))
+        if (i === 199) throw new Error('Attachment reached neither the lock nor its pending-event read')
       }
-      return Response.json({ data: [] })
-    } })
-    await reconcile(h.pool, h.clock, config, client, f.orgId, h.analytics)
-    const [row] = await h.admin`SELECT amount_paid FROM invoices WHERE stripe_invoice_id = ${invoice.id}`
-    assert.equal(Number(row!.amount_paid), 50000)
+      continueWebhook.release()
+      await webhook
+    } finally {
+      continueWebhook.release()
+      continueAttach.release()
+      await Promise.all([webhook, attachment])
+    }
+    assert.equal(await plan(f.orgId), 'enterprise')
   })
 
   it('a later delivery repairs the creation time stored by older application code', async () => {
@@ -203,6 +223,64 @@ describe('billing across subscription arrival orders', { skip: !hasDatabase }, (
     try { await waitForBlockedQuery() } finally { release() }
     await assert.doesNotReject(Promise.all([holder, writer]))
   })
+
+  it('invoice repair takes the organization before an existing invoice lock', async () => {
+    const f = await fixture()
+    const id = `in_${randomUUID()}`
+    await h.admin`INSERT INTO invoices (org_id, stripe_invoice_id, stripe_customer_id, status, last_event_at) VALUES (${f.orgId}, ${id}, ${f.customer}, 'open', '2025-01-01')`
+    await assert.doesNotReject(holdingOrganization(f.orgId, async tx => {
+      await tx`SELECT id FROM invoices WHERE stripe_invoice_id = ${id} FOR UPDATE NOWAIT`
+    }, () => h.pool.withTenant({ orgId: f.orgId }, async db => {
+      await writeInvoice(db, h.clock, f.orgId, invoiceOf({ id, customer: f.customer, status: 'paid' })!, h.clock.now())
+      await recomputePlan(db, h.clock, f.orgId, h.analytics)
+    })))
+  })
+
+  it('a payment-method delivery takes the organization before its entity lock and event foreign key', async () => {
+    const f = await fixture()
+    const id = `pm_${randomUUID()}`
+    await h.admin`INSERT INTO payment_methods (org_id, stripe_payment_method_id, stripe_customer_id, last_event_at) VALUES (${f.orgId}, ${id}, ${f.customer}, '2025-01-01')`
+    await assert.doesNotReject(holdingOrganization(f.orgId, async tx => {
+      await tx`SELECT id FROM payment_methods WHERE stripe_payment_method_id = ${id} FOR UPDATE NOWAIT`
+    }, () => handleStripeDelivery(h.pool, h.clock, config, {
+      id: `evt_${randomUUID()}`, type: 'payment_method.detached', created: h.clock.now(), object: { id, customer: f.customer },
+    }, h.analytics)))
+  })
+
+  async function holdingOrganization(orgId: string, inspect: (tx: postgres.TransactionSql) => Promise<void>, operation: () => Promise<unknown>) {
+    const locked = barrier()
+    const inspectNow = barrier()
+    const holder = h.admin.begin(async tx => {
+      await tx`SELECT id FROM organizations WHERE id = ${orgId} FOR UPDATE`
+      locked.release()
+      await inspectNow.promise
+      await inspect(tx)
+    })
+    await locked.promise
+    const writer = operation()
+    try { await waitForBlockedQuery() } finally { inspectNow.release() }
+    await Promise.all([holder, writer])
+  }
+
+  function barrier() {
+    let release!: () => void
+    const promise = new Promise<void>(resolve => { release = resolve })
+    return { promise, release }
+  }
+
+  function afterQuery(db: Db, after: (statement: string) => Promise<void>): Db {
+    return new Proxy(db, {
+      get(target, property, receiver) {
+        if (property === 'execute') return async (query: SQL) => {
+          const result = await target.execute(query)
+          await after(new PgDialect().sqlToQuery(query).sql)
+          return result
+        }
+        const value = Reflect.get(target, property, receiver)
+        return typeof value === 'function' ? value.bind(target) : value
+      },
+    })
+  }
 
   async function waitForBlockedQuery() {
     for (let attempt = 0; attempt < 200; attempt++) {


### PR DESCRIPTION
## What was wrong

A newer canceled subscription could hide an older active purchase and remove
paid access. Subscription age was the time its delivery arrived here, so two
arrival orders could grant different plans. Concurrent writers selected before
acquiring the organization lock. Customer attachment and webhook delivery could
also miss each other's uncommitted rows, leaving a paid purchase unresolved.

Full API verification found a separate analytics defect: the JavaScript job
chose UTC days, but PostgreSQL interpreted date boundaries in its server timezone.
On a Chicago-time database, midnight events disappeared from daily counts and
Monday funnels belonged to the previous week. This is a separate commit with
its own change entry.

## What changes

Billing selects the newest known entitling subscription using provider creation
time and a stable identifier tie break. An unknown price does not downgrade an
existing paid organization. Subscription writes and recomputation acquire the
organization lock before touching the deciding rows. Attachment and delivery
share a customer lock before either inserts. Invoice and payment-method writes
use the same organization-first lock order. Plan's current subscription
prefers a live purchase over a newer ended row.

Analytics uses UTC inside the existing daily-count, subject-day and funnel
transactions. The caller connection retains its timezone. The ordering-test
cleanup now uses explicit UTC bounds as well.

## Verification

- 15 new billing assertions independently failed under deliberate production
  mutations, then passed after restoration, against real PostgreSQL. The forced
  overlap case was mutated once per customer-lock call site, making 16 cells.
- 8 new analytics assertions independently failed under deliberate mutations,
  then passed, covering spring and fall daylight-saving transitions, midnight
  counts, subject days, funnel entry weeks and caller timezone restoration.
- 53 analytics tests passed on a fresh Chicago-time database. The unchanged
  45-test suite passed on a separate UTC database as a diagnostic control.
- 1,892 full API tests passed before independent review. Review found additional
  cases despite that result; after repairing them, 169 focused billing,
  deletion, entitlement and analytics tests passed, with zero skips.
- TypeScript and whitespace checks passed. Prosecheck scanned 729 files without
  findings; changecheck confirmed both visible-change entries.

## Explicit boundary from review

An initial request-start reconciliation timestamp experiment was rejected:
it fixed a stale response arriving after a newer webhook, but a fresh response
could then be overwritten by an older webhook arriving later. A local timestamp
is not a provider version. That experiment and its two insufficient tests are
removed. Canonical provider refresh with persisted generations and leases is a
separate required repair, as are cancellation response ordering and pagination.

No live Stripe charge, customer secret access, account setting change, migration
or production deployment occurred. Checkout reservation and provider idempotency
are separate work; this PR does not claim to prevent duplicate purchases.
