### PR TITLE
security: a burst of merges cancelled the day's only scheduled scan

### DIFF
--- a/.changes/a-merge-burst-cancelled-the-days-only-scan.md
+++ b/.changes/a-merge-burst-cancelled-the-days-only-scan.md
@@ -1,0 +1,13 @@
+# security
+
+A burst of merges to main cancelled the day's scheduled vulnerability scan
+while it was still pending, so the daily scan never completed. The watchdog
+that exists to notice a scan has stopped running reported it, correctly, and
+main went red for a reason no code change caused.
+
+Two halves. The scheduled scan now has its own concurrency group, so activity
+on main cannot reach it. And the watchdog skips a cancelled run rather than
+reading it as a failure, because GitHub uses that one word for three unrelated
+things and none of them is a verdict. The freshness limit still decides, so a
+schedule that is cancelled every day ages out and alarms anyway, and a scan
+that genuinely fails still alarms at once.

--- a/.github/workflows/security-watch.yml
+++ b/.github/workflows/security-watch.yml
@@ -96,12 +96,34 @@ jobs:
           # requests makes a dead schedule look fresh. The daily run is the
           # control; a pull request run is a check on that pull request and is
           # visible there.
-          run_json=$(gh api \
-            "repos/${GH_REPO}/actions/workflows/security.yml/runs?event=schedule&status=completed&per_page=1" \
-            --jq '.workflow_runs[0] // empty')
+          # CANCELLED IS NOT A VERDICT, IN EITHER DIRECTION, and reading it
+          # as one was this check's own defect. GitHub cancels a merely
+          # PENDING run when a newer one queues in the same group, so a burst
+          # of merges to main cancelled the daily scan on 2026-09-05 and this
+          # check reported that vulnerability scanning had stopped working. It
+          # had not: the scan before it passed and the scan after it passed.
+          #
+          # A watchdog that reds on somebody's merge cadence is one people
+          # learn to ignore, and it is the only thing standing between a
+          # silently disabled schedule and nobody noticing. So a cancelled run
+          # is SKIPPED rather than believed, and the age check below is what
+          # then decides. That is strictly stronger than it sounds: skipping
+          # carries no information forward, so a schedule that is cancelled
+          # every day ages past the limit and alarms anyway, while a scan that
+          # genuinely FAILED still reports `failure` and alarms immediately.
+          #
+          # security.yml now keys its concurrency on the event so a merge
+          # burst cannot reach the daily run at all. This half is the belt to
+          # that braces: it is what makes the check honest about a word GitHub
+          # uses for three unrelated things.
+          runs_json=$(gh api \
+            "repos/${GH_REPO}/actions/workflows/security.yml/runs?event=schedule&status=completed&per_page=20" \
+            --jq '[.workflow_runs[] | select(.conclusion != "cancelled")]')
+
+          run_json=$(printf '%s' "${runs_json}" | jq -r '.[0] // empty')
 
           if [ -z "${run_json}" ]; then
-            echo "problem=The Security workflow has no completed SCHEDULED run at all. Either it has never run on its cron, or the schedule was disabled before the first one." >> "$GITHUB_OUTPUT"
+            echo "problem=The Security workflow has no completed SCHEDULED run that was not cancelled. Either it has never run to a conclusion on its cron, the schedule was disabled, or every recent scheduled run was cancelled before it could start." >> "$GITHUB_OUTPUT"
             echo "url=" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,7 +18,26 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # The daily scan is in its own group, and that is not a detail.
+  #
+  # Everything below about pending runs is true, and it was written about
+  # commits. It applies to the SCHEDULE too, and there the cost is different:
+  # a push run that gets skipped is one commit without its own verdict, and
+  # the newest commit still reaches one. The scheduled run is not one of many.
+  # It is the freshness control, it is the only run `security-watch` measures,
+  # and there is exactly one a day.
+  #
+  # On 2026-09-05 a burst of merges to main cancelled it while it was pending,
+  # so the day's scan never completed, `security-watch` reported the newest
+  # SCHEDULED scan as cancelled, and it was right to. Reading a push run as a
+  # substitute is the one thing that watchdog deliberately refuses, because a
+  # busy afternoon of pull requests would otherwise make a dead schedule look
+  # fresh.
+  #
+  # Keying the group on the event separates the two. A merge burst can still
+  # skip a pending push run, which is the accepted trade below, and it can no
+  # longer touch the daily one.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'schedule' && 'schedule' || 'change' }}
   # A run on main is the verdict a tag and a deploy are read against, so it
   # is never cancelled. On a branch the saving is real and nothing depends
   # on the superseded answer, so cancelling stays.


### PR DESCRIPTION
`security.yml` put its push, pull request and scheduled runs in one
concurrency group. On main `cancel-in-progress` is false, which stops a
started run being killed, and GitHub still cancels a run that is merely
PENDING when a newer one queues behind the same in progress run. The comment
on that line already said so, and accepted the trade for commits: a push run
that gets skipped costs one commit its own verdict while the newest commit
still reaches one.

The schedule is not one of many. It is the freshness control, it is the only
run `security-watch` measures, and there is exactly one a day. Eleven merges
to main on 2026-09-05 cancelled it while it was pending, so the day's scan
never completed at all.

`security-watch` then said vulnerability scanning had stopped working, and it
was RIGHT to. It refuses to read a push triggered scan as a substitute,
deliberately, because a busy afternoon of pull requests would otherwise make a
dead schedule look fresh. That refusal is the whole value of the check.

The first half is that the scheduled run now has its own concurrency group, so
merge activity cannot reach it.

The second half is that reading `cancelled` as a failure was this watchdog's
own defect, and it is the same word this repository already has a rule about:
GitHub uses it for a run that hit its own time limit, a run somebody stopped by
hand, and a run a newer push superseded, and none of the three is a verdict. A
watchdog that reds on somebody's merge cadence is one people learn to ignore,
and it is the only thing standing between a silently disabled schedule and
nobody noticing.

So a cancelled scheduled run is now skipped rather than believed, and the age
limit decides. That is stronger than it sounds, because skipping carries no
information forward. Proved against the live API rather than described:

    skipping cancelled, the newest scheduled run is b35c2428 success,
      23h old against a 26h limit                              -> green
    newest scheduled run concluded failure                     -> ALARM
    every scheduled run cancelled                              -> ALARM, named
    schedule silently disabled, newest good run 844h old       -> ALARM