### PR TITLE
prmerge: the suite could not tell a real API from an invented one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1330,6 +1330,54 @@ jobs:
           AF_CHANGECHECK_BEFORE: ${{ github.event.before }}
         run: go run ./tools/changecheck .
 
+  mergefields:
+    name: the merge command still fits the API
+    # Only on a pull request, because it needs one to read: the field list is
+    # checked against a real pull request rather than against a fixture, and on
+    # a push to main there is none to point at.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Reads only, and each one is a read this check makes: the pull request,
+    # the check runs on its head, and the commit statuses on the same commit.
+    # A job level block replaces the workflow level one rather than adding to
+    # it, so `contents` is repeated here on purpose.
+    permissions:
+      contents: read
+      pull-requests: read
+      checks: read
+      statuses: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: engine/go.mod
+          cache-dependency-path: engine/go.sum
+
+      - name: Every field name the merge command uses is one the API has
+        # tools/prmerge asked `gh pr view` for a field called `merged`. There
+        # is no such field. All 25 of its tests passed, because every one
+        # answered from a fixture the tool's own suite had written, and the
+        # fixture invented the field the code was reading. The first real
+        # invocation died on the first call with `Unknown JSON field:
+        # "merged"`, which meant the command that exists to make merging safe
+        # could not read a pull request at all.
+        #
+        # A suite that builds its own input can be complete and still describe
+        # a system that does not exist. This is the check that reads the other
+        # side of the boundary, and it runs the same argument lists the merge
+        # path runs.
+        #
+        # It does NOT check branch protection here, and it says so rather than
+        # passing over it: that read needs administration rights and this token
+        # has none. That half is proved on the real path instead, because a
+        # wrong key there leaves an empty required list, which refuses every
+        # merge rather than allowing one.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: go run ./tools/prmerge -check-fields -pr ${{ github.event.pull_request.number }}
+
   authorship:
     name: commits are attributed to their author
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,7 +132,9 @@ Merge with `just merge <number>` and not with `gh pr merge` by hand.
 
 ```
 just merge 231
-just merge 231 -dry-run     # check everything and merge nothing
+just merge 231 -dry-run       # check everything and merge nothing
+just merge 231 -check-fields  # ask the API whether its field names still exist
+just merge 231 -confirm-only  # prove a merged commit carries the sign-off
 ```
 
 The reason is a deployment outage rather than a style preference. Six pull
@@ -168,7 +170,20 @@ the button typed. `just merge` is that thing:
   command for you to run afterwards;
 * and it reads the commit back off the remote afterwards and fails if the
   trailer is not there, because a tool that intends to sign and cannot prove it
-  did is the defect it was written to prevent.
+  did is the defect it was written to prevent. `-confirm-only` runs that one
+  check on its own against any merged pull request, so the code that decides
+  whether a commit is signed can be exercised on a real commit without merging
+  one to exercise it.
+
+The first version of this command asked `gh pr view` for a field called
+`merged`. There is no such field, and all 25 of its tests passed anyway,
+because every one of them answered from a fixture the suite itself had written.
+The first real invocation died on its first call. So `-check-fields` reads the
+other side of the boundary: it runs the same argument lists the merge path
+runs, against a real pull request, and reports a name the API does not have or
+a key a real response does not carry. It runs on every pull request in
+`.github/workflows/ci.yml` as "the merge command still fits the API", and it
+names what it could not check rather than passing over it.
 
 ## The changelog
 

--- a/justfile
+++ b/justfile
@@ -250,8 +250,11 @@ hooks:
 # hooks cannot help: a squash commit is created on GitHub's side, so nothing
 # local runs at the moment the button is pressed.
 #
-# See tools/prmerge for what it refuses and why. `-dry-run` checks everything
-# and merges nothing.
+# See tools/prmerge for what it refuses and why. Three read only modes, all of
+# which merge nothing: `-dry-run` checks everything and prints the command it
+# would run, `-check-fields` asks the real API whether the field names this
+# command reads still exist, and `-confirm-only` reads an already merged pull
+# request and proves its commit carries the sign-off.
 [doc("Squash merge a pull request with a Developer Certificate of Origin sign-off.")]
 merge pr *args:
     go run ./tools/prmerge -pr {{pr}} {{args}}

--- a/tools/gatecheck/main.go
+++ b/tools/gatecheck/main.go
@@ -637,6 +637,21 @@ func fail(format string, args ...any) {
 // An exemption naming a gate no workflow runs fails the build. See the loop
 // that fills `stale`.
 var exemptFromGate = map[string]string{
+	"tool prmerge": "" +
+		"Its answer does not come from this repository. tools/prmerge asks the " +
+		"GitHub API whether the field names it reads still exist, against a real " +
+		"pull request, so its answer moves when gh or the API moves and it needs " +
+		"the network, which `just gate` must not. It also needs a pull request to " +
+		"point at, and `just gate` runs on a branch that may not have one. " +
+		"It exists because the tool once asked `gh pr view` for a field called " +
+		"`merged`, which does not exist, with 25 green tests behind it: every one " +
+		"of them answered from a fixture the suite itself had written. What IS a " +
+		"function of the tree is every decision the tool makes, and " +
+		"`go test ./tools/prmerge` covers that inside `gate`, including that the " +
+		"request and the struct ask for the same fields. " +
+		"It runs on every pull request in ci.yml. Run it by hand with " +
+		"`just merge <number> -check-fields`.",
+
 	"tool vulncheck": "" +
 		"Its answer does not come from this repository. tools/vulncheck asks the " +
 		"Go vulnerability database which known advisories are reachable from our " +

--- a/tools/gatecheck/main_test.go
+++ b/tools/gatecheck/main_test.go
@@ -606,12 +606,38 @@ func keys(m map[string]*entry) []string {
 // Workflow supply chain. These live here because gatecheck already reads the
 // workflows, and because the tools module's tests run in CI.
 
+// The false positive that regex earned its boundary from. A permissions block
+// is not an action reference, and `statuses: read` is the line that reads like
+// one, because `statuses:` ends in the five characters `uses:`.
+func TestAPermissionIsNotAnActionReference(t *testing.T) {
+	uses := regexp.MustCompile(`(?:^|\s)uses:\s*(\S+)`)
+	block := "    permissions:\n      contents: read\n      pull-requests: read\n" +
+		"      checks: read\n      statuses: read\n"
+	// statuses is the one that matters here. The others are in the fixture so
+	// that a future permission ending in the same letters is covered too.
+	if found := uses.FindAllStringSubmatch(block, -1); len(found) != 0 {
+		t.Errorf("a permissions block was read as %d action references: %v", len(found), found)
+	}
+	// And the boundary must not have cost it the thing it is for.
+	step := "      - uses: actions/checkout@v4\n"
+	if found := uses.FindAllStringSubmatch(step, -1); len(found) != 1 || found[0][1] != "actions/checkout@v4" {
+		t.Errorf("a real action reference stopped being found: %v", found)
+	}
+}
+
 func TestEveryActionIsPinnedToACommit(t *testing.T) {
 	// A tag is mutable. `actions/checkout@v4` is a promise the publisher can
 	// change after anybody reviewed it, so the thing that was reviewed and the
 	// thing that runs are only the same by the publisher's continued goodwill.
 	// A commit cannot be changed.
-	uses := regexp.MustCompile(`uses:\s*(\S+)`)
+	// Anchored on a boundary, and that is not a detail. `uses:` is a substring
+	// of `statuses:`, so without one this reads the permissions block line
+	// `statuses: read` as an action called `read` pinned to nothing, and
+	// reports a workflow that references no such action. A check that fires on
+	// something that is not the thing is how a check gets ignored and then
+	// deleted, and this one guards a real supply chain property: a tag is
+	// mutable and a commit is not.
+	uses := regexp.MustCompile(`(?:^|\s)uses:\s*(\S+)`)
 	pinned := regexp.MustCompile(`^[\w.-]+/[\w.-]+(/[\w.-]+)*@[0-9a-f]{40}$`)
 
 	files, err := filepath.Glob(filepath.Join("..", "..", ".github", "workflows", "*.yml"))

--- a/tools/prmerge/main.go
+++ b/tools/prmerge/main.go
@@ -81,6 +81,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"reflect"
 	"regexp"
 	"sort"
 	"strings"
@@ -262,9 +263,35 @@ type hub struct {
 
 func (h hub) gh(args ...string) ([]byte, error) { return h.runner.run("gh", args...) }
 
+// The four reads this command makes, as the argument lists that make them.
+//
+// Named here rather than written inline so that the field check below runs the
+// SAME calls the merge path runs. A field check against a copy of the call is
+// a check of the copy, and the copy is the thing that stays right while the
+// original drifts.
+func pullArgs(repo string, number int) []string {
+	return []string{"pr", "view", fmt.Sprint(number), "--repo", repo, "--json", pullFields}
+}
+
+func checkRunArgs(repo, sha string) []string {
+	return []string{"api", fmt.Sprintf("repos/%s/commits/%s/check-runs?per_page=100", repo, sha)}
+}
+
+func statusArgs(repo, sha string) []string {
+	return []string{"api", fmt.Sprintf("repos/%s/commits/%s/status?per_page=100", repo, sha)}
+}
+
+func protectionArgs(repo, branch string) []string {
+	return []string{"api", fmt.Sprintf("repos/%s/branches/%s/protection", repo, branch)}
+}
+
+func commitArgs(repo, sha string) []string {
+	return []string{"api", fmt.Sprintf("repos/%s/commits/%s", repo, sha)}
+}
+
 // pull reads one pull request.
 func (h hub) pull(number int) (pull, error) {
-	out, err := h.gh("pr", "view", fmt.Sprint(number), "--repo", h.repo, "--json", pullFields)
+	out, err := h.gh(pullArgs(h.repo, number)...)
 	if err != nil {
 		return pull{}, err
 	}
@@ -282,7 +309,7 @@ func (h hub) pull(number int) (pull, error) {
 // what blocks a merge, and merging on a list nobody confirmed is exactly the
 // gate this command is supposed to be.
 func (h hub) protection(branch string) ([]string, error) {
-	out, err := h.gh("api", fmt.Sprintf("repos/%s/branches/%s/protection", h.repo, branch))
+	out, err := h.gh(protectionArgs(h.repo, branch)...)
 	if err != nil {
 		return nil, fmt.Errorf("reading the required contexts on %s: %w\n"+
 			"  This command will not merge on a required list it could not confirm. "+
@@ -301,7 +328,7 @@ func (h hub) protection(branch string) ([]string, error) {
 
 // checks is everything that reported on a commit, check runs and statuses both.
 func (h hub) checks(sha string) ([]check, error) {
-	out, err := h.gh("api", fmt.Sprintf("repos/%s/commits/%s/check-runs?per_page=100", h.repo, sha))
+	out, err := h.gh(checkRunArgs(h.repo, sha)...)
 	if err != nil {
 		return nil, fmt.Errorf("reading the check runs on %s: %w", sha, err)
 	}
@@ -322,7 +349,7 @@ func (h hub) checks(sha string) ([]check, error) {
 		all = append(all, check{Name: r.Name, Status: r.Status, Conclusion: r.Conclusion, At: r.StartedAt, ID: r.ID})
 	}
 
-	out, err = h.gh("api", fmt.Sprintf("repos/%s/commits/%s/status?per_page=100", h.repo, sha))
+	out, err = h.gh(statusArgs(h.repo, sha)...)
 	if err != nil {
 		return nil, fmt.Errorf("reading the commit statuses on %s: %w", sha, err)
 	}
@@ -353,7 +380,7 @@ func (h hub) checks(sha string) ([]check, error) {
 
 // commitMessage is the full message of a commit on the remote.
 func (h hub) commitMessage(sha string) (string, error) {
-	out, err := h.gh("api", fmt.Sprintf("repos/%s/commits/%s", h.repo, sha))
+	out, err := h.gh(commitArgs(h.repo, sha)...)
 	if err != nil {
 		return "", fmt.Errorf("reading the commit %s: %w", sha, err)
 	}
@@ -682,12 +709,263 @@ func confirm(h hub, number int, own string, attempts int, interval time.Duration
 		"git fetch origin && git log -1 --format='%%B' origin/main", last)
 }
 
+// pullFieldNames is the request's field list, split.
+func pullFieldNames() []string { return strings.Split(pullFields, ",") }
+
+// structFieldNames is every json tag on the pull struct.
+//
+// Read by reflection rather than listed, because a list would be the third
+// place the same names live and the one nobody updates.
+func structFieldNames() []string {
+	var out []string
+	t := reflect.TypeOf(pull{})
+	for i := 0; i < t.NumField(); i++ {
+		if tag := t.Field(i).Tag.Get("json"); tag != "" && tag != "-" {
+			out = append(out, strings.Split(tag, ",")[0])
+		}
+	}
+	return out
+}
+
+// fieldDrift compares what the struct reads against what the request asks for.
+//
+// This is the half of the contract that needs no network, and it is the half
+// that goes wrong silently. A field asked for and never read is dead weight; a
+// field READ and never asked for decodes as a zero value with no error at all,
+// which is a merge command quietly believing a pull request is not a draft, or
+// not merged, because nobody requested the field that says so.
+//
+// The other half, whether the API has these fields at all, cannot be answered
+// from here: gh answers it, by refusing an unknown name. That is what
+// -check-fields is for, and it is why the two exist separately.
+func fieldDrift(asked, read []string) []string {
+	inAsked, inRead := map[string]bool{}, map[string]bool{}
+	for _, f := range asked {
+		inAsked[f] = true
+	}
+	for _, f := range read {
+		inRead[f] = true
+	}
+	var problems []string
+	for _, f := range read {
+		if !inAsked[f] {
+			problems = append(problems, fmt.Sprintf(
+				"the pull struct reads %q and pullFields never asks for it, so it decodes as a "+
+					"zero value with no error. Add it to pullFields", f))
+		}
+	}
+	for _, f := range asked {
+		if !inRead[f] {
+			problems = append(problems, fmt.Sprintf(
+				"pullFields asks for %q and nothing reads it. Remove it, or add the field that "+
+					"needs it", f))
+		}
+	}
+	sort.Strings(problems)
+	return problems
+}
+
+// keysOf returns the top level keys of a JSON object, and says so when the
+// bytes were not an object at all.
+func keysOf(raw []byte) (map[string]bool, error) {
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &object); err != nil {
+		return nil, fmt.Errorf("the response was not a JSON object: %w", err)
+	}
+	keys := map[string]bool{}
+	for k := range object {
+		keys[k] = true
+	}
+	return keys, nil
+}
+
+// missing names the fields a response does not carry.
+func missing(keys map[string]bool, want []string) []string {
+	var absent []string
+	for _, f := range want {
+		if !keys[f] {
+			absent = append(absent, f)
+		}
+	}
+	return absent
+}
+
+// checkFields asks the real API whether this command's field names exist.
+//
+// WHY IT EXISTS. This command asked `gh pr view` for a field called `merged`.
+// There is no such field. All 25 of its tests passed, because every one
+// answered from a fixture this file had written and the fixture invented the
+// field the code was reading. The first real invocation died on the first call
+// with `Unknown JSON field: "merged"`. A suite that builds its own input can be
+// complete and still describe a system that does not exist.
+//
+// So this is the check that reads the other side of the boundary. It runs the
+// same argument lists the merge path runs, against a real pull request, and
+// reports a name the API does not have or a key a real response does not carry.
+//
+// WHAT IT DOES NOT CLAIM. Branch protection needs administration rights, so a
+// token without them cannot read it. That is reported as NOT CHECKED by name
+// rather than passed over, and the same for a commit that carries no check run
+// or no commit status: an element shape cannot be examined in a list with no
+// elements. The rule this repository holds to is to say what was not checked,
+// and the claim this makes is exactly the reads it managed.
+//
+// It is worth knowing that all four reads already fail CLOSED on the merge
+// path. A wrong name in pullFields makes gh refuse; a wrong key under
+// check-runs or status leaves an empty list, which reads as a required context
+// that never reported; a wrong key under protection leaves an empty required
+// list, which reads as nine contexts protection no longer requires. Every one
+// of those refuses the merge. This exists so that the refusal arrives before
+// somebody is standing at a merge button, and so that it names the field.
+func checkFields(h hub, number int, out io.Writer) error {
+	var problems, unchecked []string
+
+	if drift := fieldDrift(pullFieldNames(), structFieldNames()); len(drift) > 0 {
+		problems = append(problems, drift...)
+	} else {
+		fmt.Fprintf(out, "ok  %-44s %d fields\n", "the request and the struct ask the same", len(pullFieldNames()))
+	}
+
+	raw, err := h.gh(pullArgs(h.repo, number)...)
+	if err != nil {
+		// gh names the field it does not recognise, which is the whole point.
+		return fmt.Errorf("the pull request field list was refused: %v", err)
+	}
+	keys, err := keysOf(raw)
+	if err != nil {
+		return fmt.Errorf("reading pull request %d: %v", number, err)
+	}
+	if absent := missing(keys, pullFieldNames()); len(absent) > 0 {
+		problems = append(problems, fmt.Sprintf(
+			"gh accepted %v and the response carries no such key", absent))
+	} else {
+		fmt.Fprintf(out, "ok  %-44s #%d\n", "gh has every field pullFields asks for", number)
+	}
+
+	var p pull
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return fmt.Errorf("reading pull request %d: %v", number, err)
+	}
+
+	raw, err = h.gh(checkRunArgs(h.repo, p.HeadRefOid)...)
+	if err != nil {
+		return fmt.Errorf("reading the check runs on %s: %v", p.HeadRefOid, err)
+	}
+	var runs struct {
+		CheckRuns []map[string]json.RawMessage `json:"check_runs"`
+	}
+	if err := json.Unmarshal(raw, &runs); err != nil {
+		return fmt.Errorf("reading the check runs on %s: %v", p.HeadRefOid, err)
+	}
+	switch {
+	case len(runs.CheckRuns) == 0:
+		unchecked = append(unchecked, fmt.Sprintf(
+			"the shape of a check run, because %s carries none", p.HeadRefOid))
+	default:
+		absent := map[string]bool{}
+		for _, r := range runs.CheckRuns {
+			for _, f := range []string{"id", "name", "status", "conclusion", "started_at"} {
+				if _, ok := r[f]; !ok {
+					absent[f] = true
+				}
+			}
+		}
+		if len(absent) > 0 {
+			problems = append(problems, fmt.Sprintf(
+				"a check run carries none of %v, and this command reads them", sortedKeys(absent)))
+		} else {
+			fmt.Fprintf(out, "ok  %-44s %d runs\n", "a check run carries the five fields read", len(runs.CheckRuns))
+		}
+	}
+
+	raw, err = h.gh(statusArgs(h.repo, p.HeadRefOid)...)
+	if err != nil {
+		return fmt.Errorf("reading the commit statuses on %s: %v", p.HeadRefOid, err)
+	}
+	var statuses struct {
+		Statuses []map[string]json.RawMessage `json:"statuses"`
+	}
+	if err := json.Unmarshal(raw, &statuses); err != nil {
+		return fmt.Errorf("reading the commit statuses on %s: %v", p.HeadRefOid, err)
+	}
+	if keys, err := keysOf(raw); err == nil && !keys["statuses"] {
+		problems = append(problems, "the commit status response carries no `statuses` key, and "+
+			"this command reads one. A required context reported as a status would be invisible")
+	} else if len(statuses.Statuses) == 0 {
+		unchecked = append(unchecked, fmt.Sprintf(
+			"the shape of a commit status, because %s carries none. Every required context "+
+				"on this repository is a check run", p.HeadRefOid))
+		fmt.Fprintf(out, "ok  %-44s\n", "the commit status response has its list")
+	} else {
+		absent := map[string]bool{}
+		for _, st := range statuses.Statuses {
+			for _, f := range []string{"id", "context", "state", "created_at"} {
+				if _, ok := st[f]; !ok {
+					absent[f] = true
+				}
+			}
+		}
+		if len(absent) > 0 {
+			problems = append(problems, fmt.Sprintf(
+				"a commit status carries none of %v, and this command reads them", sortedKeys(absent)))
+		} else {
+			fmt.Fprintf(out, "ok  %-44s %d statuses\n", "a commit status carries the four fields read", len(statuses.Statuses))
+		}
+	}
+
+	raw, err = h.gh(protectionArgs(h.repo, p.BaseRefName)...)
+	switch {
+	case err != nil:
+		unchecked = append(unchecked, fmt.Sprintf(
+			"the shape of branch protection on %s, because this token cannot read it. That "+
+				"read needs administration rights, and it is proved on the real path instead: "+
+				"a wrong key there leaves an empty required list, which refuses every merge",
+			p.BaseRefName))
+	default:
+		var body struct {
+			RequiredStatusChecks struct {
+				Contexts []string `json:"contexts"`
+			} `json:"required_status_checks"`
+		}
+		if err := json.Unmarshal(raw, &body); err != nil {
+			problems = append(problems, fmt.Sprintf("reading branch protection: %v", err))
+		} else if len(body.RequiredStatusChecks.Contexts) == 0 {
+			problems = append(problems, "branch protection carries no "+
+				"`required_status_checks.contexts`, and that is the list this command refuses on. "+
+				"An empty one would let every merge past the context check")
+		} else {
+			fmt.Fprintf(out, "ok  %-44s %d contexts\n",
+				"protection carries the required list", len(body.RequiredStatusChecks.Contexts))
+		}
+	}
+
+	for _, u := range unchecked {
+		fmt.Fprintf(out, "not checked  %s\n", u)
+	}
+	if len(problems) > 0 {
+		return fmt.Errorf("the field names this command uses do not match the API.\n  %s",
+			strings.Join(problems, "\n  "))
+	}
+	return nil
+}
+
+func sortedKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
 func main() {
 	repo := flag.String("repo", "", "owner/name, defaulting to the repository gh resolves here")
 	number := flag.Int("pr", 0, "the pull request to merge")
 	bodyText := flag.String("body", "", "the squash body, which this command appends the sign-off to")
 	bodyFile := flag.String("body-file", "", "read the squash body from a file")
 	dry := flag.Bool("dry-run", false, "check everything and print the merge command without running it")
+	fields := flag.Bool("check-fields", false, "ask the real API whether this command's field names exist, and merge nothing")
+	only := flag.Bool("confirm-only", false, "read an already merged pull request and prove its commit carries the sign-off")
 	attempts := flag.Int("confirm-attempts", 10, "how many times to ask whether the merge landed")
 	interval := flag.Duration("confirm-interval", 3*time.Second, "how long to wait between asks")
 	flag.Parse()
@@ -720,7 +998,42 @@ func main() {
 		*repo = strings.TrimSpace(string(out))
 	}
 
-	if err := merge(hub{runner: r, repo: *repo}, r, *number, *bodyText, *dry, *attempts, *interval, os.Stdout); err != nil {
+	h := hub{runner: r, repo: *repo}
+
+	// Two read only modes, both of which merge nothing.
+	//
+	// -check-fields exists because this command once asked gh for a field that
+	// does not exist and every test passed anyway. -confirm-only exists
+	// because the readback that proves a merge carried its sign-off used to
+	// run only after a merge, which meant it only ever ran under a fixture. It
+	// runs against any merged pull request now, so the code path that decides
+	// whether a commit is signed can be exercised on a real commit without
+	// merging anything to exercise it.
+	switch {
+	case *fields:
+		if err := checkFields(h, *number, os.Stdout); err != nil {
+			fmt.Fprintf(os.Stderr, "\nprmerge: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("prmerge: every field name this command uses is one the API has\n")
+		return
+	case *only:
+		name, email, err := identity(r)
+		if err != nil {
+			fail("%v", err)
+		}
+		own, err := trailer(name, email)
+		if err != nil {
+			fail("%v", err)
+		}
+		if err := confirm(h, *number, own, *attempts, *interval, os.Stdout); err != nil {
+			fmt.Fprintf(os.Stderr, "\nprmerge: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	if err := merge(h, r, *number, *bodyText, *dry, *attempts, *interval, os.Stdout); err != nil {
 		fmt.Fprintf(os.Stderr, "\nprmerge: %v\n", err)
 		os.Exit(1)
 	}

--- a/tools/prmerge/main_test.go
+++ b/tools/prmerge/main_test.go
@@ -141,6 +141,7 @@ type fake struct {
 	mergeErr   error
 	configErr  error
 	protErr    error
+	pullErr    error
 
 	issued [][]string
 }
@@ -160,6 +161,9 @@ func (f *fake) run(name string, args ...string) ([]byte, error) {
 		}
 		return []byte(f.email + "\n"), nil
 	case name == "gh" && args[0] == "pr" && args[1] == "view":
+		if f.pullErr != nil {
+			return nil, f.pullErr
+		}
 		if len(f.pulls) == 0 {
 			return nil, errors.New("the test gave no pull request answer")
 		}
@@ -861,4 +865,206 @@ func TestARefusalNamesEveryReasonAtOnce(t *testing.T) {
 			t.Errorf("the refusal does not mention %q: %v", want, err)
 		}
 	}
+}
+
+// THE CONTRACT WITH THE OTHER SIDE OF THE BOUNDARY.
+//
+// Everything above this line answers from a fixture this file wrote. That is
+// how a version of this command shipped asking `gh pr view` for a field called
+// `merged`, which does not exist, with 25 green tests behind it. The tests
+// below are about the shapes the API really produces.
+
+// The half that needs no network, and the half that fails silently. A field
+// the struct reads and the request never asks for decodes as a zero value with
+// no error at all: `isDraft` unasked means every pull request looks ready,
+// `mergedAt` unasked means every merged one looks open.
+func TestTheRequestAndTheStructAskForTheSameFields(t *testing.T) {
+	if drift := fieldDrift(pullFieldNames(), structFieldNames()); len(drift) > 0 {
+		for _, d := range drift {
+			t.Error(d)
+		}
+	}
+	// A positive control on the reflection itself. If structFieldNames stopped
+	// finding tags it would return nothing, agree with everything, and this
+	// file would have a check that cannot say no.
+	if got := len(structFieldNames()); got != len(pullFieldNames()) || got == 0 {
+		t.Fatalf("the struct has %d json tags against %d requested fields",
+			got, len(pullFieldNames()))
+	}
+}
+
+// Both directions of that drift, on synthetic lists, because each one is a
+// different bug and each gets a different sentence.
+func TestFieldDriftNamesBothDirections(t *testing.T) {
+	t.Run("read but never asked for", func(t *testing.T) {
+		drift := fieldDrift([]string{"number"}, []string{"number", "mergedAt"})
+		if len(drift) != 1 || !strings.Contains(drift[0], "zero value") {
+			t.Fatalf("got %v", drift)
+		}
+	})
+	t.Run("asked for but never read", func(t *testing.T) {
+		drift := fieldDrift([]string{"number", "title"}, []string{"number"})
+		if len(drift) != 1 || !strings.Contains(drift[0], "nothing reads it") {
+			t.Fatalf("got %v", drift)
+		}
+	})
+	t.Run("agreement", func(t *testing.T) {
+		if drift := fieldDrift([]string{"a", "b"}, []string{"b", "a"}); len(drift) != 0 {
+			t.Fatalf("agreement was reported as drift: %v", drift)
+		}
+	})
+}
+
+// fieldsFake answers the four reads that -check-fields makes.
+func fieldsFake() *fake {
+	return &fake{
+		pulls:      []string{realOpenPull},
+		protection: protectionBody,
+		checkRuns:  checkRunsBody(green()),
+		statuses:   noStatuses,
+	}
+}
+
+func fields(f *fake) (string, error) {
+	var out bytes.Buffer
+	err := checkFields(hub{runner: f, repo: "antifailure/antifailure"}, 235, &out)
+	return out.String(), err
+}
+
+// The positive control for the contract check, against the payloads gh really
+// returns.
+func TestCheckFieldsPassesOnTheRealShapes(t *testing.T) {
+	out, err := fields(fieldsFake())
+	if err != nil {
+		t.Fatalf("the real shapes were reported as wrong: %v\n%s", err, out)
+	}
+	for _, want := range []string{
+		"the request and the struct ask the same",
+		"gh has every field pullFields asks for",
+		"a check run carries the five fields read",
+		"protection carries the required list",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("it never reported %q, so it did not check it:\n%s", want, out)
+		}
+	}
+}
+
+// THE EXACT CASE THAT PRODUCED THIS. gh refuses a field it does not have, and
+// the refusal names the field.
+func TestCheckFieldsRefusesAFieldTheAPIDoesNotHave(t *testing.T) {
+	f := fieldsFake()
+	// The words gh really answered with, on the first real run of this command.
+	f.pullErr = errors.New(`gh pr view 235 --repo antifailure/antifailure --json ` +
+		pullFields + `: exit status 1: Unknown JSON field: "merged"`)
+	out, err := fields(f)
+	if err == nil {
+		t.Fatalf("a refused field list was reported as fine:\n%s", out)
+	}
+	if !strings.Contains(err.Error(), "refused") {
+		t.Errorf("the failure does not say the field list was refused: %v", err)
+	}
+}
+
+// gh accepted the names and the response does not carry one. Different bug,
+// same consequence: a field read as a zero value.
+func TestCheckFieldsRefusesAResponseMissingAKeyItAskedFor(t *testing.T) {
+	f := fieldsFake()
+	f.pulls = []string{strings.Replace(realOpenPull, `"mergedAt":null,`, ``, 1)}
+	out, err := fields(f)
+	if err == nil {
+		t.Fatalf("a response missing a requested key passed:\n%s", out)
+	}
+	if !strings.Contains(err.Error(), "mergedAt") {
+		t.Errorf("the failure does not name the missing key: %v", err)
+	}
+}
+
+// The check run shape, which is where the nine required contexts are read from.
+func TestCheckFieldsRefusesACheckRunMissingAFieldItReads(t *testing.T) {
+	f := fieldsFake()
+	f.checkRuns = `{"total_count":1,"check_runs":[{"id":1,"name":"engine","status":"completed"}]}`
+	out, err := fields(f)
+	if err == nil {
+		t.Fatalf("a check run with no conclusion field passed:\n%s", out)
+	}
+	for _, want := range []string{"conclusion", "started_at"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the failure does not name %q: %v", want, err)
+		}
+	}
+}
+
+// The required list is the thing every refusal rests on. An empty one would
+// let every merge past the context check.
+func TestCheckFieldsRefusesProtectionWithNoRequiredList(t *testing.T) {
+	f := fieldsFake()
+	f.protection = `{"required_status_checks":{"strict":false,"checks":[]}}`
+	out, err := fields(f)
+	if err == nil {
+		t.Fatalf("protection carrying no required list passed:\n%s", out)
+	}
+	if !strings.Contains(err.Error(), "required_status_checks") {
+		t.Errorf("the failure does not name the key it could not find: %v", err)
+	}
+}
+
+// What it could NOT check is named rather than passed over. Reading branch
+// protection needs administration rights, so a token without them reaches this
+// every time, and a check that quietly counted that as a pass would be the
+// defect this repository keeps finding in its own instruments.
+func TestCheckFieldsNamesWhatItCouldNotCheck(t *testing.T) {
+	f := fieldsFake()
+	f.protErr = errors.New("gh: HTTP 403: Resource not accessible by personal access token")
+	out, err := fields(f)
+	if err != nil {
+		t.Fatalf("it failed over a read it never claimed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "not checked") || !strings.Contains(out, "administration rights") {
+		t.Errorf("it did not say which read it could not make:\n%s", out)
+	}
+	// The commit here carries no status, so that gap is named too rather than
+	// counted as a check of the status shape.
+	if !strings.Contains(out, "carries none") {
+		t.Errorf("it did not say the commit status shape went unexamined:\n%s", out)
+	}
+}
+
+// The readback that proves a merge carried its sign-off used to run only after
+// a merge, which meant it only ever ran under a fixture. It runs against any
+// merged pull request now, and both directions are proved: a merge commit that
+// carries the trailer and one that does not. The unsigned case is real, and it
+// is what `337f4b70` and its five siblings look like.
+func TestTheReadbackRunsAgainstAMergedPullRequest(t *testing.T) {
+	own := "Signed-off-by: Vir Sanghavi <67278851+VirSanghavi@users.noreply.github.com>"
+	t.Run("a merge that carried it", func(t *testing.T) {
+		f := ready(green(), "CLEAN")
+		f.pulls = []string{mergedPull("3692ab054444d634939b5df4bac89eb95465acd2")}
+		var out bytes.Buffer
+		if err := confirm(hub{runner: f, repo: "antifailure/antifailure"}, 235, own, 2, 0, &out); err != nil {
+			t.Fatalf("a signed merge commit was reported as unsigned: %v\n%s", err, out.String())
+		}
+		if f.merged() {
+			t.Fatal("the readback merged something")
+		}
+		// It has to SAY it read the commit. A readback that returns quietly is
+		// indistinguishable from one that did not run, which is the whole
+		// reason this path is being exercised on its own.
+		if !strings.Contains(out.String(), "the commit carries the sign-off") {
+			t.Errorf("it never said it had read the commit back:\n%s", out.String())
+		}
+	})
+	t.Run("a merge that did not", func(t *testing.T) {
+		f := ready(green(), "CLEAN")
+		f.pulls = []string{mergedPull("337f4b7000000000000000000000000000000000")}
+		f.commit = commitBody("billing: delivery order could remove paid access (#232)\n")
+		var out bytes.Buffer
+		err := confirm(hub{runner: f, repo: "antifailure/antifailure"}, 232, own, 2, 0, &out)
+		if err == nil {
+			t.Fatalf("an unsigned merge commit was reported as fine:\n%s", out.String())
+		}
+		if !strings.Contains(err.Error(), "LANDED") {
+			t.Errorf("the failure does not say the merge landed unsigned: %v", err)
+		}
+	})
 }


### PR DESCRIPTION
## What changed

`tools/prmerge` asked `gh pr view` for a field called `merged`, there is no
such field, and all 25 of its tests passed. #240 fixed the field. This fixes
the reason nothing caught it: every one of those tests answered from a fixture
the suite itself had written, so the fixtures agreed with the code instead of
with the API. A suite that builds its own input can be complete and still
describe a system that does not exist.

The check that reads the other side of the boundary comes in two halves,
because the two failures are different and only one of them needs a network.

**The half that needs no network, and the half that fails silently.** The four
`gh` reads are now named argument lists that both the merge path and the check
use, rather than strings written twice, because a field check against a copy of
the call checks the copy. `fieldDrift` compares the field list the request asks
for against the json tags the struct reads, by reflection rather than by a
third list nobody updates, and it runs inside `just gate`. A field read and
never asked for is the silent one: it decodes as a zero value with no error at
all, so `isDraft` unasked means every pull request looks ready and `mergedAt`
unasked means every merged one looks open.

**The half that does.** `just merge <n> -check-fields` runs the same argument
lists against a real pull request and reports a name the API does not have or a
key a real response does not carry: the pull request's field list, the five
fields read off a check run, the four read off a commit status, and the
required list under branch protection. It runs on every pull request in
`.github/workflows/ci.yml` as "the merge command still fits the API", and it is
exempt from `just gate` for the same reason `vulncheck` and `npmaudit` are,
with the reason recorded in `tools/gatecheck`.

It names what it could NOT check rather than passing over it. Branch protection
needs administration rights, so the CI token cannot read it and says so; a
commit carrying no commit status leaves that element shape unexamined, and it
says that too.

Worth recording alongside, because it decides how much this check is load
bearing: all four reads already fail CLOSED on the merge path. A wrong name in
the field list makes `gh` refuse outright; a wrong key under check-runs or
status leaves an empty list, which reads as a required context that never
reported; a wrong key under protection leaves an empty required list, which
reads as nine contexts protection no longer requires. Every one of those
refuses the merge. This exists so the refusal arrives before somebody is
standing at a merge button, and so that it names the field.

**The readback now runs on the real path.** The check that proves a merge
carried its sign-off used to run only after a merge, which meant it had only
ever run under a fixture, and a verification that only ever runs in a test is
the shape of defect this repository keeps finding in its own instruments.
`-confirm-only <n>` runs it on its own against any merged pull request.

## Failure paths covered

| Failure path | Test |
| --- | --- |
| The struct reads a field the request never asks for, which decodes as a zero value with no error | TestTheRequestAndTheStructAskForTheSameFields, TestFieldDriftNamesBothDirections |
| The request asks for a field nothing reads | TestFieldDriftNamesBothDirections |
| The reflection that finds the json tags stops finding them, which would make the check agree with everything | TestTheRequestAndTheStructAskForTheSameFields |
| gh refuses a field name the API does not have, which is the exact case | TestCheckFieldsRefusesAFieldTheAPIDoesNotHave |
| gh accepts the names and the response carries no such key | TestCheckFieldsRefusesAResponseMissingAKeyItAskedFor |
| A check run missing one of the five fields the nine required contexts are read from | TestCheckFieldsRefusesACheckRunMissingAFieldItReads |
| Branch protection carrying no required list, which would let every merge past the context check | TestCheckFieldsRefusesProtectionWithNoRequiredList |
| A read it could not make is named rather than counted as a pass | TestCheckFieldsNamesWhatItCouldNotCheck |
| The readback on a merged commit, in both directions | TestTheReadbackRunsAgainstAMergedPullRequest |
| The positive control, against the payloads gh really returns | TestCheckFieldsPassesOnTheRealShapes |
| A permissions block is not an action reference | TestAPermissionIsNotAnActionReference |

## Security considerations

- Secrets, masked data, the proxy, the journal: none touched. No token is
  printed or read by this code; `gh` holds the credential.
- New outbound connection or stored data class: the new CI job makes three
  read only GitHub API calls about the pull request being built. Nothing is
  stored.
- What an untrusted repository or pull request can reach: the new job takes
  `contents`, `pull-requests`, `checks` and `statuses` at `read` and nothing at
  write, and a job level block replaces the workflow level one rather than
  adding to it, so nothing is inherited. It runs no code from the pull request
  beyond the repository's own tools.
- Dependency: none. Standard library only, plus `reflect`.

One change here is a security check rather than a merge one, and it is worth
calling out. `gatecheck`'s `TestEveryActionIsPinnedToACommit` scans for
`uses:\s*(\S+)`, and `statuses:` ends in those five characters, so the new
job's `statuses: read` permission read as an action called `read` pinned to
nothing and failed the build. The regexp now requires a boundary, and a test
holds both directions: a permissions block yields no action reference, and a
real `uses: actions/checkout@v4` is still found. The property it guards is
unchanged and real, a tag is mutable and a commit is not.

## Exit criteria evidence

```
$ cd tools && go test ./... -count=1 -timeout 10m
(no output but ok lines: the whole tools suite is green)

$ go run ./tools/gatecheck .
gatecheck: 79 gates in 9 pull request workflows.
  68 paired by command and directory to a recipe `just gate` calls.
  9 exempt by name in exemptFromGate, with the reason recorded there.

$ go run ./tools/prosecheck .
prosecheck: 759 files, 0 places where the punctuation gives it away
```

### The live runs, against the real API

This is the part the fixtures could not do, and all three are real
invocations rather than reasoning.

```
$ go run ./tools/prmerge -check-fields -pr 241
ok  the request and the struct ask the same      11 fields
ok  gh has every field pullFields asks for       #241
ok  a check run carries the five fields read     22 runs
ok  the commit status response has its list
ok  protection carries the required list         9 contexts
not checked  the shape of a commit status, because a85651abdedd844a1d581c789c0fc18dd3b817d3 carries none. Every required context on this repository is a check run
prmerge: every field name this command uses is one the API has
exit 0

$ go run ./tools/prmerge -confirm-only -pr 240
ok  the commit carries the sign-off          003061181c19fcd6e79ee52f1b683efaf4663c18
exit 0

$ go run ./tools/prmerge -confirm-only -pr 232
prmerge: the merge LANDED as 337f4b70d4cfaf1ba9dc4c4928a78daaa578de65 and the commit does not carry "Signed-off-by: Vir Sanghavi <...>".
  main's `commits are attributed to their author` context will fail on it, and cd.yml's gate refuses to deploy a commit whose CI failed, so staging will not move.
  Do not rewrite main to fix this: it would break every existing clone and the merge base of every open pull request. Push a signed commit on top instead
exit 1
```

The third one is the negative control and it is not synthetic: `337f4b70` is
pull request 232, one of the six merges that started all of this, and it really
does carry no trailer. The instrument says no on the exact case that produced
it, and yes on the commit that fixed it.

### The mutation table

46 breaks, one per assertion, each confirmed red on its own and green again
after restoring, with the full suite green before the first and after the last.
Ten are new, M37 through M46, and they are the ones that matter here.

| id | the line broken, and the assertion it proves | test | broken / restored |
| --- | --- | --- | --- |
| M01 to M36 | unchanged from #235 and #240, all re-proved on this tree | (as listed there) | red / green |
| M37 | field drift where the struct reads what the request never asks for | TestFieldDriftNamesBothDirections | red / green |
| M38 | field drift where the request asks for what nothing reads | TestFieldDriftNamesBothDirections | red / green |
| M39 | the request and the struct ask for the same fields | TestTheRequestAndTheStructAskForTheSameFields | red / green |
| M40 | a field list the API refuses is reported as refused | TestCheckFieldsRefusesAFieldTheAPIDoesNotHave | red / green |
| M41 | a check run missing a field this command reads | TestCheckFieldsRefusesACheckRunMissingAFieldItReads | red / green |
| M42 | protection carrying no required list | TestCheckFieldsRefusesProtectionWithNoRequiredList | red / green |
| M43 | a protection read it could not make is named, not passed over | TestCheckFieldsNamesWhatItCouldNotCheck | red / green |
| M44 | a response missing a key it asked for | TestCheckFieldsRefusesAResponseMissingAKeyItAskedFor | red / green |
| M45 | the reflection over the struct tags still finds them | TestTheRequestAndTheStructAskForTheSameFields | red / green |
| M46 | the readback reports the commit it read | TestTheReadbackRunsAgainstAMergedPullRequest | red / green |

M31 is worth naming. It stopped matching when `checkFields` introduced a second
`strings.Join(problems, "\n  ")`, so the runner reported it as unproven rather
than as passing, which is the behaviour a mutation runner has to have. Its
anchor is now the whole return statement and it kills its test again.

## Checklist

- [x] Commits are signed off (`git commit -s`)
- [x] A changelog fragment: `.changes/merge-carries-a-sign-off.md` already
      covers this command. `just changecheck` reports this change as invisible
      to anybody outside the repository
- [x] Documentation is updated: CONTRIBUTING.md documents all three read only
      modes and why `-check-fields` exists
- [x] Every new error code has a catalog entry: no new codes
- [x] No secret, real customer record, or unredacted screenshot is included
