### PR TITLE
routecheck: the probe's oauth_states row was called expiring and is never deleted

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -181,10 +181,24 @@ jobs:
         # as a pass it did not earn.
         #
         # -allow-write-probes sends the one probe the inventory declares as
-        # writing something: GET /auth/github creates one expiring oauth_states
-        # row, exactly as a person who clicks "Continue with GitHub" and closes
-        # the tab does. There is no request that proves that route is present
+        # writing something: GET /auth/github creates one oauth_states row,
+        # exactly as a person who clicks "Continue with GitHub" and closes the
+        # tab does. There is no request that proves that route is present
         # without it, so it is declared and paid for rather than skipped.
+        #
+        # WHAT THAT ROW ACTUALLY COSTS, so this flag is not authorised by a
+        # sentence nobody re-reads. The row is unusable after ten minutes and
+        # it is never DELETED: completeSignIn removes a state on redemption and
+        # nothing sweeps the table, so one row per publish accumulates forever.
+        # That is a debt with an expiry date, not a free probe. It is not this
+        # gate's debt alone, because every abandoned real sign-in leaves the
+        # same row, and the retirement is a sweeper for oauth_states of the
+        # shape migrations 0016 and 0024 already use for devices and sessions.
+        # If that sweeper lands, this comment is the thing to come back and
+        # delete. If a cheaper presence probe is ever added to the control
+        # plane instead, note that it cannot help on the day it is needed: the
+        # gate exists precisely for a DEPLOYED image older than the commit that
+        # would have added it.
         if: ${{ env.TOKEN != '' }}
         env:
           TOKEN: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}

--- a/www/lib/control-plane-routes.ts
+++ b/www/lib/control-plane-routes.ts
@@ -130,7 +130,7 @@ export const CONTROL_PLANE_ROUTES = {
       "'Continue with GitHub' lands on a 404 page. It is the primary conversion path off this site.",
     probeEffect: "writes",
     probeReason:
-      "auth/signin.ts beginSignIn inserts one row into oauth_states unconditionally, and nothing in front of the handler refuses a request that carries no credential. A probe therefore creates one expiring state row, exactly as a person who clicks the button and then closes the tab does. There is no request that proves this route is present without doing that, so it is declared rather than hidden.",
+      "auth/signin.ts beginSignIn inserts one row into oauth_states unconditionally, and nothing in front of the handler refuses a request that carries no credential. A probe therefore creates one state row, exactly as a person who clicks the button and then closes the tab does. There is no request that proves this route is present without doing that, so it is declared rather than hidden. SAY WHAT THE ROW COSTS EXACTLY, because the imprecise version of this sentence said the row was 'expiring' and invited a reader to assume it cleans itself up. It does not. completeSignIn deletes a state ON REDEMPTION and nothing sweeps the table, so an unredeemed row is unusable after OAUTH_STATE_TTL_MS but stays in the table indefinitely. That is a real debt and it is not this gate's alone: every person who clicks the button and closes the tab leaves the same row. The retirement is a sweeper for oauth_states, of the shape migrations 0016 and 0024 already use for devices and sessions, which is worth building on its own account.",
   },
 } as const satisfies Record<string, ControlPlaneRoute>;
 


### PR DESCRIPTION
Follow-up to #249, which merged before this could be pushed to its branch.

The reviewer asked a fair question about #249 and it deserved an answer in
writing rather than a shrug: `deploy.yml` passes `-allow-write-probes`, so every
publish of the marketing site inserts one `oauth_states` row into production. Is
that acceptable forever, or is it a debt with an expiry date?

It is a debt, and answering it properly turned up a wording bug in #249 worth
fixing on its own.

**The row is never deleted.** An earlier draft of this called it "one expiring
state row", which is the kind of sentence that lets a reader assume it cleans
itself up. It does not. `completeSignIn` deletes a state ON REDEMPTION, in the
same statement that reads it, and nothing sweeps the table: `maintenance.ts`
sweeps analytics partitions and recruitment applications, and the dedicated
sweepers that exist are for devices (`0016`), sessions (`0024`) and email
sign-in tokens (`0017`). `oauth_states` has none. So an unredeemed row is
unusable after `OAUTH_STATE_TTL_MS`, ten minutes, and stays in the table
indefinitely.

**Is that acceptable forever? No. It is a debt with an expiry date.** The volume
is trivial, one small row per push to main, so this is not a capacity argument.
The objection is that a CI job writes to a security-relevant table on an
unauthenticated path, permanently, under an authorisation that lives in a YAML
comment nobody re-reads. That is precisely how a thing gets discovered in six
months rather than decided today.

**It is not this gate's debt alone, and that is the useful part.** Every person
who clicks "Continue with GitHub" and closes the tab leaves exactly the same
row. The gate does not create a new class of garbage; it makes an existing gap
slightly more visible. The table has been missing a sweeper since `0001`.

**What retires it: a sweeper for `oauth_states`**, of the shape `0016` and
`0024` already use. That is worth building on its own account, independent of
this gate, and it is small because the pattern exists twice already, including
two migrations whose names record that the first attempts could not delete
through RLS, so the trap is already documented. It belongs in its own pull
request for the same reason the 404 sentence does: it is control plane, on the
tag clock.

**What does not retire it: a cheaper presence probe.** The obvious idea is a
route that answers presence without beginning a sign-in, or a parameter
`beginSignIn` rejects before the insert. It cannot help on the day it is needed.
This gate exists for a DEPLOYED image older than the commit that would have
added such a branch, so on exactly the occasion it matters the old image has no
such route. It would only ever retire the debt prospectively, years out, and it
adds a control plane surface to save a row a sweeper deletes for free. The
sweeper is the better buy.

Until then the cost is written twice where somebody will actually meet it: in
the inventory entry, and in the `deploy.yml` comment that authorises the flag,
which now says what the row costs and names the sweeper as the thing to come
back and delete it for.

### Why not an OPTIONS preflight

An `OPTIONS` probe is the obvious way to ask without sending a body, and it was
rejected on evidence from `boundary.ts` rather than on taste. It answers about
the wrong route, and for one of these four it answers about no route at all.

`OPTIONS /v1/leads`, `OPTIONS /v1/applications` and `OPTIONS /v1/site/events`
are separate registered routes with their own entries in the register, each
classified `not-an-endpoint` with the reason "the preflight for the route above.
A browser sends it; nothing calls it." So an `OPTIONS` probe establishes that
the PREFLIGHT exists, which is not the question. `GET /auth/github` has no
`OPTIONS` entry at all, because it is a link a person clicks rather than a cross
origin fetch, so an `OPTIONS` probe of it would return 404 for a route that is
present and blame the deploy for a route that works. That is the exact false
positive that would make the gate worthless.

There is a second reason that outlives the current register. Routers commonly
answer `OPTIONS` generically, from CORS middleware ahead of routing, so a 204 to
an `OPTIONS` can come back for a path with no handler behind it whatsoever. That
is a false NEGATIVE, and a silent one.

A deliberately invalid body with the method the site uses has neither problem.
It asks about the route the site actually calls, with the verb the site actually
uses, and every one of these four handlers refuses it before doing anything.


## What is in this change

Nothing executable. The probe, the flag, and every line that runs are identical.
Two comments and one gate-internal metadata string now say what the row really
costs. `changecheck` is satisfied with a `Changelog-None` trailer rather than a
fragment, because there is no behaviour for a reader of the changelog to hear
about.

## Verified

Against this branch, on the shared Go build lock:

```
changecheck    exit 0 with the Changelog-None trailer
prosecheck     813 files, 0 places where the punctuation gives it away
gatecheck      exit 0
routecheck     the offline half, exit 0
routecheck     unit tests ok, 24 test functions
```
