### PR TITLE
prosecheck: the documentation site was read by neither list

### DIFF
--- a/.changes/the-gate-that-could-not-see-the-documentation-site.internal.md
+++ b/.changes/the-gate-that-could-not-see-the-documentation-site.internal.md
@@ -1,0 +1,44 @@
+# fixed
+
+`CLAUDE.md` said `tools/prosecheck` "enforces it across every tracked file".
+It never has. The checker keeps two lists, and neither one named the
+documentation site: `documents` held `docs/src/content/docs`, which is only the
+part of `docs` that Astro renders, and `sources` held `www` and `console` and
+not `docs` at all. So the ADRs, the RFCs, the design documents and the plan
+notes sitting beside the content collection were read by nothing, and so was
+every TypeScript file the documentation site is built from.
+
+One violation was living in that gap on main. `docs/src/pages/llms-full.txt.ts`
+assembles the plain text twin of the entire manual, and the sentence at the top
+of it saying what the route serves carried an em dash. It is the only literal
+one that was anywhere outside this checker's reach, which is the reason to fix
+the instrument rather than the file.
+
+Both lists now name `docs`. That found eighteen more defects, all in
+`docs/plan/notes`, all of them the plain shape the rule exists for, and none of
+them a case where the character was doing a job. So the widening cost nineteen
+prose edits and bought no exemption list, which is the outcome the comment
+above `banned` asks for before one gets built.
+
+The double hyphen half of the rule stops here and that is a limit rather than
+a todo, so it is written into `main.go` with the measurement behind it. `--` is
+the SQL line comment and the POSIX end of options marker. Of the 1242 lines
+outside this checker's reach that match the rule, 1120 are SQL comments, and a
+further 3982 begin with the sequence in the first column where the rule cannot
+see them at all. Roughly a hundred genuine defects sit in Go and TypeScript
+comments that this instrument will never reach, and eight more lines could
+never be changed even so: two ASCII table rules, two SQL injection payloads
+whose entire point is that `--` opens a comment, a captured Postgres error
+string, the Vale rule that names the sequence, and two of this checker's own
+fixtures. Reaching them needs something that can tell a comment from a
+statement in six languages, which is a parser.
+
+Three new tests and two sharpened ones, each watched failing first. The two
+that check the real repository now name the trees they expect to reach instead
+of counting files, because a list that quietly stops covering one tree still
+clears a threshold, and that is exactly how the plan notes stayed unread under
+a green test. One test asserts the limit: an indented SQL comment in a
+migration is not a defect. That one was written flush left first and PASSED
+against the widening it exists to refuse, because a `--` in the first column
+has no character before it to match, so it was testing column zero rather than
+scope.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -294,6 +294,23 @@ comments, docs, commit messages, and user-facing strings does not use em dashes
 or double hyphens as punctuation. Error messages are written in the second
 person, name the thing that failed, and say what to do next.
 
+`tools/prosecheck` is the gate for that rule, and it does not reach everywhere
+the rule applies, so it is worth knowing what is actually holding you. It reads
+Markdown under `docs`, `examples`, `.changes`, `www`, `console` and the
+repository root, and every file with a `ts`, `tsx` or `mjs` extension under
+`www`, `console` and `docs`. It does not read Go, SQL, Terraform, YAML, or the
+api's and runner's TypeScript. A defect in a Go comment or a Terraform comment
+is yours to catch, and the engine carries four `require.NotContains` assertions
+of its own because nothing else checks the strings the CLI prints.
+
+The double hyphen half of the rule cannot be widened past those trees, and that
+is a limit rather than something nobody has got to yet. `--` is the SQL line
+comment and the POSIX end of options marker, so outside prose it is syntax far
+more often than punctuation: of the 1242 lines outside the gate that match the
+rule, 1120 are SQL comments. An em dash collides with no language here, which
+is why the two halves of one rule do not reach equally far. The measurement and
+the reasoning are in `tools/prosecheck/main.go`.
+
 Every user-facing error carries a code from
 `engine/internal/errors/catalog.yaml`. Adding a code without a catalog entry
 fails the build, and so does a catalog entry that nothing returns.

--- a/docs/plan/notes/console-web-application.md
+++ b/docs/plan/notes/console-web-application.md
@@ -18,7 +18,7 @@ The session is a `SameSite=Lax` cookie set by the control plane's origin.
 Serving the console from `antifailure.dev` would make every data call
 cross-origin, which needs `SameSite=None` on that cookie and a CORS policy that
 allows credentials. That widens the cross-site request surface of **every**
-endpoint on the API -- ingestion, provider keys, device approval -- in order to
+endpoint on the API (ingestion, provider keys, device approval) in order to
 move a dashboard to a second hostname. The trade is not worth making.
 
 So the console is a static export that the control plane's own Hono process
@@ -26,8 +26,8 @@ serves from `/app/console-out`: one origin, one cookie policy, one process. See
 `web/apps/api/src/console/static.ts`.
 
 The consequence to design around: a static export has no server, so there are
-no dynamic route segments. A detail view is a query string on a static page --
-`/runs?run=...`, `/environments?env=...`, `/masking?repo=...` -- never
+no dynamic route segments. A detail view is a query string on a static page:
+`/runs?run=...`, `/environments?env=...`, `/masking?repo=...`, never
 `/runs/[runId]`, which cannot be exported without knowing every id at build
 time. Query strings turn out to be the better answer anyway: a specific run is
 a link somebody can send.
@@ -68,7 +68,7 @@ Four things, none of which a passing build would have shown.
 **Every navigation blanked the page.** `Shell` was inside each page rather than
 in a layout. A layout survives a client-side navigation and a page does not, so
 clicking the sidebar unmounted the shell, refetched the session, and cleared the
-whole window -- navigation rail included -- until it came back. It looked like
+whole window, navigation rail included, until it came back. It looked like
 the application crashed on every click. Fixed by moving the chrome into
 `app/(app)/layout.tsx`, which is also what makes one session fetch serve every
 screen instead of three.
@@ -84,8 +84,8 @@ question, and `Loaded` refuses to hand a null to its children so the shape of
 that mistake shows a skeleton instead of a white screen.
 
 **The CSRF header was wrong.** The client sent `x-af-csrf`; the server has
-always read `x-antifailure-csrf`. Every mutation in the console -- storing a
-key, setting a cap, changing a role, approving a terminal -- answered 403. The
+always read `x-antifailure-csrf`. Every mutation in the console (storing a
+key, setting a cap, changing a role, approving a terminal) answered 403. The
 tests caught it, which is the only reason it is in this list rather than in
 production.
 

--- a/docs/plan/notes/dogfood.md
+++ b/docs/plan/notes/dogfood.md
@@ -165,7 +165,7 @@ That path is the whole pipeline in miniature. The manifest sets
 its own success shape and records the message instead of sending it. The agent
 asks for a link, reads it out of the inbox, follows it, and lands signed in.
 Nothing is delivered to anybody, no key is configured, and the run proves that
-an isolated deployment can be signed into — which is a real customer's problem
+an isolated deployment can be signed into, which is a real customer's problem
 as well as ours.
 
 Masking then replaces every address with a synthetic one at `example.test`,
@@ -223,7 +223,7 @@ to be a name a policy can resolve.
 **2. An unclassified free-text column was copied verbatim.**
 `transforms.md` says nullify "is the default for unclassified free text", the
 shipped example's README says the same, and the planner left such a column with
-no transform at all — which `BuildPlan` skips. A `notes` column nobody had
+no transform at all, which `BuildPlan` skips. A `notes` column nobody had
 written a rule for went into every environment unchanged. It was survivable
 because the plan reported the column and the verification scan reads every
 column back, but a report is read once and a default runs every time. Fixed to
@@ -245,7 +245,7 @@ a `BASE TABLE`, so the catalogue held both, and they hold the same rows. Two
 consequences: those rows were masked twice, and because a rule names a table
 and `events` is not `events_2026_08`, the parent got the rules somebody wrote
 while each partition got the fail-closed default. Partitions sort after the
-parent, so they ran last and won — a column explicitly marked `preserve` came
+parent, so they ran last and won. A column explicitly marked `preserve` came
 out emptied, silently. Found by refreshing a golden of the control plane, whose
 `events` table is partitioned by month. Fixed by excluding partitions from the
 catalogue, which is also half the masking time: 19 tables instead of 23, 28
@@ -426,7 +426,7 @@ and `grep` finds zero constructions of either outside their own file. So the
 engine emitted a typed, sequenced, redacted event for everything it did and the
 only consumer was a terminal UI: no machine readable record of a run existed
 anywhere, `af ci` attached no sink at all, and a CI job could only scrape prose.
-This is the dead code shape exactly — the parts are all there and nothing calls
+This is the dead code shape exactly: the parts are all there and nothing calls
 them. Fixed: every command that opens an environment now writes
 `.antifailure/events/<env>.ndjson`, which is what `tools/dogfood` reads its per
 step timings out of.
@@ -437,9 +437,9 @@ nothing outside a test, so the section that tells a reviewer the data was
 proved masked was unreachable. That is the product's central promise and it was
 a field nobody filled in. `af ci` ran no insights either, although it is the
 command whose entire purpose is the pull request check. Fixed: `af ci` reads
-the golden's stored attestation, checks the signature — this is a different
+the golden's stored attestation, checks the signature (this is a different
 process from the one that signed it, which is the whole reason the signature
-exists — and renders the result, plus a new insights section that distinguishes
+exists) and renders the result, plus a new insights section that distinguishes
 "looked and found nothing" from "could not look".
 
 ### Configuration that is read by nothing
@@ -473,7 +473,7 @@ resolve different trees. Generating the lockfile was not the fix: `runner/
 .gitignore` listed `package-lock.json`, so the generated file was invisible to
 git and to a fresh checkout. Changing CI to `npm ci` without noticing that
 would have turned a quiet defect into a red build on the first clone, which is
-the only reason it was found — `git status` showed the file as neither tracked
+the only reason it was found: `git status` showed the file as neither tracked
 nor untracked. Fixed: the ignore line is gone, the lockfile is committed,
 `npm ci` succeeds in `runner/`, and CI keys its cache on the lockfile.
 

--- a/docs/plan/notes/hosted-loop.md
+++ b/docs/plan/notes/hosted-loop.md
@@ -29,7 +29,7 @@ file rolled back, and the application came up with no schema at all: `/health`
 answered `200` while every endpoint that touched a table returned `500`. The
 extension is now allow-listed in Terraform and the bootstrap job has run.
 
-**Sign-in is GitHub OAuth, with signups closed -- and it has never worked.**
+**Sign-in is GitHub OAuth, with signups closed. It has never worked.**
 The OAuth App `Antifailure (staging)` exists under the `antifailure`
 organization, client id `Ov23lipGqLbu1cZJn1EF`, with the right callback. What
 was in Key Vault under `github-client-id` and `github-client-secret` was the
@@ -49,9 +49,9 @@ a made-up token answers 404, "no such token", where a wrong secret answers 401.
 The serving replica restarted 20 minutes after the secret was written, so it is
 the value the process holds.
 
-The App has exactly one client secret now. There were three by the end -- one
+The App has exactly one client secret now. There were three by the end: one
 from yesterday, one minted during the passkey session whose plaintext went
-nowhere, and this one -- and the two that nothing could use were deleted, both
+nowhere, and this one. The two that nothing could use were deleted, both
 "Never used".
 
 What has not happened is one human click. GitHub disables the Authorize button
@@ -84,7 +84,7 @@ static export served by the control plane from its own origin so the session
 cookie stays same-origin. Environments, runs with verdicts and artifacts,
 masking rules and attestation history, the egress policy with a way to ask it
 about one request, the audit log with its chain check, members, provider keys,
-and the device approval screen -- each with a loading, an empty and an error
+and the device approval screen, each with a loading, an empty and an error
 state. The 1,400 lines of hand-written HTML it replaces rendered as unstyled
 text in a real browser for a week. See `notes/console-web-application.md` for
 what the browser found that the build did not.

--- a/docs/plan/notes/seo-geo-catalog.md
+++ b/docs/plan/notes/seo-geo-catalog.md
@@ -16,7 +16,7 @@ experiment rather than vendor blogging.
 
 ---
 
-## Part 1 — 100 SEO techniques
+## Part 1: 100 SEO techniques
 
 ### A. Crawl and index foundations
 
@@ -151,7 +151,7 @@ experiment rather than vendor blogging.
 
 ---
 
-## Part 2 — 100 GEO techniques
+## Part 2: 100 GEO techniques
 
 ### A. AI crawler access
 

--- a/docs/src/pages/llms-full.txt.ts
+++ b/docs/src/pages/llms-full.txt.ts
@@ -2,7 +2,7 @@ import type { APIRoute } from "astro";
 import { getCollection } from "astro:content";
 
 /**
- * /docs/llms-full.txt — the complete documentation as one plain-text file.
+ * /docs/llms-full.txt: the complete documentation as one plain-text file.
  *
  * This is the single most useful thing this site can hand an assistant, and it
  * is nearly free to produce: the docs are already markdown, so there is nothing

--- a/tools/prosecheck/main.go
+++ b/tools/prosecheck/main.go
@@ -62,14 +62,34 @@ import (
 // trees did not include them and the source extensions did not include Markdown.
 // Nothing was shipping through it, which is the reason to close it now rather
 // than after something is.
-var documents = []string{"docs/src/content/docs", "examples", ".changes", ".", "www", "console"}
+//
+// The entry is `docs` and not `docs/src/content/docs`, which is what it used to
+// be. The content collection is what Astro renders, so it looked like the
+// documentation, and the ADRs, the RFCs, the design documents and the plan notes
+// sitting beside it are prose this project writes that no gate had an opinion
+// about. Twenty-seven tracked `.md` files were outside every list. Four of them
+// carried eighteen defects, and all eighteen were the plain shape this rule
+// exists for: a clause separator, in a sentence, written by somebody here. The
+// remaining twenty-three were already clean, so widening cost eighteen prose
+// edits and bought no exemption.
+var documents = []string{"docs", "examples", ".changes", ".", "www", "console"}
 
 // sources are the trees whose TypeScript carries copy rather than only code.
 //
 // www is the public site and console is the signed-in application. Both write
 // their sentences as string literals and JSX text, so both are prose that this
 // project publishes and neither is documentation with a different extension.
-var sources = []string{"www", "console"}
+//
+// docs is the third for the same reason, and it was missed because the
+// documentation site is the one place where "the documentation" and "the site"
+// are the same tree. Astro builds it, so its pages are TypeScript:
+// `docs/src/pages/llms-full.txt.ts` assembles the plain text twin of the entire
+// manual, and the sentence at the top of it saying what the route serves carried
+// an em dash through every green run this gate has ever had. It was the only
+// literal violation left anywhere outside this checker's reach. The other three
+// `.ts` and `.mjs` files under docs were already clean, which is why this
+// widening reports one line and not a list.
+var sources = []string{"www", "console", "docs"}
 
 // sourceExts are the extensions scanned inside sources.
 //
@@ -105,6 +125,48 @@ var banned = []struct {
 	{regexp.MustCompile(`\x{2013}`), "an en dash", "the word to, or a hyphen in a compound"},
 	{regexp.MustCompile(`\s--\s`), "a double hyphen as punctuation", "a comma, a colon, or a new sentence"},
 }
+
+// THE TWO RULES DO NOT HAVE THE SAME REACH, and only one of them ever can.
+// This is a limit of the double hyphen rule, written down because the obvious
+// next request is to point this checker at the rest of the repository.
+//
+// An em dash is syntax in no language here, so it can be banned anywhere prose
+// is written and the only question is which trees carry prose. A double hyphen
+// is syntax in three places, and each one puts whitespace on both sides of it
+// exactly the way punctuation does, so `\s--\s` cannot tell them apart:
+//
+//	-- the SQL line comment, which is how every migration is annotated
+//	git checkout -- .        the POSIX end of options marker
+//	sh -s -- -b "$path"      the same marker, handing flags to a script
+//
+// Measured across every tracked file this checker does not read, rather than
+// assumed. 1242 lines match the rule as written. 1120 of them are SQL line
+// comments, 853 in the migrations and 267 more inside SQL written as template
+// literals in the api's TypeScript, and 16 are the end of options marker in a
+// real command. None of those can be rewritten, because there the sequence is
+// the syntax. A further 3982 lines begin with `--` in the first column, where
+// there is no character before it for `\s` to match, so the rule cannot see
+// them at all. Almost all are SQL comments too, and the number is here because
+// a count that reaches for the character instead of for this pattern gets a
+// different and much larger answer.
+//
+// The 106 that remain are mostly the genuine defect, in comments, in Go and
+// TypeScript, and that is the honest cost of stopping here rather than a thing
+// left implied: this instrument will never see about a hundred real double
+// hyphens, and nineteen more in Terraform comments. But eight of the 106 cannot
+// be changed either. Two are ASCII table rules in a doc comment, two are SQL
+// injection payloads whose entire point is that `--` opens a comment, one is a
+// captured Postgres error string, one is the Vale rule that names the sequence,
+// and two are this file's own test fixtures.
+//
+// So extending the double hyphen rule needs an exemption list before it can run
+// once, to hold cases that are syntax rather than a decision somebody should
+// have made differently. The comment above `banned` explains why this file has
+// no such list and what would justify adding one. Eight entries that can never
+// be retired is not that: it is a rule being carried past the point where it can
+// express what it means. Catching those hundred needs an instrument that knows
+// a comment from a statement in six languages, which is a parser, not a regexp,
+// and it is not this one.
 
 // escaped are the ways source code writes the same characters without typing
 // them, which a scan for the character itself cannot see.

--- a/tools/prosecheck/main_test.go
+++ b/tools/prosecheck/main_test.go
@@ -82,6 +82,16 @@ func TestTheRealDocumentsAreClean(t *testing.T) {
 	if len(files) < 20 {
 		t.Fatalf("found %d documents, which suggests this is looking in the wrong place", len(files))
 	}
+	// The trees by name, not only a count. A list that quietly stops covering
+	// one of them still clears a threshold, which is how the plan notes went
+	// unread while this test was green: `docs/src/content/docs` is what Astro
+	// renders, so it looked like the documentation, and the ADRs, the RFCs and
+	// the design notes beside it belonged to no list at all.
+	for _, tree := range []string{"docs/src/content/docs/", "docs/plan/", "docs/adr/"} {
+		if !reaches(files, tree) {
+			t.Errorf("%s is reached by nothing, so its prose is checked by nothing", tree)
+		}
+	}
 	var out strings.Builder
 	if err := run(root, &out); err != nil {
 		t.Fatalf("%v\n%s", err, out.String())
@@ -163,13 +173,13 @@ func TestTheRealSourceIsClean(t *testing.T) {
 	if len(files) < 100 {
 		t.Fatalf("found %d source files, which suggests this is looking in the wrong place", len(files))
 	}
-	var www, console bool
-	for _, f := range files {
-		www = www || strings.HasPrefix(f, "www/")
-		console = console || strings.HasPrefix(f, "console/")
-	}
-	if !www || !console {
-		t.Fatalf("www reached: %v, console reached: %v", www, console)
+	// One assertion per tree rather than one condition over all three, so that
+	// a tree dropping out of the list is reported as itself instead of hiding
+	// behind whichever check ran first.
+	for _, tree := range []string{"www/", "console/", "docs/"} {
+		if !reaches(files, tree) {
+			t.Errorf("%s is reached by nothing, so its TypeScript is checked by nothing", tree)
+		}
 	}
 	// Nothing from a dependency or a build directory, which would make the
 	// check both slow and somebody else's problem.
@@ -224,6 +234,93 @@ func TestOnlyTheGeneratorsOwnBlockIsExemptFromTheMarkdownScan(t *testing.T) {
 	}
 }
 
+// The documentation site is the one place where "the documentation" and "the
+// site" are the same tree, which is how it fell between the two lists. Astro
+// builds it, so its pages are TypeScript, and `docs/src/pages/llms-full.txt.ts`
+// writes the plain text twin of the entire manual. The sentence at the top of
+// that file saying what the route serves carried an em dash through every green
+// run this gate has ever had.
+//
+// `www/README.md` and `www/page.tsx` are controls and neither is decoration.
+// `run` refuses a tree it found no Markdown or no TypeScript in, deliberately,
+// so without a file outside docs in each walk, narrowing either list back down
+// would make `run` return an error for a reason that has nothing to do with
+// what this test is asking, and the test would pass on it. The assertion on
+// file and line closes the same hole from the other side. Both were watched
+// failing before they were trusted.
+func TestTheDocumentationSitesTypeScriptIsInScope(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "www/README.md", "Site prose.\n")
+	write(t, root, "www/page.tsx", "export const ok = 1;\n")
+	write(t, root, "docs/src/pages/llms-full.txt.ts",
+		"/**\n * /docs/llms-full.txt \u2014 the complete documentation as one file.\n */\n")
+
+	var out strings.Builder
+	if err := run(root, &out); err == nil {
+		t.Fatalf("the documentation site's TypeScript was read by nothing:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "docs/src/pages/llms-full.txt.ts:2") {
+		t.Errorf("the defect was not reported against its file and line:\n%s", out.String())
+	}
+}
+
+// The other half of the same seam. `docs/src/content/docs` is what Astro
+// renders, so it read as "the documentation", and the ADRs, the RFCs, the plan
+// notes and the design documents sitting beside it were prose that no gate in
+// this repository had an opinion about. Both rules are checked here, because
+// what those files actually carried was eighteen defects of both shapes.
+func TestDocumentationMarkdownOutsideTheContentCollectionIsInScope(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "www/README.md", "Site prose.\n")
+	write(t, root, "www/page.tsx", "export const ok = 1;\n")
+	write(t, root, "docs/src/content/docs/page.md", "Rendered documentation.\n")
+	write(t, root, "docs/plan/notes/dogfood.md",
+		"This is the dead code shape \u2014 the parts are all there.\n")
+	write(t, root, "docs/adr/0001-language-choices.md",
+		"One runtime -- and nothing else was considered.\n")
+
+	var out strings.Builder
+	if err := run(root, &out); err == nil {
+		t.Fatalf("documentation Markdown outside the collection was read by nothing:\n%s", out.String())
+	}
+	for _, want := range []string{"docs/plan/notes/dogfood.md:1", "docs/adr/0001-language-choices.md:1"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("%s was not reported:\n%s", want, out.String())
+		}
+	}
+}
+
+// A limit, asserted so that widening this checker has to argue with a test
+// rather than find out in CI.
+//
+// `--` is the SQL line comment, and this rule matches the sequence with
+// whitespace on both sides, which is exactly how a migration writes an indented
+// one. 1120 of the 1242 lines that would be flagged outside this checker's
+// reach are SQL comments: 853 in the migrations and 267 more in SQL written as
+// template literals in the api's TypeScript. They cannot be rewritten, because
+// there the sequence is the syntax and not a decision somebody should have made
+// differently. So the migrations stay out of reach on purpose, which is why
+// `sources` names three trees by hand instead of taking the repository.
+//
+// The comment in the fixture is INDENTED, and that is the whole test. A `--` at
+// the start of a line has no character before it, so `\s--\s` cannot match it
+// and an unindented SQL comment is invisible to this rule already. Written flush
+// left first, this test passed with `.sql` added to the extensions and `web`
+// added to the trees, which is the mutation it exists to catch. It was asserting
+// a property of column zero and not a property of the scope.
+func TestTheDoubleHyphenRuleDoesNotFollowSQLIntoTheMigrations(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "www/README.md", "Site prose.\n")
+	write(t, root, "www/page.tsx", "export const ok = 1;\n")
+	write(t, root, "web/packages/db/migrations/0001_init.sql",
+		"CREATE TABLE members (\n  -- Stored lowercased: providers disagree about case.\n  email text\n);\n")
+
+	var out strings.Builder
+	if err := run(root, &out); err != nil {
+		t.Fatalf("a SQL comment is syntax and must not be a prose defect: %v\n%s", err, out.String())
+	}
+}
+
 func write(t *testing.T, root, rel, body string) {
 	t.Helper()
 	path := filepath.Join(root, filepath.FromSlash(rel))
@@ -233,6 +330,17 @@ func write(t *testing.T, root, rel, body string) {
 	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
 		t.Fatal(err)
 	}
+}
+
+// reaches reports whether the walk produced anything at all from a tree. The
+// question a count cannot answer.
+func reaches(files []string, prefix string) bool {
+	for _, f := range files {
+		if strings.HasPrefix(f, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func contains(files []string, want string) bool {


### PR DESCRIPTION
## What changed

`CLAUDE.md` claimed `tools/prosecheck` "enforces it across every tracked file".
It never has. The checker keeps two lists and neither named the documentation
site: `documents` held `docs/src/content/docs`, which is only the part of `docs`
that Astro renders, and `sources` held `www` and `console` and not `docs` at
all. One real violation was living in that gap on main. Both lists now name
`docs`, the violation and eighteen more found by the widening are fixed, and the
sentence in `CLAUDE.md` now states the reach the instrument actually has. The
double hyphen half of the rule is documented as unable to travel further, with
the measurement behind that in `main.go`.

## Failure paths covered

| Failure path | Test |
| --- | --- |
| The documentation site's TypeScript is read by nothing, so an em dash in it ships under a green gate | `TestTheDocumentationSitesTypeScriptIsInScope` |
| Documentation Markdown outside the content collection is read by nothing | `TestDocumentationMarkdownOutsideTheContentCollectionIsInScope` |
| A tree silently drops out of `documents` and a file count still clears its threshold | `TestTheRealDocumentsAreClean`, one assertion per tree |
| A tree silently drops out of `sources` and a file count still clears its threshold | `TestTheRealSourceIsClean`, one assertion per tree |
| The double hyphen rule is widened into SQL, where `--` is the comment token | `TestTheDoubleHyphenRuleDoesNotFollowSQLIntoTheMigrations` |

## Security considerations

None, and here is why.

- Secrets, masked data, the proxy, the journal: untouched. The change is a
  prose linter's file selection plus prose edits in comments and plan notes.
- No new outbound connection and no new stored data class. `prosecheck` reads
  the working tree and writes to stdout.
- Nothing about what an untrusted repository or pull request can reach changes.
  The tool gains no new capability, only more paths to walk.
- No dependency added.

The one edit outside `docs` and `tools` is in this pull request's own changelog
fragment. No secret, customer record or screenshot is included, and no value
from `keyvault.tf` is quoted anywhere: the double hyphen in that file is named
by path and line only.

## Exit criteria evidence

Both directions, as the repository's own rule requires. The widened checker was
run against the tree with `docs/src/pages/llms-full.txt.ts` unfixed, then
against the fixed tree. The offending character is written as `[U+2014]` in
the quoted output below, because a pull request body here may not contain it.

```
$ go run ./tools/prosecheck .          # widened checker, defects still in place
docs/plan/notes/console-web-application.md:21  a double hyphen as punctuation. ...
docs/plan/notes/dogfood.md:168  an em dash. Write a comma, a colon, or a new sentence.
    an isolated deployment can be signed into [U+2014] which is a real customer's
...
docs/src/pages/llms-full.txt.ts:5  an em dash. Write a comma, a colon, or a new sentence.
    * /docs/llms-full.txt [U+2014] the complete documentation as one plain-text file.
prosecheck: 803 files, 19 places where the punctuation gives it away

prosecheck: 19 places use punctuation this project does not
exit status 1
EXIT CODE: 1
```

```
$ go run ./tools/prosecheck .          # after the nineteen fixes
prosecheck: 804 files, 0 places where the punctuation gives it away
EXIT CODE: 0
```

Mutation table. Twelve assertions, each broken on its own production line,
watched failing for its own message, restored, watched passing. `go test -run`
matching nothing exits 0, so every cell also required the literal
`=== RUN   <TestName>` line before believing the result.

```
CELL TEST                                                           BROKEN   RESTORED VERDICT
A1   TestTheRealDocumentsAreClean                                   RED      GREEN    OK
A2   TestTheRealDocumentsAreClean                                   RED      GREEN    OK
A3   TestTheRealDocumentsAreClean                                   RED      GREEN    OK
B1   TestTheRealSourceIsClean                                       RED      GREEN    OK
B2   TestTheRealSourceIsClean                                       RED      GREEN    OK
B3   TestTheRealSourceIsClean                                       RED      GREEN    OK
C1   TestTheDocumentationSitesTypeScriptIsInScope                   RED      GREEN    OK
C2   TestTheDocumentationSitesTypeScriptIsInScope                   RED      GREEN    OK
D1   TestDocumentationMarkdownOutsideTheContentCollectionIsInScope  RED      GREEN    OK
D2   TestDocumentationMarkdownOutsideTheContentCollectionIsInScope  RED      GREEN    OK
D3   TestDocumentationMarkdownOutsideTheContentCollectionIsInScope  RED      GREEN    OK
E1   TestTheDoubleHyphenRuleDoesNotFollowSQLIntoTheMigrations       RED      GREEN    OK
```

The breaks, one per cell: A1 to A3 each leave exactly one `docs` subtree out of
`documents`; B1 to B3 and C1 each drop one tree from `sources`; C2 reports
`f.num+1` so the run still fails but at the wrong line; D1 drops `docs` from
`documents`; D2 and D3 comment out the em dash and the double hyphen entries in
`banned` respectively; E1 adds `.sql` to `sourceExts` and `web` to `sources`,
which is the widening that test exists to refuse.

E1 is worth reading. It passed on its first attempt against that same mutation,
because its fixture wrote the SQL comment flush left and `\s--\s` cannot match a
sequence in the first column: it was asserting a property of column zero rather
than a property of the scope. Indenting the fixture is the whole test.

```
$ go run ./tools/changecheck
changecheck: 8 changed paths, none of it behaviour anybody outside can see

$ go run ./tools/gatecheck
gatecheck: 78 gates in 9 pull request workflows.
  68 paired by command and directory to a recipe `just gate` calls.
  2 paired by command only, against a justfile command whose directory
    is computed at run time, so for these the directory was not compared.
  8 exempt by name in exemptFromGate, with the reason recorded there.

$ go vet ./tools/prosecheck/ && go test ./tools/prosecheck/ -count=1
ok  	github.com/antifailure/antifailure/tools/prosecheck	0.279s
```

`just gate` was started on the rebased head and its result is reported in a
comment on this pull request rather than paraphrased here.

## What this does NOT do, stated rather than left implied

The double hyphen rule cannot leave the prose trees. Of the 1242 lines outside
this checker's reach that match the rule as written, 1120 are SQL line comments
and 16 are the POSIX end of options marker, and a further 3982 lines open with
the sequence in the first column where the rule cannot see them at all. About a
hundred genuine defects therefore sit in Go and TypeScript comments this
instrument will never reach, and nineteen more in Terraform comments, including
the one in `infra/terraform/modules/control-plane/keyvault.tf`. Eight of those
lines could not be changed even if it did reach them, so widening would need an
exemption list holding entries that can never be retired. The reasoning is in
`tools/prosecheck/main.go` above `escaped`.

`CLAUDE.md` is NOT in this diff. It is untracked, listed in
`.git/info/exclude` beside `PROGRESS.md`, so the corrected sentence was written
in the primary checkout where the file actually exists and cannot be shipped
here. `prosecheck` still reads it, because the walk is over the filesystem and
not over the index.

## Checklist

- [x] Commits are signed off (`git commit -s`)
- [x] A changelog fragment exists under `.changes/`
- [x] Documentation is updated for anything user visible
- [x] Every new error code has a catalog entry (none added)
- [x] No secret, real customer record, or unredacted screenshot is included
