### PR TITLE
infra: production could not take payment because one variable was empty

### DIFF
--- a/.changes/production-takes-payment.md
+++ b/.changes/production-takes-payment.md
@@ -1,0 +1,27 @@
+# added
+
+The hosted control plane can take payment. `stripe_price_team` is set in
+`production.tfvars`, which is the one switch the whole feature hangs from: it
+turns on the two Key Vault secret references, the three environment variables
+the process reads, and the checkout and webhook routes that were answering 503
+"This control plane is not configured to take payments" until now.
+
+Team is a flat 500 USD per month for the organization rather than per seat,
+which is why checkout sends quantity exactly 1. There is deliberately no
+enterprise price. That plan is arranged with a person, and checkout refuses it
+by name rather than reaching Stripe with an empty identifier.
+
+Two things are deliberately NOT part of this and both would have been easy to
+include by accident. `hosted_required_plan` stays empty, because turning payment
+on so somebody can buy is a different act from requiring everybody already here
+to buy, and the second one locks out every organization on the plane the moment
+it applies. `operator_sets_plan` stays unset, and Terraform refuses the
+combination anyway: a plan that can be granted by hand is not a plan anybody has
+to buy.
+
+The API key and the webhook signing secret are not in this change and are not in
+any file. They are addressed by their versionless Key Vault IDs and read by the
+Container App identity when Azure creates the revision, so Terraform never sees
+either value and no plan reads them. That also fixes the order this has to
+happen in: both secrets go into the vault BEFORE the apply, because a missing
+one fails when Azure resolves the reference rather than when Terraform plans.

--- a/infra/terraform/stacks/control-plane/production.tfvars
+++ b/infra/terraform/stacks/control-plane/production.tfvars
@@ -375,3 +375,48 @@ analytics_operator_org = "antifailure"
 # zero because nothing is being counted, rather than presenting an empty funnel
 # as a bad week.
 analytics_enabled = true
+
+# ---------------------------------------------------------------------------
+# Taking payment.
+# ---------------------------------------------------------------------------
+
+# ONE SWITCH, AND IT IS THIS LINE. An empty stripe_price_team is billing off
+# for the whole installation: modules/control-plane/keyvault.tf references no
+# Stripe secret, app.tf sets none of the three environment variables, and the
+# process says "billing is off" at start-up. Setting it turns all of that on
+# together, which is deliberate. A plane that had an API key and no price, or a
+# price and no webhook secret, would be one that can start a checkout it cannot
+# finish, and the first person to find that would be a customer holding a
+# receipt for something they did not get.
+#
+# THE VALUE HERE IS NOT A SECRET AND THE TWO THAT ARE DO NOT LIVE IN THIS FILE.
+# A price identifier is sent to a browser to start a checkout, so it belongs in
+# a tracked file. The API key and the webhook signing secret are addressed by
+# their versionless vault IDs and read by the Container App identity at deploy
+# time. Terraform never sees either value, no plan reads them, and the pull
+# request plan job holds no Key Vault data role at all.
+#
+# WHICH MEANS THE ORDER MATTERS, AND GETTING IT WRONG BREAKS A DEPLOY RATHER
+# THAN FAILING A PLAN. Azure resolves those two references when it creates the
+# revision. If the secrets are not in afcpprod-kv-centralus before the apply,
+# the plan still succeeds and the revision fails to start. Put both secrets in
+# the vault first. docs/src/content/docs/self-hosting/production.md has the
+# commands, and they pass the value on standard input so it never reaches a
+# shell history or a process listing.
+#
+# Team is a flat 500 USD per month for the organization rather than per seat,
+# which is why checkout sends quantity exactly 1. There is deliberately no
+# enterprise price: that plan is arranged with a person, and checkout refuses
+# it by name rather than reaching Stripe with an empty identifier.
+stripe_price_team = "price_1UBSGCIfNGpUWtp7OVO2YbsY"
+
+# NOT SET, AND THAT IS THE DECISION RATHER THAN THE DEFAULT. hosted_required_plan
+# would gate the product behind a paid plan, and modules/control-plane/app.tf
+# refuses it unless billing is on, so switching billing on is the moment it
+# becomes settable. It stays empty: turning payment on so somebody CAN buy is a
+# different act from requiring everybody already here to buy, and the second one
+# locks out every organization on this plane the moment it applies.
+#
+# operator_sets_plan is likewise unset and cannot be set now. Granting a plan by
+# hand on a plane that sells the same plan is refused at plan time, and the
+# process exits at start-up on the combination.


### PR DESCRIPTION
## What was actually missing

Every part of billing has been in the tree since the Stripe wiring landed: the
versionless vault references, the three environment variables, the checkout
session lifecycle, the webhook with its signed delivery ledger, and the
validations that refuse the incoherent combinations.

None of it was reachable. `stripe_price_team` was unset in `production.tfvars`,
and that variable is the switch the whole feature hangs from. Empty references
no secret, sets no environment variable, and makes the process report billing
off at start-up. Verified live against production before this change:

    POST https://app.antifailure.dev/webhooks/stripe  ->  503
    {"error":"This control plane is not configured to take payments."}

    prod app  AF_STRIPE* environment variables : []
    afcpprod-kv-centralus  secrets named stripe : []

So this is one line of configuration plus the prose explaining what it commits
to.

## Why it is one switch and not three

A plane with an API key and no price, or a price and no webhook secret, is one
that can start a checkout it cannot finish. The first person to find that would
be a customer holding a receipt for something they did not get. The module
already made the choice all-or-nothing and this change keeps it that way.

## The order this has to happen in

**The secrets go into the vault BEFORE the apply, and getting it wrong breaks a
deploy rather than failing a plan.**

Terraform addresses the API key and the webhook signing secret by their
versionless Key Vault IDs and never reads either value, which is what keeps the
pull request plan job free of any Key Vault data role. Azure resolves those
references when it creates the revision. A plan with the secrets absent
therefore still succeeds, and the revision then fails to start.

The tfvars comment says this at the line somebody would change.

## The reviewed plan

Run against the real production state with this change in place. One resource
changes, and the shape was checked field by field rather than eyeballed:

    managed resources        : 54
    managed with a change    : 1
    creates / deletes        : 0 / 0

    SERVING IMAGE unchanged  : True
    ENV added                : AF_STRIPE_PRICE_TEAM, AF_STRIPE_SECRET_KEY,
                               AF_STRIPE_WEBHOOK_SECRET
    ENV removed              : []
    SECRET REFS added        : stripe-secret-key, stripe-webhook-secret
    SECRET REFS removed      : []
      stripe-secret-key     -> .../afcpprod-kv-centralus/secrets/stripe-secret-key
      stripe-webhook-secret -> .../afcpprod-kv-centralus/secrets/stripe-webhook-secret
    traffic_weight           : unchanged

No secret value appears in the plan output quoted here or anywhere else, and
none was read to produce it.

## What is deliberately not in this

`hosted_required_plan` stays empty. Turning payment on so somebody CAN buy is a
different act from requiring everybody already on the plane to buy, and the
second locks them out the moment it applies.

`operator_sets_plan` stays unset, and `app.tf` refuses the combination at plan
time regardless: a plan that can be granted by hand is not a plan anybody has to
buy.

## Nothing here deploys itself

Merging to main deploys staging, and `staging.tfvars` carries no Stripe
settings, so staging billing stays off. `cd.yml` checks that production
infrastructure exists and never runs `terraform apply`, so production moves only
when a person runs the apply, after the secrets are in place.

## Checks

    terraform fmt      clean
    terraform validate Success! The configuration is valid.
    terraform test     tests/stripe.tftest.hcl, 2 passed, 0 failed
                       (billing_references_the_configured_secret_names,
                        billing_off_has_no_payment_secret_references)
    prosecheck         740 files, 0 places where the punctuation gives it away

`changecheck` reports "2 changed paths, none of it behaviour anybody outside can
see", so it does not gate this change either. The fragment is included by
choice.

## Still needed, and not by me

Two secret values and one Stripe dashboard endpoint. Those are handed over
separately as commands to run with the value on standard input. I have not
placed a credential and have not applied this to production.
