### PR TITLE
mcp: a browser client could not reach this product at all

### DIFF
--- a/.changes/hosted-mcp-is-manageable.md
+++ b/.changes/hosted-mcp-is-manageable.md
@@ -1,0 +1,6 @@
+# fixed
+
+The operator MCP page now shows registered clients and issued credentials,
+including their organization, approving person, expiry and last authentication.
+Operators with revocation permission can stop a credential through the existing
+audited action. Local checkout sessions are not presented as hosted measurements.

--- a/.changes/hosted-mcp.md
+++ b/.changes/hosted-mcp.md
@@ -1,0 +1,4 @@
+# added
+
+- Connect an MCP client to the control plane with explicit browser consent.
+  Hosted tools use the same tenant permissions and execution paths as the console.

--- a/.changes/mcp-access-needs-an-informed-approval.md
+++ b/.changes/mcp-access-needs-an-informed-approval.md
@@ -1,0 +1,6 @@
+# added
+
+The hosted MCP connection shows the requesting client, its permissions, the
+registered return address and the access lifetime before asking for approval.
+Signing in returns to that request without approving it. Declining grants no
+access, and incomplete or mismatched requests cannot be approved.

--- a/console/app/(app)/cli/page.tsx
+++ b/console/app/(app)/cli/page.tsx
@@ -390,7 +390,7 @@ function Tokens({ mayManage, csrf }: { mayManage: boolean; csrf: string }) {
                         <Td>
                           <span className="block text-ink">{t.name}</span>
                           <span className="block text-[12px] text-dim">
-                            {t.kind === "cli" ? "terminal" : "engine token"}
+                            {t.kind === "cli" ? "terminal" : t.kind === "mcp" ? "MCP client" : t.kind === "oidc" ? "workflow identity" : "engine token"}
                           </span>
                         </Td>
                         <Td label="Prefix" mono>

--- a/console/app/admin/platform/api-keys/page.tsx
+++ b/console/app/admin/platform/api-keys/page.tsx
@@ -62,6 +62,7 @@ const KIND_WORDS: Record<string, string> = {
   engine: "engine",
   cli: "person",
   oidc: "workflow",
+  mcp: "MCP",
 };
 
 const KIND_HINTS: Record<string, string> = {
@@ -69,6 +70,7 @@ const KIND_HINTS: Record<string, string> = {
     "Belongs to the organization rather than to whoever made it, so it keeps working after that person leaves.",
   cli: "Minted by af login for one person's machine, and it acts as them.",
   oidc: "Minted per workflow job by trading a GitHub identity. Short lived, and tied to a binding.",
+  mcp: "Approved by a person for a hosted MCP client. Reconnect the client to replace it.",
 };
 
 export default function PlatformApiKeysPage() {
@@ -210,7 +212,7 @@ function Credentials() {
       title="Credentials"
       note={
         mayRevoke
-          ? "Revoking is immediate and cannot be undone. There is no rotate: only the hash is stored, so nothing here can produce a replacement. The customer makes one with af token create."
+          ? "Revoking is immediate and cannot be undone. The customer reconnects an MCP client or creates a replacement engine credential with af token create."
           : "Your role can read this list and not change it."
       }
     >
@@ -231,6 +233,7 @@ function Credentials() {
               { value: "engine", label: "Engine" },
               { value: "cli", label: "Person" },
               { value: "oidc", label: "Workflow" },
+              { value: "mcp", label: "MCP" },
             ],
           },
           {
@@ -349,7 +352,7 @@ function RevokeCredential({
       <p>
         There is no way back. Only a hash of the value is stored, so nobody, including us, can
         recover it. {credential ? <span className="font-mono">{credential.orgSlug}</span> : null}{" "}
-        creates a replacement themselves with <span className="font-mono">af token create</span>.
+        {credential?.kind === "mcp" ? "reconnects their MCP client to approve a replacement." : <>creates a replacement themselves with <span className="font-mono">af token create</span>.</>}
       </p>
       {credential ? (
         <p className="text-[12.5px] text-dim">{KIND_HINTS[credential.kind] ?? ""}</p>

--- a/console/app/admin/platform/mcp/page.tsx
+++ b/console/app/admin/platform/mcp/page.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import { Badge, Button, Card, CardSkeleton, Confirm, Empty, Field, Loaded, Table,
-  TableWrap, Td, Th, When, inputClass } from "@/components/ui";
+  TableWrap, Td, Th, When, inputClass, toneFor } from "@/components/ui";
 import { AdminPage } from "@/components/admin/primitives";
 import { operatorMay, useAdminContext } from "@/lib/admin";
 import { revokeCredential, useMcpSurface, type McpConnection } from "@/lib/admin-platform";
@@ -54,7 +54,7 @@ export default function PlatformMcpPage() {
                     <Td label="Access"><span className="block text-[16px] sm:text-[13px]">{connection.scopes.includes("mcp:read") ? "Read" : "No read access"}</span><span className="block text-[16px] sm:text-[13px] text-muted">{connection.scopes.includes("mcp:write") ? "Request changes" : "No changes"}</span></Td>
                     <Td label="Last used">{connection.lastAuthenticatedAt ? <When value={connection.lastAuthenticatedAt} /> : <span className="text-muted">Not used yet</span>}</Td>
                     <Td label="Expires"><When value={connection.expiresAt} /></Td>
-                    <Td label="Status"><Badge>{connection.standing}</Badge></Td>
+                    <Td label="Status"><Badge tone={toneFor(connection.standing)}>{connection.standing}</Badge></Td>
                     {mayRevoke ? <Td label="Action">{connection.standing === "active" ? <Button variant="danger" onClick={() => setSelected(connection)}>Revoke<span className="sr-only"> {connection.clientName} for {connection.orgSlug}</span></Button> : <span className="text-[16px] sm:text-[13px] text-muted">Already refused</span>}</Td> : null}
                   </tr>
                 ))}</tbody></Table></TableWrap>

--- a/console/app/admin/platform/mcp/page.tsx
+++ b/console/app/admin/platform/mcp/page.tsx
@@ -1,151 +1,92 @@
 "use client";
 
-import { Card, CardSkeleton, Loaded } from "@/components/ui";
+import { useState } from "react";
+import Link from "next/link";
+import { Badge, Button, Card, CardSkeleton, Confirm, Empty, Field, Loaded, Table,
+  TableWrap, Td, Th, When, inputClass } from "@/components/ui";
 import { AdminPage } from "@/components/admin/primitives";
-import { useMcpSurface } from "@/lib/admin-platform";
+import { operatorMay, useAdminContext } from "@/lib/admin";
+import { revokeCredential, useMcpSurface, type McpConnection } from "@/lib/admin-platform";
 
-/**
- * MCP Management, and the honest answer to what there is to manage: nothing
- * here.
- *
- * WHY THIS PAGE IS NOT A FLEET OF SERVERS. `af mcp` is a real, shipped engine
- * feature, and it runs entirely on the developer's machine. It binds one
- * checkout, speaks the protocol on standard input and output, and keeps its
- * runs in that project's own state directory. It opens no connection to this
- * control plane, presents no credential and sends no event. So there is no
- * server list, no connection count, no last seen time and no adoption figure,
- * and a page showing one would be showing numbers nobody measured. This
- * repository has a check called figurecheck because an invented number shipped
- * once already.
- *
- * WHAT THE PAGE IS FOR INSTEAD. One question an operator is actually asked,
- * usually by a customer's security reviewer: can an agent use this to make a
- * check easier on itself. The answer is no, and it is provable rather than a
- * promise, because the refusal is a property of the tool schemas rather than a
- * rule the tools ask a model to respect. Every claim below carries the engine
- * file and symbol it came from, and admin-platform.test.ts opens each file and
- * looks for each symbol, so a tool renamed or unregistered fails the suite
- * rather than leaving this page describing a product that moved.
- *
- * THE ABSENCE IS SENT BY THE SERVER, not assumed here. `recordsAnything` is a
- * field on the route, so the day a write path exists this page changes because
- * the server changed rather than because somebody remembered to edit it.
- */
+/** Hosted credentials are measured separately from local checkout sessions. */
 export default function PlatformMcpPage() {
   const state = useMcpSurface();
+  const { me } = useAdminContext();
+  const [selected, setSelected] = useState<McpConnection | null>(null);
+  const mayRevoke = operatorMay(me, "admin.keys.revoke");
 
   return (
-    <AdminPage
-      href="/admin/platform/mcp"
-      lede="What this control plane knows about the MCP server, and where the answers actually live."
-    >
-      <Loaded state={state} framed skeleton={<CardSkeleton count={3} />}>
+    <AdminPage href="/admin/platform/mcp" lede="Manage the clients and credentials people have approved for the hosted control plane.">
+      <Loaded state={state} framed skeleton={<CardSkeleton count={2} />}>
         {(surface) => (
           <div className="space-y-5">
-            <Card title="This console holds no MCP record">
-              <div className="max-w-[72ch] space-y-3 px-4 py-4 text-[13px] leading-6 text-muted">
-                {surface.recordsAnything ? (
-                  // Unreachable today and deliberately written anyway. If a
-                  // write path is ever added, this page must stop claiming an
-                  // absence rather than keep asserting one that has ended.
-                  <p className="text-ink">
-                    This control plane now records something about MCP. This page has not been
-                    rebuilt for it, so read the routes rather than trusting this text.
-                  </p>
-                ) : (
-                  <>
-                    <p>{surface.why}</p>
-                    <p>
-                      Nothing on this page is a measurement, because there is nothing here to
-                      measure. What follows is the tool surface the engine serves, which is checked
-                      in and can be read from the source.
-                    </p>
-                  </>
-                )}
+            <Card title="Hosted MCP endpoint" note="Add this URL in an MCP client with HTTP and OAuth support, then sign in and choose an organization.">
+              <div className="px-4 py-4">
+                {surface.endpoint ? <code className="block break-all text-[16px] font-medium text-ink">{surface.endpoint}</code> :
+                  <p className="text-[16px] text-muted">An application URL has not been configured for this installation.</p>}
+                <p className="mt-3 text-[16px] sm:text-[13px] leading-6 text-muted">An agent can only do what its user and approved scopes allow. New environments are requested through the repository workflow.</p>
               </div>
-            </Card>
-
-            <Card
-              title="The tools an agent can call"
-              note="Served by the engine on the developer's machine, not by this control plane."
-            >
-              <ul className="divide-y divide-rule">
-                {surface.tools.map((tool) => (
-                  <li key={tool.name} className="px-4 py-4">
-                    <p className="font-mono text-[13px] font-medium text-ink">{tool.name}</p>
-                    <p className="mt-1.5 max-w-[72ch] text-[13px] leading-6 text-muted">
-                      {tool.does}
-                    </p>
-                    <p className="mt-2 max-w-[72ch] text-[13px] leading-6 text-ink">
-                      <span className="font-medium">What it refuses:</span> {tool.refuses}
-                    </p>
-                    {/* The provenance, in the smallest type on the card and
-                        never hidden. It is what makes the two paragraphs above
-                        checkable rather than a claim, and a reader who wants to
-                        verify one should not have to ask where to look. */}
-                    <p className="mt-2 text-[11.5px] leading-5 text-dim">
-                      Served by <span className="break-all font-mono">{tool.servedBy}</span>
-                    </p>
-                  </li>
+              <dl className="grid grid-cols-2 border-t border-rule lg:grid-cols-4">
+                {([
+                  ["Registered clients", surface.counts.clients],
+                  ["Active credentials", surface.counts.active],
+                  ["Revoked", surface.counts.revoked],
+                  ["Expired", surface.counts.expired],
+                ] as const).map(([label, value]) => (
+                  <div key={label} className="min-w-0 px-4 py-4">
+                    <dt className="text-[16px] sm:text-[13px] text-muted">{label}</dt>
+                    <dd className="mt-1 font-mono text-[28px] leading-9 tabular-nums text-ink">{value.toLocaleString()}</dd>
+                  </div>
                 ))}
-              </ul>
+              </dl>
             </Card>
 
-            <Card title="Why an agent cannot weaken a check">
-              <div className="max-w-[72ch] space-y-3 px-4 py-4 text-[13px] leading-6 text-muted">
-                <p>
-                  There is no argument on any tool that disables sanitization, widens the egress
-                  policy, lowers a threshold, names a database or skips the rehearsal. That is a
-                  property of the schemas rather than a convention the tools ask an agent to
-                  respect, and it holds because an argument the server does not know is refused
-                  rather than ignored.
-                </p>
-                <p className="text-[11.5px] leading-5 text-dim">
-                  The refusal is at{" "}
-                  <span className="break-all font-mono">{surface.unknownFieldRefusal}</span>
-                </p>
-                <p>
-                  Thresholds come from the policy block of the project&apos;s manifest, and the
-                  verdict is decided by the same evaluator the pull request check uses, so a tool
-                  call and a check cannot disagree about the same change.
-                </p>
-                <p className="text-[11.5px] leading-5 text-dim">
-                  The four tools above are the four registered in{" "}
-                  <span className="break-all font-mono">{surface.registeredIn}</span>, which is the
-                  whole set an agent can reach.
-                </p>
+            <Card title="Approved credentials" note="Active means unexpired and not revoked, not a live network connection. Last authentication includes protocol requests, not just tool calls.">
+              {surface.connections.length === 0 ? (
+                <Empty title="No MCP access has been approved yet">Connect an MCP client to the endpoint above, sign in and approve access. Its credential will appear here.</Empty>
+              ) : (
+                <TableWrap><Table className="sm:min-w-[760px] [&_td]:text-[16px] sm:[&_td]:text-[13px]"><thead><tr>
+                  <Th>Client and person</Th><Th>Organization</Th><Th>Access</Th><Th>Last authentication</Th><Th>Expires</Th><Th>Status</Th>{mayRevoke ? <Th>Action</Th> : null}
+                </tr></thead><tbody>{surface.connections.map((connection) => (
+                  <tr key={connection.id}>
+                    <Td><span className="block max-w-[24ch] break-words font-medium text-ink">{connection.clientName}</span><span className="block text-[16px] sm:text-[13px] text-muted">{connection.userLogin}</span><span className="block font-mono text-[12px] text-dim">{connection.prefix}</span><span className="block text-[13px] text-muted">Issued <When value={connection.createdAt} /></span></Td>
+                    <Td label="Organization"><span className="break-words">{connection.orgSlug}</span></Td>
+                    <Td label="Access"><span className="block text-[16px] sm:text-[13px]">{connection.scopes.includes("mcp:read") ? "Read" : "No read access"}</span><span className="block text-[16px] sm:text-[13px] text-muted">{connection.scopes.includes("mcp:write") ? "Request changes" : "No changes"}</span></Td>
+                    <Td label="Last used">{connection.lastAuthenticatedAt ? <When value={connection.lastAuthenticatedAt} /> : <span className="text-muted">Not used yet</span>}</Td>
+                    <Td label="Expires"><When value={connection.expiresAt} /></Td>
+                    <Td label="Status"><Badge>{connection.standing}</Badge></Td>
+                    {mayRevoke ? <Td label="Action">{connection.standing === "active" ? <Button variant="danger" onClick={() => setSelected(connection)}>Revoke<span className="sr-only"> {connection.clientName} for {connection.orgSlug}</span></Button> : <span className="text-[16px] sm:text-[13px] text-muted">Already refused</span>}</Td> : null}
+                  </tr>
+                ))}</tbody></Table></TableWrap>
+              )}
+              <div className="flex flex-wrap items-center justify-between gap-3 border-t border-rule px-4 py-3 text-[16px] sm:text-[13px] leading-6 text-muted">
+                <p>{surface.hasMore ? "Showing the newest 50 credentials. " : "All issued credentials are shown. "}Measured <When value={surface.at} />.</p>
+                <Link className="inline-flex min-h-11 items-center font-medium text-ink underline underline-offset-4" href="/admin/platform/api-keys">Search all credentials</Link>
               </div>
             </Card>
-
-            <Card title="Where MCP is actually managed">
-              <div className="max-w-[72ch] space-y-3 px-4 py-4 text-[13px] leading-6 text-muted">
-                <p>
-                  On the developer&apos;s machine, by their MCP client. The server is started by the
-                  client rather than typed by a person, with{" "}
-                  <span className="font-mono text-[12.5px] text-ink">{surface.command}</span> in the
-                  repository it is to serve.
-                </p>
-                <p>
-                  Running it in a terminal looks like it has hung. That is the protocol waiting for
-                  a client, and it is the first thing to say to somebody who reports it as broken.
-                </p>
-                <p>
-                  {/* An ordinary link to the docs site, which is served from the
-                      same installation. The one thing this page can usefully do
-                      is send the reader somewhere that has the answer. */}
-                  <a
-                    className="font-medium text-ink underline underline-offset-2"
-                    href={surface.documentation}
-                  >
-                    The MCP server reference
-                  </a>{" "}
-                  documents every tool, the three verdicts, and what makes a result inconclusive.
-                </p>
-              </div>
-            </Card>
+            <p className="max-w-[75ch] text-[16px] sm:text-[13px] leading-6 text-muted">Local <code>af mcp</code> runs inside a checkout and is separate from this hosted endpoint. Its migration rehearsals and local runs are not counted here. <a className="font-medium text-ink underline underline-offset-4" href="https://antifailure.dev/docs/reference/mcp">Read the MCP setup guide</a>.</p>
           </div>
         )}
       </Loaded>
+      {selected ? <RevokeConnection key={selected.id} connection={selected} onClose={() => setSelected(null)} onDone={() => state.reload()} /> : null}
     </AdminPage>
   );
+}
+
+function RevokeConnection({ connection, onClose, onDone }: { connection: McpConnection; onClose: () => void; onDone: () => void }) {
+  const [reason, setReason] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  async function revoke() {
+    if (reason.trim().length < 8) { setError("Give a reason of at least 8 characters."); return; }
+    setBusy(true);
+    setError(null);
+    try { await revokeCredential(connection.id, reason.trim()); onDone(); onClose(); }
+    catch (failure) { setError(failure instanceof Error ? failure.message : "Revocation failed. Try again."); }
+    finally { setBusy(false); }
+  }
+  return <Confirm open title={`Revoke ${connection.clientName}?`} phrase={connection.prefix} confirmLabel="Revoke access" busy={busy} error={error} onCancel={onClose} onConfirm={() => void revoke()}>
+    <p>The next request using this credential will be refused. Work already dispatched keeps running. {connection.userLogin} must reconnect their MCP client and approve access again.</p>
+    <Field label="Reason" hint="Required. Recorded in the operator and organization audit logs."><input className={inputClass} value={reason} onChange={(event) => setReason(event.target.value)} maxLength={500} required /></Field>
+  </Confirm>;
 }

--- a/console/app/connect-mcp/layout.tsx
+++ b/console/app/connect-mcp/layout.tsx
@@ -1,0 +1,7 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = { title: "Connect an MCP client" };
+
+export default function McpConsentLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/console/app/connect-mcp/page.tsx
+++ b/console/app/connect-mcp/page.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { Suspense, useEffect, useRef, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { ApiError, rest, useSession } from "@/lib/api";
+import { Bar, Button, Lede, LinkButton, Standalone } from "@/components/ui";
+import { approvalDestination, consentParameters, pendingConsent, mcpScopeLabels, type McpConsent } from "@/lib/mcp-consent";
+
+function LoadingRequest() {
+  return (
+    <Standalone title="Connect an MCP client" width={520}>
+      <div className="mt-6 space-y-4" role="status">
+        <Bar className="h-5 w-2/3" />
+        <Bar className="h-12 w-full" />
+        <Bar className="h-12 w-full" />
+        <span className="sr-only">Loading connection request</span>
+      </div>
+    </Standalone>
+  );
+}
+
+function Connection() {
+  const params = useSearchParams();
+  const query = params.toString();
+  const session = useSession();
+  const signedIn = session.status === "ready" && session.data?.signedIn === true;
+  const organization = session.data?.orgId ?? "";
+  const requestKey = `${query}\n${organization}`;
+  const current = useRef(requestKey);
+  current.current = requestKey;
+  const submitting = useRef(false);
+  const [retry, setRetry] = useState(0);
+  const [loaded, setLoaded] = useState<{ key: string; pending?: McpConsent; error?: string } | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [writeError, setWriteError] = useState<string | null>(null);
+  const [declined, setDeclined] = useState(false);
+
+  useEffect(() => {
+    if (!signedIn || !organization) return;
+    let active = true;
+    setLoaded(null);
+    setWriteError(null);
+    setDeclined(false);
+    try { consentParameters(query); } catch (error) {
+      setLoaded({ key: requestKey, error: (error as Error).message });
+      return;
+    }
+    void rest<unknown>(`/auth/mcp/pending?${query}`, { cache: "no-store" })
+      .then((value) => {
+        const pending = pendingConsent(value, organization);
+        if (active) setLoaded({ key: requestKey, pending });
+      })
+      .catch((error: unknown) => {
+        if (active) setLoaded({
+          key: requestKey,
+          error: error instanceof ApiError || error instanceof Error
+            ? error.message
+            : "The connection request could not be loaded. Try again.",
+        });
+      });
+    return () => { active = false; };
+  }, [query, requestKey, organization, signedIn, retry]);
+
+  if (session.status === "loading") return <LoadingRequest />;
+  if (session.status === "error") {
+    return (
+      <Standalone title="Could not check your account" width={520}>
+        <Lede>We could not check whether you are signed in. No client has been connected.</Lede>
+        <div className="mt-6"><Button onClick={session.reload}>Try again</Button></div>
+      </Standalone>
+    );
+  }
+  if (!signedIn) {
+    const back = `/connect-mcp${query ? `?${query}` : ""}`;
+    return (
+      <Standalone title="Sign in to connect your client" width={520}>
+        <Lede>Your MCP client is asking to connect to Antifailure. Sign in to review the request. Signing in does not approve it.</Lede>
+        <div className="mt-6">
+          <LinkButton href={`/auth/github?redirect_to=${encodeURIComponent(back)}`} full>Continue with GitHub</LinkButton>
+        </div>
+      </Standalone>
+    );
+  }
+  if (!organization) {
+    return (
+      <Standalone title="Join an organization first" width={520}>
+        <Lede>Your account is signed in but does not belong to an organization. Open the console to finish setup or ask an owner to add you, then return here.</Lede>
+        <div className="mt-6 flex flex-wrap gap-3">
+          <LinkButton href="/environments">Open the console</LinkButton>
+          <Button onClick={session.reload}>Check again</Button>
+        </div>
+      </Standalone>
+    );
+  }
+  if (declined) {
+    return (
+      <Standalone title="Connection declined" width={520}>
+        <Lede>You have not granted this client access. You can close this page and return to your MCP client.</Lede>
+        <div className="mt-6"><LinkButton href="/environments" variant="secondary">Back to Antifailure</LinkButton></div>
+      </Standalone>
+    );
+  }
+  if (!loaded || loaded.key !== requestKey) return <LoadingRequest />;
+  if (loaded.error || !loaded.pending) {
+    return (
+      <Standalone title="Could not load this request" width={520}>
+        <Lede>{loaded.error ?? "The connection request is incomplete. Nothing has been approved."}</Lede>
+        <div className="mt-6 flex flex-wrap gap-3">
+          <Button onClick={() => setRetry((n) => n + 1)}>Try again</Button>
+          <Button onClick={() => setDeclined(true)}>Decline</Button>
+        </div>
+      </Standalone>
+    );
+  }
+
+  const pending = loaded.pending;
+  const csrf = session.data?.csrfToken ?? "";
+
+  async function approve() {
+    if (submitting.current || !csrf) return;
+    submitting.current = true;
+    setBusy(true);
+    setWriteError(null);
+    try {
+      const result = await rest<{ redirect?: unknown }>("/auth/mcp/approve", {
+        method: "POST", csrf,
+        body: Object.fromEntries(consentParameters(query)),
+      });
+      const destination = approvalDestination(result, pending.redirectUri, params.get("state"));
+      if (current.current === requestKey) window.location.assign(destination);
+    } catch (error) {
+      if (current.current === requestKey) setWriteError(error instanceof Error ? error.message : "The request could not be approved. Try again.");
+    } finally {
+      submitting.current = false;
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Standalone title="Connect your MCP client" width={520}>
+      <Lede>Review what this client will be able to do in your current organization. Approve only if you started this connection.</Lede>
+      {session.data?.label ? <p className="mt-3 text-[13px] text-muted">Signed in as {session.data.label}</p> : null}
+      <dl className="mt-6 divide-y divide-rule border-y border-rule">
+        {pending.organizationName ? <div className="py-4">
+          <dt className="text-[13px] font-medium text-muted">Organization</dt>
+          <dd className="mt-1 break-words text-base text-ink">{pending.organizationName}</dd>
+        </div> : null}
+        <div className="py-4">
+          <dt className="text-[13px] font-medium text-muted">Client requesting access</dt>
+          <dd className="mt-1 break-words text-base font-medium text-ink">{pending.clientName}</dd>
+        </div>
+        <div className="py-4">
+          <dt className="text-[13px] font-medium text-muted">Permissions</dt>
+          <dd className="mt-2 space-y-3">
+            {pending.scopes.map((scope) => (
+              <div key={scope}>
+                <p className="text-base leading-6 text-ink">{mcpScopeLabels[scope]}</p>
+                <p className="mt-1 font-mono text-[12px] text-muted">{scope}</p>
+              </div>
+            ))}
+          </dd>
+        </div>
+        <div className="py-4">
+          <dt className="text-[13px] font-medium text-muted">Access expires</dt>
+          <dd className="mt-1 text-base text-ink">In {pending.expiresInDays} days</dd>
+        </div>
+        <div className="py-4">
+          <dt className="text-[13px] font-medium text-muted">Return address after approval</dt>
+          <dd className="mt-1 break-all font-mono text-[13px] leading-6 text-ink">{pending.redirectUri}</dd>
+        </div>
+      </dl>
+      {writeError ? <p role="alert" className="mt-4 text-[13px] leading-6 text-fail">{writeError}</p> : null}
+      {!csrf ? <p role="alert" className="mt-4 text-[13px] leading-6 text-fail">Your session could not authorize this request. Reload the page to check your session again.</p> : null}
+      <div className="mt-6 grid grid-cols-2 gap-3">
+        <Button variant="primary" onClick={() => void approve()} busy={busy} disabled={!csrf} full>{busy ? "Approving" : "Approve"}</Button>
+        <Button onClick={() => setDeclined(true)} disabled={busy} full>Decline</Button>
+      </div>
+    </Standalone>
+  );
+}
+
+export default function ConnectMcpPage() {
+  return <Suspense fallback={<LoadingRequest />}><Connection /></Suspense>;
+}

--- a/console/lib/admin-platform.ts
+++ b/console/lib/admin-platform.ts
@@ -334,6 +334,11 @@ export function useDeliveries(source: string, unhandledOnly: boolean, search: st
  * ---------------------------------------------------------------------- */
 
 export interface McpSurface {
+  at: string;
+  endpoint: string | null;
+  counts: { clients: number; active: number; revoked: number; expired: number };
+  hasMore: boolean;
+  connections: McpConnection[];
   /** Whether this control plane records anything about MCP at all. Sent by the
    *  server rather than assumed here, so the day a write path exists the page
    *  changes because the server changed. */
@@ -344,6 +349,19 @@ export interface McpSurface {
   unknownFieldRefusal: string;
   command: string;
   documentation: string;
+}
+
+export interface McpConnection {
+  id: string;
+  prefix: string;
+  orgSlug: string;
+  clientName: string;
+  userLogin: string;
+  scopes: string[];
+  createdAt: string;
+  lastAuthenticatedAt: string | null;
+  expiresAt: string;
+  standing: "active" | "revoked" | "expired";
 }
 
 export function useMcpSurface() {

--- a/console/lib/mcp-consent.test.ts
+++ b/console/lib/mcp-consent.test.ts
@@ -1,0 +1,87 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { approvalDestination, consentParameters, pendingConsent } from "./mcp-consent.ts";
+
+const org = "organization-one";
+const pending = {
+  clientName: "Development assistant", scopes: ["mcp:read", "mcp:write"],
+  organization: org, organizationName: "Example team",
+  redirectUri: "https://client.example/callback", expiresInDays: 90,
+};
+
+describe("the consent request the person actually approves", () => {
+  test("preserves encoded OAuth values without changing their meaning", () => {
+    assert.deepEqual(Object.fromEntries(consentParameters("client_id=one&state=a%2Bb%26c&scope=mcp%3Aread+mcp%3Awrite")), { client_id: "one", state: "a+b&c", scope: "mcp:read mcp:write" });
+  });
+  test("refuses duplicated parameters before approval can collapse them", () => {
+    assert.throws(() => consentParameters("client_id=one&client_id=two"), /repeats a parameter/);
+  });
+  test("shows the server's actual client, organization and permissions", () => {
+    assert.deepEqual(pendingConsent(pending, org), pending);
+  });
+  test("a read-only request never gains a write scope", () => {
+    assert.deepEqual(pendingConsent({ ...pending, scopes: ["mcp:read"] }, org).scopes, ["mcp:read"]);
+  });
+  test("a malformed optional organization name is not rendered as an object", () => {
+    assert.equal(pendingConsent({ ...pending, organizationName: {} }, org).organizationName, undefined);
+  });
+  for (const [name, value] of Object.entries({
+    missing: null,
+    client: { ...pending, clientName: " " },
+    organization: { ...pending, organization: "another-organization" },
+    emptyScopes: { ...pending, scopes: [] },
+    unknownScope: { ...pending, scopes: ["admin:all"] },
+    repeatedScope: { ...pending, scopes: ["mcp:read", "mcp:read"] },
+    lifetime: { ...pending, expiresInDays: 365 },
+  })) {
+    test(`refuses incomplete consent: ${name}`, () => {
+      assert.throws(() => pendingConsent(value, org), /incomplete or does not belong/);
+    });
+  }
+  test("an invalid pending address produces a human error", () => {
+    assert.throws(() => pendingConsent({ ...pending, redirectUri: "not a url" }, org), /invalid return address/);
+  });
+  for (const [name, redirectUri] of Object.entries({ script: "javascript:alert(1)", credentials: "https://user:pass@client.example/callback", fragment: "https://client.example/callback#other" })) {
+    test(`refuses unsafe pending address: ${name}`, () => {
+      assert.throws(() => pendingConsent({ ...pending, redirectUri }, org), /unsupported return address/);
+    });
+  }
+});
+
+describe("approval returns only to the address and request shown", () => {
+  const uri = "https://client.example/callback?client=desktop";
+  const valid = `${uri}&code=issued-code&state=a%2Bb%26c`;
+  test("preserves the registered query and encoded state", () => {
+    assert.equal(approvalDestination({ redirect: valid }, uri, "a+b&c"), valid);
+  });
+  test("a request without state does not invent one", () => {
+    assert.equal(approvalDestination({ redirect: `${uri}&code=issued-code` }, uri, null), `${uri}&code=issued-code`);
+  });
+  test("an incomplete approval cannot navigate", () => {
+    assert.throws(() => approvalDestination({}, uri, null), /response was incomplete/);
+  });
+  test("an invalid approval address produces a human error", () => {
+    assert.throws(() => approvalDestination({ redirect: "not a url" }, uri, null), /invalid address/);
+  });
+  for (const [name, redirect] of Object.entries({
+    origin: valid.replace("client.example", "different.example"),
+    path: valid.replace("/callback", "/other"),
+    registeredQuery: valid.replace("client=desktop", "client=other"),
+    duplicateRegisteredQuery: valid + "&client=other",
+    extraParameter: valid + "&next=https%3A%2F%2Fdifferent.example",
+    missingCode: valid.replace("&code=issued-code", ""),
+    emptyCode: valid.replace("issued-code", ""),
+    repeatedCode: valid + "&code=other",
+    wrongState: valid.replace("a%2Bb%26c", "other"),
+    repeatedState: valid + "&state=a%2Bb%26c",
+    credentials: valid.replace("https://", "https://user:pass@"),
+    fragment: valid + "#other",
+  })) {
+    test(`rejects a different approval: ${name}`, () => {
+      assert.throws(() => approvalDestination({ redirect }, uri, "a+b&c"), /different address or request/);
+    });
+  }
+  test("an unsolicited state cannot replace a request without state", () => {
+    assert.throws(() => approvalDestination({ redirect: valid }, uri, null), /different address or request/);
+  });
+});

--- a/console/lib/mcp-consent.ts
+++ b/console/lib/mcp-consent.ts
@@ -1,0 +1,69 @@
+export interface McpConsent {
+  clientName: string;
+  scopes: string[];
+  organization: string;
+  organizationName?: string;
+  redirectUri: string;
+  expiresInDays: number;
+}
+
+export const mcpScopeLabels: Record<string, string> = {
+  "mcp:read": "Read projects, environments, runs and reported network activity.",
+  "mcp:write": "Start environments and test workflows, and request environment cleanup.",
+};
+
+export function consentParameters(query: string): URLSearchParams {
+  const params = new URLSearchParams(query);
+  if ([...params.keys()].some((key) => params.getAll(key).length !== 1)) {
+    throw new Error("The connection request repeats a parameter. Return to your MCP client and start a new connection.");
+  }
+  return params;
+}
+
+export function pendingConsent(value: unknown, organization: string): McpConsent {
+  const p = value as Partial<McpConsent> | null;
+  if (!p || typeof p.clientName !== "string" || !p.clientName.trim() ||
+    p.organization !== organization || typeof p.redirectUri !== "string" ||
+    !Array.isArray(p.scopes) || p.scopes.length === 0 ||
+    !p.scopes.every((scope) => typeof scope === "string" && Object.hasOwn(mcpScopeLabels, scope)) ||
+    new Set(p.scopes).size !== p.scopes.length || p.expiresInDays !== 90) {
+    throw new Error("The connection request is incomplete or does not belong to your organization. Nothing has been approved.");
+  }
+  let destination: URL;
+  try { destination = new URL(p.redirectUri); } catch {
+    throw new Error("The connection request has an invalid return address. Nothing has been approved.");
+  }
+  if (!["https:", "http:"].includes(destination.protocol) || destination.username || destination.password || destination.hash) {
+    throw new Error("The connection request has an unsupported return address. Nothing has been approved.");
+  }
+  return {
+    clientName: p.clientName,
+    scopes: p.scopes,
+    organization: p.organization,
+    organizationName: typeof p.organizationName === "string" ? p.organizationName : undefined,
+    redirectUri: p.redirectUri,
+    expiresInDays: p.expiresInDays,
+  };
+}
+
+/** The server registers the destination. Its approval may add only code and state. */
+export function approvalDestination(value: unknown, registeredUri: string, state: string | null): string {
+  const result = value as { redirect?: unknown } | null;
+  if (typeof result?.redirect !== "string") {
+    throw new Error("The approval response was incomplete. Return to your client before trying again.");
+  }
+  let destination: URL;
+  try { destination = new URL(result.redirect); } catch {
+    throw new Error("The approval response has an invalid address. Return to your client before trying again.");
+  }
+  const registered = new URL(registeredUri);
+  if (destination.origin !== registered.origin || destination.pathname !== registered.pathname ||
+    destination.username || destination.password || destination.hash ||
+    ![...registered.searchParams.keys()].every((key) => JSON.stringify(destination.searchParams.getAll(key)) === JSON.stringify(registered.searchParams.getAll(key))) ||
+    ![...destination.searchParams.keys()].every((key) => registered.searchParams.has(key) || key === "code" || key === "state") ||
+    destination.searchParams.getAll("code").length !== 1 || !destination.searchParams.get("code") ||
+    destination.searchParams.getAll("state").length !== (state === null ? 0 : 1) || destination.searchParams.get("state") !== state) {
+    throw new Error("The approval response returned a different address or request. Return to your client before trying again.");
+  }
+  return destination.toString();
+}

--- a/docs/plans/2026-09-04-hosted-mcp.md
+++ b/docs/plans/2026-09-04-hosted-mcp.md
@@ -1,0 +1,33 @@
+# Hosted MCP
+
+The hosted endpoint complements the local standard-input server. It does not
+pretend that a cloud service can read a developer's checkout. Remote tools read
+reported projects, environments, runs and network events, or dispatch work through
+the existing customer-owned execution path.
+
+Use the official TypeScript SDK's stateless JSON Streamable HTTP transport. A
+server process per request avoids routing session memory between replicas.
+Standalone event streams are not supported and answer 405. Authentication is
+required for every protocol request, not only initialization.
+
+Browser authorization uses dynamic public-client registration, exact redirect URI
+matching and PKCE S256. The existing product session approves a specific client,
+organization, resource and scope. Codes expire after five minutes. Claiming a code
+and minting its access token share a transaction so a failed write cannot consume
+the grant and concurrent exchanges cannot issue two credentials.
+
+MCP tokens are distinct from engine and CLI credentials, stored only as hashes,
+bound to the configured endpoint, and checked for expiry and revocation on every
+request. Membership and role are read again. The current grant lasts ninety days,
+is revocable, and does not issue refresh tokens. The consent screen states this
+lifetime before approval.
+
+The management page must show only recorded facts: registrations, issued grants,
+their expiry, revocation and last authenticated request. Stateless HTTP requests
+are not persistent connections. Existing audited credential revocation is reused.
+Local tool invocations are not included in hosted counts.
+
+Validation includes real PostgreSQL policies, actual mounted HTTP endpoints,
+independent mutation tests, browser consent, a real SDK client and explicit negative
+controls for tenant, role, scope, audience, expiry, replay and CSRF boundaries.
+Production delivery remains subject to the release and deployment gates.

--- a/docs/plans/2026-09-04-mcp-management-design.md
+++ b/docs/plans/2026-09-04-mcp-management-design.md
@@ -1,0 +1,19 @@
+# MCP management
+
+The operator page will show the configured hosted endpoint, registered OAuth
+clients, and the credentials issued to people and organizations. Counts come
+from the database. Last authentication is not called a connection or a tool
+run. Local checkout tools remain documented separately.
+
+The existing audited credential revocation route is the chosen write path.
+A second MCP-only revocation implementation would duplicate authorization and
+audit behavior. A documentation-only page would leave the new endpoint
+unmanageable. The page uses the existing confirmation dialog and requires an
+operator reason and the credential prefix before revocation.
+
+The query returns the newest fifty credentials, an explicit truncation flag,
+and whole-installation counts. The page provides the existing searchable key
+directory for the rest. Database errors render the shared retry state; an
+empty installation explains how a client connects. Browser verification covers
+desktop, mobile, empty and populated states, refusal, and successful revocation.
+Database assertions are independently mutation tested before integration.

--- a/docs/plans/2026-09-04-mcp-management-verification.md
+++ b/docs/plans/2026-09-04-mcp-management-verification.md
@@ -40,6 +40,11 @@ not a mock response page. The operator signed in through the normal form.
 - Revocation required the prefix and a reason. Submitting it closed the dialog,
   removed the action, reduced active credentials from one to zero, and increased
   revoked credentials from one to two.
+- A separate cross-component probe minted a real hosted credential through the
+  OAuth implementation and exercised the mounted MCP handler. Tools listing
+  returned HTTP 200. After revoking that same credential in this page's browser
+  dialog, replaying the same bearer returned HTTP 401. The raw credential stayed
+  in process memory rather than appearing in a command argument or report.
 - A network failure showed the shared error and a working retry action.
 - A failed refresh after successful revocation retained the prior data with an
   explicit stale-answer warning. Retry recovered the updated credential state.

--- a/docs/plans/2026-09-04-mcp-management-verification.md
+++ b/docs/plans/2026-09-04-mcp-management-verification.md
@@ -1,0 +1,52 @@
+# MCP management verification
+
+This change is intended to land with the hosted MCP schema and transport. It
+does not duplicate that migration. Local API verification applied the migration
+as a fixture to a private UTF-8 Postgres database on a separate native server.
+
+## Database assertions
+
+Seven new tests pass. The existing developer platform suite also passes, for
+25 tests total and no skips. Each mutation below failed its intended assertion,
+then passed after the production line was restored. Mutations were applied one
+at a time.
+
+| Test | Independent production mutations caught |
+| --- | --- |
+| Counts only MCP credentials | Include an engine credential; exclude the exact expiry boundary |
+| Configured endpoint | Return the wrong endpoint path |
+| Credential metadata | Wrong client, wrong organization, missing scopes, missing last authentication, leaked hash field |
+| Distinct standing | Report an expired credential as active |
+| Revocation | Disable the database update; give the wrong replacement instruction |
+| Searchable directory | Remove MCP from the accepted filter kinds |
+| Bounded list | Return a fifty-first credential; suppress the truncation flag |
+| Existing surface contract | Claim that no MCP records exist |
+
+There are fifteen mutation cells. The existing credential tests additionally
+prove the shared revocation route records the audit entry and stops an engine
+credential authenticating. The hosted MCP authenticator is verified separately
+in the transport change.
+
+## Browser behavior
+
+The actual built console was served by the actual API with a private database,
+not a mock response page. The operator signed in through the normal form.
+
+- Populated and empty states were inspected at desktop and phone widths.
+- Final screenshots were inspected at 1440 pixels and 320 pixels, with both
+  light and dark preferences. This product deliberately retains its light
+  palette for either preference.
+- The 320 and 390 pixel viewports had no page overflow.
+- Revocation required the prefix and a reason. Submitting it closed the dialog,
+  removed the action, reduced active credentials from one to zero, and increased
+  revoked credentials from one to two.
+- A network failure showed the shared error and a working retry action.
+- A failed refresh after successful revocation retained the prior data with an
+  explicit stale-answer warning. Retry recovered the updated credential state.
+- A read-only operator had no action column.
+- The page accessibility audit reported zero violations. It reported existing
+  incomplete checks for shared time labels and duplicate navigation IDs; the
+  navigation fix belongs to the separate operator accessibility change.
+
+Console unit tests: 140 passed. Console build: 46 routes. API typecheck passed.
+No production deployment or GitHub CI result is claimed by this local report.

--- a/docs/src/content/docs/reference/api.md
+++ b/docs/src/content/docs/reference/api.md
@@ -65,7 +65,10 @@ below that take no session either.
 | `POST /v1/pr/callback-token` | a GitHub Actions workflow identity token | Exchanges a job's own identity for a credential scoped to one commit. |
 | `POST /v1/pr/report` | that credential | What a job says about the commit it checked. |
 | `POST /webhooks/github`, `POST /webhooks/stripe` | an HMAC over the raw body | Deliveries. Verified before the body is parsed, and each one handled once. |
-| `/auth/*` | varies | GitHub sign in for a browser, and the device flow `af login` uses. |
+| `/auth/*` | varies | GitHub sign in for a browser, the device flow `af login` uses, and the browser consent an MCP client is sent through. |
+| `POST /mcp` | an MCP access token issued by that consent | The hosted Model Context Protocol endpoint. Stateless JSON only, so `GET /mcp` and `DELETE /mcp` answer `405` with an `Allow: POST` header rather than opening an event stream this endpoint would have no session for. See [MCP](/docs/reference/mcp). |
+| `GET /.well-known/oauth-protected-resource` | none | Which resource `/mcp` is and which authorization server issues tokens for it, read by an MCP client before it authorizes. The resource is the configured public origin rather than the request's `Host`, so a token cannot be minted for an audience somebody else named. |
+| `GET /.well-known/oauth-authorization-server` | none | The authorization, token and registration endpoints, `authorization_code` as the one grant, and `S256` as the one challenge method. |
 | `GET /exports/deletion` | the token in the link, and nothing else | Downloads the export of an organization that has been deleted. |
 | `POST /v1/leads` | none | The enterprise contact form on the marketing site. The only route here that answers a cross-origin browser, allowed for one exact origin from `AF_SITE_ORIGIN` and carrying no credentials. Writes a row the serving role can insert into and cannot read back; an operator reads the queue with `af-control-plane-backup leads`. |
 | `POST /webhooks/github` | HMAC signature | Deliveries from the GitHub App. No session and no token: the body's signature is the credential, and an unsigned delivery is refused. |

--- a/docs/src/content/docs/reference/mcp.md
+++ b/docs/src/content/docs/reference/mcp.md
@@ -10,13 +10,13 @@ Context Protocol. An agent can ask what a migration would do to production
 shaped data, and what the environment reached for on the network, without
 being able to ask for either question to be made easier.
 
-It is started by an MCP client rather than typed by a person. It speaks the
+The local server is started by an MCP client rather than typed by a person. It speaks the
 protocol on standard input and output, so running it in a terminal looks like
 it has hung; that is the protocol waiting for a client.
 
 ## Connecting a local client
 
-In v1.1.1, `af mcp` is a local STDIO server. A client starts the process,
+`af mcp` is a local STDIO server. A client starts the process,
 talks to it over standard input and output, and stops it. The server binds the
 project it starts in and serves only that project, so the client must start it
 in the checkout or pass the checkout with `-C`.
@@ -180,41 +180,53 @@ In Claude Code, `/mcp` lists the configured servers and their state.
 `antifailure.yaml`. The server states it in its handshake instructions and at
 the end of every tool description, so an agent reads it rather than guessing.
 
-## Browser clients and remote bridges
+## Connecting to the control plane
 
-Antifailure v1.1.1 does not provide a hosted MCP endpoint yet. `claude.ai` and
-ChatGPT in a browser cannot start `af mcp` on your machine. Claude custom
-connectors need a remote MCP URL, while ChatGPT web receives remote MCP tools
-through plugins and does not read local Codex configuration.
+The hosted server uses authenticated Streamable HTTP at `/mcp` on the control
+plane's public origin. It reads reported project state and requests work through
+the same permissions and customer-owned execution paths as the console. It does
+not read a checkout on your laptop or impersonate the local rehearsal tools.
 
-A gateway can adapt this local STDIO server to Streamable HTTP. Current
-[Supergateway](https://github.com/supercorp-ai/supergateway) listens on every
-network interface and does not authenticate incoming clients. The command
-below demonstrates the transport conversion only. Run it inside an isolated
-network where port 8000 is unreachable until an authenticating HTTPS proxy is
-in front of it:
+In an MCP client that supports Streamable HTTP and OAuth with PKCE, add the URL
+shown on the operator's MCP management page. Sign in when the client opens the
+browser, check the organization, client name, callback address and requested
+permissions, then choose **Approve**. Declining creates no credential. You do
+not need to copy an API key into the client.
 
-```sh
-npx -y supergateway \
-  --stdio "af -C /absolute/path/to/your/project mcp" \
-  --outputTransport streamableHttp \
-  --port 8000
-```
+The server supports two permissions: `mcp:read` reads projects and recorded
+activity; `mcp:write` requests environments, workflow runs and cleanup. These
+permissions never grant more than your current organization role. A viewer who
+approves write access still cannot start an environment.
 
-That creates the Streamable HTTP endpoint `http://localhost:8000/mcp`.
-Supergateway defaults a STDIO input to SSE when `--outputTransport` is omitted,
-so the shorter command does not create this endpoint.
+An approved credential expires after ninety days. Removing membership or revoking
+the credential stops subsequent requests. Operators can revoke a credential on
+MCP management; an authorized tenant administrator can revoke it in the CLI token
+directory. Reconnect through the client after expiry or revocation.
 
-The command above is a transport adapter, not an authentication boundary. Do
-not publish or tunnel that endpoint as shown. A remote deployment also needs
-authorization for every caller and an isolated checkout and execution host for
-the project it serves. Anyone allowed through can invoke the rehearsal tools,
-which start containers, read the checkout and operate on production shaped
-data. Running that bridge is possible, but it is an operationally sensitive
-service rather than a safe copy and paste connection step.
+| Hosted tool | What it actually does |
+| --- | --- |
+| `list_projects` | Lists repositories connected to your organization. |
+| `list_environments` | Reads recorded environment state, with a bounded page and cursor. |
+| `list_runs` | Reads recorded runs, newest first, with a bounded page. |
+| `get_run` | Reads one recorded run's metadata by UUID, not the local rehearsal evidence contract. |
+| `inspect_recorded_egress` | Reads reported host and mode counts. Missing events are not proof of containment. |
+| `start_environment` | Dispatches an environment request through the repository workflow, subject to permissions and spending limits. |
+| `run_workflows` | Dispatches the manifest's workflows through the repository workflow. |
+| `stop_environment` | Requests cleanup. It does not claim resources disappeared before the runtime confirms it. |
 
-A hosted Antifailure endpoint is not part of v1.1.1. That is the current
-product state, not a permanent limit on the architecture.
+Use the returned project or environment identifiers rather than guessing them.
+A dispatch is not a completed run, and a run without results is not a pass.
+The hosted endpoint does not offer arguments that replace the database URL,
+weaken masking or widen network policy.
+
+An installation must include the hosted server and configure its public origin
+before this URL works. Older installations, including the original v1.1.1
+release, provide the local server only. A `404` from `/mcp` on such an installation
+is not a bad password; update the control plane before connecting remotely.
+
+The rest of this reference describes the four **local rehearsal tools**. Their
+`project_id`, verdict and on-disk run contracts do not apply to the hosted tool
+names above.
 
 ## The division of authority
 

--- a/web/apps/api/package.json
+++ b/web/apps/api/package.json
@@ -24,6 +24,7 @@
     "@antifailure/policy": "*",
     "@hono/node-server": "^2.1.1",
     "@hono/trpc-server": "^0.4.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "@trpc/server": "^11.18.0",
     "hono": "^4.13.5",
     "postgres": "^3.4.9",

--- a/web/apps/api/src/admin/permissions.ts
+++ b/web/apps/api/src/admin/permissions.ts
@@ -113,10 +113,8 @@ export const ADMIN_PERMISSIONS = [
   // What arrives here from GitHub and from Stripe, and whether it was handled.
   'admin.webhooks.read',
 
-  // The MCP page, which reads no customer data at all. It is guarded because
-  // every route in this tree is guarded, not because what it returns is
-  // sensitive: it describes the engine's own tool surface and states that this
-  // control plane holds no MCP record.
+  // Hosted MCP registrations and credential metadata across organizations.
+  // Revocation remains a separate credential permission.
   'admin.mcp.read',
   // The product itself: twins, the runs on them, and the branches they belong
   // to. One read covers all three because they are one object seen from three
@@ -277,7 +275,7 @@ export const ADMIN_PERMISSION_DESCRIPTIONS: Record<AdminPermission, string> = {
     'See the GitHub App installations and the deliveries that arrived from GitHub and Stripe, ' +
     'including the ones that were never handled.',
   'admin.mcp.read':
-    'See what this control plane records about the MCP server, and the tools the engine serves.',
+    'See hosted MCP clients, credential status, organizations, approving users and last authentication times.',
   'admin.product.read':
     'See every production twin on the installation, the agent runs, load runs and pull request ' +
     'checks against them, and the branches holding them open.',

--- a/web/apps/api/src/admin/platform.ts
+++ b/web/apps/api/src/admin/platform.ts
@@ -467,7 +467,7 @@ const repositoriesRouter = router({
 // and a customer can agree which credential they are talking about without
 // either of them holding one.
 
-const KEY_KINDS = ['engine', 'cli', 'oidc'] as const
+const KEY_KINDS = ['engine', 'cli', 'oidc', 'mcp'] as const
 
 const credentialsRouter = router({
   list: adminProcedure('admin.keys.read')
@@ -630,7 +630,9 @@ const credentialsRouter = router({
           effect:
             'The next request presenting this credential is refused. Anything already running ' +
             'keeps running until it next calls the control plane. Nobody can recover the value: ' +
-            'the customer creates a replacement with af token create.',
+            (token.kind === 'mcp'
+              ? 'the customer reconnects their MCP client and approves a new credential.'
+              : 'the customer creates a replacement with af token create.'),
         }
       })
     }),
@@ -936,25 +938,50 @@ const integrationsRouter = router({
 
 const mcpRouter = router({
   /**
-   * What this control plane knows about MCP, which is that it knows nothing.
-   *
-   * `recordsAnything: false` is the answer, sent as a field rather than left
-   * for the console to assume, so the day a write path does exist the page
-   * changes because the server changed. A console that hardcoded the absence
-   * would keep saying it after it stopped being true.
-   *
-   * Everything else here is a checked-in fact about the engine, carrying the
-   * file and symbol it came from. mcp.test.ts opens each one, so a tool renamed
-   * or unregistered in the engine fails this suite rather than leaving a page
-   * describing a product that changed underneath it.
+   * Hosted client registrations and issued credentials, not open sockets or
+   * tool executions. The separate local tool catalog is retained for callers
+   * that link to the checkout protocol; those sessions send no telemetry here.
    */
-  surface: adminProcedure('admin.mcp.read').query(() => ({
-    recordsAnything: false,
-    why:
-      'af mcp binds one checkout, speaks the protocol on standard input and output, and keeps ' +
-      'its runs in that project\'s own state directory. It opens no connection to this control ' +
-      'plane, presents no credential and sends no event, so there is nothing here to list, ' +
-      'count or manage.',
+  surface: adminProcedure('admin.mcp.read').query(async ({ ctx }) => {
+    const c = ctx as AdminContext
+    const now = c.clock.now().toISOString()
+    const recorded = await c.adminDb(async (db) => {
+      const totals = await db.execute<{ clients: string; active: string; revoked: string; expired: string }>(sql`
+        SELECT (SELECT count(*)::text FROM mcp_clients) AS clients,
+          count(*) FILTER (WHERE revoked_at IS NULL AND expires_at > ${now}::timestamptz)::text AS active,
+          count(*) FILTER (WHERE revoked_at IS NOT NULL)::text AS revoked,
+          count(*) FILTER (WHERE revoked_at IS NULL AND expires_at <= ${now}::timestamptz)::text AS expired
+FROM engine_tokens WHERE kind = 'mcp'`)
+      const rows = await db.execute<{
+        id: string; prefix: string; org_slug: string; client_name: string; user_login: string;
+        scopes: string[]; created_at: Date | string; last_used_at: Date | string | null;
+        expires_at: Date | string; revoked_at: Date | string | null;
+      }>(sql`
+        SELECT t.id, t.prefix, o.slug AS org_slug, cl.client_name,
+          u.github_login AS user_login, t.scopes, t.created_at, t.last_used_at, t.expires_at, t.revoked_at
+        FROM engine_tokens t JOIN organizations o ON o.id = t.org_id
+        JOIN mcp_clients cl ON cl.client_id = t.mcp_client_id
+        JOIN users u ON u.id = t.user_id
+        WHERE t.kind = 'mcp'
+        ORDER BY t.created_at DESC, t.id DESC LIMIT 51`)
+      return {
+        counts: { clients: Number(totals[0]?.clients ?? 0), active: Number(totals[0]?.active ?? 0),
+          revoked: Number(totals[0]?.revoked ?? 0), expired: Number(totals[0]?.expired ?? 0) },
+        hasMore: rows.length > 50,
+        connections: rows.slice(0, 50).map((r) => ({
+          id: r.id, prefix: r.prefix, orgSlug: r.org_slug, clientName: r.client_name,
+          userLogin: r.user_login, scopes: r.scopes, createdAt: iso(r.created_at),
+          lastAuthenticatedAt: isoOrNull(r.last_used_at), expiresAt: iso(r.expires_at),
+          standing: r.revoked_at !== null ? 'revoked' : new Date(r.expires_at).getTime() <= c.clock.now().getTime() ? 'expired' : 'active',
+        })),
+      }
+    })
+    return {
+    ...recorded,
+    at: now,
+    endpoint: /^https?:\/\//.test(c.appBaseUrl) ? `${c.appBaseUrl.replace(/\/+$/, '')}/mcp` : null,
+    recordsAnything: true,
+    why: 'Hosted OAuth registrations and credentials are recorded here. Local af mcp sessions stay on the developer\'s machine.',
     tools: MCP_TOOLS.map((t) => ({
       name: t.name,
       does: t.does,
@@ -965,7 +992,8 @@ const mcpRouter = router({
     unknownFieldRefusal: MCP_UNKNOWN_FIELD_REFUSAL,
     command: MCP_ELSEWHERE.command,
     documentation: MCP_ELSEWHERE.documentation,
-  })),
+    }
+  }),
 })
 
 /**

--- a/web/apps/api/src/admin/platform.ts
+++ b/web/apps/api/src/admin/platform.ts
@@ -951,7 +951,7 @@ const mcpRouter = router({
           count(*) FILTER (WHERE revoked_at IS NULL AND expires_at > ${now}::timestamptz)::text AS active,
           count(*) FILTER (WHERE revoked_at IS NOT NULL)::text AS revoked,
           count(*) FILTER (WHERE revoked_at IS NULL AND expires_at <= ${now}::timestamptz)::text AS expired
-FROM engine_tokens WHERE kind = 'mcp'`)
+        FROM engine_tokens WHERE kind = 'mcp'`)
       const rows = await db.execute<{
         id: string; prefix: string; org_slug: string; client_name: string; user_login: string;
         scopes: string[]; created_at: Date | string; last_used_at: Date | string | null;
@@ -977,21 +977,21 @@ FROM engine_tokens WHERE kind = 'mcp'`)
       }
     })
     return {
-    ...recorded,
-    at: now,
-    endpoint: /^https?:\/\//.test(c.appBaseUrl) ? `${c.appBaseUrl.replace(/\/+$/, '')}/mcp` : null,
-    recordsAnything: true,
-    why: 'Hosted OAuth registrations and credentials are recorded here. Local af mcp sessions stay on the developer\'s machine.',
-    tools: MCP_TOOLS.map((t) => ({
-      name: t.name,
-      does: t.does,
-      refuses: t.refuses,
-      servedBy: t.servedBy,
-    })),
-    registeredIn: MCP_REGISTRATION_FILE,
-    unknownFieldRefusal: MCP_UNKNOWN_FIELD_REFUSAL,
-    command: MCP_ELSEWHERE.command,
-    documentation: MCP_ELSEWHERE.documentation,
+      ...recorded,
+      at: now,
+      endpoint: /^https?:\/\//.test(c.appBaseUrl) ? `${c.appBaseUrl.replace(/\/+$/, '')}/mcp` : null,
+      recordsAnything: true,
+      why: 'Hosted OAuth registrations and credentials are recorded here. Local af mcp sessions stay on the developer\'s machine.',
+      tools: MCP_TOOLS.map((t) => ({
+        name: t.name,
+        does: t.does,
+        refuses: t.refuses,
+        servedBy: t.servedBy,
+      })),
+      registeredIn: MCP_REGISTRATION_FILE,
+      unknownFieldRefusal: MCP_UNKNOWN_FIELD_REFUSAL,
+      command: MCP_ELSEWHERE.command,
+      documentation: MCP_ELSEWHERE.documentation,
     }
   }),
 })

--- a/web/apps/api/src/admin/platform.ts
+++ b/web/apps/api/src/admin/platform.ts
@@ -65,6 +65,7 @@ import { sql } from 'drizzle-orm'
 import { TRPCError } from '@trpc/server'
 import { router } from '../trpc.ts'
 import { adminProcedure, adminAudit, type AdminContext } from './trpc.ts'
+import { hostedMcpEndpoint } from '../auth/mcp.ts'
 import {
   MCP_ELSEWHERE,
   MCP_REGISTRATION_FILE,
@@ -979,7 +980,7 @@ const mcpRouter = router({
     return {
       ...recorded,
       at: now,
-      endpoint: /^https?:\/\//.test(c.appBaseUrl) ? `${c.appBaseUrl.replace(/\/+$/, '')}/mcp` : null,
+      endpoint: hostedMcpEndpoint(c.appBaseUrl),
       recordsAnything: true,
       why: 'Hosted OAuth registrations and credentials are recorded here. Local af mcp sessions stay on the developer\'s machine.',
       tools: MCP_TOOLS.map((t) => ({

--- a/web/apps/api/src/auth/mcp.ts
+++ b/web/apps/api/src/auth/mcp.ts
@@ -8,6 +8,27 @@ import type { Actor } from '../trpc.ts'
 import { ROLES } from '../permissions.ts'
 
 export const MCP_SCOPES = ['mcp:read', 'mcp:write'] as const
+
+/**
+ * The hosted endpoint an installation serves, or null when it serves none.
+ *
+ * One function rather than the same three rules written twice. The server used
+ * to compute this to mount the route and decide the OAuth audience, and the
+ * operator page computed it again to print on screen, so a change to either
+ * could leave the page naming an address the server does not answer on.
+ *
+ * The trailing slashes are stripped with a bounded loop rather than with
+ * `/\/+$/`, which CodeQL flags as polynomial and is: on a value that does NOT
+ * end in a slash the engine retries the match from every slash in it, so the
+ * cost is quadratic in the length of a configured URL. A loop is linear and
+ * says what it does.
+ */
+export function hostedMcpEndpoint(appBaseUrl: string): string | null {
+  if (!/^https?:\/\//.test(appBaseUrl)) return null
+  let origin = appBaseUrl
+  while (origin.endsWith('/')) origin = origin.slice(0, -1)
+  return `${origin}/mcp`
+}
 const CODE_TTL_MS = 5 * 60 * 1000
 const TOKEN_TTL_MS = 90 * 24 * 60 * 60 * 1000
 const digest = (value: string): Buffer => createHash('sha256').update(value).digest()

--- a/web/apps/api/src/auth/mcp.ts
+++ b/web/apps/api/src/auth/mcp.ts
@@ -1,0 +1,195 @@
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto'
+import { sql } from 'drizzle-orm'
+import { z } from 'zod'
+import type { Pool } from '@antifailure/db'
+import { appendAudit } from '@antifailure/db'
+import type { Clock } from '../clock.ts'
+import type { Actor } from '../trpc.ts'
+import { ROLES } from '../permissions.ts'
+
+export const MCP_SCOPES = ['mcp:read', 'mcp:write'] as const
+const CODE_TTL_MS = 5 * 60 * 1000
+const TOKEN_TTL_MS = 90 * 24 * 60 * 60 * 1000
+const digest = (value: string): Buffer => createHash('sha256').update(value).digest()
+const timestamp = (value: Date | string): number => new Date(value).getTime()
+
+export class McpAuthorizationError extends Error {
+  readonly code: string
+  constructor(code: string, message: string) { super(message); this.code = code }
+}
+
+const redirectUri = z.string().max(2048).refine((value) => {
+  try {
+    const url = new URL(value)
+    const loopback = ['127.0.0.1', '[::1]', 'localhost'].includes(url.hostname)
+    return !url.username && !url.password && !url.hash &&
+      (url.protocol === 'https:' || (url.protocol === 'http:' && loopback))
+  } catch { return false }
+}, 'Use an HTTPS redirect URI, or HTTP on loopback for a local client.')
+
+const registration = z.object({
+  client_name: z.string().trim().min(1).max(200).default('MCP client'),
+  redirect_uris: z.array(redirectUri).min(1).max(10),
+  token_endpoint_auth_method: z.literal('none').default('none'),
+  grant_types: z.array(z.literal('authorization_code')).length(1).default(['authorization_code']),
+  response_types: z.array(z.literal('code')).length(1).default(['code']),
+})
+
+export async function registerMcpClient(pool: Pool, input: unknown) {
+  const parsed = registration.safeParse(input)
+  if (!parsed.success) {
+    throw new McpAuthorizationError('invalid_client_metadata', 'Register an authorization-code client using PKCE and exact redirect URIs.')
+  }
+  const clientId = randomBytes(32).toString('base64url')
+  const data = parsed.data
+  await pool.withoutTenant(async (db) => {
+    await db.execute(sql`INSERT INTO mcp_clients (client_id, client_name, redirect_uris)
+      VALUES (${clientId}, ${data.client_name}, ${sql.param(data.redirect_uris)}::text[])`)
+  }, { mcpClientId: clientId })
+  return { client_id: clientId, ...data }
+}
+
+const authorization = z.object({
+  client_id: z.string().min(1).max(200),
+  redirect_uri: redirectUri,
+  response_type: z.literal('code'),
+  code_challenge: z.string().regex(/^[A-Za-z0-9_-]{43}$/),
+  code_challenge_method: z.literal('S256'),
+  resource: z.string().max(2048),
+  scope: z.string().max(100).default('mcp:read'),
+  state: z.string().max(2048).optional(),
+})
+
+export async function describeMcpAuthorization(pool: Pool, input: unknown, resource: string) {
+  const parsed = authorization.safeParse(input)
+  if (!parsed.success) throw new McpAuthorizationError('invalid_request', 'This connection needs a valid PKCE S256 authorization request.')
+  const request = parsed.data
+  if (request.resource !== resource) throw new McpAuthorizationError('invalid_target', 'The requested resource is not this MCP endpoint.')
+  const scopes = [...new Set(request.scope.split(' ').filter(Boolean))]
+  if (!scopes.length || scopes.some((scope) => !MCP_SCOPES.includes(scope as typeof MCP_SCOPES[number]))) {
+    throw new McpAuthorizationError('invalid_scope', 'This endpoint supports mcp:read and mcp:write.')
+  }
+  const client = await pool.withoutTenant(async (db) => {
+    const rows = await db.execute<{ client_name: string; redirect_uris: string[] }>(sql`
+      SELECT client_name, redirect_uris FROM mcp_clients WHERE client_id = ${request.client_id}`)
+    return rows[0]
+  }, { mcpClientId: request.client_id })
+  if (!client || !client.redirect_uris.includes(request.redirect_uri)) {
+    throw new McpAuthorizationError('invalid_request', 'The client or redirect URI is not registered.')
+  }
+  return { request, scopes, clientName: client.client_name }
+}
+
+export async function approveMcpAuthorization(
+  pool: Pool, clock: Clock, actor: Actor, input: unknown, resource: string,
+) {
+  const approval = await describeMcpAuthorization(pool, input, resource)
+  const code = randomBytes(32).toString('base64url')
+  const hash = digest(code)
+  const expires = new Date(clock.now().getTime() + CODE_TTL_MS)
+  await pool.withTenant({ orgId: actor.orgId, userId: actor.userId }, async (db) => {
+    const membership = await db.execute(sql`SELECT user_id FROM members
+      WHERE user_id = ${actor.userId}::uuid AND org_id = ${actor.orgId}::uuid FOR SHARE`)
+    if (!membership.length) throw new McpAuthorizationError('access_denied', 'You no longer belong to this organization.')
+    await db.execute(sql`INSERT INTO mcp_authorization_codes
+      (code_hash, client_id, redirect_uri, code_challenge, code_challenge_method,
+       scopes, resource, approved_user_id, approved_org_id, expires_at)
+      VALUES (${hash}, ${approval.request.client_id}, ${approval.request.redirect_uri},
+        ${approval.request.code_challenge}, 'S256', ${sql.param(approval.scopes)}::text[],
+        ${resource}, ${actor.userId}::uuid, ${actor.orgId}::uuid, ${expires.toISOString()})`)
+    await appendAudit(db, {
+      orgId: actor.orgId, actorUserId: actor.userId, actorLabel: actor.label,
+      action: 'mcp.approved', targetType: 'mcp_client', targetId: approval.request.client_id,
+      origin: 'web', detail: { scopes: approval.scopes }, occurredAt: clock.now(),
+    })
+  }, { mcpCodeHash: hash })
+  const redirect = new URL(approval.request.redirect_uri)
+  redirect.searchParams.set('code', code)
+  if (approval.request.state !== undefined) redirect.searchParams.set('state', approval.request.state)
+  return { redirect: redirect.toString() }
+}
+
+const redemption = z.object({
+  grant_type: z.literal('authorization_code'),
+  code: z.string().min(32).max(200),
+  client_id: z.string().min(1).max(200),
+  redirect_uri: redirectUri,
+  code_verifier: z.string().regex(/^[A-Za-z0-9._~-]{43,128}$/),
+  resource: z.string().max(2048),
+})
+
+interface CodeRow extends Record<string, unknown> {
+  client_id: string; redirect_uri: string; code_challenge: string; scopes: string[]
+  resource: string; approved_user_id: string; approved_org_id: string
+  expires_at: Date | string; redeemed_at: Date | string | null
+}
+
+export async function redeemMcpAuthorization(pool: Pool, clock: Clock, input: unknown, resource: string) {
+  const parsed = redemption.safeParse(input)
+  if (!parsed.success) throw new McpAuthorizationError('invalid_request', 'The token request is incomplete.')
+  const request = parsed.data
+  if (request.resource !== resource) throw new McpAuthorizationError('invalid_target', 'The requested resource is not this MCP endpoint.')
+  const hash = digest(request.code)
+  const found = await pool.withoutTenant(async (db) => {
+    const rows = await db.execute<CodeRow>(sql`SELECT * FROM mcp_authorization_codes WHERE code_hash = ${hash}`)
+    return rows[0]
+  }, { mcpCodeHash: hash })
+  const invalid = () => new McpAuthorizationError('invalid_grant', 'This authorization code is invalid, expired, or already used.')
+  if (!found) throw invalid()
+  const accessToken = `afm_${randomBytes(32).toString('base64url')}`
+  const expiresAt = new Date(clock.now().getTime() + TOKEN_TTL_MS)
+  // Claim and mint in one transaction. A failed token INSERT must leave the
+  // code redeemable, and two exchanges must never mint two credentials.
+  await pool.withTenant({ orgId: found.approved_org_id, userId: found.approved_user_id }, async (db) => {
+    const rows = await db.execute<CodeRow>(sql`SELECT * FROM mcp_authorization_codes
+      WHERE code_hash = ${hash} FOR UPDATE`)
+    const row = rows[0]
+    if (!row || row.redeemed_at || timestamp(row.expires_at) <= clock.now().getTime() ||
+        row.client_id !== request.client_id || row.redirect_uri !== request.redirect_uri || row.resource !== resource) throw invalid()
+    const expected = Buffer.from(row.code_challenge)
+    const presented = Buffer.from(digest(request.code_verifier).toString('base64url'))
+    if (expected.length !== presented.length || !timingSafeEqual(expected, presented)) throw invalid()
+    const members = await db.execute(sql`SELECT user_id FROM members WHERE
+      user_id = ${row.approved_user_id}::uuid AND org_id = ${row.approved_org_id}::uuid FOR SHARE`)
+    if (!members.length) throw invalid()
+    await db.execute(sql`UPDATE mcp_authorization_codes SET redeemed_at = ${clock.now().toISOString()}
+      WHERE code_hash = ${hash}`)
+    await db.execute(sql`INSERT INTO engine_tokens
+      (org_id, name, token_hash, prefix, created_by, kind, user_id, scopes, expires_at, mcp_client_id, mcp_resource)
+      VALUES (${row.approved_org_id}::uuid, 'MCP connection', ${digest(accessToken)},
+        ${accessToken.slice(0, 12)}, ${row.approved_user_id}::uuid, 'mcp',
+        ${row.approved_user_id}::uuid, ${sql.param(row.scopes)}::text[],
+        ${expiresAt.toISOString()}, ${row.client_id}, ${resource})`)
+  }, { mcpCodeHash: hash })
+  return { access_token: accessToken, token_type: 'Bearer', expires_in: TOKEN_TTL_MS / 1000, scope: found.scopes.join(' ') }
+}
+
+export async function identifyMcpToken(pool: Pool, clock: Clock, token: string, resource: string) {
+  if (!/^afm_[A-Za-z0-9_-]{43}$/.test(token)) return null
+  const hash = digest(token)
+  const found = await pool.withoutTenant(async (db) => {
+    const rows = await db.execute<{
+      id: string; org_id: string; user_id: string; scopes: string[]; mcp_client_id: string
+    }>(sql`SELECT id, org_id, user_id, scopes, mcp_client_id FROM engine_tokens
+      WHERE token_hash = ${hash} AND kind = 'mcp' AND revoked_at IS NULL
+        AND mcp_resource = ${resource}
+        AND expires_at > ${clock.now().toISOString()}`)
+    return rows[0]
+  }, { mcpTokenHash: hash })
+  if (!found) return null
+  return pool.withTenant({ orgId: found.org_id, userId: found.user_id }, async (db) => {
+    const rows = await db.execute<{ role: string; github_login: string; plan: string }>(sql`
+      SELECT m.role, u.github_login, o.plan FROM members m
+      JOIN users u ON u.id = m.user_id JOIN organizations o ON o.id = m.org_id
+      WHERE m.user_id = ${found.user_id}::uuid AND m.org_id = ${found.org_id}::uuid`)
+    const member = rows[0]
+    if (!member || !ROLES.includes(member.role as typeof ROLES[number])) return null
+    await db.execute(sql`UPDATE engine_tokens SET last_used_at = ${clock.now().toISOString()}
+      WHERE id = ${found.id}::uuid`)
+    return {
+      actor: { userId: found.user_id, orgId: found.org_id, label: member.github_login,
+        role: member.role as typeof ROLES[number], plan: member.plan, sessionId: '' } satisfies Actor,
+      scopes: found.scopes, clientId: found.mcp_client_id,
+    }
+  })
+}

--- a/web/apps/api/src/limits.ts
+++ b/web/apps/api/src/limits.ts
@@ -37,6 +37,16 @@ export interface EndpointLimit {
  * ends up behind a limit sized for a cheap one.
  */
 export const ENDPOINT_LIMITS: Record<string, EndpointLimit> = {
+  'GET /.well-known/oauth-protected-resource': { rate: 10, burst: 30, key: 'ip', reason: 'Small public discovery document for MCP clients.' },
+  'GET /.well-known/oauth-authorization-server': { rate: 10, burst: 30, key: 'ip', reason: 'Small public authorization discovery document.' },
+  'POST /auth/mcp/register': { rate: 0.1, burst: 5, key: 'ip', reason: 'Client registration writes a persistent row and is needed only when connecting.' },
+  'GET /auth/mcp/authorize': { rate: 1, burst: 10, key: 'ip', reason: 'A person starts a connection and reviews consent.' },
+  'GET /auth/mcp/pending': { rate: 1, burst: 10, key: 'ip', reason: 'A signed-in person reads the pending connection once.' },
+  'POST /auth/mcp/approve': { rate: 1, burst: 5, key: 'ip', reason: 'Explicit consent mints a single-use authorization code.' },
+  'POST /auth/mcp/token': { rate: 1, burst: 10, key: 'ip', reason: 'One token exchange follows one approved connection.' },
+  'POST /mcp': { rate: 5, burst: 20, key: 'token', reason: 'Each MCP request can read tenant data or dispatch work through existing permission gates.' },
+  'GET /mcp': { rate: 5, burst: 20, key: 'ip', reason: 'Stateless MCP rejects a standalone event stream cheaply.' },
+  'DELETE /mcp': { rate: 5, burst: 20, key: 'ip', reason: 'Stateless MCP holds no transport session to delete.' },
   'GET /health': {
     rate: 50, burst: 200, key: 'ip',
     reason: 'A liveness probe from a load balancer, plus whatever else asks. Cheap, and refusing it looks like an outage.',

--- a/web/apps/api/src/mcp.ts
+++ b/web/apps/api/src/mcp.ts
@@ -1,0 +1,183 @@
+import type { Hono, Context as HttpContext } from 'hono'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'
+import { TRPCError } from '@trpc/server'
+import { z } from 'zod'
+import { sql } from 'drizzle-orm'
+import { bodyLimit } from 'hono/body-limit'
+import { appRouter } from './routers/index.ts'
+import type { Actor, Context } from './trpc.ts'
+import { readCookie, SESSION_COOKIE, CSRF_HEADER, csrfMatches } from './auth/session.ts'
+import {
+  MCP_SCOPES, McpAuthorizationError, registerMcpClient, describeMcpAuthorization,
+  approveMcpAuthorization, redeemMcpAuthorization, identifyMcpToken,
+} from './auth/mcp.ts'
+
+type BaseContext = Omit<Context, 'actor'>
+interface Options {
+  base: BaseContext
+  actorFrom: (cookie: string | undefined) => Promise<Actor | null>
+}
+
+function uniqueParameters(parameters: URLSearchParams): Record<string, string> {
+  const values: Record<string, string> = Object.create(null)
+  for (const [key, value] of parameters) {
+    if (Object.hasOwn(values, key)) throw new McpAuthorizationError('invalid_request', 'OAuth parameters must appear only once.')
+    values[key] = value
+  }
+  return values
+}
+
+/** The hosted surface calls the same authorized procedures as the console. */
+function toolServer(context: Context, scopes: string[]) {
+  const server = new McpServer({ name: 'Antifailure', version: '1.0.0' })
+  const caller = appRouter.createCaller(context)
+  async function call(write: boolean, action: () => Promise<unknown>) {
+    if (!scopes.includes(write ? 'mcp:write' : 'mcp:read')) {
+      return { isError: true, content: [{ type: 'text' as const, text: 'Reconnect and approve the scope this tool needs.' }] }
+    }
+    try {
+      const result = await action()
+      return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] }
+    } catch (error) {
+      const safe = error instanceof TRPCError && error.code !== 'INTERNAL_SERVER_ERROR'
+        ? error.message : 'The control plane could not complete this request. Try again.'
+      return { isError: true, content: [{ type: 'text' as const, text: safe }] }
+    }
+  }
+  const read = { readOnlyHint: true, destructiveHint: false, openWorldHint: false }
+  server.registerTool('list_projects', {
+    description: 'List the repositories connected to your organization.', inputSchema: z.object({}).strict(), annotations: read,
+  }, async () => call(false, () => caller.repositories.list({ includeArchived: false })))
+  server.registerTool('list_environments', {
+    description: 'List recorded environments. A ready port does not prove that application workflows passed.',
+    inputSchema: z.object({ repository: z.string().max(300).optional(), cursor: z.string().max(300).optional(),
+      limit: z.number().int().min(1).max(100).default(25) }).strict(), annotations: read,
+  }, async (input) => call(false, () => caller.environments.list(input)))
+  server.registerTool('list_runs', {
+    description: 'Read reported runs. Missing or unfinished results are not passes.',
+    inputSchema: z.object({ envId: z.string().max(200).optional(), before: z.string().max(200).optional(),
+      limit: z.number().int().min(1).max(100).default(25) }).strict(), annotations: read,
+  }, async (input) => call(false, () => caller.runs.recent(input)))
+  server.registerTool('get_run', {
+    description: 'Read one recorded run by its UUID. This does not invent a verdict for unfinished work.',
+    inputSchema: z.object({ runId: z.string().uuid() }).strict(), annotations: read,
+  }, async (input) => call(false, () => caller.runs.get(input)))
+  server.registerTool('inspect_recorded_egress', {
+    description: 'Read reported outbound host and mode counts. No recorded event is not proof of containment.',
+    inputSchema: z.object({ envId: z.string().max(200).optional(),
+      limit: z.number().int().min(1).max(100).default(25) }).strict(), annotations: read,
+  }, async (input) => call(false, () => caller.network.decisions(input)))
+  const workflow = z.string().max(100).regex(/^[A-Za-z0-9._-]+\.ya?ml$/).default('antifailure.yml')
+  server.registerTool('start_environment', {
+    description: 'Request an environment through the connected repository workflow. Returns a dispatch, not a ready environment. Existing permissions, plan limits and safety switches apply.',
+    inputSchema: z.object({ repository: z.string().min(1).max(300), branch: z.string().min(1).max(255).optional(), workflow }).strict(),
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+  }, async (input) => call(true, () => caller.environments.create(input)))
+  server.registerTool('run_workflows', {
+    description: 'Dispatch every manifest workflow against a recorded environment through the customer repository. Results appear when the engine reports them.',
+    inputSchema: z.object({ envId: z.string().min(1).max(200), workflow }).strict(),
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+  }, async (input) => call(true, () => caller.agents.run(input)))
+  server.registerTool('stop_environment', {
+    description: 'Request teardown. The environment is not gone until the runtime acknowledges cleanup.',
+    inputSchema: z.object({ envId: z.string().min(1).max(200), reason: z.string().max(500).optional(), workflow }).strict(),
+    annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: true },
+  }, async (input) => call(true, () => caller.environments.teardown(input)))
+  return server
+}
+
+export function mountHostedMcp(app: Hono<any>, options: Options): void {
+  const { base } = options
+  const origin = base.appBaseUrl.replace(/\/+$/, '')
+  // No request-derived issuer: a Host header must never mint its own audience.
+  if (!/^https?:\/\//.test(origin)) return
+  const resource = `${origin}/mcp`
+  const metadata = `${origin}/.well-known/oauth-protected-resource`
+  const boundedBody = bodyLimit({ maxSize: 32 * 1024,
+    onError: (c) => c.json({ error: 'invalid_request', error_description: 'The request is larger than 32 KiB.' }, 413) })
+  app.use('/auth/mcp/*', boundedBody)
+  app.use('/mcp', boundedBody)
+  app.use('/auth/mcp/*', async (c, next) => { await next(); c.header('cache-control', 'no-store') })
+  app.use('/mcp', async (c, next) => {
+    const requestedOrigin = c.req.header('origin')
+    if (requestedOrigin && requestedOrigin !== new URL(origin).origin) return c.json({ error: 'Untrusted request origin.' }, 403)
+    await next()
+    c.header('cache-control', 'no-store')
+  })
+  const errorResponse = (c: HttpContext, error: unknown) => {
+    if (error instanceof SyntaxError) return c.json({ error: 'invalid_request', error_description: 'The body must be valid JSON.' }, 400)
+    if (error instanceof McpAuthorizationError) return c.json({ error: error.code, error_description: error.message }, 400)
+    throw error
+  }
+  app.get('/.well-known/oauth-protected-resource', (c) => c.json({
+    resource, authorization_servers: [origin], scopes_supported: MCP_SCOPES,
+    bearer_methods_supported: ['header'], resource_name: 'Antifailure',
+  }))
+  app.get('/.well-known/oauth-authorization-server', (c) => c.json({
+    issuer: origin, authorization_endpoint: `${origin}/auth/mcp/authorize`,
+    token_endpoint: `${origin}/auth/mcp/token`, registration_endpoint: `${origin}/auth/mcp/register`,
+    response_types_supported: ['code'], grant_types_supported: ['authorization_code'],
+    token_endpoint_auth_methods_supported: ['none'], code_challenge_methods_supported: ['S256'],
+    scopes_supported: MCP_SCOPES,
+  }))
+  app.post('/auth/mcp/register', async (c) => {
+    try { return c.json(await registerMcpClient(base.pool, await c.req.json()), 201) }
+    catch (error) { return errorResponse(c, error) }
+  })
+  app.get('/auth/mcp/authorize', async (c) => {
+    try {
+      await describeMcpAuthorization(base.pool, uniqueParameters(new URL(c.req.url).searchParams), resource)
+      return c.redirect(`${origin}/connect-mcp?${new URL(c.req.url).searchParams.toString()}`)
+    } catch (error) { return errorResponse(c, error) }
+  })
+  app.get('/auth/mcp/pending', async (c) => {
+    const actor = await options.actorFrom(c.req.header('cookie'))
+    if (!actor) return c.json({ error: 'Sign in to an organization first.' }, 401)
+    try {
+      const approval = await describeMcpAuthorization(base.pool, uniqueParameters(new URL(c.req.url).searchParams), resource)
+      const organizationName = await base.pool.withTenant({ orgId: actor.orgId, userId: actor.userId }, async (db) => {
+        const rows = await db.execute<{ name: string }>(sql`SELECT name FROM organizations WHERE id = ${actor.orgId}::uuid`)
+        return rows[0]?.name ?? 'Your organization'
+      })
+      return c.json({ clientName: approval.clientName, scopes: approval.scopes, organization: actor.orgId,
+        organizationName, redirectUri: approval.request.redirect_uri, expiresInDays: 90 })
+    } catch (error) { return errorResponse(c, error) }
+  })
+  app.post('/auth/mcp/approve', async (c) => {
+    const actor = await options.actorFrom(c.req.header('cookie'))
+    if (!actor) return c.json({ error: 'Sign in to an organization first.' }, 401)
+    const cookie = readCookie(c.req.header('cookie'), SESSION_COOKIE)
+    if (!cookie || !csrfMatches(cookie, c.req.header(CSRF_HEADER))) return c.json({ error: 'Refresh this page before approving.' }, 403)
+    if (c.req.header('origin') && c.req.header('origin') !== new URL(origin).origin) return c.json({ error: 'Cross-origin approval is refused.' }, 403)
+    try { return c.json(await approveMcpAuthorization(base.pool, base.clock, actor, await c.req.json(), resource)) }
+    catch (error) { return errorResponse(c, error) }
+  })
+  app.post('/auth/mcp/token', async (c) => {
+    c.header('cache-control', 'no-store')
+    c.header('pragma', 'no-cache')
+    try {
+      const body = uniqueParameters(new URLSearchParams(await c.req.text()))
+      return c.json(await redeemMcpAuthorization(base.pool, base.clock, body, resource))
+    } catch (error) { return errorResponse(c, error) }
+  })
+  const handle = async (c: HttpContext) => {
+    const authorization = c.req.header('authorization') ?? ''
+    const token = /^Bearer /i.test(authorization) ? authorization.slice(7) : ''
+    const identity = await identifyMcpToken(base.pool, base.clock, token, resource)
+    if (!identity) {
+      c.header('www-authenticate', `Bearer resource_metadata="${metadata}", scope="mcp:read"`)
+      return c.json({ error: 'invalid_token' }, 401)
+    }
+    const transport = new WebStandardStreamableHTTPServerTransport({ enableJsonResponse: true })
+    const server = toolServer({ ...base, actor: identity.actor }, identity.scopes)
+    try {
+      await server.connect(transport)
+      return await transport.handleRequest(c.req.raw)
+    } finally { await server.close() }
+  }
+  app.post('/mcp', handle)
+  const unsupported = (c: HttpContext) => { c.header('allow', 'POST'); return c.json({ error: 'Use POST for this stateless MCP endpoint.' }, 405) }
+  app.get('/mcp', unsupported)
+  app.delete('/mcp', unsupported)
+}

--- a/web/apps/api/src/mcp.ts
+++ b/web/apps/api/src/mcp.ts
@@ -9,8 +9,9 @@ import { appRouter } from './routers/index.ts'
 import type { Actor, Context } from './trpc.ts'
 import { readCookie, SESSION_COOKIE, CSRF_HEADER, csrfMatches } from './auth/session.ts'
 import {
-  MCP_SCOPES, McpAuthorizationError, registerMcpClient, describeMcpAuthorization,
-  approveMcpAuthorization, redeemMcpAuthorization, identifyMcpToken,
+  MCP_SCOPES, McpAuthorizationError, hostedMcpEndpoint, registerMcpClient,
+  describeMcpAuthorization, approveMcpAuthorization, redeemMcpAuthorization,
+  identifyMcpToken,
 } from './auth/mcp.ts'
 
 type BaseContext = Omit<Context, 'actor'>
@@ -89,10 +90,10 @@ function toolServer(context: Context, scopes: string[]) {
 
 export function mountHostedMcp(app: Hono<any>, options: Options): void {
   const { base } = options
-  const origin = base.appBaseUrl.replace(/\/+$/, '')
   // No request-derived issuer: a Host header must never mint its own audience.
-  if (!/^https?:\/\//.test(origin)) return
-  const resource = `${origin}/mcp`
+  const resource = hostedMcpEndpoint(base.appBaseUrl)
+  if (!resource) return
+  const origin = resource.slice(0, -'/mcp'.length)
   const metadata = `${origin}/.well-known/oauth-protected-resource`
   const boundedBody = bodyLimit({ maxSize: 32 * 1024,
     onError: (c) => c.json({ error: 'invalid_request', error_description: 'The request is larger than 32 KiB.' }, 413) })

--- a/web/apps/api/src/server.ts
+++ b/web/apps/api/src/server.ts
@@ -47,6 +47,7 @@ import { actorOf } from './admin/trpc.ts'
 import { clientAddress, clientIP } from './clientaddress.ts'
 import { endImpersonation, registerImpersonationRoutes } from './admin/customers.ts'
 import { appRouter } from './routers/index.ts'
+import { mountHostedMcp } from './mcp.ts'
 import type { Context as TrpcContext, Actor } from './trpc.ts'
 import type { Clock } from './clock.ts'
 import { systemClock } from './clock.ts'
@@ -827,6 +828,22 @@ export function createServer(options: ServerOptions) {
     if (!token) return null
     return resolveSession(options.pool, clock, token)
   }
+
+  mountHostedMcp(app, {
+    base: {
+      pool: options.pool, clock, github: options.github, stripe: options.stripe ?? null,
+      appBaseUrl: options.appBaseUrl ?? '', mailer: options.emailSignIn?.mailer ?? null,
+      productName: options.emailSignIn?.productName ?? 'Antifailure', analytics,
+      analyticsOperatorOrgSlug: options.analyticsOperatorOrgSlug ?? null,
+      hostedRequiredPlan, operatorSetsPlan, admin: null, adminPool: null, origin: 'api',
+    },
+    actorFrom: async (cookie) => {
+      const session = await sessionFrom(cookie)
+      if (!session?.orgId || !session.role) return null
+      return { userId: session.userId, label: session.label, orgId: session.orgId,
+        role: session.role, sessionId: session.sessionId, plan: session.plan ?? 'free' }
+    },
+  })
 
   // -------------------------------------------------------------------------
   // Routes another edition registered

--- a/web/apps/api/test/admin-platform.test.ts
+++ b/web/apps/api/test/admin-platform.test.ts
@@ -464,11 +464,11 @@ describe('the developer platform routes', { skip: hasDb ? false : 'no database' 
     )
   })
 
-  test('the MCP route says the control plane records nothing, rather than the console assuming it', async () => {
+  test('the MCP route distinguishes recorded credentials from the local tool catalog', async () => {
     const caller = await callerFor('read_only')
     const surface = await caller.admin.platform.mcp.surface()
-    assert.equal(surface.recordsAnything, false)
+    assert.equal(surface.recordsAnything, true)
     assert.equal(surface.tools.length, MCP_TOOLS.length)
-    assert.ok(surface.why.length > 0, 'the page states an absence without saying why')
+    assert.ok(surface.why.length > 0, 'the page must explain which surface it measures')
   })
 })

--- a/web/apps/api/test/harness.ts
+++ b/web/apps/api/test/harness.ts
@@ -92,6 +92,8 @@ export interface ApiHarness {
 }
 
 export interface StartApiOptions {
+  /** Canonical origin for browser and SDK integration against a real listener. */
+  appBaseUrl?: string
   /**
    * Serve cookies the way production does. Defaults false, because the test
    * client speaks plain HTTP.
@@ -264,7 +266,7 @@ export async function startApi(options: StartApiOptions = {}): Promise<ApiHarnes
     // The test client speaks plain HTTP, and a Secure cookie would not come
     // back. Production defaults the other way and there is a test for that.
     secureCookies: options.secureCookies ?? false,
-    appBaseUrl: 'http://app.test/',
+    appBaseUrl: options.appBaseUrl ?? 'http://app.test/',
     signInAllowlist: options.signInAllowlist ?? null,
     selfServeSignup: options.selfServeSignup ?? false,
     leadNotifier: options.leadNotifier ?? null,

--- a/web/apps/api/test/hosted-mcp.test.ts
+++ b/web/apps/api/test/hosted-mcp.test.ts
@@ -11,11 +11,20 @@ describe('hosted MCP authorization and reachable tools', () => {
   let api: ApiHarness
   let org: Org
   let owner: SignedIn
+  // mcp_clients carries no org_id, so dropOrg cannot reach a registration.
+  // Left behind, these accumulate in a shared database forever and inflate the
+  // operator's installation wide client count for whatever runs next.
+  const registered: string[] = []
   before(async () => { api = await startApi(); org = await seedOrg(api.admin, 'hosted-mcp'); owner = await signInAs(api, org, 'owner') })
-  after(async () => { await dropOrg(api.admin, org.orgId); await api.close() })
+  after(async () => {
+    if (registered.length) await api.admin`DELETE FROM mcp_clients WHERE client_id = ANY(${registered})`
+    await dropOrg(api.admin, org.orgId)
+    await api.close()
+  })
 
   async function grant(scopes = 'mcp:read', person = owner, role: Actor['role'] = 'owner') {
     const client = await registerMcpClient(api.pool, { client_name: 'Integration client', redirect_uris: ['https://client.test/callback'] })
+    registered.push(client.client_id)
     const verifier = randomBytes(32).toString('base64url')
     const request = {
       client_id: client.client_id, redirect_uri: 'https://client.test/callback', response_type: 'code',
@@ -57,6 +66,23 @@ describe('hosted MCP authorization and reachable tools', () => {
     const token = await (await grant('mcp:write', viewer, 'viewer')).token()
     const body = await (await rpc(token.access_token, 'tools/call', { name: 'start_environment', arguments: { repository: org.repository } })).json() as RpcReply
     assert.match(body.result.content[0].text, /environments.create permission/)
+  })
+  // The operator page has a "Last authentication" column, and the write that
+  // fills it is an UPDATE inside withTenant on a table whose own presented_mcp_token
+  // policy is SELECT only. If tenant_isolation did not also cover that UPDATE it
+  // would affect zero rows, raise nothing, and the column would read "Not used
+  // yet" forever. The management suite sets the value with admin SQL, so only a
+  // real request through the endpoint can tell a live write from a dead one.
+  test('a real protocol request records when the credential last authenticated', async () => {
+    const token = await (await grant()).token()
+    const hash = createHash('sha256').update(token.access_token).digest()
+    const fresh = await api.admin<{ last_used_at: Date | null }[]>`
+      SELECT last_used_at FROM engine_tokens WHERE token_hash = ${hash}`
+    assert.equal(fresh[0]!.last_used_at, null, 'a credential nobody has used carries a time')
+    assert.equal((await rpc(token.access_token, 'tools/list', {})).status, 200)
+    const used = await api.admin<{ last_used_at: Date | null }[]>`
+      SELECT last_used_at FROM engine_tokens WHERE token_hash = ${hash}`
+    assert.notEqual(used[0]!.last_used_at, null)
   })
   test('a token is bound to the resource that consent approved', async () => {
     const token = await (await grant()).token()
@@ -125,8 +151,9 @@ describe('hosted MCP authorization and reachable tools', () => {
   test('registration returns a usable public-client identifier', async () => {
     const response = await api.fetch('/auth/mcp/register', { method: 'POST', headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ client_name: 'Browser client', redirect_uris: ['https://client.test/callback'] }) })
-    const registered = await response.json() as { client_id: string }
-    assert.match(registered.client_id, /^[A-Za-z0-9_-]{43}$/)
+    const created = await response.json() as { client_id: string }
+    registered.push(created.client_id)
+    assert.match(created.client_id, /^[A-Za-z0-9_-]{43}$/)
   })
   test('authorization cannot redirect a code to an unregistered address', async () => {
     const flow = await grant()
@@ -140,6 +167,61 @@ describe('hosted MCP authorization and reachable tools', () => {
   test('unauthenticated protocol response points clients to authorization discovery', async () => {
     const response = await rpc('invalid', 'tools/list', {})
     assert.match(response.headers.get('www-authenticate') ?? '', /resource_metadata="http:\/\/app.test\/\.well-known\/oauth-protected-resource"/)
+  })
+  // The write half, proved as a dispatch and never as a ready environment.
+  //
+  // Every other write assertion in this file is a REFUSAL: a read token cannot
+  // start anything, a viewer cannot either. A refusal proves the gate and says
+  // nothing about the path behind it, so the tool could have been wired to
+  // nothing and this suite would still have been green. This is the one test
+  // that lets a write through and then reads what actually happened to it.
+  test('an approved write reaches the customer repository as one dispatch', async () => {
+    const token = await (await grant('mcp:read mcp:write')).token()
+    await api.admin`INSERT INTO github_installations (org_id, installation_id, account_login, account_type)
+      VALUES (${org.orgId}, ${Math.floor(Math.random() * 1e9)}, ${org.slug}, 'Organization')`
+    api.github.addWorkflow(org.repository, 'antifailure.yml')
+    const environments = async () => {
+      const listed = await (await rpc(token.access_token, 'tools/call', { name: 'list_environments', arguments: {} })).json() as RpcReply
+      return JSON.parse(listed.result.content[0].text) as unknown
+    }
+    const before = api.github.dispatches.length
+    const environmentsBefore = await environments()
+
+    const body = await (await rpc(token.access_token, 'tools/call', { name: 'start_environment',
+      arguments: { repository: org.repository, branch: 'main', workflow: 'antifailure.yml' } })).json() as RpcReply
+    const result = JSON.parse(body.result.content[0].text) as {
+      dispatched?: boolean; repository?: string; ref?: string; workflow?: string; pending?: unknown
+    }
+
+    // What the tool told the agent.
+    assert.deepEqual({ dispatched: result.dispatched, repository: result.repository, ref: result.ref,
+      workflow: result.workflow, pendingIsStated: typeof result.pending === 'string' && result.pending.length > 0 },
+    { dispatched: true, repository: org.repository, ref: 'main', workflow: 'antifailure.yml', pendingIsStated: true })
+
+    // What GitHub was actually asked for. One dispatch, against the customer's
+    // own repository and workflow, carrying the up command.
+    assert.equal(api.github.dispatches.length - before, 1)
+    const sent = api.github.dispatches[api.github.dispatches.length - 1]!
+    assert.deepEqual({ repository: sent.repository, workflow: sent.workflow, ref: sent.ref, command: sent.inputs.command },
+      { repository: org.repository, workflow: 'antifailure.yml', ref: 'main', command: 'up' })
+
+    // What the organization's own record says a person did.
+    const audited = await api.admin<{ action: string; target_id: string }[]>`
+      SELECT action, target_id FROM audit_entries
+      WHERE org_id = ${org.orgId} AND action = 'environment.requested'`
+    assert.deepEqual(audited.map((row) => [row.action, row.target_id]), [['environment.requested', org.repository]])
+
+    // And the boundary the tool description promises: a dispatch is not a
+    // ready environment. Nothing new is readable until the engine reports it.
+    assert.deepEqual(await environments(), environmentsBefore)
+  })
+  test('a standalone event stream is refused, and says what to use instead', async () => {
+    const token = await (await grant()).token()
+    for (const method of ['GET', 'DELETE']) {
+      const response = await api.fetch('/mcp', { method, headers: { authorization: `Bearer ${token.access_token}` } })
+      assert.deepEqual({ method, status: response.status, allow: response.headers.get('allow') },
+        { method, status: 405, allow: 'POST' })
+    }
   })
   test('authorization response cannot be cached with its usable code', async () => {
     const flow = await grant()

--- a/web/apps/api/test/hosted-mcp.test.ts
+++ b/web/apps/api/test/hosted-mcp.test.ts
@@ -1,0 +1,151 @@
+import { after, before, describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { createHash, randomBytes } from 'node:crypto'
+import { startApi, seedOrg, dropOrg, signInAs, type ApiHarness, type Org, type SignedIn } from './harness.ts'
+import { registerMcpClient, approveMcpAuthorization, redeemMcpAuthorization, identifyMcpToken } from '../src/auth/mcp.ts'
+import type { Actor } from '../src/trpc.ts'
+
+const resource = 'http://app.test/mcp'
+interface RpcReply { result: { serverInfo?: { name: string }; content: [{ text: string }] } }
+describe('hosted MCP authorization and reachable tools', () => {
+  let api: ApiHarness
+  let org: Org
+  let owner: SignedIn
+  before(async () => { api = await startApi(); org = await seedOrg(api.admin, 'hosted-mcp'); owner = await signInAs(api, org, 'owner') })
+  after(async () => { await dropOrg(api.admin, org.orgId); await api.close() })
+
+  async function grant(scopes = 'mcp:read', person = owner, role: Actor['role'] = 'owner') {
+    const client = await registerMcpClient(api.pool, { client_name: 'Integration client', redirect_uris: ['https://client.test/callback'] })
+    const verifier = randomBytes(32).toString('base64url')
+    const request = {
+      client_id: client.client_id, redirect_uri: 'https://client.test/callback', response_type: 'code',
+      code_challenge: createHash('sha256').update(verifier).digest('base64url'), code_challenge_method: 'S256', resource, scope: scopes,
+    }
+    const approved = await approveMcpAuthorization(api.pool, api.clock, {
+      userId: person.userId, orgId: org.orgId, label: 'Integration owner', role, sessionId: '', plan: 'free',
+    }, request, resource)
+    const exchange = { grant_type: 'authorization_code', client_id: client.client_id,
+      redirect_uri: request.redirect_uri, resource, code_verifier: verifier, code: new URL(approved.redirect).searchParams.get('code')! }
+    return { request, exchange, token: () => redeemMcpAuthorization(api.pool, api.clock, exchange, resource) }
+  }
+  async function rpc(token: string, method: string, params: unknown) {
+    return api.fetch('/mcp', { method: 'POST', headers: {
+      authorization: `Bearer ${token}`, 'content-type': 'application/json', accept: 'application/json, text/event-stream',
+      'mcp-protocol-version': '2025-11-25',
+    }, body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }) })
+  }
+
+  test('real initialize reaches the mounted protocol server', async () => {
+    const token = await (await grant()).token()
+    const response = await rpc(token.access_token, 'initialize', { protocolVersion: '2025-11-25', capabilities: {}, clientInfo: { name: 'test', version: '1' } })
+    const body = await response.json() as RpcReply
+    assert.equal(body.result?.serverInfo?.name, 'Antifailure')
+  })
+  test('direct tool call reads the authorized tenant without tools/list first', async () => {
+    const token = await (await grant()).token()
+    const response = await rpc(token.access_token, 'tools/call', { name: 'list_projects', arguments: {} })
+    const body = await response.json() as RpcReply
+    assert.equal(JSON.parse(body.result.content[0].text)[0].full_name, org.repository)
+  })
+  test('read scope cannot start an environment through a direct tool call', async () => {
+    const token = await (await grant()).token()
+    const body = await (await rpc(token.access_token, 'tools/call', { name: 'start_environment', arguments: { repository: org.repository } })).json() as RpcReply
+    assert.match(body.result.content[0].text, /Reconnect and approve/)
+  })
+  test('write scope never overrides a viewer role', async () => {
+    const viewer = await signInAs(api, org, 'viewer')
+    const token = await (await grant('mcp:write', viewer, 'viewer')).token()
+    const body = await (await rpc(token.access_token, 'tools/call', { name: 'start_environment', arguments: { repository: org.repository } })).json() as RpcReply
+    assert.match(body.result.content[0].text, /environments.create permission/)
+  })
+  test('a token is bound to the resource that consent approved', async () => {
+    const token = await (await grant()).token()
+    assert.equal(await identifyMcpToken(api.pool, api.clock, token.access_token, 'https://other.test/mcp'), null)
+  })
+  test('revocation makes a previously working token unusable', async () => {
+    const token = await (await grant()).token()
+    await api.admin`UPDATE engine_tokens SET revoked_at = now() WHERE token_hash = ${createHash('sha256').update(token.access_token).digest()}`
+    assert.equal((await rpc(token.access_token, 'tools/list', {})).status, 401)
+  })
+  test('MCP bearer cannot authenticate the engine ingestion endpoint', async () => {
+    const token = await (await grant('mcp:write')).token()
+    const response = await api.fetch('/v1/events', { method: 'POST', headers: {
+      authorization: `Bearer ${token.access_token}`, 'content-type': 'application/json',
+    }, body: JSON.stringify({ events: [] }) })
+    assert.equal(response.status, 401)
+  })
+  test('wrong PKCE verifier leaves the legitimate exchange available', async () => {
+    const flow = await grant()
+    await assert.rejects(redeemMcpAuthorization(api.pool, api.clock, { ...flow.exchange, code_verifier: 'x'.repeat(43) }, resource), /invalid, expired, or already used/)
+    await flow.token()
+  })
+  test('concurrent code redemption issues exactly one credential', async () => {
+    const flow = await grant()
+    const outcomes = await Promise.allSettled([flow.token(), flow.token()])
+    assert.equal(outcomes.filter((outcome) => outcome.status === 'fulfilled').length, 1)
+  })
+  test('a removed membership cannot keep using a token', async () => {
+    const member = await signInAs(api, org, 'member')
+    const token = await (await grant('mcp:read', member, 'member')).token()
+    await api.admin`DELETE FROM members WHERE user_id = ${member.userId} AND org_id = ${org.orgId}`
+    assert.equal(await identifyMcpToken(api.pool, api.clock, token.access_token, resource), null)
+  })
+  test('an untrusted browser origin is refused before tool execution', async () => {
+    const token = await (await grant()).token()
+    const response = await api.fetch('/mcp', { method: 'POST', headers: { origin: 'https://evil.test', authorization: `Bearer ${token.access_token}` } })
+    assert.equal(response.status, 403)
+  })
+  test('consent cannot be submitted without the current session CSRF token', async () => {
+    const flow = await grant()
+    const response = await api.fetch('/auth/mcp/approve', { method: 'POST', headers: { cookie: owner.cookie, 'content-type': 'application/json' }, body: JSON.stringify(flow.request) })
+    assert.equal(response.status, 403)
+  })
+  test('expired credentials are refused at the protocol endpoint', async () => {
+    const token = await (await grant()).token()
+    await api.admin`UPDATE engine_tokens SET expires_at = ${new Date(api.clock.now().getTime() - 1000)}
+      WHERE token_hash = ${createHash('sha256').update(token.access_token).digest()}`
+    assert.equal((await rpc(token.access_token, 'tools/list', {})).status, 401)
+  })
+  test('OAuth token parameters cannot be repeated', async () => {
+    const flow = await grant()
+    const response = await api.fetch('/auth/mcp/token', { method: 'POST',
+      body: new URLSearchParams(flow.exchange).toString() + '&code=another-code' })
+    assert.match((await response.json() as { error_description: string }).error_description, /only once/)
+  })
+  test('malformed registration JSON is a client error', async () => {
+    const response = await api.fetch('/auth/mcp/register', { method: 'POST',
+      headers: { 'content-type': 'application/json' }, body: '{' })
+    assert.equal(response.status, 400)
+  })
+  test('oversized registration is refused before parsing', async () => {
+    const response = await api.fetch('/auth/mcp/register', { method: 'POST',
+      headers: { 'content-type': 'application/json' }, body: JSON.stringify({ padding: 'x'.repeat(40 * 1024) }) })
+    assert.equal(response.status, 413)
+  })
+  test('registration returns a usable public-client identifier', async () => {
+    const response = await api.fetch('/auth/mcp/register', { method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ client_name: 'Browser client', redirect_uris: ['https://client.test/callback'] }) })
+    const registered = await response.json() as { client_id: string }
+    assert.match(registered.client_id, /^[A-Za-z0-9_-]{43}$/)
+  })
+  test('authorization cannot redirect a code to an unregistered address', async () => {
+    const flow = await grant()
+    const response = await api.fetch('/auth/mcp/authorize?' + new URLSearchParams({ ...flow.request, redirect_uri: 'https://evil.test/callback' }))
+    assert.equal(response.status, 400)
+  })
+  test('discovery publishes the configured audience rather than request host', async () => {
+    const response = await api.fetch('/.well-known/oauth-protected-resource')
+    assert.equal((await response.json() as { resource: string }).resource, resource)
+  })
+  test('unauthenticated protocol response points clients to authorization discovery', async () => {
+    const response = await rpc('invalid', 'tools/list', {})
+    assert.match(response.headers.get('www-authenticate') ?? '', /resource_metadata="http:\/\/app.test\/\.well-known\/oauth-protected-resource"/)
+  })
+  test('authorization response cannot be cached with its usable code', async () => {
+    const flow = await grant()
+    const response = await api.fetch('/auth/mcp/approve', { method: 'POST', headers: {
+      cookie: owner.cookie, 'x-antifailure-csrf': owner.csrfToken, 'content-type': 'application/json',
+    }, body: JSON.stringify(flow.request) })
+    assert.equal(response.headers.get('cache-control'), 'no-store')
+  })
+})

--- a/web/apps/api/test/hosted-mcp.test.ts
+++ b/web/apps/api/test/hosted-mcp.test.ts
@@ -7,6 +7,27 @@ import type { Actor } from '../src/trpc.ts'
 
 const resource = 'http://app.test/mcp'
 interface RpcReply { result: { serverInfo?: { name: string }; content: [{ text: string }] } }
+// A configured origin is operator input and arrives with whatever punctuation
+// the operator typed. Stripping its trailing slashes used to be `/\/+$/`, which
+// CodeQL flags as polynomial: on a value that does not end in a slash the
+// engine retries from every slash in it. The rewrite has to keep the behaviour,
+// so the behaviour is asserted rather than the shape of the code.
+describe('the hosted audience is stripped of what an operator typed', () => {
+  test('trailing slashes do not reach the published resource', async () => {
+    const api = await startApi({ appBaseUrl: 'http://slashes.test///' })
+    try {
+      const body = await (await api.fetch('/.well-known/oauth-protected-resource')).json() as { resource: string }
+      assert.equal(body.resource, 'http://slashes.test/mcp')
+    } finally { await api.close() }
+  })
+  test('an installation with no configured origin serves no endpoint at all', async () => {
+    const api = await startApi({ appBaseUrl: '' })
+    try {
+      assert.equal((await api.fetch('/mcp', { method: 'POST' })).status, 404)
+    } finally { await api.close() }
+  })
+})
+
 describe('hosted MCP authorization and reachable tools', () => {
   let api: ApiHarness
   let org: Org

--- a/web/apps/api/test/mcp-management.test.ts
+++ b/web/apps/api/test/mcp-management.test.ts
@@ -1,0 +1,92 @@
+import { after, afterEach, before, beforeEach, describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { randomBytes, randomUUID } from 'node:crypto'
+import { startApi, seedOrg, signInAs, type ApiHarness, type Org } from './harness.ts'
+import { adminSignIn, hashPassword } from '../src/admin/session.ts'
+import { appRouter } from '../src/routers/index.ts'
+type Surface = Awaited<ReturnType<ReturnType<typeof appRouter.createCaller>['admin']['platform']['mcp']['surface']>>
+
+describe('hosted MCP operator measurements', () => {
+  let h: ApiHarness
+  let org: Org
+  let client: string
+  let active: string
+  let session: { token: string; csrfToken: string }
+  before(async () => {
+    h = await startApi()
+    h.clock.advance(Date.now() - h.clock.now().getTime())
+    const email = `mcp-operator-${randomUUID()}@example.test`
+    const password = randomBytes(24).toString('base64url')
+    const { hash, salt } = await hashPassword(password)
+    await h.admin`INSERT INTO admin_users(email,name,role,password_hash,password_salt,password_set_at)
+      VALUES(${email},'MCP operator','owner',${hash},${salt},now())`
+    session = await adminSignIn(h.pool, { email, password }, h.clock.now())
+  })
+  after(async () => { await h.close() })
+  beforeEach(async () => {
+    org = await seedOrg(h.admin, 'mcp-management')
+    const user = await signInAs(h, org, 'owner')
+    client = randomUUID()
+    await h.admin`INSERT INTO mcp_clients(client_id,client_name,redirect_uris)
+      VALUES(${client},'Integration client',ARRAY['https://client.test/cb'])`
+    const future = new Date(h.clock.now().getTime() + 86400000).toISOString()
+    const past = new Date(h.clock.now().getTime() - 86400000).toISOString()
+    for (const state of ['active', 'expired', 'revoked']) {
+      const [row] = await h.admin<{ id: string }[]>`INSERT INTO engine_tokens
+        (org_id,name,token_hash,prefix,kind,user_id,created_by,scopes,expires_at,revoked_at,mcp_client_id,mcp_resource,last_used_at)
+        VALUES(${org.orgId},'MCP connection',${randomBytes(32)},${`afm_${state}`},'mcp',${user.userId},${user.userId},
+          ARRAY['mcp:read'],${state === 'expired' ? h.clock.now().toISOString() : future},${state === 'revoked' ? past : null},${client},
+          'http://app.test/mcp',${state === 'active' ? past : null}) RETURNING id`
+      if (state === 'active') active = row!.id
+    }
+    await h.admin`INSERT INTO engine_tokens(org_id,name,token_hash,prefix,kind,expires_at)
+      VALUES(${org.orgId},'Not MCP',${randomBytes(32)},'afe_other','engine',${future})`
+  })
+  afterEach(async () => {
+    await h.admin`DELETE FROM organizations WHERE id=${org.orgId}`
+    await h.admin`DELETE FROM mcp_clients WHERE client_id=${client}`
+  })
+  async function surface() {
+    const response = await h.fetch('/trpc/admin.platform.mcp.surface', { headers: { cookie: `af_admin_session=${session.token}` } })
+    const body = await response.json() as { result?: { data?: Surface } }
+    if (!body.result?.data) throw new Error(`MCP surface returned ${response.status}`)
+    return body.result.data
+  }
+  test('counts only MCP credentials and partitions their standing', async () => {
+    assert.deepEqual((await surface()).counts, { clients: 1, active: 1, revoked: 1, expired: 1 })
+  })
+  test('the endpoint comes from configured application origin', async () => {
+    assert.equal((await surface()).endpoint, 'http://app.test/mcp')
+  })
+  test('connections show identity, scopes and authentication without token hashes', async () => {
+    const data = await surface()
+    const row = data.connections.find((r: { id: string }) => r.id === active)
+    if (!row) throw new Error('The active credential is absent')
+    assert.deepEqual({ client: row.clientName, org: row.orgSlug, scopes: row.scopes,
+      last: row.lastAuthenticatedAt !== null, state: row.standing, hash: 'token_hash' in row },
+    { client: 'Integration client', org: org.slug, scopes: ['mcp:read'], last: true, state: 'active', hash: false })
+  })
+  test('expiration and revocation remain distinct', async () => {
+    assert.deepEqual((await surface()).connections.map((r: { standing: string }) => r.standing).sort(), ['active', 'expired', 'revoked'])
+  })
+  test('revocation changes the measured state and tells the person to reconnect', async () => {
+    const response = await h.fetch('/trpc/admin.platform.keys.revoke', { method: 'POST', headers: {
+      cookie: `af_admin_session=${session.token}`, 'content-type': 'application/json', 'x-antifailure-admin-csrf': session.csrfToken,
+    }, body: JSON.stringify({ tokenId: active, reason: 'The client is no longer authorized' }) })
+    const body = await response.json() as { result?: { data?: { effect?: string } } }
+    const data = await surface()
+    assert.deepEqual({ active: data.counts.active, revoked: data.counts.revoked, reconnect: /reconnects their MCP client/.test(body.result?.data?.effect ?? '') },
+      { active: 0, revoked: 2, reconnect: true })
+  })
+  test('the searchable credential directory accepts the MCP filter', async () => {
+    const response = await h.fetch('/trpc/admin.platform.keys.list?input='+encodeURIComponent(JSON.stringify({kind:'mcp',limit:25})), {headers:{cookie:`af_admin_session=${session.token}`}})
+    assert.equal(response.status, 200)
+  })
+  test('the list is bounded and discloses truncation', async () => {
+    await h.admin`INSERT INTO engine_tokens(org_id,name,token_hash,prefix,kind,user_id,created_by,scopes,expires_at,mcp_client_id,mcp_resource)
+      SELECT org_id,name,decode(md5(g::text),'hex'),prefix,kind,user_id,created_by,scopes,expires_at,mcp_client_id,mcp_resource
+      FROM engine_tokens CROSS JOIN generate_series(1,51) g WHERE id=${active}`
+    const data = await surface()
+    assert.deepEqual({ length: data.connections.length, more: data.hasMore }, {length:50,more:true})
+  })
+})

--- a/web/apps/api/test/mcp-management.test.ts
+++ b/web/apps/api/test/mcp-management.test.ts
@@ -12,6 +12,12 @@ describe('hosted MCP operator measurements', () => {
   let client: string
   let active: string
   let session: { token: string; csrfToken: string }
+  // mcp_clients carries no org_id on purpose, so the operator's client count is
+  // installation wide and every other suite sharing this database contributes
+  // to it. The absolute number is therefore whatever ran first; what this suite
+  // owns is the ONE registration it makes, so the assertion below is a delta.
+  // Asserting the absolute number passed alone and failed in the full run.
+  let clientsBefore: number
   before(async () => {
     h = await startApi()
     h.clock.advance(Date.now() - h.clock.now().getTime())
@@ -24,6 +30,7 @@ describe('hosted MCP operator measurements', () => {
   })
   after(async () => { await h.close() })
   beforeEach(async () => {
+    clientsBefore = (await surface()).counts.clients
     org = await seedOrg(h.admin, 'mcp-management')
     const user = await signInAs(h, org, 'owner')
     client = randomUUID()
@@ -53,7 +60,10 @@ describe('hosted MCP operator measurements', () => {
     return body.result.data
   }
   test('counts only MCP credentials and partitions their standing', async () => {
-    assert.deepEqual((await surface()).counts, { clients: 1, active: 1, revoked: 1, expired: 1 })
+    const counts = (await surface()).counts
+    assert.deepEqual({ clients: counts.clients - clientsBefore, active: counts.active,
+      revoked: counts.revoked, expired: counts.expired },
+    { clients: 1, active: 1, revoked: 1, expired: 1 })
   })
   test('the endpoint comes from configured application origin', async () => {
     assert.equal((await surface()).endpoint, 'http://app.test/mcp')

--- a/web/apps/api/test/mcp-management.test.ts
+++ b/web/apps/api/test/mcp-management.test.ts
@@ -68,6 +68,14 @@ describe('hosted MCP operator measurements', () => {
   test('the endpoint comes from configured application origin', async () => {
     assert.equal((await surface()).endpoint, 'http://app.test/mcp')
   })
+  // The operator page prints an address and the server answers on one. They
+  // used to be computed from appBaseUrl twice, in two files, so a change to
+  // either could leave this page naming somewhere nothing is served. Read both
+  // and compare, rather than asserting the same literal in two suites.
+  test('the printed endpoint is the audience the server actually publishes', async () => {
+    const discovery = await (await h.fetch('/.well-known/oauth-protected-resource')).json() as { resource: string }
+    assert.equal((await surface()).endpoint, discovery.resource)
+  })
   test('connections show identity, scopes and authentication without token hashes', async () => {
     const data = await surface()
     const row = data.connections.find((r: { id: string }) => r.id === active)

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -27,6 +27,7 @@
         "@antifailure/policy": "*",
         "@hono/node-server": "^2.1.1",
         "@hono/trpc-server": "^0.4.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "@trpc/server": "^11.18.0",
         "hono": "^4.13.5",
         "postgres": "^3.4.9",
@@ -79,6 +80,46 @@
         "hono": ">=4.0.0"
       }
     },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/@trpc/server": {
       "version": "11.18.0",
       "resolved": "https://registry.npmjs.org/@trpc/server/-/server-11.18.0.tgz",
@@ -103,6 +144,224 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/drizzle-orm": {
@@ -230,6 +489,307 @@
         }
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.7.0.tgz",
+      "integrity": "sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/hono": {
       "version": "4.13.5",
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.5.tgz",
@@ -238,6 +798,272 @@
       "peer": true,
       "engines": {
         "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.11",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.11.tgz",
+      "integrity": "sha512-A5NPn7g8EAzGU3IzRs+Yiq8K5n3ypYS75M5+KKiVHdUexfpWK1kP4ZMq7QnTGDoMj6TJ1dtcEJjW60yZDXS4hg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
+      "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/negotiator/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/postgres": {
@@ -252,6 +1078,287 @@
       "funding": {
         "type": "individual",
         "url": "https://github.com/sponsors/porsager"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {
@@ -275,13 +1382,62 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/zod": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
       "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     },
     "packages/db": {

--- a/web/packages/db/migrations/0038_the_mcp_endpoint_a_browser_can_connect_to.sql
+++ b/web/packages/db/migrations/0038_the_mcp_endpoint_a_browser_can_connect_to.sql
@@ -1,0 +1,224 @@
+-- The tables a browser-based agent needs before it can call a tool.
+--
+-- WHY THIS EXISTS. `af mcp` serves the rehearsal tools over standard input and
+-- output to a process the client started. That covers every coding agent and
+-- it covers neither claude.ai nor chatgpt.com, because a web page cannot start
+-- a process on somebody's laptop. Both connect to one thing only: an HTTPS URL
+-- speaking Streamable HTTP, authorized by OAuth. This control plane already
+-- knows who a person is, which organization they are in and what their role
+-- lets them read; what it did not have was a way to say any of that to an
+-- OAuth client it had never met.
+--
+-- THREE PIECES, AND EACH ONE IS A TABLE HERE OR A COLUMN ON AN EXISTING ONE:
+--
+--   mcp_clients               who is asking. Registered dynamically, per
+--                             RFC 7591, because Claude registers itself.
+--   mcp_authorization_codes   the single-use code between the consent screen
+--                             and the token endpoint.
+--   engine_tokens kind 'mcp'  the access token itself.
+--
+-- WHY THE ACCESS TOKEN IS A FOURTH KIND RATHER THAN A FOURTH TABLE. The same
+-- reason 0012 gives for the second and 0025 for the third: the hashing, the
+-- prefix, the revocation, the expiry and the policy that lets a bearer token
+-- find its own organization are already here and already tested, and a parallel
+-- implementation of exactly those is where a subtle difference becomes a
+-- security bug.
+--
+-- WHY IT IS A DISTINCT KIND AND NOT 'cli'. This is the audience check the MCP
+-- authorization specification requires, expressed as a column rather than as a
+-- promise about the code. `identify()` in auth/device.ts selects kind = 'cli'
+-- and the MCP endpoint selects kind = 'mcp', so an `af login` token replayed at
+-- /mcp is refused and an MCP token replayed at /v1/whoami is refused, in both
+-- directions, by a WHERE clause. Sharing one kind would have made every token
+-- this control plane issues valid at every surface it serves, which is exactly
+-- the confused-deputy shape RFC 8707 exists to prevent.
+--
+-- NO REFRESH TOKEN TABLE, DELIBERATELY. The authorization specification says a
+-- client MUST NOT assume refresh tokens will be issued and leaves it to the
+-- authorization server. This one does not issue them: the access token carries
+-- the same ninety day life the device grant's CLI token has, reconnecting is
+-- one click in the client that asked, and a rotation ledger is a second place
+-- for a replay window to hide. That is a smaller surface, not a smaller
+-- feature.
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- Who is asking
+-- ---------------------------------------------------------------------------
+--
+-- No org_id, and it is not an oversight. A client registration belongs to the
+-- MCP client rather than to a tenant: one Claude registration is used by
+-- everybody in every organization who connects through it, and giving it an
+-- owner would mean the second organization to connect could not read the row
+-- the first one created.
+--
+-- What confines the application role instead is the policy below, keyed on a
+-- client_id the caller has to already hold. The client_id is 32 bytes of
+-- randomness, so declaring one you were not given returns nothing, which is
+-- the same shape as the engine token policy in 0004 and the device code policy
+-- in 0012.
+CREATE TABLE mcp_clients (
+  id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- What the client sends as client_id. Opaque and not a secret in OAuth's
+  -- model, and still unguessable here, because it is the key the policy below
+  -- confines this table by.
+  client_id           text NOT NULL UNIQUE,
+  -- SHA-256 of the client secret, or NULL for a public client. Claude
+  -- registers as a public client and authenticates with PKCE instead, which is
+  -- what OAuth 2.1 asks of a client that cannot keep a secret. The column
+  -- exists because an organization may supply its own confidential client.
+  client_secret_hash  bytea,
+  -- What the client called itself. Shown on the consent screen, so it is the
+  -- one string here a person reads, and it is written by whoever registered.
+  -- Treated as untrusted text everywhere it is rendered.
+  client_name         text NOT NULL,
+  -- Every redirect URI the client declared. An authorization request naming
+  -- anything else is refused: exact string match, no wildcards and no prefix
+  -- matching, per OAuth 2.1.
+  redirect_uris       text[] NOT NULL,
+  created_at          timestamptz NOT NULL DEFAULT now(),
+  last_used_at        timestamptz,
+  CONSTRAINT mcp_clients_has_a_redirect CHECK (cardinality(redirect_uris) > 0)
+);
+
+-- ---------------------------------------------------------------------------
+-- The code between the consent screen and the token endpoint
+-- ---------------------------------------------------------------------------
+--
+-- The columns are named approved_user_id and approved_org_id rather than
+-- user_id and org_id, following device_authorizations in 0012, and the name is
+-- load bearing twice over. It says the tenancy is established by an approval
+-- rather than carried in by the request, and it keeps this table out of the
+-- plain org_id policy loop, where a policy comparing org_id to current_org()
+-- would make the row unreadable at the one moment it has to be read: the token
+-- exchange, which has no session and no tenant and holds only the code.
+CREATE TABLE mcp_authorization_codes (
+  id                   uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- SHA-256 of the code. Same argument as every other credential in this
+  -- schema: a database that leaks leaks nothing usable.
+  code_hash            bytea NOT NULL UNIQUE,
+  client_id            text NOT NULL REFERENCES mcp_clients(client_id) ON DELETE CASCADE,
+  -- Recorded at the authorization request and compared again at the token
+  -- request, which RFC 6749 requires and which is what stops a code issued for
+  -- one registered redirect being redeemed against another.
+  redirect_uri         text NOT NULL,
+  -- PKCE. NOT NULL, so a code without a challenge cannot be stored at all: an
+  -- authorization server that accepts one is an authorization server where
+  -- interception of the code is sufficient to steal the grant.
+  code_challenge       text NOT NULL,
+  code_challenge_method text NOT NULL,
+  -- What the token will be allowed to do, decided here and read from here when
+  -- the token is minted. Never from the token request, so redemption cannot
+  -- widen what approval granted.
+  scopes               text[] NOT NULL,
+  -- RFC 8707. The resource the client said it wanted the token for, so the
+  -- token endpoint can refuse a code being exchanged for a token aimed
+  -- somewhere else.
+  resource             text,
+  approved_user_id     uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  approved_org_id      uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  created_at           timestamptz NOT NULL DEFAULT now(),
+  expires_at           timestamptz NOT NULL,
+  -- Single use. A code that could be redeemed twice mints a second token from
+  -- anywhere it has ever been, including a browser history and a proxy log.
+  redeemed_at          timestamptz,
+  CONSTRAINT mcp_codes_pkce_is_s256 CHECK (code_challenge_method = 'S256')
+);
+
+CREATE INDEX mcp_codes_expiry_idx ON mcp_authorization_codes (expires_at);
+
+-- ---------------------------------------------------------------------------
+-- The access token
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE engine_tokens DROP CONSTRAINT engine_tokens_kind;
+ALTER TABLE engine_tokens
+  ADD CONSTRAINT engine_tokens_kind CHECK (kind IN ('engine', 'cli', 'oidc', 'mcp'));
+
+-- Which registration earned it, so that deleting a client reaches the
+-- credentials it produced. Without this a deleted client would stop being able
+-- to obtain new tokens while the ones already issued kept working, which is the
+-- shape of a revocation that does not revoke.
+ALTER TABLE engine_tokens
+  ADD COLUMN mcp_client_id text REFERENCES mcp_clients(client_id) ON DELETE CASCADE;
+ALTER TABLE engine_tokens ADD COLUMN mcp_resource text;
+ALTER TABLE engine_tokens ADD CONSTRAINT engine_tokens_mcp_has_resource
+  CHECK (kind <> 'mcp' OR mcp_resource IS NOT NULL);
+
+-- An MCP token is a person, so it carries one, exactly as a 'cli' token does.
+ALTER TABLE engine_tokens
+  ADD CONSTRAINT engine_tokens_mcp_has_a_user CHECK (kind <> 'mcp' OR user_id IS NOT NULL);
+
+ALTER TABLE engine_tokens
+  ADD CONSTRAINT engine_tokens_mcp_has_a_client CHECK (kind <> 'mcp' OR mcp_client_id IS NOT NULL);
+
+-- Short lived as a property of the schema rather than as a promise about the
+-- code, the same reason 0025 gives for the OIDC kind. A future caller that
+-- forgets to pass an expiry cannot mint an immortal credential from a consent
+-- screen: the INSERT fails.
+ALTER TABLE engine_tokens
+  ADD CONSTRAINT engine_tokens_mcp_expires CHECK (kind <> 'mcp' OR expires_at IS NOT NULL);
+
+CREATE INDEX engine_tokens_mcp_client_idx ON engine_tokens (mcp_client_id)
+  WHERE mcp_client_id IS NOT NULL;
+
+-- ---------------------------------------------------------------------------
+-- Grants and policies
+-- ---------------------------------------------------------------------------
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON mcp_clients, mcp_authorization_codes
+  TO antifailure_app;
+GRANT SELECT, DELETE ON mcp_clients, mcp_authorization_codes TO antifailure_admin;
+
+-- The settings these policies read. Declared by the caller in withoutTenant,
+-- and each one is a value the caller has to already hold, so declaring one it
+-- was not given returns no rows rather than somebody else's.
+CREATE OR REPLACE FUNCTION current_mcp_client_id() RETURNS text
+  LANGUAGE sql STABLE
+  AS $$ SELECT nullif(current_setting('antifailure.mcp_client_id', true), '') $$;
+
+CREATE OR REPLACE FUNCTION current_mcp_code_hash() RETURNS bytea
+  LANGUAGE sql STABLE
+  AS $$ SELECT decode(nullif(current_setting('antifailure.mcp_code_hash', true), ''), 'hex') $$;
+
+ALTER TABLE mcp_clients ENABLE ROW LEVEL SECURITY;
+ALTER TABLE mcp_clients FORCE ROW LEVEL SECURITY;
+
+-- Both halves compare against the declared value, following device_poll in
+-- 0012 rather than allowing an unconstrained WITH CHECK. Registration mints the
+-- client_id in the application and declares it before the INSERT, so it has the
+-- value to declare; a policy that let the write through unchecked would let a
+-- statement anywhere in this server create a client row under an id it does not
+-- hold, which is a registration nobody consented to.
+CREATE POLICY presented_client ON mcp_clients
+  FOR ALL TO antifailure_app
+  USING (client_id = current_mcp_client_id())
+  WITH CHECK (client_id = current_mcp_client_id());
+
+ALTER TABLE mcp_authorization_codes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE mcp_authorization_codes FORCE ROW LEVEL SECURITY;
+
+-- Same shape. The consent screen generates the code, declares its hash, and
+-- then inserts; redemption declares the hash it was handed and reaches that row
+-- and nothing else.
+CREATE POLICY presented_code ON mcp_authorization_codes
+  FOR ALL TO antifailure_app
+  USING (code_hash = current_mcp_code_hash())
+  WITH CHECK (code_hash = current_mcp_code_hash());
+
+-- Enforce the audience split in the database too. Rolling the application back
+-- must not turn an MCP credential into an engine ingestion credential.
+ALTER POLICY presented_token ON engine_tokens
+  USING (kind <> 'mcp' AND token_hash = current_engine_token_hash())
+  WITH CHECK (kind <> 'mcp' AND token_hash = current_engine_token_hash());
+
+CREATE FUNCTION current_mcp_token_hash() RETURNS bytea
+  LANGUAGE sql STABLE
+  AS $$ SELECT decode(nullif(current_setting('antifailure.mcp_token_hash', true), ''), 'hex') $$;
+
+CREATE POLICY presented_mcp_token ON engine_tokens
+  FOR SELECT TO antifailure_app
+  USING (kind = 'mcp' AND token_hash = current_mcp_token_hash());
+
+COMMIT;

--- a/web/packages/db/migrations/0038_the_mcp_endpoint_a_browser_can_connect_to.sql
+++ b/web/packages/db/migrations/0038_the_mcp_endpoint_a_browser_can_connect_to.sql
@@ -64,11 +64,14 @@ CREATE TABLE mcp_clients (
   -- model, and still unguessable here, because it is the key the policy below
   -- confines this table by.
   client_id           text NOT NULL UNIQUE,
-  -- SHA-256 of the client secret, or NULL for a public client. Claude
-  -- registers as a public client and authenticates with PKCE instead, which is
-  -- what OAuth 2.1 asks of a client that cannot keep a secret. The column
-  -- exists because an organization may supply its own confidential client.
-  client_secret_hash  bytea,
+  -- No client secret column, and that is a decision rather than an omission.
+  -- This server registers PUBLIC clients only: the discovery document
+  -- advertises token_endpoint_auth_methods_supported as ["none"] and PKCE
+  -- S256 is what authenticates the exchange, which is what OAuth 2.1 asks of
+  -- a client that cannot keep a secret, and a browser client cannot. A
+  -- nullable secret hash nothing verifies is worse than no column: it reads
+  -- as support for confidential clients that does not exist. The day one is
+  -- supported it arrives with the code that checks it.
   -- What the client called itself. Shown on the consent screen, so it is the
   -- one string here a person reads, and it is written by whoever registered.
   -- Treated as untrusted text everywhere it is rendered.
@@ -78,7 +81,10 @@ CREATE TABLE mcp_clients (
   -- matching, per OAuth 2.1.
   redirect_uris       text[] NOT NULL,
   created_at          timestamptz NOT NULL DEFAULT now(),
-  last_used_at        timestamptz,
+  -- No last_used_at here either. When a registration was last exercised is
+  -- read off the credentials it produced, which carry engine_tokens.last_used_at
+  -- and are what the operator page shows. A second copy on this row would be
+  -- one more thing to write on every authenticated request and nothing reads it.
   CONSTRAINT mcp_clients_has_a_redirect CHECK (cardinality(redirect_uris) > 0)
 );
 

--- a/web/packages/db/src/client.ts
+++ b/web/packages/db/src/client.ts
@@ -104,6 +104,16 @@ export interface UnscopedOptions {
    *  organization it belonged to has been purged. There is no membership left
    *  to authorise against, so the link is the authorisation. */
   deletionTokenHash?: Buffer
+  /** The client_id of a registered MCP client, for reading its registration.
+   *  A client belongs to no organization, so there is no tenant to scope by;
+   *  what confines the read is that the caller already holds the value. */
+  mcpClientId?: string
+  /** The hash of an MCP authorization code, for minting it at the consent
+   *  screen and redeeming it at the token endpoint. The redemption has no
+   *  session and no tenant by definition and holds only this. */
+  mcpCodeHash?: Buffer
+  /** A presented MCP access token, isolated from engine bearer lookup. */
+  mcpTokenHash?: Buffer
 }
 
 /** What a verified webhook delivery declares it is about. */
@@ -304,6 +314,11 @@ export function createPool(options: PoolOptions): Pool {
     fn: (db: Db) => Promise<T>,
   ): Promise<T> {
     return root.transaction(async (tx) => {
+      // Clear the MCP lookup scopes for every entry point, including webhook
+      // and operator paths. Explicit settings below replace these defaults.
+      await tx.execute(rawSql`SELECT set_config('antifailure.mcp_client_id', '', true),
+        set_config('antifailure.mcp_code_hash', '', true),
+        set_config('antifailure.mcp_token_hash', '', true)`)
       await tx.execute(rawSql`SELECT set_config('statement_timeout', ${String(statementTimeout)}, true)`)
       if (options.rowSecurity === false) {
         await tx.execute(rawSql`SELECT set_config('row_security', 'off', true)`)
@@ -353,6 +368,12 @@ export function createPool(options: PoolOptions): Pool {
           // has no business declaring either.
           'antifailure.invitation_token_hash': '',
           'antifailure.deletion_token_hash': '',
+          // Cleared for the same reason. An MCP client belongs to no
+          // organization and an authorization code has none until it is
+          // redeemed, so a transaction that declares a tenant, an account, a
+          // customer or a delivery has no business declaring either.
+          'antifailure.mcp_client_id': '',
+          'antifailure.mcp_code_hash': opts?.mcpCodeHash?.toString('hex') ?? '',
           'antifailure.github_delivery': '',
           'antifailure.pr_callback_hash': '',
           'antifailure.sweeper': '',
@@ -406,6 +427,11 @@ export function createPool(options: PoolOptions): Pool {
           'antifailure.deletion_token_hash': opts?.deletionTokenHash
             ? opts.deletionTokenHash.toString('hex')
             : '',
+          'antifailure.mcp_client_id': opts?.mcpClientId ?? '',
+          'antifailure.mcp_token_hash': opts?.mcpTokenHash?.toString('hex') ?? '',
+          'antifailure.mcp_code_hash': opts?.mcpCodeHash
+            ? opts.mcpCodeHash.toString('hex')
+            : '',
           'antifailure.github_delivery': '',
           'antifailure.pr_callback_hash': '',
           'antifailure.sweeper': '',
@@ -448,6 +474,8 @@ export function createPool(options: PoolOptions): Pool {
           'antifailure.stripe_customer': '',
           'antifailure.invitation_token_hash': '',
           'antifailure.deletion_token_hash': '',
+          'antifailure.mcp_client_id': '',
+          'antifailure.mcp_code_hash': '',
           'antifailure.github_delivery': '',
           'antifailure.pr_callback_hash': '',
           'antifailure.sweeper': '',
@@ -490,6 +518,8 @@ export function createPool(options: PoolOptions): Pool {
           'antifailure.stripe_customer': customer,
           'antifailure.invitation_token_hash': '',
           'antifailure.deletion_token_hash': '',
+          'antifailure.mcp_client_id': '',
+          'antifailure.mcp_code_hash': '',
           'antifailure.github_delivery': '',
           'antifailure.pr_callback_hash': '',
           'antifailure.sweeper': '',
@@ -709,6 +739,8 @@ export function createPool(options: PoolOptions): Pool {
           'antifailure.sweeper': '',
           'antifailure.invitation_token_hash': '',
           'antifailure.deletion_token_hash': '',
+          'antifailure.mcp_client_id': '',
+          'antifailure.mcp_code_hash': '',
           // The two operator settings, cleared here like everywhere else. This
           // scope arrived from main while the operator boundary was still on a
           // branch, so it was the one scope in this file that did not name

--- a/web/packages/db/src/schema.ts
+++ b/web/packages/db/src/schema.ts
@@ -350,16 +350,23 @@ export const engineTokens = pgTable('engine_tokens', {
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   lastUsedAt: timestamp('last_used_at', { withTimezone: true }),
   revokedAt: timestamp('revoked_at', { withTimezone: true }),
-  // 'engine', 'cli' or 'oidc'. A cli token acts as a person and carries
+  // 'engine', 'cli', 'oidc' or 'mcp'. A cli token acts as a person and carries
   // user_id; an engine token is a machine and deliberately has none. See
   // migration 0012. An oidc token is one workflow job, minted by exchanging a
   // GitHub Actions identity token, and it carries the binding that earned it
-  // and an expiry the database insists on. See migration 0025.
+  // and an expiry the database insists on. See migration 0025. An mcp token is
+  // a person too, minted by the OAuth consent screen for one registered MCP
+  // client, and it is a separate kind so that the audience check the MCP
+  // authorization specification requires is a WHERE clause rather than a
+  // promise: a cli token is refused at /mcp and an mcp token is refused at
+  // /v1/whoami. See migration 0038.
   kind: text('kind').notNull().default('engine'),
   userId: uuid('user_id'),
   scopes: text('scopes').array().notNull().default([]),
   expiresAt: timestamp('expires_at', { withTimezone: true }),
   bindingId: uuid('binding_id'),
+  mcpClientId: text('mcp_client_id'),
+  mcpResource: text('mcp_resource'),
 }, (t) => [index('engine_tokens_org_idx').on(t.orgId)])
 
 // Which organization a GitHub repository may report as.
@@ -399,6 +406,40 @@ export const deviceAuthorizations = pgTable('device_authorizations', {
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
 }, (t) => [index('device_authorizations_expiry_idx').on(t.expiresAt)])
+
+// An MCP client that registered itself, per RFC 7591. It has no tenant on
+// purpose: one registration is shared by everybody in every organization who
+// connects through that client, so an owner would lock out the second one. Its
+// rows are reachable only by declaring the client_id the caller already holds,
+// the same shape as device_authorizations. See migration 0038.
+export const mcpClients = pgTable('mcp_clients', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  clientId: text('client_id').notNull(),
+  clientSecretHash: bytea('client_secret_hash'),
+  clientName: text('client_name').notNull(),
+  redirectUris: text('redirect_uris').array().notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  lastUsedAt: timestamp('last_used_at', { withTimezone: true }),
+})
+
+// The single-use code between the consent screen and the token endpoint. Same
+// classification and the same reason as device_authorizations: the token
+// exchange has no session and no tenant, and holds only the code.
+export const mcpAuthorizationCodes = pgTable('mcp_authorization_codes', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  codeHash: bytea('code_hash').notNull(),
+  clientId: text('client_id').notNull(),
+  redirectUri: text('redirect_uri').notNull(),
+  codeChallenge: text('code_challenge').notNull(),
+  codeChallengeMethod: text('code_challenge_method').notNull(),
+  scopes: text('scopes').array().notNull(),
+  resource: text('resource'),
+  approvedUserId: uuid('approved_user_id').notNull(),
+  approvedOrgId: uuid('approved_org_id').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+  redeemedAt: timestamp('redeemed_at', { withTimezone: true }),
+}, (t) => [index('mcp_codes_expiry_idx').on(t.expiresAt)])
 
 // A customer's provider key. The ciphertext is here; nothing reads it except
 // the code handing the key to the provider. See src/providers/seal.ts.

--- a/web/packages/db/src/schema.ts
+++ b/web/packages/db/src/schema.ts
@@ -415,11 +415,9 @@ export const deviceAuthorizations = pgTable('device_authorizations', {
 export const mcpClients = pgTable('mcp_clients', {
   id: uuid('id').primaryKey().defaultRandom(),
   clientId: text('client_id').notNull(),
-  clientSecretHash: bytea('client_secret_hash'),
   clientName: text('client_name').notNull(),
   redirectUris: text('redirect_uris').array().notNull(),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
-  lastUsedAt: timestamp('last_used_at', { withTimezone: true }),
 })
 
 // The single-use code between the consent screen and the token endpoint. Same

--- a/web/packages/db/test/tenancy.test.ts
+++ b/web/packages/db/test/tenancy.test.ts
@@ -94,6 +94,23 @@ describe('cross-tenant isolation', { skip: hasDatabase ? false : 'no Postgres at
         'no tenant until somebody approves it; a row is reachable only by the device code ' +
           'or the user code the caller already holds, the same shape as oauth_states',
       ],
+      [
+        'mcp_clients',
+        'an OAuth client registration belongs to the client rather than to a tenant: one ' +
+          'registration is used by everybody in every organization who connects through it, so ' +
+          'giving it an owner would stop the second organization reading the row the first one ' +
+          'created. What confines the application role is a policy keyed on a client_id of 32 ' +
+          'random bytes the caller has to already hold, the same shape as oauth_states. See ' +
+          'migrations/0038.',
+      ],
+      [
+        'mcp_authorization_codes',
+        'no tenant exists until somebody approves the connection, and the token exchange that ' +
+          'reads the row carries no session and no tenant, which is why the columns are named ' +
+          'approved_org_id and approved_user_id. A row is reachable only by presenting the hash ' +
+          'of the code the caller already holds, the same shape as device_authorizations. See ' +
+          'migrations/0038.',
+      ],
       ['schema_migrations', "the schema's own bookkeeping, not tenant data"],
       [
         'platform_controls',


### PR DESCRIPTION
`af mcp` is a real shipped feature and a web page cannot start a process on somebody's laptop, so claude.ai and ChatGPT in a browser could not reach this product at all. The reference page said so and offered a Supergateway command that listens on every interface and authenticates nobody. This adds the hosted half: authenticated Streamable HTTP at `/mcp` on the control plane's public origin, an explicit browser approval in front of it, and an operator page that shows what has actually been approved.

The endpoint uses the official TypeScript SDK's stateless JSON transport, so a request carries no session between replicas and `GET` and `DELETE` answer `405` with `Allow: POST` rather than opening an event stream nothing would hold. Registration is dynamic and public, because Claude registers itself, and the exchange is authenticated by PKCE `S256` rather than by a secret a browser cannot keep. Redirect matching is exact, the code lives five minutes, claiming it and minting the token share one transaction so a failed write cannot consume a grant and two exchanges cannot issue two credentials, and the audience is the configured origin rather than the request's `Host`.

Eight tools call the same authorised console procedures the browser calls, so a viewer who approves write access still cannot start an environment: the scope is a ceiling on the role, never a substitute for it. Membership, role and plan are read again on every request rather than frozen into the credential.

The audience split is enforced by the DATABASE and not by a promise about the code. `presented_token` now excludes `kind = 'mcp'` and a new `presented_mcp_token` reads `mcpTokenHash`, so rolling the application back to a build with no kind filter still cannot turn an MCP grant into an engine ingestion credential. Mutating that policy turned a `401` into a `202` and restoring it refused again.

`get_run` returns a recorded run's metadata and deliberately does NOT meet the local rehearsal evidence contract. The hosted service reads what a customer's engine reported to this control plane; it cannot open the checkout on somebody's laptop, and a verdict shaped like a local rehearsal's would be a claim about evidence this side has never seen. The reference page and the tool description both say so rather than leaving a reader to assume the two surfaces are the same thing.

Integrating the protocol, the consent screen and the operator page onto current main put them in front of gates no single branch had run, and that is the fifth commit. The tenancy classification gate refused both new tables. The route documentation gate refused `/mcp` and the two discovery documents. The operator's registered client count was asserted as an absolute number and is installation wide by design, so the full run measured eighteen where the file alone measured one. Three capabilities were written and unproved: the `405` contract had no assertion, the last authentication time is an UPDATE on a table whose MCP policy is SELECT only and would have written zero rows in silence, and every write assertion was a refusal, which proves a gate and nothing behind it. Two columns on `mcp_clients` had no writer and no reader and are gone.

The sixth commit is CodeQL's. It raised `js/polynomial-redos` at high severity against the trailing slash trim on the configured origin, and the finding is real: on a value that does not end in a slash the engine retries the match from every slash in it. The same three rules were also written twice, in the server that decides the audience and in the operator page that prints the address, so both now call one function that trims in a bounded loop. CodeQL passes on the fixed head.

Validation:

- Full web suite on a role isolated PostgreSQL 17 cluster of this lane's own, durable log, no edits during the run: API 1,973 passed, database package 142 passed, policy package 43 passed. Zero failed, zero skipped, zero cancelled in all three. That run covers the first five commits. The sixth touches three files and was re-run against them directly: the protocol, operator, route documentation and platform suites are 58 passed, zero failed, zero skipped, and the database and policy packages are 142 and 43 again on a database created fresh afterwards.
- Console suite 173 passed, zero failed, zero skipped. Console production build succeeded with 46 routes and 47 static pages. Documentation build succeeded with 89 pages. The marketing site built clean. Typecheck clean for the database, policy, API and console projects.
- Twenty gates run locally and green: `prosecheck` `changecheck` `conflictcheck` `authorship` `claimcheck` `varcheck` `sidebarcheck` `figurecheck` `forbidden` `spell` `vale` `docscheck` `readability` `constcheck` `keycheck` `execcheck` `deploycheck` `gatecheck` `classcheck` `motioncheck`.
- The migration is `0038`, taken as main's highest plus one at the moment of landing, and the database suite was run against a database created fresh after the renumber.
- Real browser and SDK chain against this tree, not an earlier one: registration `201`; the consent screen at 390 pixels showed the organization, client name, permission, ninety day lifetime and exact return address with zero horizontal overflow and no JavaScript errors; before any choice zero codes and zero credentials; Decline left it at zero and zero; Approve produced exactly one code and zero credentials, and the code was not left in the browser address; a wrong PKCE verifier was refused `400`; the correct one returned `200` with `mcp:read` and 7,776,000 seconds; the official SDK client connected over Streamable HTTP, identified the server as Antifailure and listed all eight tools; a read credential read the real seeded repository and was refused the write; revoking through the existing audited route returned `200` and the next protocol request `401`.
- Operator page rendered at 390 and 1440 pixels in light and dark: zero horizontal overflow, no JavaScript errors, the three credential states carry three distinct tones rather than one grey badge, and the only controls under 44 pixels are an inline prose link and the desktop Revoke button, which is 44 or more on the phone.

Mutation evidence. Every cell was proved in both directions: the mutated tree is red on the named assertion, the restored tree is green, and the restored file is byte identical to a snapshot taken before any mutation ran.

1. Classification list, first entry removed: the new client table is isolated by nothing the suite knows about.
2. Classification list, second entry removed: the same for the authorization code table.
3. Reference page, every mention of the protocol path removed: the route family gate names it.
4. Reference page, the protected resource row removed: the same.
5. Reference page, the authorization server row removed: the same.
6. Operator count reads a different table: the delta the file owns is no longer one.
7. Operator active filter drops the revocation condition: a revoked credential counts as active.
8. Operator totals drop the kind filter: an engine token counts as an MCP credential.
9. `405` becomes `200`: the standalone stream assertion.
10. The `Allow` header is not set: the same assertion, on its other half.
11. The last used UPDATE is removed: a real protocol request no longer records an authentication.
12. The create response stops saying it dispatched: the tool result assertion.
13. The GitHub call is removed from dispatch: the dispatch count assertion, zero against one.
14. The dispatch carries `down` rather than `up`: the dispatch field assertion.
15. The audit append is removed: the organization's own record assertion.
16. Creation inserts an environment immediately: the boundary assertion, because a dispatch is not a ready environment.
17. The slash trimming loop is removed: trailing slashes reach the published audience.
18. The scheme test is removed: an installation with no configured origin mounts an endpoint that must stay a `404`.
19. The operator page's endpoint drifts by one path segment: caught by reading the discovery document and comparing, rather than by asserting one literal in two suites.

A twentieth was attempted and came back GREEN, so it was replaced rather than reported. Removing only the `POST /mcp` row from the reference page passes, because that row's own description names `GET /mcp` in backticks and the gate reads the page as a whole. The honest mutation removes every mention of the path, and that one is red.

What is NOT claimed:

- No deployment. Merging deploys staging only, and production moves on a `v*` tag with a human approving the environment. Nothing here has run against production and no production client has connected.
- The endpoint is `404` on an installation whose control plane predates it or has no public origin configured. The reference page says that a `404` there is a missing deployment rather than a bad credential.
- The browser run's code replay was refused `429` by the token endpoint's own rate limit before it reached the grant check. The `400` on replay and the single credential under concurrent redemption are proved by the suite, not by that run.
- Authorization codes and client registrations accumulate with no sweep. Codes are single use and expire in five minutes and an expiry index exists for one, but nothing deletes them yet.
- The MCP actor carries an empty `sessionId`. Nothing any of the eight tools can reach compares it, and an empty string cannot match a session UUID, but it is a placeholder rather than a value.
