### PR TITLE
billing: the switch was thrown and it pointed at a runbook nobody had written

### DIFF
--- a/.changes/a-payment-path-nobody-had-walked-end-to-end.md
+++ b/.changes/a-payment-path-nobody-had-walked-end-to-end.md
@@ -1,0 +1,50 @@
+# added
+
+The runbook for turning payment on, which `production.tfvars` was already
+pointing at. Setting `stripe_price_team` made this control plane able to charge;
+the comment above it sends the reader to the production page for the commands,
+and that page had no billing section at all. It has one now, in the order that
+works: which endpoint to create at Stripe and why it has to be first, since the
+signing secret does not exist until the endpoint does; the nine events
+`HANDLED_EVENTS` acts on; the two vault entries; and four checks on the running
+control plane, where the last one asks the product for the thing the plan was
+withholding rather than asking the database what it wrote.
+
+A test that walks one organization through the whole path rather than each hop
+of it. Refused a fourth environment on the free plan, checkout through the tRPC
+route, a delivery signed over raw bytes at `POST /webhooks/stripe`, the plan,
+the subscription row, the SAME refused request now allowed, and what the billing
+screen shows a signed in browser. Every hop of that was already proven and the
+JOIN was not, which is the shape this repository keeps finding in itself: a
+route that answers 200 is not evidence that a plan changed, and a plan column
+reading `team` is not evidence that anybody got anything for their money.
+
+Four arrival orderings driven through the two real entry points rather than
+through the handler, which nothing in production calls. The delivery that beats
+the customer row is forced from inside the Stripe call, so the webhook lands
+while checkout is still between its network call and its write, which is not an
+interleaving that ordering two awaits can reach. Then the same delivery twice,
+two at once that disagree about the plan, and the delivery that never comes.
+
+# fixed
+
+The Azure page told an operator to put both Stripe credentials in the vault with
+`az keyvault secret set --value "$STRIPE_SECRET_KEY"`, which the rotating
+secrets page forbids by name for every other credential on this plane: the value
+lands in shell history and in the argument list of a running process, where `ps`
+shows it to anybody else on the machine. `production.tfvars` already told the
+reader that the documented commands pass the value on standard input, and they
+did not. They do now, taken at a prompt and written through a file nothing else
+can read, with `printf '%s'` rather than `echo`, because a signing secret with a
+trailing newline is a different string and every delivery Stripe makes is then
+answered 401 while the plan, the deploy and the dashboard all look correct.
+
+The Terraform test proved that both Stripe credentials reach the container and
+never that the price does. `AF_STRIPE_PRICE_TEAM` is the third required setting
+and a partial configuration is a refusal, so a module that delivered both
+secrets and dropped the price would have satisfied every assertion in that file,
+deployed cleanly, and taken no money, which is indistinguishable at the
+infrastructure layer from billing having never been turned on. It is asserted
+now, along with the price arriving as a value rather than as a reference to a
+vault entry nobody created, that no Enterprise price is emitted, and that
+billing off leaves no `AF_STRIPE_` setting at all.

--- a/docs/src/content/docs/self-hosting/azure.md
+++ b/docs/src/content/docs/self-hosting/azure.md
@@ -318,19 +318,76 @@ references during deployment and names any missing secret. Verify both Stripe
 credentials before enabling billing, and then verify checkout and its webhook
 through the running application.
 
+**`--value` is the wrong way to do this and it is not in the commands below.**
+`rotating-secrets.md` states the rule for every other credential on this plane
+and these three were the exception: a value passed as `--value` is in your shell
+history and in the argument list of a running process, where `ps` shows it to
+anybody else on the machine. It is also in the environment if it arrived as
+`$STRIPE_SECRET_KEY`, and an environment variable is inherited by every child
+process. The value comes from a file that nothing else can read instead, and the
+file is written by a prompt rather than by a command somebody typed.
+
+`printf '%s'` rather than `echo`, and this is the part that fails silently. A
+webhook signing secret with a trailing newline is a different string, and every
+signature computed with it is wrong, so `POST /webhooks/stripe` answers 401 on
+every real delivery while the endpoint, the deploy and the plan all look
+correct. `echo` appends a newline. `read -r` strips the one your return key
+adds. Both halves are needed.
+
 ```sh
 VAULT="$(terraform output -raw key_vault_name)"
 
-# Billing. The Team price is the switch; there is no Enterprise price and there
-# is not meant to be one, because Enterprise is arranged with a person.
-az keyvault secret set --vault-name "$VAULT" -n stripe-secret-key     --value "$STRIPE_SECRET_KEY"
-az keyvault secret set --vault-name "$VAULT" -n stripe-webhook-secret --value "$STRIPE_WEBHOOK_SECRET"
+# One helper, used for each secret below. The value is typed at a prompt, never
+# echoed, never in an argument, never in the shell history, and written with no
+# trailing byte you did not intend.
+afsecret() {
+  local name="$1" dir file
+  umask 077
+  dir="$(mktemp -d)"
+  file="$dir/value"
+  printf 'Value for %s (input is hidden): ' "$name" >&2
+  IFS= read -rs value
+  printf '\n' >&2
+  printf '%s' "$value" > "$file"
+  unset value
+  az keyvault secret set --vault-name "$VAULT" --name "$name" --file "$file" --output none
+  rm -P "$file" 2> /dev/null || rm -f "$file"
+  rmdir "$dir"
+}
+
+# Billing. The Team price is the switch and it is NOT a secret: it goes in
+# production.tfvars in plain text, because a price identifier is in the checkout
+# URL of everybody who buys. There is no Enterprise price and there is not meant
+# to be one, because Enterprise is arranged with a person.
+afsecret stripe-secret-key       # sk_live_... or sk_test_... from Stripe, Developers, API keys
+afsecret stripe-webhook-secret   # whsec_..., shown once when you create the endpoint
 
 # Signing in with a link, and inviting somebody who is not in your GitHub
 # organization. mail_from is the switch and public_url is then required.
 # READ THE DNS SECTION BELOW FIRST: a verified key is not a domain that can send.
-az keyvault secret set --vault-name "$VAULT" -n resend-api-key --value "$RESEND_API_KEY"
+afsecret resend-api-key
 ```
+
+Confirm both arrived without printing either. The first command prints names,
+the second prints a length and a checksum of what the vault holds, which is
+enough to catch a truncated paste or a stray newline and is not enough to
+reconstruct the value:
+
+```sh
+az keyvault secret list --vault-name "$VAULT" \
+  --query "[?starts_with(name, 'stripe-')].name" -o tsv
+
+for n in stripe-secret-key stripe-webhook-secret; do
+  printf '%s ' "$n"
+  az keyvault secret show --vault-name "$VAULT" --name "$n" --query value -o tsv \
+    | tr -d '\n' | wc -c
+done
+```
+
+Compare each length against the value Stripe shows you, character for character.
+One more than you expect is the trailing newline this section is about, and it
+is the difference between a webhook endpoint that works and one that answers 401
+to every delivery Stripe ever makes.
 
 #### Mail needs DNS before it needs a key
 

--- a/docs/src/content/docs/self-hosting/production.md
+++ b/docs/src/content/docs/self-hosting/production.md
@@ -532,7 +532,10 @@ Billing is off on a control plane that has never been told about Stripe, and off
 is a supported state rather than a half-finished one: a self-hosted installation
 takes no money, and every route that would charge answers `PRECONDITION_FAILED`
 naming the settings it needs. What follows turns it on, in the only order that
-works.
+works. The four sections below are deliberately not numbered, because this is
+not step sixteen of first setup: it is a separate procedure somebody runs later,
+possibly years later, on a control plane that is already serving. Run them in
+the order they are written.
 
 **Three settings, and two of them are credentials.** `web/apps/api/src/billing/plans.ts`
 requires exactly these:
@@ -555,7 +558,7 @@ Enterprise is agreed with a person, so no Stripe price exists behind it. Checkou
 refuses that plan by name and points at the contact route. A plan with no price
 is a plan that is not sold here, not a misconfiguration.
 
-### 1. Create the webhook endpoint at Stripe
+### First, create the webhook endpoint at Stripe
 
 **Your job, in a browser, at `https://dashboard.stripe.com/webhooks`.** This step
 is first because `AF_STRIPE_WEBHOOK_SECRET` does not exist until you do it:
@@ -584,7 +587,7 @@ selection costs a 200 and nothing else. A narrower one loses an entitlement.
 about.** Test mode has its own endpoint, its own signing secret, its own keys and
 its own prices, and nothing crosses between the two.
 
-### 2. Put the two credentials in Key Vault
+### Then put the two credentials in Key Vault
 
 The vault name is `afcpprod-kv-centralus` for production. Use the `afsecret`
 helper on the [Azure page](/docs/self-hosting/azure), which takes the value at a
@@ -602,7 +605,7 @@ az keyvault secret list --vault-name afcpprod-kv-centralus \
 
 Two names, or stop here.
 
-### 3. Set the price, and only then apply
+### Then set the price, and only then apply
 
 `stripe_price_team` in `production.tfvars` is the switch. Setting it makes the
 container app reference both vault secrets by their versionless ids.
@@ -614,13 +617,14 @@ vault and the only way to give it a read is to grant a pull request identity
 access to production's credentials. So a plan is green whether or not the
 secrets exist, Azure discovers a missing one while resolving references during
 deployment, and the revision fails to start on a control plane that was serving
-a moment earlier. Step 2 is not optional and it is not reorderable.
+a moment earlier. Putting the credentials in the vault is not optional and it is not
+reorderable.
 
 Apply, then shift traffic the way every other change to this app is shifted:
 the app runs in `Multiple` revision mode, so the apply creates a revision at zero
 traffic. Probe it at zero, then shift.
 
-### 4. Prove it, on the running control plane
+### Then prove it, on the running control plane
 
 **A route that answers 200 is not proof that a plan changed.** Four checks, in
 order, each of which can only pass if the one before it did.

--- a/docs/src/content/docs/self-hosting/production.md
+++ b/docs/src/content/docs/self-hosting/production.md
@@ -525,3 +525,126 @@ it refuses cleanly if any of the above was skipped.
   [operations page](/docs/self-hosting/operations) has the command.
 - The [runbooks](/docs/self-hosting/runbooks) are the pages the alerts link to.
   Read the index once now, while nothing is broken.
+
+## Turning billing on
+
+Billing is off on a control plane that has never been told about Stripe, and off
+is a supported state rather than a half-finished one: a self-hosted installation
+takes no money, and every route that would charge answers `PRECONDITION_FAILED`
+naming the settings it needs. What follows turns it on, in the only order that
+works.
+
+**Three settings, and two of them are credentials.** `web/apps/api/src/billing/plans.ts`
+requires exactly these:
+
+| Setting | Secret | Where it comes from |
+| --- | --- | --- |
+| `AF_STRIPE_SECRET_KEY` | yes, Key Vault | Stripe, Developers, API keys |
+| `AF_STRIPE_WEBHOOK_SECRET` | yes, Key Vault | shown once, when you create the webhook endpoint |
+| `AF_STRIPE_PRICE_TEAM` | no | `stripe_price_team` in `production.tfvars` |
+
+**Two of three is worse than none.** A partial configuration is reported as a
+refusal, not as a partial success: the process prints `billing is OFF and
+partially configured` with the missing names in it and takes no money at all.
+That is deliberate, because the setting people forget is the webhook secret, and
+an installation missing only that one appears to work right up until the first
+customer pays and never gets what they bought.
+
+**There is no `AF_STRIPE_PRICE_ENTERPRISE` and there is not meant to be one.**
+Enterprise is agreed with a person, so no Stripe price exists behind it. Checkout
+refuses that plan by name and points at the contact route. A plan with no price
+is a plan that is not sold here, not a misconfiguration.
+
+### 1. Create the webhook endpoint at Stripe
+
+**Your job, in a browser, at `https://dashboard.stripe.com/webhooks`.** This step
+is first because `AF_STRIPE_WEBHOOK_SECRET` does not exist until you do it:
+Stripe generates the signing secret when the endpoint is created and shows it
+once.
+
+| Field | Value |
+| --- | --- |
+| Endpoint URL | `https://app.antifailure.dev/webhooks/stripe` |
+| Listen to | Events on your account |
+| API version | your account default |
+
+Select exactly these nine events, which are the ones `HANDLED_EVENTS` in
+`web/apps/api/src/billing/webhook.ts` acts on:
+
+`customer.subscription.created`, `customer.subscription.updated`,
+`customer.subscription.deleted`, `invoice.paid`, `invoice.payment_failed`,
+`invoice.finalized`, `payment_method.attached`, `payment_method.detached`,
+`checkout.session.completed`.
+
+Subscribing to more is harmless and subscribing to fewer is not. An event this
+control plane does not act on is acknowledged and not recorded, so a wider
+selection costs a 200 and nothing else. A narrower one loses an entitlement.
+
+**Do this in test mode first, against a control plane you can afford to be wrong
+about.** Test mode has its own endpoint, its own signing secret, its own keys and
+its own prices, and nothing crosses between the two.
+
+### 2. Put the two credentials in Key Vault
+
+The vault name is `afcpprod-kv-centralus` for production. Use the `afsecret`
+helper on the [Azure page](/docs/self-hosting/azure), which takes the value at a
+prompt rather than as an argument, writes it with no trailing newline, and
+removes the file afterwards. A signing secret with a trailing newline fails every
+signature and the endpoint answers 401 to every delivery Stripe makes, while the
+plan, the deploy and the dashboard all look correct.
+
+Confirm both are there before going on. This prints names, never values:
+
+```sh
+az keyvault secret list --vault-name afcpprod-kv-centralus \
+  --query "[?starts_with(name, 'stripe-')].name" -o tsv
+```
+
+Two names, or stop here.
+
+### 3. Set the price, and only then apply
+
+`stripe_price_team` in `production.tfvars` is the switch. Setting it makes the
+container app reference both vault secrets by their versionless ids.
+
+**The plan cannot tell you the secrets are missing, and this is the one place
+that matters.** `keyvault.tf` addresses them by constructed id rather than
+reading them, because the identity that plans production holds nothing on the
+vault and the only way to give it a read is to grant a pull request identity
+access to production's credentials. So a plan is green whether or not the
+secrets exist, Azure discovers a missing one while resolving references during
+deployment, and the revision fails to start on a control plane that was serving
+a moment earlier. Step 2 is not optional and it is not reorderable.
+
+Apply, then shift traffic the way every other change to this app is shifted:
+the app runs in `Multiple` revision mode, so the apply creates a revision at zero
+traffic. Probe it at zero, then shift.
+
+### 4. Prove it, on the running control plane
+
+**A route that answers 200 is not proof that a plan changed.** Four checks, in
+order, each of which can only pass if the one before it did.
+
+The endpoint stops refusing. Before, this is a 503 saying this control plane is
+not configured to take payments; after, it is a 401, because the request is now
+being checked against a signing secret rather than turned away:
+
+```sh
+curl -sS -X POST https://app.antifailure.dev/webhooks/stripe \
+  -H 'content-type: application/json' --data '{}' -w '\n%{http_code}\n'
+```
+
+A 503 here means one of the three settings did not arrive. A 401 means all three
+did, and that the process is verifying signatures.
+
+Then **Send test webhook** from the endpoint's page in the Stripe dashboard. A
+200 proves the signing secret is byte for byte the one Stripe holds, which is the
+half a 401 above cannot distinguish from a wrong secret.
+
+Then buy something in test mode, with Stripe's `4242 4242 4242 4242` card, and
+watch the organization's plan change. Not the checkout page opening: the plan.
+
+Then ask the product for the thing the plan was withholding. Create an
+environment that the free plan's limit of three refused before the purchase. That
+is the only check that cannot be satisfied by a payment path that is connected to
+nothing.

--- a/infra/terraform/modules/control-plane/tests/stripe.tftest.hcl
+++ b/infra/terraform/modules/control-plane/tests/stripe.tftest.hcl
@@ -74,6 +74,55 @@ run "billing_references_the_configured_secret_names" {
     ]) == "stripe-webhook-secret"
     error_message = "The webhook credential reference must reach the process environment."
   }
+
+  # THE PRICE IS THE THIRD REQUIRED VARIABLE AND NOTHING HERE ASSERTED IT.
+  #
+  # The two assertions above prove the credentials arrive. src/billing/plans.ts
+  # requires three settings and treats a partial configuration as a REFUSAL:
+  # with the key and the webhook secret present and the price missing, billing
+  # is off entirely and the process says "billing is OFF and partially
+  # configured". So a module that delivered both secrets and dropped the price
+  # would satisfy every assertion this file had, deploy cleanly, and take no
+  # money, which is indistinguishable at the infrastructure layer from the state
+  # this control plane is in today.
+  assert {
+    condition = length([
+      for env in azurerm_container_app.this.template[0].container[0].env : env
+      if env.name == "AF_STRIPE_PRICE_TEAM" && env.value == "price_test"
+    ]) == 1
+    error_message = "The Team price must reach the process environment, or billing is off however many credentials arrived."
+  }
+
+  # AND IT MUST ARRIVE AS A VALUE, NOT AS A VAULT REFERENCE.
+  #
+  # A price identifier is not a credential: it is in the checkout URL of every
+  # person who buys, and it is written in plain text in production.tfvars. If
+  # somebody "tidied" it into the secret block beside the two real credentials,
+  # the container would reference a vault entry nobody has created, and the
+  # revision would fail to start on a value that was never secret.
+  assert {
+    condition = alltrue([
+      for env in azurerm_container_app.this.template[0].container[0].env :
+      env.secret_name == null || env.secret_name == ""
+      if env.name == "AF_STRIPE_PRICE_TEAM"
+    ])
+    error_message = "The Team price is a public identifier and must be set as a value, not resolved from the vault."
+  }
+
+  # NO ENTERPRISE PRICE, AND ITS ABSENCE IS THE DESIGN.
+  #
+  # Enterprise is arranged with a person, so this module deliberately has no
+  # input for it and plans.ts deliberately does not require it. A future edit
+  # that added one with a default would make checkout offer a plan that reaches
+  # Stripe with a price nobody configured. Asserted here because the module is
+  # where such an addition would be made.
+  assert {
+    condition = length([
+      for env in azurerm_container_app.this.template[0].container[0].env : env.name
+      if env.name == "AF_STRIPE_PRICE_ENTERPRISE"
+    ]) == 0
+    error_message = "Enterprise has no price and is arranged with a person; the module must not emit one."
+  }
 }
 
 run "billing_off_has_no_payment_secret_references" {
@@ -85,5 +134,18 @@ run "billing_off_has_no_payment_secret_references" {
       if startswith(secret.name, "stripe-")
     ]) == 0
     error_message = "Billing disabled must not require payment secrets."
+  }
+
+  # And no payment SETTING either, which the run above did not cover. A control
+  # plane that takes no money must not carry a half configuration: plans.ts
+  # reports one variable of the three as "billing is OFF and partially
+  # configured" and refuses to take payment, which is the right answer and a
+  # confusing one to arrive at from a deployment nobody meant to change.
+  assert {
+    condition = length([
+      for env in azurerm_container_app.this.template[0].container[0].env : env.name
+      if startswith(env.name, "AF_STRIPE_")
+    ]) == 0
+    error_message = "Billing disabled must leave no AF_STRIPE_ setting on the container."
   }
 }

--- a/web/apps/api/test/billing-production-path.test.ts
+++ b/web/apps/api/test/billing-production-path.test.ts
@@ -1,0 +1,545 @@
+// The path a paying customer actually walks, joined end to end.
+//
+// WHY THIS FILE EXISTS ALONGSIDE billing.test.ts, WHICH ALREADY HAS SIXTY
+// BILLING TESTS. Every hop of this path was already proven, and the path was
+// not. billing.test.ts proves that checkout opens a session, that a signed
+// delivery is applied, that `subscriptions.current` reports a plan, and that
+// `checkQuota` computes the right verdict. Each of those is one hop, asserted
+// against its own inputs. None of them asserts that the hops are CONNECTED:
+// that the customer checkout created is the customer the delivery names, that
+// the plan the delivery writes is the plan the quota gate reads, and that the
+// gate which refused a fourth environment a moment ago now allows it.
+//
+// That gap is the shape of the failure this repository keeps finding in itself.
+// A route returning 200 is not evidence that a plan changed, and a plan column
+// holding `team` is not evidence that anybody got anything for their money. The
+// only assertion that cannot be satisfied by a disconnected half is the one
+// that watches the SAME organization be refused, pay, and then be allowed.
+//
+// So the first test below is a single organization walked through:
+//
+//   free plan  -> the fourth environment is REFUSED, naming 3 of 3
+//   checkout   -> through the tRPC route, against the product's Stripe pack
+//   delivery   -> through POST /webhooks/stripe, HMAC signed over raw bytes
+//   entitlement-> organizations.plan and the billing_subscriptions row
+//   quota      -> the SAME fourth environment is now ALLOWED
+//   browser    -> subscriptions.current reports team, carrying no secret
+//
+// The rest of the file is the arrival orderings, driven through the two real
+// entry points rather than by calling the handler directly. billing.test.ts and
+// billing-ordering.test.ts already prove the orderings against
+// `handleStripeDelivery`. That is the right level for the locking arguments and
+// the wrong level for this question, because in production nothing calls that
+// function: Stripe posts signed bytes at an HTTP route, and a person clicks a
+// button that reaches a tRPC mutation. An ordering that is safe in the handler
+// and unsafe through the endpoint would pass every existing test.
+
+import { after, before, describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { createHmac, randomUUID } from 'node:crypto'
+import {
+  available,
+  callProcedure,
+  dropOrg,
+  errorCode,
+  seedOrg,
+  signInAs,
+  startApi,
+  stripeAgainstMockPack,
+  type ApiHarness,
+  type Org,
+  type SignedIn,
+} from './harness.ts'
+import { RealStripeClient } from '../src/billing/stripe.ts'
+import type { Billing } from '../src/billing/index.ts'
+import type { StripeConfig } from '../src/billing/plans.ts'
+
+const hasDatabase = await available()
+
+// HMAC-SHA256 over "timestamp.body", written out rather than imported from the
+// verifier for the reason billing.test.ts gives: a test that builds its input
+// with the code under test passes just as well when both sides are wrong.
+function signed(secret: string, body: string, at: Date): string {
+  const t = Math.floor(at.getTime() / 1000)
+  return `t=${t},v1=${createHmac('sha256', secret).update(`${t}.${body}`, 'utf8').digest('hex')}`
+}
+
+function envelope(type: string, object: Record<string, unknown>, created: Date, id?: string): string {
+  return JSON.stringify({
+    id: id ?? `evt_${randomUUID().replaceAll('-', '')}`,
+    object: 'event',
+    api_version: '2024-06-20',
+    created: Math.floor(created.getTime() / 1000),
+    livemode: false,
+    type,
+    pending_webhooks: 0,
+    request: { id: null, idempotency_key: null },
+    data: { object },
+  })
+}
+
+function subscriptionObject(over: {
+  id: string
+  customer: string
+  status?: string
+  priceId?: string
+  /** When STRIPE created it, which is what decides between two subscriptions
+   *  that disagree. Not the arrival time and not the local ingest clock. */
+  created?: number
+}): Record<string, unknown> {
+  return {
+    id: over.id,
+    object: 'subscription',
+    customer: over.customer,
+    created: over.created ?? 1767225600,
+    status: over.status ?? 'active',
+    current_period_start: 1767225600,
+    current_period_end: 1769904000,
+    cancel_at_period_end: false,
+    canceled_at: null,
+    items: {
+      object: 'list',
+      has_more: false,
+      data: [{
+        id: 'si_test',
+        object: 'subscription_item',
+        quantity: 1,
+        price: { id: over.priceId ?? 'price_team_afmock', object: 'price' },
+      }],
+    },
+  }
+}
+
+describe('the production billing path', { skip: !hasDatabase }, () => {
+  let h: ApiHarness
+  let config: StripeConfig
+  const orgIds: string[] = []
+
+  before(async () => {
+    const stripe = await stripeAgainstMockPack()
+    config = stripe.config
+    h = await startApi({ stripe: stripe.billing })
+
+    // ORPHANED DELIVERIES FROM AN EARLIER RUN ARE CLEARED, and this is not
+    // housekeeping, it is a correctness precondition for everything below.
+    //
+    // The mock pack mints `cus_` ids from a counter that restarts in every node
+    // process, so a second run against a database a first run used is handed
+    // the same customer id. Dropping an organization cascades the events it
+    // owns, but an event still waiting for an organization has a null org_id
+    // and survives. `resolvePending` keys on the CUSTOMER id, so the next run
+    // to attach that reused id replays the previous run's parked events onto an
+    // organization that bought nothing.
+    //
+    // Measured, not feared: a mutation run left an unresolved Enterprise
+    // delivery behind, and the next run's freshly seeded organization was on
+    // the `enterprise` plan before it had done anything, which read as a
+    // product defect and is a property of the fixture. A real Stripe customer
+    // id is globally unique and is attached to exactly one organization, so
+    // nothing here weakens what the product is being asked to do.
+    await h.admin`DELETE FROM billing_events WHERE org_id IS NULL`
+  })
+
+  after(async () => {
+    for (const orgId of orgIds) await dropOrg(h.admin, orgId)
+    await h.close()
+  })
+
+  /**
+   * An organization that can reach the quota gate.
+   *
+   * The App has to be installed and the workflow has to exist, or
+   * `environments.create` is refused one gate LATER than the quota and every
+   * assertion below would be passing on the wrong refusal.
+   */
+  async function payingOrg(label: string): Promise<{ org: Org; owner: SignedIn }> {
+    const org = await seedOrg(h.admin, label)
+    orgIds.push(org.orgId)
+    const owner = await signInAs(h, org, 'owner')
+    await h.admin`
+      INSERT INTO github_installations (org_id, installation_id, account_login, account_type)
+      VALUES (${org.orgId}, ${Math.floor(Math.random() * 1e9)}, ${org.slug}, 'Organization')`
+    h.github.addWorkflow(org.repository, 'antifailure.yml')
+    return { org, owner }
+  }
+
+  /** Takes the organization to exactly the free plan's three environments.
+   *  seedOrg already made one. */
+  async function fillFreePlan(org: Org): Promise<void> {
+    await h.admin`
+      INSERT INTO environments (org_id, repository_id, env_id, branch, state)
+      VALUES (${org.orgId}, ${org.repoId}, ${'env-fill-a'}, 'main', 'running'),
+             (${org.orgId}, ${org.repoId}, ${'env-fill-b'}, 'main', 'running')`
+  }
+
+  function createEnvironment(owner: SignedIn, org: Org) {
+    return callProcedure(h, owner, 'environments.create', 'mutation', { repository: org.repository })
+  }
+
+  async function planOf(orgId: string): Promise<string> {
+    const [row] = await h.admin<{ plan: string }[]>`
+      SELECT plan FROM organizations WHERE id = ${orgId}`
+    return row!.plan
+  }
+
+  async function deliver(body: string, at = h.clock.now()) {
+    return h.fetch('/webhooks/stripe', {
+      method: 'POST',
+      body,
+      headers: { 'stripe-signature': signed(config.webhookSecret, body, at) },
+    })
+  }
+
+  async function customerOf(orgId: string): Promise<string | null> {
+    const [row] = await h.admin<{ stripe_customer_id: string }[]>`
+      SELECT stripe_customer_id FROM billing_customers WHERE org_id = ${orgId}`
+    return row?.stripe_customer_id ?? null
+  }
+
+  // -------------------------------------------------------------------------
+  // The whole path, on one organization, in order.
+  // -------------------------------------------------------------------------
+
+  it('refuses, is paid for, and then allows the same request', async () => {
+    const { org, owner } = await payingOrg('paid-path')
+    await fillFreePlan(org)
+
+    // 1. THE QUOTA IS EFFECTIVE BEFORE ANYBODY PAYS.
+    //
+    // Asserted first and on the refusal SENTENCE rather than only on the code,
+    // because PRECONDITION_FAILED is also what a missing installation, a frozen
+    // organization and a cost cap answer. Without the sentence this test would
+    // pass while measuring a completely different gate, and would then "prove"
+    // an upgrade that never touched the quota.
+    const refused = await createEnvironment(owner, org)
+    assert.equal(errorCode(refused.body), 'PRECONDITION_FAILED', JSON.stringify(refused.body))
+    assert.match(
+      JSON.stringify(refused.body), /holding 3 of 3 environments on the free plan/,
+      'the refusal did not come from the free plan quota',
+    )
+
+    // 2. CHECKOUT, through the route a browser reaches, against the product's
+    // own Stripe pack rather than a fake written to agree with the client.
+    const bought = await callProcedure(h, owner, 'subscriptions.checkout', 'mutation', {
+      plan: 'team',
+      successUrl: 'https://app.test/billing/done',
+      cancelUrl: 'https://app.test/billing',
+    })
+    assert.equal(bought.status, 200, JSON.stringify(bought.body))
+    const session = (bought.body as { result: { data: { url: string; sessionId: string } } }).result.data
+    assert.match(session.url, /^https:\/\/checkout\.stripe\.com\//)
+
+    // The customer checkout created is the one the delivery will name. Read
+    // back rather than assumed: this is the join the rest of the path rests on,
+    // and a delivery naming a customer nobody holds is the ordering that has
+    // cost this repository money before.
+    const recorded = await customerOf(org.orgId)
+    assert.ok(recorded?.startsWith('cus_'), `checkout recorded no Stripe customer: ${recorded}`)
+    const customer = recorded!
+
+    // Paying has changed NOTHING yet, and that is correct. Stripe has taken the
+    // money and this control plane has not been told. Asserted rather than
+    // skipped over, because a plan that moved here would mean checkout was
+    // entitling people who never completed a payment.
+    assert.equal(await planOf(org.orgId), 'free', 'checkout alone moved the plan')
+
+    // 3. THE SIGNED DELIVERY, over the real HTTP endpoint, HMAC over raw bytes.
+    const body = envelope(
+      'customer.subscription.created',
+      subscriptionObject({ id: `sub_${randomUUID()}`, customer }),
+      h.clock.now(),
+    )
+    const res = await deliver(body)
+    const answered = await res.text()
+    assert.equal(res.status, 200, answered)
+    const outcome = JSON.parse(answered) as { handled: boolean; detail: string }
+    assert.equal(outcome.handled, true, answered)
+
+    // 4. THE ENTITLEMENT. Both the plan and the row behind it, because a plan
+    // column written with no subscription to justify it is a grant, not a sale.
+    assert.equal(await planOf(org.orgId), 'team', 'the delivery did not move the plan')
+    const [subscription] = await h.admin<{ status: string; plan: string }[]>`
+      SELECT status, plan FROM subscriptions WHERE org_id = ${org.orgId}`
+    assert.equal(subscription?.status, 'active')
+    assert.equal(subscription?.plan, 'team')
+
+    // 5. THE QUOTA, EFFECTIVE. The same call that was refused above, unchanged,
+    // by the same person, against the same organization. This is the assertion
+    // that a disconnected half cannot satisfy: nothing here re-reads the plan
+    // itself, it asks the product for the thing that was being withheld.
+    const allowed = await createEnvironment(owner, org)
+    assert.equal(
+      errorCode(allowed.body), null,
+      `paying for team did not lift the free plan quota: ${JSON.stringify(allowed.body)}`,
+    )
+
+    // 6. WHAT A SIGNED IN BROWSER IS SHOWN. `subscriptions.current` is what the
+    // billing screen renders, so this is the last place the upgrade could be
+    // true everywhere and invisible to the customer.
+    const shown = await callProcedure(h, owner, 'subscriptions.current', 'query', {})
+    assert.equal(shown.status, 200, JSON.stringify(shown.body))
+    const data = (shown.body as { result: { data: Record<string, unknown> } }).result.data
+    assert.equal(data.configured, true)
+    assert.equal(data.plan, 'team', `the billing screen shows ${String(data.plan)}`)
+    assert.ok(data.subscription, 'the billing screen shows no subscription after a purchase')
+
+    // And it carries neither credential. Named literals rather than a regular
+    // expression over the shape, because the two strings that must never leave
+    // this process are the two this configuration actually holds.
+    const serialized = JSON.stringify(data)
+    assert.ok(!serialized.includes(config.secretKey), 'the API key reached the browser')
+    assert.ok(!serialized.includes(config.webhookSecret), 'the webhook secret reached the browser')
+  })
+
+  // -------------------------------------------------------------------------
+  // The arrival orderings, through the endpoints rather than the handler.
+  // -------------------------------------------------------------------------
+
+  it('ordering, delivery before the customer row exists, then resolved by checkout', async () => {
+    // THE ORDERING THAT HAS COST THIS REPOSITORY MONEY, forced through both
+    // real entry points rather than simulated by calling attachCustomer.
+    //
+    // `subscriptions.checkout` creates the customer at Stripe over the network
+    // and only then opens a transaction to record it. Every instant between
+    // those two is one in which Stripe knows a customer this control plane has
+    // never heard of, and Stripe can send `customer.subscription.created` in
+    // it. The gap is real, it is a network round trip wide, and nothing in the
+    // process can shorten it.
+    //
+    // So the delivery is posted FROM INSIDE the Stripe call: the injected fetch
+    // answers POST /v1/customers, reads the id out of the answer, posts a
+    // signed delivery for that id at the live HTTP endpoint, and only then
+    // returns to checkout. The webhook therefore lands while the route is still
+    // between its network call and its write, which is not an interleaving a
+    // test can reach by ordering two awaits.
+    const { org, owner } = await payingOrg('late-attach')
+    await fillFreePlan(org)
+
+    // The SUITE'S OWN configuration is wrapped rather than a second
+    // `stripeAgainstMockPack()`. A fresh pack mints its ids from a fresh
+    // counter, so a second one hands out the same first `cus_` as the first
+    // pack already did, and the two collide on `subscriptions.stripe_customer_id`
+    // in the one database. That is a property of the fixture and not of the
+    // product, and chasing it as a product defect would waste somebody's day.
+    let delivered: { status: number; detail: string } | undefined
+    const interleaving: StripeConfig = {
+      ...config,
+      fetch: async (input, init) => {
+        const response = await config.fetch!(input, init)
+        const url = new URL(input instanceof Request ? input.url : String(input))
+        if (url.pathname === '/v1/customers' && delivered === undefined) {
+          const created = (await response.clone().json()) as { id: string }
+          const body = envelope(
+            'customer.subscription.created',
+            subscriptionObject({ id: `sub_${randomUUID()}`, customer: created.id }),
+            h.clock.now(),
+          )
+          // Posted at the ORIGINAL harness, which is a second server object on
+          // the same database holding the same webhook secret. That is what a
+          // multiple-replica Container App is: the replica that took the
+          // checkout is not the replica Stripe posts to.
+          const res = await h.fetch('/webhooks/stripe', {
+            method: 'POST',
+            body,
+            headers: { 'stripe-signature': signed(config.webhookSecret, body, h.clock.now()) },
+          })
+          const answered = (await res.json()) as { detail: string }
+          delivered = { status: res.status, detail: answered.detail }
+        }
+        return response
+      },
+    }
+    const interleaved = await startApi({
+      stripe: { config: interleaving, client: new RealStripeClient(interleaving) } satisfies Billing,
+    })
+    try {
+      // Its own FakeGitHub, so the workflow has to be registered here too or
+      // `environments.create` below is refused by the workflow gate rather than
+      // reaching the quota. That is not a hypothetical: it happened while this
+      // test was being written, and the refusal code was identical.
+      interleaved.github.addWorkflow(org.repository, 'antifailure.yml')
+      const owner2 = await signInAs(interleaved, org, 'owner', 'late')
+      const bought = await callProcedure(interleaved, owner2, 'subscriptions.checkout', 'mutation', {
+        plan: 'team',
+        successUrl: 'https://app.test/billing/done',
+        cancelUrl: 'https://app.test/billing',
+      })
+      assert.equal(bought.status, 200, JSON.stringify(bought.body))
+
+      // The early delivery was ACCEPTED and PARKED. Accepted, because refusing
+      // it would make Stripe retry a delivery that is not wrong; parked,
+      // because there is no organization to apply it to yet. A 500 here, or a
+      // 200 that recorded nothing, are the two ways this becomes a customer who
+      // paid and stayed on free.
+      assert.ok(delivered, 'the delivery never landed inside the checkout call')
+      assert.equal(delivered!.status, 200)
+      assert.match(
+        delivered!.detail, /no organization holds this customer yet/,
+        `the early delivery was not parked: ${delivered!.detail}`,
+      )
+
+      // And attaching the customer applied it, with nothing having to sweep.
+      assert.equal(await planOf(org.orgId), 'team', 'the parked delivery was never resolved')
+      const allowed = await callProcedure(interleaved, owner2, 'environments.create', 'mutation', {
+        repository: org.repository,
+      })
+      assert.equal(errorCode(allowed.body), null, JSON.stringify(allowed.body))
+      void owner
+    } finally {
+      await interleaved.close()
+    }
+  })
+
+  it('ordering, the same delivery twice, which is what a Stripe retry is', async () => {
+    const { org, owner } = await payingOrg('retry')
+    await fillFreePlan(org)
+    await callProcedure(h, owner, 'subscriptions.checkout', 'mutation', {
+      plan: 'team', successUrl: 'https://app.test/d', cancelUrl: 'https://app.test/c',
+    })
+    const customer = (await customerOf(org.orgId))!
+
+    const body = envelope(
+      'customer.subscription.created',
+      subscriptionObject({ id: `sub_${randomUUID()}`, customer }),
+      h.clock.now(),
+      `evt_retry_${randomUUID().replaceAll('-', '')}`,
+    )
+    const first = await deliver(body)
+    assert.equal(first.status, 200)
+    const second = await deliver(body)
+    const secondBody = await second.text()
+
+    // 200 rather than a conflict. Stripe retries on anything that is not a 2xx,
+    // so telling it "already handled" with a 409 would make it retry forever.
+    assert.equal(second.status, 200, secondBody)
+    const repeat = JSON.parse(secondBody) as { handled: boolean; detail: string }
+    assert.equal(repeat.handled, true)
+    assert.match(repeat.detail, /already handled/, repeat.detail)
+
+    // One event row for one event id, whatever the delivery count. This is the
+    // assertion, not the status: an endpoint that re-applied the event would
+    // also answer 200 twice.
+    // COUNTED BY ORGANIZATION, not by Stripe customer id, and that is not a
+    // stylistic preference. The mock pack mints `cus_` ids from a counter that
+    // starts again in every node process, so a second run against the same
+    // database reuses the first run's customer and this count climbs by itself.
+    // It cost a mutation run: a no-op mutation came back red at 4 against 2.
+    // The organization is freshly seeded per run and cannot collide.
+    const rows = await h.admin<{ n: string }[]>`
+      SELECT count(*) AS n FROM billing_events WHERE org_id = ${org.orgId}`
+    assert.equal(Number(rows[0]!.n), 1, 'a retried delivery was recorded twice')
+    assert.equal(await planOf(org.orgId), 'team')
+  })
+
+  it('ordering, two deliveries at once that disagree about the plan', async () => {
+    // TWO DELIVERIES THAT DISAGREE, and that is the whole design of this test.
+    //
+    // An earlier draft posted two deliveries carrying the SAME subscription at
+    // the same plan. It passed, and it was worthless: the two agreed, so the
+    // organization ended on `team` whether the handlers serialized or trampled
+    // each other. Breaking the advisory customer lock left it green, and so did
+    // breaking the organization row lock in `recomputePlan`. A check that
+    // cannot say no is worse than no check.
+    //
+    // So the two now disagree: an older Team subscription and a newer
+    // Enterprise one, posted together. Exactly one answer is correct whichever
+    // lands first, because `recomputePlan` decides on the time STRIPE created
+    // the subscription rather than on the order the deliveries arrived. That
+    // ordering is a production line a mutation can break, and this assertion
+    // goes red when it is.
+    //
+    // What this does NOT prove is the locking. Removing either lock leaves it
+    // green, because a lost update needs a real interleaving and asserting on
+    // one would be a flaky test. billing-ordering.test.ts proves the lock ORDER
+    // directly, which is the right instrument for it; this is not a second one.
+    const { org, owner } = await payingOrg('concurrent')
+    await fillFreePlan(org)
+    await callProcedure(h, owner, 'subscriptions.checkout', 'mutation', {
+      plan: 'team', successUrl: 'https://app.test/d', cancelUrl: 'https://app.test/c',
+    })
+    const customer = (await customerOf(org.orgId))!
+
+    const [a, b] = await Promise.all([
+      deliver(envelope(
+        'customer.subscription.created',
+        subscriptionObject({
+          id: `sub_older_${randomUUID()}`, customer, created: 1767225600,
+          priceId: 'price_team_afmock',
+        }),
+        h.clock.now(),
+      )),
+      deliver(envelope(
+        'customer.subscription.created',
+        subscriptionObject({
+          id: `sub_newer_${randomUUID()}`, customer, created: 1769904000,
+          priceId: 'price_enterprise_afmock',
+        }),
+        h.clock.now(),
+      )),
+    ])
+    assert.equal(a.status, 200, await a.text())
+    assert.equal(b.status, 200, await b.text())
+
+    // Both landed. A concurrent delivery that is silently dropped is a customer
+    // whose purchase Stripe believes it has already told this control plane
+    // about, and will never mention again.
+    const rows = await h.admin<{ n: string }[]>`
+      SELECT count(*) AS n FROM billing_events WHERE org_id = ${org.orgId}`
+    assert.equal(Number(rows[0]!.n), 2, 'a concurrent delivery was lost')
+    const subs = await h.admin<{ n: string }[]>`
+      SELECT count(*) AS n FROM subscriptions WHERE org_id = ${org.orgId}`
+    assert.equal(Number(subs[0]!.n), 2, 'a concurrent delivery wrote no subscription')
+
+    // And the one Stripe created LATER decides, whichever of the two this
+    // process happened to finish first.
+    assert.equal(
+      await planOf(org.orgId), 'enterprise',
+      'the arrival order of two concurrent deliveries decided the plan',
+    )
+
+    const allowed = await createEnvironment(owner, org)
+    assert.equal(errorCode(allowed.body), null, JSON.stringify(allowed.body))
+  })
+
+  it('ordering, the delivery never arrives, and the reachable route recovers it', async () => {
+    const { org, owner } = await payingOrg('no-webhook')
+    await fillFreePlan(org)
+    await callProcedure(h, owner, 'subscriptions.checkout', 'mutation', {
+      plan: 'team', successUrl: 'https://app.test/d', cancelUrl: 'https://app.test/c',
+    })
+
+    // The customer completed the checkout page, so a subscription EXISTS at
+    // Stripe. The pack is Stripe here, and this is the object the delivery
+    // would have been about.
+    const customer = (await customerOf(org.orgId))!
+    const at = await config.fetch!(new URL('/v1/subscriptions', 'https://api.stripe.com'), {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        customer,
+        'items[0][price]': 'price_team_afmock',
+        'items[0][quantity]': '1',
+      }).toString(),
+    })
+    assert.equal(at.status, 200, await at.text())
+
+    // Nothing is delivered at all. This is the endpoint being unreachable, the
+    // signing secret being wrong, or the endpoint never having been created in
+    // the Stripe dashboard, which is exactly the state this control plane is in
+    // until somebody creates it. The customer has paid and holds nothing.
+    assert.equal(await planOf(org.orgId), 'free')
+    const stillRefused = await createEnvironment(owner, org)
+    assert.equal(errorCode(stillRefused.body), 'PRECONDITION_FAILED')
+
+    // The recovery has to be REACHABLE, not merely present. Called through the
+    // tRPC route a person can press rather than by importing `reconcile`,
+    // because a recovery nothing can invoke is the dead code this repository
+    // keeps finding.
+    const repaired = await callProcedure(h, owner, 'subscriptions.reconcile', 'mutation', {})
+    assert.equal(repaired.status, 200, JSON.stringify(repaired.body))
+    assert.equal(await planOf(org.orgId), 'team', 'reconcile did not recover the missed delivery')
+
+    const allowed = await createEnvironment(owner, org)
+    assert.equal(errorCode(allowed.body), null, JSON.stringify(allowed.body))
+  })
+})


### PR DESCRIPTION
`stripe_price_team` is set in `production.tfvars` and production billing is
therefore ON in configuration. The comment PR #239 landed above that line says:

> `docs/src/content/docs/self-hosting/production.md` has the commands, and they
> pass the value on standard input so it never reaches a shell history or a
> process listing.

Neither half of that was true when it merged. `production.md` had no billing
section at all, so the pointer went nowhere. And `azure.md`, which is where the
Stripe secrets are actually documented, told the operator to run exactly the
thing that sentence promises the documentation does not:

```
az keyvault secret set --vault-name "$VAULT" -n stripe-secret-key --value "$STRIPE_SECRET_KEY"
```

That value is in the shell history, in the argument list of a running process
where `ps` shows it to anybody else on the machine, and in the environment,
inherited by every child. `rotating-secrets.md` forbids it by name for every
other credential on this plane and says every runbook below it reads the value
from a file or a pipe instead. These three were the exception.

This supplies the missing half, and proves the path the switch turns on.

## The negative control, before and after everything here

Read off production twice today, not remembered. `POST
https://app.antifailure.dev/webhooks/stripe` with an empty unsigned body:

```
HTTP 503
{"error":"This control plane is not configured to take payments."}
```

at 04:34:15Z and again at 06:02:46Z. `/readyz` reports `ready`, `v1.1.1`,
commit `59486b63`. `afcpprod-app` carries eighteen settings and none of them
starts with `AF_STRIPE_`. `afcpprod-kv-centralus` holds ten secrets and neither
Stripe one is among them. Nothing in this pull request changes any of that:
production stays exactly here until somebody puts two values in a vault and
runs an apply.

## What the operator has to do, in the order that works

`production.md` now carries it. Stripe first, because
`AF_STRIPE_WEBHOOK_SECRET` **does not exist** until the endpoint does: Stripe
generates the signing secret when the endpoint is created and shows it once.
Then the nine events `HANDLED_EVENTS` acts on. Then the vault. Then the apply.

The ordering trap is stated where somebody will hit it. `keyvault.tf` addresses
both credentials by constructed id rather than through a data source, on purpose
and at length, because the identity that plans production holds nothing on the
vault. The cost of that trade is that **a plan carrying the price is green
whether or not the secrets exist**; Azure discovers a missing one while resolving
references during deployment, and the revision fails to start on a control plane
that was serving a moment earlier.

The secret-setting shape was tested end to end with a value that is not a key,
in `bash` and in `zsh`: 37 bytes for a 37 character value, last byte not `0a`,
`az` reaching the vault DNS lookup so argument parsing and file reading both
succeeded, and the value absent from the running process argument list.

`printf '%s'` rather than `echo` is the half that fails silently. A signing
secret carrying a trailing newline is a different string, every signature
computed with it is wrong, the endpoint answers 401 to every delivery Stripe
ever makes, and the plan, the deploy and the dashboard all look correct while
it happens.

## The transition, proven locally with values that are not keys

The real Team price id with fabricated credentials, through `src/main.ts`:

| Settings | Start-up line | Empty unsigned POST |
| --- | --- | --- |
| none | `billing is off: no Stripe configuration (AF_STRIPE_SECRET_KEY is not set)` | 503 |
| two of three | `billing is OFF and partially configured: AF_STRIPE_PRICE_TEAM not set` | 503 |
| all three | `billing is on: team sold self-serve, enterprise has no price and is arranged with a person` | **401** |

That 503 to 401 flip is the first check in the runbook. It separates "no
settings arrived" from "all three did, and signatures are being verified".

## The path, walked rather than sampled

Sixty billing tests already covered this. Checkout opens a session. A signed
delivery is applied. `subscriptions.current` reports a plan. `checkQuota`
computes the right verdict. Every one of those is one hop, asserted against its
own inputs, and **not one of them asserts that the hops are connected**.

`web/apps/api/test/billing-production-path.test.ts` walks one organization
through the whole thing:

1. free plan, the fourth environment is REFUSED, asserted on the sentence
   `holding 3 of 3 environments on the free plan` and not only on the code,
   because `PRECONDITION_FAILED` is also what a missing installation, a frozen
   organization and a cost cap answer. That was not hypothetical: while this
   was being written one test passed its quota assertion on the workflow gate
   instead, with an identical code.
2. checkout through the tRPC route, against the product's own Stripe pack
3. a delivery HMAC signed over raw bytes at `POST /webhooks/stripe`
4. `organizations.plan` and the `subscriptions` row
5. **the same refused request, unchanged, now allowed**
6. what `subscriptions.current` shows a signed in browser, carrying neither
   credential

Step 5 is the one a disconnected half cannot satisfy. Nothing there re-reads the
plan; it asks the product for the thing that was being withheld.

## The orderings, through the real entry points

Driven through `POST /webhooks/stripe` and the tRPC routes rather than through
`handleStripeDelivery`, which nothing in production calls.

| Ordering | Outcome | Where |
| --- | --- | --- |
| checkout then delivery | plan `team`, quota lifted, screen shows it | test 1 |
| delivery then checkout | 200, parked `no organization holds this customer yet`, then resolved on attach | test 2 |
| the same delivery twice | 200, `already handled`, exactly one `billing_events` row | test 3 |
| two at once that disagree | both recorded, both written, the one Stripe created LATER decides | test 4 |
| no delivery at all | still `free`, still refused, then `subscriptions.reconcile` recovers it | test 5 |

The second one is forced from **inside** the Stripe call. The injected `fetch`
answers `POST /v1/customers`, reads the id out of the answer, posts a signed
delivery at the live endpoint, and only then returns to checkout. The webhook
therefore lands while the route is still between its network call and its write,
a gap one network round trip wide that nothing in the process can shorten, and
not an interleaving that ordering two awaits can reach.

Every entry point that can create the state was traced. `billing_customers` has
exactly one writer, `attachCustomer` in `store.ts`, reached from exactly one
place, `subscriptions.checkout`. `enterprise.ts` only updates an email and
`admin/routers.ts` only reads.

## A test of mine that could not say no, and what I did about it

The first concurrency test posted two deliveries carrying the same subscription
at the same plan. It passed, and it was worthless: the two agreed, so the
organization ended on `team` whether the handlers serialized or trampled each
other. **Removing the advisory customer lock left it green. So did removing the
organization row lock in `recomputePlan`.**

It now posts two that disagree, an older Team and a newer Enterprise, and
exactly one answer is correct whichever lands first, because `recomputePlan`
decides on the time Stripe created the subscription rather than on arrival
order. That is a production line a mutation can break, and the assertion goes
red when it is.

**What it still does not prove is the locking.** Both lock mutations are kept in
the table below as declared controls and they stay green, because a lost update
needs a real interleaving and asserting on one would be a flaky test.
`billing-ordering.test.ts` proves the lock ORDER directly and deterministically;
that is the right instrument and this is not a second one. The test says so in
its own comment.

## Mutation table

Every assertion, one break each, targeting the exact production line it exists
to catch. Break, confirm that assertion goes red, restore, confirm green.

| # | Assertion | Line broken | Result |
| --- | --- | --- | --- |
| M01 | the free plan refuses the fourth environment | `dispatch.ts` quota throw | RED |
| M02 | paying lifts the quota | `dispatch.ts` `plan = row?.plan` | RED, and M01 stays green |
| M03 | checkout records the Stripe customer | `store.ts` attach INSERT value | RED |
| M04 | the endpoint answers 200 | `server.ts` webhook status | RED |
| M05 | the delivery moves `organizations.plan` | `recomputePlan` UPDATE SET | RED |
| M06 | the subscription row carries the plan | `writeSubscription` VALUES | RED |
| M07 | the billing screen shows the plan | `readBillingState` plan SELECT | RED |
| M08 | no credential reaches the browser | `subscriptions.current` leak | RED |
| M09 | an unowned delivery is parked, not dropped | webhook no-org detail | RED |
| M10 | attaching applies what was parked | `resolvePending` WHERE | RED |
| M11 | a repeat delivery changes nothing | claimed short circuit | RED |
| M12 | one event id is recorded exactly once | `ON CONFLICT DO NOTHING` | RED |
| M13 | the later provider creation decides | `recomputePlan` `created_at DESC` | RED |
| M14 | both concurrent deliveries are written | claimed short circuit | RED |
| M15 | reconcile recovers a delivery that never came | `reconcile` stubbed | RED |
| M16 | CONTROL, advisory customer lock | `lockBillingCustomer` removed | green, declared |
| M17 | CONTROL, organization lock in recomputePlan | `FOR UPDATE` removed | green, declared |

M12 goes red through a query error rather than a clean assertion: without the
conflict clause the retry throws, the endpoint answers 500, and the status
assertion fails. That is the ON CONFLICT being load bearing, and it is reported
as what it is.

Terraform, same method, breaking the `app.tf` block each assertion guards:

| # | Assertion | Result |
| --- | --- | --- |
| T1 | the Team price reaches the container | RED |
| T2 | it arrives as a VALUE, not a vault reference | RED, isolated by a mutation that keeps the value correct, because the first failure masks the second otherwise |
| T3 | no Enterprise price is emitted | RED |
| T4 | billing off leaves no `AF_STRIPE_` setting | RED |

## A fixture hazard that produced a misleading red, recorded because it will recur

The mock pack mints `cus_` ids from a counter that restarts in every node
process. Dropping an organization cascades the events it owns but not the ones
still waiting for one, and `resolvePending` keys on the CUSTOMER id. A mutation
run left an unresolved Enterprise delivery behind, and the next run's freshly
seeded organization was on the `enterprise` plan before it had done anything,
which reads as a product defect and is a property of the fixture. A real Stripe
customer id is globally unique and is attached to exactly one organization. The
file clears null-org events before it starts and counts by organization rather
than by customer, and says why in both places.

## What is NOT proven

- **No real Stripe.** No test-mode account, no dashboard sign-in, no live
  charge, no refund, no product or price created. The integration is exercised
  against the engine's own Stripe mock pack, which is the same arrangement
  PR #227 used and which found five defects in that pack.
- **No deployed control plane takes payment.** Everything above is a real
  Postgres 17 and the real HTTP routes on this machine. Nothing was applied to
  staging or production, and no Terraform apply was run.
- **The vault round trip.** `az` was proven to parse the arguments and read the
  file, against a vault name that does not resolve. That the service stores the
  bytes unchanged is not proven here; the runbook's length check and Stripe's
  own **Send test webhook** are what settle it, and both are steps a person runs.
- **The locking under concurrency**, as above. Proven by
  `billing-ordering.test.ts`, not by this file.
- **The browser leg is the API's answer, not rendered pixels.** Test 6 asserts
  what `subscriptions.current` returns to a signed in session. Nobody has looked
  at the console rendering it.

## Local verification

- API suite: **1947 tests, 1947 pass, 0 fail, 0 skipped**, own Postgres 17.11 on
  127.0.0.1:55903, `TZ=UTC`, `AF_REQUIRE_DATABASE=1`. Not the shared cluster.
- `tsc --noEmit` clean.
- `terraform fmt -check -recursive`, `validate` on all five directories, and
  `terraform test` pass on 1.15.8. CI pins 1.13.4.
- `prosecheck`, `changecheck`, `conflictcheck`, `varcheck`, `figurecheck`,
  `contactcheck`, `wirecheck`, `inputcheck`, `gatecheck`, `forbidden`, `cspell`
  and `vale` all pass.
- `production.tfvars` is byte identical to `origin/main`. PR #239 owns that line
  and this does not restate it.
