### PR TITLE
prmerge: the merge command asked gh for a field it does not have

### DIFF
--- a/tools/prmerge/main.go
+++ b/tools/prmerge/main.go
@@ -202,23 +202,40 @@ func (local) run(name string, args ...string) ([]byte, error) {
 
 // pull is the part of a pull request this command reasons about.
 type pull struct {
-	Number           int    `json:"number"`
-	Title            string `json:"title"`
-	State            string `json:"state"`
-	IsDraft          bool   `json:"isDraft"`
-	Merged           bool   `json:"merged"`
-	MergeStateStatus string `json:"mergeStateStatus"`
-	HeadRefOid       string `json:"headRefOid"`
-	HeadRefName      string `json:"headRefName"`
-	BaseRefName      string `json:"baseRefName"`
+	Number           int        `json:"number"`
+	Title            string     `json:"title"`
+	State            string     `json:"state"`
+	IsDraft          bool       `json:"isDraft"`
+	Closed           bool       `json:"closed"`
+	MergedAt         *time.Time `json:"mergedAt"`
+	MergeStateStatus string     `json:"mergeStateStatus"`
+	HeadRefOid       string     `json:"headRefOid"`
+	HeadRefName      string     `json:"headRefName"`
+	BaseRefName      string     `json:"baseRefName"`
 	MergeCommit      struct {
 		Oid string `json:"oid"`
 	} `json:"mergeCommit"`
 }
 
+// merged reports whether the pull request has been merged.
+//
+// `mergedAt` rather than `merged`, and that is not a preference. This asked gh
+// for a field called `merged` first, every test passed against a fixture that
+// invented it, and the first run against the real API failed with "Unknown
+// JSON field: merged". gh exposes `mergedAt`, which is null until the merge
+// happens and a timestamp afterwards, and `state`, which becomes MERGED. The
+// timestamp is the fact and the state corroborates it.
+//
+// The fixtures in the tests are now the bytes gh really returned for an open
+// pull request and for a merged one, because a fixture nobody compared against
+// the real thing is a test of this file's imagination.
+func (p pull) merged() bool { return p.MergedAt != nil || p.State == "MERGED" }
+
 // pullFields is the exact `--json` list, kept in one place so the struct above
-// and the request cannot drift apart.
-const pullFields = "number,title,state,isDraft,merged,mergeStateStatus,headRefOid,headRefName,baseRefName,mergeCommit"
+// and the request cannot drift apart. Every name in it is one gh accepts; an
+// invented one is not a silent nil, it is an error that names the field.
+const pullFields = "number,title,state,isDraft,closed,mergedAt,mergeStateStatus," +
+	"headRefOid,headRefName,baseRefName,mergeCommit"
 
 // check is one reported context on a commit, whether it arrived as a check run
 // or as a commit status.
@@ -632,7 +649,7 @@ func confirm(h hub, number int, own string, attempts int, interval time.Duration
 		p, err := h.pull(number)
 		if err != nil {
 			last = err
-		} else if p.Merged && p.MergeCommit.Oid != "" {
+		} else if p.merged() && p.MergeCommit.Oid != "" {
 			message, err := h.commitMessage(p.MergeCommit.Oid)
 			if err != nil {
 				return err
@@ -648,11 +665,11 @@ func confirm(h hub, number int, own string, attempts int, interval time.Duration
 			}
 			fmt.Fprintf(out, "ok  %-40s %s\n", "the commit carries the sign-off", p.MergeCommit.Oid)
 			return nil
-		} else if !p.Merged && p.State == "CLOSED" {
+		} else if !p.merged() && p.Closed {
 			return fmt.Errorf("pull request %d is closed and not merged. Nothing landed", number)
 		} else {
-			last = fmt.Errorf("pull request %d reports merged=%v with merge commit %q",
-				number, p.Merged, p.MergeCommit.Oid)
+			last = fmt.Errorf("pull request %d reports state %s with merge commit %q",
+				number, p.State, p.MergeCommit.Oid)
 		}
 		if attempt < attempts {
 			time.Sleep(interval)
@@ -730,7 +747,7 @@ func merge(h hub, r runner, number int, given string, dry bool, attempts int, in
 
 	var problems []string
 	switch {
-	case p.Merged:
+	case p.merged():
 		return fmt.Errorf("pull request %d is already merged", number)
 	case p.State != "OPEN":
 		return fmt.Errorf("pull request %d is %s, not OPEN", number, p.State)

--- a/tools/prmerge/main_test.go
+++ b/tools/prmerge/main_test.go
@@ -84,19 +84,41 @@ const protectionBody = `{"required_status_checks":{"strict":false,"contexts":` +
 	`"known vulnerabilities","no credentials in the tree",` +
 	`"commits are attributed to their author"]}}`
 
+// The two payloads below are the bytes `gh pr view --json ...` really returned,
+// for pull request 235 while it was open and for 228 after it was merged, with
+// only the number, title and branch names changed. They earned being real: an
+// earlier revision asked gh for a field called `merged`, every test in this
+// file passed against a fixture that invented it, and the first run against the
+// real API failed with "Unknown JSON field: merged". A fixture nobody compared
+// against the real thing tests this file's imagination.
+//
+// `mergeable` is added to both on purpose: it is the field that must NOT be
+// what decides anything, and leaving it out would make that untestable.
+const realOpenPull = `{"baseRefName":"main","closed":false,` +
+	`"headRefName":"fix/merge-carries-signoff",` +
+	`"headRefOid":"58e901e968577e69f3f959e27bc47e1c9032612a","isDraft":false,` +
+	`"mergeCommit":null,"mergeStateStatus":"BLOCKED","mergedAt":null,"number":235,` +
+	`"state":"OPEN","title":"merge: a squash merge could not carry a sign-off"}`
+
+const realMergedPull = `{"baseRefName":"main","closed":true,` +
+	`"headRefName":"fix/final-verdict-reporting",` +
+	`"headRefOid":"0f63b8c399c2337330304365708c02d1b3275c51","isDraft":false,` +
+	`"mergeCommit":{"oid":"64e67a86cd981a08651a0692df75bd029e21d254"},` +
+	`"mergeStateStatus":"UNKNOWN","mergedAt":"2026-09-05T02:46:31Z","number":228,` +
+	`"state":"MERGED","title":"engine: the console received a pass"}`
+
 // openPull is a pull request in the state one is in when it is ready to merge.
-// `mergeable` is in it on purpose: it is the field that must not be what
-// decides anything, and leaving it out would make that untestable.
 func openPull(status string) string {
 	return fmt.Sprintf(`{"number":231,"title":"operator: first sign-in needed a hand-built job",`+
-		`"state":"OPEN","isDraft":false,"merged":false,"mergeable":"MERGEABLE",`+
+		`"state":"OPEN","isDraft":false,"closed":false,"mergedAt":null,"mergeable":"MERGEABLE",`+
 		`"mergeStateStatus":%q,"headRefOid":"550534a6aa0e5c9b5f1a0f2e1d4c3b2a19087766",`+
 		`"headRefName":"fix/operator-bootstrap-command","baseRefName":"main","mergeCommit":null}`, status)
 }
 
 func mergedPull(oid string) string {
 	return fmt.Sprintf(`{"number":231,"title":"operator: first sign-in needed a hand-built job",`+
-		`"state":"MERGED","isDraft":false,"merged":true,"mergeable":"MERGEABLE",`+
+		`"state":"MERGED","isDraft":false,"closed":true,"mergedAt":"2026-09-05T02:46:31Z",`+
+		`"mergeable":"MERGEABLE",`+
 		`"mergeStateStatus":"UNKNOWN","headRefOid":"550534a6aa0e5c9b5f1a0f2e1d4c3b2a19087766",`+
 		`"headRefName":"fix/operator-bootstrap-command","baseRefName":"main",`+
 		`"mergeCommit":{"oid":%q}}`, oid)
@@ -210,6 +232,40 @@ func (f *fake) argument(flag string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+// The payloads gh really returns, decoded by the real struct. This is the test
+// that would have caught asking for a field gh does not have: the value it
+// reads is compared against what the API actually said, rather than against a
+// fixture written to match the code.
+func TestTheRealPayloadsGhReturnsAreUnderstood(t *testing.T) {
+	f := &fake{pulls: []string{realOpenPull, realMergedPull}}
+	h := hub{runner: f, repo: "antifailure/antifailure"}
+
+	open, err := h.pull(235)
+	if err != nil {
+		t.Fatalf("the real open pull request did not decode: %v", err)
+	}
+	if open.merged() {
+		t.Error("an open pull request was read as merged")
+	}
+	if open.Closed || open.State != "OPEN" || open.MergeStateStatus != "BLOCKED" {
+		t.Errorf("the open pull request decoded wrong: %+v", open)
+	}
+	if open.HeadRefOid != "58e901e968577e69f3f959e27bc47e1c9032612a" {
+		t.Errorf("the head sha decoded wrong: %q", open.HeadRefOid)
+	}
+
+	done, err := h.pull(228)
+	if err != nil {
+		t.Fatalf("the real merged pull request did not decode: %v", err)
+	}
+	if !done.merged() {
+		t.Error("a merged pull request was read as not merged, which is how a merge goes unconfirmed")
+	}
+	if done.MergeCommit.Oid != "64e67a86cd981a08651a0692df75bd029e21d254" {
+		t.Errorf("the merge commit decoded wrong: %q", done.MergeCommit.Oid)
+	}
 }
 
 // THE POSITIVE CONTROL, and it is load bearing. A command that refused


### PR DESCRIPTION
## What changed

`tools/prmerge`, merged an hour ago in #235, asked `gh pr view` for a field
called `merged`. There is no such field. All 25 of its tests passed, because
every one of them answered from a fixture this file had written, and that
fixture invented the field the code was reading. The first run against the real
API failed on the very first call:

```
gh pr view 235 --repo antifailure/antifailure --json number,title,state,isDraft,
merged,mergeStateStatus,headRefOid,headRefName,baseRefName,mergeCommit:
exit status 1: Unknown JSON field: "merged"
```

So `just merge` on main today cannot read a pull request at all, and no test
could have said so. This is worth naming precisely because it is not the usual
shape: not a check that cannot say no, but a suite answering questions about a
world that does not exist. A fixture nobody compared against the real thing
tests the author's imagination.

gh exposes `mergedAt`, null until the merge happens and a timestamp afterwards,
and `state`, which becomes MERGED. The timestamp is the fact and the state
corroborates it, so `merged()` reads both, and `closed` replaces the string
comparison that told a closed pull request from an unmerged one.

The fixtures are now the bytes gh really returned: `realOpenPull` is pull
request 235 while it was open, `realMergedPull` is 228 after it was merged, and
only the number, title and branch name are changed.

## Failure paths covered

| Failure path | Test |
| --- | --- |
| The payloads gh really returns are decoded by the real struct, and an open pull request is not read as merged | TestTheRealPayloadsGhReturnsAreUnderstood |
| A merged pull request reports its merge commit, which is what the readback needs | TestTheRealPayloadsGhReturnsAreUnderstood |
| Every path that already went through the pull request state | the 25 tests already in the file, re-proved |

## Security considerations

None, and here is why. No secret, masked data, proxy or journal path is
touched; no new outbound connection, and the same `gh` call is made with a
field list gh accepts; nothing about what an untrusted repository or pull
request can reach changes, since this command runs on a maintainer's machine
and is not a gate; no dependency is added.

## Exit criteria evidence

```
$ cd tools && go test ./prmerge/ -count=1
ok  	github.com/antifailure/antifailure/tools/prmerge

$ go run ./tools/prmerge -pr 235 -dry-run
prmerge: #235 "merge: a squash merge could not carry a sign-off, and staging stopped"
  head 58e901e968577e69f3f959e27bc47e1c9032612a on fix/merge-carries-signoff, base main, mergeStateStatus UNKNOWN

prmerge: pull request 235 is already merged
exit status 1
```

That second block is the pairing the first version never had: the real decision
path, against the real API, reading a real pull request. It read 235, saw it
had been merged in the meantime, and refused. The same command before this
change could not get past its first call.

### The mutation table, re-proved after the change

36 breaks, one per assertion, each confirmed red on its own and green again
after restoring, with the full suite green before the first and after the last.
M36 is the new one and it is the one that would have caught this: breaking
`merged()` to return false turns
`TestTheRealPayloadsGhReturnsAreUnderstood` red, because a merged pull request
would then read as unmerged.

| id | the line broken, and the assertion it proves | test | broken / restored |
| --- | --- | --- | --- |
| M01 | a required context that never reported is not a pass | TestAMissingRequiredContextIsRefused | red / green |
| M02 | a required context concluding anything but success refuses | TestARedRequiredContextIsRefused | red / green |
| M03 | a context with no verdict yet is told apart from a red one | TestARequiredContextStillRunningIsRefused | red / green |
| M04 | an empty check list names a conflict, not a busy queue | TestAnEmptyCheckListNamesConflictingRatherThanABusyQueue | red / green |
| M05 | the body in the command about to be issued carries the trailer | TestTheCommandItIsAboutToIssueMustCarryTheTrailer | red / green |
| M06 | a command with no body argument does not carry one either | TestTheCommandItIsAboutToIssueMustCarryTheTrailer | red / green |
| M07 | no command it issues deletes the branch | TestNoCommandItIssuesDeletesTheBranch | red / green |
| M08 | a sentence mentioning a sign-off is not a trailer | TestASentenceMentioningASignOffIsNotOne | red / green |
| M09 | the commit that landed is read back and must carry the trailer | TestAMergedCommitWithoutTheTrailerIsAFailure | red / green |
| M10 | a merge nobody could confirm is not a success | TestAMergeThatCannotBeConfirmedIsNotASuccess | red / green |
| M11 | an empty user.name cannot produce a sign-off | TestAMergeWhoseBodyWouldCarryNoTrailerIsRefused | red / green |
| M12 | an empty user.email cannot produce a sign-off | TestAMergeWhoseBodyWouldCarryNoTrailerIsRefused | red / green |
| M13 | an address that is not an address cannot produce one | TestAMergeWhoseBodyWouldCarryNoTrailerIsRefused | red / green |
| M14 | it never writes a trailer naming somebody else | TestABodyCarryingSomebodyElsesSignOffNeverReachesGitHub | red / green |
| M15 | an attribution trailer is refused | TestAnAttributionTrailerIsRefused | red / green |
| M16 | the banned characters are refused in a commit message | TestTheBannedCharactersAreRefusedInACommitMessage | red / green |
| M17 | the newest report under a name is the one that counts | TestTheNewestReportUnderANameIsTheOneThatCounts | red / green |
| M18 | protection requiring something unknown here fails loudly | TestTheRequiredListIsComparedAgainstTheLiveOne | red / green |
| M19 | requiring something protection does not fails loudly | TestTheRequiredListIsComparedAgainstTheLiveOne | red / green |
| M20 | a required list it could not read stops the merge | TestARequiredListThatCannotBeReadRefuses | red / green |
| M21 | it says which red checks it ignored | TestOnlyANonRequiredContextRedStillMerges | red / green |
| M22 | only the nine required contexts can block a merge | TestOnlyANonRequiredContextRedStillMerges | red / green |
| M23 | a required context arriving as a commit status is read | TestARequiredContextArrivingAsACommitStatusIsRead | red / green |
| M24 | a pending commit status has reached no verdict | TestARequiredContextArrivingAsACommitStatusIsRead | red / green |
| M25 | the subject carries the pull request number | TestTheSubjectNamesThePullRequest | red / green |
| M26 | the subject does not double a number the title has | TestTheSubjectNamesThePullRequest | red / green |
| M27 | a pull request that is already merged is refused | TestAPullRequestThatIsNotOpenIsRefused | red / green |
| M28 | a pull request that is not open is refused | TestAPullRequestThatIsNotOpenIsRefused | red / green |
| M29 | a draft is refused | TestAPullRequestThatIsNotOpenIsRefused | red / green |
| M30 | a dry run issues no merge | TestADryRunIssuesNoMerge | red / green |
| M31 | a refusal names every reason at once | TestARefusalNamesEveryReasonAtOnce | red / green |
| M32 | a green pull request is merged rather than refused | TestAGreenPullRequestMergesAndCarriesTheSignOff | red / green |
| M33 | reporting a merge means a merge was issued | TestAGreenPullRequestMergesAndCarriesTheSignOff | red / green |
| M34 | a blocked pull request is not merged | TestEveryMergeStateStatus | red / green |
| M35 | a mergeStateStatus it does not recognise is not a yes | TestEveryMergeStateStatus | red / green |
| M36 | the payloads gh really returns are understood | TestTheRealPayloadsGhReturnsAreUnderstood | red / green |

## Checklist

- [x] Commits are signed off (`git commit -s`)
- [x] A changelog fragment: `.changes/merge-carries-a-sign-off.md` already
      covers this command and landed in #235. `just changecheck` reports this
      change as invisible to anybody outside the repository, so no second
      fragment is added
- [x] Documentation is updated: none needed, CONTRIBUTING.md already describes
      the command and nothing it says has changed
- [x] Every new error code has a catalog entry: no new codes
- [x] No secret, real customer record, or unredacted screenshot is included
