### PR TITLE
build: seven lockfiles never heard about three releases

### DIFF
--- a/.changes/lockfiles-that-never-heard-about-three-releases.internal.md
+++ b/.changes/lockfiles-that-never-heard-about-three-releases.internal.md
@@ -1,0 +1,5 @@
+# fixed
+
+Seven lockfiles recorded a version the package they lock had not carried since
+v1.0.0. Nothing a user installs changes; the entries are the workspace packages'
+own version fields, not any dependency.

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@antifailure/site-api",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@antifailure/site-api",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "dependencies": {
         "@azure/data-tables": "^13.3.0"
       }

--- a/console/package-lock.json
+++ b/console/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@antifailure/console",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@antifailure/console",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "geist": "^1.7.2",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@antifailure/docs",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@antifailure/docs",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@astrojs/starlight": "^0.41.10",

--- a/ee/web/package-lock.json
+++ b/ee/web/package-lock.json
@@ -23,7 +23,7 @@
     },
     "../../web/apps/api": {
       "name": "@antifailure/api",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@antifailure/db": "*",
@@ -46,7 +46,7 @@
     },
     "../../web/packages/db": {
       "name": "@antifailure/db",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "drizzle-orm": "^0.45.2",
@@ -62,7 +62,7 @@
     },
     "audit": {
       "name": "@antifailure-ee/audit",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "license": "SEE LICENSE IN ../../LICENSE.md",
       "dependencies": {
         "@antifailure/db": "file:../../../web/packages/db"
@@ -241,7 +241,7 @@
     },
     "rbac": {
       "name": "@antifailure-ee/rbac",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "license": "SEE LICENSE IN ../../LICENSE.md",
       "dependencies": {
         "@antifailure/api": "file:../../../web/apps/api",
@@ -254,7 +254,7 @@
     },
     "scim": {
       "name": "@antifailure-ee/scim",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "license": "SEE LICENSE IN ../../LICENSE.md",
       "dependencies": {
         "@antifailure/api": "file:../../../web/apps/api",
@@ -268,7 +268,7 @@
     },
     "sso": {
       "name": "@antifailure-ee/sso",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "license": "SEE LICENSE IN ../../LICENSE.md",
       "dependencies": {
         "@antifailure/api": "file:../../../web/apps/api",

--- a/runner/package-lock.json
+++ b/runner/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@antifailure/runner",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@antifailure/runner",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "playwright": "^1.49.0"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -20,7 +20,7 @@
     },
     "apps/api": {
       "name": "@antifailure/api",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@antifailure/db": "*",
@@ -1442,7 +1442,7 @@
     },
     "packages/db": {
       "name": "@antifailure/db",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "drizzle-orm": "^0.45.2",
@@ -1458,7 +1458,7 @@
     },
     "packages/policy": {
       "name": "@antifailure/policy",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.0.0",

--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@antifailure/www",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@antifailure/www",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "geist": "^1.7.2",


### PR DESCRIPTION
`web/package-lock.json` said `apps/api` was 1.1.0 while its package.json said
1.2.0, and six other lockfiles were further behind still, at 1.0.0. Nineteen
version fields across seven files, wrong since v1.0.0 and carried through
v1.1.0, v1.1.1 and v1.2.0 because every release bumps the package.json files
and nothing regenerates what locks them.

CI does not see it, which is why it survived three releases. A local
`just installcheck` does, so the first person to run the gate on a clean
checkout meets a red that has nothing to do with their change and everything to
do with a release nobody was in the room for.

THE OBVIOUS FIX IS DESTRUCTIVE AND THIS IS THE PART WORTH READING. Running
`npm install --package-lock-only` in each directory does correct the versions,
and it also DELETES entries. On this machine it stripped
`@tailwindcss/oxide-wasm32-wasi`'s `@emnapi/core` and `@emnapi/runtime`, every
`libc` constraint naming glibc and musl, and a set of `optional` platform
entries: 311 deletions against 40 insertions across the tree. Those are the
fallbacks another architecture installs. Regenerating a lockfile on one machine
prunes what that machine does not need, and CI runs on Linux, so the repair
would have quietly changed what a Linux `npm ci` resolves while looking like a
version bump in the diff.

So this edits the nineteen version fields and nothing else. Every changed line
in the diff is a `"version"` line, every lockfile still parses, and no
dependency, integrity hash, resolved URL or platform constraint moves.