### PR TITLE
env: expiry sweep events named the checkout instead of the target

### DIFF
--- a/.changes/a-sweep-reported-the-wrong-environment.md
+++ b/.changes/a-sweep-reported-the-wrong-environment.md
@@ -1,0 +1,5 @@
+# fixed
+
+An expiry sweep removed its target but reported lifecycle events under the
+checkout's environment name. The events now name the environment the sweep
+actually removed, so it cannot report another branch as torn down.

--- a/engine/internal/controlplane/vocabulary_test.go
+++ b/engine/internal/controlplane/vocabulary_test.go
@@ -221,17 +221,30 @@ var typeConst = regexp.MustCompile(`(?m)^\s*([A-Za-z][A-Za-z0-9]*)\s+Type\s*=\s*
 // hud.Plain.Suppressed both take an events.Type and are consumers, so a
 // reference count would call a type live because something displays it.
 //
-// The four names are the complete set of ways a constant reaches the bus:
-// Orchestrator.emit, event and eventErr in internal/env, and Bus.Emit under
-// them. emitHelpers below fails if that stops being true, because a fifth one
-// added without updating this pattern would make every type it emits look
+// The names are the complete set of ways a constant reaches the bus:
+// Orchestrator.emit, emitFor, event, eventErr and eventFor in internal/env,
+// and Bus.Emit under them. emitFor and eventFor are the forms that name an
+// environment other than the checkout's, which is what a sweep needs.
+// emitHelpers below fails if this set stops being complete, because another
+// one added without updating this pattern would make every type it emits look
 // unemitted, which is a loud failure rather than a silent one.
-var emitCall = regexp.MustCompile(`\b(?:emit|event|eventErr|Emit)\(\s*[^)\n]*?\bevents\.([A-Z][A-Za-z0-9]*)`)
+//
+// Longer names come first in the alternation so that emitFor and eventFor are
+// not shadowed by the emit and event prefixes they begin with.
+//
+// emit and emitFor take the level before the type, so what this pattern
+// actually captures from them is events.LevelInfo and never their event type.
+// That was already true of emit and it is harmless, because a level is not a
+// mapped type and because nothing reaches the bus through those two without
+// going through event, eventErr or eventFor, which put the type first. They
+// are named here so this list and the helper list the tripwire checks describe
+// the same set, rather than because the pattern can read a type out of them.
+var emitCall = regexp.MustCompile(`\b(?:emitFor|eventErr|eventFor|emit|event|Emit)\(\s*[^)\n]*?\bevents\.([A-Z][A-Za-z0-9]*)`)
 
 // emitHelpers matches any orchestrator method that takes an event type at all,
 // which is the only shape a new way to reach the bus can have.
 //
-// Matching the three known names instead would count removals and renames and
+// Matching the known names instead would count removals and renames and
 // miss the case that matters, an ADDED helper, because the count of the three
 // stays three. That was the first version of this and it went green against a
 // deliberately added fourth.
@@ -277,7 +290,7 @@ func emittedTypes(t *testing.T) map[string]bool {
 		helpers = append(helpers, string(m[1]))
 	}
 	slices.Sort(helpers)
-	if known := []string{"emit", "event", "eventErr"}; !slices.Equal(helpers, known) {
+	if known := []string{"emit", "emitFor", "event", "eventErr", "eventFor"}; !slices.Equal(helpers, known) {
 		t.Fatalf("%s declares %v as the methods taking an event type and this test's "+
 			"pattern knows %v; add the new one to emitCall, because a type only it emits "+
 			"would otherwise read as emitted by nothing", orchestrator, helpers, known)

--- a/engine/internal/env/env.go
+++ b/engine/internal/env/env.go
@@ -264,15 +264,28 @@ func (o *Orchestrator) AddSink(s events.Sink) {
 // tolerating them here is a nil check repeated at every call site plus a panic
 // the first time one is forgotten.
 func (o *Orchestrator) emit(s *session, level events.Level, t events.Type, msg string, f ...events.Field) {
+	o.emitFor(s, o.envID, level, t, msg, f...)
+}
+
+// emitFor names the environment the event is about, which is not always the
+// checkout's own. A sweep removes an environment it is not running inside, and
+// stamping o.envID on that teardown advances the wrong environment's row in
+// the control plane, so the target travels explicitly.
+func (o *Orchestrator) emitFor(s *session, envID string, level events.Level, t events.Type, msg string, f ...events.Field) {
 	if s == nil || s.bus == nil {
 		return
 	}
-	s.bus.Emit(o.envID, t, level, msg, f...)
+	s.bus.Emit(envID, t, level, msg, f...)
 }
 
 // event publishes at info level, which is what almost every lifecycle step is.
 func (o *Orchestrator) event(s *session, t events.Type, msg string, f ...events.Field) {
 	o.emit(s, events.LevelInfo, t, msg, f...)
+}
+
+// eventFor is event for an environment other than the checkout's.
+func (o *Orchestrator) eventFor(s *session, envID string, t events.Type, msg string, f ...events.Field) {
+	o.emitFor(s, envID, events.LevelInfo, t, msg, f...)
 }
 
 // eventErr publishes at error level, which is what puts a line in the

--- a/engine/internal/env/reap.go
+++ b/engine/internal/env/reap.go
@@ -161,10 +161,10 @@ func (w *sweeper) Destroy(ctx context.Context, envID string) (int, error) {
 	}
 	defer func() { _ = l.Release() }()
 
-	w.o.event(w.s, events.EnvDestroying, "removing "+envID+", which has expired")
+	w.o.eventFor(w.s, envID, events.EnvDestroying, "removing "+envID+", which has expired")
 	td := w.o.teardown(ctx, w.s, envID)
 	w.result.Teardowns[envID] = td
-	w.o.event(w.s, events.EnvDestroyed, "removed "+envID,
+	w.o.eventFor(w.s, envID, events.EnvDestroyed, "removed "+envID,
 		events.F("removed", td.Removed), events.F("pending", len(td.Pending)),
 		events.F("reason", "expired"))
 

--- a/engine/internal/env/reap_identity_internal_test.go
+++ b/engine/internal/env/reap_identity_internal_test.go
@@ -1,0 +1,53 @@
+package env
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/antifailure/antifailure/engine/internal/clock"
+	"github.com/antifailure/antifailure/engine/internal/events"
+	"github.com/antifailure/antifailure/engine/internal/journal"
+	"github.com/antifailure/antifailure/engine/internal/lease"
+	"github.com/antifailure/antifailure/engine/internal/state"
+	"github.com/antifailure/antifailure/engine/internal/testutil/fakes"
+)
+
+func TestReaperLifecycleNamesTheEnvironmentItActuallyRemoved(t *testing.T) {
+	for _, eventType := range []events.Type{events.EnvDestroying, events.EnvDestroyed} {
+		t.Run(string(eventType), func(t *testing.T) {
+			ctx := context.Background()
+			root := t.TempDir()
+			db, err := state.Open(ctx, root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = db.Close() }()
+			c := clock.New()
+			bus := events.NewBus(c)
+			sink := events.NewMemorySink(64)
+			bus.AddSink(sink)
+			o := &Orchestrator{
+				envID: "checkout-environment", opts: Options{Root: root, Clock: c},
+				progress: func(string) {},
+			}
+			s := &session{db: db, bus: bus, runtime: fakes.NewRuntime(),
+				dbProv: fakes.NewInMemoryDatabase(), journal: journal.New(db, c, bus)}
+			w := &sweeper{o: o, s: s, stateDir: root, leases: lease.NewStore(db, c),
+				result: &ReapResult{Teardowns: map[string]*Teardown{}}}
+			if _, err := w.Destroy(ctx, "expired-other-branch"); err != nil {
+				t.Fatal(err)
+			}
+			if err := bus.Close(); err != nil {
+				t.Fatal(err)
+			}
+			var targets []string
+			for _, event := range sink.OfType(eventType) {
+				targets = append(targets, event.Env)
+			}
+			if !reflect.DeepEqual(targets, []string{"expired-other-branch"}) {
+				t.Fatalf("%s targeted %v, want only the expired environment", eventType, targets)
+			}
+		})
+	}
+}


### PR DESCRIPTION
An expiry sweep tore down one environment and told the control plane a different one had been torn down. `af env reap` walks every expired environment on a machine, and each teardown emitted `env.destroying` and `env.destroyed` through the orchestrator's `event` helper, which stamps `o.envID`, the environment belonging to the checkout the sweep was invoked from. The target it actually removed was the `envID` argument, and nothing carried that argument onto the event.

The consequence is not cosmetic. The control plane's environment row advances on exactly these two events, so a sweep running from one checkout marked another branch's environment as torn down while that environment was still running, and left the environment it really removed showing as live. A sweep is the one lifecycle path that routinely operates on an environment it is not running inside, which is why it is the only place this could happen: `Down` tears down its own checkout, and its use of `o.envID` is correct.

The sweep's two emissions now name the environment they are about. `emitFor` takes the target explicitly, `eventFor` is its info-level form beside the existing `event`, and `emit` is now defined in terms of `emitFor` so there is one path to the bus rather than two.

Scope, checked rather than assumed:

- `env.destroying` and `env.destroyed` in `sweeper.Destroy` were the only misattributed emissions. Grepping every emission site in `engine/internal/env` finds forty, and the only functions that both take an `envID` argument and reach the bus are the two fixed here. `teardown` and `reconcile` take an `envID` and emit nothing.
- `Down` at `env.go` emits the same two types under `o.envID`, which is its own environment and correct.
- `af env prune` calls `runtime.Down` directly with no orchestrator, no session and no bus, so it misattributes nothing. It also reports nothing, which is a real gap in lifecycle reporting but a separate one from this defect, and it belongs with the environment lifetime identity work rather than here.

Validation:

- `go vet ./internal/env` clean.
- `go test ./internal/env -run TestReaperLifecycleNamesTheEnvironmentItActuallyRemoved` passes, both subtests.
- `go test ./internal/events` passes.

The test drives the real `sweeper.Destroy` against an orchestrator whose checkout alias deliberately differs from the environment being swept, then reads the bus. It asserts per event type, so each assertion fails for its own reason.

Mutation evidence. Each break was applied alone against the production line that assertion exists to catch, then restored and confirmed green:

1. `env.destroying` emitted through `event` again, taking `o.envID`: the `env.destroying` assertion failed and the `env.destroyed` assertion still passed.
2. `env.destroyed` emitted through `event` again, taking `o.envID`: the `env.destroyed` assertion failed and the `env.destroying` assertion still passed.
3. `emitFor` ignoring its `envID` argument and passing `o.envID` to the bus: both assertions failed.
4. `eventFor` discarding its target and delegating to `emit`: both assertions failed.

Cells 1 and 2 are what prove the two assertions are independent rather than one assertion reached twice. Cells 3 and 4 prove the helpers are load bearing rather than decorative.

The second commit exists because the first one broke a gate, and it has its own two cells:

5. The known-helper list in `vocabulary_test.go` put back to the three old names: `TestEveryMappedTypeHasSomethingInTheEngineThatEmitsIt` failed with the identical message CI reported. That is the cell that proves the fix is the thing making the gate pass.
6. `eventFor` removed from the `emitCall` alternation: the test still passed. Reported rather than hidden, because a mutation that does not fail is a fact about the gate. Every type reachable through `eventFor` is also emitted by `Down` through `event`, so that alternation entry is defensive rather than load bearing today. It is kept so the pattern and the list the tripwire compares against describe the same set.

What CI said, rather than what was assumed. The first commit alone, 76d951fc, failed two required contexts, `engine` and `edition boundary`, and both failed on one test and one line:

    --- FAIL: TestEveryMappedTypeHasSomethingInTheEngineThatEmitsIt
    vocabulary_test.go:368: ../env/env.go declares [emit emitFor event eventErr eventFor]
    as the methods taking an event type and this test's pattern knows [emit event eventErr]

That is the second commit's subject. It was confirmed to be caused by this branch rather than inherited before anything was changed: `edition boundary` is `success` on main at 64e67a86 and on PRs 229, 231 and 232, so it was not a pre-existing red, a cancellation, or a superseded credential.

Worth stating plainly, because it is the only run that covers ground the local machine could not: apart from that single test, the whole engine suite passed on both jobs, on a runner with a real Docker daemon and Postgres.

Not claimed here. The full `./internal/env` package suite wants a Docker daemon and a Postgres and the justfile allows it thirty minutes; it was not run to completion locally, and CI is what exercises it. An earlier local attempt at it did not pass: it hit the default 600 second test timeout and panicked, and is not evidence of anything either way. This changes which environment the two teardown events name and nothing else: it does not give the events a lifetime identity, so a torn-down and recreated environment of the same name is still one row to the control plane. That is the environment lifetime identity work, and it is still outstanding.
