### PR TITLE
merge: a squash merge could not carry a sign-off, and staging stopped

### DIFF
--- a/.changes/merge-carries-a-sign-off.md
+++ b/.changes/merge-carries-a-sign-off.md
@@ -1,0 +1,21 @@
+# fixed
+
+A squash merge made without a sign-off stopped deployments, and nothing could
+have caught it before it landed. `gh pr merge --squash --body ""` creates a
+commit with no `Signed-off-by` trailer, which fails the required
+`commits are attributed to their author` context on main. The deployment
+workflow waits for CI on the same commit, reads that failure and refuses, so
+its build, staging and production jobs are all skipped. Six merged pull
+requests sat undeployed behind one missing line, and staging moved again only
+when a later merge carried the trailer.
+
+The commit hooks cannot reach this, because a squash commit is created on
+GitHub's side and no hook runs there. `just merge <number>` now performs the
+merge instead. It requires all nine of main's required contexts to report the
+literal word success on the pull request's exact head sha, confirms that list
+against branch protection rather than trusting its own copy, reads
+`mergeStateStatus` rather than `mergeable`, signs off in the merging person's
+own name and refuses to write anybody else's, never passes `--delete-branch`,
+which deletes the branch even when the merge is refused and so closes the pull
+request, and reads the commit back off the remote afterwards to prove the
+trailer is really there.

--- a/.gitignore
+++ b/.gitignore
@@ -307,3 +307,12 @@ web/apps/api/zzserve.ts
 # Anchored, so it ignores the build artefact at the root and not the harness at
 # tools/preview.
 /preview
+
+# `go build ./tools/prmerge` writes ./prmerge at the repository root, for the
+# same reason /preview is here: tools/gatecheck refuses any tools directory
+# whose name is not ignored, because the next `git add -A` would otherwise
+# commit a platform specific executable.
+#
+# Anchored, so it ignores the build artefact at the root and not the command at
+# tools/prmerge.
+/prmerge

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,6 +126,50 @@ than no gate.
 So this one is a review practice and it stays one. If the message accounts for
 part of the diff, ask about the rest before approving.
 
+### Merging
+
+Merge with `just merge <number>` and not with `gh pr merge` by hand.
+
+```
+just merge 231
+just merge 231 -dry-run     # check everything and merge nothing
+```
+
+The reason is a deployment outage rather than a style preference. Six pull
+requests were merged on 2026-09-05 with `gh pr merge --squash --body ""`. A
+squash commit made that way carries no `Signed-off-by` trailer, and the trailer
+is a required context, so `commits are attributed to their author` failed on
+main. `.github/workflows/cd.yml` has a gate job that waits for CI on the same
+commit; it read that failure and skipped its build, staging and production
+jobs, so staging stayed six merges behind at `cb3f30f1` while every one of
+those changes was on main. It moved again only when the next merge,
+`597b3819`, carried the trailer.
+
+No hook can prevent this. `.githooks/prepare-commit-msg` writes the trailer
+onto local commits and a squash commit is created on GitHub's side, so the
+only thing that runs at the moment of the merge is whatever the person pressing
+the button typed. `just merge` is that thing:
+
+* it requires all nine of main's required contexts to report the literal word
+  `success` on the pull request's exact head sha, and confirms that list
+  against branch protection rather than trusting the copy in its own source;
+* it reads `mergeStateStatus` and never `mergeable`, which only says whether
+  the branch conflicts;
+* it says which red checks it is ignoring, because `Antifailure` and
+  `dogfood, against the control plane` are not required and reading a red mark
+  on either as a block has cost this project hours;
+* it builds the sign-off from your own `git config user.name` and
+  `user.email`, which is clause (c) of the Developer Certificate of Origin:
+  somebody relaying another person's contribution signs as themselves and
+  leaves the authorship alone. It refuses a body carrying anybody else's
+  sign-off rather than adding a second one;
+* it never passes `--delete-branch`, which deletes the branch even when the
+  merge is refused and so closes the pull request. It prints the deletion
+  command for you to run afterwards;
+* and it reads the commit back off the remote afterwards and fails if the
+  trailer is not there, because a tool that intends to sign and cannot prove it
+  did is the defect it was written to prevent.
+
 ## The changelog
 
 Every change to something a user can see adds a fragment under `.changes/`.

--- a/justfile
+++ b/justfile
@@ -239,6 +239,23 @@ hooks:
       exit 1
     fi
 
+# Squash merge a pull request so the commit it creates carries a sign-off.
+#
+# `gh pr merge --squash --body ""` makes a squash commit with no
+# `Signed-off-by` trailer. Six pull requests were merged that way on
+# 2026-09-05. Main's `commits are attributed to their author` context failed on
+# the result, cd.yml's gate read that failure and skipped its build, staging
+# and production jobs, and staging sat six merges behind at cb3f30f1 until the
+# next merge, 597b3819, carried the trailer and let it move again. The commit
+# hooks cannot help: a squash commit is created on GitHub's side, so nothing
+# local runs at the moment the button is pressed.
+#
+# See tools/prmerge for what it refuses and why. `-dry-run` checks everything
+# and merges nothing.
+[doc("Squash merge a pull request with a Developer Certificate of Origin sign-off.")]
+merge pr *args:
+    go run ./tools/prmerge -pr {{pr}} {{args}}
+
 # Start the Postgres the control plane suites need.
 #
 # pg_stat_statements is preloaded because the query regression work needs it and

--- a/tools/gatecheck/main.go
+++ b/tools/gatecheck/main.go
@@ -580,6 +580,13 @@ func uncalledByGate(recipes []recipe, reachable map[string]bool) []string {
 		// Running account creation as part of a source check would be a write
 		// to production, not verification. Its tests run inside test-web.
 		"operator-init": true,
+		// Merges a pull request. It writes to main, which is the furthest
+		// thing there is from a check on a tree, and the property it exists
+		// for, a squash commit carrying a sign-off, is already a required
+		// context in CI. It is here for the same reason `hooks` is: the
+		// convenience is what makes the gate satisfiable, not a substitute
+		// for it. `go test ./tools/prmerge` is what runs in `gate`.
+		"merge": true,
 	}
 
 	var uncalled []string

--- a/tools/prmerge/main.go
+++ b/tools/prmerge/main.go
@@ -1,0 +1,827 @@
+// Command prmerge squash merges a pull request and then proves the commit it
+// created carries a Developer Certificate of Origin sign-off.
+//
+// WHY THIS EXISTS. Six pull requests were merged on 2026-09-05 with
+// `gh pr merge --squash --body ""`. A squash commit made that way carries no
+// `Signed-off-by` trailer, and the trailer is a required context: the
+// `commits are attributed to their author` job failed on main in run
+// 33934603009 with "1 commits have no Developer Certificate of Origin
+// sign-off". cd.yml then did what it is built to do. Its gate job waits for CI
+// on the same commit, polled 42 times, read the failure and refused with "CI
+// concluded 'failure' on e836979577732c8d879cd96ce57ac1a447e12b91. Nothing is
+// deployed", so its build, staging and production jobs were all skipped.
+//
+// Six merged pull requests did not reach staging because a merge commit was
+// missing one line. That is the whole failure, and it is worth stating in that
+// order: the missing trailer was not a cosmetic lapse, it was a deployment
+// outage with a one line cause.
+//
+// WHY NOTHING CAUGHT IT. `.githooks/prepare-commit-msg` writes the trailer
+// onto LOCAL commits, and a squash merge is made on GitHub's side, so no hook
+// ran. `just authorship` skips merge commits and in any case cannot read a
+// commit that does not exist until somebody presses the button. The CI gate
+// does catch it, and only after the commit is on main, at which point the
+// remedies are rewriting main or pushing another commit. So the convention
+// lived in one person's memory and in the bodies of the two merges before
+// those six, `cb3f30f1` and `b23e796b`, which both carry the trailer. A
+// convention nothing can execute is a convention that holds until the day
+// somebody is in a hurry.
+//
+// WHY IT SIGNS IN THE MERGER'S OWN NAME. This is clause (c) of the Developer
+// Certificate of Origin: somebody relaying a contribution certifies that it
+// came to them from a person who certified it, and signs as themselves. So the
+// trailer is built from the merging clone's own `git config user.name` and
+// `user.email` and from nothing else. A trailer naming anybody else would be a
+// certification made in another person's name, which is worse than no trailer
+// at all, so a body arriving here with somebody else's sign-off in it is
+// refused rather than merged alongside one.
+//
+// WHAT IT REFUSES, each because it has happened here rather than as a
+// precaution:
+//
+//   - a required context that is not the literal word `success` on the pull
+//     request's exact head sha, including one that never reported;
+//   - a required list that has drifted from the nine this file names;
+//   - an unmergeable `mergeStateStatus`, read instead of `mergeable`, which
+//     only answers whether the branch conflicts;
+//   - an empty check list, which usually means the pull request conflicts and
+//     not that the queue is busy;
+//   - an identity that cannot produce a trailer, because a merge whose body
+//     would carry no sign-off is the defect this command exists for;
+//   - a subject or body carrying an em dash, an en dash or a double hyphen,
+//     which this repository bans in commit messages and which prosecheck
+//     cannot see, because a commit message is not a tracked file.
+//
+// WHAT IT NEVER DOES. It never passes `--delete-branch`. That flag deletes the
+// branch even when the merge is REFUSED, and deleting the branch closes the
+// pull request, so one refused merge silently discards the work. It prints the
+// deletion command instead, for a human to run once the merge is confirmed.
+//
+// WHAT IT DELIBERATELY DOES NOT DO. It does not sign anybody else's commits.
+// Relaying a contribution from a fork is the other operation in this area and
+// it is a different act: the contributor stays the author of their commits,
+// the maintainer adds their OWN trailer across the range, and the safe way to
+// do that is a message filter rather than a rebase, because a filter cannot
+// change content and a rebase re-applies patches and can resolve one wrongly.
+// It is proved by the tree hash being identical before and after. That is a
+// hand operation with a person's judgement in it, and automating it is not
+// what this command is for. What this command owns is the squash commit that
+// lands on main, and the only name it will ever write into a trailer is the
+// name of the person running it.
+//
+// AND IT CHECKS ITS OWN WORK. After merging it reads the commit that landed and
+// requires the trailer to be there. A tool that intends to write a trailer and
+// cannot prove it did is the same class of defect as the one it fixes.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+// required is the nine contexts main's protection blocks a merge on.
+//
+// Named here AND compared against the live list on every run. Named so a
+// refusal can say which context is missing rather than print whatever the API
+// happened to return, and compared so that this list going stale fails loudly:
+// a tenth context added to protection and not added here would otherwise be a
+// gate this command merges straight past, which is a check that cannot say no.
+//
+// `Antifailure` and `dogfood, against the control plane` are deliberately NOT
+// here. Neither is required by protection, and three agents in one session read
+// a red mark on one of them as a block and lost hours to it. A red
+// non required context is reported by this command and does not stop it.
+var required = []string{
+	"engine",
+	"control plane",
+	"edition boundary",
+	"enterprise",
+	"runner",
+	"www",
+	"known vulnerabilities",
+	"no credentials in the tree",
+	"commits are attributed to their author",
+}
+
+// willMerge are the `mergeStateStatus` values this command will merge on, with
+// why each is safe.
+//
+// `mergeable` is read nowhere in this file, on purpose. It answers a narrower
+// question, whether the branch conflicts, and a pull request with no conflicts
+// and a required check still running reports MERGEABLE. Reading it as
+// permission to merge is how a merge gets attempted against a tree nothing has
+// finished checking.
+var willMerge = map[string]string{
+	"CLEAN":     "every protection is satisfied",
+	"HAS_HOOKS": "satisfied, with a repository pre-receive hook still to run",
+	// UNSTABLE means a check protection does not require is red or still
+	// running. That is the ordinary state of a pull request here, because
+	// `Antifailure` and Dogfood are not required contexts, and refusing it
+	// would refuse nearly every pull request this repository opens. The nine
+	// required contexts are checked one by one above, so this state is not
+	// being trusted for anything protection would have blocked.
+	"UNSTABLE": "a check protection does not require is red or still running, which does not block a merge",
+}
+
+// willNotMerge are the states that stop this command, each with the sentence
+// somebody reads when their merge did not happen.
+var willNotMerge = map[string]string{
+	"DIRTY": "the branch conflicts with its base, so there is nothing to squash yet. " +
+		"Rebase or merge the base in, let the checks run again, and merge after that.",
+	"BLOCKED": "GitHub is blocking this merge. A required review, a required context that " +
+		"has not passed, or a protection this command cannot read. When it is a context, " +
+		"the required list above says which one.",
+	"BEHIND": "protection requires the branch to be up to date with its base and it is not. " +
+		"Update it, wait for its checks to run against the new head, and merge then.",
+	"DRAFT":   "the pull request is a draft. Mark it ready for review first.",
+	"UNKNOWN": "GitHub has not finished working out whether this can merge. That is not a no and it is certainly not a yes. Ask again in a moment.",
+}
+
+// banned are the characters this repository does not allow in prose, and a
+// commit message is prose.
+//
+// tools/prosecheck enforces this over tracked files, and a commit message is
+// not a tracked file, so the subject taken from a pull request title and any
+// body handed to this command are the one prose surface with no gate on it.
+// The subject in particular is written by whoever opened the pull request and
+// read again by nobody.
+var banned = []struct {
+	pattern *regexp.Regexp
+	what    string
+}{
+	{regexp.MustCompile(`\x{2014}`), "an em dash"},
+	{regexp.MustCompile(`\x{2013}`), "an en dash"},
+	{regexp.MustCompile(`\s--\s`), "a double hyphen as punctuation"},
+}
+
+// attribution are the trailers this repository does not put in a commit, in
+// the shape a key is matched: at the start of a line, case insensitively.
+var attribution = regexp.MustCompile(`(?im)^(Co-authored-by|Generated-with|Generated-by):`)
+
+// signOffLine finds any sign-off trailer in a body, so one naming somebody
+// else can be refused rather than merged alongside the merger's own.
+var signOffLine = regexp.MustCompile(`(?im)^Signed-off-by:.*$`)
+
+// runner runs one external command and returns its standard output.
+//
+// One interface for both `gh` and `git` rather than two, because the assertion
+// that matters most about this command is about the whole set of commands it
+// issues: `--delete-branch` must never appear in any of them. A test can only
+// make that assertion against a recording of every invocation, and two
+// interfaces would give it two recordings and one blind spot.
+type runner interface {
+	run(name string, args ...string) ([]byte, error)
+}
+
+// local runs commands for real.
+type local struct{}
+
+func (local) run(name string, args ...string) ([]byte, error) {
+	cmd := exec.Command(name, args...)
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		// The message matters more than the exit code here: `gh` puts the
+		// reason a merge was refused on stderr and nothing else says it.
+		if said := strings.TrimSpace(stderr.String()); said != "" {
+			return out, fmt.Errorf("%s %s: %v: %s", name, strings.Join(args, " "), err, said)
+		}
+		return out, fmt.Errorf("%s %s: %v", name, strings.Join(args, " "), err)
+	}
+	return out, nil
+}
+
+// pull is the part of a pull request this command reasons about.
+type pull struct {
+	Number           int    `json:"number"`
+	Title            string `json:"title"`
+	State            string `json:"state"`
+	IsDraft          bool   `json:"isDraft"`
+	Merged           bool   `json:"merged"`
+	MergeStateStatus string `json:"mergeStateStatus"`
+	HeadRefOid       string `json:"headRefOid"`
+	HeadRefName      string `json:"headRefName"`
+	BaseRefName      string `json:"baseRefName"`
+	MergeCommit      struct {
+		Oid string `json:"oid"`
+	} `json:"mergeCommit"`
+}
+
+// pullFields is the exact `--json` list, kept in one place so the struct above
+// and the request cannot drift apart.
+const pullFields = "number,title,state,isDraft,merged,mergeStateStatus,headRefOid,headRefName,baseRefName,mergeCommit"
+
+// check is one reported context on a commit, whether it arrived as a check run
+// or as a commit status.
+//
+// Both shapes are read. The nine required contexts are all check runs today,
+// and a required context that was a commit status would be invisible to a
+// command that read only check runs: it would report as never having run, and
+// this command would refuse a pull request that was in fact green. Refusing
+// wrongly is the safe direction and it is still wrong, and the cost of being
+// right is one more request.
+type check struct {
+	Name       string
+	Status     string
+	Conclusion string
+	At         time.Time
+	ID         int64
+}
+
+// hub is GitHub, reached through whatever runner it was given.
+type hub struct {
+	runner runner
+	repo   string
+}
+
+func (h hub) gh(args ...string) ([]byte, error) { return h.runner.run("gh", args...) }
+
+// pull reads one pull request.
+func (h hub) pull(number int) (pull, error) {
+	out, err := h.gh("pr", "view", fmt.Sprint(number), "--repo", h.repo, "--json", pullFields)
+	if err != nil {
+		return pull{}, err
+	}
+	var p pull
+	if err := json.Unmarshal(out, &p); err != nil {
+		return pull{}, fmt.Errorf("reading pull request %d: %w", number, err)
+	}
+	return p, nil
+}
+
+// protection is the live required context list for a branch.
+//
+// A failure here is fatal rather than skipped. Reading branch protection needs
+// administration rights, so a 403 means the person running this cannot confirm
+// what blocks a merge, and merging on a list nobody confirmed is exactly the
+// gate this command is supposed to be.
+func (h hub) protection(branch string) ([]string, error) {
+	out, err := h.gh("api", fmt.Sprintf("repos/%s/branches/%s/protection", h.repo, branch))
+	if err != nil {
+		return nil, fmt.Errorf("reading the required contexts on %s: %w\n"+
+			"  This command will not merge on a required list it could not confirm. "+
+			"Reading branch protection needs administration rights on the repository", branch, err)
+	}
+	var body struct {
+		RequiredStatusChecks struct {
+			Contexts []string `json:"contexts"`
+		} `json:"required_status_checks"`
+	}
+	if err := json.Unmarshal(out, &body); err != nil {
+		return nil, fmt.Errorf("reading the required contexts on %s: %w", branch, err)
+	}
+	return body.RequiredStatusChecks.Contexts, nil
+}
+
+// checks is everything that reported on a commit, check runs and statuses both.
+func (h hub) checks(sha string) ([]check, error) {
+	out, err := h.gh("api", fmt.Sprintf("repos/%s/commits/%s/check-runs?per_page=100", h.repo, sha))
+	if err != nil {
+		return nil, fmt.Errorf("reading the check runs on %s: %w", sha, err)
+	}
+	var runs struct {
+		CheckRuns []struct {
+			ID         int64     `json:"id"`
+			Name       string    `json:"name"`
+			Status     string    `json:"status"`
+			Conclusion string    `json:"conclusion"`
+			StartedAt  time.Time `json:"started_at"`
+		} `json:"check_runs"`
+	}
+	if err := json.Unmarshal(out, &runs); err != nil {
+		return nil, fmt.Errorf("reading the check runs on %s: %w", sha, err)
+	}
+	var all []check
+	for _, r := range runs.CheckRuns {
+		all = append(all, check{Name: r.Name, Status: r.Status, Conclusion: r.Conclusion, At: r.StartedAt, ID: r.ID})
+	}
+
+	out, err = h.gh("api", fmt.Sprintf("repos/%s/commits/%s/status?per_page=100", h.repo, sha))
+	if err != nil {
+		return nil, fmt.Errorf("reading the commit statuses on %s: %w", sha, err)
+	}
+	var statuses struct {
+		Statuses []struct {
+			ID        int64     `json:"id"`
+			Context   string    `json:"context"`
+			State     string    `json:"state"`
+			CreatedAt time.Time `json:"created_at"`
+		} `json:"statuses"`
+	}
+	if err := json.Unmarshal(out, &statuses); err != nil {
+		return nil, fmt.Errorf("reading the commit statuses on %s: %w", sha, err)
+	}
+	for _, s := range statuses.Statuses {
+		// A status has one field where a check run has two. `pending` is the
+		// only one of its states that means no verdict yet, so it becomes a
+		// status rather than a conclusion, and every other value becomes a
+		// conclusion that is compared against `success` like any other.
+		c := check{Name: s.Context, Status: "completed", Conclusion: s.State, At: s.CreatedAt, ID: s.ID}
+		if s.State == "pending" {
+			c.Status, c.Conclusion = "in_progress", ""
+		}
+		all = append(all, c)
+	}
+	return all, nil
+}
+
+// commitMessage is the full message of a commit on the remote.
+func (h hub) commitMessage(sha string) (string, error) {
+	out, err := h.gh("api", fmt.Sprintf("repos/%s/commits/%s", h.repo, sha))
+	if err != nil {
+		return "", fmt.Errorf("reading the commit %s: %w", sha, err)
+	}
+	var body struct {
+		Commit struct {
+			Message string `json:"message"`
+		} `json:"commit"`
+	}
+	if err := json.Unmarshal(out, &body); err != nil {
+		return "", fmt.Errorf("reading the commit %s: %w", sha, err)
+	}
+	return body.Commit.Message, nil
+}
+
+// willCarry reports whether the command about to be issued really puts the
+// trailer in the squash body.
+//
+// It reads the ARGUMENTS rather than the variable they were built from,
+// because the arguments are what GitHub sees and the variable is only what
+// this file believes. The defect that produced this command was
+// `gh pr merge --squash --body ""`, which is an argument list, and this is the
+// one line that looks at the argument list before it goes out. A command with
+// no --body at all fails it too: an absent body is not a body that carries a
+// sign-off, and gh would fill it in with something nobody chose.
+func willCarry(args []string, own string) bool {
+	for i, a := range args {
+		if a == "--body" && i+1 < len(args) {
+			return carries(args[i+1], own)
+		}
+	}
+	return false
+}
+
+// mergeArgs is the whole command, built in one place so a test can read it.
+//
+// There is no `--delete-branch` here and there must never be one. It deletes
+// the branch even when the merge is REFUSED, and deleting the branch closes the
+// pull request, so a single refusal discards the work.
+func mergeArgs(repo string, number int, subject, body string) []string {
+	return []string{"pr", "merge", fmt.Sprint(number), "--repo", repo, "--squash",
+		"--subject", subject, "--body", body}
+}
+
+// identity is the merging clone's own commit identity.
+func identity(r runner) (string, string, error) {
+	name, err := configValue(r, "user.name")
+	if err != nil {
+		return "", "", err
+	}
+	email, err := configValue(r, "user.email")
+	if err != nil {
+		return "", "", err
+	}
+	return name, email, nil
+}
+
+func configValue(r runner, key string) (string, error) {
+	out, err := r.run("git", "config", "--get", key)
+	if err != nil {
+		return "", fmt.Errorf("reading %s from git config: %v\n"+
+			"  The sign-off is built from it, so a merge made without one would carry no "+
+			"trailer, which is the failure this command exists to prevent.\n"+
+			"  Set it: git config %s \"...\"", key, err, key)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// trailer builds the sign-off, and refuses to build a broken one.
+//
+// Every refusal here is the same refusal in different clothes: a merge whose
+// body would carry no usable trailer must not happen. An empty name or address
+// is the case that produced this command. A newline is the case that would
+// produce a body with a trailer in it that is not a trailer, because git reads
+// trailers by line.
+func trailer(name, email string) (string, error) {
+	name, email = strings.TrimSpace(name), strings.TrimSpace(email)
+	switch {
+	case name == "":
+		return "", fmt.Errorf("git config user.name is empty, so there is no name to sign off in.\n" +
+			"  Set it: git config user.name \"Your Name\"")
+	case email == "":
+		return "", fmt.Errorf("git config user.email is empty, so there is no address to sign off with.\n" +
+			"  Set it: git config user.email you@example.com")
+	case !strings.Contains(email, "@"):
+		return "", fmt.Errorf("git config user.email is %q, which is not an address. A sign-off "+
+			"has to name somebody who can be reached", email)
+	case strings.ContainsAny(name, "\r\n") || strings.ContainsAny(email, "\r\n"):
+		return "", fmt.Errorf("the commit identity contains a line break. git reads trailers by " +
+			"line, so this would put something in the body that only looks like a sign-off")
+	}
+	return fmt.Sprintf("Signed-off-by: %s <%s>", name, email), nil
+}
+
+// subjectFor is the squash subject: the pull request's title with its number,
+// which is the shape every merge on main already has.
+func subjectFor(title string, number int) string {
+	title = strings.TrimSpace(title)
+	suffix := fmt.Sprintf("(#%d)", number)
+	if strings.HasSuffix(title, suffix) {
+		return title
+	}
+	return title + " " + suffix
+}
+
+// bodyFor puts the trailer at the end of the body, and refuses a body it must
+// not sign.
+//
+// The trailer goes last and after a blank line, because git only reads a
+// trailer out of the final paragraph. A sign-off in the middle of prose is not
+// a trailer, it is a sentence that looks like one, and `git interpret-trailers`
+// and the CI gate disagree about it.
+func bodyFor(given, own string) (string, error) {
+	given = strings.TrimRight(strings.ReplaceAll(given, "\r\n", "\n"), "\n \t")
+	if found := attribution.FindString(given); found != "" {
+		return "", fmt.Errorf("the body carries %q. This repository puts no attribution trailer "+
+			"in a commit", strings.TrimSuffix(strings.TrimSpace(found), ":"))
+	}
+	for _, line := range signOffLine.FindAllString(given, -1) {
+		if strings.TrimSpace(line) != own {
+			return "", fmt.Errorf("the body already carries %q, and this command signs off as "+
+				"%q.\n  Relaying somebody else's contribution is signed in your own name, "+
+				"which is clause (c) of the Developer Certificate of Origin. A trailer naming "+
+				"another person is a certification made in their name", strings.TrimSpace(line), own)
+		}
+	}
+	if given == "" {
+		return own, nil
+	}
+	if carries(given, own) {
+		return given, nil
+	}
+	return given + "\n\n" + own, nil
+}
+
+// prose refuses the characters this repository bans in a commit message.
+func prose(what, text string) []string {
+	var problems []string
+	for _, b := range banned {
+		if b.pattern.MatchString(text) {
+			problems = append(problems, fmt.Sprintf(
+				"the %s carries %s. This repository writes a comma, a colon or a new sentence "+
+					"instead, in commit messages as much as anywhere, and prosecheck cannot see "+
+					"a commit message because it is not a tracked file", what, b.what))
+		}
+	}
+	return problems
+}
+
+// latest keeps the newest report per context name.
+//
+// A commit carries more than one run under the same name: a re-run of a
+// workflow adds a check run rather than replacing one, and this repository has
+// a commit where `build` appears twice, once skipped and once successful.
+// Protection reads the newest, so this reads the newest. Taking the oldest, or
+// requiring every report under a name to be green, would refuse a pull request
+// whose re-run fixed it, and this command must not be stricter than the thing
+// it is standing in for.
+func latest(all []check) map[string]check {
+	sorted := make([]check, len(all))
+	copy(sorted, all)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		if !sorted[i].At.Equal(sorted[j].At) {
+			return sorted[i].At.Before(sorted[j].At)
+		}
+		return sorted[i].ID < sorted[j].ID
+	})
+	newest := map[string]check{}
+	for _, c := range sorted {
+		newest[c.Name] = c
+	}
+	return newest
+}
+
+// listDrift compares the required list this file names against the live one.
+func listDrift(live []string) []string {
+	want, have := map[string]bool{}, map[string]bool{}
+	for _, c := range required {
+		want[c] = true
+	}
+	for _, c := range live {
+		have[c] = true
+	}
+	var problems []string
+	for _, c := range live {
+		if !want[c] {
+			problems = append(problems, fmt.Sprintf(
+				"protection requires %q and this command does not know about it, so it would "+
+					"have merged without reading it. Add it to `required` in tools/prmerge", c))
+		}
+	}
+	for _, c := range required {
+		if !have[c] {
+			problems = append(problems, fmt.Sprintf(
+				"this command requires %q and protection does not, so it would refuse a merge "+
+					"nothing is blocking. Remove it from `required` in tools/prmerge", c))
+		}
+	}
+	sort.Strings(problems)
+	return problems
+}
+
+// contexts is the verdict on the nine, and the whole reason for reading a
+// commit's checks one by one rather than trusting a rollup.
+//
+// Only the literal word `success` passes. `skipped` and `cancelled` are the two
+// that have to be said out loud: both render as an absence of red in a list,
+// `skipped` means nothing ran, and `cancelled` is spelled the same way for a
+// job that hit its own timeout, a run somebody stopped and a run superseded by
+// a newer push. None of those is a verdict, and a thing that is not a verdict
+// is not a pass.
+func contexts(sha string, all []check, out io.Writer) []string {
+	newest := latest(all)
+	if len(all) == 0 {
+		return []string{fmt.Sprintf(
+			"nothing at all has reported on %s. An empty check list usually means the pull "+
+				"request CONFLICTS rather than that the queue is busy, so read "+
+				"mergeStateStatus before waiting for anything", sha)}
+	}
+	var problems []string
+	for _, name := range required {
+		c, reported := newest[name]
+		switch {
+		case !reported:
+			problems = append(problems, fmt.Sprintf(
+				"%q never reported on %s. A required context that is absent is not a context "+
+					"that passed", name, sha))
+		case c.Status != "completed":
+			problems = append(problems, fmt.Sprintf(
+				"%q is %s on %s, so it has reached no verdict yet", name, c.Status, sha))
+		case c.Conclusion != "success":
+			problems = append(problems, fmt.Sprintf(
+				"%q concluded %q on %s. Only the literal word success is a pass: skipped means "+
+					"nothing ran, and cancelled is how GitHub spells a timeout, a stopped run "+
+					"and a superseded run alike", name, c.Conclusion, sha))
+		default:
+			fmt.Fprintf(out, "ok  %-40s success\n", name)
+		}
+	}
+	return problems
+}
+
+// unrequired reports the contexts that are red and do not block anything.
+//
+// Printed rather than counted, because the opposite mistake is expensive here:
+// `Antifailure` and `dogfood, against the control plane` are not required, and
+// three agents in one session read a red mark on one of them as a block and
+// lost hours to it.
+func unrequired(all []check) []string {
+	want := map[string]bool{}
+	for _, c := range required {
+		want[c] = true
+	}
+	var noted []string
+	for name, c := range latest(all) {
+		if want[name] || c.Conclusion == "success" {
+			continue
+		}
+		state := c.Conclusion
+		if c.Status != "completed" {
+			state = c.Status
+		}
+		noted = append(noted, fmt.Sprintf("%s (%s)", name, state))
+	}
+	sort.Strings(noted)
+	return noted
+}
+
+// carries reports whether a commit message ends a line with exactly this
+// trailer.
+//
+// Line exact rather than a substring search: a message that mentions a
+// sign-off in a sentence is not a commit that carries one, and the CI gate
+// greps for `^Signed-off-by: `, so anything looser here would pass a commit the
+// gate then fails, which is this command lying about the one thing it is for.
+func carries(message, own string) bool {
+	for _, line := range strings.Split(strings.ReplaceAll(message, "\r\n", "\n"), "\n") {
+		if strings.TrimRight(line, " \t") == own {
+			return true
+		}
+	}
+	return false
+}
+
+// confirm reads back what the merge actually produced.
+//
+// It polls because the merge commit is not always on the pull request the
+// instant the merge returns, and an unconfirmed merge must not be reported as
+// either done or broken. Running out of attempts is its own refusal, worded so
+// that nobody reads "could not confirm" as "did not happen".
+func confirm(h hub, number int, own string, attempts int, interval time.Duration, out io.Writer) error {
+	var last error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		p, err := h.pull(number)
+		if err != nil {
+			last = err
+		} else if p.Merged && p.MergeCommit.Oid != "" {
+			message, err := h.commitMessage(p.MergeCommit.Oid)
+			if err != nil {
+				return err
+			}
+			if !carries(message, own) {
+				return fmt.Errorf("the merge LANDED as %s and the commit does not carry %q.\n"+
+					"  main's `commits are attributed to their author` context will fail on it, "+
+					"and cd.yml's gate refuses to deploy a commit whose CI failed, so staging "+
+					"will not move.\n"+
+					"  Do not rewrite main to fix this: it would break every existing clone and "+
+					"the merge base of every open pull request. Push a signed commit on top "+
+					"instead", p.MergeCommit.Oid, own)
+			}
+			fmt.Fprintf(out, "ok  %-40s %s\n", "the commit carries the sign-off", p.MergeCommit.Oid)
+			return nil
+		} else if !p.Merged && p.State == "CLOSED" {
+			return fmt.Errorf("pull request %d is closed and not merged. Nothing landed", number)
+		} else {
+			last = fmt.Errorf("pull request %d reports merged=%v with merge commit %q",
+				number, p.Merged, p.MergeCommit.Oid)
+		}
+		if attempt < attempts {
+			time.Sleep(interval)
+		}
+	}
+	return fmt.Errorf("the merge was accepted and could not be confirmed within the budget. "+
+		"The last thing GitHub said was: %v.\n"+
+		"  That is not a statement that the merge failed, it is a statement that nobody knows "+
+		"whether the commit on main carries a sign-off. Read it: "+
+		"git fetch origin && git log -1 --format='%%B' origin/main", last)
+}
+
+func main() {
+	repo := flag.String("repo", "", "owner/name, defaulting to the repository gh resolves here")
+	number := flag.Int("pr", 0, "the pull request to merge")
+	bodyText := flag.String("body", "", "the squash body, which this command appends the sign-off to")
+	bodyFile := flag.String("body-file", "", "read the squash body from a file")
+	dry := flag.Bool("dry-run", false, "check everything and print the merge command without running it")
+	attempts := flag.Int("confirm-attempts", 10, "how many times to ask whether the merge landed")
+	interval := flag.Duration("confirm-interval", 3*time.Second, "how long to wait between asks")
+	flag.Parse()
+
+	if *number == 0 && len(flag.Args()) > 0 {
+		if _, err := fmt.Sscanf(flag.Args()[0], "%d", number); err != nil {
+			fail("%q is not a pull request number", flag.Args()[0])
+		}
+	}
+	if *number <= 0 {
+		fail("prmerge needs a pull request. Pass its number: just merge 231")
+	}
+	if *bodyText != "" && *bodyFile != "" {
+		fail("pass -body or -body-file, not both")
+	}
+	if *bodyFile != "" {
+		read, err := os.ReadFile(*bodyFile)
+		if err != nil {
+			fail("reading %s: %v", *bodyFile, err)
+		}
+		*bodyText = string(read)
+	}
+
+	r := local{}
+	if *repo == "" {
+		out, err := r.run("gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner")
+		if err != nil {
+			fail("working out which repository this is: %v\n  Pass -repo owner/name.", err)
+		}
+		*repo = strings.TrimSpace(string(out))
+	}
+
+	if err := merge(hub{runner: r, repo: *repo}, r, *number, *bodyText, *dry, *attempts, *interval, os.Stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "\nprmerge: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// merge is the whole decision, kept out of main so that a test can run it end
+// to end against recorded answers rather than against GitHub.
+func merge(h hub, r runner, number int, given string, dry bool, attempts int, interval time.Duration, out io.Writer) error {
+	name, email, err := identity(r)
+	if err != nil {
+		return err
+	}
+	own, err := trailer(name, email)
+	if err != nil {
+		return err
+	}
+
+	p, err := h.pull(number)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "prmerge: #%d %q\n  head %s on %s, base %s, mergeStateStatus %s\n",
+		p.Number, p.Title, p.HeadRefOid, p.HeadRefName, p.BaseRefName, p.MergeStateStatus)
+
+	var problems []string
+	switch {
+	case p.Merged:
+		return fmt.Errorf("pull request %d is already merged", number)
+	case p.State != "OPEN":
+		return fmt.Errorf("pull request %d is %s, not OPEN", number, p.State)
+	case p.IsDraft:
+		return fmt.Errorf("pull request %d is a draft, so nobody has said it is finished. "+
+			"Mark it ready for review first", number)
+	case p.HeadRefOid == "":
+		return fmt.Errorf("pull request %d reports no head sha, so there is no commit to check", number)
+	}
+
+	live, err := h.protection(p.BaseRefName)
+	if err != nil {
+		return err
+	}
+	if drift := listDrift(live); len(drift) > 0 {
+		problems = append(problems, drift...)
+	} else {
+		fmt.Fprintf(out, "ok  %-40s %d contexts on %s\n", "the required list is the live one", len(required), p.BaseRefName)
+	}
+
+	all, err := h.checks(p.HeadRefOid)
+	if err != nil {
+		return err
+	}
+	problems = append(problems, contexts(p.HeadRefOid, all, out)...)
+
+	if why, ok := willMerge[p.MergeStateStatus]; ok {
+		fmt.Fprintf(out, "ok  %-40s %s, %s\n", "mergeStateStatus", p.MergeStateStatus, why)
+	} else if why, known := willNotMerge[p.MergeStateStatus]; known {
+		problems = append(problems, fmt.Sprintf("mergeStateStatus is %s: %s", p.MergeStateStatus, why))
+	} else {
+		problems = append(problems, fmt.Sprintf(
+			"mergeStateStatus is %q, which this command does not recognise. An unfamiliar "+
+				"answer is not a yes", p.MergeStateStatus))
+	}
+
+	subject := subjectFor(p.Title, number)
+	body, err := bodyFor(given, own)
+	if err != nil {
+		problems = append(problems, err.Error())
+	}
+	problems = append(problems, prose("subject", subject)...)
+	problems = append(problems, prose("body", body)...)
+
+	args := mergeArgs(h.repo, number, subject, body)
+
+	// The last line of defence, and it is not redundant with bodyFor. That one
+	// builds a body; this one reads the command that is about to be issued and
+	// refuses to run it if the body in it does not carry the trailer, whatever
+	// built that body. The whole failure was a command that went out with
+	// `--body ""`.
+	if !willCarry(args, own) {
+		problems = append(problems, fmt.Sprintf(
+			"the squash body would not carry %q, so the commit on %s would have no Developer "+
+				"Certificate of Origin sign-off. That is the exact defect this command exists "+
+				"to prevent: six merges made that way failed main's authorship context and "+
+				"cd.yml refused to deploy any of them", own, p.BaseRefName))
+	}
+
+	if noted := unrequired(all); len(noted) > 0 {
+		fmt.Fprintf(out, "    not required by protection, and not blocking: %s\n", strings.Join(noted, ", "))
+	}
+
+	if len(problems) > 0 {
+		return fmt.Errorf("refusing to merge #%d.\n  %s", number, strings.Join(problems, "\n  "))
+	}
+
+	if dry {
+		fmt.Fprintf(out, "\nwould run: gh %s\n", strings.Join(args, " "))
+		fmt.Fprintf(out, "dry run, so nothing was merged\n")
+		return nil
+	}
+
+	if _, err := h.gh(args...); err != nil {
+		return fmt.Errorf("the merge was refused: %v", err)
+	}
+	if err := confirm(h, number, own, attempts, interval, out); err != nil {
+		return err
+	}
+
+	// The branch is left alone, deliberately. `gh pr merge --delete-branch`
+	// deletes it even when the merge is REFUSED, and deleting the branch closes
+	// the pull request, so one refusal discards the work. The merge is confirmed
+	// by the time this prints, which is the only point at which deleting is
+	// safe, and a person does it.
+	fmt.Fprintf(out, "\nmerged #%d. The branch is still there, on purpose.\n", number)
+	fmt.Fprintf(out, "  Delete it when you are satisfied: git push origin --delete %s\n", p.HeadRefName)
+	return nil
+}
+
+func fail(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "prmerge: "+format+"\n", args...)
+	os.Exit(1)
+}

--- a/tools/prmerge/main_test.go
+++ b/tools/prmerge/main_test.go
@@ -1,0 +1,808 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// Every test in this file runs the real decision path. The only thing replaced
+// is the runner, so the arguments this command would hand to `gh` and to `git`
+// are built by production code and recorded, and the answers it reasons about
+// are the shapes the API really returns. Nothing here asserts that the source
+// contains a word.
+
+const when = "2026-09-05T01:00:00Z"
+
+// reported is one context as GitHub reports it.
+type reported struct {
+	name       string
+	status     string
+	conclusion string
+	at         string
+}
+
+// green is the nine required contexts, all successful, plus the two that are
+// NOT required and are red. That pairing is deliberate: the ordinary state of a
+// pull request in this repository is nine green and Dogfood red, and a command
+// that refused it would be a command nobody could merge with.
+func green() []reported {
+	var out []reported
+	for _, name := range required {
+		out = append(out, reported{name, "completed", "success", when})
+	}
+	out = append(out,
+		reported{"Antifailure", "completed", "action_required", when},
+		reported{"dogfood, against the control plane", "completed", "failure", when},
+	)
+	return out
+}
+
+// with returns green() having replaced one context's report, which is how each
+// refusal below is aimed at exactly one row.
+func with(name, status, conclusion string) []reported {
+	out := green()
+	for i := range out {
+		if out[i].name == name {
+			out[i].status, out[i].conclusion = status, conclusion
+			return out
+		}
+	}
+	out = append(out, reported{name, status, conclusion, when})
+	return out
+}
+
+// without removes a context entirely, which is the absent case.
+func without(name string) []reported {
+	var out []reported
+	for _, r := range green() {
+		if r.name != name {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func checkRunsBody(rs []reported) string {
+	var parts []string
+	for i, r := range rs {
+		parts = append(parts, fmt.Sprintf(
+			`{"id":%d,"name":%q,"status":%q,"conclusion":%q,"started_at":%q}`,
+			i+1, r.name, r.status, r.conclusion, r.at))
+	}
+	return fmt.Sprintf(`{"total_count":%d,"check_runs":[%s]}`, len(rs), strings.Join(parts, ","))
+}
+
+// noStatuses is what this repository's commits really return from the combined
+// status endpoint: an empty list, because every context here is a check run.
+const noStatuses = `{"state":"pending","statuses":[],"total_count":0}`
+
+const protectionBody = `{"required_status_checks":{"strict":false,"contexts":` +
+	`["engine","control plane","edition boundary","enterprise","runner","www",` +
+	`"known vulnerabilities","no credentials in the tree",` +
+	`"commits are attributed to their author"]}}`
+
+// openPull is a pull request in the state one is in when it is ready to merge.
+// `mergeable` is in it on purpose: it is the field that must not be what
+// decides anything, and leaving it out would make that untestable.
+func openPull(status string) string {
+	return fmt.Sprintf(`{"number":231,"title":"operator: first sign-in needed a hand-built job",`+
+		`"state":"OPEN","isDraft":false,"merged":false,"mergeable":"MERGEABLE",`+
+		`"mergeStateStatus":%q,"headRefOid":"550534a6aa0e5c9b5f1a0f2e1d4c3b2a19087766",`+
+		`"headRefName":"fix/operator-bootstrap-command","baseRefName":"main","mergeCommit":null}`, status)
+}
+
+func mergedPull(oid string) string {
+	return fmt.Sprintf(`{"number":231,"title":"operator: first sign-in needed a hand-built job",`+
+		`"state":"MERGED","isDraft":false,"merged":true,"mergeable":"MERGEABLE",`+
+		`"mergeStateStatus":"UNKNOWN","headRefOid":"550534a6aa0e5c9b5f1a0f2e1d4c3b2a19087766",`+
+		`"headRefName":"fix/operator-bootstrap-command","baseRefName":"main",`+
+		`"mergeCommit":{"oid":%q}}`, oid)
+}
+
+func commitBody(message string) string {
+	return fmt.Sprintf(`{"sha":"aa11bb22","commit":{"message":%q}}`, message)
+}
+
+// fake answers the four questions and the one action, and records every
+// command it was asked to run.
+type fake struct {
+	name       string
+	email      string
+	pulls      []string
+	protection string
+	checkRuns  string
+	statuses   string
+	commit     string
+	mergeErr   error
+	configErr  error
+	protErr    error
+
+	issued [][]string
+}
+
+func (f *fake) run(name string, args ...string) ([]byte, error) {
+	f.issued = append(f.issued, append([]string{name}, args...))
+	joined := strings.Join(args, " ")
+	switch {
+	case name == "git" && strings.HasSuffix(joined, "user.name"):
+		if f.configErr != nil {
+			return nil, f.configErr
+		}
+		return []byte(f.name + "\n"), nil
+	case name == "git" && strings.HasSuffix(joined, "user.email"):
+		if f.configErr != nil {
+			return nil, f.configErr
+		}
+		return []byte(f.email + "\n"), nil
+	case name == "gh" && args[0] == "pr" && args[1] == "view":
+		if len(f.pulls) == 0 {
+			return nil, errors.New("the test gave no pull request answer")
+		}
+		answer := f.pulls[0]
+		if len(f.pulls) > 1 {
+			f.pulls = f.pulls[1:]
+		}
+		return []byte(answer), nil
+	case name == "gh" && args[0] == "pr" && args[1] == "merge":
+		if f.mergeErr != nil {
+			return nil, f.mergeErr
+		}
+		return []byte("merged\n"), nil
+	case name == "gh" && args[0] == "api" && strings.Contains(joined, "/protection"):
+		if f.protErr != nil {
+			return nil, f.protErr
+		}
+		return []byte(f.protection), nil
+	case name == "gh" && args[0] == "api" && strings.Contains(joined, "/check-runs"):
+		return []byte(f.checkRuns), nil
+	case name == "gh" && args[0] == "api" && strings.Contains(joined, "/status"):
+		return []byte(f.statuses), nil
+	case name == "gh" && args[0] == "api" && strings.Contains(joined, "/commits/"):
+		return []byte(f.commit), nil
+	}
+	return nil, fmt.Errorf("the test was asked to run something it does not answer: %s %s", name, joined)
+}
+
+// ready is a fake set up for the ordinary case: a green pull request, a merge
+// that is accepted, and a commit that carries the trailer.
+func ready(rs []reported, state string) *fake {
+	return &fake{
+		name:       "Vir Sanghavi",
+		email:      "67278851+VirSanghavi@users.noreply.github.com",
+		pulls:      []string{openPull(state), mergedPull("aa11bb22cc33")},
+		protection: protectionBody,
+		checkRuns:  checkRunsBody(rs),
+		statuses:   noStatuses,
+		commit: commitBody("operator: first sign-in needed a hand-built job (#231)\n\n" +
+			"Signed-off-by: Vir Sanghavi <67278851+VirSanghavi@users.noreply.github.com>\n"),
+	}
+}
+
+func attempt(f *fake) (string, error) {
+	var out bytes.Buffer
+	err := merge(hub{runner: f, repo: "antifailure/antifailure"}, f, 231, "", false, 2, 0, &out)
+	return out.String(), err
+}
+
+// merged reports whether the fake was actually asked to merge.
+func (f *fake) merged() bool {
+	for _, cmd := range f.issued {
+		if len(cmd) > 2 && cmd[0] == "gh" && cmd[1] == "pr" && cmd[2] == "merge" {
+			return true
+		}
+	}
+	return false
+}
+
+// argument finds the value passed to a flag in the merge command.
+func (f *fake) argument(flag string) (string, bool) {
+	for _, cmd := range f.issued {
+		if len(cmd) < 3 || cmd[1] != "pr" || cmd[2] != "merge" {
+			continue
+		}
+		for i, a := range cmd {
+			if a == flag && i+1 < len(cmd) {
+				return cmd[i+1], true
+			}
+		}
+	}
+	return "", false
+}
+
+// THE POSITIVE CONTROL, and it is load bearing. A command that refused
+// everything would satisfy every refusal test in this file and would be a
+// merge tool nobody could merge with.
+func TestAGreenPullRequestMergesAndCarriesTheSignOff(t *testing.T) {
+	f := ready(green(), "CLEAN")
+	out, err := attempt(f)
+	if err != nil {
+		t.Fatalf("a pull request with all nine required contexts green was refused: %v\n%s", err, out)
+	}
+	if !f.merged() {
+		t.Fatal("it reported success without ever issuing a merge")
+	}
+	body, ok := f.argument("--body")
+	if !ok {
+		t.Fatal("the merge carried no --body at all, which is the whole defect")
+	}
+	want := "Signed-off-by: Vir Sanghavi <67278851+VirSanghavi@users.noreply.github.com>"
+	if body != want {
+		t.Errorf("the squash body is %q, want %q", body, want)
+	}
+	if subject, _ := f.argument("--subject"); subject != "operator: first sign-in needed a hand-built job (#231)" {
+		t.Errorf("the squash subject is %q", subject)
+	}
+	if !strings.Contains(out, "the commit carries the sign-off") {
+		t.Errorf("it never confirmed the commit that landed carries the trailer:\n%s", out)
+	}
+}
+
+// THE DEFECT ITSELF. A merge whose body would carry no trailer must not
+// happen. The identity is the way that state is reached in practice: a clone
+// with no `user.email` produces `gh pr merge --body ""`, which is what was
+// run six times.
+func TestAMergeWhoseBodyWouldCarryNoTrailerIsRefused(t *testing.T) {
+	for _, c := range []struct{ what, name, email, says string }{
+		{"no name", "", "vir@example.com", "user.name is empty"},
+		{"no address", "Vir Sanghavi", "", "user.email is empty"},
+		{"neither", "", "", "is empty"},
+		{"an address that is not one", "Vir Sanghavi", "vir", "not an address"},
+	} {
+		t.Run(c.what, func(t *testing.T) {
+			f := ready(green(), "CLEAN")
+			f.name, f.email = c.name, c.email
+			out, err := attempt(f)
+			if err == nil {
+				t.Fatalf("it merged with an identity that cannot produce a sign-off:\n%s", out)
+			}
+			if f.merged() {
+				t.Fatal("it refused and issued the merge anyway")
+			}
+			// The sentence matters as much as the refusal. Each of these sends
+			// somebody to a different one line fix, and a refusal that names
+			// the wrong one costs more than no refusal.
+			if !strings.Contains(err.Error(), c.says) {
+				t.Errorf("the refusal does not say %q: %v", c.says, err)
+			}
+		})
+	}
+}
+
+// The same defect reached the other way. Whatever built the body, a body
+// without the trailer in it must stop the merge, because that is the property
+// the commit on main is judged on.
+func TestABodyThatDoesNotCarryTheTrailerStopsTheMerge(t *testing.T) {
+	own := "Signed-off-by: Vir Sanghavi <67278851+VirSanghavi@users.noreply.github.com>"
+	body, err := bodyFor("some prose about the failure", own)
+	if err != nil {
+		t.Fatalf("a plain body was refused: %v", err)
+	}
+	if !carries(body, own) {
+		t.Fatalf("bodyFor produced a body with no trailer in it: %q", body)
+	}
+	if !strings.HasSuffix(body, "\n\n"+own) {
+		t.Errorf("the trailer is not the last paragraph, so git will not read it as a trailer: %q", body)
+	}
+	if carries("some prose about the failure", own) {
+		t.Error("a body with no trailer was reported as carrying one")
+	}
+}
+
+// A sentence that mentions a sign-off is not a commit that carries one. The CI
+// gate greps `^Signed-off-by: `, so anything looser here passes a commit the
+// gate then fails, which is this command lying about the one thing it is for.
+func TestASentenceMentioningASignOffIsNotOne(t *testing.T) {
+	own := "Signed-off-by: Vir Sanghavi <vir@example.com>"
+	for _, message := range []string{
+		"the merge should have had a Signed-off-by: Vir Sanghavi <vir@example.com> in it",
+		"prefix " + own,
+		"Signed-off-by: Somebody Else <else@example.com>",
+	} {
+		if carries(message, own) {
+			t.Errorf("%q was read as carrying the trailer", message)
+		}
+	}
+	if !carries("subject\n\n"+own+"\n", own) {
+		t.Error("a real trailer on its own line was not recognised")
+	}
+	if !carries("subject\n\n"+own+"   \n", own) {
+		t.Error("a real trailer with trailing whitespace was not recognised")
+	}
+}
+
+// The last look at the command before it goes out, and the one that reads the
+// argument list rather than the variable it was built from. `--body ""` is an
+// argument list, and it is exactly the one that was issued six times.
+func TestTheCommandItIsAboutToIssueMustCarryTheTrailer(t *testing.T) {
+	own := "Signed-off-by: Vir Sanghavi <vir@example.com>"
+	repo := "antifailure/antifailure"
+	if !willCarry(mergeArgs(repo, 231, "subject (#231)", own), own) {
+		t.Error("a command whose body is the trailer was read as not carrying it")
+	}
+	for what, args := range map[string][]string{
+		"an empty body, which is the defect itself": mergeArgs(repo, 231, "subject (#231)", ""),
+		"a body of prose and nothing else":          mergeArgs(repo, 231, "subject (#231)", "prose"),
+		"somebody else's trailer":                   mergeArgs(repo, 231, "subject (#231)", "Signed-off-by: Else <e@example.com>"),
+		"a mention rather than a trailer":           mergeArgs(repo, 231, "subject (#231)", "add "+own),
+		"no body argument at all":                   {"pr", "merge", "231", "--repo", repo, "--squash"},
+	} {
+		if willCarry(args, own) {
+			t.Errorf("%s was read as carrying the trailer: %v", what, args)
+		}
+	}
+}
+
+// A required context that is red must refuse, and the three ways of being red
+// are listed separately because two of them read as an absence of red.
+func TestARedRequiredContextIsRefused(t *testing.T) {
+	for _, conclusion := range []string{"failure", "cancelled", "skipped", "timed_out", "action_required", "neutral", "stale", ""} {
+		t.Run("engine "+conclusion, func(t *testing.T) {
+			f := ready(with("engine", "completed", conclusion), "UNSTABLE")
+			out, err := attempt(f)
+			if err == nil {
+				t.Fatalf("a required context concluding %q was merged:\n%s", conclusion, out)
+			}
+			if f.merged() {
+				t.Fatal("it refused and issued the merge anyway")
+			}
+			if !strings.Contains(err.Error(), `"engine"`) {
+				t.Errorf("the refusal does not name the context that failed: %v", err)
+			}
+		})
+	}
+}
+
+// A required context still running is not a pass either, and this is the state
+// that a busy queue produces. It has its own test because it takes a different
+// branch: the status rather than the conclusion.
+func TestARequiredContextStillRunningIsRefused(t *testing.T) {
+	for _, status := range []string{"queued", "in_progress", "waiting", "pending"} {
+		t.Run(status, func(t *testing.T) {
+			f := ready(with("www", status, ""), "BLOCKED")
+			out, err := attempt(f)
+			if err == nil {
+				t.Fatalf("a required context that is %s was merged:\n%s", status, out)
+			}
+			if !strings.Contains(err.Error(), `"www"`) {
+				t.Errorf("the refusal does not name the context that had not finished: %v", err)
+			}
+			// Told apart from a red one on purpose. A context that has not
+			// reported yet is waited for; one that reported red is fixed.
+			if !strings.Contains(err.Error(), "no verdict yet") {
+				t.Errorf("the refusal reads as a verdict when there is none: %v", err)
+			}
+		})
+	}
+}
+
+// A required context that never reported at all. This is the one an eye
+// misses: it is not red anywhere, it is simply not there, and reading a list
+// of green marks answers a different question from reading the nine by name.
+func TestAMissingRequiredContextIsRefused(t *testing.T) {
+	f := ready(without("commits are attributed to their author"), "UNSTABLE")
+	out, err := attempt(f)
+	if err == nil {
+		t.Fatalf("a pull request missing a required context was merged:\n%s", out)
+	}
+	if !strings.Contains(err.Error(), "never reported") {
+		t.Errorf("the refusal does not say the context never reported: %v", err)
+	}
+}
+
+// THE OTHER DIRECTION, and it matters as much. `Antifailure` and Dogfood are
+// not required contexts, three agents in one session read a red mark on one of
+// them as a block, and a command that refused on them would have refused every
+// pull request this repository has open.
+func TestOnlyANonRequiredContextRedStillMerges(t *testing.T) {
+	red := append(green(),
+		reported{"site", "completed", "failure", when},
+		reported{"helm install on kind", "completed", "cancelled", when},
+		reported{"every change says what changed", "queued", "", when},
+	)
+	f := ready(red, "UNSTABLE")
+	out, err := attempt(f)
+	if err != nil {
+		t.Fatalf("a pull request whose only red checks are not required was refused: %v\n%s", err, out)
+	}
+	if !f.merged() {
+		t.Fatal("it reported success without issuing a merge")
+	}
+	// And it says so, because silence about a red mark is what sent three
+	// people looking for a block that was not there.
+	if !strings.Contains(out, "not required by protection") {
+		t.Errorf("it never mentioned the red checks it ignored:\n%s", out)
+	}
+	for _, name := range []string{"Antifailure", "dogfood, against the control plane", "site"} {
+		if !strings.Contains(out, name) {
+			t.Errorf("the ignored check %q is not named in the output:\n%s", name, out)
+		}
+	}
+}
+
+// The commit that landed must actually carry the trailer, and a command that
+// cannot prove it did must say so rather than report a success.
+func TestAMergedCommitWithoutTheTrailerIsAFailure(t *testing.T) {
+	f := ready(green(), "CLEAN")
+	f.commit = commitBody("operator: first sign-in needed a hand-built job (#231)\n")
+	out, err := attempt(f)
+	if err == nil {
+		t.Fatalf("a merge that produced an unsigned commit was reported as done:\n%s", out)
+	}
+	if !f.merged() {
+		t.Fatal("the test never got as far as merging, so it proved nothing about the readback")
+	}
+	for _, want := range []string{"LANDED", "commits are attributed to their author", "Do not rewrite main"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the failure never mentions %q, so nobody reading it knows what to do: %v", want, err)
+		}
+	}
+}
+
+// A merge nobody can confirm is not a merge anybody may report as done.
+func TestAMergeThatCannotBeConfirmedIsNotASuccess(t *testing.T) {
+	f := ready(green(), "CLEAN")
+	f.pulls = []string{openPull("CLEAN")} // never becomes merged
+	out, err := attempt(f)
+	if err == nil {
+		t.Fatalf("an unconfirmed merge was reported as done:\n%s", out)
+	}
+	if !strings.Contains(err.Error(), "could not be confirmed") {
+		t.Errorf("the failure does not say the merge is unconfirmed: %v", err)
+	}
+}
+
+// `gh pr merge --delete-branch` deletes the branch even when the merge is
+// REFUSED, and deleting the branch closes the pull request. Every command this
+// command issues is recorded, in the refusing case and in the merging case,
+// and none of them may carry that flag.
+func TestNoCommandItIssuesDeletesTheBranch(t *testing.T) {
+	cases := map[string]*fake{
+		"merging":  ready(green(), "CLEAN"),
+		"refusing": ready(with("engine", "completed", "failure"), "UNSTABLE"),
+		"unsigned": ready(green(), "CLEAN"),
+	}
+	cases["unsigned"].commit = commitBody("no trailer here\n")
+	for what, f := range cases {
+		t.Run(what, func(t *testing.T) {
+			_, _ = attempt(f)
+			if len(f.issued) == 0 {
+				t.Fatal("it issued no commands at all, so this asserts nothing")
+			}
+			for _, cmd := range f.issued {
+				for _, a := range cmd {
+					if strings.Contains(a, "delete-branch") || strings.Contains(a, "--delete") {
+						t.Fatalf("it issued %v", cmd)
+					}
+				}
+			}
+		})
+	}
+	// And the merging case has to have got far enough to build a merge command,
+	// or this test would pass on a command that never merges anything.
+	if !cases["merging"].merged() {
+		t.Fatal("the merging case never issued a merge, so the assertion covered nothing")
+	}
+}
+
+// The state table. `mergeStateStatus` is read and `mergeable` is not, which is
+// why every fixture in this file carries `"mergeable":"MERGEABLE"`: under the
+// wrong field BLOCKED and DIRTY would both read as permission to merge.
+func TestEveryMergeStateStatus(t *testing.T) {
+	cases := map[string]bool{
+		"CLEAN":                                 true,
+		"HAS_HOOKS":                             true,
+		"UNSTABLE":                              true,
+		"BLOCKED":                               false,
+		"DIRTY":                                 false,
+		"BEHIND":                                false,
+		"DRAFT":                                 false,
+		"UNKNOWN":                               false,
+		"SOMETHING_GITHUB_HAS_NOT_INVENTED_YET": false,
+	}
+	for state, allowed := range cases {
+		t.Run(state, func(t *testing.T) {
+			f := ready(green(), state)
+			out, err := attempt(f)
+			if allowed && err != nil {
+				t.Fatalf("mergeStateStatus %s was refused: %v\n%s", state, err, out)
+			}
+			if !allowed {
+				if err == nil {
+					t.Fatalf("mergeStateStatus %s was merged:\n%s", state, out)
+				}
+				if !strings.Contains(err.Error(), state) {
+					t.Errorf("the refusal does not name the state: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// An empty check list is a conflicting pull request far more often than a busy
+// queue, and reading it as a queue is how somebody waits for checks that are
+// never going to run.
+func TestAnEmptyCheckListNamesConflictingRatherThanABusyQueue(t *testing.T) {
+	f := ready(nil, "DIRTY")
+	f.checkRuns = `{"total_count":0,"check_runs":[]}`
+	out, err := attempt(f)
+	if err == nil {
+		t.Fatalf("a pull request with nothing reported was merged:\n%s", out)
+	}
+	if !strings.Contains(err.Error(), "CONFLICTS") {
+		t.Errorf("the refusal does not name a conflict as the likely cause: %v", err)
+	}
+}
+
+// The required list is hardcoded so a refusal can be specific, and compared
+// live so that being hardcoded cannot make it wrong. Both directions of drift
+// are failures and they are different failures.
+func TestTheRequiredListIsComparedAgainstTheLiveOne(t *testing.T) {
+	t.Run("protection requires something this does not know about", func(t *testing.T) {
+		f := ready(green(), "CLEAN")
+		f.protection = strings.Replace(protectionBody, `"engine"`, `"engine","a tenth gate"`, 1)
+		out, err := attempt(f)
+		if err == nil {
+			t.Fatalf("it merged past a required context it had never heard of:\n%s", out)
+		}
+		if !strings.Contains(err.Error(), "a tenth gate") {
+			t.Errorf("the refusal does not name the context it did not know: %v", err)
+		}
+	})
+	t.Run("this requires something protection does not", func(t *testing.T) {
+		f := ready(green(), "CLEAN")
+		f.protection = strings.Replace(protectionBody, `"runner",`, ``, 1)
+		out, err := attempt(f)
+		if err == nil {
+			t.Fatalf("it merged on a required list that disagrees with protection:\n%s", out)
+		}
+		if !strings.Contains(err.Error(), "runner") {
+			t.Errorf("the refusal does not name the context that is no longer required: %v", err)
+		}
+	})
+	t.Run("agreement passes", func(t *testing.T) {
+		if drift := listDrift(required); len(drift) > 0 {
+			t.Fatalf("the list disagrees with itself: %v", drift)
+		}
+	})
+}
+
+// A required list nobody could read is not a required list anybody may merge
+// on. Reading branch protection needs administration rights, and a 403 that
+// fell through as an empty list would turn this into a command that checks
+// nothing and merges everything.
+func TestARequiredListThatCannotBeReadRefuses(t *testing.T) {
+	f := ready(green(), "CLEAN")
+	f.protErr = errors.New("gh: HTTP 403: Resource not accessible by personal access token")
+	out, err := attempt(f)
+	if err == nil {
+		t.Fatalf("it merged without reading what blocks a merge:\n%s", out)
+	}
+	if f.merged() {
+		t.Fatal("it refused and issued the merge anyway")
+	}
+	if !strings.Contains(err.Error(), "administration rights") {
+		t.Errorf("the refusal does not say why it could not read the list: %v", err)
+	}
+}
+
+// The trailer is the merger's own, which is clause (c) of the Developer
+// Certificate of Origin. A body arriving with somebody else's sign-off in it is
+// refused rather than signed alongside, because a certification made in
+// another person's name is worse than no certification.
+func TestItNeverWritesATrailerNamingSomebodyElse(t *testing.T) {
+	own := "Signed-off-by: Vir Sanghavi <vir@example.com>"
+	if _, err := bodyFor("prose\n\nSigned-off-by: Somebody Else <else@example.com>", own); err == nil {
+		t.Fatal("a body carrying another person's sign-off was accepted")
+	}
+	body, err := bodyFor("prose\n\n"+own, own)
+	if err != nil {
+		t.Fatalf("a body already carrying the merger's own sign-off was refused: %v", err)
+	}
+	if strings.Count(body, "Signed-off-by:") != 1 {
+		t.Errorf("it wrote the trailer twice: %q", body)
+	}
+}
+
+// The same rule at the merge level rather than in one function, because the
+// one hard rule is about what reaches GitHub. A maintainer relaying a
+// contribution signs in their own name and leaves the authorship alone, which
+// is clause (c); a trailer naming the contributor would be a legal
+// certification made in their name by somebody else.
+func TestABodyCarryingSomebodyElsesSignOffNeverReachesGitHub(t *testing.T) {
+	f := ready(green(), "CLEAN")
+	var out bytes.Buffer
+	err := merge(hub{runner: f, repo: "antifailure/antifailure"}, f, 231,
+		"relaying a contribution\n\nSigned-off-by: Maksym <maksym@example.com>", false, 2, 0, &out)
+	if err == nil {
+		t.Fatalf("it merged a body carrying another person's sign-off:\n%s", out.String())
+	}
+	if f.merged() {
+		t.Fatal("it refused and issued the merge anyway")
+	}
+	if !strings.Contains(err.Error(), "Developer Certificate of Origin") {
+		t.Errorf("the refusal does not say why: %v", err)
+	}
+	// And nothing carrying that name was ever handed to gh.
+	for _, cmd := range f.issued {
+		for _, a := range cmd {
+			if strings.Contains(a, "maksym@example.com") {
+				t.Fatalf("it passed another person's address to a command: %v", cmd)
+			}
+		}
+	}
+}
+
+// This repository puts no attribution trailer in a commit, anywhere.
+func TestAnAttributionTrailerIsRefused(t *testing.T) {
+	own := "Signed-off-by: Vir Sanghavi <vir@example.com>"
+	for _, given := range []string{
+		"prose\n\nCo-authored-by: Somebody <somebody@example.com>",
+		"prose\n\nco-authored-by: somebody <somebody@example.com>",
+		"prose\n\nGenerated-with: a thing",
+	} {
+		if _, err := bodyFor(given, own); err == nil {
+			t.Errorf("a body carrying an attribution trailer was accepted: %q", given)
+		}
+	}
+}
+
+// A commit message is prose and this repository bans two characters in prose.
+// prosecheck cannot see one, because a commit message is not a tracked file,
+// and the subject comes from a pull request title that nobody reads twice.
+func TestTheBannedCharactersAreRefusedInACommitMessage(t *testing.T) {
+	for _, title := range []string{
+		"operator: the job \u2014 which nobody ran \u2014 needed a database url",
+		"operator: pages 3\u20134 of the runbook were wrong",
+		"operator: the job -- which nobody ran -- needed a database url",
+	} {
+		t.Run(title, func(t *testing.T) {
+			f := ready(green(), "CLEAN")
+			f.pulls = []string{
+				strings.Replace(openPull("CLEAN"),
+					"operator: first sign-in needed a hand-built job", title, 1),
+				mergedPull("aa11bb22cc33"),
+			}
+			out, err := attempt(f)
+			if err == nil {
+				t.Fatalf("a subject carrying a banned character was merged:\n%s", out)
+			}
+			if f.merged() {
+				t.Fatal("it refused and issued the merge anyway")
+			}
+		})
+	}
+}
+
+// A re-run adds a check run rather than replacing one, so a commit carries two
+// reports under one name. Protection reads the newest, so this reads the
+// newest: being stricter than the thing it stands in for would refuse a pull
+// request whose re-run fixed it, and being looser would merge one whose re-run
+// broke it. Both directions are here.
+func TestTheNewestReportUnderANameIsTheOneThatCounts(t *testing.T) {
+	t.Run("a re-run that fixed it is a pass", func(t *testing.T) {
+		rs := with("engine", "completed", "failure")
+		rs = append(rs, reported{"engine", "completed", "success", "2026-09-05T02:00:00Z"})
+		f := ready(rs, "UNSTABLE")
+		out, err := attempt(f)
+		if err != nil {
+			t.Fatalf("a context whose re-run is green was refused: %v\n%s", err, out)
+		}
+	})
+	t.Run("a stale success does not outrank a newer failure", func(t *testing.T) {
+		rs := green()
+		rs = append(rs, reported{"engine", "completed", "failure", "2026-09-05T02:00:00Z"})
+		f := ready(rs, "UNSTABLE")
+		out, err := attempt(f)
+		if err == nil {
+			t.Fatalf("an older green report was read over a newer red one:\n%s", out)
+		}
+	})
+}
+
+// A required context can arrive as a commit status rather than as a check run.
+// None of the nine does today, and a command that read only check runs would
+// report such a context as never having run and refuse a pull request that was
+// green, so both endpoints are read.
+func TestARequiredContextArrivingAsACommitStatusIsRead(t *testing.T) {
+	f := ready(without("runner"), "CLEAN")
+	f.statuses = `{"state":"success","statuses":[` +
+		`{"id":9,"context":"runner","state":"success","created_at":"` + when + `"}],"total_count":1}`
+	out, err := attempt(f)
+	if err != nil {
+		t.Fatalf("a required context reported as a commit status was not counted: %v\n%s", err, out)
+	}
+	t.Run("and a pending one is still not a pass", func(t *testing.T) {
+		g := ready(without("runner"), "CLEAN")
+		g.statuses = `{"state":"pending","statuses":[` +
+			`{"id":9,"context":"runner","state":"pending","created_at":"` + when + `"}],"total_count":1}`
+		_, err := attempt(g)
+		if err == nil {
+			t.Fatal("a pending commit status was read as a pass")
+		}
+		// And it is read as having reached no verdict rather than as having
+		// concluded the word "pending", which is the same distinction a check
+		// run gets: one is waited for, the other is fixed.
+		if !strings.Contains(err.Error(), "no verdict yet") {
+			t.Errorf("a pending status was reported as a verdict: %v", err)
+		}
+	})
+}
+
+// The subject is the shape every merge on main already has, and it must not
+// double the number when the title already carries it.
+func TestTheSubjectNamesThePullRequest(t *testing.T) {
+	if got := subjectFor("console: align the operator overview", 225); got != "console: align the operator overview (#225)" {
+		t.Errorf("got %q", got)
+	}
+	if got := subjectFor("console: align the operator overview (#225)", 225); got != "console: align the operator overview (#225)" {
+		t.Errorf("it doubled the number: %q", got)
+	}
+}
+
+// A pull request nobody can merge is refused before anything else happens, and
+// each of these is a different sentence because each sends somebody somewhere
+// different.
+func TestAPullRequestThatIsNotOpenIsRefused(t *testing.T) {
+	cases := []struct{ what, answer, says string }{
+		{"already merged", mergedPull("aa11bb22cc33"), "already merged"},
+		{"closed", strings.Replace(openPull("DIRTY"), `"state":"OPEN"`, `"state":"CLOSED"`, 1), "not OPEN"},
+		{"a draft", strings.Replace(openPull("DRAFT"), `"isDraft":false`, `"isDraft":true`, 1), "nobody has said it is finished"},
+	}
+	for _, c := range cases {
+		t.Run(c.what, func(t *testing.T) {
+			f := ready(green(), "CLEAN")
+			f.pulls = []string{c.answer}
+			out, err := attempt(f)
+			if err == nil {
+				t.Fatalf("it merged a pull request that is %s:\n%s", c.what, out)
+			}
+			if f.merged() {
+				t.Fatal("it refused and issued the merge anyway")
+			}
+			if !strings.Contains(err.Error(), c.says) {
+				t.Errorf("the refusal does not say %q: %v", c.says, err)
+			}
+		})
+	}
+}
+
+// A dry run checks everything and merges nothing, which is what makes this
+// command safe to point at a pull request before deciding.
+func TestADryRunIssuesNoMerge(t *testing.T) {
+	f := ready(green(), "CLEAN")
+	var out bytes.Buffer
+	if err := merge(hub{runner: f, repo: "antifailure/antifailure"}, f, 231, "", true, 2, 0, &out); err != nil {
+		t.Fatalf("a dry run over a green pull request failed: %v\n%s", err, out.String())
+	}
+	if f.merged() {
+		t.Fatal("a dry run merged the pull request")
+	}
+	if !strings.Contains(out.String(), "nothing was merged") {
+		t.Errorf("a dry run did not say it merged nothing:\n%s", out.String())
+	}
+}
+
+// The refusal has to list every reason at once. A command that reports the
+// first problem and stops sends somebody round the loop once per problem, and
+// each loop is a push and twenty minutes of CI.
+func TestARefusalNamesEveryReasonAtOnce(t *testing.T) {
+	rs := without("www")
+	for i := range rs {
+		if rs[i].name == "engine" {
+			rs[i].conclusion = "failure"
+		}
+	}
+	f := ready(rs, "BLOCKED")
+	_, err := attempt(f)
+	if err == nil {
+		t.Fatal("a pull request with three separate problems was merged")
+	}
+	for _, want := range []string{"engine", "www", "BLOCKED"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the refusal does not mention %q: %v", want, err)
+		}
+	}
+}


### PR DESCRIPTION
## What changed

`just merge <number>` now performs a squash merge, and `tools/prmerge` is the
command behind it. Six pull requests were merged on 2026-09-05 with
`gh pr merge --squash --body ""`. A squash commit made that way carries no
`Signed-off-by` trailer, one of main's nine required contexts is
`commits are attributed to their author`, and that context failed on main in
run 33934603009 with "1 commits have no Developer Certificate of Origin
sign-off". `.github/workflows/cd.yml` has a gate job that waits for CI on the
same commit; it polled 42 times, read the failure, refused with "CI concluded
'failure' on e836979577732c8d879cd96ce57ac1a447e12b91. Nothing is deployed",
and its build, staging and production jobs were all skipped.

So six merged pull requests did not reach staging because a merge commit was
missing one line, and the whole chain has since been observed rather than
inferred. Staging served `cb3f30f1` while six later commits sat on main, and it
moved to `597b3819` only when the next merge carried the trailer and let main
go green. That is what makes this a deployment defect rather than an untidy
commit, and it is why the fix is a command rather than a note.

Nothing local could have caught it. `.githooks/prepare-commit-msg` writes the
trailer onto local commits and a squash commit is created on GitHub's side, so
no hook ran and none could. `just authorship` skips merge commits and cannot
read a commit that does not exist until the button is pressed. The CI gate does
catch it, and only after the commit is on main, where the only remedies are
rewriting main or pushing another commit. Main's history is deliberately NOT
rewritten here: the gate's own comments say the history before it cannot be
signed retroactively without breaking every existing clone, and a force push to
main would break the merge base of every open pull request.

## Failure paths covered

| Failure path | Test |
| --- | --- |
| A merge whose body would carry no trailer, which is the defect itself | TestAMergeWhoseBodyWouldCarryNoTrailerIsRefused |
| The command about to be issued carries `--body ""`, or no body at all | TestTheCommandItIsAboutToIssueMustCarryTheTrailer |
| A required context that reported anything but the literal word success | TestARedRequiredContextIsRefused |
| A required context that has not finished, told apart from one that failed | TestARequiredContextStillRunningIsRefused |
| A required context that never reported at all | TestAMissingRequiredContextIsRefused |
| Only a NON required context is red, which must still merge | TestOnlyANonRequiredContextRedStillMerges |
| The hardcoded required list has drifted from branch protection, both ways | TestTheRequiredListIsComparedAgainstTheLiveOne |
| Branch protection could not be read, so nothing confirmed what blocks a merge | TestARequiredListThatCannotBeReadRefuses |
| Every `mergeStateStatus`, including one GitHub has not invented yet | TestEveryMergeStateStatus |
| An empty check list, which usually means CONFLICTING and not a busy queue | TestAnEmptyCheckListNamesConflictingRatherThanABusyQueue |
| The merge landed and the commit does not carry the trailer | TestAMergedCommitWithoutTheTrailerIsAFailure |
| The merge was accepted and could not be confirmed | TestAMergeThatCannotBeConfirmedIsNotASuccess |
| Any command carrying `--delete-branch`, in the merging and refusing cases | TestNoCommandItIssuesDeletesTheBranch |
| A body carrying somebody else's sign-off, which must never be relayed | TestABodyCarryingSomebodyElsesSignOffNeverReachesGitHub |
| A body carrying an attribution trailer | TestAnAttributionTrailerIsRefused |
| A sentence mentioning a sign-off read as a trailer | TestASentenceMentioningASignOffIsNotOne |
| A subject or body carrying an em dash, an en dash or a double hyphen | TestTheBannedCharactersAreRefusedInACommitMessage |
| A re-run under a name already reported, in both directions | TestTheNewestReportUnderANameIsTheOneThatCounts |
| A required context arriving as a commit status rather than a check run | TestARequiredContextArrivingAsACommitStatusIsRead |
| An already merged, closed or draft pull request | TestAPullRequestThatIsNotOpenIsRefused |
| A dry run that merges anything | TestADryRunIssuesNoMerge |
| A refusal that stops at the first reason | TestARefusalNamesEveryReasonAtOnce |
| The positive control: a green pull request must actually merge | TestAGreenPullRequestMergesAndCarriesTheSignOff |

Every one of the 25 tests is mutation proved independently, one break per
assertion, 35 breaks in total. The table is in the evidence below.

## Security considerations

- Secrets, masked data, the proxy, the journal: none. It prints no token and
  reads none itself; `gh` holds the credential.
- New outbound connection or stored data class: none new. It talks to
  `api.github.com` through the `gh` already used to merge by hand, and stores
  nothing.
- What an untrusted repository or pull request can reach: nothing new. It runs
  on a maintainer's machine, never in a workflow, and it is not a gate. It
  makes the reachable surface smaller in one respect: reading branch protection
  needs administration rights, so somebody who cannot confirm what blocks a
  merge is refused rather than merging on an unconfirmed list.
- Dependency: none. Standard library only.

One thing worth naming because it is a legal certification rather than a
string. The trailer is built from the merging clone's own `git config
user.name` and `user.email` and from nothing else, which is clause (c) of the
Developer Certificate of Origin: somebody relaying a contribution certifies
that it reached them from a person who certified it, and signs as themselves.
A body arriving with anybody else's sign-off in it is refused rather than
signed alongside, and the test asserts that no address but the merger's own is
ever passed to a command. Signing a contributor's own commits for relay is the
other operation in this area, it is a hand operation with a person's judgement
in it, and this command deliberately does not do it.

## Exit criteria evidence

`just gate` was not run whole: it needs a Docker daemon and a Postgres, and
this machine is running ten lanes behind a single Go build lock. What was run
is below, verbatim, and CI runs the rest.

```
$ cd tools && go test ./prmerge/ -count=1 -v
--- PASS: TestAGreenPullRequestMergesAndCarriesTheSignOff
--- PASS: TestAMergeWhoseBodyWouldCarryNoTrailerIsRefused
--- PASS: TestABodyThatDoesNotCarryTheTrailerStopsTheMerge
--- PASS: TestASentenceMentioningASignOffIsNotOne
--- PASS: TestTheCommandItIsAboutToIssueMustCarryTheTrailer
--- PASS: TestARedRequiredContextIsRefused
--- PASS: TestARequiredContextStillRunningIsRefused
--- PASS: TestAMissingRequiredContextIsRefused
--- PASS: TestOnlyANonRequiredContextRedStillMerges
--- PASS: TestAMergedCommitWithoutTheTrailerIsAFailure
--- PASS: TestAMergeThatCannotBeConfirmedIsNotASuccess
--- PASS: TestNoCommandItIssuesDeletesTheBranch
--- PASS: TestEveryMergeStateStatus
--- PASS: TestAnEmptyCheckListNamesConflictingRatherThanABusyQueue
--- PASS: TestTheRequiredListIsComparedAgainstTheLiveOne
--- PASS: TestARequiredListThatCannotBeReadRefuses
--- PASS: TestItNeverWritesATrailerNamingSomebodyElse
--- PASS: TestABodyCarryingSomebodyElsesSignOffNeverReachesGitHub
--- PASS: TestAnAttributionTrailerIsRefused
--- PASS: TestTheBannedCharactersAreRefusedInACommitMessage
--- PASS: TestTheNewestReportUnderANameIsTheOneThatCounts
--- PASS: TestARequiredContextArrivingAsACommitStatusIsRead
--- PASS: TestTheSubjectNamesThePullRequest
--- PASS: TestAPullRequestThatIsNotOpenIsRefused
--- PASS: TestADryRunIssuesNoMerge
--- PASS: TestARefusalNamesEveryReasonAtOnce
PASS
ok  	github.com/antifailure/antifailure/tools/prmerge

$ go test ./claimcheck/ ./gatecheck/ ./prmerge/ -count=1
ok  	github.com/antifailure/antifailure/tools/claimcheck	10.477s
ok  	github.com/antifailure/antifailure/tools/gatecheck	6.323s
ok  	github.com/antifailure/antifailure/tools/prmerge	0.067s

$ go run ./tools/prosecheck .
prosecheck: 739 files, 0 places where the punctuation gives it away

$ go run ./tools/gatecheck .
gatecheck: 78 gates in 9 pull request workflows.
  68 paired by command and directory to a recipe `just gate` calls.
  2 paired by command only, against a justfile command whose directory
    is computed at run time, so for these the directory was not compared.
  8 exempt by name in exemptFromGate, with the reason recorded there.

$ go run ./tools/changecheck .
changecheck: 6 changed paths, none of it behaviour anybody outside can see

$ gofmt -l ./prmerge/
```

Two of this repository's own instruments refused an earlier revision of this
branch, which is worth recording because both were right. `claimcheck` found
that the new CONTRIBUTING section named `cd.yml`, which is not a path a reader
can follow; it is `.github/workflows/cd.yml` and now says so.
`gatecheck`'s `TestEveryToolsBinaryNameIsIgnored` found that
`go build ./tools/prmerge` writes `./prmerge` at the repository root and
nothing ignored it, so the next `git add -A` would have committed a platform
specific executable; `/prmerge` is in `.gitignore` beside `/preview` and for
the same reason.

### The mutation table

The rule this repository holds itself to is that a check which cannot say no is
worse than no check, so every assertion above was pointed at the exact
production line it is meant to catch. The line was broken, that test was run on
its own and confirmed red, the line was restored, and the test was confirmed
green again. One break per assertion, because `require` stops at the first
failure and a later assertion can be unreachable while still looking alive.

The runner is at `mutate.py` in the session scratchpad, the pristine source is
diffed back byte for byte after every mutation, and the full suite was
confirmed green before the first mutation and after the last.

| id | the line broken, and the assertion it proves | test | broken / restored |
| --- | --- | --- | --- |
| M01 | a required context that never reported is not a pass | TestAMissingRequiredContextIsRefused | red / green |
| M02 | a required context concluding anything but success refuses | TestARedRequiredContextIsRefused | red / green |
| M03 | a context with no verdict yet is told apart from a red one | TestARequiredContextStillRunningIsRefused | red / green |
| M04 | an empty check list names a conflict, not a busy queue | TestAnEmptyCheckListNamesConflictingRatherThanABusyQueue | red / green |
| M05 | the body in the command about to be issued carries the trailer | TestTheCommandItIsAboutToIssueMustCarryTheTrailer | red / green |
| M06 | a command with no body argument does not carry one either | TestTheCommandItIsAboutToIssueMustCarryTheTrailer | red / green |
| M07 | no command it issues deletes the branch | TestNoCommandItIssuesDeletesTheBranch | red / green |
| M08 | a sentence mentioning a sign-off is not a trailer | TestASentenceMentioningASignOffIsNotOne | red / green |
| M09 | the commit that landed is read back and must carry the trailer | TestAMergedCommitWithoutTheTrailerIsAFailure | red / green |
| M10 | a merge nobody could confirm is not a success | TestAMergeThatCannotBeConfirmedIsNotASuccess | red / green |
| M11 | an empty user.name cannot produce a sign-off | TestAMergeWhoseBodyWouldCarryNoTrailerIsRefused | red / green |
| M12 | an empty user.email cannot produce a sign-off | TestAMergeWhoseBodyWouldCarryNoTrailerIsRefused | red / green |
| M13 | an address that is not an address cannot produce one | TestAMergeWhoseBodyWouldCarryNoTrailerIsRefused | red / green |
| M14 | it never writes a trailer naming somebody else | TestABodyCarryingSomebodyElsesSignOffNeverReachesGitHub | red / green |
| M15 | an attribution trailer is refused | TestAnAttributionTrailerIsRefused | red / green |
| M16 | the banned characters are refused in a commit message | TestTheBannedCharactersAreRefusedInACommitMessage | red / green |
| M17 | the newest report under a name is the one that counts | TestTheNewestReportUnderANameIsTheOneThatCounts | red / green |
| M18 | protection requiring something unknown here fails loudly | TestTheRequiredListIsComparedAgainstTheLiveOne | red / green |
| M19 | requiring something protection does not fails loudly | TestTheRequiredListIsComparedAgainstTheLiveOne | red / green |
| M20 | a required list it could not read stops the merge | TestARequiredListThatCannotBeReadRefuses | red / green |
| M21 | it says which red checks it ignored | TestOnlyANonRequiredContextRedStillMerges | red / green |
| M22 | only the nine required contexts can block a merge | TestOnlyANonRequiredContextRedStillMerges | red / green |
| M23 | a required context arriving as a commit status is read | TestARequiredContextArrivingAsACommitStatusIsRead | red / green |
| M24 | a pending commit status has reached no verdict | TestARequiredContextArrivingAsACommitStatusIsRead | red / green |
| M25 | the subject carries the pull request number | TestTheSubjectNamesThePullRequest | red / green |
| M26 | the subject does not double a number the title has | TestTheSubjectNamesThePullRequest | red / green |
| M27 | a pull request that is already merged is refused | TestAPullRequestThatIsNotOpenIsRefused | red / green |
| M28 | a pull request that is not open is refused | TestAPullRequestThatIsNotOpenIsRefused | red / green |
| M29 | a draft is refused | TestAPullRequestThatIsNotOpenIsRefused | red / green |
| M30 | a dry run issues no merge | TestADryRunIssuesNoMerge | red / green |
| M31 | a refusal names every reason at once | TestARefusalNamesEveryReasonAtOnce | red / green |
| M32 | a green pull request is merged rather than refused | TestAGreenPullRequestMergesAndCarriesTheSignOff | red / green |
| M33 | reporting a merge means a merge was issued | TestAGreenPullRequestMergesAndCarriesTheSignOff | red / green |
| M34 | a blocked pull request is not merged | TestEveryMergeStateStatus | red / green |
| M35 | a mergeStateStatus it does not recognise is not a yes | TestEveryMergeStateStatus | red / green |

M24 is worth naming rather than hiding. It stayed green on the first pass: the
pending mapping could be deleted and the pull request was still refused, by a
different line, so the assertion was real and the line it was aimed at was not
proved. The test now asserts that a pending status is reported as having
reached no verdict rather than as having concluded the word "pending", which is
the distinction that line exists for, and the mutation kills it.

## Checklist

- [x] Commits are signed off (`git commit -s`)
- [x] A changelog fragment exists under `.changes/`
- [x] Documentation is updated: CONTRIBUTING.md has a "Merging" section, and
      the written rule and the executable one now say the same thing
- [x] Every new error code has a catalog entry: no new codes, this is a
      developer command rather than a product surface
- [x] No secret, real customer record, or unredacted screenshot is included
