### PR TITLE
careers: two founding roles, a private application queue, and a page that states the terms first

### DIFF
--- a/.changes/careers.md
+++ b/.changes/careers.md
@@ -1,0 +1,5 @@
+# added
+
+- Founding engineering and growth roles have a careers page with current
+  compensation stated upfront, a private application form, and an operator
+  review queue. Applications expire after 180 days through maintenance.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -687,7 +687,7 @@ jobs:
 
       - name: Every operator section the navigation lists was exported
         # The list above is written out by hand, which is right for a dozen
-        # routes and wrong for the operator portal: it has twenty three
+        # routes and wrong for the operator portal: it has twenty four
         # sections, six people are adding to them, and a hand kept copy would
         # be behind within a day. So this reads the navigation itself, which is
         # the same file the rail is drawn from, and checks the export for every
@@ -697,15 +697,15 @@ jobs:
         # avoid. A stray server-only import stops one page exporting, its route
         # starts answering with the 404 page, and the rail keeps the entry: the
         # reader clicks a section that is supposed to exist and gets nothing,
-        # which teaches them to distrust the other twenty two as well.
+        # which teaches them to distrust the other twenty three as well.
         run: |
           routes=$(grep -oE 'href: "/admin[^"]*"' console/lib/admin-nav.ts | cut -d'"' -f2)
           count=$(printf '%s\n' "$routes" | grep -c .)
           # A grep that stops matching returns nothing, and a loop over nothing
           # passes every time. The count is what keeps this from going quietly
           # green if the navigation is ever reformatted out from under it.
-          if [ "$count" -ne 23 ]; then
-            echo "::error::read $count routes out of console/lib/admin-nav.ts, expected 23"
+          if [ "$count" -ne 24 ]; then
+            echo "::error::read $count routes out of console/lib/admin-nav.ts, expected 24"
             exit 1
           fi
           missing=0

--- a/console/app/admin/administration/applications/page.tsx
+++ b/console/app/admin/administration/applications/page.tsx
@@ -1,0 +1,325 @@
+"use client";
+
+import { useState } from "react";
+import {
+  AdminPage,
+  DataTable,
+  Drawer,
+  EmptyList,
+  Facts,
+  FilterBar,
+  type Column,
+} from "@/components/admin/primitives";
+import { More } from "@/components/pagination";
+import {
+  Button,
+  Card,
+  Confirm,
+  Loaded,
+  TableSkeleton,
+  When,
+} from "@/components/ui";
+import { ApiError } from "@/lib/api";
+import { operatorMay, useAdminContext } from "@/lib/admin";
+import {
+  removeApplication,
+  reviewApplication,
+  roleLabel,
+  useApplications,
+  type Application,
+} from "@/lib/admin-recruitment";
+
+/**
+ * The private queue of applications for the founding roles.
+ *
+ * THIS IS THE ONLY SCREEN IN THE PORTAL THAT HOLDS SOMEBODY WHO IS NOT A
+ * CUSTOMER. Every other list here is about an organization that signed up. An
+ * applicant has no account, no organization and no relationship with us beyond
+ * having answered a form, so the two decisions on this page follow from that
+ * rather than from how the other lists work:
+ *
+ *   THE ANSWERS ARE IN A PANEL, NOT IN THE TABLE. An introduction runs to four
+ *   thousand characters. Putting it in a cell would either truncate the thing
+ *   the operator is here to read or make one row taller than the screen, and it
+ *   would put a stranger's name, address and prose on a dashboard that somebody
+ *   leaves open beside them. The table carries what is needed to choose a row;
+ *   opening one is a deliberate act.
+ *
+ *   DELETING ASKS FOR THE ADDRESS. `Confirm` takes the applicant's email as its
+ *   phrase, for the reason that component gives about typing an organization's
+ *   own slug: typing "delete" proves you can read a label, and the mistake that
+ *   actually happens is removing the row next to the one you meant. This
+ *   deletion is not recoverable from this page and it destroys the only copy of
+ *   what a person wrote to us.
+ *
+ * MARKING REVIEWED MAILS NOBODY, and the page says so out loud. It is a note
+ * that an operator has read the application, nothing more. There is no mailer
+ * on this path, so a screen that implied one would be the waitlist defect the
+ * public form was built to end, wearing an operator's clothes.
+ *
+ * THE FOUR STATES ARE ALL BUILT. `Loaded` renders the skeleton, the failed
+ * first load with a retry, and a failed reload over rows that are still worth
+ * reading; `DataTable`'s `empty` says which queue is empty and why that is
+ * normal; `More` says whether the list is complete rather than disappearing at
+ * the end; and a refused review or delete renders where the button was pressed
+ * rather than at the top of a page the operator is no longer looking at.
+ */
+
+const QUEUES = [
+  { value: "waiting", label: "Needs review" },
+  { value: "reviewed", label: "Reviewed" },
+];
+
+export default function ApplicationsPage() {
+  const { me } = useAdminContext();
+  const mayWrite = operatorMay(me, "admin.recruitment.write");
+  const [queue, setQueue] = useState("waiting");
+  const [open, setOpen] = useState<Application | null>(null);
+  const [confirming, setConfirming] = useState<Application | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [failure, setFailure] = useState<string | null>(null);
+  const state = useApplications(queue === "reviewed");
+
+  async function act(application: Application, remove: boolean) {
+    if (busy) return;
+    setBusy(true);
+    setFailure(null);
+    try {
+      if (remove) await removeApplication(application.id);
+      else await reviewApplication(application.id);
+      setConfirming(null);
+      setOpen(null);
+      state.reload();
+    } catch (error) {
+      // The server's own sentence where there is one. Both procedures refuse a
+      // row that has already been reviewed or removed, and that refusal names
+      // the reason and tells the operator to refresh, which is more use than
+      // any wording this page could invent.
+      setFailure(
+        error instanceof ApiError
+          ? error.message
+          : "The control plane could not be reached, so nothing was changed. Refresh the queue and try again.",
+      );
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const columns: Column<Application>[] = [
+    {
+      key: "name",
+      header: "Applicant",
+      // A real button, so the panel opens from the keyboard and is announced as
+      // something that does a thing. The audit page's first column is the same
+      // shape for the same reason.
+      cell: (a) => (
+        <button
+          type="button"
+          onClick={() => {
+            setFailure(null);
+            setOpen(a);
+          }}
+          className="max-w-full truncate text-left text-ink underline decoration-rule-strong underline-offset-2 hover:decoration-ink"
+        >
+          {a.name}
+        </button>
+      ),
+    },
+    { key: "role", header: "Role", cell: (a) => roleLabel(a.role) },
+    {
+      key: "link",
+      header: "Their work",
+      cell: (a) =>
+        a.projectUrl ? (
+          <a
+            href={a.projectUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-ink underline decoration-rule-strong underline-offset-2 hover:decoration-ink"
+          >
+            Open in a new tab
+          </a>
+        ) : (
+          <span className="text-dim">No link</span>
+        ),
+    },
+    { key: "received", header: "Received", cell: (a) => <When value={a.createdAt} /> },
+  ];
+
+  return (
+    <AdminPage
+      href="/admin/administration/applications"
+      lede="Applications for the founding roles, oldest first, so the person who has waited longest is at the top. This is recruitment data and it is not joined to any customer, any analytics event or any mailing list."
+    >
+      <Card>
+        <FilterBar
+          filters={[{ label: "Queue", value: queue, onChange: setQueue, options: QUEUES }]}
+          actions={
+            <Button onClick={state.reload} busy={state.refreshing}>
+              Refresh
+            </Button>
+          }
+        />
+        <p className="border-b border-rule px-4 py-2.5 text-[12px] leading-5 text-dim">
+          Marking an application reviewed records that somebody read it. It sends no email.
+          Scheduled maintenance removes every application older than 180 days, reviewed or not.
+        </p>
+        {state.refreshError ? (
+          <p role="alert" className="border-b border-rule px-4 py-2.5 text-[12px] leading-5 text-fail">
+            {state.refreshError.message}
+          </p>
+        ) : null}
+        {failure && open === null && confirming === null ? (
+          <p role="alert" className="border-b border-rule px-4 py-2.5 text-[12px] leading-5 text-fail">
+            {failure}
+          </p>
+        ) : null}
+        <Loaded state={state} skeleton={<TableSkeleton rows={6} cols={4} />}>
+          {(rows) => (
+            <DataTable
+              columns={columns}
+              rows={rows}
+              keyOf={(a) => a.id}
+              empty={
+                <EmptyList
+                  title={
+                    queue === "reviewed"
+                      ? "Nothing has been reviewed yet"
+                      : "No application is waiting"
+                  }
+                >
+                  {queue === "reviewed"
+                    ? "No application has been marked reviewed. Marking one moves it out of the waiting queue and into this one."
+                    : "Nothing has come in through the careers page since the last one was reviewed or removed. This is what an empty queue looks like, not a failed load."}
+                </EmptyList>
+              }
+              footer={
+                <More
+                  shown={rows.length}
+                  noun={{ one: "application", many: "applications" }}
+                  hasMore={state.hasMore}
+                  busy={state.busy}
+                  error={state.moreError}
+                  onMore={state.more}
+                />
+              }
+            />
+          )}
+        </Loaded>
+      </Card>
+
+      <Drawer
+        open={open !== null}
+        title={open ? open.name : "Application"}
+        onClose={() => setOpen(null)}
+        actions={
+          open && mayWrite ? (
+            <>
+              {open.reviewedAt === null ? (
+                <Button
+                  variant="primary"
+                  busy={busy}
+                  onClick={() => void act(open, false)}
+                >
+                  Mark reviewed
+                </Button>
+              ) : null}
+              <Button
+                variant="danger"
+                disabled={busy}
+                onClick={() => {
+                  setFailure(null);
+                  setConfirming(open);
+                }}
+              >
+                Delete the application
+              </Button>
+            </>
+          ) : null
+        }
+      >
+        {open ? (
+          <>
+            <Facts
+              facts={[
+                { label: "Role applied for", value: roleLabel(open.role) },
+                {
+                  label: "Email",
+                  value: (
+                    <a
+                      href={`mailto:${open.email}`}
+                      className="break-all text-ink underline decoration-rule-strong underline-offset-2 hover:decoration-ink"
+                    >
+                      {open.email}
+                    </a>
+                  ),
+                },
+                {
+                  label: "Their work",
+                  value: open.projectUrl ? (
+                    <a
+                      href={open.projectUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="break-all text-ink underline decoration-rule-strong underline-offset-2 hover:decoration-ink"
+                    >
+                      {open.projectUrl}
+                    </a>
+                  ) : null,
+                },
+                { label: "Received", value: <When value={open.createdAt} /> },
+                {
+                  label: "Reviewed",
+                  value: open.reviewedAt === null ? null : <When value={open.reviewedAt} />,
+                },
+                {
+                  label: "Compensation",
+                  value: "Acknowledged on submission. The form cannot be sent without it.",
+                },
+                { label: "Reference", value: open.id, mono: true },
+              ]}
+            />
+            <div className="border-t border-rule px-4 py-4">
+              <h3 className="text-[12px] font-medium leading-5 text-dim">
+                What they have built or grown, and why this role
+              </h3>
+              {/* whitespace-pre-wrap, because the applicant's paragraph breaks
+                  are theirs. Collapsing them turns a structured answer into one
+                  block and reads as carelessness on our side. */}
+              <p className="mt-2 whitespace-pre-wrap break-words text-[13px] leading-6 text-ink">
+                {open.why}
+              </p>
+            </div>
+            {failure && confirming === null ? (
+              <p role="alert" className="px-4 pb-1 text-[12px] leading-5 text-fail">
+                {failure}
+              </p>
+            ) : null}
+          </>
+        ) : null}
+      </Drawer>
+
+      <Confirm
+        open={confirming !== null}
+        title="Delete this application?"
+        phrase={confirming?.email}
+        confirmLabel="Delete it"
+        busy={busy}
+        error={confirming ? failure : null}
+        onCancel={() => setConfirming(null)}
+        onConfirm={() => {
+          if (confirming) void act(confirming, true);
+        }}
+      >
+        <p>
+          The name, address and answers are removed from the live database. The audit keeps the
+          action and the reference, never what was written.
+        </p>
+        <p>
+          Backups expire on their own recovery schedule, so a row is gone from every copy only
+          after that window has passed. There is no undo on this page.
+        </p>
+      </Confirm>
+    </AdminPage>
+  );
+}

--- a/console/lib/admin-nav.test.ts
+++ b/console/lib/admin-nav.test.ts
@@ -73,11 +73,11 @@ const GROUPS: { label: string; slug: string; items: Entry[] }[] = [
 
 describe("the operator portal's navigation", () => {
   test("the declaration was read, so nothing below passes over an empty list", () => {
-    // The guard the rest of this file rests on. Twenty two sections in six
+    // The guard the rest of this file rests on. Twenty three sections in six
     // groups, plus the overview above them, is the information architecture;
     // any other number here means the parser has stopped seeing the file and
     // every assertion after it is vacuous.
-    assert.equal(ENTRIES.length, 23, "expected the overview plus twenty two sections");
+    assert.equal(ENTRIES.length, 24, "expected the overview plus twenty three sections");
     assert.equal(GROUPS.length, 6);
     for (const g of GROUPS) {
       assert.ok(g.items.length > 0, `no entries were read out of the ${g.label} group`);
@@ -188,8 +188,8 @@ describe("the operator portal's navigation", () => {
     );
     assert.equal(
       GROUPS.reduce((n, g) => n + g.items.length, 0),
-      22,
-      "the information architecture has twenty two sections in six groups",
+      23,
+      "the information architecture has twenty three sections in six groups",
     );
   });
 });

--- a/console/lib/admin-nav.ts
+++ b/console/lib/admin-nav.ts
@@ -312,6 +312,13 @@ export const ADMIN_NAV: AdminNavGroup[] = [
     slug: "administration",
     items: [
       {
+        label: "Applications",
+        href: "/admin/administration/applications",
+        Icon: IconOperators,
+        permission: "admin.recruitment.read",
+        summary: "Private applications for founding roles, oldest first. Review or remove applicant details.",
+      },
+      {
         label: "Analytics & Usage",
         href: "/admin/administration/analytics",
         Icon: IconPlan,

--- a/console/lib/admin-recruitment.test.ts
+++ b/console/lib/admin-recruitment.test.ts
@@ -1,0 +1,243 @@
+// The seam between the recruitment queue the control plane serves and the
+// operator page that reads it.
+//
+// WHY THIS FILE EXISTS. Both halves of this lane passed their own suites and
+// that proved nothing about the join between them. web/apps/api/test/
+// recruitment.test.ts exercises the real routes against a real database and
+// never loads a line of this console; the console typechecks and builds and
+// never learns whether the procedure names in the strings it sends exist. A
+// procedure path is a STRING here. Rename `remove` to `delete` on the router
+// and nothing in either suite goes red: the console still compiles, the page
+// still renders, and the button answers 404 the first time an operator presses
+// it. That is the crossing, and every assertion below reads the control plane's
+// own source rather than a copy of what it says.
+//
+// It is a test of the CONSOLE, which is why it lives here rather than beside
+// the API suite. The question it answers is "does this client agree with that
+// server", and the client is the half that is wrong when the answer is no.
+//
+// WHAT IT CANNOT DO, said out loud so nobody reads more into a pass than is
+// there. It does not render the page: `npm test` in console/ is
+// `node --test lib/*.test.ts` with no loader, no DOM and no `@/` alias, so a
+// module importing React cannot be executed at all. Whether the queue draws,
+// whether the panel opens, and whether the two buttons reach the network are
+// facts about a browser and were checked in one. What is checkable without a
+// browser is the agreement between the two sides, and that is what this is.
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { APPLICATION_ROLES, roleLabel } from "./recruitment-roles.ts";
+
+const root = fileURLToPath(new URL("../../", import.meta.url));
+
+/**
+ * A file on the control plane side, or a failure that says where to look.
+ *
+ * MISSING IS A FAILURE AND NEVER A SKIP. A comparison that stands down when it
+ * cannot find the other end reports an absent check as a pass, and this
+ * repository has already paid for that once with a published-document gate that
+ * was dark for the length of a queue without anybody being able to see it.
+ */
+function readOrFail(relative: string): string {
+  try {
+    return readFileSync(`${root}${relative}`, "utf8");
+  } catch {
+    throw new Error(
+      `${relative} is not on this tree, so this console cannot be compared against the ` +
+        `control plane. If that file moved, this reference has to move with it: the ` +
+        `assertions below read it BY PATH and a missing file makes every one of them vacuous.`,
+    );
+  }
+}
+
+const recruitmentRouter = readOrFail("web/apps/api/src/admin/recruitment.ts");
+const administrationRouter = readOrFail("web/apps/api/src/admin/administration.ts");
+const permissions = readOrFail("web/apps/api/src/admin/permissions.ts");
+const consoleClient = readOrFail("console/lib/admin-recruitment.ts");
+const consoleNav = readOrFail("console/lib/admin-nav.ts");
+
+/**
+ * The migration that declares the table, found by CONTENT rather than by name.
+ *
+ * By content on purpose. Every migration's number is its filename, and a
+ * parallel branch landing first renumbers this one: it was written as 0037 and
+ * is 0038 because PR 229 got there first. A reference keyed on the filename has
+ * a live trigger that fires on the next renumber, and it fires as a thrown
+ * error in a test nobody expected to touch. Anchoring on the CREATE TABLE means
+ * the reference survives the renumber, and a missing table still fails loudly
+ * because the search returns nothing and this refuses to return nothing.
+ */
+function migrationDeclaring(table: string): string {
+  const dir = `${root}web/packages/db/migrations`;
+  const found = readdirSync(dir)
+    .filter((name) => name.endsWith(".sql"))
+    .map((name) => readFileSync(`${dir}/${name}`, "utf8"))
+    .filter((sql) => new RegExp(`CREATE TABLE ${table}\\b`).test(sql));
+  assert.equal(
+    found.length,
+    1,
+    `expected exactly one migration to CREATE TABLE ${table} and found ${found.length}. ` +
+      `Zero means the table is not on this tree and every check below it is vacuous; ` +
+      `more than one means two migrations declare it and this cannot say which is live.`,
+  );
+  return found[0]!;
+}
+
+const applicationsSql = migrationDeclaring("recruitment_applications");
+
+/** The values a column's CHECK ... IN (...) constraint allows. */
+function checkedValues(sql: string, column: string): string[] {
+  const match = new RegExp(`${column}[^,]*CHECK \\(${column} IN \\(([^)]*)\\)\\)`).exec(sql);
+  assert.ok(
+    match,
+    `no CHECK (${column} IN (...)) on ${column} in the migration, so this test is reading the ` +
+      `wrong constraint and would pass over any vocabulary at all`,
+  );
+  const values = [...match[1]!.matchAll(/'([a-z_]+)'/g)].map((m) => m[1]!);
+  assert.ok(values.length > 0, `the CHECK on ${column} parsed to no values, which is an instrument fault`);
+  return values.sort();
+}
+
+/** Every procedure the console sends to, read out of the console's own source. */
+function procedurePathsInConsole(): string[] {
+  return [...consoleClient.matchAll(/"(admin\.[a-z.]+)"/g)].map((m) => m[1]!).sort();
+}
+
+describe("the operator applications page against the control plane", () => {
+  test("the sources were all read, so nothing below passes over the wrong file", () => {
+    // The guard the rest of this file rests on. Every later assertion searches
+    // one of these strings for a substring, and a regex over the wrong file
+    // finds nothing and reports the absence as agreement.
+    //
+    // AN ANCHOR PER FILE, NOT A BYTE COUNT, and that correction is the reason
+    // this comment is here. The first version of this guard asserted only
+    // `length > 200`, and its own mutation cell walked straight through it:
+    // pointing one of the six reads at a 221 byte page component left the guard
+    // green while the file it was meant to be checking was not being read at
+    // all. A length is a proxy for "this is a source file" and it cannot
+    // distinguish the RIGHT source file, which is the only property that makes
+    // the assertions below mean anything. Each anchor is a string that exists
+    // in exactly one of these files.
+    for (const [name, body, anchor] of [
+      ["recruitment.ts", recruitmentRouter, "export const recruitmentRouter"],
+      ["administration.ts", administrationRouter, "export const administrationRouter"],
+      ["permissions.ts", permissions, "export const ADMIN_ROLE_PERMISSIONS"],
+      ["admin-recruitment.ts", consoleClient, "export function useApplications"],
+      ["admin-nav.ts", consoleNav, "export const ADMIN_NAV"],
+      ["the applications migration", applicationsSql, "CREATE TABLE recruitment_applications"],
+    ] as const) {
+      assert.ok(
+        body.includes(anchor),
+        `${name} was read as ${body.length} bytes and does not contain ${anchor}, so this file ` +
+          `is reading something other than what it names and every assertion below it is vacuous`,
+      );
+    }
+    assert.ok(
+      procedurePathsInConsole().length > 0,
+      "no procedure path was parsed out of the console client, so the crossing below is vacuous",
+    );
+  });
+
+  test("every procedure the console calls exists on the control plane", () => {
+    // The defect this is here for: a procedure path is a string, so a rename on
+    // the router leaves the console compiling and answering 404 at runtime.
+    const mounted = /applications:\s*recruitmentRouter/.test(administrationRouter);
+    assert.ok(
+      mounted,
+      "administration.ts does not mount recruitmentRouter as `applications`, so every " +
+        "admin.administration.applications.* path the console sends is a 404",
+    );
+    for (const path of procedurePathsInConsole()) {
+      const procedure = path.replace("admin.administration.applications.", "");
+      assert.notEqual(
+        procedure,
+        path,
+        `${path} is not under admin.administration.applications, so this file is not the ` +
+          `client that was meant to be checked here`,
+      );
+      assert.ok(
+        new RegExp(`^\\s{2}${procedure}:`, "m").test(recruitmentRouter),
+        `the console calls ${path} and recruitment.ts declares no \`${procedure}\` procedure`,
+      );
+    }
+  });
+
+  test("the console calls every procedure the router declares", () => {
+    // The other direction, which catches the opposite mistake: a procedure
+    // written, tested against the database, and reachable from no screen. A
+    // route with no caller is a dead shippable gap that looks like a feature.
+    const declared = [...recruitmentRouter.matchAll(/^ {2}([a-z][A-Za-z]*):/gm)].map((m) => m[1]!);
+    assert.deepEqual(declared.sort(), ["list", "remove", "review"]);
+    const called = procedurePathsInConsole();
+    for (const procedure of declared) {
+      assert.ok(
+        called.includes(`admin.administration.applications.${procedure}`),
+        `recruitment.ts declares \`${procedure}\` and no screen in this console calls it`,
+      );
+    }
+  });
+
+  test("the console knows exactly the roles the database will accept", () => {
+    // Both directions. A value the schema allows and the console does not
+    // renders as an unrecognized role; a value the console knows and the schema
+    // refuses is a filter that can never match anything.
+    assert.deepEqual(Object.keys(APPLICATION_ROLES).sort(), checkedValues(applicationsSql, "role"));
+  });
+
+  test("an unrecognized role shows the value rather than a blank", () => {
+    // An absence displayed where there is a value is the worst direction for
+    // this to be wrong in, because nobody investigates a blank.
+    assert.equal(roleLabel("founding_engineer"), "Founding engineer");
+    assert.equal(roleLabel("founding_growth"), "Founding growth");
+    assert.match(roleLabel("founding_designer"), /founding_designer/);
+  });
+
+  test("the permissions this lane gates on are declared, and only owner holds them", () => {
+    // The navigation hides the entry and the page hides the write buttons on
+    // these two strings. A permission the server does not declare is a gate
+    // that is open, or a nav entry that is hidden from everybody.
+    for (const permission of ["admin.recruitment.read", "admin.recruitment.write"]) {
+      assert.ok(
+        new RegExp(`^\\s*'${permission}',`, "m").test(permissions),
+        `${permission} is not in ADMIN_PERMISSIONS, so the gate that names it cannot resolve`,
+      );
+    }
+    // Applicant data is not customer data and it is not incident context. Owner
+    // is `[...ADMIN_PERMISSIONS]`, so it holds these; no other role's explicit
+    // list may name them.
+    const roleLists = permissions.slice(permissions.indexOf("ADMIN_ROLE_PERMISSIONS"));
+    const named = [...roleLists.matchAll(/'admin\.recruitment\.[a-z]+'/g)];
+    assert.deepEqual(
+      named.map((m) => m[0]),
+      [],
+      "a role other than owner lists a recruitment permission explicitly. Applicant personal " +
+        "data is deliberately reachable by owner alone, through owner's [...ADMIN_PERMISSIONS].",
+    );
+  });
+
+  test("the navigation entry and the route it opens agree with the read permission", () => {
+    // Three strings that have to be the same and live in three files: the nav
+    // entry's href, the exported page's directory, and the permission the list
+    // procedure demands. A drift in any one is a rail entry that opens nothing,
+    // or an entry visible to a role the server then refuses.
+    const entry = /\{[^{}]*href: "\/admin\/administration\/applications"[^{}]*\}/s.exec(consoleNav);
+    assert.ok(entry, "admin-nav.ts has no entry for /admin/administration/applications");
+    assert.match(entry[0], /permission: "admin\.recruitment\.read"/);
+    assert.match(
+      recruitmentRouter,
+      /list: adminProcedure\('admin\.recruitment\.read'\)/,
+      "the list procedure does not demand admin.recruitment.read, so the navigation shows the " +
+        "section to a role the server will refuse",
+    );
+    for (const write of ["review", "remove"]) {
+      assert.ok(
+        new RegExp(`${write}: adminProcedure\\('admin\\.recruitment\\.write'\\)`).test(recruitmentRouter),
+        `${write} does not demand admin.recruitment.write, so the page's write gate and the ` +
+          `server's disagree about who may change an application`,
+      );
+    }
+  });
+});

--- a/console/lib/admin-recruitment.ts
+++ b/console/lib/admin-recruitment.ts
@@ -1,0 +1,105 @@
+"use client";
+
+/**
+ * The recruitment lane's client: the private queue of applications for the
+ * founding roles.
+ *
+ * A fourth lane file rather than more of admin-administration.ts, for the
+ * reason that file gives for not being more of admin.ts: the transport is
+ * shared and nothing else is. The transport IS reused, unchanged. `query` and
+ * `adminMutate` come from api.ts and admin.ts, so there is no second place for
+ * the error shape, the credentials mode or the operator CSRF header to drift.
+ *
+ * WHAT IS IN HERE IS NOT CUSTOMER DATA. Everything else this console reads
+ * belongs to an organization. An application belongs to a person who is not a
+ * customer, has no account, and gave us their name and their introduction on
+ * the understanding that an operator reads it and then it expires. It is not
+ * joined to a tenant, it is not in analytics, and the two permissions that
+ * reach it are held by `owner` alone.
+ *
+ * THE ROLE VOCABULARY IS CLOSED, AND THE CONSOLE HAS TO KNOW IT. `role` arrives
+ * as a string and the migration constrains it to exactly two values with a
+ * CHECK. That list is in lib/recruitment-roles.ts rather than here, because it
+ * is a rule and this file cannot be executed by the console's test runner:
+ * admin-recruitment.test.ts reads the migration and asserts the two agree in
+ * both directions. See the header of that module for what a rule in an
+ * unrunnable file has already cost this console.
+ */
+
+import { query, usePages } from "@/lib/api";
+import { adminMutate } from "@/lib/admin";
+
+// Re-exported so a page imports one module for this lane. The values live in
+// their own import-free file because that is the only kind this console's test
+// runner can execute; see the header there.
+export { APPLICATION_ROLES, roleLabel, type ApplicationRole } from "@/lib/recruitment-roles";
+
+export interface Application {
+  id: string;
+  name: string;
+  email: string;
+  role: string;
+  /** Empty string when the applicant gave no link, never null: the column is
+   *  NOT NULL DEFAULT ''. */
+  projectUrl: string;
+  why: string;
+  createdAt: string;
+  /** Null until an operator marks it read. That is what the queue filter
+   *  splits on, so it is nullable here for the same reason it is in the
+   *  column. */
+  reviewedAt: string | null;
+}
+
+export interface ApplicationCursor {
+  id: string;
+  createdAt: string;
+}
+
+export interface ApplicationPage {
+  rows: Application[];
+  /** Null on the last page. A cursor is (createdAt, id) rather than an offset,
+   *  so removing an application does not shift the next page underneath the
+   *  operator who is reading it. */
+  nextCursor: ApplicationCursor | null;
+}
+
+/**
+ * One queue, a page at a time, with the rows already on screen kept.
+ *
+ * `usePages` rather than `useApi`, which is the difference between "show more"
+ * adding fifty rows and blanking the fifty the operator is reading. Its cursor
+ * is a string and this route's cursor is a pair, so the pair travels as JSON
+ * through it: that hook's own comment says each caller adapts its own route,
+ * because the list routes in this portal page three different ways.
+ *
+ * A KEYSET CURSOR RATHER THAN AN OFFSET, and this page depends on that
+ * property. An operator deletes applications while reading the list, and an
+ * offset would shift every later row up underneath them, so pressing "show
+ * more" would silently skip one. `(created_at, id)` names a position in the
+ * order rather than a distance from the start, so removing the row the cursor
+ * names cannot lose the next one. recruitment.test.ts proves it against a real
+ * deletion of the cursor row.
+ */
+export function useApplications(reviewed: boolean) {
+  return usePages<Application>(
+    async (cursor) => {
+      const page = await query<ApplicationPage>("admin.administration.applications.list", {
+        reviewed,
+        ...(cursor === null ? {} : { cursor: JSON.parse(cursor) as ApplicationCursor }),
+      });
+      return {
+        rows: page.rows,
+        next: page.nextCursor === null ? null : JSON.stringify(page.nextCursor),
+      };
+    },
+    [reviewed],
+  );
+}
+
+export function reviewApplication(id: string) {
+  return adminMutate<{ reviewed: true }>("admin.administration.applications.review", { id });
+}
+
+export function removeApplication(id: string) {
+  return adminMutate<{ removed: true }>("admin.administration.applications.remove", { id });
+}

--- a/console/lib/recruitment-roles.ts
+++ b/console/lib/recruitment-roles.ts
@@ -1,0 +1,42 @@
+/**
+ * The two roles an application can be for, and what each is called on screen.
+ *
+ * ITS OWN MODULE, AND IT IMPORTS NOTHING. admin-recruitment.ts next door
+ * imports React and the `@/` path alias, so the console's test runner cannot
+ * execute it: `npm test` in console/ is `node --test lib/*.test.ts` with no
+ * loader and no alias resolution. lib/admin-csrf.ts was carved out of that same
+ * file for the same reason, and the header there says what it cost: the one
+ * piece of the operator client with a rule in it sat in the one file nothing
+ * could run, and every operator mutation was refused for as long as that was
+ * true. A closed vocabulary is a rule. It lives where it can be tested.
+ *
+ * THE LIST IS THE DATABASE'S LIST. Migration 0038 constrains
+ * `recruitment_applications.role` with a CHECK naming exactly these two values,
+ * and admin-recruitment.test.ts reads that migration and asserts the two agree
+ * in both directions. So a third role added to the schema fails this console's
+ * suite rather than rendering as nothing on the operator's screen, which is the
+ * defect loadshapes.test.ts was written after: the console's copy of
+ * `verdict_value` was missing `flaky`, and a run that had found something drew
+ * as "No verdict".
+ */
+
+export const APPLICATION_ROLES = {
+  founding_engineer: "Founding engineer",
+  founding_growth: "Founding growth",
+} as const;
+
+export type ApplicationRole = keyof typeof APPLICATION_ROLES;
+
+/**
+ * A role as a person reads it.
+ *
+ * An unrecognized value renders the raw string rather than a blank or a bare
+ * "Unknown". An operator looking at an application needs to see WHICH
+ * unexpected value arrived, because the answer decides whether the fix is in
+ * this console or in the database, and a page that swallows it turns a one line
+ * diagnosis into an investigation. An absence shown where there is a value is
+ * the worst direction for this to be wrong in: nobody investigates a blank.
+ */
+export function roleLabel(role: string): string {
+  return APPLICATION_ROLES[role as ApplicationRole] ?? `Unrecognized role: ${role}`;
+}

--- a/docs/plans/2026-09-04-careers-design.md
+++ b/docs/plans/2026-09-04-careers-design.md
@@ -1,0 +1,27 @@
+# Careers and a readable application queue
+
+The public page hires founding engineers at 0.5-2% equity and founding growth
+at 0.25-2%. Both have no salary currently. It makes no promise about when salary
+starts, vesting, location, funding, or employment classification.
+
+A dedicated application form is preferable to an email link, which cannot
+confirm delivery, or the sales form, which has a different purpose. It collects
+name, email, role, an optional work URL, a short explanation, and acknowledgment
+of the current compensation. It asks for no demographic data or attachments.
+
+The public endpoint writes a separate recruitment table. An opaque submission
+key makes a retry of the same payload safe without exposing who has applied.
+Origin restrictions, bounded input and an ephemeral rate limiter constrain
+abuse. Application content is not sent to analytics or notification logs.
+
+An operator Applications page lists the oldest unreviewed submissions first,
+can mark them reviewed, and can delete their personal data. All operations use
+the existing operator authentication, authorization and audit path. Scheduled
+maintenance removes applications older than 180 days. The form discloses this
+retention and does not promise a response or an email it cannot prove was sent.
+
+Verification covers the actual public submission, database restrictions,
+operator read and review, retry/concurrency, deletion, retention, validation,
+and failed writes. Each new assertion gets an independent production mutation.
+The rendered public form and operator page are inspected at mobile and desktop
+widths, including keyboard, empty, error, sending and confirmed states.

--- a/tools/docs/figure-exemptions.tsv
+++ b/tools/docs/figure-exemptions.tsv
@@ -35,3 +35,22 @@ www/components/home/visuals/TwinIdeStage.tsx	100%	the restore line of the shaped
 www/components/pages/figures/product-load.tsx	3 of 4	how many of the panel's own four written routes carry a baseline, so the figure can show a route with none. A count of the drawing, not of anything measured.
 www/components/pages/figures/product-load.tsx	25%	the p95 regression threshold the shaped run is configured with, which is a setting the figure applies rather than a result it reports. The page captions the run as shaped and its thresholds as the ones af load produces.
 www/components/pages/figures/product-safe-state.tsx	12%	the ratio of the six row worked example this figure draws, captioned on the page as chosen. What a real subset keeps depends on the customer's own data; the rule it demonstrates is the part that is fixed.
+
+# The careers page is the one place on this site where a percentage is not a
+# measurement at all. These are the terms of an offer: the equity ranges for the
+# two founding roles, set by the founder, which the page states before it
+# describes either role. There is nothing to source them to because they are not
+# a claim about how the product performs; they are what is on the table, and the
+# page is the source. Deleting them, which is the other answer this file offers,
+# would leave a careers page that describes the work and hides the compensation,
+# which is the exact thing it was written not to do.
+
+www/components/pages/company/Careers.tsx	0.5%	the lower bound of the founding engineer equity range. A term of the offer set by the founder, stated on the page rather than measured.
+www/components/pages/company/Careers.tsx	0.25%	the lower bound of the founding growth equity range. A term of the offer set by the founder, stated on the page rather than measured.
+www/components/pages/company/Careers.tsx	2%	the upper bound of both founding equity ranges. A term of the offer set by the founder, stated on the page rather than measured.
+www/components/pages/company/ApplicationForm.tsx	0.5%	the founding engineer equity range in the acknowledgment an applicant ticks. The same term as the page above it, repeated in full so somebody who scrolled straight to the form confirms the numbers rather than a summary.
+www/components/pages/company/ApplicationForm.tsx	0.25%	the founding growth equity range in the acknowledgment an applicant ticks. The same term as the page above it, repeated in full for the same reason.
+www/components/pages/company/ApplicationForm.tsx	2%	the upper bound of both ranges in the acknowledgment an applicant ticks. The same term as the page above it.
+www/lib/routes.ts	0.5%	the founding engineer equity range in the careers page's meta description, so a search result carries the compensation rather than making somebody open the page to find it.
+www/lib/routes.ts	0.25%	the founding growth equity range in the careers page's meta description, for the same reason.
+www/lib/routes.ts	2%	the upper bound of both ranges in the careers page's meta description.

--- a/web/apps/api/src/admin/administration.ts
+++ b/web/apps/api/src/admin/administration.ts
@@ -42,6 +42,7 @@ import { router } from '../trpc.ts'
 import { adminProcedure, type AdminContext } from './trpc.ts'
 import { capsFor, round } from '../costs.ts'
 import { CONTROL_NAMES, controlStates } from './controls.ts'
+import { recruitmentRouter } from './recruitment.ts'
 
 /**
  * How far back the operator activity summary reads, in entries.
@@ -83,6 +84,7 @@ function num(value: string | number | null | undefined): number {
 }
 
 export const administrationRouter = router({
+  applications: recruitmentRouter,
   /**
    * What the installation is doing, for the page an operator lands on.
    *

--- a/web/apps/api/src/admin/permissions.ts
+++ b/web/apps/api/src/admin/permissions.ts
@@ -26,6 +26,8 @@ export const ADMIN_PERMISSIONS = [
   // every role has it, because a role that can sign in and then sees nothing
   // is indistinguishable from a broken deployment.
   'admin.portal.access',
+  'admin.recruitment.read',
+  'admin.recruitment.write',
 
   // The operator directory: who can reach this portal, and with what role.
   'admin.operators.read',
@@ -238,6 +240,8 @@ export type AdminRole = (typeof ADMIN_ROLES)[number]
  * lists would disagree and the documentation is the one that would be wrong.
  */
 export const ADMIN_PERMISSION_DESCRIPTIONS: Record<AdminPermission, string> = {
+  'admin.recruitment.read': 'Read private applications for founding roles.',
+  'admin.recruitment.write': 'Mark applications reviewed or delete applicant personal data.',
   'admin.portal.access': 'Sign in to the operator portal and see its navigation.',
   'admin.operators.read': 'See who holds an operator account and what role they have.',
   'admin.operators.write': 'Create operators, change their role, and suspend them.',

--- a/web/apps/api/src/admin/recruitment.ts
+++ b/web/apps/api/src/admin/recruitment.ts
@@ -1,0 +1,55 @@
+import { z } from 'zod'
+import { sql } from 'drizzle-orm'
+import { TRPCError } from '@trpc/server'
+import { router } from '../trpc.ts'
+import { adminAudit, adminProcedure, type AdminContext } from './trpc.ts'
+
+export const recruitmentRouter = router({
+  list: adminProcedure('admin.recruitment.read')
+    .input(z.object({ reviewed: z.boolean().default(false), cursor: z.object({ id: z.string().uuid(), createdAt: z.string().datetime() }).optional() }).default({ reviewed: false }))
+    .query(async ({ ctx, input }) => {
+      const c = ctx as AdminContext
+      return c.adminDb(async (db) => {
+        const rows = await db.execute<{
+          id: string; name: string; email: string; role: string; project_url: string;
+          why: string; created_at: Date | string; reviewed_at: Date | string | null;
+        }>(sql`
+          SELECT id, name, email, role, project_url, why, created_at, reviewed_at
+          FROM recruitment_applications
+          WHERE (reviewed_at IS NOT NULL) = ${input.reviewed}
+            AND (${input.cursor?.id ?? null}::uuid IS NULL OR (created_at, id) >
+              (${input.cursor?.createdAt ?? null}::timestamptz, ${input.cursor?.id ?? null}::uuid))
+          ORDER BY created_at, id LIMIT 51`)
+        const visible = rows.slice(0, 50)
+        return {
+          rows: visible.map((r) => ({ id: r.id, name: r.name, email: r.email, role: r.role,
+            projectUrl: r.project_url, why: r.why, createdAt: new Date(r.created_at).toISOString(),
+            reviewedAt: r.reviewed_at === null ? null : new Date(r.reviewed_at).toISOString() })),
+          nextCursor: rows.length > 50 ? { id: visible[49]!.id, createdAt: new Date(visible[49]!.created_at).toISOString() } : null,
+        }
+      })
+    }),
+  review: adminProcedure('admin.recruitment.write').input(z.object({ id: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      const c = ctx as AdminContext
+      return c.adminDb(async (db) => {
+        const rows = await db.execute(sql`
+          UPDATE recruitment_applications SET reviewed_at = ${c.clock.now().toISOString()}::timestamptz,
+            reviewed_by = ${c.admin.adminUserId}::uuid
+          WHERE id = ${input.id}::uuid AND reviewed_at IS NULL RETURNING id`)
+        if (!rows.length) throw new TRPCError({ code: 'CONFLICT', message: 'This application was already reviewed or removed. Refresh the queue.' })
+        await adminAudit(db, c, { action: 'recruitment.reviewed', targetType: 'recruitment_application', targetId: input.id, severity: 'notice', detail: {} })
+        return { reviewed: true }
+      })
+    }),
+  remove: adminProcedure('admin.recruitment.write').input(z.object({ id: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      const c = ctx as AdminContext
+      return c.adminDb(async (db) => {
+        const rows = await db.execute(sql`DELETE FROM recruitment_applications WHERE id = ${input.id}::uuid RETURNING id`)
+        if (!rows.length) throw new TRPCError({ code: 'NOT_FOUND', message: 'This application was already removed.' })
+        await adminAudit(db, c, { action: 'recruitment.removed', targetType: 'recruitment_application', targetId: input.id, severity: 'notice', detail: {} })
+        return { removed: true }
+      })
+    }),
+})

--- a/web/apps/api/src/boundary.ts
+++ b/web/apps/api/src/boundary.ts
@@ -408,6 +408,23 @@ export const ROUTE_BOUNDARY: Record<string, RouteBoundary> = {
     grounds: 'not-an-endpoint',
     reason: 'The preflight for the route above. A browser sends it; nothing calls it.',
   },
+  'POST /v1/applications': {
+    audience: 'excluded',
+    grounds: 'console-transport',
+    reason:
+      'The careers form on the marketing site posts it. Like the lead route above it is a cross origin browser call from one configured origin, it takes no credential, and nothing integrates with it. Publishing it would invite a client to post applications at us, which is the opposite of what a review queue read by one person is for.',
+  },
+  'OPTIONS /v1/applications': {
+    audience: 'excluded',
+    grounds: 'not-an-endpoint',
+    reason: 'The preflight for the route above. A browser sends it; nothing calls it.',
+  },
+  'ALL /v1/applications': {
+    audience: 'excluded',
+    grounds: 'not-an-endpoint',
+    reason:
+      'Not a handler. It is how Hono registers the middleware in front of the route above: the origin guard, the body limit, and the header that keeps a rate refusal readable by the form that was refused. Nothing answers it on its own.',
+  },
   'GET /exports/deletion': {
     audience: 'excluded',
     grounds: 'different-credential',

--- a/web/apps/api/src/limits.ts
+++ b/web/apps/api/src/limits.ts
@@ -142,6 +142,14 @@ export const ENDPOINT_LIMITS: Record<string, EndpointLimit> = {
   // through. One a second sustained is far above a person typing a form, and
   // ten at once covers somebody who pressed the button twice and a preflight
   // beside it.
+  'POST /v1/applications': {
+    rate: 1 / 60, burst: 5, key: 'ip',
+    reason: 'An applicant submits once and may retry. Five attempts cover correction without accepting a sustained submission script.',
+  },
+  'OPTIONS /v1/applications': {
+    rate: 1, burst: 10, key: 'ip',
+    reason: 'Application form preflight requests contain no applicant data and may precede corrections.',
+  },
   'POST /v1/leads': {
     rate: 1, burst: 10, key: 'ip',
     reason: 'Filling in a contact form is a human action, once. The row is written by an anonymous caller, so the address is the only key there is, and the burst covers a double press and a retry.',

--- a/web/apps/api/src/maintenance.ts
+++ b/web/apps/api/src/maintenance.ts
@@ -165,6 +165,10 @@ export async function runMaintenance(
     const usage = await admin<{ count: string }[]>`
       SELECT roll_up_environment_usage(${now.toISOString()}::timestamptz) AS count`
 
+    // Recruitment is separate from analytics and tenant usage. Personal
+    // application details expire even if no operator has reviewed the queue.
+    await admin`DELETE FROM recruitment_applications WHERE created_at < ${new Date(now.getTime() - 180 * DAY_MS).toISOString()}::timestamptz`
+
     return {
       created: [...made.created, ...analyticsPartitions.created],
       dropped,

--- a/web/apps/api/src/recruitment/applications.ts
+++ b/web/apps/api/src/recruitment/applications.ts
@@ -1,0 +1,44 @@
+import { createHash } from 'node:crypto'
+import { z } from 'zod'
+import { sql } from 'drizzle-orm'
+import type { Pool } from '@antifailure/db'
+import type { Clock } from '../clock.ts'
+
+export const applicationInput = z.object({
+  submissionId: z.string().uuid(),
+  name: z.string().trim().min(1, 'Tell us your name.').max(200),
+  email: z.string().trim().toLowerCase().email('Enter a valid email address.').max(320),
+  // With a message, because the route answers the first issue's message
+  // straight to the applicant and zod's default here names the two internal
+  // identifiers rather than telling somebody what to do about it.
+  role: z.enum(['founding_engineer', 'founding_growth'], { error: 'Choose which role you are applying for.' }),
+  projectUrl: z.string().trim().max(2000).refine((value) => {
+    if (!value) return true
+    try {
+      const url = new URL(value)
+      return (url.protocol === 'https:' || url.protocol === 'http:') && !url.username && !url.password
+    } catch { return false }
+  }, 'Use a public http or https link without credentials.'),
+  why: z.string().trim().min(1, 'Tell us about your work and why this role.').max(4000),
+  compensationAcknowledged: z.literal(true, { error: 'Confirm that you understand the current compensation.' }),
+  website: z.literal('', { error: 'The hidden website field must be empty.' }).default(''),
+}).strict()
+
+export type ApplicationInput = z.infer<typeof applicationInput>
+
+export async function recordApplication(pool: Pool, clock: Clock, input: ApplicationInput) {
+  // Identical retries get one key. A changed payload gets a different key, so
+  // a conflict never acknowledges answers that were not actually recorded.
+  const digest = createHash('sha256').update(JSON.stringify([
+    input.submissionId, input.name, input.email, input.role, input.projectUrl, input.why,
+    input.compensationAcknowledged,
+  ])).digest('hex')
+  const id = `${digest.slice(0, 8)}-${digest.slice(8, 12)}-4${digest.slice(13, 16)}-a${digest.slice(17, 20)}-${digest.slice(20, 32)}`
+  await pool.withoutTenant((db) => db.execute(sql`
+    INSERT INTO recruitment_applications
+      (id, name, email, role, project_url, why, compensation_acknowledged, created_at)
+    VALUES (${id}::uuid, ${input.name}, ${input.email}, ${input.role}, ${input.projectUrl},
+            ${input.why}, true, ${clock.now().toISOString()}::timestamptz)
+    ON CONFLICT DO NOTHING`))
+  return { id, submissionId: input.submissionId, recorded: true as const }
+}

--- a/web/apps/api/src/recruitment/routes.ts
+++ b/web/apps/api/src/recruitment/routes.ts
@@ -1,0 +1,38 @@
+import type { Hono, Context, Env } from 'hono'
+import { bodyLimit } from 'hono/body-limit'
+import type { Pool } from '@antifailure/db'
+import type { Clock } from '../clock.ts'
+import { applicationInput, recordApplication } from './applications.ts'
+
+export function mountApplicationRoutes<E extends Env>(app: Hono<E>, options: { pool: Pool; clock: Clock; siteOrigin?: string }) {
+  function origin(c: Context<E>) {
+    c.header('cache-control', 'no-store')
+    c.header('vary', 'origin')
+    if (!options.siteOrigin || c.req.header('origin') !== options.siteOrigin) return false
+    c.header('access-control-allow-origin', options.siteOrigin)
+    return true
+  }
+  app.options('/v1/applications', (c) => {
+    if (!origin(c)) return c.body(null, 403)
+    c.header('access-control-allow-methods', 'POST, OPTIONS')
+    c.header('access-control-allow-headers', 'content-type')
+    return c.body(null, 204)
+  })
+  app.use('/v1/applications', async (c, next) => {
+    if (!origin(c)) return c.json({ error: 'Use the application form on the official website.' }, 403)
+    await next()
+  })
+  app.use('/v1/applications', bodyLimit({ maxSize: 32768, onError: (c) => c.json({ error: 'This application is too large. Shorten your answers.' }, 413) }))
+  app.post('/v1/applications', async (c) => {
+    let body: unknown
+    try { body = await c.req.json() } catch { return c.json({ error: 'Send a JSON application.' }, 400) }
+    const parsed = applicationInput.safeParse(body)
+    if (!parsed.success) return c.json({ error: parsed.error.issues[0]?.message ?? 'Check your application fields.' }, 400)
+    try {
+      return c.json(await recordApplication(options.pool, options.clock, parsed.data), 201)
+    } catch {
+      // Never log an applicant's payload or a database error containing it.
+      return c.json({ error: 'We could not record your application. Please try again.' }, 503)
+    }
+  })
+}

--- a/web/apps/api/src/server.ts
+++ b/web/apps/api/src/server.ts
@@ -157,6 +157,7 @@ import { createAnalytics, type Analytics } from './analytics/record.ts'
 import { beaconCors, siteBeacon } from './analytics/beacon.ts'
 import { decideSignIn, extensionRoutes } from './extensions.ts'
 import { validateLead, recordLead, leadMessage, type LeadNotifier } from './enterprise/leads.ts'
+import { mountApplicationRoutes } from './recruitment/routes.ts'
 import {
   limitFor, bucketFor, servedRoute, ENDPOINT_LIMITS, type EndpointLimit,
 } from './limits.ts'
@@ -526,6 +527,15 @@ export function createServer(options: ServerOptions) {
   // the one that has never been load tested, and answering 500 to it is a bug
   // report while leaving it open is an outage.
   // -------------------------------------------------------------------------
+  // A rate refusal must remain readable by the careers form's allowed origin.
+  app.use('/v1/applications', async (c, next) => {
+    c.header('cache-control', 'no-store')
+    c.header('vary', 'origin')
+    if (options.siteOrigin && c.req.header('origin') === options.siteOrigin) {
+      c.header('access-control-allow-origin', options.siteOrigin)
+    }
+    await next()
+  })
   const buckets = new Map<string, RateLimiter>()
   function limiterFor(limit: EndpointLimit): RateLimiter {
     const signature = `${limit.key}:${limit.rate}:${limit.burst}`
@@ -1684,6 +1694,8 @@ export function createServer(options: ServerOptions) {
     c.header('vary', 'origin')
     return true
   }
+
+  mountApplicationRoutes(app, { pool: options.pool, clock, ...(options.siteOrigin ? { siteOrigin: options.siteOrigin } : {}) })
 
   app.options('/v1/leads', (c) => {
     if (!allowLeadOrigin(c)) return c.body(null, 403)

--- a/web/apps/api/test/recruitment.test.ts
+++ b/web/apps/api/test/recruitment.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, before, after, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { randomUUID } from 'node:crypto'
+import { sql } from 'drizzle-orm'
+import { startApi, type ApiHarness } from './harness.ts'
+import { adminSignIn, hashPassword, adminCsrfTokenFor } from '../src/admin/session.ts'
+import { runMaintenance } from '../src/maintenance.ts'
+import { adminUrl } from './harness.ts'
+
+const SITE = 'https://careers.test'
+const valid = () => ({ submissionId: randomUUID(), name: 'Ada', email: 'ada@example.test', role: 'founding_engineer', projectUrl: '', why: 'Built a compiler.', compensationAcknowledged: true, website: '' })
+
+/** What the route answers an applicant with, read as the form itself reads it. */
+const recorded = async (response: Response) =>
+  await response.json() as { id: string; submissionId: string; recorded: boolean }
+
+/** One page of the operator queue, in the envelope tRPC puts it in. */
+const listed = async (response: Response) =>
+  await response.json() as {
+    result?: { data?: { rows?: { name: string; why: string }[]; nextCursor?: { id: string; createdAt: string } | null } }
+  }
+
+describe('a careers application reaches a real private queue', () => {
+  let h: ApiHarness
+  let headers: Record<string, string>
+  let caller = 0
+  const post = (value: unknown, origin = SITE) => h.fetch('/v1/applications', {
+    method: 'POST', headers: { origin, 'content-type': 'application/json', 'x-forwarded-for': `192.0.2.${++caller}` }, body: JSON.stringify(value),
+  })
+  const mutation = (action: string, id: string) => h.fetch(`/trpc/admin.administration.applications.${action}`, {
+    method: 'POST', headers, body: JSON.stringify({ id }),
+  })
+  before(async () => {
+    h = await startApi({ siteOrigin: SITE })
+    h.clock.now = () => new Date()
+    const password = 'careers-local-test-only'
+    const { hash, salt } = await hashPassword(password)
+    await h.admin`INSERT INTO admin_users (email, name, role, password_hash, password_salt, password_set_at)
+      VALUES ('careers-owner@example.test', 'Careers owner', 'owner', ${hash}, ${salt}, now())
+      ON CONFLICT (email) DO UPDATE SET password_hash = ${hash}, password_salt = ${salt}`
+    const signed = await adminSignIn(h.pool, { email: 'careers-owner@example.test', password }, new Date())
+    headers = { cookie: `af_admin_session=${signed.token}`, 'x-antifailure-admin-csrf': adminCsrfTokenFor(signed.token), 'content-type': 'application/json' }
+  })
+  beforeEach(async () => { await h.admin`DELETE FROM recruitment_applications` })
+  after(async () => { await h?.close() })
+
+  it('confirms the durable submission with a real reference', async () => {
+    const response = await post(valid())
+    assert.equal(response.status, 201, await response.text())
+  })
+  it('stores exactly the applicant answers', async () => {
+    await post(valid())
+    const rows = await h.admin`SELECT name, email, role, project_url, why, compensation_acknowledged FROM recruitment_applications`
+    assert.deepEqual(Array.from(rows), [{ name: 'Ada', email: 'ada@example.test', role: 'founding_engineer', project_url: '', why: 'Built a compiler.', compensation_acknowledged: true }])
+  })
+  it('concurrent identical retries create one application', async () => {
+    const input = valid()
+    const responses = await Promise.all([post(input), post(input)])
+    assert.deepEqual({ statuses: responses.map((r) => r.status), rows: (await h.admin`SELECT count(*)::int AS n FROM recruitment_applications`)[0]!.n }, { statuses: [201, 201], rows: 1 })
+  })
+  it('an altered payload never acknowledges an old answer', async () => {
+    const input = valid()
+    await post(input)
+    await post({ ...input, why: 'Built a database.' })
+    assert.deepEqual((await h.admin`SELECT why FROM recruitment_applications ORDER BY why`).map((r) => r.why), ['Built a compiler.', 'Built a database.'])
+  })
+  it('the serving database credential cannot read applications', async () => {
+    await post(valid())
+    await assert.rejects(h.pool.withoutTenant((db) => db.execute(sql`SELECT * FROM recruitment_applications`)), (error: unknown) => (error as { cause?: { code?: string } }).cause?.code === '42501')
+  })
+  it('a recorded application is readable through the actual operator route', async () => {
+    await post(valid())
+    const response = await h.fetch('/trpc/admin.administration.applications.list', { headers })
+    const body = await listed(response)
+    assert.equal(body.result?.data?.rows?.[0]?.why, 'Built a compiler.', JSON.stringify(body))
+  })
+  it('anonymous requests cannot read the queue', async () => {
+    assert.equal((await h.fetch('/trpc/admin.administration.applications.list')).status, 401)
+  })
+  it('review changes the stored state', async () => {
+    const saved = await recorded(await post(valid()))
+    const response = await mutation('review', saved.id)
+    const rows = await h.admin`SELECT reviewed_at IS NOT NULL AS reviewed FROM recruitment_applications`
+    assert.equal(rows[0]?.reviewed, true, await response.text())
+  })
+  it('review racing review records one audit action', async () => {
+    const saved = await recorded(await post(valid()))
+    await Promise.all([mutation('review', saved.id), mutation('review', saved.id)])
+    assert.equal((await h.admin`SELECT count(*)::int AS n FROM admin_audit_entries WHERE action = 'recruitment.reviewed' AND target_id = ${saved.id}`)[0]!.n, 1)
+  })
+  it('delete removes the actual personal data', async () => {
+    const saved = await recorded(await post(valid()))
+    if (!saved.recorded) throw new Error('Fixture application was not recorded')
+    const response = await mutation('remove', saved.id)
+    assert.equal((await h.admin`SELECT count(*)::int AS n FROM recruitment_applications`)[0]!.n, 0, await response.text())
+  })
+  it('the scheduled maintenance path expires an old application', async () => {
+    const saved = await recorded(await post(valid()))
+    if (!saved.recorded) throw new Error('Fixture application was not recorded')
+    await h.admin`UPDATE recruitment_applications SET created_at = now() - interval '181 days'`
+    await runMaintenance({ adminUrl }, h.clock)
+    assert.equal((await h.admin`SELECT count(*)::int AS n FROM recruitment_applications`)[0]!.n, 0)
+  })
+  it('maintenance retains an application inside the window', async () => {
+    await post(valid())
+    await runMaintenance({ adminUrl }, h.clock)
+    assert.equal((await h.admin`SELECT count(*)::int AS n FROM recruitment_applications`)[0]!.n, 1)
+  })
+  it('refuses a different website origin', async () => { assert.equal((await post(valid(), 'https://evil.test')).status, 403) })
+  it('refuses missing compensation acknowledgement', async () => { assert.equal((await post({ ...valid(), compensationAcknowledged: false })).status, 400) })
+  it('refuses a hidden spam field', async () => { assert.equal((await post({ ...valid(), website: 'spam' })).status, 400) })
+  it('refuses an executable work URL', async () => { assert.equal((await post({ ...valid(), projectUrl: 'javascript:alert(1)' })).status, 400) })
+  it('refuses unknown payload fields', async () => { assert.equal((await post({ ...valid(), secret: 'not accepted' })).status, 400) })
+  it('refuses a payload above the body limit', async () => { assert.equal((await post({ ...valid(), why: 'x'.repeat(40000) })).status, 413) })
+  it('rate refusals remain readable from the allowed site', async () => {
+    const headers = { origin: SITE, 'content-type': 'application/json', 'x-forwarded-for': '198.51.100.199' }
+    let response: Response | undefined
+    for (let i = 0; i < 6; i++) response = await h.fetch('/v1/applications', { method: 'POST', headers, body: JSON.stringify(valid()) })
+    assert.deepEqual({ status: response!.status, origin: response!.headers.get('access-control-allow-origin') }, { status: 429, origin: SITE })
+  })
+  it('a refused database write cannot report recorded', async () => {
+    await h.admin`REVOKE INSERT ON recruitment_applications FROM antifailure_app`
+    try { assert.equal((await post(valid())).status, 503) }
+    finally { await h.admin`GRANT INSERT ON recruitment_applications TO antifailure_app` }
+  })
+  it('a removed application cannot be marked reviewed', async () => {
+    const saved = await recorded(await post(valid()))
+    if (!saved.recorded) throw new Error('Fixture application was not recorded')
+    await mutation('remove', saved.id)
+    assert.equal((await mutation('review', saved.id)).status, 409)
+  })
+  it('an operator without recruitment permission cannot read applicant details', async () => {
+    await h.admin`UPDATE admin_users SET role = 'support' WHERE email = 'careers-owner@example.test'`
+    try { assert.equal((await h.fetch('/trpc/admin.administration.applications.list', { headers })).status, 403) }
+    finally { await h.admin`UPDATE admin_users SET role = 'owner' WHERE email = 'careers-owner@example.test'` }
+  })
+  it('a review without the operator CSRF token is refused', async () => {
+    const saved = await recorded(await post(valid()))
+    const response = await h.fetch('/trpc/admin.administration.applications.review', { method: 'POST', headers: { cookie: headers.cookie!, 'content-type': 'application/json' }, body: JSON.stringify({ id: saved.id }) })
+    assert.equal(response.status, 403)
+  })
+  it('pagination survives removal of the cursor application', async () => {
+    for (let i = 0; i < 51; i++) await h.admin`INSERT INTO recruitment_applications
+      (id, name, email, role, why, compensation_acknowledged, created_at)
+      VALUES (${randomUUID()}, ${`Applicant ${i}`}, 'paging@example.test', 'founding_engineer', 'Paging fixture', true,
+              ${new Date(Date.UTC(2026, 0, 1, 0, i)).toISOString()})`
+    const first = await listed(await h.fetch('/trpc/admin.administration.applications.list', { headers }))
+    const cursor = first.result?.data?.nextCursor
+    if (!cursor) throw new Error('The first page did not produce a cursor')
+    await h.admin`DELETE FROM recruitment_applications WHERE id = ${cursor.id}`
+    const next = await listed(await h.fetch(`/trpc/admin.administration.applications.list?input=${encodeURIComponent(JSON.stringify({ cursor }))}`, { headers }))
+    assert.deepEqual(next.result?.data?.rows?.map((r) => r.name), ['Applicant 50'])
+  })
+})

--- a/web/packages/db/migrations/0039_career_applications.sql
+++ b/web/packages/db/migrations/0039_career_applications.sql
@@ -1,0 +1,23 @@
+BEGIN;
+
+CREATE TABLE recruitment_applications (
+  id uuid PRIMARY KEY,
+  name text NOT NULL CHECK (length(name) BETWEEN 1 AND 200),
+  email text NOT NULL CHECK (length(email) BETWEEN 3 AND 320),
+  role text NOT NULL CHECK (role IN ('founding_engineer', 'founding_growth')),
+  project_url text NOT NULL DEFAULT '' CHECK (length(project_url) <= 2000),
+  why text NOT NULL CHECK (length(why) BETWEEN 1 AND 4000),
+  compensation_acknowledged boolean NOT NULL CHECK (compensation_acknowledged),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  reviewed_at timestamptz,
+  reviewed_by uuid REFERENCES admin_users(id) ON DELETE SET NULL
+);
+CREATE INDEX recruitment_applications_queue ON recruitment_applications(created_at, id);
+ALTER TABLE recruitment_applications ENABLE ROW LEVEL SECURITY;
+ALTER TABLE recruitment_applications FORCE ROW LEVEL SECURITY;
+CREATE POLICY recruitment_insert ON recruitment_applications
+  FOR INSERT TO antifailure_app WITH CHECK (true);
+GRANT INSERT ON recruitment_applications TO antifailure_app;
+GRANT SELECT, UPDATE, DELETE ON recruitment_applications TO antifailure_admin;
+
+COMMIT;

--- a/web/packages/db/src/schema.ts
+++ b/web/packages/db/src/schema.ts
@@ -1555,6 +1555,19 @@ export const tenantScopedTables = [
  * SELECT on this table at all.
  * ------------------------------------------------------------------------ */
 
+export const recruitmentApplications = pgTable('recruitment_applications', {
+  id: uuid('id').primaryKey(),
+  name: text('name').notNull(),
+  email: text('email').notNull(),
+  role: text('role').notNull(),
+  projectUrl: text('project_url').notNull().default(''),
+  why: text('why').notNull(),
+  compensationAcknowledged: boolean('compensation_acknowledged').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  reviewedAt: timestamp('reviewed_at', { withTimezone: true }),
+  reviewedBy: uuid('reviewed_by'),
+})
+
 export const enterpriseLeads = pgTable('enterprise_leads', {
   id: uuid('id').primaryKey().defaultRandom(),
   email: text('email').notNull(),

--- a/web/packages/db/test/tenancy.test.ts
+++ b/web/packages/db/test/tenancy.test.ts
@@ -131,6 +131,17 @@ describe('cross-tenant isolation', { skip: hasDatabase ? false : 'no Postgres at
           'migration role, through af-control-plane-backup leads. See migrations/0035.',
       ],
       [
+        'recruitment_applications',
+        'somebody applying for a job, who is not a customer, has no organization and is not ' +
+          'going to get one from applying. It is the same shape as enterprise_leads and for ' +
+          'the same reason: what confines the application role is a GRANT rather than a ' +
+          'policy, INSERT and no SELECT, so the anonymous careers form can write a row and no ' +
+          'query on a public path can read an applicant\'s name, address or answers back even ' +
+          'holding the id. Reading, reviewing and deleting are antifailure_admin through the ' +
+          'operator portal alone. recruitment.test.ts asserts the 42501 on the read. See ' +
+          'migrations/0039.',
+      ],
+      [
         'admin_notes',
         'an operator\'s words about a customer rather than the customer\'s data; ' +
           'the application role holds no grant on it at all, which the test below proves',

--- a/www/app/careers/page.tsx
+++ b/www/app/careers/page.tsx
@@ -1,0 +1,8 @@
+import { CareersPage } from "@/components/pages/company/Careers";
+import { pageMetadata } from "@/lib/seo";
+
+export const metadata = pageMetadata("/careers");
+
+export default function Page() {
+  return <CareersPage />;
+}

--- a/www/components/pages/company/ApplicationForm.tsx
+++ b/www/components/pages/company/ApplicationForm.tsx
@@ -1,0 +1,399 @@
+"use client";
+
+import { useEffect, useId, useRef, useState } from "react";
+import { CONTROL_PLANE_URL } from "@/lib/site";
+
+/**
+ * The application form, and the four things it refuses to get wrong.
+ *
+ * IT NEVER SAYS "SENT" UNLESS A ROW EXISTS. The control plane answers 201 with
+ * the id it wrote and the submission key it was given. Both are checked here
+ * before the confirmation replaces the form, so a 200 from a proxy, a truncated
+ * body, or a response belonging to an earlier attempt all land in the failure
+ * branch with the answers still on screen. The failure that shape prevents is
+ * the one the enterprise form was built to end: a cheerful confirmation over a
+ * write that did not happen. A candidate who is told their application is in a
+ * queue does not apply again.
+ *
+ * A RETRY OF THE SAME ANSWERS IS NOT A SECOND APPLICATION. The submission key
+ * is generated once per distinct payload and reused for every retry of it, and
+ * the server derives the row's primary key from the key and the answers
+ * together. So pressing the button again after a timeout cannot create a
+ * duplicate, and EDITING an answer and pressing again cannot be silently
+ * swallowed as a duplicate of the old one: a changed payload is a new key, a
+ * new row, and a real acknowledgment of what was actually recorded.
+ *
+ * THE ANSWERS SURVIVE EVERY FAILURE. Nothing is reset on a refusal and nothing
+ * is cleared on a network error. Every text field is uncontrolled, the chosen
+ * role is held in state that no failure branch touches, and the fieldset is
+ * disabled only while a request is in flight, so a failed submission leaves a
+ * filled-in form and a button that says to try again. Making somebody retype an
+ * introduction is how a retry becomes an abandonment.
+ *
+ * THE TWO ROLE IDS ARE FIXED, not `useId` values, because /careers links at
+ * them: the role cards above point at `#apply-founding_engineer` and
+ * `#apply-founding_growth`. The fragment gives the browser a real focusable
+ * target, and the effect below reads the same fragment and selects that role,
+ * so following the link chooses what the link said it would. Every other field
+ * here takes a generated id, which is what the rest of the site's forms do.
+ */
+
+const ROLES = [
+  { value: "founding_engineer", label: "Founding engineer" },
+  { value: "founding_growth", label: "Founding growth" },
+] as const;
+
+type Role = (typeof ROLES)[number]["value"];
+
+/** The fragment a role card links at, for the one role it names. */
+const ANCHOR: Record<string, Role> = {
+  "apply-founding_engineer": "founding_engineer",
+  "apply-founding_growth": "founding_growth",
+};
+
+type State =
+  | { kind: "idle" }
+  | { kind: "sending" }
+  | { kind: "failed"; message: string }
+  | { kind: "sent"; reference: string };
+
+const FIELD =
+  "mt-1.5 h-11 w-full rounded-[8px] border border-black/15 bg-white px-3 text-[15px] text-black outline-none placeholder:text-black/40 focus-visible:border-black/45 focus-visible:ring-2 focus-visible:ring-black/10 disabled:opacity-60";
+const LABEL = "block text-[13px] tracking-extra-tight text-gray-new-40";
+
+export function ApplicationForm() {
+  const [state, setState] = useState<State>({ kind: "idle" });
+  const [role, setRole] = useState<Role | "">("");
+  const id = useId();
+
+  const sending = state.kind === "sending";
+
+  // The role a card above linked at. Read on mount and again on every
+  // fragment change, because a reader who is already on this page and presses
+  // the other role's card gets a hashchange and no remount.
+  useEffect(() => {
+    const fromFragment = () => {
+      const chosen = ANCHOR[window.location.hash.replace(/^#/, "")];
+      if (chosen) setRole(chosen);
+    };
+    fromFragment();
+    window.addEventListener("hashchange", fromFragment);
+    return () => window.removeEventListener("hashchange", fromFragment);
+  }, []);
+
+  // One key per distinct set of answers. A ref rather than state, because it
+  // must not depend on a rerender having happened: two submissions in one tick
+  // would otherwise both read the initial value and mint two keys for one set
+  // of answers, which is the duplicate this exists to prevent.
+  const attempt = useRef<{ payload: string; key: string } | null>(null);
+  const inFlight = useRef(false);
+
+  async function submit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    // The ref rather than `sending`, for the same reason: the state behind
+    // `sending` is one render behind a submission that has just started.
+    if (inFlight.current) return;
+    const data = new FormData(event.currentTarget);
+    const values = {
+      name: String(data.get("name") ?? ""),
+      email: String(data.get("email") ?? ""),
+      role: String(data.get("role") ?? ""),
+      projectUrl: String(data.get("projectUrl") ?? ""),
+      why: String(data.get("why") ?? ""),
+      compensationAcknowledged: data.get("compensation") === "on",
+      website: String(data.get("website") ?? ""),
+    };
+    const payload = JSON.stringify(values);
+    if (attempt.current?.payload !== payload) {
+      attempt.current = { payload, key: crypto.randomUUID() };
+    }
+    const key = attempt.current.key;
+    inFlight.current = true;
+    setState({ kind: "sending" });
+    try {
+      await send(values, key);
+    } finally {
+      // In `finally` and nowhere else. Clearing it after the fetch resolves but
+      // before the body is read leaves a window in which a second press starts
+      // a second request while this one is still deciding what happened.
+      inFlight.current = false;
+    }
+  }
+
+  async function send(values: Record<string, unknown>, key: string) {
+    let response: Response;
+    try {
+      response = await fetch(`${CONTROL_PLANE_URL}/v1/applications`, {
+        method: "POST",
+        // No cookie leaves this browser for the control plane. The endpoint is
+        // anonymous, and sending credentials to it would be the only reason it
+        // needed a credentialed CORS policy.
+        credentials: "omit",
+        headers: { "content-type": "application/json" },
+        signal: AbortSignal.timeout(20000),
+        body: JSON.stringify({ ...values, submissionId: key }),
+      });
+    } catch {
+      setState({
+        kind: "failed",
+        message:
+          "Could not reach the server. Nothing you typed is lost, and pressing it again with the same answers cannot create a duplicate.",
+      });
+      return;
+    }
+
+    if (response.status === 429) {
+      setState({
+        kind: "failed",
+        message: "That was a lot of attempts at once. Wait a minute and press it again.",
+      });
+      return;
+    }
+
+    if (!response.ok) {
+      // The server's own sentence when it gave one: its refusals name the
+      // field to fix, and a generic message here would hide that.
+      let message = "Something went wrong on our side. Press it again in a moment.";
+      try {
+        const body = (await response.json()) as { error?: unknown };
+        if (typeof body.error === "string" && body.error) message = body.error;
+      } catch {
+        // Keep the default. A body that is not JSON says nothing the status
+        // has not already said.
+      }
+      setState({ kind: "failed", message });
+      return;
+    }
+
+    // The confirmation is earned here and nowhere else.
+    let recorded: { id?: unknown; submissionId?: unknown; recorded?: unknown } = {};
+    try {
+      recorded = (await response.json()) as typeof recorded;
+    } catch {
+      // Falls through to the check below, which refuses an unreadable body.
+    }
+    if (
+      recorded.recorded !== true ||
+      recorded.submissionId !== key ||
+      typeof recorded.id !== "string" ||
+      !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(recorded.id)
+    ) {
+      setState({
+        kind: "failed",
+        message:
+          "We could not confirm your application was recorded, so we will not tell you it was. Nothing you typed is lost. Press it again; the same answers cannot create a duplicate.",
+      });
+      return;
+    }
+    setState({ kind: "sent", reference: recorded.id });
+  }
+
+  if (state.kind === "sent") {
+    return (
+      <div role="status" className="rounded-[8px] bg-white p-7 ring-1 ring-black/10 max-md:p-6">
+        <h2 className="text-[22px] leading-snug tracking-tighter text-black">
+          It is written down.
+        </h2>
+        <p className="mt-4 text-[15px] leading-6 tracking-extra-tight text-gray-new-40">
+          Your application is in the private queue a person reads, oldest first.
+          This confirms that the row exists. It is not an offer, and it is not a
+          promise of a reply on a known day: nothing here mails you on a
+          schedule, so no automatic message has been sent.
+        </p>
+        <p className="mt-4 text-[15px] leading-6 tracking-extra-tight text-gray-new-40">
+          Keep this reference if you need to ask us to remove it.
+        </p>
+        <p className="mt-2 font-mono text-[13px] leading-6 break-all text-black">
+          {state.reference}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    // NO `noValidate`, and that is the one place this form deliberately parts
+    // from the enterprise form next door. Two of its controls are a radio group
+    // and a required acknowledgment checkbox, and the browser's own refusal
+    // names and focuses the exact control that is missing. Turning that off to
+    // own the wording would mean a round trip to learn "choose a role", and the
+    // server's answer would arrive as a sentence at the bottom of the form
+    // rather than at the control. Everything the browser cannot check, which is
+    // the work link's scheme, the hidden field, the rate limit and a refused
+    // write, still renders in the alert below.
+    <form onSubmit={submit} className="rounded-[8px] bg-white p-7 ring-1 ring-black/10 max-md:p-6">
+      <fieldset disabled={sending} className="min-w-0">
+        <legend className={LABEL}>Which role</legend>
+        <div className="mt-1.5 grid gap-1">
+          {ROLES.map((option) => (
+            <label
+              key={option.value}
+              // scroll-mt because this is a fragment target: the site's sticky
+              // header is 64px, and `scroll-padding-top` in globals.css covers
+              // the document scroll, but the label is what a reader should see
+              // whole when the browser lands on the radio inside it.
+              className="flex min-h-11 scroll-mt-24 cursor-pointer items-center gap-3 text-[15px] tracking-extra-tight text-black"
+              htmlFor={`apply-${option.value}`}
+            >
+              <input
+                id={`apply-${option.value}`}
+                type="radio"
+                name="role"
+                value={option.value}
+                checked={role === option.value}
+                onChange={() => setRole(option.value)}
+                required
+                className="size-4 accent-black"
+              />
+              {option.label}
+            </label>
+          ))}
+        </div>
+
+        <div className="mt-5 grid grid-cols-2 gap-x-5 gap-y-5 max-sm:grid-cols-1">
+          <div>
+            <label className={LABEL} htmlFor={`${id}-name`}>
+              Your name
+            </label>
+            <input
+              id={`${id}-name`}
+              name="name"
+              autoComplete="name"
+              required
+              maxLength={200}
+              className={FIELD}
+            />
+          </div>
+          <div>
+            <label className={LABEL} htmlFor={`${id}-email`}>
+              Email
+            </label>
+            <input
+              id={`${id}-email`}
+              name="email"
+              type="email"
+              autoComplete="email"
+              required
+              maxLength={320}
+              className={FIELD}
+            />
+          </div>
+        </div>
+
+        <div className="mt-5">
+          <label className={LABEL} htmlFor={`${id}-project`}>
+            {/* Full `gray-new-40`, not the /70 the sibling enterprise form uses
+                for its own hint. Tailwind v4 emits that opacity as a
+                `color-mix`, which resolves to #909297 on white and measures
+                3.11:1: an axe run on this page named it, and it is a WCAG AA
+                failure on the one word that tells somebody a field is
+                skippable. Measured 5.36:1 as written. */}
+            Link to your work <span className="text-gray-new-40">(optional)</span>
+          </label>
+          <input
+            id={`${id}-project`}
+            name="projectUrl"
+            type="url"
+            maxLength={2000}
+            placeholder="https://"
+            className={FIELD}
+          />
+        </div>
+
+        <div className="mt-5">
+          <label className={LABEL} htmlFor={`${id}-why`}>
+            What have you built or grown, and why this role
+          </label>
+          <textarea
+            id={`${id}-why`}
+            name="why"
+            rows={6}
+            required
+            maxLength={4000}
+            placeholder="What you made, what broke, what you did about it. A paragraph is fine."
+            className={`${FIELD} h-auto py-2.5 leading-6`}
+          />
+        </div>
+
+        {/* Empty for a person and filled by most scripted posts. `hidden`
+            rather than off-screen positioning, so a screen reader is never
+            handed a field it must be told to leave alone. */}
+        <div hidden aria-hidden="true">
+          <label htmlFor={`${id}-website`}>Leave this empty</label>
+          <input id={`${id}-website`} name="website" tabIndex={-1} autoComplete="off" />
+        </div>
+
+        <label
+          className="mt-5 flex items-start gap-3 text-[13px] leading-6 tracking-extra-tight text-gray-new-40"
+          htmlFor={`${id}-compensation`}
+        >
+          <input
+            id={`${id}-compensation`}
+            name="compensation"
+            type="checkbox"
+            required
+            className="mt-1 size-4 shrink-0 accent-black"
+          />
+          {/* The numbers, not a summary of them. Somebody who scrolled straight
+              to the form has not read the terms band above it. */}
+          <span>
+            I understand there is no salary for either role currently. Founding
+            engineer equity is 0.5% to 2%; founding growth equity is 0.25% to
+            2%. The specific terms are not yet agreed.
+          </span>
+        </label>
+      </fieldset>
+
+      {state.kind === "failed" ? (
+        <p
+          role="alert"
+          className="mt-5 rounded-[8px] bg-[#fdf2f0] px-4 py-3 text-[14px] leading-6 tracking-extra-tight text-[#b32d18]"
+        >
+          {state.message}
+        </p>
+      ) : null}
+
+      <div className="mt-6 flex flex-wrap items-center gap-x-5 gap-y-3">
+        <button
+          type="submit"
+          disabled={sending}
+          className="inline-flex min-h-11 items-center rounded-full bg-black px-6 text-[15px] font-medium text-white transition-colors hover:bg-[#292929] disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {/* The label says what is happening. There is no spinner: a disabled
+              control with a changed label carries the same state without
+              animating. */}
+          {sending
+            ? "Recording it"
+            : state.kind === "failed"
+              ? "Try it again"
+              : "Send application"}
+        </button>
+        <p className="text-[13px] leading-5 tracking-extra-tight text-gray-new-40">
+          Read by a person, never sold or added to a newsletter. Removed after
+          180 days under our{" "}
+          <a
+            href="/data-retention"
+            className="text-black underline decoration-black/20 underline-offset-4"
+          >
+            retention policy
+          </a>{" "}
+          and described in our{" "}
+          <a
+            href="/privacy"
+            className="text-black underline decoration-black/20 underline-offset-4"
+          >
+            privacy policy
+          </a>
+          .
+        </p>
+      </div>
+
+      <noscript>
+        <p className="mt-4 text-[14px] leading-6 tracking-extra-tight text-[#b32d18]">
+          This form needs JavaScript to send an application. With it turned off,
+          nothing here can reach us, so please use a browser that allows it
+          rather than pressing the button.
+        </p>
+      </noscript>
+    </form>
+  );
+}

--- a/www/components/pages/company/Careers.tsx
+++ b/www/components/pages/company/Careers.tsx
@@ -1,0 +1,209 @@
+import { Button } from "@/components/layout/Button";
+import {
+  Callout,
+  PageHeading,
+  PageHero,
+  PageSection,
+  PageShell,
+  Prose,
+  RelatedGrid,
+} from "@/components/pages/kit";
+import { REPO_URL } from "@/lib/site";
+import { ApplicationForm } from "./ApplicationForm";
+
+/**
+ * The hiring page, and the reason the compensation is above the roles.
+ *
+ * A careers page that describes the work first and the terms last wastes the
+ * time of everybody it does not suit, and this one has terms that decide it for
+ * most readers: there is no salary for either role currently. Somebody who
+ * needs a salary should be able to learn that in the first screen and close the
+ * tab, without reading two role descriptions to find out. So the terms band
+ * sits directly under the hero, before either role, and the acknowledgment on
+ * the form repeats the same two numbers rather than a summary of them.
+ *
+ * WHAT THIS PAGE MAY NOT SAY. The equity ranges and the absence of salary are
+ * the whole of the offer that exists. There is deliberately no date when salary
+ * begins, no vesting schedule, no funding claim, no location, no benefit list
+ * and no traction number anywhere on it, because none of those has been
+ * decided, and a careers page is the worst place to imply one that has not: a
+ * candidate reads an implication as an offer and arrives believing it.
+ *
+ * THE TWO ROLE ANCHORS ARE REAL CONTROLS. "Apply for a founding engineer role"
+ * points at `#apply-founding_engineer`, which is the id of that role's radio
+ * inside the form below. The fragment scrolls the form into view AND moves
+ * focus onto the control the link named, and ApplicationForm reads the same
+ * fragment to select it, so following the link leaves the reader with the role
+ * chosen rather than at a form that has forgotten which link they clicked.
+ * That is why those two ids are fixed strings rather than `useId` values: they
+ * are addressed from another component, which a generated id cannot be.
+ */
+
+const ROLES = [
+  {
+    id: "founding_engineer",
+    title: "Founding engineer",
+    equity: "0.5% to 2% equity",
+    work: "Build the path from a developer's repository to a working production rehearsal. Own the engine, the control plane, or the developer experience, and follow your own work all the way to a result somebody can inspect.",
+    proof: "Show us something you built, a hard failure you diagnosed, or a system you made dependable. A public repository is welcome and not required.",
+  },
+  {
+    id: "founding_growth",
+    title: "Founding growth",
+    equity: "0.25% to 2% equity",
+    work: "Help developers find Antifailure, understand what it does, and reach their first useful result. Own the experiments in positioning, distribution and activation, with real conversations behind the numbers.",
+    proof: "Show us something you helped people discover or adopt. Say what you tried, what changed, and what you learned when it did not work.",
+  },
+] as const;
+
+export function CareersPage() {
+  return (
+    <PageShell>
+      <PageHero
+        path="/careers"
+        eyebrow="Careers"
+        title="Build the proof before the deploy."
+        lead="Two founding roles, one on the product and one on how developers find it. The compensation is on this page rather than behind a conversation, because it decides this for most people and they should not have to ask."
+        actions={
+          <>
+            <Button href="#apply" theme="filled">
+              Apply to join
+            </Button>
+            <Button href={REPO_URL} theme="outlined">
+              Read the source first
+            </Button>
+          </>
+        }
+      />
+
+      {/* Above both roles, deliberately. See the note at the top of this file. */}
+      <PageSection>
+        <PageHeading
+          kicker="The terms"
+          title="<strong>There is no salary for either role currently.</strong> Both equity ranges are written down here."
+        />
+        <div className="mt-14 grid grid-cols-[minmax(0,720px)_minmax(260px,420px)] gap-x-20 gap-y-10 max-lg:mt-10 max-lg:grid-cols-1">
+          <Prose>
+            <p>
+              These are the ranges, not a finalized offer, and the specific
+              number inside a range would be agreed with you. What is fixed is
+              the part above: no salary is paid for either role today.
+            </p>
+            <p>
+              Nothing on this page says when that changes, because nothing has
+              decided it. There is no vesting schedule here, no funding
+              announcement, no location requirement and no benefits list, and
+              their absence is the honest state rather than an omission. If you
+              need any of those to be true, this is the wrong time to join and
+              it costs you nothing to have read one screen.
+            </p>
+          </Prose>
+          <div className="self-start">
+            <Callout label="Current compensation" tone="warn">
+              Founding engineer: 0.5% to 2% equity.
+              <span className="mt-2 block">Founding growth: 0.25% to 2% equity.</span>
+              <span className="mt-2 block">No salary for either, currently.</span>
+            </Callout>
+          </div>
+        </div>
+      </PageSection>
+
+      <PageSection tone="panel">
+        <PageHeading
+          kicker="Two roles"
+          title="<strong>One builds the product, one builds how developers reach it.</strong> Both are early enough to own an area outright."
+        />
+        <ul className="mt-14 grid grid-cols-2 gap-5 max-lg:mt-10 max-md:grid-cols-1">
+          {ROLES.map((role) => (
+            <li
+              key={role.id}
+              className="flex flex-col rounded-[8px] bg-white p-7 ring-1 ring-black/10 max-md:p-6"
+            >
+              <h2 className="text-[22px] leading-snug tracking-tighter text-black">
+                {role.title}
+              </h2>
+              <p className="mt-3 text-[15px] leading-6 tracking-extra-tight text-black">
+                {role.equity}
+                <span className="block text-gray-new-40">No salary currently</span>
+              </p>
+              <p className="mt-5 text-[15px] leading-6 tracking-extra-tight text-gray-new-40">
+                {role.work}
+              </p>
+              <p className="mt-4 text-[15px] leading-6 tracking-extra-tight text-gray-new-40">
+                {role.proof}
+              </p>
+              {/* Points at the role's own radio in the form below, which the
+                  form then selects from the fragment. */}
+              <a
+                href={`#apply-${role.id}`}
+                className="mt-6 inline-flex min-h-11 items-center self-start rounded-full bg-black px-5 text-[14px] font-medium text-white transition-colors hover:bg-[#292929]"
+              >
+                Apply for this role
+              </a>
+            </li>
+          ))}
+        </ul>
+      </PageSection>
+
+      {/* `ruled` rather than `panel`, for the reason /contact gives at the same
+          spot: the form is a white surface with a hairline ring, and a white
+          card on a white band loses its own boundary. */}
+      <PageSection tone="ruled">
+        <div id="apply" className="scroll-mt-24">
+          <PageHeading
+            kicker="Apply"
+            title="<strong>Show us your work.</strong> A short introduction is enough."
+          />
+          <div className="mt-10 grid grid-cols-[minmax(0,720px)_minmax(260px,420px)] gap-x-20 gap-y-10 max-lg:grid-cols-1">
+            <div className="min-w-0">
+              <ApplicationForm />
+            </div>
+            <div className="self-start">
+              {/* No size override. `Prose` sets text-[17px] and `cn` is a plain
+                  join with no tailwind-merge, so a text-[15px] written beside it
+                  would be emitted and lose, which is the class that never
+                  applies `just classcheck` refuses. */}
+              <Prose>
+                <p>
+                  No account and no resume upload. Please leave out confidential
+                  work, credentials, and anything sensitive about you that this
+                  does not ask for.
+                </p>
+                <p>
+                  What you send goes to a private review queue that an
+                  authorized operator reads. It is not a public issue, a mailing
+                  list, or an analytics event. Applications are removed after
+                  180 days by scheduled maintenance, and you can ask for yours
+                  to be removed sooner.
+                </p>
+              </Prose>
+            </div>
+          </div>
+        </div>
+      </PageSection>
+
+      <RelatedGrid
+        items={[
+          {
+            href: "/about",
+            title: "About the project",
+            description:
+              "What Antifailure is, the category it claims, and the limits it states rather than footnotes.",
+          },
+          {
+            href: "/product/architecture",
+            title: "How it is built",
+            description:
+              "The control plane, the engine, and where the boundary between them falls.",
+          },
+          {
+            href: "/privacy",
+            title: "What we hold about you",
+            description:
+              "Including the application itself: what is stored, who reads it, and when it expires.",
+          },
+        ]}
+      />
+    </PageShell>
+  );
+}

--- a/www/components/pages/company/Legal.tsx
+++ b/www/components/pages/company/Legal.tsx
@@ -141,6 +141,10 @@ export function PrivacyPage() {
                 "Raw snapshots, secrets, captured request bodies until redacted, raw logs and traces, sanitization, provisioning, egress enforcement, and cleanup.",
               ],
               [
+                "Careers applications",
+                "Name, email, selected role, an optional work link, your introduction, and acknowledgment of the current compensation. These are stored separately for recruitment review by an authorized operator, not added to customer analytics or a mailing list. No applicant IP address or browser user agent is stored in the application record. Applications expire through scheduled maintenance after 180 days, or an operator can delete them sooner. Backups expire separately. Contact us privately to request removal and include your application reference.",
+              ],
+              [
                 "This site",
                 "Nothing, until you use the contact form. That writes your name, work email, company, an optional seat count and your message into the control plane's own database, with the page it came from and the time. The role that serves public requests can insert into that table and cannot read it back, so no request to this site can ever return somebody else's contact details.",
               ],
@@ -1207,6 +1211,10 @@ export function DataRetentionPage() {
               [
                 "Contact form messages",
                 "Kept until you ask for removal, which is carried out by hand: the role serving public requests holds insert and no select on that table, so there is deliberately no endpoint that reads one back or deletes one. An operator reads the queue on a separate credential and marks each one handled, which is how a request for removal reaches somebody.",
+              ],
+              [
+                "Careers applications",
+                "Removed from the live database by the scheduled maintenance pass once they are older than 180 days, whether reviewed or not. An operator can remove an application sooner. If maintenance fails, removal waits for the next successful pass. Audit records retain a record identifier and action, not the applicant's answers. Existing backups expire on their separate recovery schedule.",
               ],
               [
                 "Database backups",

--- a/www/lib/nav.ts
+++ b/www/lib/nav.ts
@@ -167,6 +167,7 @@ export const FOOTER_MENUS = [
       { text: "Marketplaces", href: "/solutions/marketplaces" },
       { text: "Developer tools", href: "/solutions/devtools" },
       { text: "About", href: "/about" },
+      { text: "Careers", href: "/careers" },
       { text: "Contact", href: "/contact" },
       { text: "Request access", href: "/signup" },
     ],

--- a/www/lib/routes.ts
+++ b/www/lib/routes.ts
@@ -333,6 +333,17 @@ export const ROUTES: readonly Route[] = [
     schemaType: "ContactPage",
   },
 
+  {
+    path: "/careers",
+    title: pageTitle("Careers"),
+    description: "Two founding roles. Founding engineer: 0.5% to 2% equity. Founding growth: 0.25% to 2% equity. No salary for either currently. Read the terms and apply on the page.",
+    summary: "Two founding roles, the current compensation stated before the work, and a private application form.",
+    section: "company",
+    indexable: true,
+    priority: 0.6,
+    parent: "/",
+  },
+
   // Sign-up and sign-in.
   //
   // These two entries said "Join the waitlist" and "There is no hosted control


### PR DESCRIPTION
There was no way to apply to work here and no way to read an application. The
only written routes this site published were the contact form, which is for
buying, and a GitHub issue, which is public. Nothing in the schema could hold a
person who is not a customer, so an application had nowhere to go that was not a
tenant's table.

This adds the whole path: a public /careers page, a form that posts to the
control plane, a separate recruitment table the serving credential can write and
cannot read, an owner-only operator queue for reading and removing applications,
and a real 180 day retention writer on the scheduled maintenance pass.

The compensation is above the roles rather than under them. There is no salary
for either role currently, and that settles the question for most people who
will open the page, so they should not have to read two role descriptions to
find it. Founding engineer is 0.5% to 2% equity, founding growth is 0.25% to 2%,
and the acknowledgment on the form repeats both numbers in full rather than
summarising them. The page makes no other promise: no date when salary begins,
no vesting schedule, no funding claim, no location, no benefits list and no
traction number, and it says that their absence is the honest state rather than
an omission.

Two failure modes shaped the write path, and both have been paid for in this
repository before. A form that says "sent" over a write that did not happen is
the waitlist defect the enterprise lead route was built to end, so the browser
checks the id and the submission key the control plane answers with before the
confirmation replaces the form, and a failed write answers 503 rather than
anything the form could read as success. A retry that becomes a second
application is the other, so the row's id is derived from the submission key and
the answers together: an identical retry collides and does nothing, and an
edited answer derives a different id and is recorded as the new application it
is.

The applicant is confined rather than trusted, and so is what we hold about
them. The route answers the configured site origin only, refuses unknown fields
and a work link that is not http or https, refuses a payload over 32KB before
parsing it, and is rate limited per address at one a minute with a burst of
five. No resume, no demographic field, no IP address and no user agent is
stored. Nothing about an applicant reaches a log or an analytics event, and the
failure branch deliberately logs nothing because a database error carries the
row. The audit records the action and the reference and never the answers.

The operator side is owner only. Applicant data is not customer data and it is
not incident context, so the two new permissions are deliberately out of reach
of super_admin, infrastructure and support. The queue is keyset paged on
(created_at, id) rather than offset, because an operator deletes rows while
reading the list and an offset would shift the next page underneath them.

The operator page had been written and never run, which is the second half of
this branch. It compiled, it built, and nothing had loaded it in a browser or
asserted that a single procedure name in it exists. A tRPC path is a string in
that client: renaming a procedure on the router leaves the console compiling and
failing at the one moment it matters. It is now built from the portal's own
DataTable, FilterBar and Drawer instead of a second vocabulary of hand rolled
cards, deleting demands the applicant's address through Confirm's phrase, and
console/lib/admin-recruitment.test.ts is the crossing the two existing suites
left open.

The migration is 0039, taken as main's highest plus one at the moment this
landed. It has now been renumbered twice: it was written as 0037, moved to 0038
when PR 229 got there first, and moved again when PR 234 took 0038 for the MCP
endpoint. That is exactly why the console test that reads it finds it by its
CREATE TABLE rather than by filename, and why the classification in
tenancy.test.ts is the only line that has to move with the number.
