### PR TITLE
engine: af runner check said ready about a runner af test never ran

### DIFF
--- a/.changes/runner-check-answers-about-the-runner-that-runs.md
+++ b/.changes/runner-check-answers-about-the-runner-that-runs.md
@@ -1,0 +1,19 @@
+# fixed
+
+`af runner check` reported the runner ready while `af test` ran a different
+copy and died in node.
+
+The check read `~/.antifailure/runner`, which is where `af runner install` puts
+its copy. A run resolves its runner with a search that offers the checkout's own
+`runner/` first, and on a fresh clone that directory is source with no
+`node_modules`. Both commands were honest about the directory each looked at,
+neither said which, and the failure surfaced three commands later as
+`Cannot find package 'playwright'` from inside the runner.
+
+The check now reports on the runner a run started in that directory would use,
+and prints its path. A run takes the nearest runner that can actually run rather
+than the nearest one that exists, so a `runner/` whose dependencies were never
+installed is passed over and named rather than started and crashed. When nothing
+anywhere can run, `af test` refuses with the directory and the missing package
+instead of a node stack trace. `af runner check -o json` now exits non zero when
+it reports the runner incomplete, which it previously did only without `-o json`.

--- a/docs/src/content/docs/getting-started/quickstart.md
+++ b/docs/src/content/docs/getting-started/quickstart.md
@@ -165,6 +165,15 @@ the runner executes, because knowing that means starting node and launching a
 browser, which is what `af test` is. Anything it cannot determine it reports as
 not checked rather than as ok.
 
+It reports on the runner `af test` would use from where you are standing, and
+prints that path. A run looks for a runner in your own checkout before it looks
+at `~/.antifailure/runner`, and it takes the nearest one that can actually run
+rather than the nearest one that exists, so a `runner/` directory whose
+dependencies were never installed is passed over rather than started and
+crashed. When that happens the check names the directory it went past and says
+what is missing from it, because a report about a tree you did not mean is
+worse than no report.
+
 A failed browser download is not fatal. The runner is usable the moment a
 browser arrives, and until then a workflow that needs a page read comes back
 `unverified` rather than guessed at.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -1669,6 +1669,13 @@ Say whether the runner can run.
 Reports each thing af test needs from the runner separately: the source, the
 dependencies it declares, a node new enough to run it, and the browser.
 
+It reports on the runner af test would actually use from here, which is the
+nearest one that can run rather than the nearest one that exists. Any runner it
+went past is named, with what is wrong with it, because a report about a
+directory the reader did not mean is how this command came to say a runner was
+ready while the run took a different copy and died on a module it could not
+resolve.
+
 It does not claim the runner executes. Knowing that means starting node and
 launching a browser, which is what af test is. Anything this cannot determine
 is reported as not checked rather than as ok, because a check that answers ok

--- a/engine/internal/cli/runner.go
+++ b/engine/internal/cli/runner.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"io/fs"
@@ -10,7 +9,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -235,10 +233,10 @@ type runnerCheck struct {
 // cannot be determined, because answering ok about something unexamined is the
 // defect being fixed rather than a smaller version of it.
 func checkRunner(ctx context.Context, target string) []runnerCheck {
+	state := runnerpath.Inspect(target)
 	out := []runnerCheck{}
 
-	entry := filepath.Join(target, "src", "main.ts")
-	if _, err := os.Stat(entry); err != nil {
+	if !state.Exists() {
 		return append(out, runnerCheck{
 			label: "runner", symbol: SymbolFail,
 			detail:  "no runner at " + target,
@@ -247,43 +245,76 @@ func checkRunner(ctx context.Context, target string) []runnerCheck {
 		})
 	}
 	out = append(out, runnerCheck{label: "runner", symbol: SymbolOK, detail: target})
-
-	manifest, manifestErr := readRunnerManifest(filepath.Join(target, "package.json"))
-	if manifestErr != nil {
-		out = append(out, runnerCheck{
-			label: "dependencies", symbol: SymbolSkip,
-			detail:  "not checked: " + manifestErr.Error(),
-			blocker: false,
-		})
-	} else {
-		out = append(out, dependencyCheck(target, manifest))
-	}
-
-	out = append(out, nodeCheck(nodeVersion(ctx), manifest))
+	out = append(out, dependencyCheck(state))
+	out = append(out, nodeCheck(nodeVersion(ctx), state))
 	out = append(out, browserCheck())
 	return out
 }
 
-// runnerManifest is the part of the runner's package.json this reads. Its own
-// manifest rather than a constant here, so the requirement cannot drift from
-// the thing that declares it.
-type runnerManifest struct {
-	Engines struct {
-		Node string `json:"node"`
-	} `json:"engines"`
-	Dependencies map[string]string `json:"dependencies"`
+// passedOverChecks names the runners nearer than the one being reported on
+// that a run would go past, and why.
+//
+// Without these lines the command would answer about ~/.antifailure/runner
+// while standing in a checkout whose own runner/ is the thing the reader is
+// editing, and say nothing about the difference. Reporting the truth about a
+// directory the reader did not mean is how this went wrong in the first place.
+//
+// A warning rather than a failure, because the run does work: it uses the one
+// below. The remedy deliberately does not say af runner install, which
+// populates ~/.antifailure/runner and would not touch this directory.
+func passedOverChecks(passed []runnerpath.State) []runnerCheck {
+	out := make([]runnerCheck, 0, len(passed))
+	for _, p := range passed {
+		out = append(out, runnerCheck{
+			label:  "passed over",
+			symbol: SymbolWarn,
+			detail: p.Dir + " " + p.Why() + ", so af test goes past it",
+			remedy: "If that is the runner you meant to run, install its dependencies: " +
+				"npm ci in " + p.Dir,
+		})
+	}
+	return out
 }
 
-func readRunnerManifest(path string) (runnerManifest, error) {
-	var m runnerManifest
-	blob, err := os.ReadFile(path)
+// runnerToCheck is the runner this command should report on: the one a run
+// started in dir would use.
+//
+// It used to be ~/.antifailure/runner unconditionally, which is where
+// af runner install puts its copy and NOT where a run looks first. On
+// 2026-09-05 the walkthrough installed a runner, was told by this command that
+// the runner was ready, and then died in the next command because the run had
+// taken the checkout's runner/ instead. Both answers were true about the
+// directory each looked at, and nothing compared them.
+//
+// When nothing runnable was found, the nearest runner IN THE CHECKOUT is
+// reported instead, so the reader is told what is wrong with the tree they
+// have rather than that a path they have never heard of is empty.
+//
+// Only the checkout's. A release keeps its runner source at
+// $PREFIX/share/antifailure/runner and expects af runner install to resolve it
+// somewhere else, so on a machine that has installed af and not yet run that
+// command there is always a blocked runner there. Reporting on it would answer
+// the commonest first run of all with "node_modules is missing" under a path
+// nobody has heard of, when the true and useful answer is that the runner has
+// not been installed yet. So that case falls through to Home, whose finding is
+// "no runner at ~/.antifailure/runner" and whose remedy is the command the
+// installer already printed.
+func runnerToCheck(dir string) (target string, passedOver []runnerpath.State, err error) {
+	choice := runnerpath.Choose(dir)
+	if choice.Runner.Exists() {
+		return choice.Runner.Dir, choice.InCheckout(), nil
+	}
+	if reported := choice.InCheckout(); len(reported) > 0 {
+		// The nearest one is the subject of the report, so it is dropped from
+		// the list of ones gone past. Printing it in both places describes a
+		// machine that does not exist.
+		return reported[0].Dir, reported[1:], nil
+	}
+	home, err := RunnerHome()
 	if err != nil {
-		return m, fmt.Errorf("package.json could not be read")
+		return "", nil, aferrors.Wrap(err, aferrors.AFAGT004, "detail", err.Error())
 	}
-	if err := json.Unmarshal(blob, &m); err != nil {
-		return m, fmt.Errorf("package.json could not be parsed")
-	}
-	return m, nil
+	return home, nil, nil
 }
 
 // dependencyCheck is the one that would have caught the reproduced tree.
@@ -292,9 +323,24 @@ func readRunnerManifest(path string) (runnerManifest, error) {
 // directory existing on its own is not enough: an interrupted npm install
 // leaves one behind, and a check that stops at "node_modules is there" is the
 // same shape of lie as the one that stopped at "src/main.ts is there".
-func dependencyCheck(target string, m runnerManifest) runnerCheck {
-	modules := filepath.Join(target, "node_modules")
-	if _, err := os.Stat(modules); err != nil {
+//
+// The reading is runnerpath.Inspect's, not a second one written here. The
+// search a run uses has to skip a runner that cannot resolve its dependencies,
+// and this has to report the same fact about the same directory. Two readings
+// that agree today are two readings that can disagree tomorrow, and the
+// symptom last time was a check reporting ready about a tree the run never used.
+func dependencyCheck(s runnerpath.State) runnerCheck {
+	// A manifest that could not be read is a question this did not answer.
+	// Answering ok anyway is the defect being fixed rather than a smaller
+	// version of it.
+	if s.Undetermined != "" {
+		return runnerCheck{
+			label: "dependencies", symbol: SymbolSkip,
+			detail:  "not checked: " + s.Undetermined,
+			blocker: false,
+		}
+	}
+	if s.NoModules && s.Declared > 0 {
 		return runnerCheck{
 			label: "dependencies", symbol: SymbolFail,
 			detail:  "node_modules is missing",
@@ -302,19 +348,10 @@ func dependencyCheck(target string, m runnerManifest) runnerCheck {
 			blocker: true,
 		}
 	}
-	var missing []string
-	for name := range m.Dependencies {
-		// filepath.Join handles the scoped @scope/name form, which is two
-		// directory levels on disk rather than one.
-		if _, err := os.Stat(filepath.Join(modules, filepath.FromSlash(name))); err != nil {
-			missing = append(missing, name)
-		}
-	}
-	if len(missing) > 0 {
-		sort.Strings(missing)
+	if len(s.Missing) > 0 {
 		return runnerCheck{
 			label: "dependencies", symbol: SymbolFail,
-			detail:  "missing " + strings.Join(missing, ", "),
+			detail:  "missing " + strings.Join(s.Missing, ", "),
 			remedy:  "Install them with: af runner install",
 			blocker: true,
 		}
@@ -325,25 +362,25 @@ func dependencyCheck(target string, m runnerManifest) runnerCheck {
 	// no idea which versions they are, so it says so rather than reporting the
 	// same ok as a pinned one. A warning rather than a failure: the runner does
 	// run, it just runs something nobody chose.
-	if _, err := os.Stat(filepath.Join(target, "package-lock.json")); err != nil {
+	if !s.Pinned {
 		return runnerCheck{
 			label: "dependencies", symbol: SymbolWarn,
 			detail: fmt.Sprintf("%d declared, all present, and not pinned: no package-lock.json",
-				len(m.Dependencies)),
+				s.Declared),
 			remedy: "Reinstall from a release that ships the lockfile: af runner install",
 		}
 	}
 	return runnerCheck{
 		label: "dependencies", symbol: SymbolOK,
-		detail: fmt.Sprintf("%d declared, all present, pinned by package-lock.json", len(m.Dependencies)),
+		detail: fmt.Sprintf("%d declared, all present, pinned by package-lock.json", s.Declared),
 	}
 }
 
 // nodeCheck compares against the range the runner declares rather than only
 // reporting what it found. The old line printed the version and called it ok,
 // so a node too old to run the runner passed a check named after readiness.
-func nodeCheck(found string, m runnerManifest) runnerCheck {
-	want := m.Engines.Node
+func nodeCheck(found string, s runnerpath.State) runnerCheck {
+	want := s.Node
 	if found == "" {
 		detail := "not found"
 		if want != "" {
@@ -353,6 +390,15 @@ func nodeCheck(found string, m runnerManifest) runnerCheck {
 			label: "node", symbol: SymbolFail, detail: detail,
 			remedy:  "Install node from https://nodejs.org, then run af runner check again.",
 			blocker: true,
+		}
+	}
+	// A requirement nobody could read is not a requirement that was met. The
+	// dependencies line already says the manifest could not be read; saying ok
+	// here would quietly claim this node was compared against something.
+	if s.Undetermined != "" {
+		return runnerCheck{
+			label: "node", symbol: SymbolSkip,
+			detail: found + ", not checked against a requirement: " + s.Undetermined,
 		}
 	}
 	if want == "" {
@@ -480,6 +526,13 @@ func newRunnerCheckCommand(e *Env) *cobra.Command {
 Reports each thing af test needs from the runner separately: the source, the
 dependencies it declares, a node new enough to run it, and the browser.
 
+It reports on the runner af test would actually use from here, which is the
+nearest one that can run rather than the nearest one that exists. Any runner it
+went past is named, with what is wrong with it, because a report about a
+directory the reader did not mean is how this command came to say a runner was
+ready while the run took a different copy and died on a module it could not
+resolve.
+
 It does not claim the runner executes. Knowing that means starting node and
 launching a browser, which is what af test is. Anything this cannot determine
 is reported as not checked rather than as ok, because a check that answers ok
@@ -489,11 +542,11 @@ of an install with no dependencies at all, and the real failure surfaced much
 later inside af test as a node error about a module it could not resolve.`),
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			target, err := RunnerHome()
+			target, passedOver, err := runnerToCheck(e.WorkDir)
 			if err != nil {
 				return err
 			}
-			results := checkRunner(cmd.Context(), target)
+			results := append(passedOverChecks(passedOver), checkRunner(cmd.Context(), target)...)
 
 			ready := true
 			node := ""
@@ -507,10 +560,23 @@ later inside af test as a node error about a module it could not resolve.`),
 			}
 
 			if e.Out.Format == FormatJSON {
-				return e.Out.JSON(RunnerCheckJSON{
+				// The document first, then the same verdict the rendered
+				// report gives. This used to return here, so `-o json` exited
+				// 0 on a runner it had just described as incomplete, and any
+				// script that read the exit code rather than parsing the
+				// document was told the runner was ready. silentError carries
+				// the code and prints nothing, which is the only thing that
+				// can follow a JSON document without corrupting it.
+				if err := e.Out.JSON(RunnerCheckJSON{
 					Path: target, Node: node, Complete: ready,
 					Checks: checksJSON(results),
-				})
+				}); err != nil {
+					return err
+				}
+				if !ready {
+					return &silentError{code: aferrors.ExitConfiguration}
+				}
+				return nil
 			}
 			for _, r := range results {
 				e.Out.Status(r.symbol, r.label, r.detail)

--- a/engine/internal/cli/runner_check_test.go
+++ b/engine/internal/cli/runner_check_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/antifailure/antifailure/engine/internal/runnerpath"
 )
 
 // af runner check reported "ok runner" on a tree with no node_modules.
@@ -138,7 +140,7 @@ func TestAnEmptyNodeModulesDoesNotPass(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(dir, "node_modules"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	got := dependencyCheck(dir, runnerManifest{Dependencies: map[string]string{"playwright": "^1.49.0"}})
+	got := dependencyCheck(runnerpath.Inspect(dir))
 	if got.symbol != SymbolFail {
 		t.Errorf("reported %q for an empty node_modules, want fail", got.symbol)
 	}
@@ -198,8 +200,7 @@ func TestAnUnreadableManifestIsReportedAsUnchecked(t *testing.T) {
 // The old line printed the version it found and called it ok, so a node too
 // old to run the runner passed a check named after readiness.
 func TestNodeIsComparedAgainstWhatTheRunnerDeclares(t *testing.T) {
-	m := runnerManifest{}
-	m.Engines.Node = ">=22.6"
+	m := runnerpath.State{Node: ">=22.6"}
 
 	cases := []struct {
 		found  string
@@ -229,8 +230,7 @@ func TestNodeIsComparedAgainstWhatTheRunnerDeclares(t *testing.T) {
 // A range this cannot read is reported as unread. Treating it as satisfied
 // would put the check back where it started.
 func TestAnUnreadableNodeRangeIsNotTreatedAsSatisfied(t *testing.T) {
-	m := runnerManifest{}
-	m.Engines.Node = "^22 || ^24"
+	m := runnerpath.State{Node: "^22 || ^24"}
 	got := nodeCheck("v24.2.0", m)
 	if got.symbol != SymbolSkip {
 		t.Errorf("reported %q for a range it cannot parse, want skip", got.symbol)
@@ -307,8 +307,7 @@ func TestEveryFailureCarriesARemedyThatFitsIt(t *testing.T) {
 			t.Errorf("%s reported %q with no remedy", r.label, r.symbol)
 		}
 	}
-	m := runnerManifest{}
-	m.Engines.Node = ">=22.6"
+	m := runnerpath.State{Node: ">=22.6"}
 	if got := nodeCheck("", m).remedy; !strings.Contains(got, "nodejs.org") {
 		t.Errorf("a missing node advises %q, which does not say where to get node", got)
 	}
@@ -326,7 +325,15 @@ func TestTheRemedyIsNotPrintedTwiceOnAMachineWithNoRunner(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
 	var buf bytes.Buffer
-	e := &Env{Out: NewOutput(&buf, &buf), Getenv: func(string) string { return "" }}
+	// WorkDir matters now: the command reports on the runner a run started
+	// HERE would use, so a test that means "a machine with no runner" has to
+	// stand somewhere with no runner rather than in this checkout, which has
+	// one.
+	e := &Env{
+		Out:     NewOutput(&buf, &buf),
+		WorkDir: t.TempDir(),
+		Getenv:  func(string) string { return "" },
+	}
 	cmd := newRunnerCheckCommand(e)
 	if err := cmd.RunE(cmd, nil); err == nil {
 		t.Fatal("af runner check exited 0 against a home with no runner in it")

--- a/engine/internal/cli/runner_resolution_test.go
+++ b/engine/internal/cli/runner_resolution_test.go
@@ -1,0 +1,367 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/antifailure/antifailure/engine/internal/runnerpath"
+)
+
+// af runner check answered about a runner that was not the one af test would
+// run, and so it said the runner was ready on a machine where nothing could run.
+//
+// Run 33956075704, job 101279553597, commit b66ca628, on 2026-09-05:
+//
+//	af runner install       15.8
+//	af runner check          0.0
+//	walkthrough: af test failed after 0s: AF-AGT-003 ...
+//	Cannot find package 'playwright' imported from
+//	  /home/runner/work/antifailure/antifailure/runner/src/browser.ts
+//
+// The install put a working runner in ~/.antifailure/runner and the check read
+// it and was right about it. The run resolved the CHECKOUT's runner/, which on
+// a fresh clone is source with no node_modules. Every test here is written
+// against that tree.
+
+// runnerFixture builds the walkthrough's shape: a checkout with a runner at
+// its top, a project underneath it, and a home directory.
+type runnerFixture struct {
+	root, project, home string
+}
+
+func newRunnerFixture(t *testing.T) runnerFixture {
+	t.Helper()
+	base := t.TempDir()
+	f := runnerFixture{
+		root:    filepath.Join(base, "checkout"),
+		project: filepath.Join(base, "checkout", "examples", "go-api"),
+		home:    filepath.Join(base, "home"),
+	}
+	for _, d := range []string{filepath.Join(f.root, ".git"), f.project, f.home} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("HOME", f.home)
+	t.Setenv("USERPROFILE", f.home)
+	// Without this the browser line answers about whoever is running the
+	// tests, and every case below would report differently on a laptop that
+	// happens to have chromium and on one that does not.
+	t.Setenv("PLAYWRIGHT_BROWSERS_PATH", filepath.Join(base, "no-browsers"))
+	return f
+}
+
+// checkoutRunner puts the runner source in the checkout, which is what a fresh
+// clone and tools/release/build.sh both produce: no node_modules.
+func (f runnerFixture) checkoutRunner(t *testing.T) string {
+	t.Helper()
+	return writeRunnerSource(t, filepath.Join(f.root, "runner"))
+}
+
+// installedCheckoutRunner is a contributor's checkout with the runner's
+// dependencies actually installed into it, which is the tree where the runner
+// that would run is NOT the one in the home directory.
+func (f runnerFixture) installedCheckoutRunner(t *testing.T) string {
+	t.Helper()
+	dir := f.checkoutRunner(t)
+	if err := os.MkdirAll(filepath.Join(dir, "node_modules", "playwright"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// homeRunner puts a complete runner where af runner install puts one.
+func (f runnerFixture) homeRunner(t *testing.T) string {
+	t.Helper()
+	dir := writeRunnerSource(t, filepath.Join(f.home, ".antifailure", "runner"))
+	if err := os.MkdirAll(filepath.Join(dir, "node_modules", "playwright"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func writeRunnerSource(t *testing.T, dir string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for name, body := range map[string]string{
+		filepath.Join("src", "main.ts"): "// runner\n",
+		"package.json":                  manifestJSON,
+		"package-lock.json":             `{"lockfileVersion":3}`,
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+// runCheck runs the real command from dir and returns its report and its error.
+func runCheck(t *testing.T, dir string) (report RunnerCheckJSON, out string, err error) {
+	t.Helper()
+	var buf bytes.Buffer
+	e := &Env{
+		Out:     NewOutput(&buf, &buf),
+		WorkDir: dir,
+		Getenv:  func(string) string { return "" },
+	}
+	e.Out.Format = FormatJSON
+	cmd := newRunnerCheckCommand(e)
+	cmd.SetContext(t.Context())
+	err = cmd.RunE(cmd, nil)
+	out = buf.String()
+	if jsonErr := json.Unmarshal([]byte(out), &report); jsonErr != nil {
+		t.Fatalf("the command did not print a document this can read: %v\n%s", jsonErr, out)
+	}
+	return report, out, err
+}
+
+func item(t *testing.T, r RunnerCheckJSON, name string) RunnerCheckItemJSON {
+	t.Helper()
+	for _, c := range r.Checks {
+		if c.Name == name {
+			return c
+		}
+	}
+	t.Fatalf("no check named %q in %v", name, r.Checks)
+	return RunnerCheckItemJSON{}
+}
+
+// Can it say no. Point it at a runner with playwright absent from
+// node_modules, with no other runner anywhere, and it has to fail and name the
+// package. This is the tree that made af test die, and the command that exists
+// to find that tree used to exit 0 on it.
+func TestTheCheckFailsOnARunnerMissingADeclaredPackage(t *testing.T) {
+	f := newRunnerFixture(t)
+	dir := f.checkoutRunner(t)
+	if err := os.MkdirAll(filepath.Join(dir, "node_modules"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	report, out, err := runCheck(t, f.project)
+
+	if err == nil {
+		t.Error("af runner check exited 0 on a runner that cannot resolve playwright")
+	}
+	if report.Complete {
+		t.Error("the report says the runner is complete, and it cannot run")
+	}
+	if report.Path != dir {
+		t.Errorf("it reported on %q, and af test would run %q", report.Path, dir)
+	}
+	deps := item(t, report, "dependencies")
+	if deps.Result != SymbolFail {
+		t.Errorf("dependencies reported %q, want fail:\n%s", deps.Result, out)
+	}
+	if !strings.Contains(deps.Detail, "playwright") {
+		t.Errorf("the failure is %q, which does not name the package", deps.Detail)
+	}
+}
+
+// Can it say yes. A complete runner passes, or the command is useless.
+func TestTheCheckPassesOnACompleteRunner(t *testing.T) {
+	f := newRunnerFixture(t)
+	home := f.homeRunner(t)
+
+	report, out, err := runCheck(t, f.project)
+
+	if err != nil {
+		t.Errorf("af runner check refused a complete runner: %v\n%s", err, out)
+	}
+	if !report.Complete {
+		t.Errorf("the report says the runner is not complete:\n%s", out)
+	}
+	if report.Path != home {
+		t.Errorf("it reported on %q, want the installed runner at %q", report.Path, home)
+	}
+	if deps := item(t, report, "dependencies"); deps.Result != SymbolOK {
+		t.Errorf("dependencies reported %q on a complete tree: %s", deps.Result, deps.Detail)
+	}
+}
+
+// A missing browser and a missing dependency are DIFFERENT answers.
+//
+// af runner install treats a failed browser download as non fatal on purpose,
+// and af test comes back unverified rather than guessing, so the quickstart
+// says the runner is usable the moment a browser arrives. Collapsing the two
+// into one "not ready" would make the command refuse a runner that works.
+func TestAMissingBrowserIsADifferentAnswerFromAMissingDependency(t *testing.T) {
+	f := newRunnerFixture(t)
+	f.homeRunner(t)
+
+	report, out, err := runCheck(t, f.project)
+
+	if err != nil {
+		t.Errorf("a missing browser blocked the command: %v\n%s", err, out)
+	}
+	if !report.Complete {
+		t.Error("a missing browser made the runner incomplete, which is stricter than af test is")
+	}
+	browser := item(t, report, "browser")
+	if browser.Result != SymbolWarn {
+		t.Errorf("browser reported %q, want warn", browser.Result)
+	}
+	if deps := item(t, report, "dependencies"); deps.Result != SymbolOK {
+		t.Errorf("dependencies reported %q, and only the browser is missing", deps.Result)
+	}
+}
+
+// Anything it cannot determine is reported as not checked rather than as ok.
+// The quickstart promises exactly that sentence.
+func TestWhatCannotBeDeterminedIsReportedAsNotChecked(t *testing.T) {
+	f := newRunnerFixture(t)
+	dir := f.homeRunner(t)
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	report, out, _ := runCheck(t, f.project)
+
+	deps := item(t, report, "dependencies")
+	if deps.Result != SymbolSkip {
+		t.Errorf("dependencies reported %q for an unreadable manifest, want skip:\n%s", deps.Result, out)
+	}
+	if !strings.Contains(deps.Detail, "not checked") {
+		t.Errorf("the detail is %q, which does not say the question went unanswered", deps.Detail)
+	}
+	// The node line was the quieter half of the same lie: with no readable
+	// manifest there is no range to compare against, and it printed the
+	// version it found and called that ok.
+	node := item(t, report, "node")
+	if node.Result == SymbolOK {
+		t.Errorf("node reported ok against a requirement nobody could read: %s", node.Detail)
+	}
+}
+
+// The whole defect, end to end through the real command: the check reports on
+// the runner af test would use, not on the one af runner install wrote.
+func TestTheCheckReportsOnTheRunnerTheRunWouldUse(t *testing.T) {
+	f := newRunnerFixture(t)
+	stale := f.checkoutRunner(t)
+	home := f.homeRunner(t)
+
+	report, out, err := runCheck(t, f.project)
+
+	if err != nil {
+		t.Errorf("af runner check refused: %v\n%s", err, out)
+	}
+	if report.Path != home {
+		t.Errorf("reported on %q, and a run from %q uses %q", report.Path, f.project, home)
+	}
+	// And it says what it went past, because reporting the truth about a
+	// directory the reader did not mean is the whole failure.
+	passed := item(t, report, "passed over")
+	if !strings.Contains(passed.Detail, stale) {
+		t.Errorf("the report does not name the runner it went past: %q", passed.Detail)
+	}
+	if !strings.Contains(passed.Detail, "node_modules") {
+		t.Errorf("the report does not say why it went past it: %q", passed.Detail)
+	}
+}
+
+// One resolution, not two that agree today.
+//
+// The check and the run each had their own answer to "which runner", and the
+// two drifted the moment the run learned to look at the top of the checkout.
+// This holds the check to runnerpath.Choose, which is what the run uses.
+func TestTheCheckResolvesTheRunnerRunnerpathChose(t *testing.T) {
+	f := newRunnerFixture(t)
+	f.checkoutRunner(t)
+	f.homeRunner(t)
+
+	target, _, err := runnerToCheck(f.project)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := runnerpath.Choose(f.project).Runner.Dir; target != want {
+		t.Errorf("the check reports on %q and a run would use %q", target, want)
+	}
+}
+
+// The chosen runner is not always the one in the home directory, and a check
+// that reported the home one would be right by accident whenever they agree.
+//
+// A contributor with runner/ installed in their checkout runs THAT copy, and
+// the command has to say so, or somebody debugging their own runner edits is
+// reading a report about a different tree.
+func TestTheCheckReportsOnTheCheckoutRunnerWhenThatIsTheOneThatWouldRun(t *testing.T) {
+	f := newRunnerFixture(t)
+	mine := f.installedCheckoutRunner(t)
+	home := f.homeRunner(t)
+
+	report, out, err := runCheck(t, f.project)
+
+	if err != nil {
+		t.Errorf("af runner check refused a complete checkout runner: %v\n%s", err, out)
+	}
+	if report.Path == home {
+		t.Fatal("it reported on the installed home runner, and a run here uses the checkout's")
+	}
+	if report.Path != mine {
+		t.Errorf("it reported on %q, and a run from %q uses %q", report.Path, f.project, mine)
+	}
+	for _, c := range report.Checks {
+		if c.Name == "passed over" {
+			t.Errorf("nothing needed passing over and it reported %q", c.Detail)
+		}
+	}
+}
+
+// The runner it reports on is not also listed as one it went past.
+//
+// When nothing anywhere can run, the command reports on the nearest runner
+// that exists so the reader learns what is wrong with the tree they have. That
+// tree is in the passed over list too, and printing it twice, once as the
+// subject and once as something skipped, describes a machine that does not
+// exist.
+func TestTheRunnerItReportsOnIsNotAlsoListedAsPassedOver(t *testing.T) {
+	f := newRunnerFixture(t)
+	f.checkoutRunner(t)
+
+	report, _, err := runCheck(t, f.project)
+	if err == nil {
+		t.Fatal("af runner check exited 0 with no runner that can run anywhere")
+	}
+	for _, c := range report.Checks {
+		if c.Name == "passed over" && strings.Contains(c.Detail, report.Path) {
+			t.Errorf("%s is both the runner it reported on and one it says it went past", report.Path)
+		}
+	}
+}
+
+// A machine that has installed af and not yet run af runner install is the
+// commonest first run there is, and its answer has to stay the friendly one.
+//
+// The check reports on the runner a run would use, and on such a machine that
+// is the release's own SOURCE beside the binary, which has no node_modules by
+// design and always will. Reporting on it would answer a first run with
+// "node_modules is missing" under a path nobody has heard of. The true and
+// useful answer is that the runner is not installed yet, so this falls through
+// to the home directory and says so.
+func TestAMachineWithNoRunnerInItsCheckoutIsToldTheRunnerIsNotInstalled(t *testing.T) {
+	f := newRunnerFixture(t)
+
+	report, out, err := runCheck(t, f.project)
+
+	if err == nil {
+		t.Fatal("af runner check exited 0 with no runner installed anywhere")
+	}
+	want := filepath.Join(f.home, ".antifailure", "runner")
+	if report.Path != want {
+		t.Errorf("it reported on %q, want the place af runner install writes to, %q",
+			report.Path, want)
+	}
+	r := item(t, report, "runner")
+	if !strings.Contains(r.Detail, "no runner at") {
+		t.Errorf("a first run is told %q rather than that the runner is not installed", r.Detail)
+	}
+	if !strings.Contains(r.Remedy, "af runner install") {
+		t.Errorf("the remedy is %q, and the installer already printed af runner install:\n%s",
+			r.Remedy, out)
+	}
+}

--- a/engine/internal/cli/start.go
+++ b/engine/internal/cli/start.go
@@ -311,15 +311,22 @@ func dockerState(ctx context.Context, e *Env, p startProbe) stage {
 // rung of its own rather than being folded into the machine check.
 func runnerState(ctx context.Context, e *Env, p startProbe) stage {
 	s := stage{name: "the agent runner", command: "af runner install"}
-	home, err := p.home()
-	target := filepath.Join(home, ".antifailure", "runner")
-	if err != nil {
+	if _, err := p.home(); err != nil {
 		s.state, s.why = StageUnchecked, "this platform did not report a home directory"
 		s.detail, s.command = "not checked", ""
 		return s
 	}
+	// The runner af test would use from here, not ~/.antifailure/runner
+	// unconditionally. This rung reported "installed" while a run in the same
+	// directory took a nearer runner with no dependencies and died in node.
+	target, passedOver, err := runnerToCheck(e.WorkDir)
+	if err != nil {
+		s.state, s.why = StageUnchecked, err.Error()
+		s.detail, s.command = "not checked", ""
+		return s
+	}
 	var blockers, warnings []string
-	for _, r := range checkRunner(ctx, target) {
+	for _, r := range append(passedOverChecks(passedOver), checkRunner(ctx, target)...) {
 		if r.symbol == SymbolOK || r.symbol == SymbolSkip {
 			continue
 		}

--- a/engine/internal/env/find_runner_test.go
+++ b/engine/internal/env/find_runner_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/antifailure/antifailure/engine/internal/runnerpath"
 )
 
 // emptyHome gives a test a home directory of its own.
@@ -144,5 +146,162 @@ func TestFindRunnerRefusesAnOverrideThatIsNotThere(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), missing) {
 		t.Errorf("the refusal does not name the path that was asked for: %v", err)
+	}
+}
+
+// runnableCheckout is runnerCheckout plus the two things that decide whether a
+// runner can actually run: the manifest that declares its dependencies, and
+// whether they are installed.
+//
+// runnerCheckout above writes src/main.ts and nothing else, which is a runner
+// nothing can be determined about. That is deliberately still chosen, because
+// an unreadable tree is not a proven broken one. These build trees where the
+// answer IS known.
+func runnableCheckout(t *testing.T, installedInCheckout, installedInHome bool) (root, project, home string) {
+	t.Helper()
+	base := t.TempDir()
+	home = filepath.Join(base, "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	root = filepath.Join(base, "checkout")
+	if err := os.MkdirAll(filepath.Join(root, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	project = filepath.Join(root, "examples", "go-api")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeRunner(t, filepath.Join(root, "runner"), installedInCheckout)
+	if installedInHome {
+		writeRunner(t, filepath.Join(home, ".antifailure", "runner"), true)
+	}
+	return root, project, home
+}
+
+func writeRunner(t *testing.T, dir string, withDependencies bool) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "src", "main.ts"), []byte("//\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	body := `{"engines":{"node":">=22.6"},"dependencies":{"playwright":"^1.49.0"}}`
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if withDependencies {
+		if err := os.MkdirAll(filepath.Join(dir, "node_modules", "playwright"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// The defect, on the run's side.
+//
+// Widening the search to the top of the checkout put this repository's own
+// runner/ ahead of the installed one for every run inside it, and on a fresh
+// clone runner/ is source with no node_modules. So af runner install did its
+// job, af runner check read the tree it wrote and said ready, and the run took
+// runner/ and died with ERR_MODULE_NOT_FOUND on playwright before it reached a
+// single workflow. Run 33956075704 on 2026-09-05.
+func TestFindRunnerGoesPastACheckoutRunnerWithNoDependencies(t *testing.T) {
+	root, project, home := runnableCheckout(t, false, true)
+
+	o := &Orchestrator{opts: Options{Root: project}}
+	got, err := o.findRunner("")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stale := filepath.Join(root, "runner", "src", "main.ts")
+	if got == stale {
+		t.Fatal("the run took the checkout runner, which cannot resolve playwright")
+	}
+	if want := filepath.Join(home, ".antifailure", "runner", "src", "main.ts"); got != want {
+		t.Errorf("ran %q, want the installed runner at %q", got, want)
+	}
+}
+
+// And it is not silent about it. A contributor editing runner/ whose
+// dependencies are not installed would otherwise watch their edits do nothing
+// while a different copy ran.
+func TestFindRunnerSaysWhichRunnerItWentPast(t *testing.T) {
+	root, project, _ := runnableCheckout(t, false, true)
+
+	var said []string
+	o := &Orchestrator{
+		opts:     Options{Root: project},
+		progress: func(line string) { said = append(said, line) },
+	}
+	if _, err := o.findRunner(""); err != nil {
+		t.Fatal(err)
+	}
+
+	joined := strings.Join(said, "\n")
+	if !strings.Contains(joined, filepath.Join(root, "runner")) {
+		t.Errorf("the run did not say it went past the checkout runner: %q", joined)
+	}
+	if !strings.Contains(joined, "node_modules") {
+		t.Errorf("the run did not say why it went past it: %q", joined)
+	}
+}
+
+// The checkout runner still wins when it can run, so a contributor working on
+// the runner runs the copy they are editing rather than a stale installed one.
+func TestFindRunnerStillPrefersACheckoutRunnerThatCanRun(t *testing.T) {
+	root, project, _ := runnableCheckout(t, true, true)
+
+	o := &Orchestrator{opts: Options{Root: project}}
+	got, err := o.findRunner("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(root, "runner", "src", "main.ts"); got != want {
+		t.Errorf("ran %q, want the checkout runner at %q", got, want)
+	}
+}
+
+// When nothing can run, the refusal names the tree and the reason.
+//
+// This case used to be returned as success, and the reader met it as a node
+// stack trace about a module resolution, which names a package rather than the
+// fact that no runner was ever installed.
+func TestFindRunnerRefusesWithTheReasonWhenNothingCanRun(t *testing.T) {
+	root, project, _ := runnableCheckout(t, false, false)
+
+	o := &Orchestrator{opts: Options{Root: project}}
+	got, err := o.findRunner("")
+	if err == nil {
+		t.Fatalf("ran %q, and it cannot resolve playwright", got)
+	}
+	if !strings.Contains(err.Error(), filepath.Join(root, "runner")) {
+		t.Errorf("the refusal does not name the tree: %v", err)
+	}
+	if !strings.Contains(err.Error(), "node_modules") {
+		t.Errorf("the refusal does not say what is wrong with it: %v", err)
+	}
+	if !strings.Contains(err.Error(), "af runner install") {
+		t.Errorf("the refusal does not say what to do: %v", err)
+	}
+}
+
+// One resolution, not two that agree today. The check and the run each had
+// their own, and they drifted the moment the run learned to look at the top of
+// the checkout.
+func TestTheRunUsesTheRunnerRunnerpathChose(t *testing.T) {
+	_, project, _ := runnableCheckout(t, false, true)
+
+	o := &Orchestrator{opts: Options{Root: project}}
+	got, err := o.findRunner("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := runnerpath.Choose(project).Runner.Entry; got != want {
+		t.Errorf("the run uses %q and runnerpath chose %q", got, want)
 	}
 }

--- a/engine/internal/env/test.go
+++ b/engine/internal/env/test.go
@@ -514,6 +514,16 @@ func (o *Orchestrator) driveRunner(ctx context.Context, job runnerJob) (*TestRep
 // leg that ran an example under examples/ failed here, naming four paths and
 // not the one the runner was in, and so did any customer whose manifest is not
 // at the top of their repository.
+//
+// Nearest that CAN RUN, not simply nearest. Widening the search to the top of
+// the checkout put this repository's own runner/ ahead of ~/.antifailure/runner
+// for every run inside it, and on a fresh checkout runner/ is source with no
+// node_modules. So `af runner install` populated Home, `af runner check` read
+// Home and said ready, and the run took runner/ and died inside node with
+// ERR_MODULE_NOT_FOUND on playwright. A directory that cannot resolve the
+// dependencies it declares is not a runner, and runnerpath.Choose is where
+// that is decided, so this and `af runner check` cannot answer about different
+// trees again.
 func (o *Orchestrator) findRunner(override string) (string, error) {
 	if override != "" {
 		if _, err := os.Stat(override); err == nil {
@@ -521,15 +531,37 @@ func (o *Orchestrator) findRunner(override string) (string, error) {
 		}
 		return "", aferrors.Coded(aferrors.AFAGT004, "detail", "looked in "+override)
 	}
-	dirs := runnerpath.ToRun(o.opts.Root)
-	candidates := make([]string, 0, len(dirs))
-	for _, d := range dirs {
-		candidates = append(candidates, filepath.Join(d, "src", "main.ts"))
-	}
-	for _, c := range candidates {
-		if _, err := os.Stat(c); err == nil {
-			return c, nil
+	choice := runnerpath.Choose(o.opts.Root)
+	if choice.Runner.Exists() {
+		// Said out loud rather than substituted quietly. A nearer runner that
+		// cannot run is still the one somebody is editing, and watching your
+		// edits do nothing because a different copy ran is a worse afternoon
+		// than being told which copy ran.
+		//
+		// Guarded because a directly constructed Orchestrator has no progress
+		// func, and a run must not crash for want of somewhere to say this.
+		for _, p := range choice.InCheckout() {
+			if o.progress != nil {
+				o.progress(fmt.Sprintf("the runner at %s %s, so this run uses the one at %s",
+					p.Dir, p.Why(), choice.Runner.Dir))
+			}
 		}
+		return choice.Runner.Entry, nil
+	}
+	// A runner that is present and cannot run is a better thing to report than
+	// the list of every path that held nothing. This case used to be returned
+	// as success, and af test then died inside node with ERR_MODULE_NOT_FOUND,
+	// which named a package rather than the fact that the runner was never
+	// installed.
+	if len(choice.PassedOver) > 0 {
+		p := choice.PassedOver[0]
+		return "", aferrors.Coded(aferrors.AFAGT004,
+			"detail", "the runner at "+p.Dir+" "+p.Why()+
+				", and no other runner was found; install one with: af runner install")
+	}
+	candidates := make([]string, 0, len(choice.Looked))
+	for _, d := range choice.Looked {
+		candidates = append(candidates, filepath.Join(d, "src", "main.ts"))
 	}
 	return "", aferrors.Coded(aferrors.AFAGT004,
 		"detail", "looked in "+strings.Join(candidates, ", "))

--- a/engine/internal/runnerpath/readiness.go
+++ b/engine/internal/runnerpath/readiness.go
@@ -1,0 +1,213 @@
+package runnerpath
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// A runner directory that cannot resolve its own declared dependencies is not
+// a runner, and this is the one place that says so.
+//
+// The question was answered in two places that never compared answers.
+// `af runner check` read ~/.antifailure/runner and reported every dependency
+// against node_modules, which is thorough and was pointed at the wrong tree: a
+// run resolves its runner with ToRun, and ToRun offers the checkout's own
+// runner/ BEFORE Home. On a fresh checkout that directory is source with no
+// node_modules, so on 2026-09-05 the walkthrough ran `af runner install`, ran
+// `af runner check`, was told the runner was ready, and then died inside the
+// next command with
+//
+//	Cannot find package 'playwright' imported from
+//	  /home/runner/work/antifailure/antifailure/runner/src/browser.ts
+//
+// Both commands were honest about the directory they looked at. They looked at
+// different directories, and neither said which. install.sh already carries
+// half of this rule, in shell, for exactly one path: it deletes $PREFIX/runner
+// when it has no node_modules, because "af test finds it before it finds
+// anything else". That rule belongs to the engine and to every path the search
+// offers, not to one path a shell script happens to know about.
+
+// State is what could be learned about one runner directory without running it.
+//
+// Proven unrunnable and unknown are kept apart on purpose. A manifest that
+// cannot be parsed is not a broken runner, it is a runner nothing could be
+// said about, and reporting the two the same way is how a check starts
+// answering ok about things it never examined.
+type State struct {
+	// Dir is the directory that was inspected, whether or not it holds a runner.
+	Dir string
+	// Entry is Dir/src/main.ts when a runner is here, and empty when none is.
+	Entry string
+	// Node is the version range the runner's manifest requires, empty when the
+	// manifest declares none or could not be read.
+	Node string
+	// Declared is how many dependencies the manifest names.
+	Declared int
+	// Missing names the declared dependencies with nothing under node_modules,
+	// sorted, so a report of them reads the same twice.
+	Missing []string
+	// NoModules reports that node_modules itself is absent.
+	NoModules bool
+	// Pinned reports that package-lock.json sits beside the manifest, which is
+	// what makes two people installing one release get one tree.
+	Pinned bool
+	// Undetermined says why the dependencies could not be read, and is empty
+	// when they could.
+	Undetermined string
+	// InCheckout says this directory was found at or above the manifest,
+	// inside the checkout, rather than beside the af binary.
+	//
+	// It decides whether being passed over is worth telling anybody about. A
+	// release installs its runner SOURCE at $PREFIX/share/antifailure/runner
+	// and expects af runner install to resolve it elsewhere, so that copy has
+	// no node_modules on every machine, for ever, by design. Reporting it as
+	// passed over would put a warning on every af runner check anybody ever
+	// runs. A runner inside the checkout is different: it is the copy somebody
+	// may be editing, and going past it silently is how their edits do nothing.
+	InCheckout bool
+}
+
+// Exists reports whether this directory holds a runner at all.
+func (s State) Exists() bool { return s.Entry != "" }
+
+// Blocked reports whether this runner was PROVEN unable to run.
+//
+// Only a proof counts. A runner whose manifest could not be read is not
+// blocked here, because a search that skipped every directory it could not
+// understand would silently pick a further one for a reason nobody could see.
+// A runner declaring no dependencies at all is not blocked by an absent
+// node_modules either, because it needs none.
+func (s State) Blocked() bool {
+	if !s.Exists() || s.Undetermined != "" || s.Declared == 0 {
+		return false
+	}
+	return s.NoModules || len(s.Missing) > 0
+}
+
+// Why names what Blocked found, in a sentence that follows the directory.
+// Empty when nothing was proven, so a caller cannot print a reason that does
+// not exist.
+func (s State) Why() string {
+	if !s.Blocked() {
+		return ""
+	}
+	if s.NoModules {
+		return "has no node_modules"
+	}
+	return "is missing " + strings.Join(s.Missing, ", ")
+}
+
+// Inspect reads one runner directory. It runs nothing.
+func Inspect(dir string) State {
+	s := State{Dir: dir}
+	entry := filepath.Join(dir, "src", "main.ts")
+	if _, err := os.Stat(entry); err != nil {
+		return s
+	}
+	s.Entry = entry
+
+	if _, err := os.Stat(filepath.Join(dir, "package-lock.json")); err == nil {
+		s.Pinned = true
+	}
+
+	blob, err := os.ReadFile(filepath.Join(dir, "package.json"))
+	if err != nil {
+		s.Undetermined = "package.json could not be read"
+		return s
+	}
+	var m struct {
+		Engines struct {
+			Node string `json:"node"`
+		} `json:"engines"`
+		Dependencies map[string]string `json:"dependencies"`
+	}
+	if err := json.Unmarshal(blob, &m); err != nil {
+		s.Undetermined = "package.json could not be parsed"
+		return s
+	}
+	s.Node = m.Engines.Node
+	s.Declared = len(m.Dependencies)
+
+	modules := filepath.Join(dir, "node_modules")
+	if _, err := os.Stat(modules); err != nil {
+		s.NoModules = true
+		return s
+	}
+	for name := range m.Dependencies {
+		// filepath.Join handles the scoped @scope/name form, which is two
+		// directory levels on disk rather than one.
+		if _, err := os.Stat(filepath.Join(modules, filepath.FromSlash(name))); err != nil {
+			s.Missing = append(s.Missing, name)
+		}
+	}
+	sort.Strings(s.Missing)
+	return s
+}
+
+// Choice is which runner a run would use and what it went past to get there.
+type Choice struct {
+	// Runner is the one that would run. Runner.Exists() is false when none of
+	// the candidates held a runner that could.
+	Runner State
+	// PassedOver holds the runners nearer than Runner that this could PROVE
+	// would not run, nearest first.
+	//
+	// It is returned rather than discarded because a run that quietly used a
+	// different runner from the nearest one has to be able to say so. A
+	// contributor editing runner/src whose node_modules is not installed would
+	// otherwise watch their edits do nothing.
+	//
+	// It holds every one of them, including the release's own source beside
+	// the binary, so a refusal can name a concrete tree. Only the InCheckout
+	// ones are worth REPORTING when a runner was found; see State.InCheckout.
+	PassedOver []State
+	// Looked is every directory considered, in order, so a refusal can name
+	// them all.
+	Looked []string
+}
+
+// InCheckout returns the passed over runners that are worth reporting: the
+// ones inside the checkout, which somebody may be editing. The release's own
+// source beside the binary is expected to have no node_modules and reporting
+// it would be a warning nobody can act on and everybody sees.
+func (c Choice) InCheckout() []State {
+	var out []State
+	for _, s := range c.PassedOver {
+		if s.InCheckout {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// Choose is the runner a run rooted at dir would use: the nearest candidate
+// that was not proven unable to run.
+//
+// Nearest-that-works rather than nearest. The nearest rule sent every run in
+// this checkout at runner/, which on a fresh clone is source with no
+// dependencies, and made `af runner install` pointless: it populates Home, and
+// Home was never reached.
+func Choose(dir string) Choice {
+	inside := map[string]bool{}
+	for _, d := range inCheckout(dir) {
+		inside[d] = true
+	}
+	c := Choice{Looked: ToRun(dir)}
+	for _, d := range c.Looked {
+		s := Inspect(d)
+		s.InCheckout = inside[d]
+		if !s.Exists() {
+			continue
+		}
+		if s.Blocked() {
+			c.PassedOver = append(c.PassedOver, s)
+			continue
+		}
+		c.Runner = s
+		return c
+	}
+	return c
+}

--- a/engine/internal/runnerpath/readiness_test.go
+++ b/engine/internal/runnerpath/readiness_test.go
@@ -1,0 +1,265 @@
+package runnerpath
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const manifest = `{
+  "engines": { "node": ">=22.6" },
+  "dependencies": { "playwright": "^1.49.0" }
+}`
+
+// source is a runner as it sits in a checkout: complete source, a manifest, a
+// lockfile, and nothing installed. This is what a fresh clone holds and what
+// tools/release/build.sh ships, which is why it is the shape everything here
+// is written against.
+func source(t *testing.T, dir string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "src", "main.ts"), []byte("// runner\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "package-lock.json"), []byte(`{"lockfileVersion":3}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// installed is what af runner install leaves behind: the same source with its
+// dependencies resolved into it.
+func installed(t *testing.T, dir string) string {
+	t.Helper()
+	source(t, dir)
+	if err := os.MkdirAll(filepath.Join(dir, "node_modules", "playwright"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// The tree the walkthrough ran on, and the reason this file exists.
+func TestARunnerWithNoNodeModulesIsProvenUnableToRun(t *testing.T) {
+	s := Inspect(source(t, t.TempDir()))
+
+	if !s.Exists() {
+		t.Fatal("the source is there, so the runner exists")
+	}
+	if !s.Blocked() {
+		t.Error("a runner with no node_modules is not reported as unable to run, " +
+			"which is what let af test take it and die inside node")
+	}
+	if !strings.Contains(s.Why(), "node_modules") {
+		t.Errorf("Why() is %q, which does not name what is missing", s.Why())
+	}
+}
+
+// node_modules existing is not the dependencies being installed. An
+// interrupted npm install leaves the directory behind.
+func TestADeclaredDependencyWithNothingUnderNodeModulesIsProvenMissing(t *testing.T) {
+	dir := source(t, t.TempDir())
+	if err := os.MkdirAll(filepath.Join(dir, "node_modules"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	s := Inspect(dir)
+
+	if !s.Blocked() {
+		t.Error("an empty node_modules is not reported as unable to run")
+	}
+	if !strings.Contains(s.Why(), "playwright") {
+		t.Errorf("Why() is %q, which does not name the package", s.Why())
+	}
+}
+
+func TestAnInstalledRunnerIsNotBlocked(t *testing.T) {
+	s := Inspect(installed(t, t.TempDir()))
+
+	if s.Blocked() {
+		t.Errorf("a complete runner is reported as unable to run: %s", s.Why())
+	}
+	if !s.Pinned {
+		t.Error("the lockfile is there and Pinned says it is not")
+	}
+	if s.Declared != 1 {
+		t.Errorf("Declared is %d, want the 1 the manifest names", s.Declared)
+	}
+}
+
+// Proven unable to run and nothing could be determined are different answers,
+// and a search that skipped both would pick a further runner for a reason
+// nobody could see.
+func TestAManifestThatCannotBeReadIsNotProofOfAnything(t *testing.T) {
+	dir := source(t, t.TempDir())
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s := Inspect(dir)
+
+	if s.Undetermined == "" {
+		t.Error("an unparseable package.json is reported as read")
+	}
+	if s.Blocked() {
+		t.Error("a runner nothing could be said about is treated as proven broken")
+	}
+	if s.Why() != "" {
+		t.Errorf("Why() is %q, and nothing was proven", s.Why())
+	}
+}
+
+// A runner that declares no dependencies needs no node_modules, so an absent
+// one proves nothing about it.
+func TestARunnerThatDeclaresNoDependenciesIsNotBlockedByAnAbsentNodeModules(t *testing.T) {
+	dir := t.TempDir()
+	source(t, dir)
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"engines":{"node":">=22.6"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if s := Inspect(dir); s.Blocked() {
+		t.Errorf("a runner declaring nothing is blocked for want of node_modules: %s", s.Why())
+	}
+}
+
+// checkout builds the shape the walkthrough runs in: a checkout with a runner
+// at its top and a project some directories down, plus a home directory that
+// may or may not hold an installed runner.
+func checkout(t *testing.T) (root, project, home string) {
+	t.Helper()
+	base := t.TempDir()
+	home = filepath.Join(base, "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	root = filepath.Join(base, "checkout")
+	if err := os.MkdirAll(filepath.Join(root, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	project = filepath.Join(root, "examples", "go-api")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return root, project, home
+}
+
+// The defect itself, in one test.
+//
+// Run 33956075704 on 2026-09-05: af runner install put a working runner in
+// ~/.antifailure/runner, af runner check said the runner was ready, and the
+// next command resolved the checkout's own runner/, which on a fresh clone has
+// no node_modules, and died with
+//
+//	Cannot find package 'playwright' imported from .../runner/src/browser.ts
+func TestChooseGoesPastACheckoutRunnerThatCannotRun(t *testing.T) {
+	root, project, home := checkout(t)
+	source(t, filepath.Join(root, "runner"))
+	wanted := installed(t, filepath.Join(home, ".antifailure", "runner"))
+
+	c := Choose(project)
+
+	if c.Runner.Dir != wanted {
+		t.Errorf("chose %q, want the installed runner at %q", c.Runner.Dir, wanted)
+	}
+	if len(c.PassedOver) != 1 {
+		t.Fatalf("passed over %d runners, want the checkout's one: %v", len(c.PassedOver), c.PassedOver)
+	}
+	if c.PassedOver[0].Dir != filepath.Join(root, "runner") {
+		t.Errorf("passed over %q, want the checkout runner", c.PassedOver[0].Dir)
+	}
+	if !strings.Contains(c.PassedOver[0].Why(), "node_modules") {
+		t.Errorf("the reason is %q, which does not say why it was passed over", c.PassedOver[0].Why())
+	}
+}
+
+// The nearest runner still wins when it can run, so a contributor working on
+// runner/ still runs the copy they are editing.
+func TestChooseTakesTheNearestRunnerWhenItCanRun(t *testing.T) {
+	root, project, home := checkout(t)
+	wanted := installed(t, filepath.Join(root, "runner"))
+	installed(t, filepath.Join(home, ".antifailure", "runner"))
+
+	c := Choose(project)
+
+	if c.Runner.Dir != wanted {
+		t.Errorf("chose %q, want the checkout runner at %q", c.Runner.Dir, wanted)
+	}
+	if len(c.PassedOver) != 0 {
+		t.Errorf("passed over %v, and nothing needed passing over", c.PassedOver)
+	}
+}
+
+// When the only runner anywhere cannot run, that is what the caller is told.
+// Choosing it anyway is what turned an uninstalled runner into a node stack
+// trace three commands later.
+func TestChooseFindsNothingRunnableWhenTheOnlyRunnerIsBlocked(t *testing.T) {
+	root, project, _ := checkout(t)
+	source(t, filepath.Join(root, "runner"))
+
+	c := Choose(project)
+
+	if c.Runner.Exists() {
+		t.Errorf("chose %q, and it cannot run", c.Runner.Dir)
+	}
+	if len(c.PassedOver) != 1 {
+		t.Fatalf("passed over %d, want the one blocked runner", len(c.PassedOver))
+	}
+	if len(c.Looked) == 0 {
+		t.Error("nothing was recorded as looked at, so a refusal can name nothing")
+	}
+}
+
+// A release keeps its runner SOURCE beside the binary and expects
+// af runner install to resolve it somewhere else, so that copy has no
+// node_modules on every machine there has ever been. Reporting it as passed
+// over would put a warning nobody can act on under every af runner check.
+// Only the runners inside the checkout are worth naming.
+func TestOnlyTheCheckoutsOwnRunnersAreWorthReporting(t *testing.T) {
+	root, project, home := checkout(t)
+	source(t, filepath.Join(root, "runner"))
+	source(t, filepath.Join(home, ".antifailure", "runner"))
+
+	c := Choose(project)
+
+	if len(c.PassedOver) != 2 {
+		t.Fatalf("passed over %d runners, want the checkout's and the installed one: %v",
+			len(c.PassedOver), c.PassedOver)
+	}
+	reported := c.InCheckout()
+	if len(reported) != 1 {
+		t.Fatalf("reported %d of them, want only the one in the checkout: %v", len(reported), reported)
+	}
+	if reported[0].Dir != filepath.Join(root, "runner") {
+		t.Errorf("reported %q, want the checkout's runner", reported[0].Dir)
+	}
+}
+
+// Undetermined outranks anything else that was read.
+//
+// Through Inspect the two never meet, because a manifest that failed to parse
+// leaves Declared at zero, so the guard in Blocked looks redundant and a
+// mutation that removed it kept every other test green. Blocked is exported
+// and its contract is the thing being relied on: "nothing could be determined"
+// must beat a partial reading, or a later Inspect that fills a field in before
+// it gives up would start proving runners broken on no evidence.
+func TestNothingDeterminedOutranksAPartialReading(t *testing.T) {
+	s := State{
+		Dir:          "/somewhere",
+		Entry:        "/somewhere/src/main.ts",
+		Declared:     1,
+		NoModules:    true,
+		Undetermined: "package.json could not be parsed",
+	}
+	if s.Blocked() {
+		t.Error("a runner nothing could be determined about is reported as proven broken")
+	}
+	if s.Why() != "" {
+		t.Errorf("Why() is %q, and nothing was proven", s.Why())
+	}
+}

--- a/tools/walkthrough/main.go
+++ b/tools/walkthrough/main.go
@@ -149,14 +149,19 @@ func walk(root, example string, budget time.Duration) error {
 			// between "pinned by" and "package-lock.json". A check that reads
 			// prose is measuring the wrap.
 			out, err := w.af_(ctx, "runner", "check", "-o", "json")
-			if err != nil {
-				return fmt.Errorf("the runner is not ready after af runner install: %w", err)
-			}
 			var report struct {
-				Complete bool `json:"complete"`
+				Path     string `json:"path"`
+				Complete bool   `json:"complete"`
 				Checks   []struct {
 					Name, Result, Detail string
 				} `json:"checks"`
+			}
+			// The document is read before the exit code is judged, because
+			// the report says WHICH check failed and the exit code says only
+			// that one did. The message a person gets from this step has to
+			// be the one they can act on.
+			if err != nil {
+				return fmt.Errorf("the runner is not ready after af runner install: %w\n%s", err, out)
 			}
 			if jsonErr := json.Unmarshal([]byte(out), &report); jsonErr != nil {
 				return fmt.Errorf("af runner check did not return a document this can read: %w\n%s",
@@ -182,7 +187,7 @@ func walk(root, example string, budget time.Duration) error {
 					"are whatever npm resolved today rather than what this release was tested "+
 					"with: %s", deps)
 			}
-			return nil
+			return runnerStarts(ctx, report.Path)
 		}},
 		{"af explain", func(ctx context.Context, w *world) error {
 			out, err := w.af_(ctx, "explain")
@@ -318,6 +323,43 @@ func walk(root, example string, budget time.Duration) error {
 	fmt.Printf("\nwalkthrough: the getting started path took %s\n", total.Round(time.Second))
 	if budget > 0 && total > budget {
 		return fmt.Errorf("that is longer than the %s budget", budget)
+	}
+	return nil
+}
+
+// runnerStarts loads the runner af runner check named and confirms node can
+// resolve it, which is the one claim that command deliberately does not make.
+//
+// af runner check reads a directory. It reported ready while the run resolved
+// a DIFFERENT directory, so the walkthrough learned about a runner with no
+// dependencies three steps later, from inside af test, as
+//
+//	Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'playwright' imported
+//	  from /home/runner/work/antifailure/antifailure/runner/src/browser.ts
+//
+// which names a package and not the fact that the runner was never installed.
+// Starting the runner here costs a process and puts that failure at the step
+// whose whole job is to answer the question. It exits immediately for want of
+// a job document, so this waits on nothing.
+func runnerStarts(ctx context.Context, dir string) error {
+	if dir == "" {
+		return errors.New("af runner check named no path, so there is nothing to start")
+	}
+	entry := filepath.Join(dir, "src", "main.ts")
+	cmd := exec.CommandContext(ctx, "node", "--experimental-strip-types", entry)
+	cmd.Stdin = strings.NewReader("")
+	out, err := cmd.CombinedOutput()
+	// A non zero exit is expected: with no job document the runner refuses.
+	// What is not expected is node failing to load the program at all, which
+	// is what an uninstalled dependency looks like.
+	if strings.Contains(string(out), "ERR_MODULE_NOT_FOUND") ||
+		strings.Contains(string(out), "Cannot find package") {
+		return fmt.Errorf("af runner check called %s ready and node cannot load it, so "+
+			"af test would die inside the runner rather than reaching a workflow:\n%s",
+			dir, out)
+	}
+	if err != nil && !strings.Contains(string(out), "job document") {
+		return fmt.Errorf("the runner at %s did not start: %w\n%s", dir, err, out)
 	}
 	return nil
 }

--- a/tools/walkthrough/main_test.go
+++ b/tools/walkthrough/main_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -140,5 +143,104 @@ func TestAWholeReportReadsBack(t *testing.T) {
 	}
 	if counts["passed"] != 6 {
 		t.Errorf("passed read back as %d, want 6", counts["passed"])
+	}
+}
+
+// runnerStarts is the assertion af runner check deliberately does not make.
+//
+// The check reads a directory and reports what is in it. On 2026-09-05 it
+// reported ready while the run resolved a DIFFERENT directory, so this
+// walkthrough learned about a runner with no dependencies three steps later,
+// from inside af test, as ERR_MODULE_NOT_FOUND on playwright. Loading the
+// runner the check NAMED puts that failure at the step whose job is to answer
+// the question.
+//
+// Written against a real runner source and a real node, because a test that
+// only proved the function contains the right words would prove nothing about
+// whether node agrees.
+func runnerTree(t *testing.T, withDependency bool) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	main := "import './dep.ts';\nprocess.stderr.write('af-runner: expected a job document on standard input\\n');\nprocess.exit(2);\n"
+	if err := os.WriteFile(filepath.Join(dir, "src", "main.ts"), []byte(main), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// The import that fails, standing in for runner/src/browser.ts importing
+	// playwright, which is the line the real failure came from.
+	if err := os.WriteFile(filepath.Join(dir, "src", "dep.ts"), []byte("import 'af-walkthrough-fixture';\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"type":"module"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if withDependency {
+		pkg := filepath.Join(dir, "node_modules", "af-walkthrough-fixture")
+		if err := os.MkdirAll(pkg, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(pkg, "package.json"),
+			[]byte(`{"name":"af-walkthrough-fixture","version":"1.0.0","type":"module","main":"index.js"}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(pkg, "index.js"), []byte("export default 1;\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func needsNode(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("node"); err != nil {
+		// Said rather than passed. A skip that reads as a pass is the thing
+		// this repository keeps finding in its own instruments.
+		t.Skip("node is not on this machine, so the runner cannot be started and this proves nothing")
+	}
+}
+
+func TestRunnerStartsRefusesARunnerNodeCannotLoad(t *testing.T) {
+	needsNode(t)
+	dir := runnerTree(t, false)
+
+	err := runnerStarts(t.Context(), dir)
+	if err == nil {
+		t.Fatal("a runner whose import cannot be resolved was reported as starting, " +
+			"which is exactly the tree af runner check called ready")
+	}
+	if !strings.Contains(err.Error(), dir) {
+		t.Errorf("the refusal does not name the runner it tried: %v", err)
+	}
+	// The specific message, not just some error. A generic "did not start"
+	// would also fire here, and it does not tell the reader that the check
+	// called this tree ready, which is the whole finding.
+	if !strings.Contains(err.Error(), "node cannot load it") {
+		t.Errorf("the refusal reads %q, which does not say the check called an unloadable "+
+			"runner ready", err)
+	}
+}
+
+func TestRunnerStartsAcceptsARunnerThatRefusesForWantOfAJobDocument(t *testing.T) {
+	needsNode(t)
+
+	// The real runner exits non zero here, because there is no job document on
+	// standard input. That is the runner working, and treating a non zero exit
+	// as failure would fail every walkthrough.
+	if err := runnerStarts(t.Context(), runnerTree(t, true)); err != nil {
+		t.Errorf("a runner that started and asked for a job document was refused: %v", err)
+	}
+}
+
+func TestRunnerStartsRefusesWhenTheCheckNamedNoPath(t *testing.T) {
+	err := runnerStarts(t.Context(), "")
+	if err == nil {
+		t.Fatal("an empty path was treated as a runner that starts")
+	}
+	// Named, rather than reaching node with a relative path and coming back
+	// with whatever node says about a file called src/main.ts.
+	if !strings.Contains(err.Error(), "named no path") {
+		t.Errorf("the refusal reads %q, which does not say the check named nothing", err)
 	}
 }


### PR DESCRIPTION
## The defect

`Walkthrough` has been red on main since at least 2026-09-04, in all three
examples. It is not a required context and it runs on a schedule, and it is the
only check that drives the documented getting started sequence end to end.

Run [33956075704](https://github.com/antifailure/antifailure/actions/runs/33956075704),
job 101279553597, on `b66ca628`:

```
step                seconds
af runner install       15.8
af runner check          0.0
walkthrough: af test failed after 0s: af test refused before it reached a
workflow: AF-AGT-003 The agent runner produced no readable output:
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'playwright' imported from
/home/runner/work/antifailure/antifailure/runner/src/browser.ts
```

The install reported success. The check reported success, and
`tools/walkthrough` re-runs it specifically to refuse an unready runner, so the
check was consulted and it said ready. Then the very next command died on a
package `runner/package.json` declares correctly.

The path in that error is the tell. It is the CHECKOUT's runner, not
`~/.antifailure/runner`.

## Which of the three it was

Neither `af runner install` nor `af runner check` was wrong about the directory
it looked at. **They looked at different directories, and neither said which.**

- `af runner install` copies the runner to `~/.antifailure/runner` and runs
  `npm ci` there. It worked. 15.8s is `npm ci` for one package plus a browser
  step, not a failure.
- `af runner check` read `~/.antifailure/runner` and reported every declared
  dependency against `node_modules`. It was right about that tree.
- A run resolves its runner with `runnerpath.ToRun`, which since #209 ascends
  to the top of the checkout so a manifest in a subdirectory can find the
  runner above it. That put this repository's own `runner/` ahead of the
  installed one for every run inside it, and on a fresh clone `runner/` is
  source with no `node_modules`.

So the install populated one directory, the check read that directory, and the
run took a third.

`install.sh` already carries half of this rule, in shell, for exactly one path.
It deletes `$PREFIX/runner` when it has no `node_modules`, and its comment says
why: "af test finds it before it finds anything else", and "af runner check
'ok runner', because it stats src/main.ts, on a tree with no node_modules. So
the breakage surfaced later, inside af test, as a node error." That rule belongs
to the engine and to every path the search offers.

## The fix

One place decides whether a directory holds a runner that can run,
`engine/internal/runnerpath`, and both the search and the check use it.

- A run takes the nearest runner that **can run** rather than the nearest one
  that exists, and says through `Progress` when it goes past one, because a
  contributor editing `runner/src` with no `node_modules` would otherwise watch
  their edits do nothing while a different copy ran. A nearest runner that can
  run still wins, so working on the runner is unchanged.
- `af runner check` reports on the runner a run started there would use and
  prints its path, and names any it went past with what is wrong with it.
- Proven unable to run and nothing could be determined stay different answers.
  An unreadable `package.json` reports as not checked for the dependencies and
  now for node too, which used to print the version it found and call that ok
  against a requirement nobody had read.
- When nothing anywhere can run, `af test` refuses with AF-AGT-004 naming the
  directory and the missing package. That case used to be returned as success.
- `af runner check -o json` exits non zero when it reports the runner
  incomplete. The JSON branch returned before the readiness check, so a script
  reading the exit code was told a runner was ready in the same breath as the
  document saying `"complete": false`.
- `af start`'s runner rung reuses the same resolution.
- The walkthrough loads the runner the check named and confirms node can
  resolve it, so this class of failure lands at the step whose job is to answer
  the question rather than three steps later inside a stack trace.

A first run is unchanged on purpose. A release keeps its runner SOURCE at
`$PREFIX/share/antifailure/runner`, which has no `node_modules` by design and
always will, so reporting on it would answer the commonest state of all with
"node_modules is missing" under a path nobody has heard of. Only runners inside
the checkout are reported as gone past, and a machine with none falls through to
"no runner at ~/.antifailure/runner". Verified against a real release layout.

## Can it say no

Four real directory trees, the real binary, real runs.

1. **playwright absent from `node_modules`, no other runner anywhere.**
   `fail  dependencies  missing playwright`, exit 3, and exit 3 with `-o json` too.
2. **A complete runner.** Every line ok, exit 0, reporting the path of the
   runner a run there would use.
3. **Dependencies complete, browser missing.** `ok  dependencies` beside
   `warn  browser  no chromium in ...`, exit 0. A distinct answer, not the same
   refusal.
4. **`package.json` unparseable.** `skip  dependencies  not checked:
   package.json could not be parsed`, and node reports `skip` rather than ok,
   exit 0.

A missing browser and a missing dependency stay different answers, because
`af runner install` treats a failed browser download as non fatal and `af test`
returns `unverified` rather than guessing.

## Testing

31 mutations, each breaking one production line, each confirmed red on the
assertion it was aimed at and green again after restoring. Five stayed green on
the first pass and those five assertions were rewritten until they could
discriminate: the fixture had made the chosen runner and the home runner the
same directory, and two walkthrough assertions accepted any error rather than
the message a person reads.

Full engine suite run. `internal/cli`, `internal/env` and `internal/runnerpath`
all pass; the whole `tools` module passes. Four Docker backed packages fail on
this machine with `Error response from daemon: all predefined address pools
have been fully subnetted` against 33 networks and 75 containers from other
lanes. None of them imports `runnerpath` or touches anything in this diff.

## Does a stranger following the quickstart hit this

Not on the ordinary path. Their project has no `runner/` directory, so the
search reaches `~/.antifailure/runner` and finds what `af runner install` wrote.
Two nearby cases were real and are fixed: a repository that happens to hold a
`runner/` with a `src/main.ts` above the manifest, and anyone who runs `af test`
before `af runner install`, who met the release's own uninstalled source and a
node stack trace, and now gets a refusal naming the tree and the command to run.
