### PR TITLE
www: the careers form posted to a route the deployed control plane did not have

### DIFF
--- a/.changes/the-site-shipped-ahead-of-the-api-it-posts-to.md
+++ b/.changes/the-site-shipped-ahead-of-the-api-it-posts-to.md
@@ -1,0 +1,27 @@
+# added
+
+A gate that refuses to publish the marketing site when it calls a control plane
+route the deployed control plane does not serve.
+
+Somebody filled in the careers form on antifailure.dev and was told "Could not
+reach the server". Nothing was broken in either half: the form posts to
+`POST /v1/applications`, the route was registered, and every test of both sides
+passed. The site publishes on every merge to main and the control plane only
+moves when a `v*` tag is promoted, so the careers page went live the moment its
+pull request merged while the API it posts to was still serving v1.1.1, twenty
+two commits behind. `POST /v1/applications` answered 404 and the form's `catch`
+turned that into the only sentence a visitor ever saw.
+
+`tools/routecheck` asks the deployment rather than the tree, because a check
+comparing the site against main's `server.ts` passes on exactly this failure.
+It runs before the publish, and it fails when it cannot establish an answer
+rather than reporting a pass it did not earn.
+
+This does not by itself restore the careers form. The route reaches production
+when a `v*` tag is promoted, as every control plane change does. What changes
+today is that the site can no longer be published in front of an API that does
+not serve it.
+
+Every control plane URL the site builds is now declared in
+`www/lib/control-plane-routes.ts`, and a call site that builds one anywhere else
+fails the `www` gate naming the file and the line.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -658,6 +658,27 @@ jobs:
         # same reason.
         run: go run ./tools/classcheck .
 
+      - name: The site calls control plane routes that exist
+        # Somebody filled in the careers form on antifailure.dev and was told
+        # "Could not reach the server". The form was correct and the route was
+        # correct: `POST https://app.antifailure.dev/v1/applications` answered
+        # 404, because this site publishes on every merge to main and the
+        # control plane only moves when a `v*` tag is promoted. The page was
+        # live in front of an API twenty two commits behind it.
+        #
+        # This is the half a pull request can prove, and it is deliberately not
+        # the half that catches the failure above: it checks that every control
+        # plane URL the site builds is declared in one module, and that every
+        # route declared there is one this repository's control plane mounts.
+        # On the day the form broke, main's server.ts did declare the route, so
+        # this would have been green. It exists so that the inventory the other
+        # half reads cannot go stale or go quietly incomplete, and it says out
+        # loud when it finishes that what is DEPLOYED was not checked here.
+        #
+        # The half that would have caught it needs a live origin and runs in
+        # deploy.yml, immediately before the publish.
+        run: go run ./tools/routecheck -root .
+
       - name: No animation that never stops
         # If a piece of UI animates on an infinite loop while the user does
         # nothing, it is wrong. Reads the built stylesheet and HTML rather than

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,6 +82,13 @@ jobs:
             www/package-lock.json
             docs/package-lock.json
 
+      # For routecheck below, which is the last thing standing between a site
+      # that calls a route and a control plane that does not serve it.
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: tools/go.mod
+          cache-dependency-path: tools/go.sum
+
       - name: Build the marketing site
         # next.config.ts sets output: "export", so this writes static files and
         # needs no server.
@@ -144,6 +151,58 @@ jobs:
             exit 1
           fi
           echo "no documentation link escapes the /docs base"
+
+      - name: The control plane this site is about to call actually serves it
+        # THE FAILURE. Somebody filled in the careers form on antifailure.dev
+        # and was told "Could not reach the server". The form was correct, the
+        # route was correct, and this is what production answered:
+        #
+        #   POST https://app.antifailure.dev/v1/applications  ->  404
+        #   POST https://app.antifailure.dev/v1/leads         ->  400
+        #
+        # The site publishes on every merge to main; the control plane only
+        # moves when a `v*` tag is promoted. The careers page went live the
+        # instant its pull request merged, in front of an API twenty two commits
+        # behind it that had never heard of the route it posts to.
+        #
+        # The step below on the machine-readable surfaces already wrote this
+        # split down and decided it was tolerable, "because the paths are
+        # additive and a caller reading an operation that is not there yet gets
+        # a 404". That is right about openapi.json, which somebody READS. It is
+        # wrong about this site, which is a CALLER, and for a caller a 404 is a
+        # form that does not work.
+        #
+        # It runs HERE rather than in ci.yml because the question is not what
+        # main declares. It is what the origin this build is about to point
+        # browsers at will answer them, and that can change between the merge
+        # and the publish without a commit. It fails closed: an origin that
+        # cannot be reached, that answers 5xx, or whose reply did not come from
+        # the control plane at all is reported as undetermined and fails, never
+        # as a pass it did not earn.
+        #
+        # -allow-write-probes sends the one probe the inventory declares as
+        # writing something: GET /auth/github creates one expiring oauth_states
+        # row, exactly as a person who clicks "Continue with GitHub" and closes
+        # the tab does. There is no request that proves that route is present
+        # without it, so it is declared and paid for rather than skipped.
+        if: ${{ env.TOKEN != '' }}
+        env:
+          TOKEN: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          control="${NEXT_PUBLIC_CONTROL_PLANE_URL:-https://app.antifailure.dev}"
+
+          # The origin checked has to be the origin the bundle calls. Nothing
+          # here sets NEXT_PUBLIC_CONTROL_PLANE_URL, so the build baked in the
+          # default above, and this proves that rather than assuming it. A gate
+          # that probed a different origin than the one shipped would be a
+          # green tick over the same class of failure.
+          if ! grep -rqF "$control" site/_next 2>/dev/null; then
+            echo "::error::the built site does not contain $control, so routecheck would probe an origin the bundle does not call."
+            exit 1
+          fi
+
+          go run ./tools/routecheck -root . -origin "$control" -allow-write-probes
 
       - name: Publish
         # Skipped, with the job still green, until somebody sets the token.

--- a/.gitignore
+++ b/.gitignore
@@ -167,6 +167,7 @@ runner/artifacts/
 /reltar
 /runbookcheck
 /sbomcheck
+/routecheck
 /scanrepo
 /schemadoc
 /sidebarcheck

--- a/justfile
+++ b/justfile
@@ -82,6 +82,7 @@ gate: _reports
     run "closed sets are counted right"  just constcheck
     run "self-hosting inputs are stable" just inputcheck
     run "documented config can be set"   just wirecheck
+    run "the site calls routes that exist" just routecheck
     run "payment secrets reach the app"  just test-infra-config
     run "no unfinished merge"            just conflictcheck
     run "prose reads like a person"      just prosecheck
@@ -977,6 +978,35 @@ inputcheck:
 # that has stopped being needed is reported so the file cannot rot.
 wirecheck:
     go run ./tools/wirecheck .
+
+# The site does not call a control plane route that is not there.
+#
+# Somebody filled in the careers form on antifailure.dev and was told "Could not
+# reach the server". The form was right, the route was right, and
+# `POST https://app.antifailure.dev/v1/applications` answered 404: the site
+# publishes on every merge to main and the control plane only moves on a `v*`
+# tag, so the page was live against an API twenty two commits behind it.
+#
+# This is the OFFLINE half, which is what a pull request can prove. It checks
+# that every control plane URL the site builds is declared in
+# www/lib/control-plane-routes.ts and that every route declared there is one
+# this repository's control plane actually mounts. It CANNOT see the failure
+# above, and says so when it finishes: on the day the careers form broke, main's
+# API did declare the route. The half that would have caught it needs a live
+# origin and runs in deploy.yml against the control plane the site is about to
+# be published in front of.
+routecheck:
+    go run ./tools/routecheck -root .
+
+# The same command against a control plane that is actually running.
+#
+# Not part of `just gate`, because it asks the internet and a gate that blocks a
+# merge on a network timeout is a gate people learn to re-run rather than read.
+# deploy.yml runs it before the publish step, which is where the answer matters:
+# the question is not what main declares, it is what the origin this build is
+# about to point browsers at will answer them.
+routecheck-deployed origin="https://app.antifailure.dev":
+    go run ./tools/routecheck -root . -origin {{origin}} -allow-write-probes
 
 # Mocked providers exercise the rendered payment references without cloud access.
 test-infra-config:

--- a/tools/claimcheck/main.go
+++ b/tools/claimcheck/main.go
@@ -815,7 +815,19 @@ var siteClaims = []siteClaim{
 		// screen sends a browser at a control plane's GitHub exchange. If this
 		// product ever stops having one, that link is the first thing to go, and
 		// whoever removes it is told to revisit what the site may say.
-		premise: [2]string{"www/components/AuthScreen.tsx", `CONTROL_PLANE_URL + "/auth/github"`},
+		//
+		// Re-anchored a second time, and for a smaller reason than the first.
+		// The premise was the expression `CONTROL_PLANE_URL + "/auth/github"`
+		// until every control plane URL this site builds became a value in
+		// www/lib/control-plane-routes.ts, so that tools/routecheck can prove
+		// the DEPLOYED control plane serves each one. The link is unchanged and
+		// still points at the same place; only the accessor moved, exactly as
+		// `c.token` became `c.bearer()` in the rule above. The fact worth
+		// anchoring is that this screen sends a browser at the control plane's
+		// GitHub exchange, and `controlPlaneUrl("auth.github")` is now the way
+		// that is said. Deleting the link still trips this rule, which is the
+		// whole point of it.
+		premise: [2]string{"www/components/AuthScreen.tsx", `controlPlaneUrl("auth.github")`},
 		reason: "the hosted control plane is deployed and open, and AuthScreen sends " +
 			"people to it. The denial survived once as the meta description of " +
 			"/signin and /signup, which is what a crawler and a link preview read, " +

--- a/tools/gatecheck/main.go
+++ b/tools/gatecheck/main.go
@@ -557,6 +557,18 @@ func uncalledByGate(recipes []recipe, reachable map[string]bool) []string {
 		// is the moment a lapsed certificate is worth knowing about. Run it by
 		// hand with `just check-tls`.
 		"check-tls": true,
+		// The deployed route contract. The same shape as check-tls and out for
+		// the same reason: its answer is not a function of the tree. It asks
+		// the control plane that is running right now whether it serves the
+		// routes the marketing site calls, so the same commit is green today
+		// and red the moment the site publishes ahead of a control plane that
+		// has not been promoted, which is the failure it exists for. It needs
+		// the network, which `just gate` must not, and it runs in deploy.yml
+		// immediately before the publish, which is the moment the answer can
+		// still stop something. What IS a function of the tree is that the
+		// inventory it reads is complete and names routes this repository
+		// serves, and `just routecheck` covers that inside `gate`.
+		"routecheck-deployed": true,
 	}
 
 	// Recipes that are gates rather than conveniences. A recipe that mutates

--- a/tools/routecheck/inventory.go
+++ b/tools/routecheck/inventory.go
@@ -1,0 +1,200 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+const (
+	inventoryPath = "www/lib/control-plane-routes.ts"
+	boundaryPath  = "web/apps/api/src/boundary.ts"
+	// The two files in www that are allowed to name CONTROL_PLANE_URL in code:
+	// the one that defines it and the one that turns it into a route's URL.
+	// Anywhere else is a call site nothing can enumerate.
+	definitionFile = "lib/site.ts"
+	inventoryFile  = "lib/control-plane-routes.ts"
+)
+
+// Route is one entry of www/lib/control-plane-routes.ts.
+type Route struct {
+	Name        string
+	Method      string
+	Path        string
+	CalledFrom  string
+	WhenMissing string
+	ProbeEffect string
+	ProbeReason string
+}
+
+// Inert reports whether the inventory says a probe of this route cannot reach
+// the handler behind it.
+func (r Route) Inert() bool { return r.ProbeEffect == "inert" }
+
+// quoted returns the contents of the first double quoted string on a line, or
+// "" when there is none. The inventory wraps long sentences across lines and
+// only the first fragment is needed: it is what a person reads in the report.
+func quoted(line string) string {
+	i := strings.Index(line, `"`)
+	if i < 0 {
+		return ""
+	}
+	j := strings.Index(line[i+1:], `"`)
+	if j < 0 {
+		return ""
+	}
+	return line[i+1 : i+1+j]
+}
+
+var (
+	entryStart = regexp.MustCompile(`^\s*"([a-z][a-zA-Z0-9.]*)":\s*\{\s*$`)
+	fieldLine  = regexp.MustCompile(`^\s*(method|path|calledFrom|probeEffect):\s*"([^"]*)",\s*$`)
+)
+
+// ParseInventory reads the route inventory.
+//
+// It is deliberately a line parser over a deliberately rigid literal rather
+// than anything that evaluates TypeScript. The trade is stated out loud: this
+// cannot read an entry written in a shape it does not expect, so it FAILS on
+// one rather than passing over it. A parser that skipped what it could not read
+// would report a clean run over an inventory it had understood half of, which
+// is the exact defect this command was written to stop happening elsewhere.
+func ParseInventory(path string) ([]Route, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read the route inventory: %w", err)
+	}
+	defer f.Close()
+
+	var (
+		routes  []Route
+		current *Route
+		inBlock bool
+		pending string
+		line    int
+	)
+	scan := bufio.NewScanner(f)
+	scan.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scan.Scan() {
+		line++
+		text := scan.Text()
+		if !inBlock {
+			if strings.Contains(text, "export const CONTROL_PLANE_ROUTES") {
+				inBlock = true
+			}
+			continue
+		}
+		if current == nil {
+			if strings.HasPrefix(text, "} as const") {
+				break
+			}
+			if m := entryStart.FindStringSubmatch(text); m != nil {
+				current = &Route{Name: m[1]}
+				pending = ""
+			}
+			continue
+		}
+		if strings.TrimSpace(text) == "}," {
+			if err := current.validate(path); err != nil {
+				return nil, err
+			}
+			routes = append(routes, *current)
+			current = nil
+			pending = ""
+			continue
+		}
+		if m := fieldLine.FindStringSubmatch(text); m != nil {
+			switch m[1] {
+			case "method":
+				current.Method = m[2]
+			case "path":
+				current.Path = m[2]
+			case "calledFrom":
+				current.CalledFrom = m[2]
+			case "probeEffect":
+				current.ProbeEffect = m[2]
+			}
+			continue
+		}
+		if strings.Contains(text, "probeReason:") {
+			current.ProbeReason = "declared"
+			pending = "probeReason"
+			continue
+		}
+		if strings.Contains(text, "whenMissing:") {
+			pending = "whenMissing"
+			if v := quoted(text); v != "" {
+				current.WhenMissing = v
+			}
+			continue
+		}
+		if pending == "whenMissing" && current.WhenMissing == "" {
+			if v := quoted(text); v != "" {
+				current.WhenMissing = v
+			}
+			continue
+		}
+		if pending == "probeReason" {
+			if v := quoted(text); v != "" {
+				current.ProbeReason = v
+			}
+			continue
+		}
+		// A continuation of a wrapped string literal, or prose. Ignored on
+		// purpose: the fields that matter are matched exactly above, and an
+		// entry missing one of them is caught by validate rather than by
+		// this loop guessing.
+	}
+	if err := scan.Err(); err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+	if current != nil {
+		return nil, fmt.Errorf("%s: the entry named %q is still open at line %d. The inventory has to parse completely, because a half-read inventory is a route this command silently does not check", path, current.Name, line)
+	}
+	if !inBlock {
+		return nil, fmt.Errorf("%s: no `export const CONTROL_PLANE_ROUTES` in the file. Either it moved or this parser is now reading the wrong thing, and both mean the routes below were not checked", path)
+	}
+	return routes, nil
+}
+
+func (r *Route) validate(path string) error {
+	switch {
+	case r.Method != "GET" && r.Method != "POST":
+		return fmt.Errorf("%s: route %q has method %q. Only GET and POST are understood, because a probe with the wrong method reads exactly like a route that is not there", path, r.Name, r.Method)
+	case !strings.HasPrefix(r.Path, "/"):
+		return fmt.Errorf("%s: route %q has path %q, which is not a path", path, r.Name, r.Path)
+	case r.ProbeEffect != "inert" && r.ProbeEffect != "writes":
+		return fmt.Errorf("%s: route %q declares probeEffect %q. It has to be \"inert\" or \"writes\": what a probe costs is the one thing this command is not allowed to assume", path, r.Name, r.ProbeEffect)
+	case r.ProbeReason == "":
+		return fmt.Errorf("%s: route %q declares probeEffect %q and no probeReason. The reason is what makes the claim checkable against the API's source, so an entry without one is unfinished", path, r.Name, r.ProbeEffect)
+	case r.CalledFrom == "":
+		return fmt.Errorf("%s: route %q does not say where it is called from", path, r.Name)
+	}
+	return nil
+}
+
+// ParseBoundaryRegister reads the keys of the API's route register.
+//
+// web/apps/api/src/boundary.ts classifies every route the router mounts, and
+// route-boundary.test.ts walks the server's own route table and fails on one
+// that is not in it. That makes the register's key set a complete list of what
+// this repository's control plane serves, which is a stronger source than
+// grepping server.ts for app.post: the register is already PROVEN complete by a
+// test, and a grep is only true on the day it is run.
+func ParseBoundaryRegister(path string) (map[string]bool, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read the route register: %w", err)
+	}
+	key := regexp.MustCompile(`(?m)^\s*'(GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD|ALL) (/[^']*)':\s*\{`)
+	found := map[string]bool{}
+	for _, m := range key.FindAllStringSubmatch(string(raw), -1) {
+		found[m[1]+" "+m[2]] = true
+	}
+	if len(found) == 0 {
+		return nil, fmt.Errorf("%s parsed to no routes at all. Its shape has changed, and an empty register would let every route in the inventory pass unchecked", path)
+	}
+	return found, nil
+}

--- a/tools/routecheck/main.go
+++ b/tools/routecheck/main.go
@@ -1,0 +1,128 @@
+// Command routecheck refuses a marketing site that calls a control plane route
+// the control plane it is about to talk to does not serve.
+//
+// THE FAILURE IT WAS WRITTEN FOR. Somebody filled in the careers form on
+// antifailure.dev and was told "Could not reach the server." The form was
+// correct. `www/components/pages/company/ApplicationForm.tsx` posts to
+// `/v1/applications`, the route is registered in the control plane's server.ts,
+// and every test of both halves passed. What was wrong was neither half:
+//
+//	POST https://app.antifailure.dev/v1/applications  ->  404
+//	POST https://app.antifailure.dev/v1/leads         ->  400
+//
+//	git show v1.1.1:web/apps/api/src/server.ts    | grep -c v1/applications  ->  0
+//	git show origin/main:web/apps/api/src/server.ts | grep -c v1/applications -> 1
+//
+// The site publishes on every merge to main. The control plane only moves when
+// a `v*` tag is promoted to production. The careers page went live the instant
+// its pull request merged and the API it posts to was still serving v1.1.1,
+// twenty two commits behind. The front end had shipped ahead of its own back
+// end and nothing anywhere said a word.
+//
+// WHY THE OBVIOUS CHECK IS THE WRONG ONE, and this is the whole point. Extract
+// the routes www calls, compare them against the routes server.ts declares, and
+// the check PASSES: main's API declares /v1/applications. The mismatch is not
+// between two files in one tree. It is between the front end and the control
+// plane that is CURRENTLY RUNNING. A gate that compares the tree against itself
+// answers a nearby question, and this repository has thrown away enough
+// instruments that answered a nearby question to know what that is worth. So
+// the second half of this asks the deployment.
+//
+// deploy.yml had already written the split down. Its comment on the published
+// document says the site "can be ahead of what app.antifailure.dev serves. That
+// is tolerable while the API VERSION agrees, because the paths are additive and
+// a caller reading an operation that is not there yet gets a 404." That is
+// right about openapi.json, which is a document somebody READS. It is wrong
+// about this site, which is a CALLER, and for a caller a 404 is a form that
+// does not work.
+//
+// WHAT IT WILL NOT DO. It will not send a request that reaches a handler
+// unless it is told to in as many words. Finding out whether the careers
+// endpoint exists must not file a job application, so every route in the
+// inventory carries the request that proves it is there and the reason that
+// request cannot reach what is behind it, checked against the API's source.
+// The one route with no such request, `/auth/github`, says so, and is refused
+// rather than skipped unless -allow-write-probes is passed.
+//
+// WHAT IT REFUSES TO GUESS. A route is ABSENT only when the control plane
+// itself answered 404. If something in front of the application answered, if
+// the origin could not be reached, or if it answered 5xx to a probe, the answer
+// is not "absent" and it is not "present": it is that this run did not find
+// out, and the run fails saying so. A gate that reported a pass it did not earn
+// because a network was briefly down is worse than no gate.
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+func main() {
+	root := flag.String("root", ".", "repository root")
+	origin := flag.String("origin", "", "control plane origin to probe, for example https://app.antifailure.dev. Omitted runs the offline half only.")
+	allowWrites := flag.Bool("allow-write-probes", false, "send the probes the inventory declares as writing something. Without it a route that has no inert probe is reported as not checked and fails.")
+	timeout := flag.Duration("timeout", 20*time.Second, "per request timeout")
+	attempts := flag.Int("attempts", 3, "attempts per route before a transport failure is final")
+	flag.Parse()
+
+	if err := run(*root, *origin, *allowWrites, *timeout, *attempts, os.Stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "\nroutecheck: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(root, origin string, allowWrites bool, timeout time.Duration, attempts int, out io.Writer) error {
+	routes, err := ParseInventory(filepath.Join(root, inventoryPath))
+	if err != nil {
+		return err
+	}
+	if len(routes) == 0 {
+		return fmt.Errorf("%s declares no routes. An empty inventory would pass every check in this command while the site went on calling whatever it liked, so it is refused rather than treated as nothing to do", inventoryPath)
+	}
+
+	strays, err := FindStrayCallSites(filepath.Join(root, "www"))
+	if err != nil {
+		return err
+	}
+	if len(strays) > 0 {
+		var b strings.Builder
+		fmt.Fprintf(&b, "%d place(s) in www build a control plane URL outside the inventory:\n", len(strays))
+		for _, s := range strays {
+			fmt.Fprintf(&b, "  %s:%d: %s\n", s.File, s.Line, strings.TrimSpace(s.Text))
+		}
+		b.WriteString("\nEvery control plane call has to be declared in " + inventoryPath + " so that this\n")
+		b.WriteString("command can prove the deployed control plane serves it. Import controlPlaneUrl\n")
+		b.WriteString("from that module instead of building the URL here.")
+		return errors.New(b.String())
+	}
+	fmt.Fprintf(out, "the site builds control plane URLs in one place, and declares %d route(s) there\n", len(routes))
+
+	served, err := ParseBoundaryRegister(filepath.Join(root, boundaryPath))
+	if err != nil {
+		return err
+	}
+	var undeclared []string
+	for _, r := range routes {
+		if !served[r.Method+" "+r.Path] {
+			undeclared = append(undeclared, r.Name+" calls "+r.Method+" "+r.Path)
+		}
+	}
+	if len(undeclared) > 0 {
+		sort.Strings(undeclared)
+		return fmt.Errorf("the site calls %d route(s) this repository's control plane does not serve at all:\n  %s\n\n%s classifies every route the router mounts, and route-boundary.test.ts\nfails on one that is missing from it, so a route absent from that register is a\nroute absent from the server", len(undeclared), strings.Join(undeclared, "\n  "), boundaryPath)
+	}
+	fmt.Fprintf(out, "every route it declares is one this repository's control plane mounts\n")
+
+	if origin == "" {
+		fmt.Fprintf(out, "\nno -origin given, so what is DEPLOYED was not checked. The offline half cannot\nsee the failure this command exists for: it passed on the day the careers form\nbroke, because main's API did declare the route.\n")
+		return nil
+	}
+	return probeAll(origin, routes, allowWrites, timeout, attempts, out)
+}

--- a/tools/routecheck/main_test.go
+++ b/tools/routecheck/main_test.go
@@ -1,0 +1,293 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The inventory as the repository really writes it, so a change to the file's
+// shape that this parser cannot read fails here rather than silently reducing
+// the number of routes checked.
+const inventoryFixture = `import { CONTROL_PLANE_URL } from "./site";
+
+export const CONTROL_PLANE_ROUTES = {
+  "applications.create": {
+    method: "POST",
+    path: "/v1/applications",
+    calledFrom: "components/pages/company/ApplicationForm.tsx",
+    whenMissing:
+      "The careers form says 'Could not reach the server'.",
+    probeEffect: "inert",
+    probeReason:
+      "An origin guard answers 403 before the handler.",
+  },
+  "auth.github": {
+    method: "GET",
+    path: "/auth/github",
+    calledFrom: "components/AuthScreen.tsx",
+    whenMissing: "Continue with GitHub lands on a 404.",
+    probeEffect: "writes",
+    probeReason:
+      "beginSignIn inserts one oauth_states row.",
+  },
+} as const satisfies Record<string, ControlPlaneRoute>;
+`
+
+func writeFile(t *testing.T, dir, rel, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, rel)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestParseInventoryReadsEveryRouteAndItsProbeCost(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "inventory.ts", inventoryFixture)
+	routes, err := ParseInventory(path)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(routes) != 2 {
+		t.Fatalf("read %d routes, want 2: %+v", len(routes), routes)
+	}
+	if routes[0].Method != "POST" || routes[0].Path != "/v1/applications" {
+		t.Errorf("first route is %s %s", routes[0].Method, routes[0].Path)
+	}
+	if !routes[0].Inert() {
+		t.Error("the applications route is declared inert and did not read as inert")
+	}
+	if routes[1].Inert() {
+		t.Error("the auth route is declared as writing and read as inert, which would send a probe nobody authorised")
+	}
+	if !strings.Contains(routes[0].WhenMissingLine(), "careers form") {
+		t.Errorf("whenMissing did not survive the parse: %q", routes[0].WhenMissingLine())
+	}
+}
+
+// The parser must FAIL on an inventory it cannot read, never return the part it
+// understood. A short read is a route nothing checks.
+func TestParseInventoryRefusesAnEntryItCannotRead(t *testing.T) {
+	cases := map[string]string{
+		"no method":       strings.Replace(inventoryFixture, `    method: "POST",`+"\n", "", 1),
+		"unknown effect":  strings.Replace(inventoryFixture, `"inert"`, `"probably fine"`, 1),
+		"no probe reason": strings.Replace(inventoryFixture, "    probeReason:\n      \"An origin guard answers 403 before the handler.\",\n", "", 1),
+		"renamed export":  strings.Replace(inventoryFixture, "export const CONTROL_PLANE_ROUTES", "export const ROUTES_V2", 1),
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := writeFile(t, dir, "inventory.ts", body)
+			if _, err := ParseInventory(path); err == nil {
+				t.Fatal("parsed an inventory it should have refused")
+			}
+		})
+	}
+}
+
+func TestFindStrayCallSitesNamesTheFileAndLine(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "lib/site.ts", "export const CONTROL_PLANE_URL = \"x\";\n")
+	writeFile(t, dir, "lib/control-plane-routes.ts", "import { CONTROL_PLANE_URL } from \"./site\";\n")
+	writeFile(t, dir, "components/Ok.tsx", "import { controlPlaneUrl } from \"@/lib/control-plane-routes\";\n")
+	writeFile(t, dir, "components/Bad.tsx", "const a = 1;\nfetch(`${CONTROL_PLANE_URL}/v1/sneaky`);\n")
+
+	strays, err := FindStrayCallSites(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(strays) != 1 {
+		t.Fatalf("found %d strays, want 1: %+v", len(strays), strays)
+	}
+	if !strings.HasSuffix(strays[0].File, filepath.Join("components", "Bad.tsx")) {
+		t.Errorf("named %q", strays[0].File)
+	}
+	if strays[0].Line != 2 {
+		t.Errorf("reported line %d, want 2", strays[0].Line)
+	}
+}
+
+func TestFindStrayCallSitesIgnoresProseAndVendoredCode(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "lib/site.ts", "export const CONTROL_PLANE_URL = \"x\";\n")
+	writeFile(t, dir, "lib/control-plane-routes.ts", "// inventory\n")
+	writeFile(t, dir, "lib/beacon.ts", "// follows CONTROL_PLANE_URL for the same reason\n/* also CONTROL_PLANE_URL\n   here */\nexport const E = 1;\n")
+	writeFile(t, dir, "node_modules/pkg/index.js", "const x = CONTROL_PLANE_URL;\n")
+
+	strays, err := FindStrayCallSites(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(strays) != 0 {
+		t.Fatalf("tripped on prose or on node_modules: %+v", strays)
+	}
+}
+
+func TestParseBoundaryRegisterReadsTheKeys(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "boundary.ts", `export const ROUTES = {
+  'POST /v1/leads': {
+    audience: 'excluded',
+  },
+  'GET /auth/github': {
+    audience: 'excluded',
+  },
+}`)
+	served, err := ParseBoundaryRegister(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !served["POST /v1/leads"] || !served["GET /auth/github"] {
+		t.Fatalf("read %v", served)
+	}
+	if served["POST /v1/applications"] {
+		t.Error("invented a route the register does not hold")
+	}
+}
+
+func TestParseBoundaryRegisterRefusesAnEmptyRead(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "boundary.ts", "export const ROUTES = {}\n")
+	if _, err := ParseBoundaryRegister(path); err == nil {
+		t.Fatal("an empty register passed, which would let every route through unchecked")
+	}
+}
+
+// THE HOLE THIS SCANNER SHIPPED WITH, and the reason it is string aware.
+//
+// stripComments used to break out of the line at the first `//` it saw,
+// wherever it saw it. So this call site:
+//
+//	const u = "https://antifailure.dev" + CONTROL_PLANE_URL;
+//
+// had everything after `https:` discarded as a comment, the identifier was
+// never seen, and the gate reported a clean run over a control plane URL built
+// outside the inventory. That is a false NEGATIVE, which is silent, in the one
+// instrument whose whole job is to make an unenumerable call site loud.
+func TestStripCommentsDoesNotLoseCodeAfterAUrlInAString(t *testing.T) {
+	kept := []struct{ name, line string }{
+		{"a url in a double quoted string", `const u = "https://antifailure.dev" + CONTROL_PLANE_URL;`},
+		{"a url in a single quoted string", `const u = 'https://antifailure.dev' + CONTROL_PLANE_URL;`},
+		{"a url in a template literal", "const u = `https://antifailure.dev${CONTROL_PLANE_URL}`;"},
+		{"the identifier inside a template expression", "fetch(`${CONTROL_PLANE_URL}/v1/sneaky`);"},
+		{"an escaped quote before it", `const u = "he said \"hi\" //" + CONTROL_PLANE_URL;`},
+		{"code after a block comment closes", `/* a url https:// in prose */ const u = CONTROL_PLANE_URL;`},
+	}
+	for _, c := range kept {
+		t.Run(c.name, func(t *testing.T) {
+			code, _ := stripComments(c.line, scanState{})
+			if !strings.Contains(code, "CONTROL_PLANE_URL") {
+				t.Errorf("the identifier was lost, so a call site written this way passes unseen.\n  line:    %s\n  stripped: %s", c.line, code)
+			}
+		})
+	}
+
+	dropped := []struct{ name, line string }{
+		{"a line comment", `// follows CONTROL_PLANE_URL for the same reason`},
+		{"a trailing line comment", `const a = 1; // CONTROL_PLANE_URL is not used here`},
+		{"a single line block comment", `/* CONTROL_PLANE_URL in prose */`},
+	}
+	for _, c := range dropped {
+		t.Run(c.name, func(t *testing.T) {
+			code, _ := stripComments(c.line, scanState{})
+			if strings.Contains(code, "CONTROL_PLANE_URL") {
+				t.Errorf("prose was read as code, which is a rule people route around by rewording a sentence.\n  line:     %s\n  stripped: %s", c.line, code)
+			}
+		})
+	}
+}
+
+// A template literal survives a newline, so the state has to as well, or the
+// line after a multi line template is scanned in the wrong mode.
+func TestStripCommentsCarriesATemplateLiteralAcrossLines(t *testing.T) {
+	_, st := stripComments("const q = `line one // not a comment", scanState{})
+	if !st.inTemplate {
+		t.Fatal("an open template literal did not carry to the next line")
+	}
+	code, st := stripComments("line two` + CONTROL_PLANE_URL;", st)
+	if st.inTemplate {
+		t.Error("the closing backtick did not end the template")
+	}
+	if !strings.Contains(code, "CONTROL_PLANE_URL") {
+		t.Errorf("lost the identifier after a multi line template: %s", code)
+	}
+
+	_, st = stripComments("/* a block comment opens", scanState{})
+	if !st.inComment {
+		t.Fatal("an open block comment did not carry to the next line")
+	}
+	code, _ = stripComments("CONTROL_PLANE_URL still inside it */", st)
+	if strings.Contains(code, "CONTROL_PLANE_URL") {
+		t.Errorf("read the inside of a block comment as code: %s", code)
+	}
+}
+
+// The suite is skipped, and that is a decision rather than an oversight. The
+// test pinning these URLs has to import CONTROL_PLANE_URL to assert that
+// controlPlaneUrl() still produces the string the call sites used to build by
+// hand, and a rule refusing that would forbid the one check proving the
+// refactor changed nothing. Nothing under www/test reaches a browser.
+//
+// The exclusion has to be the suite DIRECTORY and not the word "test", or a
+// component named for what it renders would walk through it.
+func TestFindStrayCallSitesSkipsTheSuiteButNotAComponent(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "lib/site.ts", "export const CONTROL_PLANE_URL = \"x\";\n")
+	writeFile(t, dir, "lib/control-plane-routes.ts", "// inventory\n")
+	writeFile(t, dir, "test/control-plane-routes.test.ts", "import { CONTROL_PLANE_URL } from '../lib/site'\n")
+
+	strays, err := FindStrayCallSites(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(strays) != 0 {
+		t.Fatalf("the suite was treated as a call site: %+v", strays)
+	}
+
+	writeFile(t, dir, "components/TestimonialCard.tsx", "fetch(`${CONTROL_PLANE_URL}/v1/sneaky`);\n")
+	strays, err = FindStrayCallSites(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(strays) != 1 {
+		t.Fatalf("found %d strays, want the one in components/: %+v", len(strays), strays)
+	}
+}
+
+// THE HOLE, END TO END. The unit test above proves the scanner keeps the
+// identifier; this proves the COMMAND refuses the file. They are separate
+// because stripComments returning the right string is worth nothing if the
+// walk never asks it about that file.
+func TestFindStrayCallSitesSeesACallSiteHiddenBehindAUrl(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "lib/site.ts", "export const CONTROL_PLANE_URL = \"x\";\n")
+	writeFile(t, dir, "lib/control-plane-routes.ts", "// inventory\n")
+	// Line 1 is the failure exactly as it was found: the URL and the identifier
+	// on the SAME line, which is the only arrangement the old stripper could
+	// swallow. An earlier version of this test put them on separate lines and
+	// stayed GREEN with the hole reopened, which the mutation run caught. Line 2
+	// is the split arrangement, kept so the easy case cannot silently regress.
+	writeFile(t, dir, "components/Sneaky.tsx",
+		"const u = \"https://antifailure.dev\" + CONTROL_PLANE_URL + \"/v1/sneaky\";\n"+
+			"const v = base + CONTROL_PLANE_URL;\n")
+
+	strays, err := FindStrayCallSites(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(strays) != 2 {
+		t.Fatalf("found %d strays, want 2. A call site whose own line holds a URL was invisible: %+v", len(strays), strays)
+	}
+	if strays[0].Line != 1 {
+		t.Errorf("reported line %d for the same-line call site, want 1", strays[0].Line)
+	}
+	if strays[1].Line != 2 {
+		t.Errorf("reported line %d for the split call site, want 2", strays[1].Line)
+	}
+}

--- a/tools/routecheck/probe.go
+++ b/tools/routecheck/probe.go
@@ -1,0 +1,234 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Verdict is what one probe found out.
+type Verdict string
+
+const (
+	// Present: the control plane answered as something that has this route.
+	Present Verdict = "present"
+	// Absent: the control plane itself answered 404. This is the failure the
+	// command exists for.
+	Absent Verdict = "absent"
+	// Unknown: this run did not find out. Never a pass.
+	Unknown Verdict = "unknown"
+	// NotProbed: the inventory says a probe of this route writes something and
+	// the run was not told it could. Never a pass either.
+	NotProbed Verdict = "not probed"
+)
+
+// Result is one row of the report.
+type Result struct {
+	Route   Route
+	Verdict Verdict
+	Status  int
+	Detail  string
+}
+
+// probeAll asks a live origin about every route in the inventory.
+func probeAll(origin string, routes []Route, allowWrites bool, timeout time.Duration, attempts int, out io.Writer) error {
+	origin = strings.TrimRight(origin, "/")
+	client := &http.Client{
+		Timeout: timeout,
+		// A redirect is an answer. Following it would ask a different server a
+		// different question, and 302 is exactly how /auth/github says it is
+		// there.
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
+
+	fmt.Fprintf(out, "\nasking %s what it actually serves\n\n", origin)
+	results := make([]Result, 0, len(routes))
+	for _, r := range routes {
+		results = append(results, probeOne(client, origin, r, allowWrites, attempts))
+	}
+
+	width := 0
+	for _, res := range results {
+		if n := len(res.Route.Method + " " + res.Route.Path); n > width {
+			width = n
+		}
+	}
+	for _, res := range results {
+		status := "   -"
+		if res.Status != 0 {
+			status = fmt.Sprintf("%4d", res.Status)
+		}
+		fmt.Fprintf(out, "  %-*s  %s  %-10s  %s\n", width, res.Route.Method+" "+res.Route.Path, status, res.Verdict, res.Detail)
+	}
+
+	var absent, unknown, notProbed []Result
+	for _, res := range results {
+		switch res.Verdict {
+		case Absent:
+			absent = append(absent, res)
+		case Unknown:
+			unknown = append(unknown, res)
+		case NotProbed:
+			notProbed = append(notProbed, res)
+		}
+	}
+
+	var b strings.Builder
+	if len(absent) > 0 {
+		fmt.Fprintf(&b, "\n%s does not serve %d route(s) this site calls:\n", origin, len(absent))
+		for _, res := range absent {
+			fmt.Fprintf(&b, "\n  %s %s\n", res.Route.Method, res.Route.Path)
+			fmt.Fprintf(&b, "    called from www/%s\n", res.Route.CalledFrom)
+			fmt.Fprintf(&b, "    %s\n", res.Route.WhenMissingLine())
+		}
+		b.WriteString("\nThe site publishes on every merge to main and the control plane only moves on a\n")
+		b.WriteString("`v*` tag promoted to production, so a route merged but not yet released is live\n")
+		b.WriteString("on the front end and missing on the back. Promote the control plane before\n")
+		b.WriteString("publishing a site that calls it.\n")
+	}
+	if len(unknown) > 0 {
+		fmt.Fprintf(&b, "\n%d route(s) could not be established either way, which is not a pass:\n", len(unknown))
+		for _, res := range unknown {
+			fmt.Fprintf(&b, "  %s %s: %s\n", res.Route.Method, res.Route.Path, res.Detail)
+		}
+	}
+	if len(notProbed) > 0 {
+		fmt.Fprintf(&b, "\n%d route(s) were NOT CHECKED:\n", len(notProbed))
+		for _, res := range notProbed {
+			fmt.Fprintf(&b, "  %s %s: %s\n", res.Route.Method, res.Route.Path, res.Detail)
+		}
+		b.WriteString("\nPass -allow-write-probes to send them, having read what the inventory says each\n")
+		b.WriteString("one costs. They are refused rather than skipped because a route this command\n")
+		b.WriteString("quietly passed over is a route nothing checks at all.\n")
+	}
+	if b.Len() > 0 {
+		return errors.New(b.String())
+	}
+	fmt.Fprintf(out, "\nall %d route(s) the site calls are served by %s\n", len(results), origin)
+	return nil
+}
+
+// WhenMissingLine is the sentence describing what a person loses. It lives on
+// Route rather than here so the inventory owns the wording.
+func (r Route) WhenMissingLine() string {
+	if r.WhenMissing != "" {
+		return r.WhenMissing
+	}
+	return "the site calls it and it is not there"
+}
+
+func probeOne(client *http.Client, origin string, r Route, allowWrites bool, attempts int) Result {
+	if !r.Inert() && !allowWrites {
+		return Result{Route: r, Verdict: NotProbed, Detail: "the inventory says probing it writes something: " + firstSentence(r.ProbeReason)}
+	}
+
+	var (
+		last       string
+		lastStatus int
+	)
+	for attempt := 1; attempt <= attempts; attempt++ {
+		res, retry, detail := attemptOne(client, origin, r)
+		if !retry {
+			return res
+		}
+		last, lastStatus = detail, res.Status
+		if attempt < attempts {
+			time.Sleep(time.Duration(attempt) * 2 * time.Second)
+		}
+	}
+	return Result{Route: r, Verdict: Unknown, Status: lastStatus, Detail: fmt.Sprintf("no usable answer in %d attempts: %s", attempts, last)}
+}
+
+// attemptOne sends one probe. The bool says whether the caller should try
+// again: a transport failure and a 5xx are both worth a retry, and neither is
+// ever reported as a pass if the retries run out.
+func attemptOne(client *http.Client, origin string, r Route) (Result, bool, string) {
+	ctx, cancel := context.WithTimeout(context.Background(), client.Timeout)
+	defer cancel()
+
+	var body io.Reader
+	if r.Method == "POST" {
+		// The body every inert POST probe sends. It is valid JSON, so a route
+		// that refuses malformed JSON is not answered by the wrong branch, and
+		// it carries no field any handler here accepts, so validation refuses
+		// it on its first check.
+		body = strings.NewReader(`{}`)
+	}
+	req, err := http.NewRequestWithContext(ctx, r.Method, origin+r.Path, body)
+	if err != nil {
+		return Result{Route: r, Verdict: Unknown, Detail: err.Error()}, false, err.Error()
+	}
+	if r.Method == "POST" {
+		req.Header.Set("content-type", "application/json")
+	}
+	// No Origin header, deliberately. Three of these routes are guarded by an
+	// origin check that refuses anything that is not the marketing site, and
+	// that refusal is what makes the probe unable to reach the handler. Sending
+	// an Origin would defeat the one property that makes this safe.
+	//
+	// No x-request-id either. The control plane honours a caller-supplied one,
+	// so sending one would put our own value in the response and destroy the
+	// only evidence that the application, rather than something in front of it,
+	// answered.
+	req.Header.Set("user-agent", "antifailure-routecheck/1 (+deployed route contract gate)")
+	req.Header.Set("accept", "application/json, text/html;q=0.5")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return Result{Route: r}, true, "transport: " + err.Error()
+	}
+	defer resp.Body.Close()
+	preview, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+
+	if resp.Header.Get("x-request-id") == "" {
+		// Every response the control plane produces carries one, minted by the
+		// middleware that runs before routing, including both of its 404s. A
+		// reply without one did not come from the application: a WAF, a CDN
+		// error page, or an ingress with no revision behind it. It cannot be
+		// read as either answer.
+		detail := fmt.Sprintf("HTTP %d with no x-request-id, so the control plane did not answer this: %s", resp.StatusCode, oneLine(preview))
+		return Result{Route: r, Verdict: Unknown, Status: resp.StatusCode, Detail: detail}, true, detail
+	}
+	if resp.StatusCode >= 500 {
+		detail := fmt.Sprintf("HTTP %d: %s", resp.StatusCode, oneLine(preview))
+		return Result{Route: r, Verdict: Unknown, Status: resp.StatusCode, Detail: detail}, true, detail
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		// The control plane answers 404 for a path it does not have AND for a
+		// path it has under a different method, which is why the probe uses the
+		// method the site itself uses. For these four routes a 404 cannot mean
+		// anything else: each one refuses this exact request with 400, 403, 429
+		// or a redirect when it is present, and none of them has a branch that
+		// answers 404. That is a property of the four handlers, recorded in the
+		// inventory's probeReason, not a general rule about HTTP.
+		return Result{Route: r, Verdict: Absent, Status: 404, Detail: "the control plane answered 404 to the request the site makes"}, false, ""
+	}
+	return Result{
+		Route:   r,
+		Verdict: Present,
+		Status:  resp.StatusCode,
+		Detail:  "answered as a route that exists: " + oneLine(preview),
+	}, false, ""
+}
+
+func oneLine(b []byte) string {
+	s := strings.TrimSpace(strings.ReplaceAll(strings.ReplaceAll(string(b), "\n", " "), "\r", ""))
+	if s == "" {
+		return "(no body)"
+	}
+	if len(s) > 90 {
+		return s[:90] + "..."
+	}
+	return s
+}
+
+func firstSentence(s string) string {
+	if i := strings.Index(s, ". "); i > 0 {
+		return s[:i+1]
+	}
+	return s
+}

--- a/tools/routecheck/probe_test.go
+++ b/tools/routecheck/probe_test.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func inertRoute(method, path string) Route {
+	return Route{Name: "t", Method: method, Path: path, CalledFrom: "x.tsx", WhenMissing: "the form breaks", ProbeEffect: "inert", ProbeReason: "a guard refuses first"}
+}
+
+// A server that behaves the way the control plane does: it mints an
+// x-request-id on every reply, including its 404s.
+func controlPlaneLike(h http.HandlerFunc) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("x-request-id", "11111111-2222-3333-4444-555555555555")
+		h(w, r)
+	}))
+}
+
+func probe(t *testing.T, srv *httptest.Server, routes []Route, allowWrites bool) (string, error) {
+	t.Helper()
+	var out bytes.Buffer
+	err := probeAll(srv.URL, routes, allowWrites, 5*time.Second, 2, &out)
+	return out.String(), err
+}
+
+// THE FAILURE ITSELF. A route the site calls that the deployed control plane
+// answers 404 to has to fail, and has to name the route.
+func TestAbsentRouteFails(t *testing.T) {
+	srv := controlPlaneLike(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/leads" {
+			w.WriteHeader(400)
+			w.Write([]byte(`{"error":"Tell us your name."}`))
+			return
+		}
+		w.WriteHeader(404)
+		w.Write([]byte(`{"error":"No endpoint at this path."}`))
+	})
+	defer srv.Close()
+
+	_, err := probe(t, srv, []Route{inertRoute("POST", "/v1/applications"), inertRoute("POST", "/v1/leads")}, false)
+	if err == nil {
+		t.Fatal("a route the origin 404s passed")
+	}
+	if !strings.Contains(err.Error(), "/v1/applications") {
+		t.Errorf("the failure did not name the missing route: %v", err)
+	}
+	if strings.Contains(err.Error(), "/v1/leads") {
+		t.Errorf("the failure named a route that answered 400, which is present: %v", err)
+	}
+}
+
+// THE FALSE POSITIVE THAT WOULD MAKE IT USELESS. A route that exists and
+// refuses the probe is PRESENT. On production today /v1/leads answers 400 and
+// /v1/site/events answers 403 to exactly this request.
+func TestARouteThatRejectsTheProbeIsPresent(t *testing.T) {
+	for _, status := range []int{400, 401, 403, 405, 413, 415, 422, 429, 200, 201, 204, 302} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			srv := controlPlaneLike(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(status) })
+			defer srv.Close()
+			if _, err := probe(t, srv, []Route{inertRoute("POST", "/v1/leads")}, false); err != nil {
+				t.Fatalf("HTTP %d read as anything but present: %v", status, err)
+			}
+		})
+	}
+}
+
+// FAIL CLOSED, ONE. An origin that cannot be reached is not a pass.
+func TestAnUnreachableOriginFails(t *testing.T) {
+	var out bytes.Buffer
+	// Port 1 on the loopback address refuses immediately, so this is a
+	// transport failure rather than a slow test.
+	err := probeAll("http://127.0.0.1:1", []Route{inertRoute("POST", "/v1/applications")}, false, 2*time.Second, 2, &out)
+	if err == nil {
+		t.Fatal("an unreachable origin passed")
+	}
+	if !strings.Contains(err.Error(), "not a pass") {
+		t.Errorf("did not report it as undetermined: %v", err)
+	}
+	if strings.Contains(out.String(), string(Absent)) {
+		t.Error("an unreachable origin was reported as the route being absent, which would blame the wrong thing")
+	}
+}
+
+// FAIL CLOSED, TWO. An origin that answers 500 to everything knows nothing
+// about what it serves, and must not read as either answer.
+func TestAnOriginThatFailsEverythingIsNotAPass(t *testing.T) {
+	srv := controlPlaneLike(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(500) })
+	defer srv.Close()
+	out, err := probe(t, srv, []Route{inertRoute("POST", "/v1/applications")}, false)
+	if err == nil {
+		t.Fatal("an origin answering 500 to everything passed")
+	}
+	if strings.Contains(out, string(Absent)) {
+		t.Error("a 500 was read as the route being absent")
+	}
+}
+
+// FAIL CLOSED, THREE. Something in front of the application answering instead
+// of it. A WAF's own 404 page has no x-request-id, and reading it as "the route
+// is gone" would blame the application for a proxy.
+func TestSomethingInFrontOfTheAppIsNotAnAnswer(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(404)
+		w.Write([]byte("<html>Request blocked</html>"))
+	}))
+	defer srv.Close()
+	out, err := probe(t, srv, []Route{inertRoute("POST", "/v1/applications")}, false)
+	if err == nil {
+		t.Fatal("a reply that did not come from the control plane passed")
+	}
+	if strings.Contains(out, string(Absent)) {
+		t.Error("a proxy's 404 was read as the control plane not serving the route")
+	}
+	if !strings.Contains(err.Error(), "not a pass") {
+		t.Errorf("did not report it as undetermined: %v", err)
+	}
+}
+
+// A ROUTE IT CANNOT PROBE INERTLY IS REFUSED, NOT SKIPPED.
+func TestAWritingProbeIsNotSentUnlessAllowed(t *testing.T) {
+	var asked int
+	srv := controlPlaneLike(func(w http.ResponseWriter, r *http.Request) {
+		asked++
+		w.WriteHeader(302)
+	})
+	defer srv.Close()
+
+	writes := Route{Name: "auth.github", Method: "GET", Path: "/auth/github", CalledFrom: "AuthScreen.tsx", WhenMissing: "sign in 404s", ProbeEffect: "writes", ProbeReason: "beginSignIn inserts a row. It writes."}
+
+	out, err := probe(t, srv, []Route{writes}, false)
+	if err == nil {
+		t.Fatal("a route that was never checked passed")
+	}
+	if !strings.Contains(err.Error(), "NOT CHECKED") {
+		t.Errorf("did not say the route went unchecked: %v", err)
+	}
+	if asked != 0 {
+		t.Errorf("sent %d request(s) the run was not authorised to send", asked)
+	}
+	if !strings.Contains(out, string(NotProbed)) {
+		t.Errorf("the report did not show it as not probed: %s", out)
+	}
+
+	if _, err := probe(t, srv, []Route{writes}, true); err != nil {
+		t.Fatalf("with -allow-write-probes it should have been sent and passed: %v", err)
+	}
+	if asked == 0 {
+		t.Error("-allow-write-probes did not actually send the probe")
+	}
+}
+
+// The probe must ask with the method the site uses. A route registered for POST
+// answers 404 to a GET, so a probe that used the wrong method would report a
+// present route as missing.
+func TestTheProbeUsesTheMethodTheSiteUses(t *testing.T) {
+	var seen []string
+	srv := controlPlaneLike(func(w http.ResponseWriter, r *http.Request) {
+		seen = append(seen, r.Method+" "+r.URL.Path)
+		if r.Method == "POST" {
+			w.WriteHeader(400)
+			return
+		}
+		w.WriteHeader(404)
+	})
+	defer srv.Close()
+
+	if _, err := probe(t, srv, []Route{inertRoute("POST", "/v1/leads")}, false); err != nil {
+		t.Fatalf("a POST route probed with POST failed: %v", err)
+	}
+	if len(seen) != 1 || seen[0] != "POST /v1/leads" {
+		t.Fatalf("asked %v", seen)
+	}
+}
+
+// A redirect is an answer, not something to follow. /auth/github says it is
+// there with a 302 to github.com, and following it would ask GitHub a question
+// about our control plane.
+func TestARedirectIsTheAnswerAndIsNotFollowed(t *testing.T) {
+	var hits int
+	srv := controlPlaneLike(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		http.Redirect(w, r, "https://github.example/login", 302)
+	})
+	defer srv.Close()
+
+	route := inertRoute("GET", "/auth/github")
+	if _, err := probe(t, srv, []Route{route}, false); err != nil {
+		t.Fatalf("a 302 did not read as present: %v", err)
+	}
+	if hits != 1 {
+		t.Errorf("made %d requests for one route, so it followed the redirect", hits)
+	}
+}
+
+// The probe must not send an Origin header. Three of the four routes are only
+// inert because an origin guard refuses them first, and an Origin that matched
+// would put the probe through to the handler.
+func TestTheProbeSendsNoOriginAndNoRequestId(t *testing.T) {
+	var origin, requestID string
+	srv := controlPlaneLike(func(w http.ResponseWriter, r *http.Request) {
+		origin = r.Header.Get("origin")
+		requestID = r.Header.Get("x-request-id")
+		w.WriteHeader(403)
+	})
+	defer srv.Close()
+
+	if _, err := probe(t, srv, []Route{inertRoute("POST", "/v1/applications")}, false); err != nil {
+		t.Fatal(err)
+	}
+	if origin != "" {
+		t.Errorf("sent Origin %q, which would defeat the guard that makes the probe safe", origin)
+	}
+	if requestID != "" {
+		t.Errorf("sent x-request-id %q, which the control plane echoes, destroying the evidence that it answered", requestID)
+	}
+}
+
+// A transport failure that clears on a retry is a pass. The gate runs against
+// the internet and must not turn one dropped connection into a blocked deploy.
+func TestATransientFailureIsRetried(t *testing.T) {
+	var n int
+	srv := controlPlaneLike(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		if n == 1 {
+			w.WriteHeader(503)
+			return
+		}
+		w.WriteHeader(400)
+	})
+	defer srv.Close()
+
+	if _, err := probe(t, srv, []Route{inertRoute("POST", "/v1/leads")}, false); err != nil {
+		t.Fatalf("a route that answered on the second attempt failed: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("made %d attempts", n)
+	}
+}

--- a/tools/routecheck/recorded_test.go
+++ b/tools/routecheck/recorded_test.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// THE RECORDED FAILURE, REPLAYED.
+//
+// The other tests in this package assert one property each against a server
+// written to exercise it. This one asserts the whole command against the thing
+// that actually happened, so that the four routes, their real status codes and
+// the verdict for each are pinned together rather than one at a time.
+//
+// Every status code and body below was OBSERVED, not composed. The production
+// column was captured at 2026-09-05T09:27:44Z and again at 09:33:24Z from
+// https://app.antifailure.dev while `/readyz` reported v1.1.1 / 59486b63, which
+// is the deployment the careers form was posting into when somebody filled it
+// in and was told the server could not be reached. The staging column was
+// captured at 09:33:24Z from https://app.dev.antifailure.dev while `/readyz`
+// reported v1.2.0 / b66ca628, which is the same tree with the route released.
+//
+// The two columns differ in exactly one cell, and that cell is the bug.
+type recordedReply struct {
+	status int
+	body   string
+}
+
+// What production answered while it was serving v1.1.1.
+var recordedProduction = map[string]recordedReply{
+	"POST /v1/applications": {404, `{"error":"No endpoint at this path. GET /openapi.json lists every endpoint this control plane serves."}`},
+	"POST /v1/leads":        {400, `{"error":"Tell us your name so a reply is addressed to somebody."}`},
+	"POST /v1/site/events":  {403, `{"error":"This endpoint serves the marketing site only."}`},
+	"GET /auth/github":      {302, ``},
+}
+
+// What staging answered while it was serving v1.2.0, the same tree with the
+// route released. One cell differs: 403 from the origin guard instead of 404.
+var recordedStaging = map[string]recordedReply{
+	"POST /v1/applications": {403, `{"error":"Use the application form on the official website."}`},
+	"POST /v1/leads":        {400, `{"error":"Tell us your name so a reply is addressed to somebody."}`},
+	"POST /v1/site/events":  {403, `{"error":"This endpoint serves the marketing site only."}`},
+	"GET /auth/github":      {302, ``},
+}
+
+// replay serves a recorded observation. It mints an x-request-id on every
+// reply, including the 404, because the real control plane does: the middleware
+// that mints it runs before routing. A replay that omitted it would be testing
+// the "something in front of the app answered" branch by accident and would
+// never reach the verdict this file is about.
+func replay(t *testing.T, recorded map[string]recordedReply) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reply, ok := recorded[r.Method+" "+r.URL.Path]
+		if !ok {
+			t.Errorf("the command asked for %s %s, which is not in the recording", r.Method, r.URL.Path)
+			w.WriteHeader(599)
+			return
+		}
+		w.Header().Set("x-request-id", "00000000-1111-2222-3333-444444444444")
+		if reply.status == 302 {
+			w.Header().Set("location", "https://github.com/login/oauth/authorize?client_id=x")
+		}
+		w.WriteHeader(reply.status)
+		_, _ = w.Write([]byte(reply.body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// The four routes as the inventory declares them, so the replay is driven by
+// the same list the command reads in production rather than by a second copy.
+func recordedRoutes() []Route {
+	return []Route{
+		{Name: "applications.create", Method: "POST", Path: "/v1/applications", CalledFrom: "components/pages/company/ApplicationForm.tsx", WhenMissing: "The careers form says 'Could not reach the server' and a job application is lost.", ProbeEffect: "inert", ProbeReason: "An origin guard answers 403 before the handler."},
+		{Name: "leads.create", Method: "POST", Path: "/v1/leads", CalledFrom: "components/pages/company/EnterpriseForm.tsx", WhenMissing: "The enterprise contact form says 'Could not reach the server'.", ProbeEffect: "inert", ProbeReason: "validateLead is pure and refuses an empty name with 400."},
+		{Name: "site.events", Method: "POST", Path: "/v1/site/events", CalledFrom: "lib/beacon.ts", WhenMissing: "The site beacon posts into nothing and no reader sees an error.", ProbeEffect: "inert", ProbeReason: "An origin guard answers 403 before the ingest."},
+		{Name: "auth.github", Method: "GET", Path: "/auth/github", CalledFrom: "components/AuthScreen.tsx", WhenMissing: "'Continue with GitHub' lands on a 404 page.", ProbeEffect: "writes", ProbeReason: "beginSignIn inserts one oauth_states row unconditionally."},
+	}
+}
+
+// ROW ONE. Against the control plane that was really serving antifailure.dev
+// when the form broke, the command has to say NO, and it has to name the route
+// rather than reporting that something somewhere is wrong.
+func TestTheRecordedProductionIsRefusedAndTheRouteIsNamed(t *testing.T) {
+	srv := replay(t, recordedProduction)
+
+	var out bytes.Buffer
+	err := probeAll(srv.URL, recordedRoutes(), true, 5*time.Second, 2, &out)
+	if err == nil {
+		t.Fatal("the deployment that answered the careers form with a 404 passed the gate")
+	}
+	if !strings.Contains(err.Error(), "POST /v1/applications") {
+		t.Errorf("the refusal did not name the missing route:\n%v", err)
+	}
+	if !strings.Contains(err.Error(), "does not serve") {
+		t.Errorf("the refusal did not say the route is missing, so a reader cannot tell it from a network failure:\n%v", err)
+	}
+	// It must name the ONE route that was missing. Naming all four would be a
+	// gate that says "something is wrong" and sends a person to read four
+	// handlers, which is how a check gets ignored.
+	for _, present := range []string{"/v1/leads", "/v1/site/events", "/auth/github"} {
+		if strings.Contains(err.Error(), present) {
+			t.Errorf("blamed %s, which answered as a route that exists:\n%v", present, err)
+		}
+	}
+	// And it has to say where the call comes from, so the person reading a red
+	// deploy knows which file to open. That sentence belongs to the FAILURE,
+	// not to the table: the table is the record of what was asked and answered,
+	// and the failure is what somebody has to act on. This assertion was
+	// written against out.String() first and CI caught it, which is the whole
+	// argument for checking the stream a message actually goes to rather than
+	// the one it feels like it should.
+	if !strings.Contains(err.Error(), "ApplicationForm.tsx") {
+		t.Errorf("the failure did not say where the call comes from:\n%v", err)
+	}
+	// The table still has to carry the four rows, on the other stream.
+	if !strings.Contains(out.String(), "POST /v1/applications") {
+		t.Errorf("the report did not list the route it asked about:\n%s", out.String())
+	}
+}
+
+// ROW ONE, THE HALF THAT MAKES IT USEFUL. Three of the four routes REFUSED the
+// probe on that same recorded production, with 400, 403 and a 302. A gate that
+// read a refusal as an absence would have called every one of them missing and
+// been wrong three times out of four while being right once by accident.
+func TestTheRecordedRefusalsAreReadAsRoutesThatExist(t *testing.T) {
+	srv := replay(t, recordedProduction)
+
+	var out bytes.Buffer
+	_ = probeAll(srv.URL, recordedRoutes(), true, 5*time.Second, 2, &out)
+	report := out.String()
+
+	for _, want := range []string{
+		"POST /v1/leads          400  present",
+		"POST /v1/site/events    403  present",
+		"GET /auth/github        302  present",
+		"POST /v1/applications   404  absent",
+	} {
+		if !strings.Contains(report, want) {
+			t.Errorf("the report does not contain %q:\n%s", want, report)
+		}
+	}
+}
+
+// ROW TWO. The same command, the same inventory, against the same tree with the
+// route released. It has to PASS, or the gate is a wall rather than a check.
+func TestTheRecordedStagingPasses(t *testing.T) {
+	srv := replay(t, recordedStaging)
+
+	var out bytes.Buffer
+	if err := probeAll(srv.URL, recordedRoutes(), true, 5*time.Second, 2, &out); err != nil {
+		t.Fatalf("a control plane serving all four routes was refused:\n%v\n%s", err, out.String())
+	}
+	if !strings.Contains(out.String(), "all 4 route(s) the site calls are served") {
+		t.Errorf("passed without saying what it established:\n%s", out.String())
+	}
+}

--- a/tools/routecheck/strays.go
+++ b/tools/routecheck/strays.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Stray is one place in www that builds a control plane URL by hand.
+type Stray struct {
+	File string
+	Line int
+	Text string
+}
+
+// FindStrayCallSites reports every line of www source that names
+// CONTROL_PLANE_URL outside the file that defines it and the file that holds
+// the inventory.
+//
+// WHY THIS AND NOT AN EXTRACTOR. The call sites used to read
+//
+//	fetch(`${CONTROL_PLANE_URL}/v1/applications`, { ... })
+//
+// and the first design here was to pull the paths back out of those template
+// literals. That cannot be made honest. A template literal can hold an
+// expression, a path can arrive in a variable, and a route can be assembled a
+// segment at a time; an extractor that reads four call sites and cannot read
+// the fifth has to either guess or say nothing, and saying nothing is how a
+// gate reports a clean run over the one call it did not understand.
+//
+// So the rule is inverted. The site is not allowed to build a control plane URL
+// anywhere except the inventory, and this refuses one that does. There is no
+// call site this can fail to see, because the failure mode of not seeing one is
+// now a failure rather than a silence. The paths themselves are then plain
+// string literals in one file, which needs no cleverness to read.
+//
+// Comments are stripped first. A rule that tripped on the word in a sentence is
+// a rule people route around by rewording the sentence.
+func FindStrayCallSites(wwwRoot string) ([]Stray, error) {
+	var strays []Stray
+	err := filepath.WalkDir(wwwRoot, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case "node_modules", ".next", "out", ".git":
+				return filepath.SkipDir
+			case "test":
+				// The suite, which is not bundled into the site: next.config.ts
+				// exports from app/, components/ and lib/, and nothing under
+				// test/ reaches a browser. It is skipped because the test that
+				// pins these URLs has to import CONTROL_PLANE_URL to assert
+				// that controlPlaneUrl() still produces the same string the
+				// call sites used to build by hand, and a rule that refused
+				// that would forbid the one check proving the refactor changed
+				// nothing. A call site cannot hide here: this directory ships
+				// nowhere.
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		switch filepath.Ext(path) {
+		case ".ts", ".tsx", ".js", ".jsx", ".mjs":
+		default:
+			return nil
+		}
+		rel, relErr := filepath.Rel(wwwRoot, path)
+		if relErr != nil {
+			rel = path
+		}
+		if rel == definitionFile || rel == inventoryFile {
+			return nil
+		}
+		f, openErr := os.Open(path)
+		if openErr != nil {
+			return openErr
+		}
+		defer f.Close()
+
+		scan := bufio.NewScanner(f)
+		scan.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		line, st := 0, scanState{}
+		for scan.Scan() {
+			line++
+			code, next := stripComments(scan.Text(), st)
+			st = next
+			if strings.Contains(code, "CONTROL_PLANE_URL") {
+				strays = append(strays, Stray{File: filepath.Join("www", rel), Line: line, Text: scan.Text()})
+			}
+		}
+		return scan.Err()
+	})
+	return strays, err
+}
+
+// scanState is what a line of source leaves the scanner in. A block comment
+// and a template literal both survive a newline, so both have to be carried to
+// the next line or a `CONTROL_PLANE_URL` on the line after either one is read
+// in the wrong mode.
+type scanState struct {
+	inComment  bool
+	inTemplate bool
+}
+
+// stripComments removes // and /* */ comments from one line, given the state
+// the previous line ended in, and reports the state this one ends in.
+//
+// IT IS STRING AWARE, AND THAT IS NOT A REFINEMENT. The first version was not,
+// and it had a silent hole big enough to drive the whole failure through:
+//
+//	const u = "https://antifailure.dev" + CONTROL_PLANE_URL;
+//
+// The `//` inside `https://` read as the start of a comment, the rest of the
+// line was discarded, and the identifier vanished. A call site written that way
+// passed the gate without a word, which is precisely the defect this command
+// exists to stop: a check that cannot say no is worse than no check.
+// TestStripCommentsDoesNotLoseCodeAfterAUrlInAString is the instrument for it.
+//
+// String CONTENTS are kept rather than blanked, deliberately. The identifier in
+//
+//	fetch(`${CONTROL_PLANE_URL}/v1/applications`)
+//
+// is inside a template literal and is real code, so blanking literals would
+// reintroduce the same hole from the other direction. The cost is that the
+// characters `CONTROL_PLANE_URL` written inside an ordinary string would be
+// reported as a call site. That is a false positive, which is loud and gets
+// fixed in a minute, rather than a false negative, which is silent forever.
+//
+// It is not a JavaScript parser and does not need to be: it is only ever asked
+// whether an identifier survives. The one construct it does not model is a
+// regular expression literal, because to hide the identifier there a line would
+// have to open a regex containing `//`, and `//` does not open a regex.
+func stripComments(line string, st scanState) (string, scanState) {
+	var out strings.Builder
+	quote := byte(0)
+	if st.inTemplate {
+		quote = '`'
+	}
+	for i := 0; i < len(line); i++ {
+		c := line[i]
+		if st.inComment {
+			if strings.HasPrefix(line[i:], "*/") {
+				st.inComment = false
+				i++
+			}
+			continue
+		}
+		if quote != 0 {
+			// Inside a string. Nothing here opens a comment, and the contents
+			// are kept because `${CONTROL_PLANE_URL}` is code.
+			out.WriteByte(c)
+			if c == '\\' && i+1 < len(line) {
+				i++
+				out.WriteByte(line[i])
+				continue
+			}
+			if c == quote {
+				quote = 0
+			}
+			continue
+		}
+		if c == '"' || c == '\'' || c == '`' {
+			quote = c
+			out.WriteByte(c)
+			continue
+		}
+		if strings.HasPrefix(line[i:], "//") {
+			break
+		}
+		if strings.HasPrefix(line[i:], "/*") {
+			st.inComment = true
+			i++
+			continue
+		}
+		out.WriteByte(c)
+	}
+	// A `"` or `'` left open at the end of a line is a syntax error rather than
+	// a continuation, so only a template literal carries over.
+	st.inTemplate = quote == '`'
+	return out.String(), st
+}

--- a/www/components/AuthScreen.tsx
+++ b/www/components/AuthScreen.tsx
@@ -3,7 +3,7 @@
 import { useEffect } from "react";
 import { useChrome } from "./Chrome";
 import { LogoMark } from "./icons";
-import { CONTROL_PLANE_URL } from "@/lib/site";
+import { controlPlaneUrl } from "@/lib/control-plane-routes";
 import { ctaEngaged } from "@/lib/analytics";
 
 function GitHubMark({ className }: { className?: string }) {
@@ -166,7 +166,7 @@ export function AuthScreen({ mode }: { mode: "signin" | "signup" }) {
             </p>
 
             <a
-              href={CONTROL_PLANE_URL + "/auth/github"}
+              href={controlPlaneUrl("auth.github")}
               className="mt-6 flex h-12 w-full items-center justify-center gap-2.5 rounded-full bg-black text-[15px] font-medium text-white hover:bg-[#292929]"
             >
               <GitHubMark className="h-[18px] w-[18px]" />

--- a/www/components/pages/company/ApplicationForm.tsx
+++ b/www/components/pages/company/ApplicationForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useId, useRef, useState } from "react";
-import { CONTROL_PLANE_URL } from "@/lib/site";
+import { controlPlaneUrl } from "@/lib/control-plane-routes";
 
 /**
  * The application form, and the four things it refuses to get wrong.
@@ -123,7 +123,7 @@ export function ApplicationForm() {
   async function send(values: Record<string, unknown>, key: string) {
     let response: Response;
     try {
-      response = await fetch(`${CONTROL_PLANE_URL}/v1/applications`, {
+      response = await fetch(controlPlaneUrl("applications.create"), {
         method: "POST",
         // No cookie leaves this browser for the control plane. The endpoint is
         // anonymous, and sending credentials to it would be the only reason it

--- a/www/components/pages/company/EnterpriseForm.tsx
+++ b/www/components/pages/company/EnterpriseForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useId, useRef, useState } from "react";
-import { CONTROL_PLANE_URL } from "@/lib/site";
+import { controlPlaneUrl } from "@/lib/control-plane-routes";
 import { leadSubmitted } from "@/lib/analytics";
 
 /**
@@ -62,7 +62,7 @@ export function EnterpriseForm() {
 
     let response: Response;
     try {
-      response = await fetch(`${CONTROL_PLANE_URL}/v1/leads`, {
+      response = await fetch(controlPlaneUrl("leads.create"), {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({

--- a/www/lib/beacon.ts
+++ b/www/lib/beacon.ts
@@ -2,7 +2,8 @@
  * The site beacon: everything it sends, and everything it refuses to.
  *
  * SPLIT FROM analytics.ts SO THAT IT CAN BE TESTED. This file imports nothing
- * but lib/site.ts and lib/bots.ts, neither of which imports a framework, so a
+ * but lib/control-plane-routes.ts and lib/bots.ts, and the first of those
+ * imports only lib/site.ts, so nothing on the path pulls in a framework and a
  * plain `node --test` can load it and drive the queue, the session rules and
  * the opt out against stub globals. analytics.ts holds the one React hook and
  * re-exports the rest, because next/navigation does not resolve outside the
@@ -49,7 +50,7 @@
  * the correct answer.
  */
 
-import { CONTROL_PLANE_URL } from "./site";
+import { controlPlaneUrl } from "./control-plane-routes";
 import { looksAutomated } from "./bots";
 
 /**
@@ -65,7 +66,7 @@ import { looksAutomated } from "./bots";
  * looks finished, which is the defect this repository has shipped most often.
  */
 const ENDPOINT =
-  process.env.NEXT_PUBLIC_AF_ANALYTICS_ENDPOINT ?? `${CONTROL_PLANE_URL}/v1/site/events`;
+  process.env.NEXT_PUBLIC_AF_ANALYTICS_ENDPOINT ?? controlPlaneUrl("site.events");
 
 const SESSION_KEY = "af.session.v1";
 

--- a/www/lib/control-plane-routes.ts
+++ b/www/lib/control-plane-routes.ts
@@ -1,0 +1,148 @@
+/**
+ * Every control plane route this site calls, in one place, as a value.
+ *
+ * THE FAILURE THIS EXISTS FOR. The careers form posted to
+ * `POST /v1/applications`. The form was correct, the route was correct, and the
+ * route was in `web/apps/api/src/server.ts` on main. A person filling the form
+ * in on antifailure.dev was told "Could not reach the server", because the
+ * control plane answering that origin was still serving v1.1.1 and v1.1.1 has
+ * no such route. The site had shipped 22 commits ahead of the API it posts to.
+ *
+ * That is not a bug in either half. It is the deployment split working as
+ * designed: this site publishes on every merge to main, and the control plane
+ * only moves when a `v*` tag is promoted. deploy.yml already writes that split
+ * down, and already decided it was tolerable, on the grounds that "the paths
+ * are additive and a caller reading an operation that is not there yet gets a
+ * 404". That reasoning is sound for `openapi.json`, which is a document a
+ * reader consults. It is wrong here, because this site is not a reader of the
+ * control plane. It is a CALLER of it, and a caller that gets a 404 is a form
+ * that does not work.
+ *
+ * WHY A LIST AND NOT A GREP. The URLs were built at the call sites, as
+ * `` fetch(`${CONTROL_PLANE_URL}/v1/applications`) ``. Nothing can enumerate
+ * those reliably: a template literal can hold an expression, a path can be
+ * assembled from a variable, and an extractor that reads four of five call
+ * sites and says nothing about the fifth is the shape of instrument this
+ * repository keeps having to throw away. So the inventory is a value that the
+ * call sites read, rather than a pattern something tries to recognise in them,
+ * and `tools/routecheck` refuses any file in www that builds a control plane
+ * URL outside this module. There is no call site it can fail to see, because a
+ * call site it cannot see does not compile past the gate.
+ *
+ * WHY THE PROBE IS DESCRIBED HERE. Proving that the deployed control plane
+ * serves a route means asking it, and asking it means sending it a request.
+ * A request that reached a handler would be a real job application in a review
+ * queue read by a person, which is not a thing a gate may create. So each entry
+ * carries the request that proves the route is there and the reason that
+ * request cannot reach the handler behind it. The reason is checked by reading
+ * the API's source, not assumed, and it is written next to the route it is
+ * about so that a route added here without one is visibly unfinished.
+ *
+ * @see tools/routecheck for the gate that reads this.
+ */
+
+import { CONTROL_PLANE_URL } from "./site";
+
+/**
+ * What a probe of this route does to the deployment it is aimed at.
+ *
+ * A closed set, so the question "which of these writes something" is answered
+ * by counting rather than by reading five sentences and forming an impression.
+ */
+export type ProbeEffect =
+  /**
+   * The request cannot reach the route's handler. Middleware in front of it
+   * refuses first, or the handler's own validation refuses before it touches
+   * anything. Nothing is written and nothing is sent.
+   */
+  | "inert"
+  /**
+   * The request reaches the handler and the handler writes. Naming it here is
+   * the point: `tools/routecheck` refuses to send one of these unless it is
+   * told to in as many words, so a probe with a cost is never sent by a run
+   * that did not know it was paying it.
+   */
+  | "writes";
+
+/** One route this site calls, and how to find out whether it is really there. */
+export interface ControlPlaneRoute {
+  /** The method the site itself uses. A route registered for POST answers 404
+   *  to a GET, so a probe with the wrong method cannot tell "the route is not
+   *  there" from "I asked the wrong way". */
+  readonly method: "GET" | "POST";
+  /** The path, as a literal. Never assembled. */
+  readonly path: string;
+  /** Where in this site it is reached from, so a reader can go and look. */
+  readonly calledFrom: string;
+  /** What breaks for a person when the deployed control plane lacks it. */
+  readonly whenMissing: string;
+  /** What a probe costs. See ProbeEffect. */
+  readonly probeEffect: ProbeEffect;
+  /** Why the probe is what it says it is, checked against the API's source.
+   *  For "inert", this names the code that refuses before any write. For
+   *  "writes", it names what gets written. */
+  readonly probeReason: string;
+}
+
+/**
+ * The inventory.
+ *
+ * Adding a route here is how a new call site is declared. Adding a call site
+ * without one fails `tools/routecheck` in the `www` gate, naming the file and
+ * the line, before the pull request that added it can merge.
+ */
+export const CONTROL_PLANE_ROUTES = {
+  "applications.create": {
+    method: "POST",
+    path: "/v1/applications",
+    calledFrom: "components/pages/company/ApplicationForm.tsx",
+    whenMissing:
+      "The careers form says 'Could not reach the server' and a job application is lost.",
+    probeEffect: "inert",
+    probeReason:
+      "recruitment/routes.ts registers an `app.use` in front of the route that answers 403 unless the Origin header is exactly the configured site origin. A probe sends no Origin, so it is refused before the body is read and recordApplication is never called.",
+  },
+  "leads.create": {
+    method: "POST",
+    path: "/v1/leads",
+    calledFrom: "components/pages/company/EnterpriseForm.tsx",
+    whenMissing:
+      "The enterprise contact form says 'Could not reach the server' and a sales enquiry is lost.",
+    probeEffect: "inert",
+    probeReason:
+      "server.ts validates the body with validateLead, which is pure, and returns 400 on an empty name before recordLead is reached. A probe sends {} and is refused on the first check. It does spend one token of the shared auth rate limit bucket, which is why a 429 from this route counts as the route being present.",
+  },
+  "site.events": {
+    method: "POST",
+    path: "/v1/site/events",
+    calledFrom: "lib/beacon.ts",
+    whenMissing:
+      "The site beacon posts into nothing. No reader sees an error, which is why this one needs a gate more than the forms do.",
+    probeEffect: "inert",
+    probeReason:
+      "server.ts refuses the route with 403 'This endpoint serves the marketing site only.' unless the Origin header matches the configured site origin. A probe sends no Origin and never reaches the ingest.",
+  },
+  "auth.github": {
+    method: "GET",
+    path: "/auth/github",
+    calledFrom: "components/AuthScreen.tsx",
+    whenMissing:
+      "'Continue with GitHub' lands on a 404 page. It is the primary conversion path off this site.",
+    probeEffect: "writes",
+    probeReason:
+      "auth/signin.ts beginSignIn inserts one row into oauth_states unconditionally, and nothing in front of the handler refuses a request that carries no credential. A probe therefore creates one expiring state row, exactly as a person who clicks the button and then closes the tab does. There is no request that proves this route is present without doing that, so it is declared rather than hidden.",
+  },
+} as const satisfies Record<string, ControlPlaneRoute>;
+
+/** The name of a route in the inventory. */
+export type ControlPlaneRouteName = keyof typeof CONTROL_PLANE_ROUTES;
+
+/**
+ * The absolute URL of a route, for a call site to fetch or link to.
+ *
+ * The one function that turns an entry above into a URL. CONTROL_PLANE_URL has
+ * any trailing slash stripped by lib/site.ts, so this is a plain join.
+ */
+export function controlPlaneUrl(name: ControlPlaneRouteName): string {
+  return CONTROL_PLANE_URL + CONTROL_PLANE_ROUTES[name].path;
+}

--- a/www/test/control-plane-routes.test.ts
+++ b/www/test/control-plane-routes.test.ts
@@ -1,0 +1,85 @@
+// The URLs the site calls, pinned to the exact strings it called before they
+// became an inventory.
+//
+// The call sites used to build these by hand, as
+// `` fetch(`${CONTROL_PLANE_URL}/v1/applications`) ``, and were changed to read
+// them out of lib/control-plane-routes.ts so that tools/routecheck can prove
+// the deployed control plane serves every one of them. That refactor is only
+// safe if it changed nothing about the request that leaves the browser, and
+// "it type checks" does not prove that: a wrong path, a doubled slash or a
+// missing segment all compile. So the strings are asserted literally.
+//
+// It also asserts the properties tools/routecheck depends on and cannot check
+// from the outside: that no two entries claim the same route, and that every
+// entry carries the probe cost and the reason behind it. A gate reading an
+// inventory with a silently duplicated or half-filled entry is a gate checking
+// fewer routes than it reports.
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { CONTROL_PLANE_ROUTES, controlPlaneUrl } from '../lib/control-plane-routes'
+import { CONTROL_PLANE_URL } from '../lib/site'
+
+describe('the control plane URLs the site builds', () => {
+  it('are the same absolute URLs the call sites built by hand', () => {
+    assert.equal(controlPlaneUrl('applications.create'), `${CONTROL_PLANE_URL}/v1/applications`)
+    assert.equal(controlPlaneUrl('leads.create'), `${CONTROL_PLANE_URL}/v1/leads`)
+    assert.equal(controlPlaneUrl('site.events'), `${CONTROL_PLANE_URL}/v1/site/events`)
+    assert.equal(controlPlaneUrl('auth.github'), `${CONTROL_PLANE_URL}/auth/github`)
+  })
+
+  it('point at the production control plane when nothing is configured', () => {
+    // The default matters more than it looks. AuthScreen.tsx once held a bare
+    // constant reading the staging origin, and every invited person who clicked
+    // sign in on the marketing site landed on a deployment with a different
+    // OAuth application and a different database.
+    if (!process.env.NEXT_PUBLIC_CONTROL_PLANE_URL) {
+      assert.equal(controlPlaneUrl('auth.github'), 'https://app.antifailure.dev/auth/github')
+    }
+  })
+
+  it('never doubles a slash, whatever the origin is spelled like', () => {
+    for (const name of Object.keys(CONTROL_PLANE_ROUTES) as (keyof typeof CONTROL_PLANE_ROUTES)[]) {
+      const url = controlPlaneUrl(name)
+      assert.ok(!url.slice('https://'.length).includes('//'), `${name} produced ${url}`)
+      assert.ok(url.startsWith('http'), `${name} produced ${url}`)
+    }
+  })
+})
+
+describe('the inventory tools/routecheck reads', () => {
+  it('names each route once, so the gate cannot check fewer than it reports', () => {
+    const seen = new Set<string>()
+    for (const [name, route] of Object.entries(CONTROL_PLANE_ROUTES)) {
+      const key = `${route.method} ${route.path}`
+      assert.ok(!seen.has(key), `${key} is declared twice, the second time as ${name}`)
+      seen.add(key)
+    }
+    assert.equal(seen.size, Object.keys(CONTROL_PLANE_ROUTES).length)
+  })
+
+  it('says what every probe costs and why', () => {
+    for (const [name, route] of Object.entries(CONTROL_PLANE_ROUTES)) {
+      assert.ok(
+        route.probeEffect === 'inert' || route.probeEffect === 'writes',
+        `${name} declares probeEffect ${route.probeEffect}`,
+      )
+      // The reason is what makes the claim checkable against the API's source.
+      // An entry asserting "inert" with nothing behind it is the shape of thing
+      // that gets a probe sent at a handler nobody meant to reach.
+      assert.ok(route.probeReason.length > 40, `${name} has no real probeReason`)
+      assert.ok(route.whenMissing.length > 20, `${name} does not say what breaks`)
+      assert.ok(route.calledFrom.endsWith('.tsx') || route.calledFrom.endsWith('.ts'), `${name} calledFrom is ${route.calledFrom}`)
+    }
+  })
+
+  it('declares only methods a probe can tell apart', () => {
+    // The control plane answers 404 both for a path it does not have and for a
+    // path it has under a different method. routecheck therefore probes with
+    // the method the site itself uses, and only understands these two.
+    for (const [name, route] of Object.entries(CONTROL_PLANE_ROUTES)) {
+      assert.ok(['GET', 'POST'].includes(route.method), `${name} uses ${route.method}`)
+      assert.ok(route.path.startsWith('/'), `${name} has path ${route.path}`)
+    }
+  })
+})


### PR DESCRIPTION
## The failure

Somebody filled in the careers form on `https://antifailure.dev/careers` and was
told "Could not reach the server."

The form was correct. The route was correct. This is what production answered,
and it went on answering it for the whole time this branch was being written:

```
POST https://app.antifailure.dev/v1/applications  ->  404
POST https://app.antifailure.dev/v1/leads         ->  400
```

```
git show v1.1.1:web/apps/api/src/server.ts      | grep -c v1/applications  ->  0
git show origin/main:web/apps/api/src/server.ts | grep -c v1/applications  ->  1
```

Neither half was broken. `www` publishes on every merge to main and the control
plane only moves when a `v*` tag is promoted to production, so the careers page
went live the instant #238 merged, in front of an API twenty two commits behind
it that had never heard of the route the page posts to. The `catch` around that
`fetch` turned a 404 into the one sentence a visitor ever saw.

`deploy.yml` had already written this split down. Its comment on the published
document says the site "can be ahead of what app.antifailure.dev serves. That is
tolerable while the API VERSION agrees, because the paths are additive and a
caller reading an operation that is not there yet gets a 404." That is right
about `openapi.json`, which is a document somebody READS. It is wrong about this
site, which is a CALLER, and for a caller a 404 is a form that does not work.

## Why the obvious check is the wrong one

Extract the routes `www` calls, compare them against the routes
`web/apps/api/src/server.ts` declares, and the check PASSES on this exact
failure: main's API does declare `/v1/applications`. The mismatch is not between
two files in one tree, it is between the front end and the control plane that is
CURRENTLY RUNNING. So the second half of this asks the deployment.

## What is here

**Every control plane URL the site builds is now a value.** They used to be
assembled at the call sites as `` fetch(`${CONTROL_PLANE_URL}/v1/applications`) ``.
Nothing can enumerate those honestly: a template literal can hold an expression,
a path can arrive in a variable, and an extractor that reads four call sites and
cannot read the fifth has to either guess or say nothing. So the rule is
inverted. `www/lib/control-plane-routes.ts` owns the list, the call sites import
`controlPlaneUrl` from it, and `routecheck` refuses any file in `www` that names
`CONTROL_PLANE_URL` outside that module and the one that defines it, naming the
file and the line. **There is no call site it can fail to see, because a call
site it cannot see is now a failure rather than a silence.** Comments are
stripped first, so the rule cannot be routed around by rewording a sentence.

### That scanner shipped with the exact hole it exists to close

The claim above is only worth what the scanner behind it is worth, so the
scanner was attacked rather than admired. It broke.

The comment stripper broke out of the line at the first `//` it saw, wherever it
saw it. So this call site was invisible to it:

```ts
const u = "https://antifailure.dev" + CONTROL_PLANE_URL;
```

Everything after `https:` was discarded as a comment, the identifier was never
seen, and the gate reported a clean run over a control plane URL built outside
the inventory. A false negative, silent, in the one instrument whose entire job
is to make an unenumerable call site loud. Reproduced first, then fixed: the
stripper now tracks string and template literals, keeps their contents because
`${CONTROL_PLANE_URL}` is code rather than text, and carries an open template
literal across a newline the way it already carried a block comment.

Keeping string contents is a deliberate trade in the loud direction. The
characters `CONTROL_PLANE_URL` written inside an ordinary string are now
reported as a call site, which is a false positive that somebody fixes in a
minute, rather than a false negative that nobody ever sees.

Two tests hold it, not one, because a stripper returning the right string is
worth nothing if the walk never asks it about that file:
`TestStripCommentsDoesNotLoseCodeAfterAUrlInAString` on the stripper, and
`TestFindStrayCallSitesSeesACallSiteHiddenBehindAUrl` on the whole walk. Both
were mutation tested against the original one-line break.

Four call sites moved and nothing about the requests changed:
`ApplicationForm.tsx`, `EnterpriseForm.tsx`, `AuthScreen.tsx` and `lib/beacon.ts`.
`www/test/control-plane-routes.test.ts` pins the four absolute URLs literally,
because "it type checks" does not prove a path is unchanged.

One existing instrument was anchored on a line this refactor moved, and it
caught it on the first CI run rather than being noticed by a person.
`claimcheck`'s rule "there is no hosted control plane" forbids the site denying
that a hosted plane exists, and its premise was the expression
`CONTROL_PLANE_URL + "/auth/github"` in `AuthScreen.tsx`. The link is unchanged
and still points at the same place; only the accessor moved. The premise is
re-anchored on `controlPlaneUrl("auth.github")`, exactly as the rule directly
above it re-anchored from `c.token` to `c.bearer()` for the same kind of reason,
with a comment saying which anchoring this is and why. Deleting the link still
trips the rule, which is the whole point of it.

`/auth/github` is in the inventory even though it is a link rather than a fetch.
A 404 there is exactly as broken for the person as a failed fetch, from the same
cause, and it is the primary conversion path off the site.

**`tools/routecheck` has two halves and only one needs a network.**

The offline half runs in the `www` required context and in `just gate`. It
proves the inventory is complete and that every route in it is one this
repository's control plane actually mounts, read from `boundary.ts`, whose key
set `route-boundary.test.ts` already proves complete against the router's own
route table. It CANNOT see the failure above and says so when it finishes: on
the day the form broke, main's `server.ts` did declare the route.

The online half runs in `deploy.yml`, in the `site` job, immediately before
`Publish`. That is where the answer matters, because what the origin will answer
can change between the merge and the publish without a commit. It also asserts
that the origin it is about to probe is the origin the built bundle contains, so
it cannot return a green tick for a different control plane than the one shipped.

That last assertion is fail closed, which means a version of it that could never
succeed would block every site deploy forever, so it was run rather than
reasoned about. `npm run build` in `www` then `cp -R www/out/. site/` locally,
exactly as `tools/site/assemble.sh` does it, and the grep finds the origin in
`site/_next/static/chunks/0v-_pyb_kq0ss.js`. The same build also shows all four
declared paths present in the shipped bundle, which is independent evidence that
the inventory describes the site that actually gets published rather than a list
somebody wrote next to it.

No new required context. The offline half joins the nine that already exist.

## Probing without doing anything

The gate must not find out whether the careers endpoint exists by filing a job
application. Each entry declares what its probe costs and why, checked against
the API's source rather than assumed:

| route | probe | why it cannot reach the handler |
| --- | --- | --- |
| `POST /v1/applications` | inert | `recruitment/routes.ts` registers an `app.use` that answers 403 unless `Origin` is exactly the site origin. The probe sends none. |
| `POST /v1/leads` | inert | `validateLead` is pure and returns 400 on an empty name before `recordLead`. The probe sends `{}`. |
| `POST /v1/site/events` | inert | Same origin guard, answering 403. |
| `GET /auth/github` | **writes** | `beginSignIn` inserts one `oauth_states` row unconditionally and nothing in front of it refuses. There is no request that proves this route is present without doing that. |

The last one is declared rather than hidden. `routecheck` refuses to send it
unless `-allow-write-probes` says so, and reports the route as NOT CHECKED and
fails rather than passing over it, because a route the gate quietly skipped is a
route nothing checks at all. When it is sent it creates one expiring state row,
exactly as a person who clicks "Continue with GitHub" and closes the tab does.

The probe uses the method the site itself uses. The control plane answers 404
both for a path it does not have and for a path it has under a different method,
so a probe with the wrong method reads exactly like a route that is gone.

### The one write probe: what it costs, and what would retire it

`deploy.yml` passes `-allow-write-probes`, so every publish inserts one
`oauth_states` row into production. That is declared rather than hidden, and
here is the judgement behind it rather than just the disclosure.

**The row is never deleted.** An earlier draft of this called it "one expiring
state row", which is the kind of sentence that lets a reader assume it cleans
itself up. It does not. `completeSignIn` deletes a state ON REDEMPTION, in the
same statement that reads it, and nothing sweeps the table: `maintenance.ts`
sweeps analytics partitions and recruitment applications, and the dedicated
sweepers that exist are for devices (`0016`), sessions (`0024`) and email
sign-in tokens (`0017`). `oauth_states` has none. So an unredeemed row is
unusable after `OAUTH_STATE_TTL_MS`, ten minutes, and stays in the table
indefinitely.

**Is that acceptable forever? No. It is a debt with an expiry date.** The volume
is trivial, one small row per push to main, so this is not a capacity argument.
The objection is that a CI job writes to a security-relevant table on an
unauthenticated path, permanently, under an authorisation that lives in a YAML
comment nobody re-reads. That is precisely how a thing gets discovered in six
months rather than decided today.

**It is not this gate's debt alone, and that is the useful part.** Every person
who clicks "Continue with GitHub" and closes the tab leaves exactly the same
row. The gate does not create a new class of garbage; it makes an existing gap
slightly more visible. The table has been missing a sweeper since `0001`.

**What retires it: a sweeper for `oauth_states`**, of the shape `0016` and
`0024` already use. That is worth building on its own account, independent of
this gate, and it is small because the pattern exists twice already, including
two migrations whose names record that the first attempts could not delete
through RLS, so the trap is already documented. It belongs in its own pull
request for the same reason the 404 sentence does: it is control plane, on the
tag clock.

**What does not retire it: a cheaper presence probe.** The obvious idea is a
route that answers presence without beginning a sign-in, or a parameter
`beginSignIn` rejects before the insert. It cannot help on the day it is needed.
This gate exists for a DEPLOYED image older than the commit that would have
added such a branch, so on exactly the occasion it matters the old image has no
such route. It would only ever retire the debt prospectively, years out, and it
adds a control plane surface to save a row a sweeper deletes for free. The
sweeper is the better buy.

Until then the cost is written twice where somebody will actually meet it: in
the inventory entry, and in the `deploy.yml` comment that authorises the flag,
which now says what the row costs and names the sweeper as the thing to come
back and delete it for.

### Why not an OPTIONS preflight

An `OPTIONS` probe is the obvious way to ask without sending a body, and it was
rejected on evidence from `boundary.ts` rather than on taste. It answers about
the wrong route, and for one of these four it answers about no route at all.

`OPTIONS /v1/leads`, `OPTIONS /v1/applications` and `OPTIONS /v1/site/events`
are separate registered routes with their own entries in the register, each
classified `not-an-endpoint` with the reason "the preflight for the route above.
A browser sends it; nothing calls it." So an `OPTIONS` probe establishes that
the PREFLIGHT exists, which is not the question. `GET /auth/github` has no
`OPTIONS` entry at all, because it is a link a person clicks rather than a cross
origin fetch, so an `OPTIONS` probe of it would return 404 for a route that is
present and blame the deploy for a route that works. That is the exact false
positive that would make the gate worthless.

There is a second reason that outlives the current register. Routers commonly
answer `OPTIONS` generically, from CORS middleware ahead of routing, so a 204 to
an `OPTIONS` can come back for a path with no handler behind it whatsoever. That
is a false NEGATIVE, and a silent one.

A deliberately invalid body with the method the site uses has neither problem.
It asks about the route the site actually calls, with the verb the site actually
uses, and every one of these four handlers refuses it before doing anything.

## Telling "it is missing" apart from "I did not find out"

A route is ABSENT only when the control plane itself answered 404. Every reply
the control plane produces carries an `x-request-id` minted before routing,
including both of its 404s, so a reply without one did not come from the
application and cannot be read as either answer. The probe sends no
`x-request-id` of its own, because the control plane honours a supplied one and
that would destroy the only evidence available.

Unreachable, 5xx after retries, and a reply from something in front of the app
are all reported as undetermined and all fail. None of them can produce a pass.

## Proving it can say no

**Rows 1, 2 and 4 are live observations of real origins, not replays, and the
window they were taken in has since closed.** At `09:33:24Z` production was
still serving `v1.1.1` / `59486b63` with `cd` run `33958063854` sitting in status
`waiting` on the `production` environment's human approval, and
`POST /v1/applications` still answered 404. That approval has since been given:
`33958063854` is `completed/success`, production now reports `v1.2.0` /
`b66ca628`, the route answers 403 from its origin guard, and the careers form
works. Row 1 can no longer be reproduced against a live origin, which is exactly
why `recorded_test.go` replays it.

| # | origin | observed | verdict |
| --- | --- | --- | --- |
| 1 | production `app.antifailure.dev` at `09:33:24Z`, `/readyz` says `v1.1.1` / `59486b63` | `/v1/applications` **404**, `/v1/leads` 400, `/v1/site/events` 403, `/auth/github` 302 | **FAILS**, naming `POST /v1/applications` and nothing else, `exit=1` |
| 2 | staging `app.dev.antifailure.dev` at `09:33:24Z`, `/readyz` says `v1.2.0` / `b66ca628` | `/v1/applications` 403, `/v1/leads` 400, `/v1/site/events` 403, `/auth/github` 302 | **PASSES**, `exit=0` |
| 2b | production at `11:00Z`, after the promotion, `/readyz` says `v1.2.0` / `b66ca628`, probed with the binary built from this branch's head | `/v1/applications` 403, `/v1/leads` 400, `/v1/site/events` 403, `/auth/github` 302 | **PASSES**, `exit=0` |
| 3a | an origin with nothing listening | transport refused | FAILS as undetermined, never as absent, `exit=1` |
| 3b | an origin answering 500 to everything | 500 with an `x-request-id` | FAILS as undetermined, never as absent, `exit=1` |
| 3c | something in front of the app answering 404 with no `x-request-id` | 404, no request id | FAILS as undetermined, never as absent, `exit=1` |
| 4 | the no-false-positive row, inside rows 1 and 2 | `/v1/leads` 400 and `/v1/site/events` 403 on production | both reported **present**, and neither is named in row 1's failure |

Row 4 is the one that decides whether this is worth having. Three of the four
routes REFUSE the probe on production right now, with 400, 403 and a 302. A gate
that read a refusal as an absence would have called every one of them missing,
and would have been wrong three times out of four while being right once by
accident.

Row 1's exact output:

```
  POST /v1/applications   404  absent      the control plane answered 404 to the request the site makes
  POST /v1/leads          400  present     answered as a route that exists: {"error":"Tell us your name so a reply is addressed to somebody."}
  POST /v1/site/events    403  present     answered as a route that exists: {"error":"This endpoint serves the marketing site only."}
  GET /auth/github        302  present     answered as a route that exists: (no body)

https://app.antifailure.dev does not serve 1 route(s) this site calls:

  POST /v1/applications
    called from www/components/pages/company/ApplicationForm.tsx
    The careers form says 'Could not reach the server' and a job application is lost.
```

The same two states are pinned as tests, so they keep holding after production
is promoted and the live experiment closes. `recorded_test.go` replays both
columns of the recorded observation, status code by status code and body by
body, and asserts the whole command against them rather than one property at a
time. The two columns differ in exactly one cell, and that cell is the bug.

## Why the control plane does not publish a route inventory for this

The obvious alternative is to have the control plane list its own routes and
have the gate read that instead of inferring anything. It already does. The 404
this failure produced says so in as many words: "No endpoint at this path. GET
/openapi.json lists every endpoint this control plane serves." Production serves
that document, it is 94 paths, and it is the wrong authority here:

| route the site calls | in production's openapi.json | that gate would say | probed reality |
| --- | --- | --- | --- |
| `POST /v1/applications` | no | absent | 404, absent |
| `POST /v1/leads` | no | absent | 400, **present** |
| `POST /v1/site/events` | no | absent | 403, **present** |
| `GET /auth/github` | no | absent | 302, **present** |

Checked live rather than reasoned about, at `2026-09-05T09:33:24Z`, against
BOTH origins: each serves `openapi.json` with 94 paths, and zero of the four
routes the site calls appears in either. (`/v1/auth/github-oidc` is in the
document and is a different route; a substring match on `/auth/github` finds it
and that is a trap of its own.)

Three false positives out of four, and the one it gets right it gets right by
accident. That is not a defect in the document. `boundary.ts` excludes all four
deliberately and says why for each: the two forms are cross origin browser calls
from one configured origin that nothing integrates with, and publishing the
careers endpoint "would invite a client to post applications at us, which is the
opposite of what a review queue read by one person is for."

Adding a second, complete inventory endpoint was considered and rejected on two
grounds. It cannot exist on the currently deployed image, so it could not answer
the question on the one day the question was being asked, and every future
occurrence of this failure is by definition a deployed image older than the
commit that would have added it. And a complete unauthenticated route list is
strictly more disclosure than a probe of a route somebody already knows about:
it hands over the admin, breakglass and operator paths that `boundary.ts` keeps
out of the published document on purpose.

So the gate asks about the routes the site calls, one at a time, with the method
the site uses, and learns nothing it did not already know from reading the site's
own bundle.

### That 404 sentence is false, and it is deliberately not fixed here

`web/apps/api/src/notfound.ts:35` tells every caller of an unrouted path that
"GET /openapi.json lists every endpoint this control plane serves." It does not.
Somebody who mistypes `/v1/application` reads that sentence, fetches the
document, does not find `/v1/applications` in it either, and concludes the
endpoint does not exist when it does.

It belongs in its own pull request, for four reasons rather than as a
convenience. `apiNotFound` is the 404 for the entire API and for the console as
well (`console/index.ts:325`), so changing it changes the body every unrouted
request in the product receives, which deserves its own review rather than a
paragraph inside a gate. It ships on the tag clock, and this change ships on the
merge clock, which is the exact split this whole pull request is about. Nothing
here reads it: `routecheck` decides on the status line and the `x-request-id`
header and never looks at the body, so the two are genuinely independent, and
no test pins the sentence today. And the `.changes` grammar takes one first
line per file, where this is `# added` and that is `# fixed`.

The replacement wording, ready for whoever takes it: "No endpoint at this path.
GET /openapi.json describes the endpoints a client can integrate with; some
routes this control plane serves are deliberately not in it." 

## What this does not do

It did not restore the careers form, and nothing here could have. That route
reached production when the `v1.2.0` tag was promoted, as every control plane
change does, which happened while this branch was being written: `cd` run
`33958063854` is `completed/success` and the form works now. What changes here is
that the site can no longer be PUBLISHED in front of an API that does not serve
it, and that the next occurrence stops at the deploy rather than at a person
filling in a form.

It also does not check the site's own `/api` routes, the docs, or anything the
browser fetches from the site's own origin. `api/index/index.js` names
`https://app.antifailure.dev` and is deliberately not in scope: it advertises the
origin as metadata in an index document and calls no route on it, so there is no
contract there to break. The console is out of scope for the reason `boundary.ts`
already gives, that it is a static export served by the control plane process
from the same commit, so there is no second client and no version skew. The failure it was written for is
specifically the deployment split between two things that ship on different
triggers, and widening it to surfaces that ship together would be a check that
cannot say no.

## The consequence of merging this

`AZURE_STATIC_WEB_APPS_API_TOKEN` is set on the repository, confirmed with
`gh secret list`, so the `if: env.TOKEN != ''` guard is satisfied and the online
half really runs rather than skipping. That is what makes it a gate and not dead
code.

**This was a live concern for most of the time this branch was being written and
it no longer is.** While production was serving `v1.1.1`, merging would have
made `deploy.yml`'s `site` job fail on every push to main until the promotion,
and the site would have stopped publishing. The promotion has since happened.
Probed at `11:00Z` with the binary built from this branch's head, production
serves all four routes and the gate exits 0, so merging now changes nothing
about whether the site publishes.

It is written down rather than deleted because it is the behaviour to expect the
next time the site merges a call to a route that has not been released, which is
the whole point of the gate. When that happens the `site` job goes red and the
publish stops, and the two ways out are both correct: promote the control plane,
or stop calling the route.

Nothing else is affected. `site` is the only job in `deploy.yml` and nothing
depends on it, `deploy.yml` runs on push to main rather than on pull requests so
it blocks no merge, and it is not one of the nine required contexts. The offline
half added to the `www` context passes on this tree today.

## Mutation testing

Every assertion was mutation tested: break the production line it is meant to
catch, confirm it goes red, restore it, confirm it goes green. One break per
cell, because an assertion after a failed one is unreachable and still looks
alive, and each cell asserts the named test actually RAN, because `go test -run`
matching nothing exits 0 and reads exactly like a pass.

**The run caught two instruments that could not say no, and both are fixed
here.** That is the whole reason for doing it rather than reporting that it was
done.

The harness read every Go cell as `UNCLEAR`. `--- PASS: TestX (0.00s)` ends in a
duration, and the pattern anchored end of line straight after the test name, so
it matched neither verdict. The `=== RUN` line does end at the name, so the
"did this test run at all" check passed and hid the fault. A mutation harness
that cannot read its own results is the same defect it exists to find.

Then, with the harness reading correctly,
`TestFindStrayCallSitesSeesACallSiteHiddenBehindAUrl` stayed **GREEN with the
hole reopened**. Its fixture put the URL on one line and the identifier on the
next, and the arrangement that actually broke is both on the SAME line. The
fixture now carries both arrangements, and the cell goes red.

| cell | line broken | assertion | broken | restored |
| --- | --- | --- | --- | --- |
| M01 | the 404 verdict becomes `Present` | `TestAbsentRouteFails` | RED | GREEN |
| M02 | a non-404 verdict becomes `Absent` | `TestARouteThatRejectsTheProbeIsPresent` | RED | GREEN |
| M03 | a transport failure reads as present | `TestAnUnreachableOriginFails` | RED | GREEN |
| M04 | the 5xx branch is never taken | `TestAnOriginThatFailsEverythingIsNotAPass` | RED | GREEN |
| M05 | the `x-request-id` check is disabled | `TestSomethingInFrontOfTheAppIsNotAnAnswer` | RED | GREEN |
| M06 | the write-probe refusal is disabled | `TestAWritingProbeIsNotSentUnlessAllowed` | RED | GREEN |
| M07 | the probe always uses GET | `TestTheProbeUsesTheMethodTheSiteUses` | RED | GREEN |
| M08 | redirects are followed | `TestARedirectIsTheAnswerAndIsNotFollowed` | RED | GREEN |
| M09 | the probe sends an `Origin` header | `TestTheProbeSendsNoOriginAndNoRequestId` | RED | GREEN |
| M10 | retries reduced to one attempt | `TestATransientFailureIsRetried` | RED | GREEN |
| M11 | the stray match is disabled | `TestFindStrayCallSitesNamesTheFileAndLine` | RED | GREEN |
| M12 | comments are no longer stripped | `TestFindStrayCallSitesIgnoresProseAndVendoredCode` | RED | GREEN |
| M13 | inventory validation returns early | `TestParseInventoryRefusesAnEntryItCannotRead` | RED | GREEN |
| M14 | an empty register is accepted | `TestParseBoundaryRegisterRefusesAnEmptyRead` | RED | GREEN |
| M15 | every route reads as inert | `TestParseInventoryReadsEveryRouteAndItsProbeCost` | RED | GREEN |
| M16 | the failure stops naming the route | `TestTheRecordedProductionIsRefusedAndTheRouteIsNamed` | RED | GREEN |
| M17 | the report stops printing the verdict | `TestTheRecordedRefusalsAreReadAsRoutesThatExist` | RED | GREEN |
| M18 | the pass stops saying what it established | `TestTheRecordedStagingPasses` | RED | GREEN |
| M19 | string literals no longer open string mode | `TestStripCommentsDoesNotLoseCodeAfterAUrlInAString` | RED | GREEN |
| M20 | an open template does not carry to the next line | `TestStripCommentsCarriesATemplateLiteralAcrossLines` | RED | GREEN |
| M21 | the in-string branch is never taken | `TestFindStrayCallSitesSeesACallSiteHiddenBehindAUrl` | RED | GREEN |
| M22 | the suite directory is no longer skipped | `TestFindStrayCallSitesSkipsTheSuiteButNotAComponent` | RED | GREEN |
| M23 | `/v1/applications` becomes `/v1/application` | www: the four absolute URLs | RED | GREEN |
| M24 | two entries claim the same route | www: each route named once | RED | GREEN |

M21 is the cell that read GREEN before the fixture was fixed. It is in the table
at its corrected value, and the paragraph above says what it read before, because
a mutation table that only ever shows RED is indistinguishable from one nobody
ran.

## Everything else that was run

Local, `2026-09-05T10:20Z`, on the shared Go build lock:

```
routecheck unit tests            24 test functions, all PASS, 0 fail
the offline half on this tree    exit 0, and says DEPLOYED was not checked
a stray call site                exit 1, naming www/components/StrayProbe.tsx:1 and :2
the same-line hidden call site   exit 1, naming the line
gatecheck own suite              ok
gatecheck                        80 gates, 69 paired, 2 by command, 9 exempt, exit 0
prosecheck                       811 files, 0 places where the punctuation gives it away
changecheck                      5 changes a user could notice, described by the fragment
www npm test                     46 pass, 0 fail, 0 skipped
```

CI on the head of this branch: all four workflows `success`, all twelve `CI`
jobs `success`, every one of the nine required contexts passing, and
`mergeStateStatus=CLEAN`. `The gates themselves`, which runs
`cd tools && go test ./...`, is where the Go tests above are proved in a clean
environment.
