### PR TITLE
control plane: the 404 sent people to a document the route was never in

### DIFF
--- a/.changes/the-404-sent-people-to-a-document-that-omits-the-route.md
+++ b/.changes/the-404-sent-people-to-a-document-that-omits-the-route.md
@@ -1,0 +1,21 @@
+# fixed
+
+The API's 404 told callers to look somewhere the route was never going to be.
+
+A request to a path with no route answered "No endpoint at this path. GET
+/openapi.json lists every endpoint this control plane serves." The second half
+of that was false. The published document describes the endpoints a client can
+integrate with, and the transport behind the console, the `af` command line and
+the engine is deliberately left out of it, route by route and with reasons
+recorded. Fifty one of the sixty three routes the control plane registers are
+not in the document.
+
+So somebody who mistyped `/v1/applications` read that sentence, fetched the
+document, did not find the route there either, and had been told by us to
+conclude it does not exist. It does.
+
+The 404 now says what the document is and what it leaves out, so a route
+missing from it reads as possibly excluded rather than as absent. A test holds
+the sentence to the register in both directions: the route it names has to be
+one this process serves, and the disclaimer has to be there exactly while the
+document is not exhaustive.

--- a/web/apps/api/src/notfound.ts
+++ b/web/apps/api/src/notfound.ts
@@ -27,13 +27,37 @@ import type { Context } from 'hono'
  * The resolution names an endpoint this same process serves rather than a
  * documentation page, so it cannot rot: if `GET /openapi.json` ever stops
  * answering, the answer to this is broken in a way a test can see.
+ *
+ * IT ALSO HAS TO BE TRUE, WHICH IT WAS NOT. This sentence used to say the
+ * document "lists every endpoint this control plane serves". Production serves
+ * that document with 94 paths and none of the four routes the marketing site
+ * calls appears in it, because `boundary.ts` classifies all four `excluded`
+ * with stated grounds and route-boundary.test.ts fails if the document ever
+ * carries one. So somebody who mistyped `/v1/application` read this line,
+ * fetched the document, did not find `/v1/applications` there either, and had
+ * been told by us to conclude that the endpoint does not exist. It does.
+ *
+ * The replacement says what the document IS, which is the surface a client can
+ * integrate with, and what it deliberately leaves out, which is the transport
+ * three first party callers use. "Some endpoints are not listed" would have
+ * been a hedge that helps nobody: a reader needs to know whether the thing
+ * they were looking for is the kind of thing that would be in there.
+ *
+ * Nothing pinned the old sentence, which is why it stayed false through the
+ * change that made it false. route-boundary.test.ts now holds this body to the
+ * register in both directions: the route it names has to be one this process
+ * serves, and the disclaimer has to be present exactly while there are routes
+ * served here that the document does not carry.
  */
 export function apiNotFound(c: Context): Response {
   return c.json(
     {
       error:
-        'No endpoint at this path. GET /openapi.json lists every endpoint this ' +
-        'control plane serves.',
+        'No endpoint at this path. GET /openapi.json describes the endpoints a ' +
+        'client can integrate with. It is not everything this control plane ' +
+        'serves: the wire behind the console, the af command line and the engine ' +
+        'is deliberately left out, so a route missing from that document may ' +
+        'still exist here.',
     },
     404,
   )

--- a/web/apps/api/test/route-boundary.test.ts
+++ b/web/apps/api/test/route-boundary.test.ts
@@ -341,3 +341,163 @@ describe('the route boundary', () => {
     assert.deepEqual(missing, ['GET /v1/invented'], 'a contract route absent from the document was not caught')
   })
 })
+
+// ---------------------------------------------------------------------------
+// What the 404 says about the document, held to the same register.
+// ---------------------------------------------------------------------------
+//
+// `apiNotFound` used to tell every caller "GET /openapi.json lists every
+// endpoint this control plane serves". That was false the moment #93 withheld
+// the operator surface and stayed false through every route classified
+// `excluded` since. Production serves the document with 94 paths and not one
+// of the four routes the marketing site calls is in it.
+//
+// The cost is specific rather than cosmetic. Somebody who mistypes
+// `/v1/application` gets that sentence, fetches the document, does not find
+// `/v1/applications` in it either, and concludes from what we told them that
+// the endpoint does not exist. It does. Watch the near miss while reading
+// this: `/v1/auth/github-oidc` IS in the document and is a different route
+// from `GET /auth/github`, which is not.
+//
+// Nothing pinned the sentence, so nothing could notice it had gone false.
+// These three assertions are what a false claim in this particular error body
+// is catchable BY, and the reason it is catchable at all is that the claim is
+// about a document this same process serves and a register this repository
+// already keeps. Neither of those is true of error bodies in general, and no
+// assertion here would catch a false claim about anything else.
+describe('the 404 the API answers with', () => {
+  /** The body the running server actually returns for an unrouted path. */
+  async function notFoundBody(): Promise<string> {
+    const { app } = createServer({
+      pool: {} as unknown as Pool,
+      github: {} as unknown as GitHubClient,
+    })
+    // A path with the shape of the mistake this is for: one character off a
+    // route that exists and is deliberately not in the document.
+    const res = await app.request('/v1/application')
+    assert.equal(res.status, 404, 'the path chosen for this test is routed after all')
+    const body = (await res.json()) as { error?: string }
+    assert.ok(typeof body.error === 'string' && body.error.length > 0, 'the 404 carries no message')
+    return body.error
+  }
+
+  /**
+   * The disclaimer the body has to carry while the document is not exhaustive,
+   * and has to drop when it is.
+   *
+   * A substring rather than the whole sentence, because pinning the whole
+   * sentence would fail on a comma and teach people to update the literal
+   * without re-reading the claim. A substring rather than a pattern for words
+   * like "every" or "all", because the honest sentence has to be able to
+   * NEGATE a completeness claim and a rule that cannot tell a mention from a
+   * use would refuse it. That distinction has cost this repository four
+   * instruments in one day.
+   */
+  const NOT_EXHAUSTIVE = 'not everything this control plane serves'
+
+  it('names a route this same process serves, so the answer cannot rot', async () => {
+    const message = await notFoundBody()
+    const named = message.match(/\b(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS) (\/\S*)/)
+    assert.ok(
+      named,
+      `the 404 names no route to go and look at, so nothing here can check what it points ` +
+        `somebody at: ${JSON.stringify(message)}`,
+    )
+    // The trailing punctuation of the sentence is not part of the path, and
+    // the dot in `/openapi.json` is. Stripping only the sentence enders keeps
+    // both true; a character class that excluded dots read the route as
+    // `/openapi` and failed on the correct message.
+    const route = `${named[1]} ${named[2]!.replace(/[.,;:]+$/, '')}`
+    assert.ok(
+      servedRoutes().includes(route),
+      `the 404 sends a caller to ${route} and this process does not serve it`,
+    )
+  })
+
+  /**
+   * The rule, as a function, so both of its branches can be exercised.
+   *
+   * Returns what is wrong or null. The real assertion below feeds it the real
+   * numbers and the real body; the control after it feeds it fabricated ones,
+   * because a rule that has only ever been shown agreeing with today's tree is
+   * evidence that today's tree is consistent and not that an inconsistent one
+   * would be caught.
+   */
+  function claimProblem(absent: string[], served: number, message: string): string | null {
+    if (absent.length > 0) {
+      if (message.includes(NOT_EXHAUSTIVE)) return null
+      return (
+        `${absent.length} of the ${served} routes this process serves are not in openapi.json, ` +
+        `and the 404 does not say so:\n  ${JSON.stringify(message)}\n` +
+        `A caller who mistyped one of them reads this, fetches the document, does not find the ` +
+        `route there either, and concludes it does not exist. Among the absent: ` +
+        `${absent.slice(0, 4).join(', ')}`
+      )
+    }
+    if (!message.includes(NOT_EXHAUSTIVE)) return null
+    return (
+      `the document now carries every route this process serves, so the 404 has nothing left ` +
+      `to disclaim. Delete the clause naming ${JSON.stringify(NOT_EXHAUSTIVE)}.`
+    )
+  }
+
+  it('does not tell a caller the document is complete while it is not', async () => {
+    // The decidable half. "Is the document exhaustive" is a set comparison
+    // this file already knows how to do, so the claim in the body is checked
+    // against the answer rather than against a form of words.
+    const served = servedRoutes()
+    assert.ok(
+      served.length > 50,
+      `only ${served.length} routes were found, so this comparison is not looking at the server`,
+    )
+    const absent = served.filter((route) => {
+      const space = route.indexOf(' ')
+      return !generated.has(`${route.slice(0, space)} ${documentPath(route.slice(space + 1))}`)
+    })
+    assert.equal(claimProblem(absent, served.length, await notFoundBody()), null)
+  })
+
+  it('catches the claim in both directions, on fabricated numbers', () => {
+    // The negative control. Without it the assertion above is only evidence
+    // that the sentence and the register agree today.
+    assert.match(
+      claimProblem(['GET /auth/github'], 100, 'GET /openapi.json lists every endpoint this control plane serves.') ?? '',
+      /does not say so/,
+      'a completeness claim over a document missing a served route was not caught',
+    )
+    assert.equal(
+      claimProblem(['GET /auth/github'], 100, `it is ${NOT_EXHAUSTIVE}`),
+      null,
+      'an honest disclaimer was reported as a problem',
+    )
+    assert.match(
+      claimProblem([], 100, `it is ${NOT_EXHAUSTIVE}`) ?? '',
+      /nothing left to disclaim/,
+      'a disclaimer left behind after the document became complete was not caught',
+    )
+    assert.equal(
+      claimProblem([], 100, 'GET /openapi.json describes the endpoints a client can integrate with.'),
+      null,
+      'a body with no claim to make was reported as a problem',
+    )
+  })
+
+  it('is false about the four routes the site calls, which is what produced this', async () => {
+    // The concrete case, named so it cannot be argued away as theoretical. If
+    // any of these is ever published the assertion fails and whoever published
+    // it deletes the line, the same self-emptying device as
+    // CONTRACT_NOT_YET_IN_DOCUMENT above.
+    const siteCalls = ['GET /auth/github', 'POST /v1/applications', 'POST /v1/leads']
+    const served = new Set(servedRoutes())
+    for (const route of siteCalls) {
+      assert.ok(served.has(route), `${route} is not served, so this case no longer says anything`)
+      const space = route.indexOf(' ')
+      const published = `${route.slice(0, space)} ${documentPath(route.slice(space + 1))}`
+      assert.ok(
+        !generated.has(published),
+        `${route} is in the document now. Delete it from this list; the 404's disclaimer is ` +
+          `about the routes that are not.`,
+      )
+    }
+  })
+})


### PR DESCRIPTION
## The failure

`web/apps/api/src/notfound.ts` answered every unrouted path with:

> No endpoint at this path. GET /openapi.json lists every endpoint this control plane serves.

The second sentence was false, and false in the direction that costs somebody
their afternoon. Fifty one of the sixty three routes this process registers are
absent from `openapi.json`, because `boundary.ts` classifies them `excluded`
with a recorded ground: the console's own wire, the wire underneath an `af`
command, the wire between the engine and the control plane, another vendor's
shapes, the operator surface. `route-boundary.test.ts` already fails if one of
them ever appears in the document.

So a caller who mistypes `/v1/applications` reads that sentence, fetches the
document, does not find the route there either, and concludes from what we told
them that the endpoint does not exist. It exists. Watch the near miss while
reviewing: `/v1/auth/github-oidc` IS in the document and is a different route
from `GET /auth/github`, which is not.

## Why it stayed false

Nothing pinned it. It was true when written and became false when #93 withheld
the operator surface; every route classified `excluded` since made it more so.
No test in the tree reads this body, and `routecheck` decides on the status line
and the `x-request-id` header rather than on what the body says.

## The replacement

> No endpoint at this path. GET /openapi.json describes the endpoints a client
> can integrate with. It is not everything this control plane serves: the wire
> behind the console, the af command line and the engine is deliberately left
> out, so a route missing from that document may still exist here.

"Some endpoints are not listed" would have been a hedge. A reader needs to know
whether the thing they were looking for is the kind of thing that would be in
there, and the answer is that first party transport is not.

## Can it say no

Three assertions in `route-boundary.test.ts`, which needs no database because
`createServer` registers every route synchronously. They read the body the
running server actually returns for `/v1/application`, not a constant.

1. **The route it names is one this process serves.** The resolution deliberately
   points at an endpoint rather than a documentation page, so it cannot rot, and
   nothing was checking that.
2. **The disclaimer is present exactly while the document is not exhaustive.**
   A set comparison against the register, not a reading of English. Both
   branches are live: if the document ever carries everything, the test fails
   and asks for the clause to be deleted.
3. **The routes the site calls are still absent from the document.** The
   concrete case, self-emptying: publish one and the line has to go.

The rule in 2 is a function, exercised on fabricated numbers as well as real
ones, so it is not merely evidence that today's tree is self consistent.

It deliberately does NOT pattern match on "every" or "all". The honest sentence
has to be able to NEGATE a completeness claim, and a rule that cannot tell a
mention from a use would refuse the fix. Four instruments in this repository
failed exactly that way in one day.

## Mutation table

| mutation | baseline | mutated | restored |
| --- | --- | --- | --- |
| the old, false sentence is put back | PASS | FAIL | PASS |
| the 404 points at a document this process does not serve | PASS | FAIL | PASS |
| the 404 stops naming a route at all | PASS | FAIL | PASS |
| a route the site calls stops being served | PASS | FAIL | PASS |

The first one fails with the specific thing rather than a shrug:

```
51 of the 63 routes this process serves are not in openapi.json, and the 404
does not say so:
  "No endpoint at this path. GET /openapi.json lists every endpoint this control plane serves."
A caller who mistyped one of them reads this, fetches the document, does not
find the route there either, and concludes it does not exist. Among the
absent: ALL /*, ALL /trpc/*, ALL /v1/applications, DELETE /console/api/providers/:provider
```

## Is a false claim in an error body catchable in general

Not cheaply, and this one is catchable for a reason that does not generalise:
it is a claim about a document the same process serves, held against a register
this repository already keeps, so it reduces to comparing two sets. A claim
about anything else in an error body reduces to reading English, where the
honest fix and the lie use the same vocabulary. The full argument is in the
lane report; the short version is that the instrument worth having is not a
scanner over error strings but the habit of pinning any error string that makes
a checkable claim, at the place where the claim is decidable.

## Deployment

Control plane, so this reaches production on the tag clock. `apiNotFound` is
also the console's 404 for a path with no console class, so the same sentence
moves there.
