### PR TITLE
api: analytics that stopped said the same thing as analytics that never started

### DIFF
--- a/.changes/analytics-that-stopped-is-not-analytics-that-never-started.md
+++ b/.changes/analytics-that-stopped-is-not-analytics-that-never-started.md
@@ -1,0 +1,36 @@
+# fixed
+
+An installation that recorded analytics and then stopped said exactly what an
+installation that never recorded says, and only one of them is a fault. Both
+render as a dashboard that is not moving, both logged "analytics is NOT
+recording: AF_ANALYTICS_SURROGATE_SECRET is not set" at start-up, and the page
+offered the same instruction to switch it on. That sentence is correct and
+useless for the installation that was recording until Tuesday, because the
+numbers on the screen are real, they are frozen, and nothing says so.
+
+The way to get there is a rollback. The surrogate secret and the operator
+organization reach the process as environment variables, and rolling a Container
+App back goes to an earlier revision with its environment attached, so a
+rollback to any revision from before analytics was configured switches recording
+off while everything else keeps working.
+
+The absent variable cannot detect its own absence. A rolled back deployment and
+a control plane that never wanted analytics present the identical environment,
+and the second is a legitimate way to run this: staging does it, and so does any
+self-hosted installation whose operator does not want the numbers. A rule that
+refused a missing variable would refuse both.
+
+So the question is asked of the database instead, which is the one party a
+rollback does not move. `analytics_rollup_state.last_run_at` is null until the
+rollup first runs and set forever after, and the application role could already
+read it. Null with recording off means this installation never recorded, and the
+existing wording is right. Set with recording off means it recorded and stopped,
+and now the start-up log says so at error level with the timestamp of the last
+rollup, and the dashboard says the numbers end where they end rather than
+offering to switch on something that was already on.
+
+This deliberately does not refuse to start. A rollback happens during an
+incident, the image carries this code into whichever revision is rolled back to,
+and Container Apps cannot add a variable to a revision that already exists, so a
+start-up refusal would block the recovery at the moment it was needed and turn
+lost analytics into a control plane that is down.

--- a/console/app/(app)/analytics/page.tsx
+++ b/console/app/(app)/analytics/page.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useState } from "react";
 import { useSessionContext } from "@/components/session";
 import { query, useApi } from "@/lib/api";
+import { recordingState } from "@/lib/analytics-provenance";
 import { mayReadAnalytics } from "@/lib/roles";
 import { DayColumns, Meter } from "@/components/Meter";
 import {
@@ -70,6 +71,9 @@ interface Provenance {
   lastRolledUpAt: string | null;
   settledAfter: string | null;
   recording: boolean;
+  /** True when this installation recorded once and is not recording now. Off
+   *  and never on read identically as zeros, and only one of them is a fault. */
+  recordingStopped: boolean;
   /** The three insight shapes settle at different rates, so each panel says
    *  which of these applies to it rather than sharing one line. */
   funnelsFinalBefore: string | null;
@@ -629,12 +633,20 @@ function Analytics() {
 /**
  * Where the numbers came from, above the numbers.
  *
- * Three states that all render as zeros and mean different things: recording is
- * off, the rollup has never run, and nothing happened. A page that cannot tell
- * a reader which of those they are looking at is a page that will be believed
- * about the wrong one.
+ * Four states that all render as flat or empty and mean different things:
+ * recording was never on, recording was on and has STOPPED, the rollup has
+ * never run, and nothing happened. A page that cannot tell a reader which of
+ * those they are looking at is a page that will be believed about the wrong
+ * one.
+ *
+ * The second is the one worth the extra sentence. Numbers that stopped moving
+ * look exactly like numbers nobody is generating, so a control plane rolled
+ * back past its analytics variables shows a plausible dashboard of real but
+ * frozen figures. Saying "off" there is true and useless; saying it stopped is
+ * what sends somebody to look.
  */
 function Provenance({ p }: { p: Provenance }) {
+  const recording = recordingState(p);
   return (
     <div className="rounded-lg border border-rule bg-card px-4 py-3">
       <p className="text-[13px] leading-6 text-muted">
@@ -642,12 +654,18 @@ function Provenance({ p }: { p: Provenance }) {
           {p.from} to {p.to}
         </span>
         {". "}
-        {p.recording ? null : (
+        {recording === "stopped" ? (
+          <span className="text-warn">
+            Recording has stopped on this control plane. It was recording and it is not now, so
+            the numbers below end where they end instead of being current. A rollback to a
+            revision from before AF_ANALYTICS_SURROGATE_SECRET was set does exactly this.{" "}
+          </span>
+        ) : recording === "never-recorded" ? (
           <span className="text-warn">
             Recording is switched off on this control plane, so nothing new is arriving. Set
             AF_ANALYTICS_SURROGATE_SECRET to turn it on.{" "}
           </span>
-        )}
+        ) : null}
         {p.lastRolledUpAt === null ? (
           <span className="text-warn">
             The rollup has never run, so every number here is zero because nothing has been

--- a/console/lib/analytics-provenance.test.ts
+++ b/console/lib/analytics-provenance.test.ts
@@ -1,0 +1,39 @@
+// Which of the three things the page says about recording.
+//
+// The two that matter are the ones that render the same otherwise: an
+// installation that never recorded and one that has stopped both show a
+// dashboard that is not moving, and only the second is a fault. Saying "off"
+// for both is true and useless.
+//
+// One test per outcome rather than three assertions in one, because an
+// assertion that throws stops the ones after it, and an outcome that was never
+// checked looks exactly like one that passed.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { recordingState } from "./analytics-provenance.ts";
+
+describe("what the analytics page says about recording", () => {
+  it("says nothing special while it is recording", () => {
+    assert.equal(recordingState({ recording: true, recordingStopped: false }), "recording");
+  });
+
+  it("says it never recorded when it is off and has never recorded", () => {
+    // Staging and self-hosted installations live here. This has to stay the
+    // quiet message or the loud one stops meaning anything.
+    assert.equal(recordingState({ recording: false, recordingStopped: false }), "never-recorded");
+  });
+
+  it("says it STOPPED when it is off and recorded before", () => {
+    assert.equal(recordingState({ recording: false, recordingStopped: true }), "stopped");
+  });
+
+  it("stays on recording even if the server contradicts itself", () => {
+    // recording true with recordingStopped true should not happen: the server
+    // derives the second from the first. If it ever does, the page says the
+    // system is working rather than showing an alarm it cannot explain, and
+    // the honest signal is the one on the server, which logs.
+    assert.equal(recordingState({ recording: true, recordingStopped: true }), "recording");
+  });
+});

--- a/console/lib/analytics-provenance.ts
+++ b/console/lib/analytics-provenance.ts
@@ -1,0 +1,26 @@
+/**
+ * Which sentence the analytics page owes the reader about recording.
+ *
+ * Three outcomes rather than a boolean, because "not recording" covers two
+ * situations that look identical on the page and mean opposite things. A
+ * control plane that never switched analytics on is running as intended:
+ * staging does it, and so does any self-hosted installation whose operator does
+ * not want the numbers. A control plane that recorded until some point and does
+ * not now has lost something, and the numbers on screen are real but frozen,
+ * which is the more convincing kind of wrong.
+ *
+ * The server decides which of the two it is, because it is the half that can
+ * see the database, and `recordingStopped` carries the answer. This function
+ * exists so that the choice is one named thing with a test rather than a
+ * nested conditional inside a component, and so the page and the API cannot
+ * drift into disagreeing about what the same two booleans mean.
+ */
+export type RecordingState = "recording" | "never-recorded" | "stopped";
+
+export function recordingState(p: {
+  recording: boolean;
+  recordingStopped: boolean;
+}): RecordingState {
+  if (p.recording) return "recording";
+  return p.recordingStopped ? "stopped" : "never-recorded";
+}

--- a/web/apps/api/src/analytics/read.ts
+++ b/web/apps/api/src/analytics/read.ts
@@ -53,6 +53,38 @@ export interface Freshness {
   subjectDaysKept: number | null
 }
 
+/**
+ * Whether this installation recorded analytics once and is not recording now.
+ *
+ * THE FAILURE THIS EXISTS TO CATCH. The surrogate secret and the operator
+ * organization reach the container as environment variables, and a Container
+ * Apps rollback goes to a whole earlier revision, environment and all. Roll
+ * back past the revision that introduced them and analytics switches off
+ * silently: the process starts, every route answers, and the only symptom is
+ * that the numbers stop moving. Nobody notices a chart that has stopped, they
+ * notice a chart that is wrong, and by then the hole is however long it took.
+ *
+ * WHY THE ANSWER IS IN THE DATABASE AND NOT IN THE ENVIRONMENT. The absent
+ * variable cannot be its own detector. An installation that has never recorded
+ * and one that has been rolled back present exactly the same environment, and
+ * the first is a legitimate way to run this: staging does it, and so does any
+ * self-hosted control plane whose operator does not want analytics. A rule that
+ * refuses the absent variable refuses both. `last_run_at` separates them,
+ * because it is written by the rollup and survives what the rollback removed:
+ * null forever on an installation that never recorded, and set on one that did.
+ *
+ * This deliberately does not refuse to start. A rollback happens during an
+ * incident, the image carries this code into whichever revision is rolled back
+ * to, and Container Apps cannot add a variable to a revision that exists, so a
+ * startup refusal would block the recovery at the moment it was needed and turn
+ * lost analytics into a control plane that is down. `ensureBypass()` earns its
+ * refusal because the admin pool is load bearing for every request. This is
+ * not, so it is loud instead of fatal.
+ */
+export function recordingStopped(recording: boolean, lastRolledUpAt: string | null): boolean {
+  return !recording && lastRolledUpAt !== null
+}
+
 export async function freshness(db: Db): Promise<Freshness> {
   const rows = await db.execute<{
     last_run_at: Date | string | null

--- a/web/apps/api/src/main.ts
+++ b/web/apps/api/src/main.ts
@@ -25,6 +25,7 @@ import { RealRepositoryApi } from './github/api.ts'
 import { sweepGenerations, sweepTeardowns, type LifecycleDeps } from './github/lifecycle.ts'
 import { pricesFrom } from './providers/pricing.ts'
 import { retentionFromEnv, startMaintenance } from './maintenance.ts'
+import { freshness, recordingStopped } from './analytics/read.ts'
 import { surrogateSecretFrom } from './analytics/record.ts'
 import { analyticsRetentionFromEnv } from './analytics/rollup.ts'
 import { ResendMailer } from './auth/mail.ts'
@@ -254,6 +255,42 @@ console.log(
     ? `the analytics dashboard is readable by owners and admins of ${analyticsOperatorOrgSlug}`
     : 'the analytics dashboard is readable by nobody: AF_ANALYTICS_OPERATOR_ORG is not set',
 )
+
+// Did this installation record once and stop?
+//
+// "Analytics is not recording" is the correct and unremarkable state for a
+// staging environment and for any self-hosted control plane whose operator
+// never wanted it, so the line above cannot be an alarm. On an installation
+// that HAS recorded it is a regression, and the usual way to reach it is a
+// rollback to a revision that predates the analytics variables, which takes the
+// environment back with it and leaves everything else working.
+//
+// The database is asked because it is the only party to this that a rollback
+// does not move. See recordingStopped in analytics/read.ts for why an absent
+// variable cannot detect its own absence.
+//
+// A failed read is reported as a failed read. An installation whose rollup
+// state cannot be reached has not been shown to be healthy, and printing
+// nothing here would be indistinguishable from printing nothing because there
+// was nothing to say.
+try {
+  const state = await pool.withoutTenant((db) => freshness(db))
+  if (recordingStopped(analyticsSecret !== null, state.lastRunAt)) {
+    console.error(
+      'ANALYTICS HAS STOPPED RECORDING. This installation was recording, and the ' +
+        `last rollup ran at ${state.lastRunAt}, but AF_ANALYTICS_SURROGATE_SECRET is ` +
+        'not set on this revision, so nothing new is being written and the dashboard ' +
+        'will keep serving the numbers up to that point. A rollback to a revision ' +
+        'from before analytics was configured does exactly this. Restore the ' +
+        'variable, or if analytics was switched off deliberately, expect a hole.',
+    )
+  }
+} catch (err) {
+  console.error(
+    'could not check whether analytics has stopped recording: ' +
+      (err instanceof Error ? err.message : String(err)),
+  )
+}
 
 let hostedRequiredPlan
 let githubAppInstallUrl

--- a/web/apps/api/src/routers/analytics.ts
+++ b/web/apps/api/src/routers/analytics.ts
@@ -41,6 +41,7 @@ import {
   funnelOrder,
   organizationFunnel,
   planMix,
+  recordingStopped,
   retention,
   retentionGrid,
   series,
@@ -114,6 +115,15 @@ export interface Provenance {
   /** False when no surrogate secret is configured, so nothing is recorded. */
   recording: boolean
   /**
+   * True when this installation recorded once and is not recording now, which
+   * is a different thing from never having recorded and reads identically on
+   * the page unless it is said. The usual cause is a rollback to a revision
+   * that predates the analytics variables. `recording` alone cannot express it:
+   * false covers both the installation that switched analytics on yesterday and
+   * lost it, and the one that never wanted it.
+   */
+  recordingStopped: boolean
+  /**
    * The three insight shapes settle at different rates, so each carries its
    * own answer. One freshness line for all of them would be right about the
    * daily counts and wrong about the other two: a funnel week is still gaining
@@ -137,6 +147,7 @@ async function provenanceFor(c: OrgContext, days: number): Promise<Provenance> {
     lastRolledUpAt: state.lastRunAt,
     settledAfter: state.settledAfter,
     recording: c.analytics.enabled,
+    recordingStopped: recordingStopped(c.analytics.enabled, state.lastRunAt),
     funnelsFinalBefore: state.funnelsFinalBefore,
     cohortsCompleteThrough: state.cohortsCompleteThrough,
     subjectDaysKept: state.subjectDaysKept,

--- a/web/apps/api/test/analytics-recording-regression.test.ts
+++ b/web/apps/api/test/analytics-recording-regression.test.ts
@@ -1,0 +1,116 @@
+// The dashboard has to distinguish a control plane that never recorded from one
+// that recorded and stopped, and the distinction has to survive the wire.
+//
+// analytics-recording-stopped.test.ts proves the rule. This file proves the
+// rule is REACHED: that provenanceFor actually calls it and that the answer
+// arrives at a caller. A predicate with no caller is a dead, shippable gap that
+// looks exactly like a working feature, and the page can only draw a state the
+// server sends it.
+//
+// The three cases run against ONE database on purpose, in an order that changes
+// only one thing at a time. Recording stays off across the first two and the
+// only difference between them is that the rollup has run, which is the whole
+// claim: the fact that separates "never recorded" from "stopped recording"
+// lives in the database rather than in the environment.
+
+import { after, before, describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  available,
+  callProcedure,
+  dropOrg,
+  seedOrg,
+  signInAs,
+  startApi,
+  type ApiHarness,
+  type Org,
+} from './harness.ts'
+import { rollUp } from '../src/analytics/rollup.ts'
+
+const hasDatabase = await available()
+
+interface SeenProvenance {
+  recording: boolean
+  recordingStopped: boolean
+  lastRolledUpAt: string | null
+}
+
+describe(
+  'the dashboard says when recording stopped rather than only that it is off',
+  { skip: hasDatabase ? false : 'no Postgres at AF_TEST_DATABASE_URL' },
+  () => {
+    let off: ApiHarness
+    let operator: Org
+
+    const provenance = async (h: ApiHarness): Promise<SeenProvenance> => {
+      const session = await signInAs(h, operator, 'owner')
+      const res = await callProcedure(h, session, 'analytics.overview', 'query', { days: 28 })
+      assert.equal(res.status, 200, JSON.stringify(res.body))
+      const body = res.body as { result: { data: { provenance: SeenProvenance } } }
+      return body.result.data.provenance
+    }
+
+    before(async () => {
+      const seeding = await startApi()
+      operator = await seedOrg(seeding.admin, 'operator')
+      await seeding.close()
+      off = await startApi({ analyticsOperatorOrgSlug: operator.slug, analyticsSecret: null })
+
+      // Establish the precondition rather than inherit it.
+      //
+      // analytics_rollup_state is ONE row for the whole installation and it is
+      // never torn down between suites, so a database that has run any rollup
+      // before, including this file's own second test on a previous run,
+      // arrives with last_run_at already set. The first test below would then
+      // fail for a reason that has nothing to do with the code it is about.
+      // This suite is the thing that decides whether the rollup has run, so it
+      // says so out loud here instead of hoping for a clean database.
+      await off.admin.unsafe(
+        `UPDATE analytics_rollup_state SET last_run_at = NULL, settled_after = NULL`,
+      )
+    })
+
+    after(async () => {
+      await dropOrg(off.admin, operator.orgId)
+      await off.close()
+    })
+
+    it('does not call it stopped on an installation that never recorded', async () => {
+      // Staging, and every self-hosted control plane that never wanted
+      // analytics. Recording is off and that is not a fault.
+      const p = await provenance(off)
+      assert.equal(p.recording, false)
+      assert.equal(p.lastRolledUpAt, null)
+      assert.equal(p.recordingStopped, false)
+    })
+
+    it('calls it stopped once something has rolled up and recording is still off', async () => {
+      // Nothing about the server changed between this and the test above. The
+      // rollup ran, so the database now remembers that this installation was
+      // recording, which is precisely what a rollback cannot take away.
+      await rollUp(off.admin, off.clock, { lookbackDays: 1 })
+      const p = await provenance(off)
+      assert.equal(p.recording, false)
+      assert.notEqual(p.lastRolledUpAt, null)
+      assert.equal(p.recordingStopped, true)
+    })
+
+    it('does not call it stopped while it is recording, rollup or no rollup', async () => {
+      // Same database, rollup already run, recording switched back on. The
+      // healthy state has to stay quiet or the warning is worthless.
+      const on = await startApi({ analyticsOperatorOrgSlug: operator.slug })
+      try {
+        const session = await signInAs(on, operator, 'owner')
+        const res = await callProcedure(on, session, 'analytics.overview', 'query', { days: 28 })
+        assert.equal(res.status, 200, JSON.stringify(res.body))
+        const p = (res.body as { result: { data: { provenance: SeenProvenance } } }).result.data
+          .provenance
+        assert.equal(p.recording, true)
+        assert.notEqual(p.lastRolledUpAt, null)
+        assert.equal(p.recordingStopped, false)
+      } finally {
+        await on.close()
+      }
+    })
+  },
+)

--- a/web/apps/api/test/analytics-recording-stopped.test.ts
+++ b/web/apps/api/test/analytics-recording-stopped.test.ts
@@ -1,0 +1,54 @@
+// Telling "never recorded" apart from "stopped recording".
+//
+// Both render as a dashboard that is not moving, and only one of them is a
+// fault. An installation that never switched analytics on is running the way
+// its operator meant it to: staging does this, and so does any self-hosted
+// control plane that does not want the numbers. An installation that recorded
+// until last Tuesday and does not now has lost something, and the usual way to
+// get there is a rollback to a container revision from before the analytics
+// variables existed, which takes the environment back with it.
+//
+// The environment cannot answer this. A rolled back revision and a control
+// plane that never wanted analytics carry the identical absence, so a rule that
+// reads "the variable is missing" refuses both or neither. `last_run_at` is
+// written by the rollup and lives in the database, which is the one party a
+// rollback does not move, so it is the fact that separates them.
+//
+// Four cells, one test each rather than four assertions in one, because an
+// assertion that throws stops the ones after it and a cell that never ran looks
+// exactly like a cell that passed.
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { recordingStopped } from '../src/analytics/read.ts'
+
+const A_ROLLUP_HAS_RUN = '2026-09-04T03:17:00.000Z'
+
+describe('whether analytics recorded once and stopped', () => {
+  it('is not stopped while it is recording and has rolled up', () => {
+    // The ordinary healthy installation. Nothing to say.
+    assert.equal(recordingStopped(true, A_ROLLUP_HAS_RUN), false)
+  })
+
+  it('is not stopped while it is recording and has never rolled up', () => {
+    // Switched on, nothing computed yet. The page says the rollup has never
+    // run, which is a different sentence and already exists.
+    assert.equal(recordingStopped(true, null), false)
+  })
+
+  it('is NOT stopped when it never recorded at all', () => {
+    // The cell that decides the whole design. Staging is here, and so is every
+    // self-hosted control plane whose operator never set the secret. If this
+    // one answered true, the check would cry wolf on every correctly
+    // configured installation that does not want analytics, and a warning that
+    // is wrong most of the time is one nobody reads by the time it is right.
+    assert.equal(recordingStopped(false, null), false)
+  })
+
+  it('IS stopped when it recorded before and is not recording now', () => {
+    // The regression. Recording is off, yet something has rolled up, so this
+    // installation was recording at some point and is not now.
+    assert.equal(recordingStopped(false, A_ROLLUP_HAS_RUN), true)
+  })
+})


### PR DESCRIPTION
## The defect

Rolling a Container App back goes to an earlier revision with its environment
attached, so a rollback to any revision from before analytics was configured
takes `AF_ANALYTICS_SURROGATE_SECRET` away with it. Recording stops. Everything
else keeps working, every route answers, and the only symptom is a dashboard
whose numbers are real and have stopped moving.

Nothing said so. Start-up printed "analytics is NOT recording", which is the
same line staging prints, and the page offered to switch on something that had
been on that morning. Numbers that stopped look exactly like numbers nobody is
generating, which is the more convincing kind of wrong.

## Why the obvious fix cannot work

Refusing to start when the analytics variables are absent was the first idea and
it is wrong twice.

It cannot tell the two cases apart. A rolled back production revision and a
control plane that never wanted analytics carry the identical environment. On
the deployments this was checked against, the name sets differed by one variable
that has nothing to do with analytics, and neither carried any `AF_ANALYTICS*`
at all. So "the variable is missing" refuses staging on its next deploy, and a
new "enabled" flag fails identically, because that flag is equally absent on a
revision predating the feature. The absent variable cannot be its own detector.

And it would block the recovery. Both revisions run the same image digest, so a
check compiled into the image is present in whichever revision is rolled back
to, a rollback happens during an incident, and Container Apps cannot add a
variable to a revision that already exists. A start-up refusal would fire at the
moment the rollback was needed and turn lost analytics into a control plane that
is down. `ensureBypass()` earns its refusal because the admin pool is load
bearing for every request. Analytics is not.

## What this does instead

Asks the database, which is the one party to this that a rollback does not move.

Migration 0032 already built the instrument, and its own comment says why it
exists: `analytics_rollup_state` is one row "so a rollup that has never run is
distinguishable from one that ran and found nothing". `last_run_at` is null
until the rollup first runs and set from then on, and `antifailure_app` already
holds `SELECT` on it.

- Null with recording off: never recorded. Staging, and any self-hosted
  installation whose operator does not want the numbers. The existing wording is
  right and nothing changes.
- Set with recording off: recorded and stopped. Start-up logs at error level
  naming the last rollup timestamp, and the dashboard says the numbers end where
  they end rather than offering to switch on what was already on.

`recordingStopped()` lives in `analytics/read.ts` beside the `freshness()` that
already reads that row. The console asks one named function in
`console/lib/analytics-provenance.ts` rather than nesting a second condition in
a component, so the page and the API cannot drift about what the same two
booleans mean.

## Proof

Three mutation matrices, each cell its own test because an assertion that throws
hides the ones after it.

Predicate, four cells:

    mutation                      c1  c2  c3  c4
    M1 always false             green green green  RED
    M2 always true                RED   RED   RED green
    M3 ignores the rollup       green green   RED green
    M4 ignores the secret         RED green green green
    restored                    green green green green

c3 is "never recorded stays quiet" and c4 is "the regression fires". Each has a
unique killer, M3 and M1. M3 is the one that matters: it is the mutation that
would make this cry wolf on staging.

API wiring, three tests:

    mutation                      t1    t2    t3
    I1 always false             green   RED green
    I2 always true                RED green   RED
    I3 field never sent at all    RED   RED   RED
    restored                    green green green

I3 is the dead code control. Delete the field from the producer and all three
notice, so these prove `provenanceFor` actually calls the predicate and the
answer reaches a caller.

Console function, four cells: C1 kills only c3, C2 kills c1 and c4, C3 kills c1,
c2 and c4, C4 kills c2 and c3. All restored green.

**A real defect the restore step caught.** The first API matrix came back with
t1 red after restoring, which was not the mutation.
`analytics_rollup_state` is one row for the whole installation and is never torn
down, so once t2 runs a rollup the database keeps `last_run_at` and t1 could only
ever pass on a pristine database. It passed once and would have failed every run
after, including in CI on a shared container. The suite now sets its own
precondition and says why. Confirmed by two consecutive runs against the
permanently contaminated database: pass 3, fail 0 both times.

**Real server, both directions.** Against a disposable local Postgres in the
stopped state, `node src/main.ts` printed:

    ANALYTICS HAS STOPPED RECORDING. This installation was recording, and the last
    rollup ran at 2026-09-05T04:18:44.571Z, but AF_ANALYTICS_SURROGATE_SECRET is not
    set on this revision, ...

Then `last_run_at` was nulled and the same server restarted against the same
configuration: zero occurrences, started normally.

**Real pixels, both states.** Signed in as an owner of the operator
organisation, 1440x900 and 390x844, light and dark. Stopped state renders
"Recording has stopped on this control plane ... the numbers below end where
they end instead of being current". Never recorded renders the original
"Recording is switched off ... Set AF_ANALYTICS_SURROGATE_SECRET to turn it on",
with the new sentence absent. Horizontal overflow false and zero console errors
on all four. Existing `text-warn` token inside the existing card, no new colour
and no animation.

**Suites.** 708 tests, zero failures, zero skips: 137 analytics plus
config-docs, 412 openapi/openapi-wire/openapi-artifact/permissions/route-boundary/console,
159 console. `tsc` clean on `web/apps/api` and `console`. prosecheck 743 files,
0 places. changecheck names the fragment, and unlike a documentation only
change it genuinely gates this one: the same commit with the fragment deleted
exits 1.

## What this does not do

The start-up block in `main.ts` is entrypoint code no suite imports, so it has
no automated test. The predicate it calls is covered four ways and the wiring is
covered by the two real server runs above, and by nothing else. Putting it under
test means extracting that block into something importable, which is a larger
change than this one.

A log line and a dashboard state are not impossible to miss for somebody who
opens neither. An Azure Monitor alert on that log line through the existing
`azurerm_monitor_action_group.pager` is separate work that this does not do, and
is named here rather than left to look covered.
