### PR TITLE
release: v1.2.0, for a form posting to a route production does not have

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,243 @@ and the per change entries are what make it a wall. `just relnotes` refuses an
 unbalanced marker, a second region in one section, an empty region, and a
 section that omits all of itself.
 
+## v1.2.0
+
+Merging deploys staging. Only a tag deploys production, so everything below has
+been on `main` for days and none of it exists for anybody outside this
+repository until this tag is pushed. The careers page is the clearest case and
+it is why this release was cut when it was. The page is served by the website,
+which publishes on every merge to `main`; the form on it posts to
+`/v1/applications` on the control plane, which does not. Somebody filling that
+form in was told the server could not be reached, and the server was answering
+correctly: the route it was asked for did not exist in the build it was running.
+
+**An agent in a browser can reach this product.** `af mcp` served the rehearsal
+tools over standard input and output to a process the client started, which
+covers every coding agent and covers neither claude.ai nor chatgpt.com, because
+a web page cannot start a process on somebody's laptop. There is now an HTTPS
+endpoint speaking Streamable HTTP and authorized by OAuth, with dynamic client
+registration, PKCE, a consent screen that names the requesting client, its
+permissions, its registered return address and the lifetime of the access
+before anybody approves anything, and an operator page that lists every
+credential the registration produced and can revoke one through the existing
+audited action. The access token is a fourth kind on the token table this
+control plane already had rather than a fourth table, so it inherits hashing,
+expiry and revocation that were already tested, and the audience check is a
+`WHERE` clause in both directions: an `af login` token replayed at `/mcp` is
+refused, and an MCP token replayed at `/v1/whoami` is refused.
+
+**`af update`, because the command line knew it was out of date and could only
+tell you to go and find the fix.** Upgrading meant returning to the website and
+running the install script by hand, landing on whatever version the page
+happened to serve. `af update` reads the published release, checks the archive
+against the SHA256 in `checksums.txt` before unpacking anything, unpacks beside
+the binary, and replaces the binary last by a rename, so a failure at any
+earlier step leaves the installation that was already working. It refuses a
+package managed installation, an enterprise binary and a downgrade rather than
+guessing. `af doctor` now reports whether this binary is current and whether
+the project's manifest is valid, and it no longer signs off with "This machine
+can run Antifailure" while carrying a check that has just said it could not
+tell.
+
+**The hosted control plane can take payment, and pushing this tag is not what
+turns it on.** The checkout and webhook routes that answered 503 are wired, the
+price is set in `production.tfvars`, and the two Stripe credentials are
+addressed by versionless Key Vault reference and resolved by the application's
+identity, so no Terraform plan ever reads either value. What enables billing is
+an apply with both secrets already in the vault, which is a deliberate act by a
+person and not something a tag performs. Team is a flat price for the
+organization rather than per seat, which is why checkout sends a quantity of
+exactly one. `hosted_required_plan` stays empty on purpose: turning payment on
+so somebody can buy is a different act from requiring everybody already here to
+buy, and the second one locks out every organization on the plane the moment it
+applies.
+
+**And another run of defects that every instrument was green about.** A
+manifest could enable load and exploration while the pull request check skipped
+both, and the report presented that absence as a clean result rather than as
+something it had not looked at. The hosted check ignored policy findings
+whenever the browser workflows passed. The console could show a workflow as
+passed after the engine had already marked it unverified for using a response a
+model invented. An installation whose analytics had stopped said exactly what
+an installation that never started says, and only one of those is a fault. Two
+billing decoders read Stripe field paths that Stripe had moved a version
+earlier, coerced the missing field to null, and wrote rows that looked
+complete. In each case something was checking, and it was answering a nearby
+question.
+
+### What moves when this tag is pushed
+
+The tag deploys the control plane image and applies the migrations production
+has not seen, in the bootstrap job, before any traffic moves. Three are new
+since v1.1.1 and all three are additive: `0037` retains an environment's
+recorded consumption through cleanup, `0038` adds the two tables and the token
+kind the MCP endpoint needs, and `0039` adds the private application queue
+behind the careers form. Nothing in them drops a column, drops a table, renames
+anything, or makes an existing column NOT NULL, which is the property that lets
+the revision currently serving keep running against the new schema if traffic
+has to go back to it. Migrations are not rolled back; traffic is.
+
+It also publishes the binary that the install script hands to a stranger, and
+the installer follows `releases/latest`, so the download changes the moment the
+release is created.
+
+The two Terraform `image_tag` defaults keep naming v1.1.1 until this tag has
+published. They are read by an apply from `main` with no `ignore_changes`, so
+naming an unpublished tag produces a failed apply on the stack that runs the
+product rather than a stale deployment. They move in their own commit
+afterwards.
+
+### Behaviour you may depend on that changed
+
+- **`af init` no longer treats a Dockerfile as a service without runtime
+  evidence.** An image used only to execute isolated snippets was being
+  detected as a web server, and a repository's Alembic migration was assigned
+  to it even though the image contained neither Alembic nor the schema. A
+  framework or a Compose command supplies that evidence. A migration command
+  outside a unique service directory now requires an explicit image owner, and
+  an unattended run refuses to guess rather than choosing wrongly and reporting
+  success.
+- **Enabled load and exploration goals now run during pull request checks.** A
+  manifest could turn either on while CI skipped it. Load now sends a bounded
+  read only smoke to the literal safe routes when no traffic source exists, and
+  reports the request counts; an incomplete load experiment is inconclusive
+  rather than a pass. If your manifest enables either, your checks now do work
+  they were silently skipping.
+- **A failing policy finding fails the hosted pull request check.** It was
+  ignored whenever the browser workflows passed. A check that was green may now
+  be red, and that is the defect being fixed rather than a new one.
+- **Checkout sends a quantity of exactly one.** The old request omitted
+  quantity, and its test required that omission. An older client sending a seat
+  count no longer multiplies the price by the number of members.
+- **Removing an environment or a repository no longer erases its recorded
+  consumption.** Usage retains each environment's interval through cleanup, so
+  operator analytics and the rolling cost cap survive a teardown. Deleting an
+  organization still erases its history, and history already deleted cannot be
+  recovered.
+- **`af doctor` fails for an outdated stable release**, and reports unknown
+  rather than current for a development build, for a version newer than
+  anything published, and for a lookup that could not complete. A version check
+  that cannot reach the network and answers "current" is worse than no check.
+- **`just merge` performs the merge now.** `gh pr merge --squash --body ""`
+  creates a commit with no `Signed-off-by` trailer, which fails a required
+  context on `main`, which makes the deploy workflow refuse. Six merged pull
+  requests sat undeployed behind one missing line. No hook can reach this,
+  because a squash commit is created on GitHub's side.
+
+<!-- relnotes:omit -->
+
+### Added
+
+- An MCP endpoint a browser based client can connect to, with dynamic client
+  registration, PKCE, and hosted tools that use the same tenant permissions and
+  execution paths as the console (#234).
+- The MCP consent screen shows the requesting client, its permissions, its
+  registered return address and the access lifetime before asking for approval.
+  Signing in returns to the request without approving it, declining grants no
+  access, and an incomplete or mismatched request cannot be approved (#234).
+- `af update`, which installs the latest release rather than telling you how
+  to. It verifies the archive before unpacking, replaces the binary last by a
+  rename, refuses a package managed installation, an enterprise binary and a
+  downgrade, and finishes an interrupted update on the next run. Asking for
+  `--check` reports the latest release and changes no file (#241).
+- Founding engineering and growth roles have a careers page with compensation
+  stated upfront, a private application form, and an operator review queue.
+  Applications expire after 180 days through maintenance (#238).
+- The hosted control plane can take payment. `stripe_price_team` turns on the
+  two Key Vault secret references, the three environment variables the process
+  reads, and the checkout and webhook routes that were answering 503. There is
+  deliberately no enterprise price: checkout refuses that plan by name rather
+  than reaching Stripe with an empty identifier (#239).
+- The runbook for turning payment on, in the order that works, and a test that
+  walks one organization through the whole path rather than each hop of it: a
+  refused fourth environment, checkout, a delivery signed over raw bytes, the
+  plan, the subscription row, the same request now allowed, and what the
+  billing screen shows a signed in browser (#244).
+
+### Fixed
+
+- The billing decoders read two Stripe field paths that Stripe had removed. A
+  webhook is delivered at the version its endpoint was created with, and no
+  version older than Basil is on offer when a destination is created, so every
+  delivered event arrived in a shape the decoders read one version too early.
+  Neither failure threw: both coerced the missing field to null and wrote a row
+  that looked complete, so a cancelling customer lost the entitlement window
+  they had paid for and every invoice lost its link to its subscription (#246).
+- Billing could remove a paid plan when a newer canceled subscription arrived,
+  choose a plan by webhook arrival time, or miss a payment event while its
+  customer was being attached (#232).
+- Checkout sent no quantity for a licensed recurring price, and its test
+  required that omission (#227).
+- Enabling Stripe made a production Terraform plan read the payment
+  credentials. It constructs Key Vault references instead and lets the
+  application's identity resolve them at deployment, so the planning identity
+  keeps its existing permissions (#227).
+- Enabled load and exploration goals never ran during pull request checks, and
+  their absence was reported as a clean result. Explicit safe pages filtered
+  away the only default route. Exploration only runs no longer claim to be
+  using a model merely because a model key is configured, and one unreadable
+  exploration result no longer discards the evidence from the others (#243).
+- The hosted pull request check ignored policy findings whenever the browser
+  workflows passed (#243).
+- The console could show a workflow as passed after the engine had marked it
+  unverified for using a response a model invented (#228).
+- An installation that recorded analytics and then stopped said exactly what an
+  installation that never recorded says. The absent variable cannot detect its
+  own absence, so the question is asked of the database instead, which is the
+  one party a rollback does not move (#237).
+- Analytics could omit midnight events and assign funnels to the wrong week
+  when PostgreSQL used a local timezone (#232).
+- Removing an environment or a repository erased its consumption from operator
+  analytics and could reset the rolling cost cap (#229).
+- An expiry sweep removed its target and reported lifecycle events under the
+  checkout's environment name (#233).
+- An image used only to execute isolated snippets was detected as a web server,
+  and a repository's Alembic migration was assigned to it. Initialization now
+  requires runtime evidence before treating a Dockerfile as a service, and a
+  migration command outside a unique service directory requires an explicit
+  image owner (#224).
+- A successful HTTP response with a missing tRPC result left console cards
+  loading forever (#226).
+- The console's first result guide stopped at commands that prepare a manifest
+  and inspect the machine, without ever executing a test (#226).
+- The operator MCP page did not show registered clients or issued credentials,
+  and presented local checkout sessions as hosted measurements (#234).
+- The first operator required a hand built container job and a database URL on
+  the command line. `just operator-init production` opens secure interactive
+  setup in the running deployment, using its existing credential (#231).
+- The operator sidebar and mobile menu shared their section identifiers, which
+  made both navigations' accessible labels ambiguous, and success badges used a
+  translucent green fill that put text contrast below 4.5:1 (#225).
+- A squash merge made without a sign off stopped deployments, and nothing could
+  have caught it before it landed. `just merge` performs the merge now (#235).
+- Continuous deployment left the scheduled maintenance job on the image from
+  the last Terraform apply, so production served v1.1.0 while maintenance still
+  ran v1.0.0. A revision whose private address cannot be read now refuses
+  promotion instead of skipping the candidate health check (#230).
+- The npm advisory gate discarded the reason an audit endpoint refused a
+  request, and a slow registry could exhaust the Security job without ever
+  writing a report (#221).
+- The self hosting guide explained the zero percent revision trap with the
+  wrong mechanism. Terraform does send a traffic block; `ignore_changes`
+  decides which one. The stored state file keeps the old revision suffix
+  indefinitely, so what is serving comes from Azure and not from `terraform
+  state show` (#236).
+- The Azure page told an operator to pass both Stripe credentials on the
+  command line, which the rotating secrets page forbids by name for every other
+  credential on this plane (#244).
+
+### Changed
+
+- The product and solutions pages draw the run they describe. Six figures and
+  the homepage's twin lifecycle were redrawn from the shared figure kit, each
+  carrying the caption it needs, so a number chosen for an illustration reads
+  as chosen and every figure that reads as a measurement names its source. Four
+  classes that set a property another class had already set were doing nothing,
+  and four figures were cut off at 320px rather than reflowed (#223).
+
+<!-- relnotes:end -->
+
 ## v1.1.1
 
 A patch release, cut for one reason: two fixes that only take effect once the

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antifailure/site-api",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "description": "The managed functions behind antifailure.dev.",
   "scripts": {

--- a/console/package.json
+++ b/console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antifailure/console",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "description": "The control plane's web application, served by the control plane itself.",
   "license": "MIT",

--- a/deploy/helm/antifailure-control-plane/Chart.yaml
+++ b/deploy/helm/antifailure-control-plane/Chart.yaml
@@ -16,8 +16,8 @@ type: application
 # values.yaml keeps its name, its type, and whether it is required for the whole
 # of chart 1.x, tools/inputcheck holds this chart to that, and 0.1.1 would now
 # be telling an operator the opposite of what is true.
-version: 1.1.1
-appVersion: "v1.1.1"
+version: 1.2.0
+appVersion: "v1.2.0"
 
 home: https://antifailure.dev
 sources:

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antifailure/docs",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "description": "The Antifailure documentation site, served at https://antifailure.dev/docs.",
   "license": "Apache-2.0",

--- a/docs/src/content/docs/security/releases.md
+++ b/docs/src/content/docs/security/releases.md
@@ -67,7 +67,7 @@ Install [cosign](https://docs.sigstore.dev/cosign/system_config/installation/).
 The identity is long and you need it three times, so name it once:
 
 ```sh
-TAG=v1.1.1
+TAG=v1.2.0
 REPO=antifailure/antifailure
 WORKFLOW=.github/workflows/release.yml
 
@@ -136,10 +136,10 @@ trusting either of us.
 ```sh
 git clone https://github.com/antifailure/antifailure
 cd antifailure
-git checkout v1.1.1
-./tools/release/build.sh linux amd64 1.1.1 \
+git checkout v1.2.0
+./tools/release/build.sh linux amd64 1.2.0 \
   "$(git rev-parse HEAD)" "$(git show -s --format=%cI HEAD)" dist stage
-sha256sum dist/antifailure_1.1.1_linux_amd64.tar.gz
+sha256sum dist/antifailure_1.2.0_linux_amd64.tar.gz
 ```
 
 That hash should be the line for your platform in `checksums.txt`. You need the
@@ -207,8 +207,8 @@ of them goes red.
 3. Tag and push:
 
    ```sh
-   git tag -a v1.1.1 -m "v1.1.1"
-   git push origin v1.1.1
+   git tag -a v1.2.0 -m "v1.2.0"
+   git push origin v1.2.0
    ```
 
    The tag is annotated and carries no signature. What is signed is
@@ -285,7 +285,7 @@ because it means holding a private key. Four steps, once:
    git config --global tag.gpgsign true
    ```
 
-Step 3 of the runbook then becomes `git tag -s`, and `git verify-tag v1.1.1`
+Step 3 of the runbook then becomes `git tag -s`, and `git verify-tag v1.2.0`
 starts answering. Until somebody does that, this page describes what the
 repository does rather than what it could do.
 

--- a/ee/web/audit/package.json
+++ b/ee/web/audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antifailure-ee/audit",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "license": "SEE LICENSE IN ../../LICENSE.md",
   "type": "module",

--- a/ee/web/rbac/package.json
+++ b/ee/web/rbac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antifailure-ee/rbac",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "license": "SEE LICENSE IN ../../LICENSE.md",
   "type": "module",

--- a/ee/web/scim/package.json
+++ b/ee/web/scim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antifailure-ee/scim",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "license": "SEE LICENSE IN ../../LICENSE.md",
   "type": "module",

--- a/ee/web/sso/package.json
+++ b/ee/web/sso/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antifailure-ee/sso",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "license": "SEE LICENSE IN ../../LICENSE.md",
   "type": "module",

--- a/runner/package.json
+++ b/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antifailure/runner",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "description": "Drives an application the way a person does, and returns a verdict with evidence.",
   "license": "MIT",

--- a/web/apps/api/package.json
+++ b/web/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antifailure/api",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/web/packages/db/package.json
+++ b/web/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antifailure/db",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/web/packages/policy/package.json
+++ b/web/packages/policy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antifailure/policy",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/www/package.json
+++ b/www/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antifailure/www",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "description": "Public Antifailure website: marketing pages, docs, and sign-in.",
   "license": "MIT",


### PR DESCRIPTION
## The failure

Vir filled in the careers form on `antifailure.dev/careers` and was told the
server could not be reached. The form is correct and the server was answering
correctly: `POST /v1/applications` does not exist in the build production is
running. Reproduced:

```
$ curl -sS -o /dev/null -w '%{http_code}\n' -X POST https://app.antifailure.dev/v1/applications
404
$ curl -sS https://app.antifailure.dev/readyz
{"ready":true,"version":"v1.1.1","commit":"59486b63b0babb7f36b425a2c3bb8e6a79653b1c"}
```

The page is served by the website, which publishes on every merge to `main`.
The route is served by the control plane, which moves only when a `v*` tag is
pushed. Production has been serving v1.1.1 while `main` has carried that route
for days. A tag is the mechanism that closes the gap, and this is the writing
work that has to exist before one.

## Why the section comes first

`release.yml` passes `generate_release_notes: false` and a `body_path` that
`tools/relnotes` writes from the `## vX.Y.Z` section of `CHANGELOG.md`. A tag
whose section is missing or empty fails the release job, and by then the tag is
pushed and the only remedy is deleting a tag people may already have fetched.
`just relnotes` asks the same question while it is still cheap.

## Why v1.2.0

By this repository's own rule rather than by semver from first principles. The
v1.0.0 section says "New commands and new flags are minor releases", and this
range adds `af update`, an MCP endpoint a browser client can connect to, a
careers page with a private application queue, and the configuration that lets
the hosted plane take payment. Nothing in the range removes or renames anything
on the stable surface, which is what a major would cost.

## No counted figure in the section

The v1.0.0 section shipped a commit count that had drifted by 40 percent before
anybody looked, and `just figurecheck` reads only `www`, so nothing checks this
file. The migrations are named rather than counted, so a fourth arriving makes
the sentence visibly wrong instead of quietly wrong. That one enumeration is
the only thing in the section that has to be re-read against the commit being
tagged.

## What else moves, and what deliberately does not

`tools/tagsync` decides this, not taste:

```
ok  v1.1.1   the control plane stack's image_tag default
ok  v1.1.1   the control plane module's image_tag default
ok  v1.2.0   the chart's appVersion, the release being prepared
ok  v1.2.0   the tag the signature verification example checks
ok  v1.2.0   the tag the rebuild example checks out
ok  v1.2.0   the version the rebuild example passes to build.sh
ok  v1.2.0   the archive the rebuild example hashes
```

Both `image_tag` defaults stay at v1.1.1. They are read by an apply from `main`
with no `ignore_changes`, so naming an unpublished tag produces a failed apply
on the stack that runs the product. They move in their own commit after the tag
publishes.

The four pinned literals in the verification page are kind `current`, which
tagsync requires to name the release being prepared. The three unpinned v1.1.1
mentions on that page move too, because 704bb8a7 moved all seven and a worked
example naming the previous release is the exact defect the pins exist for, one
step outside their reach. The package versions follow c7f23627: a minor moves
them, a patch does not.

## Why `Changelog-None` rather than a fragment

The release note for this tag IS the section this commit adds. A fragment under
`.changes/` is raw material for the NEXT release, and the site groups fragments
by the release they land in, so a fragment here would file the v1.2.0 notes
under v1.2.1. 704bb8a7 made the same call for the same reason.

## Gates

Run locally on this tree, output verbatim:

```
ldcheck       3 symbols in tools/release/build.sh, every one present and a string
relnotes      every section in CHANGELOG.md publishes something (4 checked)
tagsync       every version pin names a tag that exists, or the release being prepared
releasecheck  6 assets, every one named before it is published, every signature published
prosecheck    772 files, 0 places where the punctuation gives it away
conflictcheck 2198 files, no unresolved merge, 0 exemptions all still needed
```

This does not tag anything. Pushing the tag fires `release.yml`, which publishes
a public GitHub release with no human gate, and that needs Vir's explicit
confirmation.
