### PR TITLE
engine: af runner check said complete about a tree it could not read

### DIFF
--- a/.changes/complete-true-about-a-runner-nothing-could-read.md
+++ b/.changes/complete-true-about-a-runner-nothing-could-read.md
@@ -1,0 +1,21 @@
+# fixed
+
+`af runner check` said the runner was complete about a tree it had just said it
+could not read.
+
+A runner whose `package.json` cannot be parsed reports its dependencies as not
+checked, which is right: an unanswered question is not a proven failure, and
+reporting one as the other sends somebody to reinstall over the manifest that
+is the thing wrong with the tree. The verdict underneath was then computed as
+"nothing proved a blockage, therefore ready". So the command printed the honest
+line and the wrong conclusion beneath it, answered `complete: true`, and exited
+0. A script reading the exit code was told a tree nobody could inspect was fine.
+
+The verdict now has three values rather than two, because `complete` and
+`not complete` cannot say "I could not tell". Ready exits 0, blocked exits 3,
+and undetermined exits 9, the code the error reference publishes as "nothing
+was measured". `complete` is true only for ready, and the document names the
+question that went unanswered.
+
+`af start` had the same gap on the same function and now reports that runner
+step as not checked, which is the state it already uses everywhere else.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -1684,6 +1684,14 @@ command used to report "ok runner" whenever src/main.ts existed, which was true
 of an install with no dependencies at all, and the real failure surfaced much
 later inside af test as a node error about a module it could not resolve.
 
+The verdict has three values and not two, for the same reason. Ready means
+every question that decides whether af test can run was asked and answered ok,
+and exits 0. Blocked means one of them was answered no, and exits 3. Undetermined
+means one of them could not be answered at all, which is neither, and exits 9,
+the code reference/errors.md publishes as "nothing was measured".
+A runner whose package.json cannot be parsed used to land in the first of those
+and report itself complete.
+
 ```
 af runner check
 ```

--- a/engine/internal/cli/runner.go
+++ b/engine/internal/cli/runner.go
@@ -42,10 +42,25 @@ func RunnerHome() (string, error) {
 // caller got and it does not say whether node is missing, the dependencies are,
 // or there is no runner at all, which are three different things to do next.
 type RunnerCheckJSON struct {
-	Path     string                `json:"path"`
-	Node     string                `json:"node"`
-	Complete bool                  `json:"complete"`
-	Checks   []RunnerCheckItemJSON `json:"checks"`
+	Path string `json:"path"`
+	Node string `json:"node"`
+	// Verdict is ready, blocked or undetermined. Read this rather than
+	// Complete when the difference between "no" and "I could not tell"
+	// matters, which for anything deciding whether to start a run it does.
+	Verdict RunnerVerdict `json:"verdict"`
+	// Complete is true only for a ready verdict.
+	//
+	// It used to be true for an undetermined one as well, because it was
+	// computed as "nothing proved a blockage". A runner whose package.json
+	// could not be parsed was reported complete, and a script reading this
+	// field was told a tree nobody could inspect was fine.
+	Complete bool `json:"complete"`
+	// Unanswered names the deciding questions that went unanswered, empty
+	// unless Verdict is undetermined. A caller that has to act on this needs
+	// to know WHICH question, and re-deriving it from Checks means knowing
+	// which of them decide.
+	Unanswered []string              `json:"unanswered,omitempty"`
+	Checks     []RunnerCheckItemJSON `json:"checks"`
 }
 
 // RunnerCheckItemJSON is one question and its answer.
@@ -205,11 +220,79 @@ func lockState(locked bool) string {
 // under every failure, including a missing node, where installing again does
 // nothing.
 type runnerCheck struct {
-	label   string
-	symbol  string
-	detail  string
-	remedy  string
-	blocker bool // a false answer here means af test cannot run at all
+	label  string
+	symbol string
+	detail string
+	remedy string
+	// decides marks a question whose answer settles whether af test can run.
+	//
+	// It used to be spelled `blocker` and set only on the branches that had
+	// PROVED a failure, and the verdict was computed from it as "no blocker,
+	// therefore ready". That reads as an answer and is not one. A runner whose
+	// package.json cannot be parsed produces a dependencies line of `skip`, no
+	// blocker was set because nothing was proved, and `af runner check`
+	// reported complete about a tree it had just said it could not read.
+	//
+	// The field names the QUESTION rather than the answer, so the three cases
+	// stay apart: a deciding question answered ok is readiness, answered fail
+	// is a blockage, and not answered at all is neither. The browser is not a
+	// deciding question, because a missing browser degrades a workflow to
+	// unverified rather than stopping the run, so a browser nobody could look
+	// for does not make the whole verdict unknown.
+	decides bool
+}
+
+// RunnerVerdict is what af runner check concluded, in three states rather than
+// two.
+//
+// `complete: true` and `complete: false` cannot express "I could not tell",
+// and the boolean was being derived in a way that folded the third case into
+// the first. Two of the states below are the two the boolean had; the third is
+// the one it was quietly reporting as ready.
+type RunnerVerdict string
+
+const (
+	// VerdictReady means every deciding question was asked and answered ok.
+	VerdictReady RunnerVerdict = "ready"
+	// VerdictBlocked means one of them was answered, and the answer was no.
+	VerdictBlocked RunnerVerdict = "blocked"
+	// VerdictUndetermined means one of them could not be answered, so nothing
+	// is claimed either way. It beats nothing and loses to a proven blockage:
+	// a reader with a real failure in front of them should be told about the
+	// failure, not about the question that went unasked beside it.
+	VerdictUndetermined RunnerVerdict = "undetermined"
+)
+
+// runnerVerdict reduces the findings to one of three answers.
+//
+// Blocked wins over undetermined deliberately. Both mean "do not proceed", and
+// between them the actionable one is the proof.
+func runnerVerdict(results []runnerCheck) RunnerVerdict {
+	verdict := VerdictReady
+	for _, r := range results {
+		if !r.decides {
+			continue
+		}
+		switch r.symbol {
+		case SymbolFail:
+			return VerdictBlocked
+		case SymbolSkip:
+			verdict = VerdictUndetermined
+		}
+	}
+	return verdict
+}
+
+// unanswered names the deciding questions that could not be answered, so a
+// refusal can say what it did not look at rather than only that it gave up.
+func unanswered(results []runnerCheck) []string {
+	var out []string
+	for _, r := range results {
+		if r.decides && r.symbol == SymbolSkip {
+			out = append(out, r.label+": "+r.detail)
+		}
+	}
+	return out
 }
 
 // checkRunner answers what it can about an installed runner without executing
@@ -241,10 +324,10 @@ func checkRunner(ctx context.Context, target string) []runnerCheck {
 			label: "runner", symbol: SymbolFail,
 			detail:  "no runner at " + target,
 			remedy:  "Install it with: af runner install",
-			blocker: true,
+			decides: true,
 		})
 	}
-	out = append(out, runnerCheck{label: "runner", symbol: SymbolOK, detail: target})
+	out = append(out, runnerCheck{label: "runner", symbol: SymbolOK, detail: target, decides: true})
 	out = append(out, dependencyCheck(state))
 	out = append(out, nodeCheck(nodeVersion(ctx), state))
 	out = append(out, browserCheck())
@@ -337,7 +420,7 @@ func dependencyCheck(s runnerpath.State) runnerCheck {
 		return runnerCheck{
 			label: "dependencies", symbol: SymbolSkip,
 			detail:  "not checked: " + s.Undetermined,
-			blocker: false,
+			decides: true,
 		}
 	}
 	if s.NoModules && s.Declared > 0 {
@@ -345,7 +428,7 @@ func dependencyCheck(s runnerpath.State) runnerCheck {
 			label: "dependencies", symbol: SymbolFail,
 			detail:  "node_modules is missing",
 			remedy:  "Install them with: af runner install",
-			blocker: true,
+			decides: true,
 		}
 	}
 	if len(s.Missing) > 0 {
@@ -353,7 +436,7 @@ func dependencyCheck(s runnerpath.State) runnerCheck {
 			label: "dependencies", symbol: SymbolFail,
 			detail:  "missing " + strings.Join(s.Missing, ", "),
 			remedy:  "Install them with: af runner install",
-			blocker: true,
+			decides: true,
 		}
 	}
 	// Present is not the same as pinned, and this command exists because
@@ -367,12 +450,14 @@ func dependencyCheck(s runnerpath.State) runnerCheck {
 			label: "dependencies", symbol: SymbolWarn,
 			detail: fmt.Sprintf("%d declared, all present, and not pinned: no package-lock.json",
 				s.Declared),
-			remedy: "Reinstall from a release that ships the lockfile: af runner install",
+			remedy:  "Reinstall from a release that ships the lockfile: af runner install",
+			decides: true,
 		}
 	}
 	return runnerCheck{
 		label: "dependencies", symbol: SymbolOK,
-		detail: fmt.Sprintf("%d declared, all present, pinned by package-lock.json", s.Declared),
+		detail:  fmt.Sprintf("%d declared, all present, pinned by package-lock.json", s.Declared),
+		decides: true,
 	}
 }
 
@@ -389,7 +474,7 @@ func nodeCheck(found string, s runnerpath.State) runnerCheck {
 		return runnerCheck{
 			label: "node", symbol: SymbolFail, detail: detail,
 			remedy:  "Install node from https://nodejs.org, then run af runner check again.",
-			blocker: true,
+			decides: true,
 		}
 	}
 	// A requirement nobody could read is not a requirement that was met. The
@@ -398,11 +483,12 @@ func nodeCheck(found string, s runnerpath.State) runnerCheck {
 	if s.Undetermined != "" {
 		return runnerCheck{
 			label: "node", symbol: SymbolSkip,
-			detail: found + ", not checked against a requirement: " + s.Undetermined,
+			detail:  found + ", not checked against a requirement: " + s.Undetermined,
+			decides: true,
 		}
 	}
 	if want == "" {
-		return runnerCheck{label: "node", symbol: SymbolOK, detail: found}
+		return runnerCheck{label: "node", symbol: SymbolOK, detail: found, decides: true}
 	}
 	ok, comparable := nodeSatisfies(found, want)
 	if !comparable {
@@ -410,7 +496,8 @@ func nodeCheck(found string, s runnerpath.State) runnerCheck {
 		// would put this back where it started.
 		return runnerCheck{
 			label: "node", symbol: SymbolSkip,
-			detail: found + ", against an unreadable requirement of " + want,
+			detail:  found + ", against an unreadable requirement of " + want,
+			decides: true,
 		}
 	}
 	if !ok {
@@ -418,10 +505,14 @@ func nodeCheck(found string, s runnerpath.State) runnerCheck {
 			label: "node", symbol: SymbolFail,
 			detail:  found + ", and the runner needs " + want,
 			remedy:  "Upgrade node to " + want + ", then run af runner check again.",
-			blocker: true,
+			decides: true,
 		}
 	}
-	return runnerCheck{label: "node", symbol: SymbolOK, detail: found + ", which satisfies " + want}
+	return runnerCheck{
+		label: "node", symbol: SymbolOK,
+		detail:  found + ", which satisfies " + want,
+		decides: true,
+	}
 }
 
 // nodeSatisfies handles the one range shape the runner declares, ">=x.y[.z]".
@@ -539,7 +630,15 @@ is reported as not checked rather than as ok, because a check that answers ok
 about something it never examined is worse than one that admits the gap: this
 command used to report "ok runner" whenever src/main.ts existed, which was true
 of an install with no dependencies at all, and the real failure surfaced much
-later inside af test as a node error about a module it could not resolve.`),
+later inside af test as a node error about a module it could not resolve.
+
+The verdict has three values and not two, for the same reason. Ready means
+every question that decides whether af test can run was asked and answered ok,
+and exits 0. Blocked means one of them was answered no, and exits 3. Undetermined
+means one of them could not be answered at all, which is neither, and exits 9,
+the code reference/errors.md publishes as "nothing was measured".
+A runner whose package.json cannot be parsed used to land in the first of those
+and report itself complete.`),
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			target, passedOver, err := runnerToCheck(e.WorkDir)
@@ -548,12 +647,9 @@ later inside af test as a node error about a module it could not resolve.`),
 			}
 			results := append(passedOverChecks(passedOver), checkRunner(cmd.Context(), target)...)
 
-			ready := true
+			verdict := runnerVerdict(results)
 			node := ""
 			for _, r := range results {
-				if r.blocker && r.symbol != SymbolOK {
-					ready = false
-				}
 				if r.label == "node" && r.symbol != SymbolFail {
 					node = strings.SplitN(r.detail, ",", 2)[0]
 				}
@@ -568,15 +664,15 @@ later inside af test as a node error about a module it could not resolve.`),
 				// the code and prints nothing, which is the only thing that
 				// can follow a JSON document without corrupting it.
 				if err := e.Out.JSON(RunnerCheckJSON{
-					Path: target, Node: node, Complete: ready,
-					Checks: checksJSON(results),
+					Path: target, Node: node,
+					Verdict:    verdict,
+					Complete:   verdict == VerdictReady,
+					Unanswered: unanswered(results),
+					Checks:     checksJSON(results),
 				}); err != nil {
 					return err
 				}
-				if !ready {
-					return &silentError{code: aferrors.ExitConfiguration}
-				}
-				return nil
+				return runnerCheckExit(verdict)
 			}
 			for _, r := range results {
 				e.Out.Status(r.symbol, r.label, r.detail)
@@ -593,7 +689,20 @@ later inside af test as a node error about a module it could not resolve.`),
 					e.Out.Printf("  %s\n", r)
 				}
 			}
-			if !ready {
+			if verdict == VerdictUndetermined {
+				// No remedy, because there is nothing to repair: something
+				// this command has to read could not be read, and the reader
+				// is owed the question rather than a guess at the answer.
+				// Reaching for "af runner install" here would send somebody to
+				// reinstall over a tree whose manifest is the thing that is
+				// wrong with it.
+				e.Out.Println("")
+				e.Out.Printf("  Not ready and not broken: %s\n",
+					strings.Join(unanswered(results), "; "))
+				e.Out.Printf("  Nothing above proves this runner cannot run. Nothing proves it can.\n")
+				return runnerCheckExit(verdict)
+			}
+			if verdict == VerdictBlocked {
 				// The trailing hint used to print unconditionally, and the
 				// commonest failure of all is a machine with no runner, whose
 				// only remedy is that same sentence. So the first command a
@@ -605,10 +714,43 @@ later inside af test as a node error about a module it could not resolve.`),
 					e.Out.Println("")
 					e.Out.Hint("Install it with", "af runner install")
 				}
-				return &silentError{code: aferrors.ExitConfiguration}
 			}
-			return nil
+			return runnerCheckExit(verdict)
 		},
+	}
+}
+
+// runnerCheckExit maps the three verdicts onto three exit codes.
+//
+// A script asking "can I run af test here" gets a different answer from each,
+// which is the whole point of there being three. Undetermined used to exit 0
+// alongside `complete: true`, so a caller was told a tree nobody could inspect
+// was fine.
+//
+// Undetermined exits 9, which the published table in reference/errors.md calls
+// "Nothing was measured. No workflow reached a verdict, or a workload did not
+// finish". That is this case exactly: nothing about this runner was concluded.
+// af ci already lands there through AF-AGT-007 on the same reasoning, that a
+// run in which every workflow was blocked "has not declined to blame the
+// application; it has not looked at it, and exiting zero tells the pipeline
+// that it did".
+//
+// READ THE CODE OFF THE CATALOG AND NOT OFF THE CONSTANT'S NAME. 9 is spelled
+// ExitInterruptedClean in errors.go and nothing returns it for an interrupt: a
+// second interrupt exits 10, and the only entries carrying 9 are AF-AGT-007
+// and AF-WLD-014. tools/errgen carries that correction in a comment, because
+// the page it generates once published a sentence describing something the
+// binary never does. ExitVerification, 7, was the first choice here and is
+// wrong for the same reason in reverse: its published meaning is
+// "Verification failed", which is an answer, and this is the absence of one.
+func runnerCheckExit(v RunnerVerdict) error {
+	switch v {
+	case VerdictBlocked:
+		return &silentError{code: aferrors.ExitConfiguration}
+	case VerdictUndetermined:
+		return &silentError{code: aferrors.ExitInterruptedClean}
+	default:
+		return nil
 	}
 }
 

--- a/engine/internal/cli/runner_check_test.go
+++ b/engine/internal/cli/runner_check_test.go
@@ -67,13 +67,18 @@ func TestATreeInstalledWithNoLockfileIsNotReportedAsPinned(t *testing.T) {
 	if err := os.Remove(filepath.Join(dir, "package-lock.json")); err != nil {
 		t.Fatal(err)
 	}
-	deps := find(t, checkRunner(t.Context(), dir), "dependencies")
+	results := checkRunner(t.Context(), dir)
+	deps := find(t, results, "dependencies")
 
 	if deps.symbol != SymbolWarn {
 		t.Errorf("dependencies reported %q on an unpinned tree, want warn", deps.symbol)
 	}
-	if deps.blocker {
-		t.Error("an unpinned tree is treated as a blocker, but the runner does run")
+	// Asserted on the verdict rather than on a field, because the verdict is
+	// what a caller acts on and it used to be derived from the field in a way
+	// that lost a case. The runner DOES run on an unpinned tree; it just runs
+	// versions nobody chose.
+	if v := runnerVerdict(results); v != VerdictReady {
+		t.Errorf("an unpinned tree gave the verdict %q, want ready: the runner does run", v)
 	}
 	if !strings.Contains(deps.detail, "package-lock.json") {
 		t.Errorf("detail %q does not name what is missing", deps.detail)
@@ -116,8 +121,8 @@ func TestTheTreeInstallShLeftBehindDoesNotPass(t *testing.T) {
 	if deps.symbol != SymbolFail {
 		t.Errorf("dependencies reported %q on a tree with no node_modules, want fail", deps.symbol)
 	}
-	if !deps.blocker {
-		t.Error("missing dependencies is not treated as a blocker, so the command exits 0")
+	if v := runnerVerdict(results); v != VerdictBlocked {
+		t.Errorf("a tree with no node_modules gave the verdict %q, want blocked, so the command exits 0", v)
 	}
 	if !strings.Contains(deps.detail, "node_modules") {
 		t.Errorf("detail %q does not say what is missing", deps.detail)
@@ -172,28 +177,49 @@ func TestNoRunnerAtAllIsOneClearFailure(t *testing.T) {
 	if len(results) != 1 {
 		t.Fatalf("want one finding when there is no runner, got %d: %v", len(results), results)
 	}
-	if results[0].symbol != SymbolFail || !results[0].blocker {
-		t.Errorf("no runner reported %q, blocker=%v", results[0].symbol, results[0].blocker)
+	if results[0].symbol != SymbolFail || !results[0].decides {
+		t.Errorf("no runner reported %q, decides=%v", results[0].symbol, results[0].decides)
+	}
+	if v := runnerVerdict(results); v != VerdictBlocked {
+		t.Errorf("no runner at all gave the verdict %q, want blocked", v)
 	}
 }
 
 // A package.json that cannot be read is a question this did not answer, and
 // answering ok anyway is the defect being fixed rather than a smaller version.
+//
+// THE ASSERTION THIS TEST WAS MISSING, and it is why `complete: true` came
+// back about a tree nobody could inspect. It said an unanswered question must
+// not be reported as a proven failure, which is right and is kept below. It
+// said nothing about what the whole command then concluded, and the verdict
+// was computed as "nothing proved a blockage, therefore ready". The test was
+// asserting the right thing about the finding and had no opinion about the
+// answer, so the answer was free to be wrong.
 func TestAnUnreadableManifestIsReportedAsUnchecked(t *testing.T) {
 	t.Setenv("PLAYWRIGHT_BROWSERS_PATH", t.TempDir())
 	dir := brokenTree(t)
 	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte("{not json"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	deps := find(t, checkRunner(t.Context(), dir), "dependencies")
+	results := checkRunner(t.Context(), dir)
+	deps := find(t, results, "dependencies")
 	if deps.symbol != SymbolSkip {
 		t.Errorf("reported %q for an unparseable package.json, want skip", deps.symbol)
 	}
-	if deps.blocker {
-		t.Error("an unanswered question must not be a blocker; it is not a known failure")
+	if deps.symbol == SymbolFail {
+		t.Error("an unanswered question was reported as a proven failure; it is not one")
+	}
+	if deps.remedy != "" {
+		t.Errorf("an unanswered question carries the remedy %q, which claims to fix something nobody diagnosed", deps.remedy)
 	}
 	if !strings.Contains(deps.detail, "not checked") {
 		t.Errorf("detail %q does not say the question went unanswered", deps.detail)
+	}
+	if v := runnerVerdict(results); v != VerdictUndetermined {
+		t.Errorf("a runner whose manifest could not be read gave the verdict %q, want undetermined", v)
+	}
+	if got := unanswered(results); len(got) == 0 {
+		t.Error("the verdict is undetermined and nothing names the question that went unanswered")
 	}
 }
 
@@ -274,8 +300,8 @@ func TestAMissingBrowserWarnsWithoutBlocking(t *testing.T) {
 	if got.symbol != SymbolWarn {
 		t.Errorf("reported %q for a missing browser, want warn", got.symbol)
 	}
-	if got.blocker {
-		t.Error("a missing browser blocks the run, which is stricter than af test is")
+	if got.decides {
+		t.Error("the browser is treated as deciding whether af test can run, which is stricter than af test is")
 	}
 	if !strings.Contains(got.remedy, "af runner install") {
 		t.Errorf("remedy %q does not say what to do", got.remedy)

--- a/engine/internal/cli/runner_verdict_test.go
+++ b/engine/internal/cli/runner_verdict_test.go
@@ -1,0 +1,204 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	aferrors "github.com/antifailure/antifailure/engine/internal/errors"
+)
+
+// af runner check said complete: true about a tree it had just said it could
+// not read.
+//
+// A runner whose package.json cannot be parsed reports its dependencies as
+// `skip`, with the detail "not checked", which is correct and deliberate: an
+// unanswered question is not a proven failure and reporting it as one would
+// send somebody to reinstall over a manifest that is the thing wrong with the
+// tree. The verdict was then computed as "nothing proved a blockage, therefore
+// ready", so the command printed the honest per-check line and the dishonest
+// conclusion under it, exited 0, and told any script reading the exit code
+// that a tree nobody could inspect was fine.
+//
+// The fix is a third state and not a flipped boolean. `complete` and
+// `not complete` cannot say "I could not tell", and flipping it would have
+// merged an unread manifest with a missing node, which are different things to
+// do next. `af ci` had already drawn this exact line: a run in which every
+// workflow was blocked "has not declined to blame the application; it has not
+// looked at it, and exiting zero tells the pipeline that it did".
+//
+// Every test here is written against the unreadable manifest.
+
+// unreadableManifestRunner is a runner whose source is present and whose
+// manifest cannot be parsed, which is the tree the old verdict called
+// complete.
+func unreadableManifestRunner(t *testing.T, dir string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "src", "main.ts"), []byte("// runner\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestAnUnreadableRunnerIsUndeterminedRatherThanComplete(t *testing.T) {
+	f := newRunnerFixture(t)
+	unreadableManifestRunner(t, filepath.Join(f.home, ".antifailure", "runner"))
+
+	report, out, _ := runCheck(t, f.project)
+
+	if report.Complete {
+		t.Errorf("complete: true about a runner whose manifest could not be read\n%s", out)
+	}
+	if report.Verdict != VerdictUndetermined {
+		t.Errorf("verdict %q, want %q\n%s", report.Verdict, VerdictUndetermined, out)
+	}
+	if len(report.Unanswered) == 0 {
+		t.Errorf("the verdict is undetermined and the document names no unanswered question\n%s", out)
+	}
+	// The per-check line was always right. It is the conclusion drawn from it
+	// that was wrong, so both are asserted: a fix that made the finding say
+	// "fail" would satisfy the verdict and lose the distinction.
+	if got := item(t, report, "dependencies"); got.Result != SymbolSkip {
+		t.Errorf("dependencies reported %q, want skip: nothing was proved about this tree", got.Result)
+	}
+}
+
+func TestUndeterminedDoesNotExitZero(t *testing.T) {
+	f := newRunnerFixture(t)
+	unreadableManifestRunner(t, filepath.Join(f.home, ".antifailure", "runner"))
+
+	_, out, err := runCheck(t, f.project)
+	if err == nil {
+		t.Fatalf("af runner check exited 0 on a runner it could not inspect\n%s", out)
+	}
+	if code := exitCodeOfSilent(t, err); code != aferrors.ExitInterruptedClean {
+		t.Errorf("exit code %d, want %d: an unread tree is not a configuration error, it is nothing measured",
+			code, aferrors.ExitInterruptedClean)
+	}
+}
+
+func TestTheThreeVerdictsGetThreeExitCodes(t *testing.T) {
+	// The whole point of a third state is that a caller can tell the three
+	// apart, and two of them sharing a code would be the boolean again wearing
+	// a longer name.
+	if err := runnerCheckExit(VerdictReady); err != nil {
+		t.Errorf("a ready runner exits non zero: %v", err)
+	}
+	blocked := exitCodeOfSilent(t, runnerCheckExit(VerdictBlocked))
+	undetermined := exitCodeOfSilent(t, runnerCheckExit(VerdictUndetermined))
+	if blocked != aferrors.ExitConfiguration {
+		t.Errorf("blocked exits %d, want %d", blocked, aferrors.ExitConfiguration)
+	}
+	if undetermined != aferrors.ExitInterruptedClean {
+		t.Errorf("undetermined exits %d, want %d", undetermined, aferrors.ExitInterruptedClean)
+	}
+	if blocked == undetermined {
+		t.Errorf("blocked and undetermined both exit %d, so a script cannot tell a proven failure from an unanswered question", blocked)
+	}
+}
+
+func TestAProvenFailureBeatsAnUnansweredQuestion(t *testing.T) {
+	// Both mean do not proceed, and between them the actionable one is the
+	// proof. A reader with a missing node in front of them should be told
+	// about the node, not about the manifest that could not be parsed beside
+	// it.
+	results := []runnerCheck{
+		{label: "dependencies", symbol: SymbolSkip, decides: true, detail: "not checked: package.json could not be parsed"},
+		{label: "node", symbol: SymbolFail, decides: true, detail: "not found"},
+	}
+	if v := runnerVerdict(results); v != VerdictBlocked {
+		t.Errorf("verdict %q with a proven failure present, want blocked", v)
+	}
+	// And with the failure removed, the same set is undetermined rather than
+	// ready. Without this the assertion above passes on a verdict that is
+	// always blocked.
+	if v := runnerVerdict(results[:1]); v != VerdictUndetermined {
+		t.Errorf("verdict %q with only the unanswered question, want undetermined", v)
+	}
+}
+
+func TestABrowserNobodyCouldLookForIsNotUndetermined(t *testing.T) {
+	// The browser is not a deciding question. af runner install treats a
+	// failed download as non fatal and af test returns unverified rather than
+	// a wrong answer without one, so a platform whose browser cache location
+	// is unknown must not turn the whole verdict into "I could not tell".
+	results := []runnerCheck{
+		{label: "runner", symbol: SymbolOK, decides: true},
+		{label: "dependencies", symbol: SymbolOK, decides: true},
+		{label: "node", symbol: SymbolOK, decides: true},
+		{label: "browser", symbol: SymbolSkip, detail: "not checked: this platform's browser cache location is not known here"},
+	}
+	if v := runnerVerdict(results); v != VerdictReady {
+		t.Errorf("verdict %q when only the browser went unchecked, want ready", v)
+	}
+	if got := unanswered(results); len(got) != 0 {
+		t.Errorf("the browser was reported as an unanswered deciding question: %v", got)
+	}
+}
+
+func TestTheRenderedReportSaysWhatItCouldNotCheck(t *testing.T) {
+	f := newRunnerFixture(t)
+	unreadableManifestRunner(t, filepath.Join(f.home, ".antifailure", "runner"))
+	// A browser the fixture can find, so that NOTHING in this report carries a
+	// remedy. Without it the browser line warns with "Download it with: af
+	// runner install", the closing hint is suppressed because a remedy already
+	// named that command, and the assertion below that the hint is absent
+	// could not have failed however the branch was written. Measured: the
+	// mutation that sends undetermined through the blocked branch stayed green
+	// until this fixture changed.
+	browsers := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(browsers, "chromium-1234"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PLAYWRIGHT_BROWSERS_PATH", browsers)
+
+	var buf bytes.Buffer
+	e := &Env{Out: NewOutput(&buf, &buf), WorkDir: f.project, Getenv: func(string) string { return "" }}
+	cmd := newRunnerCheckCommand(e)
+	cmd.SetContext(t.Context())
+	err := cmd.RunE(cmd, nil)
+	out := buf.String()
+
+	if err == nil {
+		t.Fatalf("the rendered report exited 0 on a runner it could not inspect\n%s", out)
+	}
+	if !strings.Contains(out, "Not ready and not broken") {
+		t.Errorf("the report does not say the verdict is neither:\n%s", out)
+	}
+	if !strings.Contains(out, "package.json could not be parsed") {
+		t.Errorf("the report does not name what it could not read:\n%s", out)
+	}
+	// The remedy for a blockage is the wrong thing to print here. Nothing is
+	// missing; something is unreadable, and reinstalling over it changes
+	// nothing about the manifest.
+	if strings.Contains(out, "Install it with") {
+		t.Errorf("the report told somebody to install over a manifest that cannot be parsed:\n%s", out)
+	}
+}
+
+func TestAfStartDoesNotCallAnUnreadableRunnerInstalled(t *testing.T) {
+	// The same defect one command over, and the reason it is fixed here too:
+	// this rung skipped past a `skip` with the other unremarkable answers and
+	// reported the runner step done. af start already has StageUnchecked for
+	// exactly this case and every other rung uses it.
+	f := newRunnerFixture(t)
+	unreadableManifestRunner(t, filepath.Join(f.home, ".antifailure", "runner"))
+
+	e := &Env{Out: NewOutput(&bytes.Buffer{}, &bytes.Buffer{}), WorkDir: f.project, Getenv: func(string) string { return "" }}
+	s := runnerState(t.Context(), e, startProbe{home: func() (string, error) { return f.home, nil }})
+	if s.state != StageUnchecked {
+		t.Errorf("the runner rung reported %q about a manifest it could not parse, want %q (detail %q)",
+			s.state, StageUnchecked, s.detail)
+	}
+	if !strings.Contains(s.why, "package.json") {
+		t.Errorf("why %q does not name what could not be read", s.why)
+	}
+}

--- a/engine/internal/cli/start.go
+++ b/engine/internal/cli/start.go
@@ -325,18 +325,28 @@ func runnerState(ctx context.Context, e *Env, p startProbe) stage {
 		s.detail, s.command = "not checked", ""
 		return s
 	}
+	results := append(passedOverChecks(passedOver), checkRunner(ctx, target)...)
 	var blockers, warnings []string
-	for _, r := range append(passedOverChecks(passedOver), checkRunner(ctx, target)...) {
+	for _, r := range results {
 		if r.symbol == SymbolOK || r.symbol == SymbolSkip {
 			continue
 		}
-		if r.blocker {
+		if r.decides {
 			blockers = append(blockers, r.label+": "+r.detail)
 			continue
 		}
 		warnings = append(warnings, r.label+": "+r.detail)
 	}
 	switch {
+	case runnerVerdict(results) == VerdictUndetermined && len(blockers) == 0:
+		// A deciding question that could not be answered. This rung used to
+		// skip past a `skip` with the other unremarkable answers and report
+		// "installed", so a runner whose package.json cannot be parsed made
+		// af start say the runner step was done. Every other rung in this
+		// command already has StageUnchecked for exactly this; the runner rung
+		// was the one that did not use it.
+		s.state, s.why = StageUnchecked, strings.Join(unanswered(results), "; ")
+		s.detail, s.command = "not checked", ""
 	case len(blockers) > 0:
 		// Pending rather than blocked. Nothing is wrong with the machine; the
 		// runner has simply not been installed yet, and af runner install is

--- a/tools/walkthrough/main.go
+++ b/tools/walkthrough/main.go
@@ -150,9 +150,16 @@ func walk(root, example string, budget time.Duration) error {
 			// prose is measuring the wrap.
 			out, err := w.af_(ctx, "runner", "check", "-o", "json")
 			var report struct {
-				Path     string `json:"path"`
-				Complete bool   `json:"complete"`
-				Checks   []struct {
+				Path string `json:"path"`
+				// Verdict is ready, blocked or undetermined. Read beside
+				// Complete rather than instead of it: this runs against the
+				// binary built from the checkout, and reading only the newer
+				// field would make this step silently vacuous against one that
+				// predates it.
+				Verdict    string   `json:"verdict"`
+				Complete   bool     `json:"complete"`
+				Unanswered []string `json:"unanswered"`
+				Checks     []struct {
 					Name, Result, Detail string
 				} `json:"checks"`
 			}
@@ -168,7 +175,12 @@ func walk(root, example string, budget time.Duration) error {
 					jsonErr, out)
 			}
 			if !report.Complete {
-				return fmt.Errorf("af runner check exited 0 and reports the runner incomplete:\n%s", out)
+				// The verdict says which of two very different things this is:
+				// a runner proven unable to run, or one nothing could be
+				// determined about. The second used to arrive here as
+				// complete: true and exit 0.
+				return fmt.Errorf("af runner check exited 0 and reports the runner %s:\n%s",
+					incompleteAs(report.Verdict, report.Unanswered), out)
 			}
 			deps := ""
 			for _, c := range report.Checks {
@@ -487,4 +499,23 @@ func jsonField(doc, key string) string {
 		return ""
 	}
 	return rest[:k]
+}
+
+// incompleteAs describes a runner check that did not come back ready.
+//
+// A binary older than the verdict field reports neither value, so this says
+// "incomplete" for it rather than inventing a state. Being vague about an old
+// binary is better than being specific and wrong about it.
+func incompleteAs(verdict string, unanswered []string) string {
+	switch verdict {
+	case "undetermined":
+		if len(unanswered) > 0 {
+			return "undetermined: " + strings.Join(unanswered, "; ")
+		}
+		return "undetermined, with nothing named as unanswered"
+	case "blocked":
+		return "blocked"
+	default:
+		return "incomplete"
+	}
 }


### PR DESCRIPTION
## The failure

A runner whose `package.json` cannot be parsed reports its dependencies as
`skip`, detail "not checked". That line is right, it is deliberate, and a test
defends it: an unanswered question is not a proven failure, and reporting one as
the other sends somebody to reinstall over the manifest that is the thing wrong
with the tree.

The conclusion drawn from it was not right. `ready` was computed as "no finding
proved a blockage", so a skip left it true. `af runner check` printed the honest
per-check line and, underneath it, `complete: true`, and exited 0. A script
reading the exit code was told a tree nobody could inspect was fine.

## The existing test, and what it was actually protecting

`TestAnUnreadableManifestIsReportedAsUnchecked` asserted `deps.blocker == false`
with the message "an unanswered question must not be a blocker; it is not a
known failure".

**It was asserting the right thing, not merely the current thing.** Conflating
"could not read" with "proved broken" is a real defect and that assertion still
holds. What it had no opinion about was the verdict the command then computed
from that flag, and the verdict was where the lie lived. The test is kept, its
claim intact, and it gains the assertion it was missing. That is recorded in a
comment on the test itself so the next reader does not have to work it out.

## Why a third state and not a flipped boolean

`complete` and `not complete` cannot express "I could not tell". Flipping it
would have merged an unread manifest with a missing node, and those are
different things to do next: one is repaired by `af runner install`, the other
is not repaired by anything this command can name.

- `verdict: ready` exits 0
- `verdict: blocked` exits 3
- `verdict: undetermined` exits 9

`complete` is true only for ready. The document also carries `unanswered`,
naming the questions that went unanswered, so a caller does not have to know
which checks decide in order to act.

`blocker` is renamed `decides`, and that rename is what makes the bug hard to
reintroduce. The old name described the ANSWER, so a finding that had proved
nothing carried `false` and was counted as harmless. The new one describes the
QUESTION. The browser is deliberately not a deciding question: `af runner
install` treats a failed download as non fatal and `af test` returns unverified
rather than a wrong answer, so a platform whose browser cache location is
unknown must not turn the whole verdict into "I could not tell".

## The exit code, and the constant name that nearly got it wrong

Undetermined exits **9**, which `reference/errors.md` publishes as "Nothing was
measured. No workflow reached a verdict, or a workload did not finish". `af ci`
already lands there through `AF-AGT-007` on the same reasoning: a run in which
every workflow was blocked "has not declined to blame the application; it has
not looked at it, and exiting zero tells the pipeline that it did".

9 is spelled `ExitInterruptedClean` in `errors.go` and **nothing returns it for
an interrupt**; a second interrupt exits 10. `tools/errgen` already carries that
correction in a comment, because the page it generates once published a sentence
describing something the binary never does. This branch was first written
against `ExitVerification`, 7, which is wrong in the mirror image: its published
meaning is "Verification failed", which is an answer, and this is the absence of
one. Reading the code off the catalog rather than off the constant's name is the
only thing that caught it.

## The same defect one command over

`af start`'s runner rung skipped past a `skip` alongside the other unremarkable
answers and reported "installed", so a manifest it could not parse read as a
completed step. Every other rung in that command already uses `StageUnchecked`
for exactly this case. Fixed here rather than named and left, because it is the
same function and the same conflation.

The walkthrough now reads `verdict` beside `complete`, so its failure message
says which of the two things went wrong, and still reads `complete` so the step
is not silently vacuous against a binary older than the field.

## Mutation table

Eleven cells, each aimed at one assertion. Baseline PASS, mutated FAIL,
restored PASS, with what the failure actually said.

| mutation | baseline | mutated | restored | what the failure said |
| --- | --- | --- | --- | --- |
| a skip stops making the verdict undetermined | PASS | FAIL | PASS | complete: true about a runner whose manifest could not be read |
| complete goes back to meaning not blocked | PASS | FAIL | PASS | complete: true about a runner whose manifest could not be read |
| the document stops naming the unanswered question | PASS | FAIL | PASS | the verdict is undetermined and the document names no unanswered question |
| undetermined exits 0 again | PASS | FAIL | PASS | af runner check exited 0 on a runner it could not inspect |
| undetermined shares an exit code with blocked | PASS | FAIL | PASS | undetermined exits 3, want 9 |
| an unanswered question outranks a proven failure | PASS | FAIL | PASS | verdict "undetermined" with a proven failure present, want blocked |
| every skip counts, deciding question or not | PASS | FAIL | PASS | verdict "undetermined" when only the browser went unchecked, want ready |
| the rendered report stops saying what it could not check | PASS | FAIL | PASS | the report does not say the verdict is neither |
| undetermined falls through to the blocked branch | PASS | FAIL | PASS | the report told somebody to install over a manifest that cannot be parsed |
| af start calls an unreadable runner installed again | PASS | FAIL | PASS | the runner rung reported "done" about a manifest it could not parse, want "unchecked" |
| an unreadable manifest is reported as a proven failure | PASS | FAIL | PASS | reported "fail" for an unparseable package.json, want skip |

**One cell stayed GREEN and the fixture was at fault, not the mutation.** The
assertion that the report must not tell somebody to install could not fail with
the fixture as written: the browser line was warning with "Download it with: af
runner install", so `namesRunnerInstall` suppressed the closing hint no matter
how the branch was written. The fixture now provides a browser, so the report
carries no remedy at all and the hint is reachable. That is recorded in a
comment on the test.

The harness itself had the bug this repository has already paid for once. It
looked for the error lines AFTER `--- FAIL:` and `go test` prints them before,
so the first pass reported every cell with an empty reason. Corrected before the
table above was produced.

## Local runs

- `go test ./internal/cli ./internal/runnerpath -count=1` ok
- `golangci-lint run --timeout 15m ./...` in `engine`: **0 issues**
- `go test ./walkthrough/... ./docs/...` in `tools`: ok
- `gofmt -l internal/cli`: clean
- `tools/prosecheck`: 814 files, 0 findings
- `docs/src/content/docs/reference/cli.md` regenerated from the command tree, not hand edited
