### PR TITLE
docs: the guide explained the zero percent revision trap with the wrong mechanism

### DIFF
--- a/.changes/traffic-weight-state-is-not-what-is-serving.md
+++ b/.changes/traffic-weight-state-is-not-what-is-serving.md
@@ -1,0 +1,37 @@
+# fixed
+
+The self-hosting guide explained the zero percent revision trap with the wrong
+mechanism. It said the new revision comes up at zero percent "because Terraform
+does not touch traffic weights", and Terraform does touch them.
+
+Ignoring an attribute is not omitting it. Terraform sends a traffic block either
+way, and `ignore_changes` decides which one: the value refreshed from Azure
+rather than the one in the configuration. The configuration asks for
+`latest_revision = true` at one hundred percent, which would put every new
+revision straight into service. Azure, after any deploy has run, holds a pin
+naming one revision. So the apply puts back the arrangement it just read, and
+the revision it is creating is not in that arrangement.
+
+That distinction is the difference between a rule and a coincidence. A reader
+who believes traffic is never sent has no reason to look at what decides the
+outcome.
+
+The other half was documented nowhere. The stored state file keeps the OLD
+revision suffix indefinitely, because `ignore_changes` is exactly what stops
+anything writing the real weight back. Both environments were stale that way,
+each by more than one deploy, and that is the intended resting state rather than
+drift to repair. What it costs is worth knowing, and it turns on a distinction
+the guide now draws: a plan and an apply REFRESH, so they act on a current
+value, while `terraform state show` and `state pull` read the stored file and do
+not. On this deployment the stored file named a revision that had already been
+deactivated while the plan's own view named the one actually serving. So the
+answer to "what is serving" comes from Azure, and an empty plan is not an answer
+either, because the attribute that would say so is the ignored one.
+
+Removing that `ignore_changes` is called out in all three places, with the
+consequence the stale file misleads people about. The stored suffix is not what
+would take effect, the configuration is: `latest_revision = true` wins, traffic
+follows the newest revision automatically, every apply puts its own revision
+into service with no chance to probe it first, and each apply undoes the pin the
+deploy sets. That is a deliberate change to how releases work here, not a
+tidy-up of a stale field.

--- a/docs/src/content/docs/self-hosting/azure.md
+++ b/docs/src/content/docs/self-hosting/azure.md
@@ -194,11 +194,38 @@ traffic weights. The module says so, with `ignore_changes` on
 is what lets the two run on their own schedules instead of undoing each other.
 
 The consequence is not obvious and it has already caught us once. Any Terraform
-change to the template creates a **new revision**, and because Terraform does
-not touch traffic weights, that revision comes up with **zero percent of
-traffic**. Terraform reports a successful apply. Production is still serving the
-old revision, without the change. Add an environment variable this way and the
-application will not see it, for as long as nobody deploys.
+change to the template creates a **new revision**, and that revision comes up
+with **zero percent of traffic**. Terraform reports a successful apply.
+Production is still serving the old revision, without the change. Add an
+environment variable this way and the application will not see it, for as long
+as nobody deploys.
+
+The mechanism is worth stating exactly, because the obvious explanation is the
+wrong one. Terraform does not leave the traffic block out. It sends one, and
+`ignore_changes` decides which one: the value it refreshed from Azure rather
+than the value written in the configuration.
+
+Those two do not say the same thing. The configuration asks for
+`latest_revision = true` at one hundred percent, which would put every new
+revision straight into service. What Azure actually holds, once any deploy has
+run, is a pin naming one revision:
+
+```hcl
+traffic_weight = [{
+  latest_revision = false
+  percentage      = 100
+  revision_suffix = "c64e67a86-031648"
+}]
+```
+
+So the apply reasserts the pin it just read, the revision named there keeps all
+of the traffic, and the one Terraform has built gets none of it. It is not that
+Terraform declines to move traffic. It is that Terraform faithfully puts back
+the arrangement it found, and the revision it is creating is not in it.
+
+Which is why the question "where will the traffic be after this apply" is
+answered by Azure and not by anything in this repository. Ask it directly, with
+the commands below, before and after.
 
 So after an apply that touched the template, check what is actually serving:
 
@@ -219,6 +246,37 @@ az containerapp ingress traffic set -n afcp-app -g af-cp-centralus \
 
 Moving it by hand is a traffic shift and not a rollback: both revisions run the
 same image unless a deploy happened in between.
+
+### Terraform state is not a record of what is serving
+
+Once traffic moves, whether a deploy moved it or you moved it with the command
+above, the stored state file keeps the OLD revision suffix, and it keeps it
+indefinitely. Nothing writes the true value back, because `ignore_changes` on
+`ingress[0].traffic_weight` is exactly what stops Terraform caring.
+
+Both of our environments were stale that way when this was written, each by more
+than one deploy. Neither was a fault and neither needed repairing.
+
+The distinction that matters is between the STORED file and a REFRESH. A plan
+and an apply both refresh, so the value they act on is the one they just read
+from Azure, and it is current. `terraform state show` and `terraform state pull`
+read the stored file, and it is not. On the deployment this was written against,
+the stored file named a revision that had already been deactivated while the
+plan's own view named the one actually serving.
+
+So: **do not ask this repository what is serving.** Not the state file, which
+answers confidently and wrongly, and not a plan either. An empty plan means
+Terraform intends no change, and because this attribute is ignored, that is not
+a statement about where traffic is. Ask Azure, with the two commands above.
+
+The one case that needs real care is REMOVING that `ignore_changes`, and the
+consequence is the opposite of what the stale file suggests. The stored suffix
+is not what would take effect: the configuration is. `latest_revision = true`
+would win, so traffic would follow the newest revision automatically, every
+Terraform apply would put its own revision into service at one hundred percent
+with no opportunity to probe it first, and each apply would undo the pin the
+deploy pipeline sets. If you want that, it is a deliberate change to how
+releases work here and not a tidy-up of a stale field.
 
 ### Grant yourself write access to the vault, once
 

--- a/docs/src/content/docs/self-hosting/production.md
+++ b/docs/src/content/docs/self-hosting/production.md
@@ -413,6 +413,13 @@ az containerapp ingress traffic set -n afcpprod-app -g af-cp-prod-centralus \
   --revision-weight <newest-revision>=100
 ```
 
+Read that from Azure and not from Terraform. The stored state file records the
+traffic weight from before the last deploy and `ignore_changes` deliberately
+keeps it there, so it is stale by design and says nothing about what is serving.
+An empty plan is not an answer either, because the attribute that would say so
+is the ignored one. See
+[the revision mode trap](/docs/self-hosting/azure#terraform-state-is-not-a-record-of-what-is-serving).
+
 ### 12. Install the App on the organization
 
 On the App's page, **Install App**, and choose the account and repositories.

--- a/infra/terraform/modules/control-plane/app.tf
+++ b/infra/terraform/modules/control-plane/app.tf
@@ -724,6 +724,31 @@ resource "azurerm_container_app" "this" {
   # the old one. Add an environment variable here and the application does not
   # see it until somebody deploys. Check what is actually serving after an apply
   # that touched the template; the self-hosting guide has the two commands.
+  #
+  # WHY THE NEW REVISION GETS NOTHING, since the obvious reading is wrong.
+  # Ignoring an attribute does not mean omitting it. Terraform sends a traffic
+  # block either way, and this line decides which one: the value refreshed from
+  # Azure rather than the one written below. The block below asks for
+  # latest_revision = true at 100 percent; Azure, after any deploy, holds a pin
+  # naming one revision. The apply puts back the arrangement it just read, and
+  # the revision it is creating is not in that arrangement, so it gets zero.
+  #
+  # THE STORED STATE FILE IS A STALE COPY OF THAT, and it stays stale because
+  # this line is what stops Terraform caring. A plan and an apply refresh, so
+  # they act on the current value; `terraform state show` and `state pull` read
+  # the stored one and do not. On this deployment the stored file named a
+  # revision that had already been DEACTIVATED while the plan's own view named
+  # the one actually serving. Neither is a fault to repair. It means only this:
+  # do not ask Terraform what is serving, and do not read an empty plan as an
+  # answer either, because the attribute that would say so is this one. Ask
+  # Azure.
+  #
+  # If this line is ever REMOVED, the consequence is the opposite of what the
+  # stale file suggests. The stored suffix is not what would take effect, the
+  # configuration is: latest_revision = true wins, traffic follows the newest
+  # revision automatically, every apply puts its own revision straight into
+  # service with no chance to probe it, and each apply undoes the pin the deploy
+  # sets. That is a deliberate change to how releases work, not a tidy-up.
   lifecycle {
     ignore_changes = [
       template[0].container[0].image,


### PR DESCRIPTION
## The defect

`docs/src/content/docs/self-hosting/azure.md` has told readers that a Terraform
apply leaves the new container app revision at zero percent of traffic "because
Terraform does not touch traffic weights".

Terraform does touch them, and the distinction is the whole rule.

Ignoring an attribute is not omitting it. Terraform sends a traffic block either
way, and `ignore_changes` on `ingress[0].traffic_weight` decides which one: the
value it **refreshed from Azure**, rather than the one written in the
configuration. The configuration asks for `latest_revision = true` at one
hundred percent, which would put every new revision straight into service.
Azure, once any deploy has run, holds a pin naming one revision. So the apply
puts back the arrangement it just read, and the revision it is creating is not
in that arrangement.

It is not that Terraform declines to move traffic. It is that it faithfully
restores what it found. A reader who believes traffic is never sent has no
reason to look at the thing that actually decides the outcome.

## The half that was documented nowhere

The stored state file keeps the OLD revision suffix indefinitely, because
`ignore_changes` is precisely what stops anything writing the real weight back.
Both environments were stale that way when this was written, each by more than
one deploy. Neither is a fault and neither needs repairing.

What it costs turns on a distinction the guide now draws explicitly:

- A plan and an apply **refresh**, so they act on a value that is current.
- `terraform state show` and `terraform state pull` read the **stored file**,
  and it is not.

On this deployment the stored file named a revision that had already been
deactivated, while the plan's own view named the one actually serving. So the
answer to "what is serving" comes from Azure. An empty plan is not an answer
either, because the attribute that would say so is the ignored one.

I will be plain about how that last part was found: the first version of this
correction told readers to predict the outcome by reading stored state with
`terraform state show`. That is wrong for exactly the reason above, and it is
the same species of error the pull request set out to fix. It was caught by
comparing a real plan's refreshed `before` against a real `state pull` on the
production deployment, and both are quoted in the commit.

## Removing the ignore

The consequence is the opposite of what the stale file suggests, and the first
version of this got it backwards too. The stored suffix is not what would take
effect, the configuration is. `latest_revision = true` wins, so traffic would
follow the newest revision automatically, every apply would put its own revision
straight into service with no chance to probe it first, and each apply would
undo the pin the deploy pipeline sets. That is a deliberate change to how
releases work here, not a tidy-up of a stale field.

## Where it landed

- `docs/src/content/docs/self-hosting/azure.md`: the corrected mechanism and a
  new section, "Terraform state is not a record of what is serving".
- `docs/src/content/docs/self-hosting/production.md`: the short version at the
  step where a person is already reading traffic weights.
- `infra/terraform/modules/control-plane/app.tf`: the same beside the
  `ignore_changes`, for whoever reads the Terraform rather than the guide.

## Checks

    prosecheck        740 files, 0 places where the punctuation gives it away
    terraform fmt     -check -recursive on the module, clean
    terraform validate Success! The configuration is valid.
    132 added lines scanned for em dash, en dash and double hyphen: 0

Every factual claim here was checked against the live deployments rather than
reasoned about: the staging and production stored weights, the plan's refreshed
view, and the deactivated revision the stored file still names.

The new cross page anchor was verified rather than assumed. The slug algorithm
was reproduced against an anchor already in that file that is known to resolve,
then confirmed to produce the value the link uses, appearing once and colliding
with nothing.

One honest note. `changecheck` does not gate this change. Run as a real control
at the same commit with the fragment deleted, it printed byte identical output
and passed both ways, because `Requires(p)` does not classify documentation or
Terraform comments as user visible. The fragment is included by choice, not
because a check demanded it.
