### PR TITLE
dogfood: enabled load and exploration never ran, and their failures could publish as a pass

### DIFF
--- a/.changes/exploration-in-ci.md
+++ b/.changes/exploration-in-ci.md
@@ -1,0 +1,8 @@
+# fixed
+
+Enabled exploration goals now run during pull request checks. Reports retain
+the browser observations and evidence, and identify goals that could not run
+instead of presenting missing exploration as a clean result.
+Exploration-only runs no longer claim to be using a model merely because a
+model key is configured.
+One unreadable exploration result no longer discards evidence from other goals.

--- a/.changes/hosted-policy-findings.md
+++ b/.changes/hosted-policy-findings.md
@@ -1,0 +1,5 @@
+# fixed
+
+- The hosted pull-request check ignored policy findings whenever the browser
+  workflows passed. Failing findings now fail the check, and an incomplete load
+  experiment remains inconclusive instead of being reported as a pass.

--- a/.changes/load-that-sends-traffic.md
+++ b/.changes/load-that-sends-traffic.md
@@ -1,0 +1,8 @@
+# fixed
+
+- A manifest could enable load while CI skipped it, and explicit safe pages
+  filtered away the only default route. CI now honors the manifest, sends a
+  bounded read-only smoke to literal safe routes when no traffic source exists,
+  and reports the request counts. An incomplete load experiment is inconclusive.
+- Synthetic smoke requests count missing pages as errors, and load does not
+  follow unapproved redirects.

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -310,6 +310,7 @@ jobs:
             --mode pr \
             --report "$GITHUB_WORKSPACE/dogfood-report.md" \
             --report-json "$GITHUB_WORKSPACE/dogfood-report.json" \
+            --require-load \
             --record "$GITHUB_WORKSPACE/dogfood-record.json"
 
       # The verdict, to the check the App posts on this pull request.
@@ -697,6 +698,8 @@ jobs:
             --af "$GITHUB_WORKSPACE/bin/af" \
             --mode nightly \
             --refresh-golden \
+            --require-load \
+            --report-json "$GITHUB_WORKSPACE/dogfood-report.json" \
             --record "$GITHUB_WORKSPACE/dogfood-record.json"
 
       - name: Nothing was left behind
@@ -719,6 +722,7 @@ jobs:
           name: nightly-${{ strategy.job-index }}
           path: |
             dogfood-record.json
+            dogfood-report.json
             ${{ matrix.manifest }}/.antifailure/logs
           retention-days: 30
           # Same reason as the control plane job above: without this the log is

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -412,6 +412,7 @@ jobs:
             dogfood-report.json
             dogfood-record.json
             .antifailure/logs
+            .antifailure/artifacts
           retention-days: 30
           # Two reasons the event log was never in this artifact, and fixing
           # either alone would have left it empty. The path said
@@ -724,6 +725,7 @@ jobs:
             dogfood-record.json
             dogfood-report.json
             ${{ matrix.manifest }}/.antifailure/logs
+            ${{ matrix.manifest }}/.antifailure/artifacts
           retention-days: 30
           # Same reason as the control plane job above: without this the log is
           # a dotted path and the action skips it silently.

--- a/antifailure.yaml
+++ b/antifailure.yaml
@@ -281,6 +281,18 @@ workflows:
       - "Scope"
     tags: [policy, rbac]
 
+explore:
+  enabled: true
+  goals:
+    - name: find-a-run-as-a-viewer
+      goal: Find a run and read its verdict and evidence.
+      persona: viewer
+      seed: viewer-run-evidence
+      start_path: /environments
+      slow_ms: 3000
+      budget:
+        steps: 12
+
 invariants:
   # Each of these returns the rows that break it rather than a count of them.
   #

--- a/antifailure.yaml
+++ b/antifailure.yaml
@@ -334,14 +334,27 @@ insights:
   query_regression: true
   plan_diff: true
 
+policy:
+  # This is an availability smoke with no timing baseline. An observed error
+  # rate breach must fail dogfood rather than leave a warning beside success.
+  load_regression: fail
+
 load:
   enabled: true
   source: none
   # A smoke, not a benchmark. The question is whether the control plane answers
   # under any load at all, on a shared CI runner where a number would mean
   # nothing anyway.
-  scale: 0.05
-  duration: 60s
+  #
+  # scale was 0.05 and it was a fraction of a rate that does not exist. It
+  # means a multiplier on PRODUCTION'S arrival rate, and `source: none` has no
+  # production to take one from, so the number it multiplied was the default
+  # shape's 5 requests a second. A quarter of a request a second for a minute
+  # is fifteen requests, which is not a smoke of anything. 1 against a
+  # synthesised 5 is the honest reading of "as fast as the default sends", and
+  # thirty seconds of it is 150 requests across the four pages below.
+  scale: 1
+  duration: 30s
   safe_routes:
     - GET /environments
     - GET /runs

--- a/docs/src/content/docs/concepts/change-analysis.md
+++ b/docs/src/content/docs/concepts/change-analysis.md
@@ -27,7 +27,7 @@ af change --diff pr.patch          against a diff you already have
   run   migration    migrations/20260824_add_billing_status.sql: the path is inside a migrations directory
   run   invariants   migrations/20260824_add_billing_status.sql: the path is inside a migrations directory
   run   workflows    api/billing.ts: the manifest declares the service api at the repository root, so every file in the repository is part of it (and 6 more)
-  gap   load         load is off in the manifest, and af ci generates it only with --load
+  gap   load         load is off in the manifest, so af ci runs it only when it is handed --load
   run   egress       api/billing.ts: an added line names api.stripe.com, which the manifest routes to mode mock (and 1 more)
   skip  masking      nothing this change touches is exercised by it
 ```

--- a/docs/src/content/docs/concepts/exploration.md
+++ b/docs/src/content/docs/concepts/exploration.md
@@ -30,6 +30,15 @@ explore:
 Run it with `af explore`. Every finding names the page, the control and the
 step, so you can go and look.
 
+`af ci` also runs enabled goals, before declared workflows and their final
+database invariants, so those invariants observe writes made while exploring.
+Its JSON and pull request report retain the observations, page and move counts,
+and trace paths. No extra flag or model key is required. Set a step budget on
+each goal to bound the work. A configured goal with no browser evidence makes
+the check incomplete, not a clean exploration; observations remain advisory.
+That incomplete result takes precedence over warnings and flaky workflows,
+but never hides a real workflow, invariant or policy failure.
+
 ## An exploration cannot fail your build
 
 `af explore` reports `pass` unless it could not run at all, and it exits zero

--- a/docs/src/content/docs/concepts/load.md
+++ b/docs/src/content/docs/concepts/load.md
@@ -31,10 +31,23 @@ load:
 | --- | --- |
 | `otel` | An OpenTelemetry trace export in OTLP/JSON, at `source_config.path` |
 | `access_log` | A combined format log file, at `source_config.path` |
-| `none` | No shape; a default that exercises the root, and says so |
+| `none` | Equal-weight literal safe GET and HEAD routes, or the root when none can be derived. Reported as an assumed smoke, not production traffic. |
 
 Both file sources are read from the repository, so no credential and no
 outbound call is involved in deciding what traffic to send.
+
+`af ci` runs load when `load.enabled` is true. The `--load` flag also requests
+it when the block is absent or disabled. With no telemetry, literal read routes
+in `safe_routes` become a five-request-per-second smoke before `scale` applies.
+Glob patterns are filters, not URLs, and write methods are never invented.
+`unsafe_routes` still overrides every allowance. If filtering leaves no route,
+the report is inconclusive, not a pass. Each completed route's request and
+error counts appear in the report.
+
+A smoke counts 4xx responses as errors: a literal page you named must exist.
+An observed production mix retains its recorded 4xx semantics. Neither generator
+follows redirects, because a response cannot authorize another route
+or an external destination.
 
 ```
 AF-LOD-012 There is no load source called datadog.

--- a/docs/src/content/docs/concepts/verdicts.md
+++ b/docs/src/content/docs/concepts/verdicts.md
@@ -26,6 +26,10 @@ check produced a warning or intermittent result. A real failure still wins.
 Completed workflows do not stand in for load that sent no requests or could
 not measure its required baseline.
 
+An incomplete configured exploration is the same exception: it reports
+`blocked` before warnings or flaky workflows, while a real failure still takes
+priority.
+
 ## Blocked is not a failure
 
 `blocked` is the one worth reading twice. It means a browser did not start, an

--- a/docs/src/content/docs/concepts/verdicts.md
+++ b/docs/src/content/docs/concepts/verdicts.md
@@ -21,6 +21,11 @@ When more than one applies, the run reports the worst: `fail`, then `flaky`,
 then `warn`, then `blocked`, then `unverified`. Whichever word wins, the
 comment lists every finding worst first, so nothing is hidden by the order.
 
+A required load experiment that did not complete is `blocked`, even if another
+check produced a warning or intermittent result. A real failure still wins.
+Completed workflows do not stand in for load that sent no requests or could
+not measure its required baseline.
+
 ## Blocked is not a failure
 
 `blocked` is the one worth reading twice. It means a browser did not start, an

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -108,6 +108,9 @@ migrations are rehearsed against a throwaway branch of the golden, and what the
 environment reached for is summarised. Every finding is ranked by the manifest's
 policy block, which decides what fails the check and what is only reported.
 
+Load runs when the manifest enables it. A missing traffic source produces a
+read-only smoke from the literal safe routes, not a production benchmark.
+
 Teardown happens whatever the outcome, including a failure and including an
 interrupt, because an environment that outlives its pull request is the leak
 this product exists to prevent. It happens before the report is written, so a
@@ -135,7 +138,7 @@ af ci --report report.md --report-json report.json --keep
 | `--branch` | - | Branch to check, defaulting to the checked out one. |
 | `--docs` | - | Where documentation links point. |
 | `--keep` | `false` | Leave the environment up, for debugging a failure. |
-| `--load` | `false` | Generate load as well as running the workflows. |
+| `--load` | `false` | Generate load even when the manifest's load block is off. |
 | `--report` | - | Write the report here as well as to the terminal. |
 | `--report-json` | - | Write the same report here as JSON, for a program to read. |
 | `--runner` | - | Path to the runner's entry point. |

--- a/engine/internal/change/change.go
+++ b/engine/internal/change/change.go
@@ -533,7 +533,7 @@ func available(c Check, m *schema.Manifest) (bool, string) {
 		return true, ""
 	case CheckLoad:
 		if m.Load == nil || !m.Load.Enabled {
-			return false, "load is off in the manifest, and af ci generates it only with --load"
+			return false, "load is off in the manifest, so af ci runs it only when it is handed --load"
 		}
 		return true, ""
 	case CheckEgress:

--- a/engine/internal/cli/ci.go
+++ b/engine/internal/cli/ci.go
@@ -19,6 +19,7 @@ import (
 	"github.com/antifailure/antifailure/engine/internal/load"
 	"github.com/antifailure/antifailure/engine/internal/report"
 	"github.com/antifailure/antifailure/engine/internal/runtime/local"
+	"github.com/antifailure/antifailure/engine/pkg/schema"
 )
 
 // af ci is the whole check in one command, because that is how it is used.
@@ -51,6 +52,9 @@ The agents drive the workflows, the invariants are asked of the data, the
 migrations are rehearsed against a throwaway branch of the golden, and what the
 environment reached for is summarised. Every finding is ranked by the manifest's
 policy block, which decides what fails the check and what is only reported.
+
+Load runs when the manifest enables it. A missing traffic source produces a
+read-only smoke from the literal safe routes, not a production benchmark.
 
 Teardown happens whatever the outcome, including a failure and including an
 interrupt, because an environment that outlives its pull request is the leak
@@ -211,7 +215,7 @@ change.`),
 			migration = readDatabase(ctx, e, o, gate,
 				insights.Configure(m.Insights), &run, baseline, saveBaseline)
 
-			if withLoad {
+			if shouldRunLoad(m, withLoad) {
 				e.Out.Section("Generating load")
 				// DefaultDuration rather than Duration, so the manifest's own
 				// load.duration still decides. The hardcoded 30s used to sit
@@ -226,6 +230,7 @@ change.`),
 					// section and no finding, and silence is read as success.
 					e.Out.Printf("  %s %s\n", e.Out.S(StyleWarn, SymbolWarn), lErr.Error())
 					run.Notes = append(run.Notes, "the load run did not complete: "+lErr.Error())
+					run.Load = incompleteLoadReport(res, refused, lErr)
 				default:
 					p95, errorRate := o.Thresholds()
 					run.Load = loadReport(res, refused, p95, errorRate, &run)
@@ -257,7 +262,8 @@ change.`),
 	cmd.Flags().StringVar(&jsonOutput, "report-json", "",
 		"Write the same report here as JSON, for a program to read")
 	cmd.Flags().BoolVar(&skipTeardown, "keep", false, "Leave the environment up, for debugging a failure")
-	cmd.Flags().BoolVar(&withLoad, "load", false, "Generate load as well as running the workflows")
+	cmd.Flags().BoolVar(&withLoad, "load", false,
+		"Generate load even when the manifest's load block is off")
 	cmd.Flags().DurationVar(&timeout, "timeout", 30*time.Minute, "Give up after this long")
 	cmd.Flags().StringVar(&docsBase, "docs", "", "Where documentation links point")
 	cmd.Flags().StringVar(&runner, "runner", "", "Path to the runner's entry point")
@@ -267,6 +273,12 @@ change.`),
 	cmd.Flags().StringVar(&saveBaseline, "save-baseline", "",
 		"Save this run's queries and plans, to compare a later branch against")
 	return cmd
+}
+
+// shouldRunLoad honors the manifest and permits an explicit upward override.
+// The flag cannot silently disable a check the manifest requires.
+func shouldRunLoad(m *schema.Manifest, forced bool) bool {
+	return forced || (m != nil && m.Load != nil && m.Load.Enabled)
 }
 
 // ciExit turns the verdict into an exit status.
@@ -596,6 +608,16 @@ func reportTeardown(e *Env, td *env.Teardown, err error) {
 // at the call site, so `af ci --load` said the same thing whether the safe list
 // let through every route or one out of forty. `af load run` has always
 // reported it. Found by `loadgolden`, which had the other half of this block.
+func incompleteLoadReport(res *load.Result, refused []load.Route, cause error) *report.Load {
+	if res == nil {
+		res = &load.Result{}
+	}
+	var run report.Run
+	l := loadReport(res, refused, 0, 0, &run)
+	l.Unavailable = cause.Error()
+	return l
+}
+
 func loadReport(
 	res *load.Result, refused []load.Route, p95Increase, errorRate float64, run *report.Run,
 ) *report.Load {
@@ -603,11 +625,19 @@ func loadReport(
 		Sent: res.Sent, Rate: res.Rate,
 		ErrorRate: res.ErrorRate, P95Ms: res.Overall.P95Ms,
 		Refused: refusedRoutes(refused),
+		Source:  res.Source,
+	}
+	for _, route := range res.Routes {
+		l.Routes = append(l.Routes, report.LoadRoute{Route: route.Route, Sent: route.Sent, Errors: route.Errors})
+	}
+	if res.Sent == 0 {
+		l.Unavailable = "the load run completed without sending any requests"
 	}
 	for _, b := range res.Breaches(p95Increase, errorRate) {
 		l.Regressed = append(l.Regressed, b.What)
 	}
 	if res.InertP95(p95Increase) {
+		l.Unavailable = "no route had a baseline for the configured p95 threshold"
 		run.Notes = append(run.Notes,
 			"load.thresholds sets p95_increase and no route had a baseline to compare against, "+
 				"so nothing was measured against it")

--- a/engine/internal/cli/ci.go
+++ b/engine/internal/cli/ci.go
@@ -15,6 +15,7 @@ import (
 	"github.com/antifailure/antifailure/engine/internal/egress"
 	"github.com/antifailure/antifailure/engine/internal/env"
 	aferrors "github.com/antifailure/antifailure/engine/internal/errors"
+	"github.com/antifailure/antifailure/engine/internal/explore"
 	"github.com/antifailure/antifailure/engine/internal/insights"
 	"github.com/antifailure/antifailure/engine/internal/load"
 	"github.com/antifailure/antifailure/engine/internal/report"
@@ -104,6 +105,7 @@ change.`),
 				Declared: len(m.Workflows),
 			}
 			started := e.Clock.Now()
+			run.Exploration = declaredExploration(m)
 			var migration []report.Finding
 
 			// Teardown runs at most once and it runs BEFORE the report is
@@ -179,6 +181,13 @@ change.`),
 			// into a signup form would otherwise be indistinguishable from a
 			// masking rule that missed.
 			run.Verification = verifyMasking(ctx, e, o, gate, &run)
+
+			// Exploration can submit forms. Run it before Test so the final
+			// invariants observe those writes instead of blessing earlier data.
+			if run.Exploration != nil {
+				e.Out.Section("Exploring configured goals")
+				exploreConfigured(ctx, o, env.ExploreOptions{RunnerPath: runner}, run.Exploration)
+			}
 
 			e.Out.Section("Running workflows")
 			test, testErr := o.Test(ctx, env.TestOptions{Attempts: 2, RunnerPath: runner})
@@ -273,6 +282,46 @@ change.`),
 	cmd.Flags().StringVar(&saveBaseline, "save-baseline", "",
 		"Save this run's queries and plans, to compare a later branch against")
 	return cmd
+}
+
+// explorer is the one method exploreConfigured needs, so the wiring below has
+// a test of its own. The defect being repaired was a capability with no caller
+// at all, and a call site inside a command body that needs Docker to reach is
+// a call site nothing can assert.
+type explorer interface {
+	Explore(context.Context, env.ExploreOptions) (*explore.Report, error)
+}
+
+// declaredExploration is the report field an enabled manifest requires.
+//
+// Nil when the manifest did not ask for exploration, because an absent field
+// and an empty one mean different things: nothing was configured, against a
+// configured experiment that produced nothing. Only the second is incomplete.
+func declaredExploration(m *schema.Manifest) *report.Exploration {
+	if m == nil || m.Explore == nil || !m.Explore.Enabled {
+		return nil
+	}
+	x := &report.Exploration{}
+	for _, goal := range m.Explore.Goals {
+		x.Declared = append(x.Declared, goal.Name)
+	}
+	return x
+}
+
+// exploreConfigured runs the goals and folds what the browser saw into the
+// report. A refusal is recorded rather than returned, because an exploration
+// that could not run is an incomplete experiment and not a failed change, and
+// whatever it did manage to observe before refusing is still evidence.
+func exploreConfigured(
+	ctx context.Context, x explorer, opts env.ExploreOptions, into *report.Exploration,
+) {
+	observed, err := x.Explore(ctx, opts)
+	if err != nil {
+		into.Unavailable = err.Error()
+	}
+	if observed != nil {
+		into.Results = observed.Explorations
+	}
 }
 
 // shouldRunLoad honors the manifest and permits an explicit upward override.

--- a/engine/internal/cli/ci_exploration_test.go
+++ b/engine/internal/cli/ci_exploration_test.go
@@ -1,0 +1,124 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/antifailure/antifailure/engine/internal/env"
+	"github.com/antifailure/antifailure/engine/internal/explore"
+	"github.com/antifailure/antifailure/engine/internal/report"
+	"github.com/antifailure/antifailure/engine/pkg/schema"
+)
+
+func TestCIWritesExplorationEvidenceIntoItsActualJSONReport(t *testing.T) {
+	x := explore.Exploration{Name: "find-evidence", Seed: "repeatable", Visited: []string{"/runs"}}
+	x.Evidence.Trace = "explore.trace.zip"
+	run := report.Run{Exploration: &report.Exploration{Declared: []string{x.Name}, Results: []explore.Exploration{x}}}
+	for _, needle := range []string{`"Declared":["find-evidence"]`, `"seed":"repeatable"`, `"trace":"explore.trace.zip"`} {
+		t.Run(needle, func(t *testing.T) {
+			body, err := json.Marshal(writeJSONReport(t, run))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(body), needle) {
+				t.Fatalf("missing %s from %s", needle, body)
+			}
+		})
+	}
+}
+
+// The defect this guards is a capability with no caller. Declaring the field
+// and calling the browser are separate steps and each one alone looks done.
+func TestConfiguredGoalsAreDeclaredInTheReport(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		manifest *schema.Manifest
+		declared []string
+		want     bool
+	}{
+		{"nil", nil, nil, false},
+		{"absent", &schema.Manifest{}, nil, false},
+		{"disabled", &schema.Manifest{Explore: &schema.Explore{Goals: []schema.Goal{{Name: "a"}}}}, nil, false},
+		{"enabled", &schema.Manifest{Explore: &schema.Explore{Enabled: true, Goals: []schema.Goal{{Name: "a"}, {Name: "b"}}}}, []string{"a", "b"}, true},
+		{"enabled with no goal", &schema.Manifest{Explore: &schema.Explore{Enabled: true}}, nil, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			x := declaredExploration(tc.manifest)
+			t.Run("configured", func(t *testing.T) {
+				if (x != nil) != tc.want {
+					t.Fatalf("exploration field is %v, want configured=%v", x, tc.want)
+				}
+			})
+			t.Run("goals", func(t *testing.T) {
+				if x == nil {
+					return
+				}
+				if !reflect.DeepEqual(x.Declared, tc.declared) {
+					t.Fatalf("declared %v, want %v", x.Declared, tc.declared)
+				}
+			})
+		})
+	}
+}
+
+type fakeExplorer struct {
+	called int
+	opts   env.ExploreOptions
+	report *explore.Report
+	err    error
+}
+
+func (f *fakeExplorer) Explore(_ context.Context, opts env.ExploreOptions) (*explore.Report, error) {
+	f.called++
+	f.opts = opts
+	return f.report, f.err
+}
+
+func TestConfiguredGoalsActuallyReachTheBrowser(t *testing.T) {
+	observed := explore.Exploration{Name: "goal", Visited: []string{"/runs"}}
+	observed.Outcome.Verdict = "pass"
+	f := &fakeExplorer{report: &explore.Report{Explorations: []explore.Exploration{observed}}}
+	into := &report.Exploration{Declared: []string{"goal"}}
+	exploreConfigured(context.Background(), f, env.ExploreOptions{RunnerPath: "runner.ts"}, into)
+	t.Run("called", func(t *testing.T) {
+		if f.called != 1 {
+			t.Fatalf("Explore was called %d times", f.called)
+		}
+	})
+	t.Run("runner", func(t *testing.T) {
+		if f.opts.RunnerPath != "runner.ts" {
+			t.Fatalf("runner path %q did not reach the explorer", f.opts.RunnerPath)
+		}
+	})
+	t.Run("results", func(t *testing.T) {
+		if len(into.Results) != 1 || into.Results[0].Name != "goal" {
+			t.Fatalf("observations did not reach the report: %v", into.Results)
+		}
+	})
+	t.Run("available", func(t *testing.T) {
+		if into.Unavailable != "" {
+			t.Fatalf("a completed exploration was recorded unavailable: %q", into.Unavailable)
+		}
+	})
+}
+
+func TestARefusedExplorationIsRecordedRatherThanReturned(t *testing.T) {
+	partial := explore.Exploration{Name: "goal"}
+	f := &fakeExplorer{report: &explore.Report{Explorations: []explore.Exploration{partial}}, err: errors.New("no browser")}
+	into := &report.Exploration{Declared: []string{"goal"}}
+	exploreConfigured(context.Background(), f, env.ExploreOptions{}, into)
+	t.Run("unavailable", func(t *testing.T) {
+		if into.Unavailable != "no browser" {
+			t.Fatalf("refusal was not recorded: %q", into.Unavailable)
+		}
+	})
+	t.Run("partial evidence kept", func(t *testing.T) {
+		if len(into.Results) != 1 {
+			t.Fatalf("evidence observed before the refusal was discarded: %v", into.Results)
+		}
+	})
+}

--- a/engine/internal/cli/load_enabled_test.go
+++ b/engine/internal/cli/load_enabled_test.go
@@ -1,0 +1,26 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/pkg/schema"
+)
+
+func TestCILoadEnabled(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		manifest    *schema.Manifest
+		force, want bool
+	}{
+		{"nil", nil, false, false},
+		{"absent", &schema.Manifest{}, false, false},
+		{"disabled", &schema.Manifest{Load: &schema.Load{}}, false, false},
+		{"enabled", &schema.Manifest{Load: &schema.Load{Enabled: true}}, false, true},
+		{"forced absent", &schema.Manifest{}, true, true},
+		{"forced disabled", &schema.Manifest{Load: &schema.Load{}}, true, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) { require.Equal(t, tc.want, shouldRunLoad(tc.manifest, tc.force)) })
+	}
+}

--- a/engine/internal/cli/load_smoke_result_test.go
+++ b/engine/internal/cli/load_smoke_result_test.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/internal/load"
+	"github.com/antifailure/antifailure/engine/internal/report"
+)
+
+func TestLoadSmokeRealFailureThenRecovery(t *testing.T) {
+	for _, tc := range []struct {
+		code    int
+		verdict string
+	}{
+		{http.StatusInternalServerError, report.VerdictFail},
+		{http.StatusOK, report.VerdictPass},
+	} {
+		t.Run(tc.verdict, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(tc.code) }))
+			defer server.Close()
+			shape, _ := load.ShapeFromSafeRoutes([]string{"GET /runs"})
+			res, err := load.Run(context.Background(), load.Options{BaseURL: server.URL, Shape: shape, Scale: 100, Duration: 100 * time.Millisecond, Seed: 1})
+			require.NoError(t, err)
+			run := report.Run{Workflows: []report.Workflow{{Name: "read", Verdict: "pass"}}}
+			run.Load = loadReport(res, nil, 0, 0.02, &run)
+			if finding := loadFinding(run.Load, report.Policy{LoadRegression: report.LevelFail}); finding != nil {
+				run.Findings = append(run.Findings, *finding)
+			}
+			require.Equal(t, tc.verdict, run.Verdict())
+			require.Contains(t, run.Markdown(), "GET /runs:")
+		})
+	}
+}
+
+func TestLoadSmokeReportCarriesMeasurements(t *testing.T) {
+	run := report.Run{}
+	l := loadReport(&load.Result{Sent: 4, Source: "safe_routes", Routes: []load.RouteResult{{Route: "GET /runs", Sent: 4, Errors: 1}}}, nil, 0, 0.02, &run)
+	require.Equal(t, "safe_routes", l.Source)
+	require.Equal(t, []report.LoadRoute{{Route: "GET /runs", Sent: 4, Errors: 1}}, l.Routes)
+	run.Load = l
+	require.Contains(t, run.Markdown(), "Traffic source: safe_routes.")
+	require.Contains(t, run.Markdown(), "GET /runs: 4 requests, 1 errors.")
+}
+
+func TestIncompleteLoadPreservesPartialMeasurements(t *testing.T) {
+	l := incompleteLoadReport(&load.Result{Sent: 4}, nil, errors.New("interrupted"))
+	require.Equal(t, 4, l.Sent)
+	require.Equal(t, "interrupted", l.Unavailable)
+}
+
+func TestIncompleteLoadWithoutAResult(t *testing.T) {
+	l := incompleteLoadReport(nil, nil, errors.New("no safe route"))
+	require.Equal(t, "no safe route", l.Unavailable)
+}
+
+func TestLoadSmokeMissingMeasurementsAreInconclusive(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		result *load.Result
+		p95    float64
+	}{
+		{"zero requests", &load.Result{}, 0},
+		{"no baseline", &load.Result{Sent: 1, Routes: []load.RouteResult{{Route: "GET /runs", Sent: 1}}}, 0.2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			run := report.Run{Workflows: []report.Workflow{{Name: "read", Verdict: "pass"}}}
+			run.Load = loadReport(tc.result, nil, tc.p95, 0.02, &run)
+			require.Equal(t, report.VerdictBlocked, run.Verdict())
+			require.Contains(t, run.Markdown(), "Load was inconclusive:")
+		})
+	}
+}

--- a/engine/internal/env/exploration_decode_test.go
+++ b/engine/internal/env/exploration_decode_test.go
@@ -1,0 +1,68 @@
+package env
+
+import (
+	"reflect"
+	"testing"
+)
+
+const mixedExplorations = `{"explorations":[{"name":"before","outcome":{"verdict":"pass"}},{"name":"broken","visited":17},{"name":"after","outcome":{"verdict":"pass"}}]}`
+
+func TestUnreadableExplorationDoesNotDiscardItsNeighbours(t *testing.T) {
+	r, err := decodeExplorationReport([]byte(mixedExplorations))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var names []string
+	for _, x := range r.Explorations {
+		names = append(names, x.Name)
+	}
+	if !reflect.DeepEqual(names, []string{"before", "broken", "after"}) {
+		t.Fatalf("lost results: %v", names)
+	}
+}
+
+func TestUnreadableExplorationIsBlocked(t *testing.T) {
+	r, err := decodeExplorationReport([]byte(mixedExplorations))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := r.Explorations[1].Outcome.Verdict; got != "blocked" {
+		t.Fatalf("unreadable result is %q", got)
+	}
+}
+
+func TestNullExplorationIsAnExplicitBlockedResult(t *testing.T) {
+	r, err := decodeExplorationReport([]byte(`{"explorations":[null]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := r.Explorations[0].Outcome.Verdict; got != "blocked" {
+		t.Fatalf("null result is %q", got)
+	}
+}
+
+func TestNonJSONExplorationReportRefuses(t *testing.T) {
+	if _, err := decodeExplorationReport([]byte("unreadable")); err == nil {
+		t.Fatal("unreadable document was accepted")
+	}
+}
+
+func TestUnknownExplorationVerdictIsBlocked(t *testing.T) {
+	r, err := decodeExplorationReport([]byte(`{"explorations":[{"name":"goal","outcome":{"verdict":"future"}}]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := r.Explorations[0].Outcome.Verdict; got != "blocked" {
+		t.Fatalf("unknown result is %q", got)
+	}
+}
+
+func TestANamelessExplorationIsBlocked(t *testing.T) {
+	r, err := decodeExplorationReport([]byte(`{"explorations":[{"outcome":{"verdict":"pass"}}]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := r.Explorations[0].Outcome.Verdict; got != "blocked" {
+		t.Fatalf("a result the runner did not name is %q", got)
+	}
+}

--- a/engine/internal/env/explore.go
+++ b/engine/internal/env/explore.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -51,7 +52,7 @@ type goalDoc struct {
 // about. The workflow half of the same document is decoded into TestReport by
 // Test, which is why the counts and the results are not repeated here.
 type resultDocument struct {
-	Explorations []explore.Exploration `json:"explorations"`
+	Explorations []json.RawMessage `json:"explorations"`
 }
 
 // Explore sends agents at the manifest's goals with no declared workflow.
@@ -103,12 +104,42 @@ func (o *Orchestrator) Explore(ctx context.Context, opts ExploreOptions) (*explo
 	if err != nil {
 		return nil, err
 	}
+	return decodeExplorationReport(out)
+}
+
+// Decode one result at a time so a malformed neighbor cannot erase evidence
+// from goals that the browser really exercised.
+func decodeExplorationReport(out []byte) (*explore.Report, error) {
 	var doc resultDocument
 	if err := json.Unmarshal(out, &doc); err != nil {
 		return nil, aferrors.Wrap(err, aferrors.AFAGT003,
 			"detail", "the runner's output could not be read: "+err.Error())
 	}
-	return &explore.Report{Explorations: doc.Explorations}, nil
+	result := &explore.Report{}
+	for i, raw := range doc.Explorations {
+		var x explore.Exploration
+		err := json.Unmarshal(raw, &x)
+		unknown := x.Outcome.Verdict != "pass" && x.Outcome.Verdict != "blocked"
+		if err != nil || x.Name == "" || unknown {
+			name := x.Name
+			named := name != ""
+			if name == "" {
+				name = fmt.Sprintf("unreadable-result-%d", i+1)
+			}
+			x = explore.Exploration{Name: name}
+			x.Outcome.Verdict = "blocked"
+			x.Outcome.Cause = "runner-failure"
+			x.Outcome.Detail = "The runner returned an exploration with no readable name."
+			if unknown && named {
+				x.Outcome.Detail = "The runner returned an unsupported exploration verdict."
+			}
+			if err != nil {
+				x.Outcome.Detail = "The runner returned an unreadable exploration: " + err.Error()
+			}
+		}
+		result.Explorations = append(result.Explorations, x)
+	}
+	return result, nil
 }
 
 // Goals is what the manifest declares, for a caller that has to map a result

--- a/engine/internal/env/load_safe_source_test.go
+++ b/engine/internal/env/load_safe_source_test.go
@@ -1,0 +1,36 @@
+package env
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/internal/load"
+	"github.com/antifailure/antifailure/engine/pkg/schema"
+)
+
+func TestTrafficShapeLiteralSafeRoutes(t *testing.T) {
+	for _, source := range []schema.LoadSource{"", schema.LoadNone} {
+		t.Run("source_"+string(source), func(t *testing.T) {
+			shape, err := loadOrchestrator(t, t.TempDir(), &schema.Load{Source: source, SafeRoutes: []string{"GET /runs"}}).trafficShape()
+			require.NoError(t, err)
+			require.Equal(t, []load.Route{{Method: "GET", Path: "/runs", Weight: 1}}, shape.Routes)
+		})
+	}
+}
+
+func TestTrafficShapeGlobFallbackStillFilters(t *testing.T) {
+	shape, err := loadOrchestrator(t, t.TempDir(), &schema.Load{SafeRoutes: []string{"GET /runs/*"}}).trafficShape()
+	require.NoError(t, err)
+	require.Equal(t, "default", shape.Source)
+	safe, _ := shape.Safe([]string{"GET /runs/*"}, nil)
+	require.Empty(t, safe.Routes)
+}
+
+func TestTrafficShapeExplicitSourceWinsOverSafeRoutes(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "access.log", `1.2.3.4 - - [01/Jun/2026:12:00:00 +0000] "GET /observed HTTP/1.1" 200 12`+"\n")
+	shape, err := loadOrchestrator(t, root, &schema.Load{Source: schema.LoadAccessLog, SourceConfig: map[string]string{"path": "access.log"}, SafeRoutes: []string{"GET /invented"}}).trafficShape()
+	require.NoError(t, err)
+	require.Equal(t, "/observed", shape.Routes[0].Path)
+}

--- a/engine/internal/env/test.go
+++ b/engine/internal/env/test.go
@@ -827,6 +827,18 @@ func (o *Orchestrator) Thresholds() (p95Increase, errorRate float64) {
 func (o *Orchestrator) trafficShape() (load.Shape, error) {
 	cfg := o.opts.Manifest.Load
 	if cfg == nil || cfg.Source == "" || cfg.Source == schema.LoadNone {
+		// The safe list before the default, because a project that wrote one
+		// has said more about its own traffic than the default knows. The
+		// default's only route is `GET /`, and Safe below can only remove
+		// routes, so a manifest naming four pages and no source produced an
+		// empty mix and AF-LOD-010 on every run. Falling back when nothing
+		// concrete survives keeps the smoke test for a manifest whose safe
+		// list is a single glob.
+		if cfg != nil {
+			if shape, ok := load.ShapeFromSafeRoutes(cfg.SafeRoutes); ok {
+				return shape, nil
+			}
+		}
 		return load.DefaultShape(), nil
 	}
 

--- a/engine/internal/explore/explore.go
+++ b/engine/internal/explore/explore.go
@@ -229,18 +229,24 @@ func (r Report) Headline() string {
 	if len(r.Explorations) == 0 {
 		return "No exploration ran."
 	}
-	if b := r.Blocked(); b == len(r.Explorations) {
+	b := r.Blocked()
+	if b == len(r.Explorations) {
 		return fmt.Sprintf("%s could not run, so nothing was explored.",
 			plural(b, "exploration", "explorations"))
 	}
 	findings := r.Findings()
+	observed := len(r.Explorations) - b
+	suffix := ""
+	if b > 0 {
+		suffix = fmt.Sprintf(" Not explored: %s could not run.", plural(b, "exploration", "explorations"))
+	}
 	if len(findings) == 0 {
 		return fmt.Sprintf("%s wandered the application and found nothing worth reporting.",
-			plural(len(r.Explorations), "exploration", "explorations"))
+			plural(observed, "exploration", "explorations")) + suffix
 	}
 	return fmt.Sprintf("%s found %s. None of it counts against this change.",
-		plural(len(r.Explorations), "exploration", "explorations"),
-		plural(len(findings), "thing", "things"))
+		plural(observed, "exploration", "explorations"),
+		plural(len(findings), "thing", "things")) + suffix
 }
 
 func plural(n int, one, many string) string {

--- a/engine/internal/explore/partial_test.go
+++ b/engine/internal/explore/partial_test.go
@@ -1,0 +1,30 @@
+package explore
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPartialExplorationNeverCountsBlockedGoalsAsObserved(t *testing.T) {
+	for _, name := range []string{"clean", "findings"} {
+		t.Run(name, func(t *testing.T) {
+			good, bad := Exploration{}, Exploration{}
+			good.Outcome.Verdict = "pass"
+			bad.Outcome.Verdict = "blocked"
+			if name == "findings" {
+				good.Findings = []Finding{{Kind: KindNoEffect}}
+			}
+			headline := (Report{Explorations: []Exploration{good, bad}}).Headline()
+			t.Run("observed", func(t *testing.T) {
+				if !strings.HasPrefix(headline, "1 exploration ") {
+					t.Fatalf("miscounted execution: %s", headline)
+				}
+			})
+			t.Run("blocked", func(t *testing.T) {
+				if !strings.Contains(headline, "1 exploration could not run") {
+					t.Fatalf("missing blocked goals: %s", headline)
+				}
+			})
+		})
+	}
+}

--- a/engine/internal/load/run.go
+++ b/engine/internal/load/run.go
@@ -130,6 +130,8 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 
 	client := &http.Client{
 		Timeout: 30 * time.Second,
+		// A response cannot authorize traffic outside the selected safe route.
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse },
 		Transport: &http.Transport{
 			MaxIdleConnsPerHost: opts.Concurrency,
 			// Compression off, so the numbers measure the application rather
@@ -160,7 +162,7 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 		go func(r Route) {
 			defer wg.Done()
 			defer func() { <-sem }()
-			send(ctx, client, opts.BaseURL, r, m, opts.Clock)
+			send(ctx, client, opts.BaseURL, r, m, opts.Clock, opts.Shape.Source == "safe_routes" || opts.Shape.Source == "default")
 		}(route)
 
 		if opts.Progress != nil && !opts.Clock.Now().Before(reportAt) {
@@ -188,19 +190,19 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 
 func send(
 	ctx context.Context, client *http.Client, baseURL string,
-	route Route, m *meter, c clock.Clock,
+	route Route, m *meter, c clock.Clock, smoke bool,
 ) {
 	status, elapsed, err := sendOnce(ctx, client, baseURL, route, c)
 	reason := ""
 	switch {
 	case err != nil:
 		reason = classify(err)
-	case status >= 500:
+	case status >= 500 || (smoke && status >= 400):
 		// A mix read from production contains the routes production serves,
 		// and some of those answer 404 for most of their traffic. Counting a
 		// 404 here would report the shape's own contents as a failure. A
-		// scenario is judged differently, because a declared journey that
-		// gets a 404 is a broken journey.
+		// scenario or synthetic smoke is judged differently: a declared path
+		// that gets a 404 is broken rather than observed production traffic.
 		reason = strconv.Itoa(status)
 	}
 	m.record(route.String(), elapsed, reason)

--- a/engine/internal/load/safe_shape_test.go
+++ b/engine/internal/load/safe_shape_test.go
@@ -1,0 +1,122 @@
+package load_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/internal/load"
+)
+
+func TestSafeShapeConcreteReads(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		safe   []string
+		routes []load.Route
+	}{
+		{"get", []string{"GET /runs"}, []load.Route{{Method: "GET", Path: "/runs", Weight: 1}}},
+		{"head", []string{"HEAD /health"}, []load.Route{{Method: "HEAD", Path: "/health", Weight: 1}}},
+		{"methodless", []string{"/runs"}, []load.Route{{Method: "GET", Path: "/runs", Weight: 1}}},
+		{"duplicates", []string{"GET /runs", "get /runs", "/runs"}, []load.Route{{Method: "GET", Path: "/runs", Weight: 1}}},
+		{"malformed beside valid", []string{"GET bad", "GET /bad path", "GET /bad#fragment", "GET /bad\\path", "", "GET /runs"}, []load.Route{{Method: "GET", Path: "/runs", Weight: 1}}},
+		{"bad escape beside valid", []string{"GET /bad%zz", "GET /runs"}, []load.Route{{Method: "GET", Path: "/runs", Weight: 1}}},
+		{"absolute url beside valid", []string{"GET http://elsewhere.example/x", "GET /runs"}, []load.Route{{Method: "GET", Path: "/runs", Weight: 1}}},
+		{"lowercase method", []string{"get /runs"}, []load.Route{{Method: "GET", Path: "/runs", Weight: 1}}},
+		{"writes and globs", []string{"POST /charge", "DELETE /runs", "GET /runs/*", "GET /runs"}, []load.Route{{Method: "GET", Path: "/runs", Weight: 1}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			shape, _ := load.ShapeFromSafeRoutes(tc.safe)
+			require.Equal(t, tc.routes, shape.Routes)
+		})
+	}
+}
+
+func TestLoadSmokeMissingPageIsAnError(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+	for _, tc := range []struct {
+		source    string
+		errorRate float64
+	}{
+		{"safe_routes", 1}, {"default", 1}, {"access_log", 0},
+	} {
+		t.Run(tc.source, func(t *testing.T) {
+			res, err := load.Run(context.Background(), load.Options{BaseURL: server.URL, Shape: load.Shape{Source: tc.source, RequestsPerSecond: 500, Routes: []load.Route{{Method: "GET", Path: "/missing", Weight: 1}}}, Duration: 100 * time.Millisecond})
+			require.NoError(t, err)
+			require.Equal(t, tc.errorRate, res.ErrorRate)
+		})
+	}
+}
+
+func TestLoadCannotFollowAnUnapprovedRedirect(t *testing.T) {
+	for _, kind := range []string{"mix", "scenario"} {
+		t.Run(kind, func(t *testing.T) {
+			var outside atomic.Int64
+			var inside atomic.Int64
+			destination := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { outside.Add(1); w.WriteHeader(http.StatusOK) }))
+			defer destination.Close()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				inside.Add(1)
+				http.Redirect(w, r, destination.URL, http.StatusFound)
+			}))
+			defer server.Close()
+			var err error
+			if kind == "mix" {
+				_, err = load.Run(context.Background(), load.Options{BaseURL: server.URL, Shape: load.DefaultShape(), Scale: 100, Duration: 100 * time.Millisecond})
+			} else {
+				_, err = load.RunScenarios(context.Background(), load.ScenarioOptions{
+					BaseURL: server.URL, SafeRoutes: []string{"GET /"},
+					Runs: []load.ScenarioRun{{Scenario: mustParse(t, "scenario: redirect\nsteps:\n  - request: GET /\n"), Sessions: 1, Iterations: 1}},
+				})
+			}
+			require.NoError(t, err)
+			require.Positive(t, inside.Load())
+			require.Zero(t, outside.Load())
+		})
+	}
+}
+
+func TestSafeShapeFallback(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		routes []string
+	}{
+		{"empty", nil}, {"glob", []string{"GET /**"}}, {"write", []string{"POST /charge"}}, {"malformed", []string{"bad"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, ok := load.ShapeFromSafeRoutes(tc.routes)
+			require.False(t, ok)
+		})
+	}
+}
+
+func TestSafeShapeSendsDeclaredReads(t *testing.T) {
+	var mu sync.Mutex
+	hits := map[string]int{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		hits[r.Method+" "+r.URL.Path]++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	shape, _ := load.ShapeFromSafeRoutes([]string{"GET /runs", "HEAD /health", "POST /charge", "GET /blocked"})
+	shape, _ = shape.Safe([]string{"/**"}, []string{"GET /blocked"})
+	result, err := load.Run(context.Background(), load.Options{BaseURL: server.URL, Shape: shape, Scale: 100, Duration: 300 * time.Millisecond, Seed: 5})
+	require.NoError(t, err)
+	mu.Lock()
+	defer mu.Unlock()
+	require.Positive(t, hits["GET /runs"])
+	require.Positive(t, hits["HEAD /health"])
+	require.Zero(t, hits["POST /charge"])
+	require.Zero(t, hits["GET /blocked"])
+	require.Equal(t, hits["GET /runs"]+hits["HEAD /health"], result.Sent)
+	require.Equal(t, "safe_routes", result.Source)
+	require.Equal(t, float64(500), result.TargetRate)
+}

--- a/engine/internal/load/scenario_run.go
+++ b/engine/internal/load/scenario_run.go
@@ -144,6 +144,8 @@ func RunScenarios(ctx context.Context, opts ScenarioOptions) ([]ScenarioResult, 
 
 	client := &http.Client{
 		Timeout: 30 * time.Second,
+		// A response cannot authorize traffic outside the selected safe route.
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse },
 		Transport: &http.Transport{
 			MaxIdleConnsPerHost: opts.Concurrency,
 			// Compression off, so the numbers measure the application rather

--- a/engine/internal/load/shape.go
+++ b/engine/internal/load/shape.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"net/url"
 	"sort"
 	"strings"
 	"time"
@@ -186,8 +187,8 @@ func (p *Picker) Interval(perSecond float64) time.Duration {
 
 // DefaultShape is what a project with no traffic source gets.
 //
-// A guess, and it says so. It exercises the root and a health path, which
-// every application has, at a rate low enough to be pointless as a load test
+// A guess, and it says so. It exercises the root
+// at a rate low enough to be pointless as a load test
 // and useful as a smoke test. The report says the source was a default so
 // nobody mistakes it for production's shape.
 func DefaultShape() Shape {
@@ -198,6 +199,54 @@ func DefaultShape() Shape {
 			{Method: "GET", Path: "/", Weight: 10},
 		},
 	}
+}
+
+// ShapeFromSafeRoutes builds a mix out of the routes the manifest named safe.
+//
+// DefaultShape only names the root. Filtering it through an explicit list of
+// pages previously removed every route, so naming safe routes prevented any
+// traffic. With no telemetry, those literal read routes are the available
+// smoke shape, equally weighted and explicitly not a production measurement.
+// Globs cannot be expanded into real URLs. A methodless route becomes GET;
+// neither a methodless allowance nor a safe write route invents write traffic.
+//
+// ok is false when nothing concrete survives, so the caller falls back to the
+// default rather than running against an empty mix.
+func ShapeFromSafeRoutes(safe []string) (Shape, bool) {
+	shape := Shape{Source: "safe_routes", RequestsPerSecond: 5}
+	seen := map[string]bool{}
+	for _, p := range safe {
+		method, path, hasMethod := strings.Cut(strings.TrimSpace(p), " ")
+		if !hasMethod {
+			path, method = method, "GET"
+		}
+		path = strings.TrimSpace(path)
+		if path == "" || !strings.HasPrefix(path, "/") || strings.ContainsAny(path, "* \t\r\n#\\") {
+			continue
+		}
+		if _, err := url.ParseRequestURI(path); err != nil {
+			continue
+		}
+		method = strings.ToUpper(strings.TrimSpace(method))
+		// GET and HEAD only. A safe list is about what may be CALLED, and a
+		// project that lists `POST /search` because a person may safely press
+		// the button has not agreed to four hundred of them a second. The
+		// route is still allowed through Safe when a real source carries it;
+		// what is refused is inventing traffic for it out of nothing.
+		if method != "GET" && method != "HEAD" {
+			continue
+		}
+		route := Route{Method: method, Path: path, Weight: 1}
+		if seen[route.String()] {
+			continue
+		}
+		seen[route.String()] = true
+		shape.Routes = append(shape.Routes, route)
+	}
+	if len(shape.Routes) == 0 {
+		return Shape{}, false
+	}
+	return shape, true
 }
 
 // FromAccessLog reads a shape out of a combined format access log.

--- a/engine/internal/report/exploration_test.go
+++ b/engine/internal/report/exploration_test.go
@@ -1,0 +1,135 @@
+package report
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/antifailure/antifailure/engine/internal/explore"
+)
+
+func exploredGoal() explore.Exploration {
+	x := explore.Exploration{Name: "read-evidence", Visited: []string{"/runs"}}
+	x.Outcome.Verdict = "pass"
+	x.Evidence.Trace = "artifacts/trace.zip"
+	return x
+}
+
+func TestConfiguredExplorationRequiresEvidence(t *testing.T) {
+	for _, name := range []string{"complete", "absent", "blocked", "unknown", "no-page", "no-trace", "duplicate", "duplicate-declaration", "wrong-goal", "extra-goal", "unavailable", "empty-config"} {
+		t.Run(name, func(t *testing.T) {
+			x := exploredGoal()
+			e := &Exploration{Declared: []string{x.Name}, Results: []explore.Exploration{x}}
+			switch name {
+			case "absent":
+				e.Results = nil
+			case "blocked":
+				e.Results[0].Outcome.Verdict = "blocked"
+			case "unknown":
+				e.Results[0].Outcome.Verdict = "future"
+			case "no-page":
+				e.Results[0].Visited = nil
+			case "no-trace":
+				e.Results[0].Evidence.Trace = ""
+			case "duplicate":
+				e.Results = append(e.Results, x)
+			case "duplicate-declaration":
+				// Two goals of the same name. The counts match and every
+				// declared name is present, so only the repeated result
+				// itself says one browser run cannot stand in for two goals.
+				e.Declared = []string{x.Name, x.Name}
+				e.Results = append(e.Results, x)
+			case "wrong-goal":
+				e.Results[0].Name = "another"
+			case "extra-goal":
+				// Every declared goal is accounted for and every result is
+				// complete, and there is still one result too many. Only the
+				// count catches this, so without it the line is untested.
+				extra := exploredGoal()
+				extra.Name = "unasked"
+				e.Results = append(e.Results, extra)
+			case "unavailable":
+				e.Unavailable = "browser refused"
+			case "empty-config":
+				e.Declared = nil
+				e.Results = nil
+			}
+			r := Run{Workflows: []Workflow{{Name: "existing", Verdict: "pass"}}, Exploration: e}
+			want := VerdictBlocked
+			if name == "complete" {
+				want = VerdictPass
+			}
+			if got := r.Verdict(); got != want {
+				t.Fatalf("got %s, want %s", got, want)
+			}
+		})
+	}
+}
+
+func TestExplorationObservationIsNotAnApplicationFailure(t *testing.T) {
+	x := exploredGoal()
+	x.Findings = []explore.Finding{{Kind: explore.KindNoEffect, URL: "/runs", Detail: "Read report did nothing", Step: 2}}
+	r := Run{Workflows: []Workflow{{Verdict: "pass"}}, Exploration: &Exploration{Declared: []string{x.Name}, Results: []explore.Exploration{x}}}
+	if got := r.Verdict(); got != VerdictPass {
+		t.Fatalf("observation changed verdict: %s", got)
+	}
+}
+
+func TestIncompleteExplorationCannotBeHiddenByAnAdvisory(t *testing.T) {
+	for _, name := range []string{"flaky", "warning"} {
+		t.Run(name, func(t *testing.T) {
+			r := Run{Workflows: []Workflow{{Verdict: "flaky"}}, Exploration: &Exploration{Declared: []string{"goal"}}}
+			if name == "warning" {
+				r.Workflows[0].Verdict = "pass"
+				r.Findings = []Finding{{Level: LevelWarn}}
+			}
+			if got := r.Verdict(); got != VerdictBlocked {
+				t.Fatalf("incomplete exploration was hidden by %s", got)
+			}
+		})
+	}
+}
+
+func TestExplorationReportRetainsObservedEvidence(t *testing.T) {
+	x := exploredGoal()
+	x.Findings = []explore.Finding{{Kind: explore.KindNoEffect, URL: "/runs", Detail: "Read report did nothing", Step: 2}}
+	x.Missing = []string{"Delete refused"}
+	x.Journey = []explore.Move{{Kind: "click", Control: "Read report"}}
+	r := Run{Exploration: &Exploration{Declared: []string{x.Name}, Results: []explore.Exploration{x}}}
+	for _, needle := range []string{"read-evidence", "1 page visited, 1 move, 1 observation", "Read report did nothing", "Delete refused", "artifacts/trace.zip"} {
+		t.Run(needle, func(t *testing.T) {
+			if !strings.Contains(r.Markdown(), needle) {
+				t.Fatalf("missing %q", needle)
+			}
+		})
+	}
+}
+
+func TestIncompleteExplorationNamesTheMissingExperiment(t *testing.T) {
+	r := Run{Workflows: []Workflow{{Verdict: "pass"}}, Exploration: &Exploration{Declared: []string{"goal"}, Unavailable: "browser refused"}}
+	for _, needle := range []string{"Configured exploration could not be completed", "browser refused", "not a clean exploration", "Goal `goal` produced no browser result"} {
+		t.Run(needle, func(t *testing.T) {
+			if !strings.Contains(r.Markdown(), needle) {
+				t.Fatalf("missing %q", needle)
+			}
+		})
+	}
+}
+
+func TestARealFailureStillOutranksAnIncompleteExploration(t *testing.T) {
+	for _, name := range []string{"workflow", "invariant", "finding"} {
+		t.Run(name, func(t *testing.T) {
+			r := Run{Exploration: &Exploration{Declared: []string{"goal"}}}
+			switch name {
+			case "workflow":
+				r.Workflows = []Workflow{{Verdict: VerdictFail}}
+			case "invariant":
+				r.Invariants = []Invariant{{Name: "one", Held: false}}
+			case "finding":
+				r.Findings = []Finding{{Level: LevelFail}}
+			}
+			if got := r.Verdict(); got != VerdictFail {
+				t.Fatalf("an incomplete exploration hid a real failure as %s", got)
+			}
+		})
+	}
+}

--- a/engine/internal/report/load_incomplete_test.go
+++ b/engine/internal/report/load_incomplete_test.go
@@ -1,0 +1,30 @@
+package report_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/internal/report"
+)
+
+func TestIncompleteLoadPriority(t *testing.T) {
+	for _, tc := range []struct {
+		name, workflow string
+		level          report.Level
+		verdict        string
+	}{
+		{"warning", "pass", report.LevelWarn, report.VerdictBlocked},
+		{"intermittent", "flaky", report.LevelIgnore, report.VerdictBlocked},
+		{"real failure", "pass", report.LevelFail, report.VerdictFail},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			run := report.Run{
+				Workflows: []report.Workflow{{Name: "read", Verdict: tc.workflow}},
+				Findings:  []report.Finding{{Level: tc.level}},
+				Load:      &report.Load{Unavailable: "interrupted"},
+			}
+			require.Equal(t, tc.verdict, run.Verdict())
+		})
+	}
+}

--- a/engine/internal/report/report.go
+++ b/engine/internal/report/report.go
@@ -13,6 +13,8 @@ import (
 	"slices"
 	"sort"
 	"strings"
+
+	"github.com/antifailure/antifailure/engine/internal/explore"
 )
 
 // Run is everything one pull request check produced.
@@ -23,6 +25,7 @@ type Run struct {
 	Commit      string
 	Golden      string
 	Workflows   []Workflow
+	Exploration *Exploration
 	// Declared is how many workflows the manifest asked for, which is not the
 	// same number as len(Workflows) and was being read as though it were.
 	//
@@ -64,6 +67,80 @@ type Run struct {
 	// DocsBase is where links point, so a self hosted instance can point at
 	// its own copy rather than at ours.
 	DocsBase string
+}
+
+// Exploration preserves the actual browser observations separately from
+// declared workflow assertions. Missing goals are incomplete, never clean.
+type Exploration struct {
+	Declared    []string
+	Results     []explore.Exploration
+	Unavailable string
+}
+
+// Incomplete names a configured exploration whose execution was not proved.
+func (e *Exploration) Incomplete() bool {
+	if e == nil {
+		return false
+	}
+	if e.Unavailable != "" || len(e.Declared) == 0 {
+		return true
+	}
+	seen := map[string]bool{}
+	for _, x := range e.Results {
+		if x.Outcome.Verdict != VerdictPass || len(x.Visited) == 0 || x.Evidence.Trace == "" {
+			return true
+		}
+		if seen[x.Name] {
+			return true
+		}
+		seen[x.Name] = true
+	}
+	for _, name := range e.Declared {
+		if !seen[name] {
+			return true
+		}
+	}
+	return len(e.Results) != len(e.Declared)
+}
+
+func (e *Exploration) markdown() string {
+	if e == nil {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("<details><summary>Exploration observations</summary>\n\n")
+	b.WriteString("These are observations, not workflow assertions.\n\n")
+	if e.Incomplete() {
+		b.WriteString("Configured exploration is incomplete. This is not a clean exploration.\n\n")
+	}
+	if e.Unavailable != "" {
+		fmt.Fprintf(&b, "%s\n\n", flatten(e.Unavailable))
+	}
+	for _, name := range e.Declared {
+		found := false
+		for _, x := range e.Results {
+			if x.Name == name {
+				found = true
+			}
+		}
+		if !found {
+			fmt.Fprintf(&b, "Goal `%s` produced no browser result.\n\n", oneLine(name))
+		}
+	}
+	for _, x := range e.Results {
+		fmt.Fprintf(&b, "Goal `%s`: %s visited, %s, %s. %s\n\n", oneLine(x.Name), plural(len(x.Visited), "page", "pages"), plural(len(x.Journey), "move", "moves"), plural(len(x.Findings), "observation", "observations"), flatten(x.Outcome.Detail))
+		for _, f := range x.Findings {
+			fmt.Fprintf(&b, "- %s at %s, step %d: %s\n", f.Kind.Title(), oneLine(f.URL), f.Step, flatten(f.Detail))
+		}
+		for _, missing := range x.Missing {
+			fmt.Fprintf(&b, "Not explored: %s\n\n", flatten(missing))
+		}
+		if x.Evidence.Trace != "" {
+			fmt.Fprintf(&b, "Trace: `%s`\n\n", oneLine(x.Evidence.Trace))
+		}
+	}
+	b.WriteString("</details>\n\n")
+	return b.String()
 }
 
 // Workflow is one agent result.
@@ -253,8 +330,8 @@ type Cleanup struct {
 	Error string
 }
 
-// The six verdicts, worst first. Nothing outside this list is a run verdict,
-// and the order here is the order Verdict resolves them in.
+// The six verdicts. Verdict also refuses to hide an incomplete configured
+// experiment behind an advisory result.
 const (
 	// VerdictFail is a real finding about the change that stops the merge: a
 	// workflow that failed, an invariant that did not hold, or a finding a
@@ -309,6 +386,8 @@ type Scan struct {
 // A failure outranks everything, then flaky, then warn, then blocked. Blocked
 // below all three on purpose: a flaky workflow and a warning are real signals
 // about the application, and a blocked one is a signal about us.
+// A configured exploration that never completed is an exception: it reports
+// blocked before advisories, matching the hosted check's incomplete result.
 //
 // Warn sits under flaky rather than over it only because flaky already has a
 // headline of its own; the findings section lists everything worst first
@@ -322,7 +401,7 @@ func (r Run) Verdict() string {
 	switch {
 	case counts[VerdictFail] > 0, r.InvariantsViolated() > 0, fail > 0:
 		return VerdictFail
-	case r.Load != nil && r.Load.Unavailable != "":
+	case r.Load != nil && r.Load.Unavailable != "", r.Exploration.Incomplete():
 		return VerdictBlocked
 	case counts[VerdictFlaky] > 0:
 		return VerdictFlaky
@@ -409,6 +488,9 @@ func (r Run) Headline() string {
 		return fmt.Sprintf("Nothing failed, and %s to look at.",
 			plural(warns, "finding", "findings"))
 	case VerdictBlocked:
+		if r.Exploration.Incomplete() {
+			return "Configured exploration could not be completed. Nothing here counts against the change."
+		}
 		if len(r.Workflows) == 0 {
 			return "Nothing ran."
 		}
@@ -578,6 +660,7 @@ func (r Run) Markdown() string {
 	}
 
 	b.WriteString(r.findingSection())
+	b.WriteString(r.Exploration.markdown())
 
 	if len(r.Invariants) > 0 {
 		b.WriteString(r.invariantSection())

--- a/engine/internal/report/report.go
+++ b/engine/internal/report/report.go
@@ -95,11 +95,15 @@ func (i Invariant) Violated() bool { return i.Error == "" && !i.Held }
 
 // Load is a traffic result.
 type Load struct {
-	Sent      int
-	Rate      float64
-	ErrorRate float64
-	P95Ms     float64
-	Regressed []string
+	// Unavailable distinguishes an incomplete experiment from a healthy one.
+	Unavailable string
+	Source      string
+	Routes      []LoadRoute
+	Sent        int
+	Rate        float64
+	ErrorRate   float64
+	P95Ms       float64
+	Regressed   []string
 	// Refused are the routes the generator would not send, because nothing in
 	// the manifest named them safe.
 	//
@@ -109,6 +113,13 @@ type Load struct {
 	// it. The number of requests cannot show it: sending 500 requests at one
 	// route looks like sending 500 across forty.
 	Refused []string
+}
+
+// LoadRoute is the observed request count for one endpoint.
+type LoadRoute struct {
+	Route  string
+	Sent   int
+	Errors int
 }
 
 // Egress summarises outbound traffic.
@@ -311,6 +322,8 @@ func (r Run) Verdict() string {
 	switch {
 	case counts[VerdictFail] > 0, r.InvariantsViolated() > 0, fail > 0:
 		return VerdictFail
+	case r.Load != nil && r.Load.Unavailable != "":
+		return VerdictBlocked
 	case counts[VerdictFlaky] > 0:
 		return VerdictFlaky
 	case warn > 0:
@@ -644,8 +657,17 @@ func (r Run) Markdown() string {
 	}
 
 	if l := r.Load; l != nil {
+		if l.Unavailable != "" {
+			fmt.Fprintf(&b, "Load was inconclusive: %s\n", oneLine(l.Unavailable))
+		}
 		fmt.Fprintf(&b, "Load: %d requests at %.0f a second, p95 %.0fms, %.1f%% failed.\n",
 			l.Sent, l.Rate, l.P95Ms, l.ErrorRate*100)
+		if l.Source != "" {
+			fmt.Fprintf(&b, "Traffic source: %s.\n", oneLine(l.Source))
+		}
+		for _, route := range l.Routes {
+			fmt.Fprintf(&b, "- %s: %d requests, %d errors.\n", oneLine(route.Route), route.Sent, route.Errors)
+		}
 		if len(l.Regressed) > 0 {
 			fmt.Fprintf(&b, "Slower than production: %s\n", strings.Join(l.Regressed, ", "))
 		}

--- a/runner/src/main.ts
+++ b/runner/src/main.ts
@@ -100,7 +100,7 @@ async function main(): Promise<number> {
       )
     : undefined;
 
-  if (model) {
+  if (model && doc.workflows?.length) {
     const how = cassette
       ? `${cassette.mode === 'record' ? 'recording' : 'replaying'} ${cassette.size()} answers in ${cassette.dir}`
       : 'live';

--- a/runner/test/main.test.ts
+++ b/runner/test/main.test.ts
@@ -32,7 +32,7 @@ interface RunnerOutput {
   explorations: unknown[];
 }
 
-async function runMain(doc: Record<string, unknown>): Promise<{
+async function runMain(doc: Record<string, unknown>, environment = process.env): Promise<{
   code: number | null;
   stdout: string;
   stderr: string;
@@ -40,6 +40,7 @@ async function runMain(doc: Record<string, unknown>): Promise<{
   const artifacts = mkdtempSync(join(tmpdir(), 'af-runner-main-'));
   const child = spawn(process.execPath, ['--experimental-strip-types', main], {
     stdio: ['pipe', 'pipe', 'pipe'],
+    env: environment,
   });
   let stdout = '';
   let stderr = '';
@@ -72,6 +73,14 @@ test('a document whose workflows are null is a document with no workflows', asyn
   const doc = JSON.parse(stdout) as RunnerOutput;
   assert.deepEqual(doc.results, []);
   assert.deepEqual(doc.explorations, []);
+});
+
+test('a runner with no workflows does not claim it is using a model', async () => {
+  const result = await runMain({
+    base_url: 'http://127.0.0.1:1', workflows: [], goals: [], personas: [],
+  }, { ...process.env, ANTHROPIC_API_KEY: 'AF_FAKE_UNUSED_MODEL_KEY' });
+  if (result.code !== 0) throw new Error(result.stderr);
+  assert.doesNotMatch(result.stderr, /reading pages with/);
 });
 
 test('a document with no workflows key at all is the same answer', async () => {

--- a/tools/dogfood/exploration.go
+++ b/tools/dogfood/exploration.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+func (r *runner) readExplorationEvidence(run *Run) {
+	refuse := func(reason string) {
+		run.Green = false
+		run.Findings = append(run.Findings, "Exploration evidence could not be verified: "+reason+". The experiment is inconclusive, not an application failure.")
+	}
+	var manifest struct {
+		Explore *struct {
+			Enabled bool
+			Goals   []struct{ Name string }
+		}
+	}
+	body, err := os.ReadFile(filepath.Join(r.root, "antifailure.yaml"))
+	if err != nil {
+		refuse("the manifest could not be read")
+		return
+	}
+	if err = yaml.Unmarshal(body, &manifest); err != nil {
+		refuse("the manifest could not be decoded")
+		return
+	}
+	if manifest.Explore == nil || !manifest.Explore.Enabled {
+		return
+	}
+	var doc struct {
+		Exploration *struct {
+			Unavailable string
+			Results     []struct {
+				Name    string   `json:"name"`
+				Visited []string `json:"visited"`
+				Outcome struct {
+					Verdict string `json:"verdict"`
+				} `json:"outcome"`
+				Evidence struct {
+					Trace string `json:"trace"`
+				} `json:"evidence"`
+			}
+		}
+	}
+	body, err = os.ReadFile(r.reportJSONPath)
+	if err != nil {
+		refuse("the JSON report could not be read")
+		return
+	}
+	if err = json.Unmarshal(body, &doc); err != nil || doc.Exploration == nil {
+		refuse("the report has no readable exploration result")
+		return
+	}
+	if doc.Exploration.Unavailable != "" {
+		refuse(doc.Exploration.Unavailable)
+		return
+	}
+	seen := map[string]bool{}
+	for _, x := range doc.Exploration.Results {
+		if seen[x.Name] || x.Outcome.Verdict != "pass" || len(x.Visited) == 0 || x.Evidence.Trace == "" {
+			refuse(fmt.Sprintf("goal %q has no complete browser evidence", x.Name))
+			return
+		}
+		seen[x.Name] = true
+	}
+	for _, g := range manifest.Explore.Goals {
+		if !seen[g.Name] {
+			refuse(fmt.Sprintf("goal %q did not run", g.Name))
+			return
+		}
+	}
+	if len(seen) != len(manifest.Explore.Goals) || len(seen) == 0 {
+		refuse("the results do not match the declared goals")
+	}
+}

--- a/tools/dogfood/exploration_test.go
+++ b/tools/dogfood/exploration_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDogfoodRequiresConfiguredExploration(t *testing.T) {
+	for name, result := range map[string]string{
+		"complete":    `{"Exploration":{"Results":[{"name":"goal","outcome":{"verdict":"pass"},"visited":["/"],"evidence":{"trace":"trace.zip"}}]}}`,
+		"absent":      `{}`,
+		"unreadable":  `not-json`,
+		"unavailable": `{"Exploration":{"Unavailable":"browser failed"}}`,
+		"empty":       `{"Exploration":{"Results":[]}}`,
+		"blocked":     `{"Exploration":{"Results":[{"name":"goal","outcome":{"verdict":"blocked"},"visited":["/"],"evidence":{"trace":"trace.zip"}}]}}`,
+		"no-page":     `{"Exploration":{"Results":[{"name":"goal","outcome":{"verdict":"pass"},"visited":[],"evidence":{"trace":"trace.zip"}}]}}`,
+		"no-trace":    `{"Exploration":{"Results":[{"name":"goal","outcome":{"verdict":"pass"},"visited":["/"],"evidence":{}}]}}`,
+		// Each of these three reaches exactly one refusal. The goal ran and
+		// left complete evidence, so nothing else in the gate can say no.
+		"unavailable-after-a-complete-goal": `{"Exploration":{"Unavailable":"the browser died during teardown","Results":[{"name":"goal","outcome":{"verdict":"pass"},"visited":["/"],"evidence":{"trace":"trace.zip"}}]}}`,
+		"another-goal-entirely":             `{"Exploration":{"Results":[{"name":"other","outcome":{"verdict":"pass"},"visited":["/"],"evidence":{"trace":"trace.zip"}}]}}`,
+		"one-goal-too-many":                 `{"Exploration":{"Results":[{"name":"goal","outcome":{"verdict":"pass"},"visited":["/"],"evidence":{"trace":"trace.zip"}},{"name":"unasked","outcome":{"verdict":"pass"},"visited":["/"],"evidence":{"trace":"trace.zip"}}]}}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			if err := os.WriteFile(filepath.Join(root, "antifailure.yaml"), []byte("explore:\n  enabled: true\n  goals:\n    - name: goal\n"), 0600); err != nil {
+				t.Fatal(err)
+			}
+			path := filepath.Join(root, "report.json")
+			if err := os.WriteFile(path, []byte(result), 0600); err != nil {
+				t.Fatal(err)
+			}
+			run := &Run{Green: true}
+			(&runner{root: root, reportJSONPath: path}).readExplorationEvidence(run)
+			if run.Green != (name == "complete") {
+				t.Fatalf("green=%v, findings=%v", run.Green, run.Findings)
+			}
+		})
+	}
+}
+
+func TestDogfoodCannotSkipUnreadableExplorationConfiguration(t *testing.T) {
+	for _, name := range []string{"missing-manifest", "malformed-manifest", "missing-report", "disabled"} {
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			body := "explore:\n  enabled: true\n  goals:\n    - name: goal\n"
+			if name == "malformed-manifest" {
+				body = "explore: ["
+			}
+			if name == "disabled" {
+				body = "explore:\n  enabled: false\n"
+			}
+			if name != "missing-manifest" {
+				if err := os.WriteFile(filepath.Join(root, "antifailure.yaml"), []byte(body), 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			run := &Run{Green: true}
+			(&runner{root: root, reportJSONPath: filepath.Join(root, "absent.json")}).readExplorationEvidence(run)
+			if run.Green != (name == "disabled") {
+				t.Fatalf("green=%v, findings=%v", run.Green, run.Findings)
+			}
+		})
+	}
+}

--- a/tools/dogfood/load.go
+++ b/tools/dogfood/load.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// readLoadEvidence keeps an omitted or empty experiment out of the green streak.
+// An infrastructure gap is named as such, not blamed on the application.
+func (r *runner) readLoadEvidence(run *Run) {
+	if !r.requireLoad {
+		return
+	}
+	body, err := os.ReadFile(r.reportJSONPath)
+	if err != nil {
+		run.Green = false
+		run.Findings = append(run.Findings, "Load evidence is unreadable: "+err.Error())
+		return
+	}
+	if err := checkLoadEvidence(body); err != nil {
+		run.Green = false
+		run.Findings = append(run.Findings, "Load was inconclusive: "+err.Error())
+	}
+}
+
+func checkLoadEvidence(body []byte) error {
+	var report struct {
+		Load *struct {
+			Sent        int
+			Unavailable string
+			Routes      []struct {
+				Route string
+				Sent  int
+			}
+		}
+	}
+	if err := json.Unmarshal(body, &report); err != nil {
+		return fmt.Errorf("invalid report: %w", err)
+	}
+	if report.Load == nil {
+		return fmt.Errorf("the report contains no load result")
+	}
+	l := report.Load
+	if l.Unavailable != "" {
+		return fmt.Errorf("%s", l.Unavailable)
+	}
+	if l.Sent <= 0 {
+		return fmt.Errorf("the load generator sent no requests")
+	}
+	total := 0
+	for _, route := range l.Routes {
+		if route.Route == "" || route.Sent <= 0 {
+			return fmt.Errorf("route %q has no observed requests", route.Route)
+		}
+		total += route.Sent
+	}
+	if total != l.Sent {
+		return fmt.Errorf("route requests total %d but load reports %d", total, l.Sent)
+	}
+	return nil
+}

--- a/tools/dogfood/load_test.go
+++ b/tools/dogfood/load_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadEvidence(t *testing.T) {
+	for _, tc := range []struct {
+		name, body string
+		valid      bool
+	}{
+		{"valid", `{"Load":{"Sent":4,"Routes":[{"Route":"GET /runs","Sent":4}]}}`, true},
+		{"invalid JSON", `{`, false},
+		{"omitted", `{}`, false},
+		{"unavailable", `{"Load":{"Unavailable":"unsafe routes","Sent":4,"Routes":[{"Route":"GET /runs","Sent":4}]}}`, false},
+		{"empty", `{"Load":{"Sent":0}}`, false},
+		{"missing routes", `{"Load":{"Sent":4}}`, false},
+		{"unsent route", `{"Load":{"Sent":4,"Routes":[{"Route":"GET /runs","Sent":4},{"Route":"GET /audit","Sent":0}]}}`, false},
+		{"unnamed route", `{"Load":{"Sent":4,"Routes":[{"Sent":4}]}}`, false},
+		{"wrong sum", `{"Load":{"Sent":4,"Routes":[{"Route":"GET /runs","Sent":3}]}}`, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := checkLoadEvidence([]byte(tc.body)); (err == nil) != tc.valid {
+				t.Fatalf("valid=%v, error=%v", tc.valid, err)
+			}
+		})
+	}
+}
+
+func TestLoadEvidenceControlsDogfoodGreen(t *testing.T) {
+	for _, tc := range []struct {
+		name                          string
+		required, write, valid, green bool
+	}{
+		{"not required", false, false, false, true},
+		{"unreadable", true, false, false, false},
+		{"empty experiment", true, true, false, false},
+		{"observed requests", true, true, true, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "report.json")
+			if tc.write {
+				body := `{}`
+				if tc.valid {
+					body = `{"Load":{"Sent":4,"Routes":[{"Route":"GET /runs","Sent":4}]}}`
+				}
+				if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			run := &Run{Green: true}
+			(&runner{requireLoad: tc.required, reportJSONPath: path}).readLoadEvidence(run)
+			if run.Green != tc.green {
+				t.Fatalf("green=%v, findings=%v", run.Green, run.Findings)
+			}
+		})
+	}
+}

--- a/tools/dogfood/main.go
+++ b/tools/dogfood/main.go
@@ -66,9 +66,10 @@ func main() {
 		// written, with no caller.
 		reportJSON = flag.String("report-json", "",
 			"Where af ci writes the same report as JSON, for the control plane")
-		scale   = flag.Float64("budget-scale", 1, "Multiply every budget, for a slower machine")
-		refresh = flag.Bool("refresh-golden", false, "Refresh the golden first, as the nightly does")
-		keep    = flag.Bool("keep", false, "Leave the environment up, for debugging")
+		scale       = flag.Float64("budget-scale", 1, "Multiply every budget, for a slower machine")
+		refresh     = flag.Bool("refresh-golden", false, "Refresh the golden first, as the nightly does")
+		keep        = flag.Bool("keep", false, "Leave the environment up, for debugging")
+		requireLoad = flag.Bool("require-load", false, "Require a completed load report with actual requests")
 	)
 	flag.Parse()
 
@@ -90,6 +91,7 @@ func main() {
 	r := &runner{
 		root: abs, af: binary, mode: *mode, scale: *scale,
 		keep: *keep, refresh: *refresh, reportPath: *report, reportJSONPath: *reportJSON,
+		requireLoad: *requireLoad,
 	}
 	run := r.do()
 
@@ -183,6 +185,7 @@ type runner struct {
 	// reportPath because the Markdown is read by a person on the pull request
 	// and this one is read by the control plane's check.
 	reportJSONPath string
+	requireLoad    bool
 }
 
 // Step is one command, timed and judged.
@@ -275,6 +278,7 @@ func (r *runner) do() *Run {
 	ci := r.step(run, "ci", append([]string{r.af}, args...)...)
 
 	r.readVerdicts(run)
+	r.readLoadEvidence(run)
 
 	// Only ask about events when the run reached the point of making an
 	// environment. `af ci` refusing a directory with no manifest produces no

--- a/tools/dogfood/main.go
+++ b/tools/dogfood/main.go
@@ -279,6 +279,7 @@ func (r *runner) do() *Run {
 
 	r.readVerdicts(run)
 	r.readLoadEvidence(run)
+	r.readExplorationEvidence(run)
 
 	// Only ask about events when the run reached the point of making an
 	// environment. `af ci` refusing a directory with no manifest produces no

--- a/web/apps/api/src/github/exploration.ts
+++ b/web/apps/api/src/github/exploration.ts
@@ -1,0 +1,27 @@
+/** A configured experiment needs observed pages and a trace for every goal.
+ * An older engine omits this field; that is not a configured experiment. */
+export function explorationIncomplete(value: unknown): boolean {
+  if (value === null || value === undefined) return false
+  if (typeof value !== 'object') return true
+  const report = value as Record<string, unknown>
+  if (report.Unavailable) return true
+  if (
+    !Array.isArray(report.Declared) || report.Declared.length === 0 ||
+    !Array.isArray(report.Results)
+  ) return true
+  const seen = new Set<string>()
+  for (const item of report.Results) {
+    if (!item || typeof item !== 'object') return true
+    const result = item as Record<string, unknown>
+    const outcome = result.outcome as { verdict?: unknown } | null
+    const evidence = result.evidence as { trace?: unknown } | null
+    if (
+      typeof result.name !== 'string' || seen.has(result.name) ||
+      outcome?.verdict !== 'pass' || !Array.isArray(result.visited) ||
+      result.visited.length === 0 || typeof evidence?.trace !== 'string' || !evidence.trace
+    ) return true
+    seen.add(result.name)
+  }
+  return report.Declared.some(name => typeof name !== 'string' || !seen.has(name)) ||
+    seen.size !== report.Declared.length
+}

--- a/web/apps/api/src/github/findings.ts
+++ b/web/apps/api/src/github/findings.ts
@@ -1,0 +1,30 @@
+import type { ReportCounts } from './states.ts'
+
+/** Policy findings and incomplete load are part of the verdict, not just prose. */
+export function countPolicyAndLoad(run: Record<string, unknown>, counts: ReportCounts): void {
+  if (run.Findings != null && !Array.isArray(run.Findings)) counts.unverified += 1
+  for (const item of Array.isArray(run.Findings) ? run.Findings : []) {
+    const finding = item as { Level?: unknown } | null
+    switch (finding?.Level) {
+      case 'fail':
+        counts.failed += 1
+        break
+      case 'warn':
+      case 'ignore':
+        break
+      default:
+        counts.unverified += 1
+    }
+  }
+  if (run.Load == null) return
+  if (typeof run.Load !== 'object' || Array.isArray(run.Load)) {
+    counts.unverified += 1
+    return
+  }
+  const load = run.Load as { Unavailable?: unknown; Sent?: unknown }
+  if (typeof load.Unavailable === 'string' && load.Unavailable !== '') {
+    counts.blocked += 1
+  } else if (typeof load.Sent !== 'number' || !Number.isFinite(load.Sent) || load.Sent <= 0) {
+    counts.unverified += 1
+  }
+}

--- a/web/apps/api/src/github/lifecycle.ts
+++ b/web/apps/api/src/github/lifecycle.ts
@@ -33,6 +33,7 @@ import type { Db, Pool } from '@antifailure/db'
 import type { Clock } from '../clock.ts'
 import { suspensionReason } from '../ingest.ts'
 import { GitHubApiError, GitHubPermissionError, type RepositoryApi } from './api.ts'
+import { countPolicyAndLoad } from './findings.ts'
 import {
   CHECK_NAME,
   COMMENT_MARKER,
@@ -1134,6 +1135,7 @@ export function decodeReport(value: unknown): DecodedReport {
     }
   }
 
+  countPolicyAndLoad(run, counts)
   return {
     counts,
     environment: text(run.Environment),

--- a/web/apps/api/src/github/lifecycle.ts
+++ b/web/apps/api/src/github/lifecycle.ts
@@ -28,6 +28,7 @@
 // credential and no address, by design.
 
 import { randomBytes, createHash } from 'node:crypto'
+import { explorationIncomplete } from './exploration.ts'
 import { sql } from 'drizzle-orm'
 import type { Db, Pool } from '@antifailure/db'
 import type { Clock } from '../clock.ts'
@@ -1099,6 +1100,7 @@ export function decodeReport(value: unknown): DecodedReport {
   }
 
   const workflows = Array.isArray(run.Workflows) ? run.Workflows : []
+  if (explorationIncomplete(run.Exploration)) counts.blocked += 1
   for (const item of workflows) {
     const workflow = item as { Verdict?: unknown }
     switch (workflow?.Verdict) {

--- a/web/apps/api/test/exploration-report.test.ts
+++ b/web/apps/api/test/exploration-report.test.ts
@@ -1,0 +1,32 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { decodeReport } from '../src/github/lifecycle.ts'
+import { stateFromReport } from '../src/github/states.ts'
+
+const observed = { name: 'goal', outcome: { verdict: 'pass' }, visited: ['/runs'], evidence: { trace: 'trace.zip' } }
+const complete = { Declared: ['goal'], Results: [observed] }
+const cases: Record<string, unknown> = {
+  complete,
+  legacy: undefined,
+  unavailable: { ...complete, Unavailable: 'browser refused' },
+  absent: { Declared: ['goal'], Results: [] },
+  'null-results': { Declared: ['goal'], Results: null },
+  blocked: { ...complete, Results: [{ ...observed, outcome: { verdict: 'blocked' } }] },
+  'unknown-verdict': { ...complete, Results: [{ ...observed, outcome: { verdict: 'future' } }] },
+  'malformed-element': { Declared: ['goal', 'other'], Results: [observed, null] },
+  'no-page': { ...complete, Results: [{ ...observed, visited: [] }] },
+  'no-trace': { ...complete, Results: [{ ...observed, evidence: {} }] },
+  duplicate: { Declared: ['goal', 'other'], Results: [observed, observed] },
+  unknown: { ...complete, Results: [{ ...observed, name: 'other' }] },
+  malformed: 'unreadable',
+}
+for (const [name, exploration] of Object.entries(cases)) {
+  test(`hosted report exploration ${name}`, () => {
+    const counts = decodeReport({ Workflows: [{ Verdict: 'pass' }], Exploration: exploration }).counts
+    assert.equal(stateFromReport(counts), name === 'complete' || name === 'legacy' ? 'passed' : 'blocked')
+  })
+}
+
+test('exploration observations do not hide a real workflow failure', () => {
+  assert.equal(stateFromReport(decodeReport({ Workflows: [{ Verdict: 'fail' }], Exploration: { ...complete, Unavailable: 'browser refused' } }).counts), 'failed')
+})

--- a/web/apps/api/test/prlifecycle.test.ts
+++ b/web/apps/api/test/prlifecycle.test.ts
@@ -479,6 +479,28 @@ describe(
       assert.equal((await generation(head))?.state, 'passed')
     })
 
+    for (const [name, extra, conclusion] of [
+      ['load policy failure', { Findings: [{ Level: 'fail', Rule: 'load_regression' }] }, 'failure'],
+      ['incomplete load', { Load: { Sent: 0, Unavailable: 'all routes refused' } }, 'action_required'],
+    ] as const) {
+      it(`a reported ${name} reaches the GitHub check`, async () => {
+        const head = sha(name)
+        await deliver('pull_request', pullRequestPayload('opened', 301, head))
+        await deliver('workflow_run', workflowRunPayload('in_progress', head, 5301))
+        const token = await callbackFor(head, 5301)
+        const response = await h.fetch('/v1/pr/report', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+          body: JSON.stringify({
+            head_sha: head,
+            report: { Workflows: [{ Name: 'read', Verdict: 'pass' }], ...extra },
+          }),
+        })
+        if (response.status !== 200) throw new Error(`report refused: ${response.status}`)
+        assert.equal(checkFor(head)?.conclusion, conclusion)
+      })
+    }
+
     // -----------------------------------------------------------------------
     // ordering: callback then request
     // -----------------------------------------------------------------------

--- a/web/apps/api/test/prlifecycle.test.ts
+++ b/web/apps/api/test/prlifecycle.test.ts
@@ -502,6 +502,29 @@ describe(
     }
 
     // -----------------------------------------------------------------------
+    // ordering: exploration report then hosted conclusion
+    // -----------------------------------------------------------------------
+
+    for (const [name, exploration, conclusion] of [
+      ['missing exploration', { Declared: ['goal'], Results: [] }, 'action_required'],
+      ['observed exploration', { Declared: ['goal'], Results: [{ name: 'goal', outcome: { verdict: 'pass' }, visited: ['/runs'], evidence: { trace: 'trace.zip' } }] }, 'success'],
+    ] as const) {
+      it(`a reported ${name} reaches the GitHub check`, async () => {
+        const head = sha(name)
+        await deliver('pull_request', pullRequestPayload('opened', 302, head))
+        await deliver('workflow_run', workflowRunPayload('in_progress', head, 5302))
+        const token = await callbackFor(head, 5302)
+        const response = await h.fetch('/v1/pr/report', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+          body: JSON.stringify({ head_sha: head, report: { Workflows: [{ Verdict: 'pass' }], Exploration: exploration } }),
+        })
+        if (response.status !== 200) throw new Error(`report refused: ${response.status}`)
+        assert.equal(checkFor(head)?.conclusion, conclusion)
+      })
+    }
+
+    // -----------------------------------------------------------------------
     // ordering: callback then request
     // -----------------------------------------------------------------------
 

--- a/web/apps/api/test/report-findings.test.ts
+++ b/web/apps/api/test/report-findings.test.ts
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { countPolicyAndLoad } from '../src/github/findings.ts'
+import { stateFromReport, type ReportCounts } from '../src/github/states.ts'
+import { decodeReport } from '../src/github/lifecycle.ts'
+
+for (const [name, run, expected] of [
+  ['policy failure', { Findings: [{ Level: 'fail' }] }, 'failed'],
+  ['warning', { Findings: [{ Level: 'warn' }] }, 'passed'],
+  ['ignored', { Findings: [{ Level: 'ignore' }] }, 'passed'],
+  ['unknown finding', { Findings: [{ Level: 'new-level' }] }, 'unverified'],
+  ['malformed finding', { Findings: [null] }, 'unverified'],
+  ['malformed list', { Findings: {} }, 'unverified'],
+  ['one bad row preserves failure', { Findings: [null, { Level: 'fail' }] }, 'failed'],
+  ['incomplete load', { Load: { Sent: 4, Unavailable: 'generator stopped' } }, 'blocked'],
+  ['empty load', { Load: { Sent: 0 } }, 'unverified'],
+  ['malformed load', { Load: [] }, 'unverified'],
+  ['missing count', { Load: {} }, 'unverified'],
+  ['NaN count', { Load: { Sent: NaN } }, 'unverified'],
+  ['healthy load', { Load: { Sent: 4 } }, 'passed'],
+  ['old report without load', {}, 'passed'],
+  ['failed finding outranks incomplete load', { Findings: [{ Level: 'fail' }], Load: { Sent: 0, Unavailable: 'stopped' } }, 'failed'],
+] as const) {
+  test(name, () => {
+    const counts: ReportCounts = { passed: 1, failed: 0, flaky: 0, blocked: 0, unverified: 0 }
+    countPolicyAndLoad(run, counts)
+    assert.equal(stateFromReport(counts), expected)
+  })
+}
+
+test('the actual callback decoder includes load policy failure', () => {
+  const decoded = decodeReport({ Workflows: [{ Verdict: 'pass' }], Findings: [{ Level: 'fail', Rule: 'load_regression' }] })
+  assert.equal(stateFromReport(decoded.counts), 'failed')
+})
+
+test('the actual callback decoder includes incomplete load', () => {
+  const decoded = decodeReport({ Workflows: [{ Verdict: 'pass' }], Load: { Sent: 1, Unavailable: 'interrupted' } })
+  assert.equal(stateFromReport(decoded.counts), 'blocked')
+})


### PR DESCRIPTION
## What was wrong

Three separate ways a check that had not looked reported that it had.

**The hosted decoder dropped fields.** `decodeReport` in `github/lifecycle.ts`
read `Workflows` and `Invariants` and nothing else. A run whose policy findings
contained a `fail`, or whose load experiment never completed, arrived at the
control plane and was published as a passing GitHub check, because the fields
carrying that news were never decoded. The engine was right and the check was
wrong, which is the worst arrangement of the two.

**Load was enabled and never ran.** `af ci` generated load only when handed
`--load`, so `load.enabled: true` in a manifest did nothing on a pull request.
When it did run with no traffic source it used `DefaultShape`, whose only route
is `GET /`, and the safe list can only remove routes, so a manifest naming four
pages and no source produced an empty mix and `AF-LOD-010` on every run. A load
result that sent zero requests was reported beside a green verdict.

**Exploration was configured and never ran.** Nothing called `Explore` from
`af ci`. A project could enable exploration, declare goals, and get a clean
report from a browser that was never started, and the report had no field in
which a missing goal could have been noticed. The runner's results were decoded
as one array, so a single malformed element discarded every goal the browser
really did exercise, and the run then read as an exploration that found nothing.
An exploration-only run also announced that it was reading pages with a model
because a key was configured, when the goals are walked by the bounded
deterministic explorer and no model call is made.

## What changes

Three commits, in that order.

The decoder counts policy findings and load. A finding at `fail` fails the
check, an unrecognised level is unverified rather than ignored, an incomplete
load is blocked, and one malformed row cannot erase the rest of the list.
Exploration is decoded the same way: a configured experiment needs a visited
page and a replayable trace for every declared goal, and anything less is
blocked. A report with no exploration field at all is an older engine, not a
configured experiment, and still passes.

`af ci` honours the manifest, and `--load` can only turn load on, never off.
With no traffic source the smoke is built from the literal safe routes: `GET`
and `HEAD` only, no globs, no absolute URLs, deduplicated, falling back to the
default when nothing concrete survives. A safe write route is still allowed
through when a real source carries it; what is refused is inventing four
hundred requests a second for it out of nothing. Both HTTP generators refuse
redirects, because a response cannot authorise traffic outside the selected
route. A synthetic route answering 404 is an error, while observed production
traffic answering 404 is not. The report carries the source and the per route
request counts, and an experiment that sent nothing, or measured a threshold
against no baseline, is `blocked` rather than silent.

The configured goals run before teardown and before the workflows, so the final
invariants observe whatever the exploration submitted instead of blessing
earlier data. Observations stay advisory under the existing contract. Results
are decoded one at a time. Dogfood refuses to count a run green when a required
load or a configured exploration produced no evidence, and names the gap as an
inconclusive experiment rather than an application failure.

## Verification

**91 mutation cells, 90 killed.** Each breaks the exact production line one
assertion exists to catch, runs only that assertion, and is restored before the
next. The harness refuses a cell whose mutation text does not occur exactly
once, so a replacement that silently matched nothing cannot be reported as a
pass, and it diffs every mutated file against a pristine snapshot at the end.
Both runs finished `TREE BYTE IDENTICAL TO PRISTINE: True`.

Eight cells survived the first run and every one of them was a real gap in the
tests rather than a bad mutation. They are now covered by fixtures that isolate
the line: a safe route naming another host, which `url.ParseRequestURI` accepts
and which would have aimed traffic off the sandbox; a safe route written in
lower case; two goals sharing a name; a goal that ran under a different name; a
result nobody asked for; a result the runner did not name; and an exploration
that refused after finishing its goal.

The single surviving cell is `checkLoadEvidence`'s JSON error branch. An
unreadable document cannot populate `Load`, so the `Load == nil` refusal below
it, which is itself proven, already refuses the same input. The branch is kept
because it names the cause; it is reported here as redundant rather than as
proven.

**The decoder fix is proven against a real report, not a structural test.** The
four new lifecycle assertions deliver a `pull_request` and a `workflow_run`
webhook, mint the callback token the runner would use, POST an actual report to
the mounted `/v1/pr/report` endpoint, and read back the conclusion on the
GitHub check. A reported load policy failure arrives as `failure`, an
incomplete load as `action_required`, a missing exploration as
`action_required`, and an observed exploration as `success`. Against my own
PostgreSQL in UTC, `prlifecycle.test.ts` is 43 of 43 with zero skips, and the
GitHub area together is 128 of 128 with `AF_REQUIRE_DATABASE=1`, so a skip
would have been a failure.

**Orderings.** The exploration and load results are folded into one report and
then read by three independent consumers, so each was proven in both directions.
A report carrying a policy failure and an incomplete load reports `failure`, not
`action_required`. A report carrying an incomplete exploration and a failed
workflow reports `failure`. An incomplete experiment beside a warning or an
intermittent workflow reports blocked rather than being hidden by the advisory,
and the same case with a real failure reports the failure. An exploration that
refused after observing pages keeps the evidence it gathered before refusing.
A report with the exploration field absent entirely is an older engine and
passes. Every entry point that can create the state was traced: `af ci` for the
engine, `tools/dogfood` for the streak, and `decodeReport` for the hosted
check, and all three now refuse the same incomplete evidence.

**Integration.** The two lanes were merged deliberately rather than trusted to
a clean apply. Both touch `cli/ci.go`, `report/report.go`, `tools/dogfood/main.go`,
`dogfood.yml`, `verdicts.md` and the hosted decoder. Four conflicts were
resolved by deciding what the merged file should say, and afterwards every added
line from each lane was checked to be present: the only four absent are the two
verdict cases deliberately merged into one and the doc paragraph deliberately
reworded. Every new symbol was confirmed to be defined exactly once and to have
a live call site, and every new field to have a reader on each side of the
boundary.

Also: `tsc --noEmit` clean; runner `main.test.ts` 4 of 4. The five failures in
runner `browser.test.ts` are pre-existing and reproduce identically with
`origin/main`'s `src/main.ts`, so they are not from this change.

## What this does NOT cover

Dogfood exercises more than these two lanes and this pull request does not
touch the rest of it. Custom command migration rehearsal, the query baseline and
`pg_stat_statements`, oracle and fidelity, scenario journeys, change analysis
and fetch depth, and the difference between this repository's own up, agents and
load dispatch and the richer example are all unaddressed. Do not read this as
"all dogfood features are now exercised."

Within the lanes: the one line in the `af ci` command body that calls
`exploreConfigured` cannot be reached by a unit test, because the surrounding
body needs a real environment. The wiring either side of it is now behind
`declaredExploration` and `exploreConfigured`, which are tested and mutation
proven, so the untested surface is that single call. It is verified by grep and
by the dogfood job itself, which now refuses to go green without exploration
evidence.

The separate defect where a RERUN of the Dogfood workflow skips its report step
is another lane's and is untouched here.

## Adjacent work checked

PR 228, "the console received a pass before the engine made it unverified",
moves the run stream events to the end of `Orchestrator.Test`. It does not
disagree with this change. `Explore` publishes nothing to the run stream, so
running it before `Test` cannot announce a completed run early, and the
invariants and `markSynthesized` still run after the workflows, which is what
makes exploration's writes visible to them. Where a run would previously have
reported `unverified`, an incomplete experiment now reports `blocked`; the
documented precedence already ranks blocked above unverified, and neither is a
pass.
