### PR TITLE
site: the one origin check had never opened the documentation

### DIFF
--- a/.changes/the-one-origin-check-read-three-fifths-of-the-site.internal.md
+++ b/.changes/the-one-origin-check-read-three-fifths-of-the-site.internal.md
@@ -1,0 +1,27 @@
+# fixed
+
+The check that every published file names one origin had never opened the
+documentation.
+
+It asserted, in its own words, that no built file spells the site any way but
+the canonical origin. It read `www/out`, which is 307 of the published site's
+499 served files. The other 192 are the documentation, the installer and the
+JSON schemas, which are copied into the tree by `tools/site/assemble.sh` and
+which that check had never seen. Roughly three fifths of the site carried a
+claim made about all of it, and the deploy step that does read the documentation
+resolves links and has no opinion about which host a page names. A documentation
+page could have sent a reader to an address that is not the canonical one and
+every stage would have stayed green.
+
+Nothing was wrong in the unread part on the day this moved. That is the reason
+to move the check rather than a reason to leave it: a gate whose claim is wider
+than its reach has not been lucky, it has never been asked the question.
+
+The assertion now lives in `tools/site/assemble.sh`, which is the only step that
+holds both builds plus the files neither build produces, and it asserts its own
+reach as well as its content. It requires the canonical origin to appear both
+under the documentation and outside it, so a walk that narrows back to one half
+of the site fails by name instead of passing over an empty set. The wrong
+spellings are derived from the canonical one rather than listed, because the
+list it used to carry was a survey of the spellings somebody had thought of and
+the one that caused trouble arrived after it was written.

--- a/tools/site/assemble.sh
+++ b/tools/site/assemble.sh
@@ -528,6 +528,145 @@ print(
 )
 SLASH
 
+# One origin, across the whole assembled site.
+#
+# THE FAILURE. This assertion lived in www/scripts/check-seo.mjs, where it read
+# www/out and said, in its own words, "no built file spells the site any way but
+# https://antifailure.dev". The published site is not www/out. It is this tree,
+# and 192 of its 499 served files are the documentation, the installer and the
+# schemas, none of which that gate had ever opened. The sentence was true about
+# three fifths of the site and was written about all of it.
+#
+# Nothing was wrong in the unread three fifths on the day this moved, which is
+# the reason to move it rather than the reason not to: a gate whose claim is
+# wider than its reach is not a gate that has been lucky, it is a gate that has
+# never been asked the question. The deploy step that does read site/docs
+# resolves hrefs and has no opinion about which host a page names, so a
+# documentation page could tell a visitor to go to the wrong address and every
+# stage would stay green.
+#
+# WHY HERE. Same argument the trailing-slash block above makes: this script is
+# the only step that has both builds plus the files neither build produces. The
+# marketing half is not checked twice; check-seo.mjs now points here, and the
+# comment there says why a narrower copy must not come back.
+#
+# THE SPELLINGS ARE DERIVED, NOT LISTED. The old check carried three literals.
+# A list is a survey of the wrong answers somebody thought of, and www is the
+# one that arrived after it was written. This matches any http-or-https,
+# apex-or-www spelling and refuses everything that is not the canonical one, so
+# a fourth spelling is caught by a check nobody had to remember to update.
+# Other subdomains are deliberately untouched: blog.antifailure.dev is a
+# different site, not a different spelling of this one.
+#
+# MENTION VERSUS USE, and this is the fourth instrument in this repository to
+# meet it, so it is worth naming rather than rediscovering. prosecheck refuses
+# an exemption list for em dashes; cspell needed the real tool name tfsec added
+# to a dictionary; gatecheck's action-pin pattern matched `statuses: read`
+# because `statuses:` ends in those five characters; and the origin check could
+# not tell a planning note discussing the www hostname from a page telling a
+# visitor to go there.
+#
+# They are one root cause and three different answers, and pretending they are
+# one answer is how the wrong one gets applied. The root cause: each check
+# matched TEXT while its claim was about a POSITION in a structure. The answers,
+# in the order to try them:
+#
+#   1. Parse the position. gatecheck's was this: an action reference is the
+#      value of a `uses:` key, and a pattern anchored there cannot be fooled by
+#      a word that ends in the same five characters. No exemption was needed
+#      because the mention was never in the position.
+#   2. Narrow the input until every occurrence in it IS a use. This check is
+#      this one. Walking the served tree instead of the repository is what makes
+#      docs/plan/notes/www-tls.md a non-question: it is a planning note, it is
+#      not published, and a gate over published files never sees it. The
+#      distinction the old check could not draw is one it no longer has to.
+#   3. A closed list with a stated reason per row, LAST. cspell's dictionary and
+#      tools/docs/wiring-exemptions.tsv are this, legitimately: spelling and
+#      deploy wiring have no structure left to appeal to, the sets are small,
+#      and a row that has stopped being needed is reported so the list cannot
+#      rot. prosecheck refuses one because for punctuation there is no true
+#      exception to state, and a list with nothing true in it is a place to put
+#      findings nobody understood.
+#
+# Reach for 3 only when 1 and 2 are genuinely unavailable. An exemption is a
+# sentence somebody has to keep being right about; a narrower input is not.
+#
+# THE REACH IS ASSERTED, not assumed, and that is the half that would have
+# caught the original defect. Content assertions cannot: they were green while
+# the gate read three fifths of the site, and they would be green again if
+# somebody narrowed the walk back tomorrow. So this requires the canonical
+# origin to appear BOTH under site/docs and outside it. A run that has stopped
+# reading either half fails by name instead of passing over an empty set.
+python3 - <<'ORIGIN' || exit 1
+import os, re, sys
+
+CANONICAL = "https://antifailure.dev"
+SERVED = re.compile(r"\.(html|md|txt|xml|json|js|webmanifest)$", re.I)
+SPELLING = re.compile(r"https?://(?:www\.)?antifailure\.dev", re.I)
+
+offenders = {}
+served = 0
+canonical_in = {"docs": 0, "www": 0}
+
+for dirpath, _, filenames in os.walk("site"):
+    for name in filenames:
+        if not SERVED.search(name):
+            continue
+        path = os.path.join(dirpath, name)
+        rel = os.path.relpath(path, "site")
+        served += 1
+        with open(path, encoding="utf-8", errors="replace") as f:
+            body = f.read()
+        half = "docs" if rel == "docs" or rel.startswith("docs" + os.sep) else "www"
+        for match in SPELLING.finditer(body):
+            if match.group(0) == CANONICAL:
+                canonical_in[half] += 1
+            else:
+                offenders.setdefault(rel, set()).add(match.group(0))
+
+problems = []
+if served < 200:
+    problems.append(
+        f"read only {served} served files out of site/, which is below the floor. "
+        "A walk that has stopped matching looks exactly like a site with nothing "
+        "in it, and both pass"
+    )
+for half, where in (("www", "outside site/docs"), ("docs", "under site/docs")):
+    if canonical_in[half] == 0:
+        problems.append(
+            f"no file {where} names {CANONICAL} at all, so this check is not "
+            f"reading the {half} half of the assembled site. That is the exact "
+            "defect it was moved here to end: it used to read www/out only, and "
+            "claimed to have read every built file"
+        )
+
+if problems:
+    print("the one-origin check cannot make the claim it makes:")
+    for problem in problems:
+        print("  " + problem)
+    sys.exit(1)
+
+if offenders:
+    total = sum(len(s) for s in offenders.values())
+    print(f"{len(offenders)} served files spell the site as something other than {CANONICAL}:")
+    for rel in sorted(offenders)[:20]:
+        print(f"  {rel}: {', '.join(sorted(offenders[rel]))}")
+    if len(offenders) > 20:
+        print(f"  ... and {len(offenders) - 20} more files")
+    print(
+        f"{total} wrong spellings. Every absolute URL this site emits has to be "
+        f"{CANONICAL}: www and the http form are both live and both split every "
+        "signal that points here between two spellings of one page."
+    )
+    sys.exit(1)
+
+print(
+    f"one origin: {served} served files, {canonical_in['www'] + canonical_in['docs']} "
+    f"occurrences of {CANONICAL}, {canonical_in['docs']} of them under /docs, "
+    "and no other spelling anywhere"
+)
+ORIGIN
+
 # Assert the promises, rather than trusting the copies above. Each of these is
 # an address something already shipped points at.
 for required in \

--- a/www/scripts/check-seo.mjs
+++ b/www/scripts/check-seo.mjs
@@ -40,14 +40,14 @@ const OUT = path.join(ROOT, "out");
  * plaintext request to one, but it is the wrong URL in the index and it splits
  * every signal that points at the site between two spellings of it.
  *
- * Both wrong spellings are asserted against, not just the scheme: www is a
- * second live origin serving this same build on its own certificate, so the www
- * origin is reachable, returns 200, and is exactly as wrong to canonicalise to
- * as the http:// one.
+ * The assertions here reach the tags this file parses: canonicals, og:urls,
+ * robots and the sitemaps. The sweep for every OTHER spelling of the site, in
+ * every file the host serves, is in tools/site/assemble.sh, because it has to
+ * read the documentation half of the site and this file never has. See the note
+ * where that check used to be, at the bottom of this file.
  *
  * THIS DOES NOT CONTRADICT AF_SITE_ORIGIN ACCEPTING THE www ORIGIN, and the two
  * arrived within a day of each other so somebody will meet them together.
- *
  * They govern different things. This rule is about what the site PUBLISHES: one
  * spelling in the index, one target for every inbound signal, no split between
  * two addresses for the same page. AF_SITE_ORIGIN is about which page the API
@@ -56,35 +56,8 @@ const OUT = path.join(ROOT, "out");
  * person arrived on is how the marketing site spent a week with every form and
  * every beacon returning 403 to anybody who typed four extra characters. Both
  * rules are right, and holding only one of them is what broke it.
- *
- * THERE IS DELIBERATELY NO EXEMPTION FOR PROSE THAT NAMES THE HOSTNAME, and the
- * changelog is where that bites: `.changes/*.md` is rendered into /changelog,
- * so a release note about a www bug trips this. It was tempting to exempt a
- * mention as opposed to a use, and the reason not to is measured rather than
- * felt. In changelog.html the string sits inside a <code> element and really is
- * inert. In changelog.md and llms-full.txt, which are the surfaces built FOR
- * machines, the backticks are stripped and it appears as a BARE URL. llms-full
- * .txt is what an agent fetches instead of reading the site, so a "mention"
- * there is a link an agent may follow or cite, pointed at the exact origin every
- * rel=canonical on the site asks it to ignore. That is a use.
- *
- * The other reason is this check's own design, in the comment above the
- * assertion: it searches for the wrong answer rather than surveying the right
- * one, so it needs no list of files allowed to mention the site and a file added
- * later cannot fall outside it. An exemption list is the one thing that reopens
- * that hole, and the person who adds the second row is always in a hurry.
- *
- * A note can still be completely specific without emitting the origin: name the
- * hostname, say the header carried it, quote the status code and the message the
- * visitor saw. Going vague to get past this is not the deal. See
- * .changes/the-www-hostname-could-not-talk-to-its-own-api.md for one that does.
  */
 const ORIGIN = "https://antifailure.dev";
-const WRONG_ORIGINS = [
-  "http://antifailure.dev",
-  "http://www.antifailure.dev",
-  "https://www.antifailure.dev",
-];
 
 let failures = 0;
 let checks = 0;
@@ -846,38 +819,21 @@ assert(
 
 // One origin, everywhere, in every file the host will serve.
 //
-// The tag checks above reach canonicals and og:urls. They do not reach a
-// JSON-LD @id, a link written by hand in MDX, a URL baked into a JS chunk, or
-// the markdown twins, and every one of those is a place the site states its own
-// address. This is the assertion that covers all of them at once, and it is
-// deliberately a search for the wrong answer rather than a survey of the right
-// one: it needs no list of the files that are allowed to mention the site, so
-// a file added later cannot fall outside it.
-console.log("\nOne origin");
-const SERVED = /\.(html|md|txt|xml|json|js|webmanifest)$/i;
-function servedFiles(dir) {
-  const found = [];
-  for (const entry of readdirSync(dir)) {
-    const full = path.join(dir, entry);
-    if (statSync(full).isDirectory()) found.push(...servedFiles(full));
-    else if (SERVED.test(entry)) found.push(full);
-  }
-  return found;
-}
-const offOrigin = [];
-for (const file of servedFiles(OUT)) {
-  const body = readFileSync(file, "utf8");
-  for (const wrong of WRONG_ORIGINS) {
-    if (body.includes(wrong)) offOrigin.push(`${path.relative(OUT, file)} (${wrong})`);
-  }
-}
-assert(
-  offOrigin.length === 0,
-  `no built file spells the site any way but ${ORIGIN}`,
-  offOrigin.length > 0
-    ? `${offOrigin.length} occurrences: ${offOrigin.slice(0, 5).join(", ")}${offOrigin.length > 5 ? " ..." : ""}`
-    : "",
-);
+// MOVED, to tools/site/assemble.sh, and the move is the point rather than a
+// tidy-up. This assertion used to live here and read OUT, which is www/out. It
+// said "no built file spells the site any way but https://antifailure.dev", and
+// www/out is 307 of the published site's 499 served files: the documentation,
+// the installer and the schemas were never opened by the gate that claimed to
+// have read every one of them.
+//
+// assemble.sh is the only step that has both builds plus the files neither
+// build produces, which is the same reason the trailing-slash policy is
+// asserted there and not here. It also asserts its own reach now, by requiring
+// the canonical origin under site/docs and outside it, so a walk that narrows
+// back to one half fails by name instead of passing over an empty set.
+//
+// Do not put a copy back here. A second, narrower copy of a claim is how the
+// two drift into disagreeing, and the narrower one is the one that goes green.
 
 console.log(`\n${checks - failures}/${checks} passed`);
 if (failures > 0) {


### PR DESCRIPTION
It asserted, in its own words, that "no built file spells the site any way but
https://antifailure.dev". It walked www/out. The published site is not www/out:
tools/site/assemble.sh builds it from www AND docs, and then copies in install.sh
and schemas/, which neither build produces. Measured on this tree, www/out holds
307 served files and the assembled site holds 499. The gate had never opened 192
of them, and 89 of those are documentation pages, which is the majority of the
site by page count.

So the sentence was true about three fifths of the site and was written about
all of it. The deploy time step that does read site/docs resolves hrefs and has
no opinion about which host a page names, so a documentation page could tell a
reader to go to an address the product does not canonicalise to, and nothing
anywhere would have said so.

Nothing is wrong in the unread three fifths today, and that is the argument for
moving the check rather than against it. A gate whose claim is wider than its
reach has not been lucky. It has never been asked the question, and the day
somebody writes the wrong address into a documentation page is the day it turns
out nobody was reading.

Moved into assemble.sh, for the same reason the trailing slash policy is
asserted there: it is the only step that has both builds plus the files neither
build produces. check-seo.mjs keeps ORIGIN, which eleven other assertions in it
read, and carries a note where the block used to be saying not to put a narrower
copy back.

Two things changed in the moving.

The wrong spellings are DERIVED rather than listed. The old check carried three
literals, and the one that caused the trouble, the www hostname, was added to
that list after it was written. This matches any http or https, apex or www
spelling and refuses everything that is not the canonical one, so a fourth
spelling is caught without anybody remembering to add it. Other subdomains are
deliberately untouched: a different subdomain is a different site, not a
different spelling of this one.

And the REACH is asserted, which is the half that would have caught the original
defect. A content assertion cannot: it was green while the gate read three
fifths of the site and would be green again if somebody narrowed the walk
tomorrow. The check now requires the canonical origin to appear both under
site/docs and outside it, and says which half it stopped reading. Narrowing the
walk to www/out fails it by name.

Verified, both directions, on a real build. Against the tree as it stands: 499
served files, 7311 occurrences of the canonical origin, 1218 of them under
/docs, no other spelling, exit 0. Against a documentation page carrying the www
hostname: the check names docs/index.html, docs/index.md and docs/llms-full.txt
and exits 1, while the previous gate, run unmodified against www/out on that
same tree, prints "ok no built file spells the site any way but
https://antifailure.dev" and passes 89 of 89.