### PR TITLE
runner: the careers form was broken on the live site and the agent could not have said so

### DIFF
--- a/.changes/production-careers-form-smoke.md
+++ b/.changes/production-careers-form-smoke.md
@@ -1,0 +1,41 @@
+# fixed
+
+The careers form on the deployed site said "Could not reach the server" and
+nothing anybody had could see it. The site publishes on every merge to main and
+the control plane only moves when a version tag is promoted, so the page was
+live against an API twenty two commits behind it, and every check was green: the
+tree declared the route, the form posted to it, and the agents that drive the
+product on every pull request were pointed at a disposable stack built from one
+commit, where the front end and the API necessarily agree.
+
+`tools/sitesmoke` drives the real deployed site with the product's own agent and
+asserts on what a PERSON sees. It fills the careers form in on every hostname
+the site answers on, presses the button, and requires the page to show the
+control plane's own answer. When it does not, the failure quotes the sentence
+the page actually showed rather than saying that something went wrong. It runs
+on a schedule as well as after a deploy, because the failure that is live today
+arrived with no deploy at all: a second custom domain was bound to the site and
+the control plane had never heard of it, so every form on `www.antifailure.dev`
+has been refused ever since. It files no job applications: the scheduled
+workflow answers the optional work link with a URL the control plane's own
+validation refuses, so the request reaches the handler and is turned away before
+anything is written.
+
+The agent needed four fixes before it could have found this at any target. A
+checkbox reports a value whether or not it is ticked, so the snapshot called
+every required acknowledgment and every radio group already answered and the
+planner skipped them. A required field whose label matched no known shape was
+left empty, so the browser refused to submit the form at all. The submit button
+said "Send application", which is on no list of words that move a workflow
+forward, and once the document's own submit controls were consulted the site
+header's "Sign in" link still won, so the agent filled in the whole form and
+then navigated away from it. And "Could not reach the server" was on no list of
+failure signals, so the page telling the agent that its request never arrived
+was judged unreadable, the verdict was unverified, and unverified exits zero.
+
+An expectation may now be quoted, and a quoted one is required on the page
+character for character. Without that, expectations are judged by how many of
+their meaningful words appear anywhere on the page, which is right for a
+sentence about a product and wrong for a sentence a page either renders or does
+not: the control plane's own refusal scores six of its seven words against the
+careers page before the form has been touched.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -679,6 +679,20 @@ jobs:
         # deploy.yml, immediately before the publish.
         run: go run ./tools/routecheck -root .
 
+      - name: The production smoke waits for sentences we still produce
+        # tools/sitesmoke drives the deployed careers form with the product's
+        # own agent and asserts on what a PERSON sees: the confirmation when it
+        # works, and the page's own error sentence when it does not. That half
+        # runs on a schedule and after a deploy, in sitesmoke.yml, because it
+        # asks the internet.
+        #
+        # This is its offline half. It reads the sentences that check waits for
+        # out of the files that are supposed to render them, because an
+        # expectation waiting for words the site no longer shows fails every
+        # deployment, and one satisfied by the wrong page passes every one. It
+        # says out loud when it finishes that NO DEPLOYMENT WAS CHECKED.
+        run: go run ./tools/sitesmoke -root .
+
       - name: No animation that never stops
         # If a piece of UI animates on an infinite loop while the user does
         # nothing, it is wrong. Reads the built stylesheet and HTML rather than

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -471,6 +471,34 @@ jobs:
         run: node scripts/indexnow.mjs --submit
         working-directory: www
 
+      - name: A person can still use the careers form
+        # A PUBLISH IS NOT A WORKING FORM, and this is the assertion level the
+        # steps above deliberately do not reach. routecheck asked the control
+        # plane whether the route exists and got a status line. The API answers
+        # step asked whether the function app is alive and got a JSON body.
+        # Neither of them opens the page, runs its JavaScript, or makes a cross
+        # origin request from the hostname somebody typed, and "Could not reach
+        # the server" is what a person read while every one of those was green.
+        #
+        # After the publish rather than before it, on purpose. It drives the
+        # site that is now live; a check against the previous build would be
+        # answering about something nobody is using any more. Nothing here can
+        # stop the publish, and that is the honest position: this deployment
+        # split is what it is, and what this buys is that main goes red within
+        # minutes instead of somebody finding out by filling in the form.
+        #
+        # It files no job applications. See tools/sitesmoke.
+        if: ${{ env.TOKEN != '' }}
+        env:
+          TOKEN: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
+        run: |
+          npm --prefix runner ci --no-audit --no-fund
+          npx playwright install --with-deps chromium
+          go run ./tools/sitesmoke -root . \
+            -origin https://antifailure.dev \
+            -origin https://www.antifailure.dev \
+            -artifacts "${RUNNER_TEMP}/sitesmoke"
+
       - name: Say so when it was not published
         if: ${{ env.TOKEN == '' }}
         env:

--- a/.github/workflows/sitesmoke.yml
+++ b/.github/workflows/sitesmoke.yml
@@ -1,0 +1,114 @@
+name: Site smoke
+
+# A person filling in the careers form, from outside, on every hostname.
+#
+# THE FAILURE. Somebody filled in the form on the real https://antifailure.dev
+# and was told "Could not reach the server." Nothing in this repository was
+# wrong: main declared the route, the form posted to it, CI was green and the
+# deploy was green. The site publishes on every merge to main and the control
+# plane only moves when a `v*` tag is promoted, so the page was live against an
+# API twenty two commits behind it, and no check anybody had could see the space
+# between two independently versioned deployments.
+#
+# The dogfood run could not see it either, and the reason is structural rather
+# than an oversight: it builds a disposable stack out of ONE commit, so the
+# front end and the API necessarily agree, the form submits, and the run
+# correctly reports nothing wrong. Same agent, same Chromium, same form, wrong
+# target.
+#
+# WHY THIS IS NOT tools/routecheck, which merged before it and runs before the
+# site publishes. That asks the control plane whether a route exists, and it
+# reports `POST /v1/applications -> 404`. A person reads "Could not reach the
+# server." Only the second is the failure anybody had, and reaching it needs the
+# real page, its JavaScript, the control plane URL baked into the build, and a
+# cross origin request from the exact hostname somebody typed. Both are wanted.
+# Neither is the other.
+#
+# IT FILES NO JOB APPLICATIONS. The scheduled workflow answers the optional work
+# link with a URL the control plane's own validation refuses, so the request
+# reaches the handler and is refused before anything is written. The path that
+# includes the write needs -allow-writes and is not run here. The reason each
+# workflow is inert is in tools/sitesmoke/workflows.go, checked against the
+# API's source rather than assumed.
+#
+# ON A SCHEDULE AS WELL AS AFTER A DEPLOY, and the schedule is not the
+# afterthought. The failure that is live as this is written arrived with no
+# deploy at all: antifailure.dev and www.antifailure.dev are two custom domains
+# on one Static Web App, the control plane's site_origin held one of them, and
+# every form on www has been refused ever since somebody bound the second
+# domain. Nothing shipped on the day it broke.
+
+on:
+  schedule:
+    # 08:00 UTC daily, an hour after the sign-up probe, so no two scheduled
+    # jobs compete for the same runner minute.
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+  workflow_call:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sitesmoke
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    name: a person can use the careers form
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    # Same guard as deploy.yml and signup.yml. A fork running this on a
+    # schedule would drive somebody else's production site.
+    if: ${{ github.repository == 'antifailure/antifailure' }}
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: tools/go.mod
+          cache-dependency-path: tools/go.sum
+
+      - name: Install the runner and its browser
+        # The product's own agent, not a second browser harness beside it.
+        # `af runner install` resolves the same dependencies; this job installs
+        # them directly because it has no engine binary and needs no
+        # environment.
+        run: |
+          npm --prefix runner ci --no-audit --no-fund
+          npx playwright install --with-deps chromium
+
+      - name: Drive the careers form on every hostname
+        # EXPECT www TO BE RED UNTIL A TAG SHIPS THE ORIGIN FIX, and do not
+        # "fix" it here. antifailure.dev and www.antifailure.dev are two custom
+        # domains on one Static Web App, and production's site_origin names one
+        # of them, so a cross origin request from www is refused 403 and the
+        # form shows "Could not reach the server." That is a real, live,
+        # user facing breakage and it is what this check is for. The
+        # configuration fix is on a branch; production carries it only when
+        # somebody promotes a `v*` tag.
+        #
+        # Both hostnames, because both are bound, both serve every page, and
+        # neither redirects to the other, so both are addresses people type.
+        run: |
+          go run ./tools/sitesmoke -root . \
+            -origin https://antifailure.dev \
+            -origin https://www.antifailure.dev \
+            -artifacts "${RUNNER_TEMP}/sitesmoke"
+
+      - name: Keep the evidence
+        # Uploaded on a failure, because the failure is the run somebody has to
+        # reproduce and it is the hardest one to reproduce by hand.
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sitesmoke-evidence
+          path: ${{ runner.temp }}/sitesmoke
+          retention-days: 7
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -169,6 +169,7 @@ runner/artifacts/
 /runbookcheck
 /sbomcheck
 /routecheck
+/sitesmoke
 /scanrepo
 /schemadoc
 /sidebarcheck

--- a/docs/src/content/docs/guides/workflows.md
+++ b/docs/src/content/docs/guides/workflows.md
@@ -52,6 +52,38 @@ Expectations can name things outside the browser. "A welcome message arrives in
 the inbox" is checked against [the inbox](/docs/guides/inbox), which is why capture
 mode exists.
 
+## Quote a sentence the page either shows or does not
+
+An ordinary expectation is a sentence about the product, and it is judged by how
+many of its meaningful words appear on the page. Two thirds of them is enough,
+because an expectation carries connective words no page repeats and requiring
+all of them would mean writing expectations for the matcher instead of for a
+person.
+
+That reading is wrong for a page that renders one specific sentence when
+something works and a different one when it does not, which is the ordinary case
+for a form. Put such a sentence in double quotes and it is required on the page
+character for character, up to case and runs of whitespace:
+
+```yaml
+expect:
+  - '"It is written down."'
+```
+
+Two thirds of the words is a low bar on a page with four thousand characters of
+prose on it. Our own careers page is the case that earned this: the control
+plane's refusal, "Use a public http or https link without credentials", scores
+six of its seven words against that page before the form has been touched,
+because `public`, `link`, `use`, `credentials` and an install command containing
+`https` are all already on it. The expectation was satisfied before the agent
+did anything, and the workflow passed in one step over a form it never
+submitted.
+
+A quoted expectation that is absent is a FAILURE rather than an unclear result.
+A string is on the page or it is not, and there is no third answer to hedge
+towards. That is the difference that matters: an unclear result is `unverified`,
+and `unverified` exits zero.
+
 ## Ordering
 
 Workflows share an environment and run in order, because a subscription usually

--- a/justfile
+++ b/justfile
@@ -84,6 +84,7 @@ gate: _reports
     run "documented config can be set"   just wirecheck
     run "the site calls routes that exist" just routecheck
     run "every hostname has an origin"   just origincheck
+    run "the smoke waits for real sentences" just sitesmoke
     run "payment secrets reach the app"  just test-infra-config
     run "no unfinished merge"            just conflictcheck
     run "prose reads like a person"      just prosecheck
@@ -1049,6 +1050,34 @@ routecheck-deployed origin="https://app.antifailure.dev":
 # it is what keeps hostnames.txt from being a list somebody typed.
 origincheck:
     go run ./tools/origincheck origins
+
+# The sentences the production smoke waits for are still the ones we produce.
+#
+# THE OFFLINE HALF of tools/sitesmoke, and it is deliberately modest about what
+# it proves. It cannot see a deployment, and on the day the careers form broke
+# the tree was perfect: main declared the route and production was serving a
+# version from before it existed. What it CAN prove is the one way the online
+# half could go quietly wrong. The smoke waits for the control plane's own
+# refusal, "Use a public http or https link without credentials", and for the
+# site's own confirmation, "It is written down." An expectation waiting for a
+# sentence this repository no longer produces fails every deployment forever;
+# one satisfied by the wrong page passes every deployment forever. So the
+# sentences are read out of the files that are supposed to render them.
+sitesmoke:
+    go run ./tools/sitesmoke -root .
+
+# The same command against the site that is actually deployed.
+#
+# Not part of `just gate`, for the reason routecheck-deployed gives: it asks the
+# internet, and a gate that blocks a merge on somebody's bad afternoon is a gate
+# people learn to re-run rather than read. It runs on a schedule and after a
+# deploy in .github/workflows/sitesmoke.yml, which is where the answer matters.
+#
+# It files no job applications. Add -allow-writes to run the workflow that
+# does, which is the only way to prove through a browser that a valid
+# application actually reaches the database.
+sitesmoke-deployed origin="https://antifailure.dev":
+    go run ./tools/sitesmoke -root . -origin {{origin}}
 
 # Mocked providers exercise the rendered payment references without cloud access.
 test-infra-config:

--- a/runner/src/browser.ts
+++ b/runner/src/browser.ts
@@ -94,6 +94,67 @@ async function settled(pw: PWPage): Promise<void> {
   await pw.waitForLoadState('networkidle', { timeout: RENDER_MS }).catch(() => {});
 }
 
+/** How long a press gets to finish what it started, and how long still counts
+ *  as the page having stopped changing.
+ *
+ * THE FAILURE. A press on a form that submits through `fetch` returns the
+ * instant the click lands, and the page's own handler then disables the
+ * fieldset while the request is in flight. The snapshot taken immediately
+ * afterwards reads a form with every field disabled and a submit button
+ * relabelled "Recording it", which the snapshot reports as a page offering
+ * nothing at all. Driving this repository's own careers form, the agent filled
+ * it in, pressed "Send application", looked at the page a millisecond later,
+ * decided nothing there moved it forward, and followed the "Sign in" link in
+ * the site header instead. It had filled in a form and then walked away from
+ * it, and the run reported a careers page with no controls on it.
+ *
+ * `settled` CANNOT FIX THIS AND IT IS WORTH KNOWING WHY, because it looks like
+ * it should. `waitForLoadState('networkidle')` asks whether the CURRENT
+ * DOCUMENT has already reached that state, not whether the page is quiet right
+ * now. A client rendered page reaches it seconds after it loads and stays
+ * there, so every later call returns immediately, and a press that starts a
+ * request is followed by a "wait" that waits for nothing. It is still right
+ * after a navigation, which is a new document, and that is what it is kept
+ * for.
+ *
+ * What is actually being waited for is the page settling, so that is what is
+ * measured: the rendered text is read until it stops changing.
+ */
+const PRESS_MS = 15_000;
+const QUIET_MS = 300;
+
+/** Waits until the page's rendered text stops changing, or the budget runs out.
+ *
+ * Bounded on both sides on purpose. A page that never stops changing, because
+ * something on it animates or polls, must not hold a run forever; and a page
+ * that changed once must not be read in the middle of changing again.
+ */
+async function quiet(
+  pw: PWPage, budgetMs: number, inFlight: () => number,
+): Promise<void> {
+  const deadline = Date.now() + budgetMs;
+  let last: string | undefined;
+  let since = Date.now();
+  for (;;) {
+    const now = await pw.locator('body').innerText().catch(() => '');
+    // A request still in the air is the case this is really about. The form
+    // disables its own fieldset for exactly as long as the request takes, so
+    // the text is perfectly stable while the page is at its least readable:
+    // no fields, no submit control, and a button labelled "Recording it".
+    // Text alone said "settled" there, and a slow answer from the control
+    // plane was enough to make the agent walk off to the site header.
+    const busy = inFlight() > 0;
+    if (busy || now !== last) {
+      last = now;
+      since = Date.now();
+    } else if (Date.now() - since >= QUIET_MS) {
+      return;
+    }
+    if (Date.now() >= deadline) return;
+    await pw.waitForTimeout(100);
+  }
+}
+
 /** Session is one browser, one context, one page, and its evidence. */
 export class Session {
   readonly #browser: Browser;
@@ -101,6 +162,8 @@ export class Session {
   readonly #page: PWPage;
   readonly #console: string[] = [];
   readonly #failed: string[] = [];
+  /** How many requests this page has in the air right now. See quiet. */
+  #inFlight = 0;
   readonly #artifacts: string;
 
   private constructor(browser: Browser, context: BrowserContext, page: PWPage, artifacts: string) {
@@ -134,12 +197,15 @@ export class Session {
     const page = await context.newPage();
     const session = new Session(browser, context, page, options.artifacts);
 
+    page.on('request', () => { session.#inFlight++; });
+    page.on('requestfinished', () => { session.#inFlight--; });
     page.on('console', (m) => {
       if (m.type() === 'error' || m.type() === 'warning') {
         session.#console.push(`${m.type()}: ${m.text()}`);
       }
     });
     page.on('requestfailed', (r) => {
+      session.#inFlight--;
       // The egress policy is the usual cause, and naming the request is the
       // difference between a mystery and a one line fix.
       session.#failed.push(`${r.method()} ${r.url()}: ${r.failure()?.errorText ?? 'failed'}`);
@@ -150,6 +216,10 @@ export class Session {
   /** page returns the adapter the login and workflow code drives. */
   page(): Page {
     const pw = this.#page;
+    // Read through a closure rather than passed as a number, because it has to
+    // be the count AT THE MOMENT IT IS ASKED, not the count when the press
+    // started, which is always zero.
+    const inFlight = () => this.#inFlight;
     return {
       async goto(url: string) {
         await pw.goto(url, { waitUntil: 'domcontentloaded', timeout: 30_000 });
@@ -162,6 +232,13 @@ export class Session {
         // reachability and does not need to be long.
         await (await locate(pw, field, 3_000)).fill(value, { timeout: 10_000 });
       },
+      async check(field: RegExp) {
+        // A checkbox and a radio are not filled, they are chosen, and `fill`
+        // on either throws. Separated here rather than branched inside `fill`
+        // because the caller already knows which it wants: a planner that
+        // decided to tick an acknowledgment has not decided to type into it.
+        await (await locate(pw, field, 3_000)).check({ timeout: 10_000 });
+      },
       async has(field: RegExp, timeoutMs: number) {
         const half = Math.max(250, Math.floor(timeoutMs / 2));
         try {
@@ -172,20 +249,27 @@ export class Session {
         }
       },
       async click(control: RegExp) {
-        const button = pw.getByRole('button', { name: control });
-        if (await button.count() > 0) {
-          await button.first().click({ timeout: 10_000 });
-          return;
-        }
-        const link = pw.getByRole('link', { name: control });
-        if (await link.count() > 0) {
-          await link.first().click({ timeout: 10_000 });
-          return;
-        }
-        // Falls back to anything with that accessible name, which covers the
-        // div somebody made into a button. Failing here rather than guessing
-        // at a selector keeps the failure honest.
-        await pw.getByText(control).first().click({ timeout: 10_000 });
+        const press = async () => {
+          const button = pw.getByRole('button', { name: control });
+          if (await button.count() > 0) {
+            await button.first().click({ timeout: 10_000 });
+            return;
+          }
+          const link = pw.getByRole('link', { name: control });
+          if (await link.count() > 0) {
+            await link.first().click({ timeout: 10_000 });
+            return;
+          }
+          // Falls back to anything with that accessible name, which covers the
+          // div somebody made into a button. Failing here rather than guessing
+          // at a selector keeps the failure honest.
+          await pw.getByText(control).first().click({ timeout: 10_000 });
+        };
+        await press();
+        // A navigation first, which is a new document and the one thing
+        // `settled` still answers honestly, then the page's own rerender.
+        await settled(pw);
+        await quiet(pw, PRESS_MS, inFlight);
       },
       async waitForAny(patterns: readonly RegExp[], timeoutMs: number) {
         const deadline = Date.now() + timeoutMs;
@@ -227,16 +311,59 @@ export class Session {
         if (wrapping?.textContent) return wrapping.textContent.trim();
         return el.getAttribute('placeholder') ?? el.getAttribute('name') ?? '';
       };
-      const out: { name: string; type: string; filled: boolean }[] = [];
+      // A checkbox and a radio carry a `value` whether or not anybody chose
+      // them: an unticked <input type=checkbox> reads "on" and an unchosen
+      // radio reads whatever the markup gave it. So `filled: !!input.value`
+      // was TRUE for every one of them, always, and a planner that skips
+      // filled fields skipped every acknowledgment and every option group on
+      // every page. That is the reason this repository's own careers form
+      // could not be completed by its own agent: the required "I understand
+      // there is no salary" box and the role radios all reported themselves
+      // as already answered.
+      //
+      // A radio is answered when its GROUP has a chosen member rather than
+      // when this particular option is the chosen one. Reported per option it
+      // would send a planner to tick the second role after the first, which
+      // in a radio group means changing its mind rather than making progress.
+      const chosenInGroup = (input: HTMLInputElement): boolean => {
+        const scope = input.form ?? document;
+        if (!input.name) return input.checked;
+        return Array.from(
+          scope.querySelectorAll<HTMLInputElement>(
+            `input[type="radio"][name="${CSS.escape(input.name)}"]`),
+        ).some((option) => option.checked);
+      };
+      const answered = (input: HTMLInputElement): boolean => {
+        if (input.type === 'checkbox') return input.checked;
+        if (input.type === 'radio') return chosenInGroup(input);
+        return !!input.value;
+      };
+      const out: {
+        name: string; type: string; filled: boolean; required: boolean;
+      }[] = [];
       for (const el of document.querySelectorAll('input, textarea, select')) {
         const input = el as HTMLInputElement;
         if (input.type === 'hidden' || input.disabled) continue;
+        // A field the browser will not let anybody interact with is not a
+        // field. The honeypot on this repository's own careers form is the
+        // case: it is a labelled text input inside a `hidden` div, so it
+        // reported itself as ordinary here, and a planner that filled it
+        // would either time out against an invisible element or, worse,
+        // succeed and be refused by the server as a bot.
+        if (typeof input.checkVisibility === 'function' && !input.checkVisibility()) continue;
         const name = named(el);
         if (!name) continue;
-        out.push({ name, type: input.type || el.tagName.toLowerCase(), filled: !!input.value });
+        out.push({
+          name,
+          type: input.type || el.tagName.toLowerCase(),
+          filled: answered(input),
+          required: input.required,
+        });
       }
       return out;
-    }).catch(() => [] as { name: string; type: string; filled: boolean }[]);
+    }).catch(() => [] as {
+      name: string; type: string; filled: boolean; required: boolean;
+    }[]);
 
     const interactive = await pw.evaluate(() => {
       const out: string[] = [];
@@ -258,14 +385,34 @@ export class Session {
         add(el.getAttribute('aria-label') ?? el.getAttribute('title')
           ?? el.textContent ?? (el as HTMLInputElement).value);
       }
-      return { controls: out, unnamed };
-    }).catch(() => ({ controls: [] as string[], unnamed: 0 }));
+      // Which of those controls submits a form, by name.
+      //
+      // A deterministic planner knows the words that move a sign up or a
+      // checkout forward, and it cannot know the words on every form anybody
+      // writes. "Send application" is the button on this repository's own
+      // careers form and it matches none of them, so the agent filled the
+      // whole form in and then had nothing it was willing to press. The
+      // document already knows which control submits; asking it is better
+      // than adding another word to a list that can never be finished.
+      const submits: string[] = [];
+      for (const el of document.querySelectorAll(
+        'button[type="submit"], input[type="submit"], form button:not([type])')) {
+        const input = el as HTMLInputElement;
+        if (input.disabled) continue;
+        if (typeof input.checkVisibility === 'function' && !input.checkVisibility()) continue;
+        const name = (el.getAttribute('aria-label') ?? el.getAttribute('title')
+          ?? el.textContent ?? input.value ?? '').trim();
+        if (name && name.length < 60 && !submits.includes(name)) submits.push(name);
+      }
+      return { controls: out, unnamed, submits };
+    }).catch(() => ({ controls: [] as string[], unnamed: 0, submits: [] as string[] }));
 
     return {
       url: pw.url(),
       title: await pw.title().catch(() => ''),
       fields,
       controls: interactive.controls,
+      submits: interactive.submits,
       unnamed: interactive.unnamed,
       text: await pw.locator('body').innerText().catch(() => ''),
     };

--- a/runner/src/execute.ts
+++ b/runner/src/execute.ts
@@ -10,7 +10,7 @@ import { Session } from './browser.ts';
 import { signIn, type Persona, type Page } from './login.ts';
 import type { InboxSource } from './inbox.ts';
 import {
-  DeterministicPlanner, freshIdentity, judgeAll,
+  DeterministicPlanner, failureSentence, freshIdentity, judgeAll,
   type Action, type Planner, type Snapshot, type Workflow,
 } from './workflow.ts';
 import { classify, type Attempt, type Cause, type Outcome } from './verdict.ts';
@@ -200,6 +200,10 @@ async function attemptOnce(
         await page.fill(action.field, action.value);
         taken.push(`Fill ${action.field.source.replace(/[\^$]/g, '')}: ${action.why}`);
         break;
+      case 'check':
+        await page.check(action.field);
+        taken.push(`Choose ${action.field.source.replace(/[\^$]/g, '')}: ${action.why}`);
+        break;
       case 'click':
         await page.click(action.control);
         taken.push(`Press ${action.control.source.replace(/[\^$]/g, '')}: ${action.why}`);
@@ -232,12 +236,22 @@ function finalJudgement(
   switch (judgeAll(workflow.expect, snapshot.text)) {
     case 'met':
       return { cause: 'succeeded', detail: 'Every expectation is visible on the page.', taken };
-    case 'unmet':
+    case 'unmet': {
+      // Quoted, not summarised. "The page shows an error rather than what was
+      // expected" was the whole of this sentence, and it is the same sentence
+      // for a route that does not exist, a hostname the control plane refuses,
+      // a database that is down and a card that was declined. The words on the
+      // screen are the only thing that tells those apart, and they were being
+      // thrown away one line before the report was written.
+      const said = failureSentence(snapshot.text);
       return {
         cause: 'expectation-not-met',
-        detail: `${why} The page shows an error rather than what was expected.`,
+        detail: said
+          ? `${why} The page shows an error rather than what was expected. It says: "${said}"`
+          : `${why} The page shows an error rather than what was expected.`,
         taken,
       };
+    }
     default:
       return {
         // page-unreadable, not synthesized-response. This branch is about a

--- a/runner/src/login.ts
+++ b/runner/src/login.ts
@@ -60,6 +60,10 @@ export interface Page {
   goto(url: string): Promise<void>;
   /** fill types into the field with an accessible name matching the pattern. */
   fill(field: RegExp, value: string): Promise<void>;
+  /** check chooses the checkbox or radio with that accessible name. A
+   *  browser refuses to type into either, so this is not `fill` with a
+   *  different value. */
+  check(field: RegExp): Promise<void>;
   /** has answers whether that field is on the page right now, without
    *  throwing. It is what lets the sign-in path be searched rather than
    *  assumed: a fill against the wrong page costs ten seconds and reports a

--- a/runner/src/workflow.ts
+++ b/runner/src/workflow.ts
@@ -26,11 +26,34 @@ export interface Workflow {
   /** startPath is where to begin. Empty starts at the root. */
   readonly startPath?: string;
   readonly maxSteps?: number;
+  /** answers are what to type into fields this workflow names, keyed by any
+   *  part of a field's accessible name and matched case insensitively.
+   *
+   *  A table, not a script. It says what an answer IS, never what order to do
+   *  things in or which control to press, so a workflow with answers is still
+   *  a sentence with some of its nouns pinned down rather than a sequence of
+   *  clicks. The planner still decides everything else.
+   *
+   *  It exists for two things the shared shapes cannot cover. A field whose
+   *  label nothing recognises, "How many seats" or "VAT number", is otherwise
+   *  filled with a sentence saying an agent typed it, which is right for free
+   *  text and wrong for a number. And a run against a DEPLOYED application
+   *  sometimes has to submit an answer the application will refuse: proving
+   *  that a form reaches its server must not mean filing a real job
+   *  application in a queue a person reads. See tools/sitesmoke, which is the
+   *  caller this was added for.
+   */
+  readonly answers?: Readonly<Record<string, string>>;
 }
 
 /** One thing to do next. */
 export type Action =
   | { readonly kind: 'fill'; readonly field: RegExp; readonly value: string; readonly why: string }
+  /** check chooses a checkbox or a radio. Separate from `fill` because the
+   *  browser refuses to type into either, and because the two are different
+   *  decisions: typing an answer and agreeing to a term are not the same act
+   *  even when they are the same element to a selector. */
+  | { readonly kind: 'check'; readonly field: RegExp; readonly why: string }
   | { readonly kind: 'click'; readonly control: RegExp; readonly why: string }
   | { readonly kind: 'goto'; readonly url: string; readonly why: string }
   | { readonly kind: 'done'; readonly why: string }
@@ -40,10 +63,24 @@ export type Action =
 export interface Snapshot {
   readonly url: string;
   readonly title: string;
-  /** fields are the form fields, by accessible name. */
-  readonly fields: readonly { readonly name: string; readonly type: string; readonly filled: boolean }[];
+  /** fields are the form fields, by accessible name.
+   *
+   *  `filled` means answered rather than non-empty: a ticked checkbox and a
+   *  radio group with a chosen option are filled, an untouched one is not.
+   *  `required` is the browser's own `required`, which is what decides
+   *  whether a field nothing here recognises still has to be answered before
+   *  the form will submit at all. */
+  readonly fields: readonly {
+    readonly name: string; readonly type: string;
+    readonly filled: boolean; readonly required: boolean;
+  }[];
   /** controls are the buttons and links, by accessible name. */
   readonly controls: readonly string[];
+  /** submits are the controls that submit a form, by accessible name.
+   *
+   *  A subset of `controls`, kept apart so a planner has an answer on a form
+   *  whose button says something no list of words could have predicted. */
+  readonly submits: readonly string[];
   /** unnamed counts the interactive elements that have no accessible name at
    *  all, so they appear in neither `controls` nor `fields`.
    *
@@ -74,6 +111,15 @@ export interface Identity {
   readonly phone: string;
   readonly card: string;
   readonly postcode: string;
+  /** statement is what goes into a required field nothing here recognises.
+   *
+   *  A form does not submit while a required field is empty, and the browser
+   *  refuses it without a round trip, so a planner that only fills the shapes
+   *  it knows presses the button and watches nothing happen. It then reports a
+   *  page that proved nothing, on a form it never actually sent. The value
+   *  says what wrote it, so a row that reaches a person is obviously an
+   *  agent's rather than somebody's real answer. */
+  readonly statement: string;
 }
 
 /** freshIdentity makes one that is unique per run. */
@@ -91,6 +137,9 @@ export function freshIdentity(seed: string): Identity {
     // real processor will charge.
     card: '4242424242424242',
     postcode: 'SW1A 1AA',
+    statement:
+      'This text was typed by an Antifailure agent driving this form, not by a person. ' +
+      'Nothing here is a real answer.',
   };
 }
 
@@ -120,6 +169,9 @@ const FIELD_VALUES: readonly { readonly match: RegExp; readonly pick: (id: Ident
 export function identityValueFor(field: string, identity: Identity): string | undefined {
   return FIELD_VALUES.find((r) => r.match.test(field))?.pick(identity);
 }
+
+/** Field types that are chosen rather than typed into. */
+const CHOSEN_TYPES = new Set(['checkbox', 'radio']);
 
 /** Controls a deterministic planner will press, most likely first. */
 const PROGRESS_CONTROLS: readonly RegExp[] = [
@@ -152,11 +204,31 @@ export class DeterministicPlanner implements Planner {
       return { kind: 'done', why: 'Every expectation is visible on the page.' };
     }
 
+    // What this workflow said to type, before anything this planner guesses.
+    // An answer the caller wrote down beats a shape this file recognises,
+    // always: the caller can see the application and this table cannot.
+    for (const field of snapshot.fields) {
+      if (field.filled || CHOSEN_TYPES.has(field.type)) continue;
+      const answer = answerFor(workflow, field.name);
+      if (answer === undefined) continue;
+      if (history.some(
+        (a) => a.kind === 'fill' && a.field.source === anchored(field.name).source)) continue;
+      return {
+        kind: 'fill',
+        field: anchored(field.name),
+        value: answer,
+        why: `${field.name} is answered by this workflow.`,
+      };
+    }
+
     // Fill before pressing, always. A form submitted with a field still empty
     // produces a validation error that looks exactly like a broken
     // application, and the agent then reports a failure it caused itself.
     for (const field of snapshot.fields) {
       if (field.filled) continue;
+      // A checkbox named "Email me about releases" matches the email rule, and
+      // typing into a checkbox throws. Chosen fields are handled below.
+      if (CHOSEN_TYPES.has(field.type)) continue;
       const rule = FIELD_VALUES.find((r) => r.match.test(field.name));
       if (!rule) continue;
       const already = history.some(
@@ -171,20 +243,99 @@ export class DeterministicPlanner implements Planner {
       };
     }
 
-    for (const pattern of PROGRESS_CONTROLS) {
-      const control = snapshot.controls.find((c) => pattern.test(c));
-      if (!control) continue;
-      const pressedBefore = history.filter(
-        (a) => a.kind === 'click' && a.control.source === anchored(control).source,
-      ).length;
-      // Pressing the same button twice is how an agent loops forever on a page
-      // that did not change. Twice is allowed, because one retry is often
-      // exactly right after a field was filled.
-      if (pressedBefore >= 2) continue;
+    // Then the fields nothing above recognised but the browser will not let
+    // the form be submitted without. Before the choices below rather than
+    // after, because typing is the cheaper action to redo if a page rerenders.
+    for (const field of snapshot.fields) {
+      if (field.filled || !field.required) continue;
+      if (CHOSEN_TYPES.has(field.type)) continue;
+      if (FIELD_VALUES.some((r) => r.match.test(field.name))) continue;
+      if (answerFor(workflow, field.name) !== undefined) continue;
+      if (history.some(
+        (a) => a.kind === 'fill' && a.field.source === anchored(field.name).source)) continue;
+      return {
+        kind: 'fill',
+        field: anchored(field.name),
+        value: this.#identity.statement,
+        why:
+          `${field.name} is required and empty, and nothing here recognises what it wants. ` +
+          `A required field left empty is a form the browser refuses to send.`,
+      };
+    }
+
+    // Then the acknowledgments and the option groups.
+    //
+    // Required only, deliberately. A checkbox that is not required is a
+    // preference, and an agent that ticks every optional box on a page is
+    // subscribing somebody to a newsletter to see what happens. A radio group
+    // is always answered when it is required and left alone when it is not,
+    // for the same reason: choosing an option nobody asked for is a decision,
+    // not progress.
+    for (const field of snapshot.fields) {
+      if (field.filled || !field.required || !CHOSEN_TYPES.has(field.type)) continue;
+      if (history.some(
+        (a) => a.kind === 'check' && a.field.source === anchored(field.name).source)) continue;
+      return {
+        kind: 'check',
+        field: anchored(field.name),
+        why: field.type === 'radio'
+          ? `${field.name} is one option of a required choice that has not been made.`
+          : `${field.name} is a required acknowledgment and it is not ticked.`,
+      };
+    }
+
+    // Pressing the same control twice is how an agent loops forever on a page
+    // that did not change. Twice is allowed, because one retry is often
+    // exactly right after a field was filled.
+    const pressedBefore = (control: string) => history.filter(
+      (a) => a.kind === 'click' && a.control.source === anchored(control).source,
+    ).length;
+    const submit = snapshot.submits.find((c) => pressedBefore(c) < 2);
+    const known = snapshot.controls.find(
+      (c) => PROGRESS_CONTROLS.some((p) => p.test(c)) && pressedBefore(c) < 2);
+
+    // A form that has been filled in is finished by pressing what SENDS it,
+    // and by nothing else on the page.
+    //
+    // Two failures, one ordering. PROGRESS_CONTROLS is a list of the words
+    // that move the shapes every application shares, and it can never be
+    // finished: "Send application" is the button on this repository's own
+    // careers form and matches none of them, so the agent filled the form in
+    // completely and then declared itself stuck in front of the only control
+    // that mattered. Adding the document's own submit controls fixed that and
+    // exposed the second half, which is worse: this site's header carries a
+    // "Sign in" link, `^(sign in|log in|login)$` matches it, and the word list
+    // is consulted first. So the agent filled in every field of the careers
+    // form, ignored "Send application", followed the header link to the sign
+    // in page, and reported that the careers page offered nothing. It had
+    // filled in a form and then navigated away from it.
+    //
+    // So: once anything has been typed or chosen, the submit control wins.
+    // Before that, the words win, because a page with a search box and a
+    // "Choose Pro" button offers a submit control that sends nobody anywhere.
+    //
+    // AND ONCE A FORM HAS BEEN SENT AS OFTEN AS IT IS GOING TO BE, THE ANSWER
+    // IS STUCK RATHER THAN SOMEWHERE ELSE. That is not a refinement of the
+    // rule above, it is the half that makes the report usable. Wandering off
+    // to the header link left the run's LAST page as the sign-in screen, so
+    // the failure was reported against a page that had nothing to do with the
+    // workflow and the error banner the form had just shown was gone from the
+    // evidence, the screenshot and the quoted sentence. A page offering a
+    // submit control that has already been pressed twice offers this workflow
+    // nothing, and saying so is the honest end. A flow whose next step is not
+    // a submit control at all, a wizard with a "Continue" link, still falls
+    // through to the word list.
+    const answeredSomething = history.some((a) => a.kind === 'fill' || a.kind === 'check');
+    const control = answeredSomething
+      ? (submit ?? (snapshot.submits.length > 0 ? undefined : known))
+      : (known ?? submit);
+    if (control) {
       return {
         kind: 'click',
         control: anchored(control),
-        why: `${control} is the control that moves this workflow forward.`,
+        why: control === submit && answeredSomething
+          ? `${control} sends the form this workflow has just filled in.`
+          : `${control} is the control that moves this workflow forward.`,
       };
     }
 
@@ -203,6 +354,29 @@ export class DeterministicPlanner implements Planner {
         `not counted against it.`,
     };
   }
+}
+
+/** answerFor returns what this workflow said to type into a field, if it said.
+ *
+ * Matched as a case insensitive substring of the accessible name rather than
+ * as an exact string, because an accessible name is computed from everything
+ * inside a wrapping label and carries hint text nobody would think to repeat:
+ * "Link to your work (optional)" is the name of a field somebody would key as
+ * "Link to your work". The longest key that matches wins, so a page with both
+ * "Email" and "Email me a copy" can be answered separately.
+ */
+export function answerFor(workflow: Workflow, field: string): string | undefined {
+  if (!workflow.answers) return undefined;
+  const name = field.toLowerCase();
+  let best: string | undefined;
+  let bestKey = '';
+  for (const [key, value] of Object.entries(workflow.answers)) {
+    if (!key || !name.includes(key.toLowerCase())) continue;
+    if (key.length <= bestKey.length) continue;
+    bestKey = key;
+    best = value;
+  }
+  return best;
 }
 
 /** anchored turns an accessible name into a pattern that matches it exactly. */
@@ -235,19 +409,101 @@ function describe(snapshot: Snapshot): string {
  */
 export type Judgement = 'met' | 'unmet' | 'unclear';
 
-/** Signals that a page is showing a failure rather than a result. */
+/** Signals that a page is showing a failure rather than a result.
+ *
+ * THE ONE THAT WAS MISSING, and it is the sentence this repository's own site
+ * shows when its forms cannot reach their control plane. Somebody filled in
+ * the careers form on antifailure.dev and read "Could not reach the server."
+ * Nothing here matched it, so `judge` returned `unclear`, the attempt came
+ * back `page-unreadable`, the verdict was UNVERIFIED, and the runner exited
+ * zero over a form that did not work. An agent that drives a page and cannot
+ * recognise the page telling it the request never arrived is an agent that
+ * cannot say no about the failure it is most likely to meet.
+ *
+ * Written as the shapes a front end actually renders rather than as the one
+ * sentence: "could not reach", "unable to reach", "network error", "check your
+ * connection", "try again" alongside a refusal. Each is a sentence a page
+ * shows INSTEAD of a result, which is the whole membership rule here. A page
+ * that merely mentions an error somewhere in its help text does not match,
+ * because every pattern requires the wording a failure banner uses.
+ */
 const FAILURE_SIGNALS: readonly RegExp[] = [
   /\bsomething went wrong\b/i,
   /\bunexpected error\b/i,
   /\binternal server error\b/i,
   /\bpayment (failed|declined)\b/i,
-  /\bcould not (complete|process)\b/i,
+  /\bcould not (complete|process|record|confirm|reach|connect)\b/i,
+  /\b(could|can)(\s+not|not|n?['’]t) reach\b/i,
+  /\b(unable|failed) to (reach|connect|load|send|submit)\b/i,
+  /\bnetwork error\b/i,
+  /\bcheck your connection\b/i,
   /\b(500|502|503)\b.*\berror\b/i,
 ];
+
+/** failureSentence returns the sentence a failure signal matched, or nothing.
+ *
+ * The point of it is the report. `expectation-not-met` used to be reported as
+ * "The page shows an error rather than what was expected", which tells a
+ * reader that something is wrong and not one word about what. The sentence the
+ * page actually showed is the difference between a red mark somebody has to
+ * reproduce and a red mark somebody can act on, and between two failures that
+ * look identical in a summary: a control plane that has no such route and a
+ * control plane that refused this hostname both break the same form, and the
+ * page says something different about each.
+ */
+export function failureSentence(text: string): string | undefined {
+  // Split on sentence ends and on line breaks, because a banner is usually its
+  // own block and often carries no full stop at all.
+  const pieces = text.split(/\n+|(?<=[.!?])\s+/).map((p) => p.trim()).filter(Boolean);
+  for (const piece of pieces) {
+    if (FAILURE_SIGNALS.some((p) => p.test(piece))) {
+      return piece.length > 300 ? piece.slice(0, 297) + '...' : piece;
+    }
+  }
+  // A signal that spans the pieces this split produced still has to be
+  // reportable, so fall back to saying which pattern matched the whole page
+  // rather than returning nothing and losing the only evidence there is.
+  const whole = FAILURE_SIGNALS.find((p) => p.test(text));
+  return whole ? text.slice(0, 297) : undefined;
+}
+
+/** An expectation asking for a string exactly, rather than for its sense.
+ *
+ * `"It is written down."`, quotes included. Anything between a leading and a
+ * trailing double quote is required on the page character for character, up to
+ * case and run of whitespace.
+ *
+ * WHY THIS EXISTS. The word ratio below is right for an expectation written as
+ * a sentence about the product, and it is badly wrong for a sentence a page
+ * either shows or does not. Two thirds of the meaningful words is a low bar on
+ * a page with four thousand characters of prose on it: "Use a public http or
+ * https link without credentials", the control plane's own refusal, scores six
+ * of seven against the UNSUBMITTED careers page, because `public`, `link`,
+ * `use`, `credentials` and an install command containing `https` are all
+ * already there. The expectation was met before the agent touched the form.
+ *
+ * A page that renders a specific sentence when something works and a different
+ * one when it does not is the ordinary case for a form, and for that case
+ * there is nothing to infer. Quoting it says so, and turns a miss into `unmet`
+ * rather than `unclear`: a string is present or absent, and there is no third
+ * answer to hedge towards.
+ */
+function verbatim(expectation: string): string | undefined {
+  const quoted = /^\s*"([\s\S]+)"\s*$/.exec(expectation);
+  return quoted?.[1];
+}
 
 /** judge decides one expectation against the page. */
 export function judge(expectation: string, text: string): Judgement {
   const haystack = normalize(text);
+  const exact = verbatim(expectation);
+  if (exact !== undefined) {
+    // Never `unclear`. The whole point of quoting a sentence is that its
+    // absence is an answer, and the run that found this needed exactly that:
+    // "Could not reach the server" is on the page instead, and reporting the
+    // careers form as UNVERIFIED over it exits zero.
+    return haystack.includes(normalize(exact)) ? 'met' : 'unmet';
+  }
   const words = keywords(expectation);
   if (words.length === 0) return 'unclear';
 

--- a/runner/test/browser.test.ts
+++ b/runner/test/browser.test.ts
@@ -417,3 +417,249 @@ test('the snapshot reads rendered text, never markup', async () => {
       `browser.ts reads ${forbidden}, so the page's markup can reach the model`);
   }
 });
+
+/** A form shaped like this repository's own careers form, served over HTTP.
+ *
+ * THE FAILURE THIS EXISTS FOR. Somebody filled in the careers form on
+ * antifailure.dev and read "Could not reach the server." The obvious question
+ * was why the agents had not found it, and the obvious answer was that they had
+ * been pointed at an environment built from one commit, where the site and the
+ * control plane necessarily agree. That answer was true and it was not the
+ * whole of it. Pointed straight at the deployed site, the agent could not have
+ * found it either, for four separate reasons, and every one of them is a
+ * property of this form's SHAPE rather than of the target:
+ *
+ *  1. The required acknowledgment is a checkbox. A checkbox carries value="on"
+ *     whether or not it is ticked, so the snapshot reported it as already
+ *     filled and the planner skipped it.
+ *  2. The role is a radio group, filled for the same wrong reason.
+ *  3. "What have you built" is required and matches no known field shape, so it
+ *     was left empty and the browser refused to submit the form at all.
+ *  4. The button says "Send application", which is on no list of words that
+ *     move a workflow forward, so nothing pressed it.
+ *
+ *  And after all four, the sentence the broken page shows was on no list of
+ *  failure signals, so the run came back UNVERIFIED and exited zero.
+ *
+ * `reachable: false` is the deployed control plane refusing the request, which
+ * is what a 404 from a version behind and a 403 from an unconfigured hostname
+ * both look like from inside the page: the fetch rejects and the form shows its
+ * own sentence.
+ */
+function careersForm(options: {
+  readonly reachable: boolean;
+  /** How long the control plane takes to answer. See the slow test below. */
+  readonly answerAfterMs?: number;
+}): {
+  server: Server; url: Promise<string>; received: Record<string, unknown>[];
+} {
+  const received: Record<string, unknown>[] = [];
+  const server = createServer((req, res) => {
+    const url = new URL(req.url ?? '/', 'http://localhost');
+    if (req.method === 'POST' && url.pathname === '/v1/applications') {
+      if (!options.reachable) {
+        // No CORS header and a refusal, which is what the browser turns into a
+        // rejected fetch and the page turns into its banner. Modelled here as
+        // a plain refusal because this server is same origin: what the test
+        // needs is the page's failure branch, and the page takes it on any
+        // response it cannot confirm.
+        res.writeHead(404, { 'content-type': 'application/json' });
+        res.end('{}');
+        return;
+      }
+      let body = '';
+      req.on('data', (c) => { body += c; });
+      req.on('end', () => {
+        received.push(JSON.parse(body || '{}') as Record<string, unknown>);
+        setTimeout(() => {
+          res.writeHead(201, { 'content-type': 'application/json' });
+          res.end(JSON.stringify({ id: 'written-down', recorded: true }));
+        }, options.answerAfterMs ?? 0);
+      });
+      return;
+    }
+    res.writeHead(200, { 'content-type': 'text/html' });
+    res.end(`<html><body>
+      <a href="/signin">Sign in</a>
+      <h1>Careers</h1>
+      <form id="apply">
+        <fieldset>
+          <legend>Which role</legend>
+          <label for="r1"><input id="r1" type="radio" name="role" value="founding_engineer" required> Founding engineer</label>
+          <label for="r2"><input id="r2" type="radio" name="role" value="founding_growth" required> Founding growth</label>
+        </fieldset>
+        <label for="n">Your name</label><input id="n" name="name" required>
+        <label for="e">Email</label><input id="e" name="email" type="email" required>
+        <label for="w">What have you built or grown, and why this role</label>
+        <textarea id="w" name="why" required></textarea>
+        <div hidden aria-hidden="true">
+          <label for="hp">Company</label><input id="hp" name="website" tabindex="-1">
+        </div>
+        <label for="c"><input id="c" name="compensation" type="checkbox" required> I understand there is no salary for either role currently.</label>
+        <button type="submit">Send application</button>
+      </form>
+      <div id="out"></div>
+      <script>
+        document.getElementById('apply').addEventListener('submit', async (event) => {
+          event.preventDefault();
+          const data = new FormData(event.target);
+          const values = {
+            name: data.get('name'), email: data.get('email'), role: data.get('role'),
+            why: data.get('why'), website: data.get('website') || '',
+            compensationAcknowledged: data.get('compensation') === 'on',
+          };
+          let response;
+          try {
+            response = await fetch('/v1/applications', {
+              method: 'POST', headers: { 'content-type': 'application/json' },
+              body: JSON.stringify(values),
+            });
+            if (!response.ok) throw new Error('refused');
+            const recorded = await response.json();
+            if (recorded.recorded !== true) throw new Error('unconfirmed');
+          } catch {
+            document.getElementById('out').textContent =
+              'Could not reach the server. Check your connection and press it again; nothing you typed is lost.';
+            return;
+          }
+          document.getElementById('apply').remove();
+          document.getElementById('out').textContent =
+            'It is written down. Your application is in the private queue a person reads, oldest first.';
+        });
+      </script>
+    </body></html>`);
+  });
+  const url = new Promise<string>((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      resolve(`http://127.0.0.1:${typeof addr === 'object' && addr ? addr.port : 0}`);
+    });
+  });
+  return { server, url, received };
+}
+
+const apply: Workflow = {
+  name: 'apply-for-a-founding-role',
+  description: 'Apply for a founding role and confirm the application is recorded.',
+  startPath: '/careers',
+  // Quoted, so the sentence is required on the page character for character.
+  // This is what tools/sitesmoke sends, and the unquoted form is satisfied by
+  // its own words being scattered about a page of prose.
+  expect: ['"It is written down."'],
+};
+
+// Collected rather than asserted one at a time, and that is not a style either.
+//
+// `assert` throws on the first failure, so five assertions after a failing one
+// are unreachable and still look alive. Driving a real browser costs eight
+// seconds a run, so splitting them into six tests would cost a minute; keeping
+// them in one test with a plain `assert` would mean every mutation of any of
+// these lines reported the same first failure, and a mutation table built on
+// that says nothing about which assertion catches which break.
+function problem(into: string[], ok: boolean, said: string) {
+  if (!ok) into.push(said);
+}
+
+test('it completes a form with a radio, a required acknowledgment and an unfamiliar field',
+  { timeout: 120_000 }, async () => {
+    const { server, url, received } = careersForm({ reachable: true });
+    const baseURL = await url;
+    const artifacts = mkdtempSync(join(tmpdir(), 'af-runner-'));
+    try {
+      const results = await run({
+        baseURL, artifacts, workflows: [apply], personas: nobody, attempts: 1,
+      });
+      const result = results[0]!;
+      const sent = (received[0] ?? {}) as Record<string, unknown>;
+      const found: string[] = [];
+      problem(found, result.outcome.verdict === 'pass',
+        `the verdict is ${result.outcome.verdict}, not pass: ${result.outcome.detail}`);
+      // The verdict alone would pass on a form that was never sent, because a
+      // page that never changed shows no failure signal either. What proves
+      // the agent completed it is the application the server received.
+      problem(found, received.length === 1,
+        `the server received ${received.length} applications, not one`);
+      problem(found, sent.role === 'founding_engineer', 'no role was chosen from the radio group');
+      problem(found, sent.compensationAcknowledged === true,
+        'the required acknowledgment was not ticked');
+      problem(found, String(sent.why ?? '').length > 0,
+        'the required field nothing recognises was left empty');
+      problem(found, sent.website === '', 'the agent filled the hidden honeypot field');
+      problem(found, String(sent.email ?? '').includes('@'), 'no email address was typed');
+      assert.deepEqual(found, [], `${found.join('\n')}\nsteps:\n${result.steps.join('\n')}`);
+    } finally {
+      server.close();
+    }
+  });
+
+test('a form that cannot reach its server FAILS, and the report quotes what the page said',
+  { timeout: 120_000 }, async () => {
+    // The whole point of this one is the verdict. Before the failure signals
+    // learned this sentence it came back UNVERIFIED, which exits zero, so a
+    // careers form that could not reach its control plane produced a green run
+    // with a sad line in a log.
+    const { server, url, received } = careersForm({ reachable: false });
+    const baseURL = await url;
+    const artifacts = mkdtempSync(join(tmpdir(), 'af-runner-'));
+    try {
+      const results = await run({
+        baseURL, artifacts, workflows: [apply], personas: nobody, attempts: 1,
+      });
+      const result = results[0]!;
+      const found: string[] = [];
+      problem(found, result.outcome.verdict === 'fail',
+        `the verdict is ${result.outcome.verdict}, not fail`);
+      problem(found, result.outcome.cause === 'expectation-not-met',
+        `the cause is ${result.outcome.cause}, not expectation-not-met`);
+      problem(found, /Could not reach the server/.test(result.outcome.detail),
+        'the report does not quote the sentence the page showed');
+      problem(found, exitCodeFor([result.outcome]) === 8,
+        `the run exits ${exitCodeFor([result.outcome])}, not 8`);
+      problem(found, received.length === 0, 'a refused server still recorded something');
+      assert.deepEqual(found, [],
+        `${found.join('\n')}\ndetail: ${result.outcome.detail}\nsteps:\n${result.steps.join('\n')}`);
+    } finally {
+      server.close();
+    }
+  });
+
+test('a control plane that takes its time does not make the agent walk away',
+  { timeout: 120_000 }, async () => {
+    // THE FAILURE, and it is the one that turned a working production origin
+    // red about one run in ten. A press returns the instant the click lands,
+    // and this form disables its own fieldset for exactly as long as the
+    // request takes. So the snapshot read a page with no fields and a button
+    // labelled "Recording it", decided nothing there moved the workflow
+    // forward, and followed the "Sign in" link in the header instead. The
+    // agent had filled in a form and then navigated away from it, and the
+    // run reported a careers page that offered nothing.
+    //
+    // `networkidle` cannot see this: it asks whether the CURRENT DOCUMENT has
+    // already reached that state, and a client rendered page reached it
+    // seconds ago and stays there. Nor can waiting for the rendered text to
+    // stop changing, because the text is perfectly stable for the whole time
+    // the page is at its least readable. What settles it is the request
+    // itself, which is what the session now counts.
+    //
+    // A second and a half, which is slower than the deployed control plane on
+    // a good day and well inside what it does on a bad one.
+    const { server, url, received } = careersForm({ reachable: true, answerAfterMs: 1_500 });
+    const baseURL = await url;
+    const artifacts = mkdtempSync(join(tmpdir(), 'af-runner-'));
+    try {
+      const results = await run({
+        baseURL, artifacts, workflows: [apply], personas: nobody, attempts: 1,
+      });
+      const result = results[0]!;
+      const found: string[] = [];
+      problem(found, result.outcome.verdict === 'pass',
+        `the verdict is ${result.outcome.verdict}, not pass: ${result.outcome.detail}`);
+      problem(found, received.length === 1,
+        `the server received ${received.length} applications, not one`);
+      problem(found, !result.steps.some((s) => /Press Sign in/.test(s)),
+        'the agent left the form it had filled in and followed the header link');
+      assert.deepEqual(found, [], `${found.join('\n')}\nsteps:\n${result.steps.join('\n')}`);
+    } finally {
+      server.close();
+    }
+  });

--- a/runner/test/explore.test.ts
+++ b/runner/test/explore.test.ts
@@ -18,7 +18,8 @@ interface Screen {
   readonly title: string;
   readonly text: string;
   readonly controls?: readonly string[];
-  readonly fields?: readonly { name: string; type: string }[];
+  readonly fields?: readonly { name: string; type: string; required?: boolean }[];
+  readonly submits?: readonly string[];
   readonly unnamed?: number;
   /** where a control leads. A control with no entry here does nothing. */
   readonly links?: Readonly<Record<string, string>>;
@@ -46,8 +47,10 @@ class Site implements Surface {
       title: screen.title,
       fields: (screen.fields ?? []).map((f) => ({
         name: f.name, type: f.type, filled: this.#filled.has(`${this.#at}|${f.name}`),
+        required: f.required ?? false,
       })),
       controls: screen.controls ?? [],
+      submits: screen.submits ?? [],
       unnamed: screen.unnamed ?? 0,
       text: screen.text,
     };
@@ -362,7 +365,8 @@ test('destructive names the controls it should and nothing else', () => {
 
 test('a page signature changes when anything a person would notice changes', () => {
   const base: Snapshot = {
-    url: '/a', title: 'A', fields: [], controls: ['One'], unnamed: 0, text: 'hello',
+    url: '/a', title: 'A', fields: [], controls: ['One'], submits: [], unnamed: 0,
+    text: 'hello',
   };
   const same = signature(base);
   assert.equal(signature({ ...base }), same);
@@ -372,7 +376,10 @@ test('a page signature changes when anything a person would notice changes', () 
   assert.notEqual(signature({ ...base, unnamed: 1 }), same);
   assert.notEqual(signature({ ...base, text: 'goodbye' }), same);
   assert.notEqual(
-    signature({ ...base, fields: [{ name: 'Email', type: 'email', filled: false }] }), same);
+    signature({
+      ...base,
+      fields: [{ name: 'Email', type: 'email', filled: false, required: false }],
+    }), same);
   // Control order is the DOM's business, not the page's meaning.
   assert.equal(signature({ ...base, controls: ['One'] }), same);
 });

--- a/runner/test/login.test.ts
+++ b/runner/test/login.test.ts
@@ -20,6 +20,8 @@ class FakePage implements Page {
 
   async goto(url: string) { this.visited.push(url); this.current = url; }
   async fill(field: RegExp, value: string) { this.filled[field.source] = value; }
+  checked: string[] = [];
+  async check(field: RegExp) { this.checked.push(field.source); }
   async has(_field: RegExp) {
     if (this.signInAt === null) return true;
     return this.signInAt.some((p) => this.current.endsWith(p));

--- a/runner/test/model.test.ts
+++ b/runner/test/model.test.ts
@@ -16,8 +16,9 @@ const workflow: Workflow = {
 const snapshot: Snapshot = {
   url: 'https://app.test/pricing',
   title: 'Pricing',
-  fields: [{ name: 'Card number', type: 'text', filled: false }],
+  fields: [{ name: 'Card number', type: 'text', filled: false, required: false }],
   controls: ['Choose Pro', 'Back'],
+  submits: [],
   unnamed: 0,
   text: 'Pricing. Free or Pro.',
 };

--- a/runner/test/workflow.test.ts
+++ b/runner/test/workflow.test.ts
@@ -1,0 +1,289 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  DeterministicPlanner, answerFor, failureSentence, freshIdentity, judge, judgeAll,
+  type Action, type Snapshot, type Workflow,
+} from '../src/workflow.ts';
+
+/** A page, in the terms a decision is made in. */
+function page(over: Partial<Snapshot> = {}): Snapshot {
+  return {
+    url: 'https://antifailure.dev/careers',
+    title: 'Careers',
+    fields: [],
+    controls: [],
+    submits: [],
+    unnamed: 0,
+    text: '',
+    ...over,
+  };
+}
+
+/** The careers form as the snapshot sees it, before anything is answered. */
+function careersFields(over: { readonly filled?: readonly string[] } = {}) {
+  const filled = new Set(over.filled ?? []);
+  return [
+    { name: 'Founding engineer', type: 'radio', filled: filled.has('role'), required: true },
+    { name: 'Founding growth', type: 'radio', filled: filled.has('role'), required: true },
+    { name: 'Your name', type: 'text', filled: filled.has('Your name'), required: true },
+    { name: 'Email', type: 'email', filled: filled.has('Email'), required: true },
+    { name: 'Link to your work (optional)', type: 'url', filled: filled.has('link'), required: false },
+    {
+      name: 'What have you built or grown, and why this role',
+      type: 'textarea', filled: filled.has('why'), required: true,
+    },
+    {
+      name: 'I understand there is no salary for either role currently.',
+      type: 'checkbox', filled: filled.has('ack'), required: true,
+    },
+  ];
+}
+
+const apply: Workflow = {
+  name: 'apply-for-a-founding-role',
+  description: 'Apply for a founding role.',
+  expect: ['"It is written down."'],
+};
+
+function planner() {
+  return new DeterministicPlanner(freshIdentity('apply-for-a-founding-role'));
+}
+
+async function next(workflow: Workflow, snapshot: Snapshot, history: Action[] = []) {
+  return planner().next(workflow, snapshot, history);
+}
+
+// A required acknowledgment is ticked, not typed into and not skipped.
+//
+// A checkbox carries value="on" whether or not anybody ticked it, so the
+// snapshot used to report every one of them as already filled. The planner
+// skips filled fields, so this repository's own careers form could not be
+// completed by its own agent: the box that says "I understand there is no
+// salary" was never ticked and the browser refused to submit the form.
+test('a required acknowledgment is chosen', async () => {
+  const action = await next(apply, page({
+    fields: careersFields({ filled: ['role', 'Your name', 'Email', 'why'] }),
+    submits: ['Send application'],
+  }));
+  assert.equal(action.kind, 'check');
+  assert.match('I understand there is no salary for either role currently.',
+    (action as { field: RegExp }).field);
+});
+
+// A required choice is made, and only one option of it.
+test('a required radio group is chosen', async () => {
+  const action = await next(apply, page({
+    fields: careersFields({ filled: ['Your name', 'Email', 'why', 'ack'] }),
+    submits: ['Send application'],
+  }));
+  assert.equal(action.kind, 'check');
+  assert.match('Founding engineer', (action as { field: RegExp }).field);
+});
+
+// A checkbox is never typed into.
+//
+// "Email me about releases" matches the email rule in the value table, and
+// `fill` on a checkbox throws, so a page with one would have ended the run as
+// a runner failure.
+test('a checkbox whose name matches a value rule is still chosen and not typed into', async () => {
+  const action = await next(apply, page({
+    fields: [{ name: 'Email me about releases', type: 'checkbox', filled: false, required: true }],
+    submits: ['Send'],
+  }));
+  assert.equal(action.kind, 'check');
+});
+
+// An optional checkbox is left alone.
+//
+// An agent that ticks every box on a page has subscribed somebody to a
+// newsletter to see what happens.
+test('an optional checkbox is not ticked', async () => {
+  const action = await next(apply, page({
+    fields: [{ name: 'Send me the newsletter', type: 'checkbox', filled: false, required: false }],
+    submits: ['Send'],
+  }));
+  assert.equal(action.kind, 'click');
+});
+
+// A required field nothing recognises is still answered.
+//
+// "What have you built or grown, and why this role" matches no shape any
+// application shares, and a required field left empty is a form the browser
+// refuses to send. The agent pressed the button and watched nothing happen.
+test('a required field nothing recognises is answered anyway', async () => {
+  const action = await next(apply, page({
+    fields: careersFields({ filled: ['role', 'Your name', 'Email', 'ack'] }),
+    submits: ['Send application'],
+  }));
+  assert.equal(action.kind, 'fill');
+  assert.match('What have you built or grown, and why this role',
+    (action as { field: RegExp }).field);
+  assert.match((action as { value: string }).value, /Antifailure agent/);
+});
+
+// An optional field nothing recognises is left empty.
+test('an optional field nothing recognises is left empty', async () => {
+  const action = await next(apply, page({
+    fields: [{ name: 'Anything else', type: 'text', filled: false, required: false }],
+    submits: ['Send'],
+  }));
+  assert.equal(action.kind, 'click');
+});
+
+// What the workflow said to type beats what the planner would have guessed.
+test('an answer the workflow wrote down wins over the value table', async () => {
+  const answered: Workflow = { ...apply, answers: { 'Link to your work': 'https://x.test/' } };
+  const action = await next(answered, page({
+    fields: careersFields({ filled: ['role', 'Your name', 'Email', 'why', 'ack'] }),
+    submits: ['Send application'],
+  }));
+  assert.equal(action.kind, 'fill');
+  assert.equal((action as { value: string }).value, 'https://x.test/');
+});
+
+test('the longest matching answer wins, and a name it does not match is untouched', () => {
+  const w: Workflow = {
+    ...apply,
+    answers: { 'Email': 'a@example.test', 'Email me a copy': 'yes' },
+  };
+  assert.equal(answerFor(w, 'Email me a copy at'), 'yes');
+  assert.equal(answerFor(w, 'Email address'), 'a@example.test');
+  assert.equal(answerFor(w, 'Your name'), undefined);
+  assert.equal(answerFor(apply, 'Email'), undefined);
+});
+
+// The form's own submit control is pressed when no known word matches.
+//
+// "Send application" is on no list of words that move a workflow forward, so
+// the agent filled the whole form in and then declared itself stuck in front of
+// the only control that mattered.
+test('the control that submits the form is pressed when no known word matches', async () => {
+  const action = await next(apply, page({
+    fields: careersFields({ filled: ['role', 'Your name', 'Email', 'why', 'ack'] }),
+    controls: ['Skip to content', 'Send application', 'Apply to join'],
+    submits: ['Send application'],
+  }), [{ kind: 'fill', field: /^Your name$/, value: 'x', why: 'y' }]);
+  assert.equal(action.kind, 'click');
+  assert.match('Send application', (action as { control: RegExp }).control);
+});
+
+// A form that has been filled in is finished by pressing what SENDS it.
+//
+// THE FAILURE. Once the document's own submit controls were consulted, the
+// word list was still consulted FIRST, and this site's header carries a "Sign
+// in" link that `^(sign in|log in|login)$` matches. So the agent filled in
+// every field of the careers form, ignored "Send application", followed the
+// header link, and reported that the careers page offered nothing.
+test('a filled in form is not abandoned for a link in the site header', async () => {
+  const action = await next(apply, page({
+    fields: careersFields({ filled: ['role', 'Your name', 'Email', 'why', 'ack'] }),
+    controls: ['Sign in', 'Send application'],
+    submits: ['Send application'],
+  }), [{ kind: 'check', field: /^ack$/, why: 'y' }]);
+  assert.equal(action.kind, 'click');
+  assert.match('Send application', (action as { control: RegExp }).control);
+});
+
+// And once it has been sent as often as it is going to be, the answer is stuck.
+//
+// Wandering off left the run's LAST page as the sign-in screen, so the failure
+// was reported against a page with nothing to do with the workflow and the
+// error banner the form had just shown was gone from the evidence, the
+// screenshot and the quoted sentence.
+test('a form whose submit control is spent is stuck, not somewhere else', async () => {
+  const pressed: Action[] = [
+    { kind: 'check', field: /^ack$/, why: 'y' },
+    { kind: 'click', control: /^Try it again$/, why: 'y' },
+    { kind: 'click', control: /^Try it again$/, why: 'y' },
+  ];
+  const action = await next(apply, page({
+    fields: careersFields({ filled: ['role', 'Your name', 'Email', 'why', 'ack'] }),
+    controls: ['Sign in', 'Try it again'],
+    submits: ['Try it again'],
+  }), pressed);
+  assert.equal(action.kind, 'stuck');
+});
+
+// Before anything is answered, the words still win.
+//
+// A pricing page with a search box offers a submit control that sends nobody
+// anywhere, and "Choose Pro" is the control that moves a checkout forward.
+test('before anything is answered the known words still win', async () => {
+  const action = await next(apply, page({
+    controls: ['Search', 'Continue'],
+    submits: ['Search'],
+  }));
+  assert.equal(action.kind, 'click');
+  assert.match('Continue', (action as { control: RegExp }).control);
+});
+
+// A quoted expectation is required on the page character for character.
+//
+// THE CASE THAT FOUND THIS. The control plane's refusal of a work link with
+// credentials scores six of its seven meaningful words against the careers page
+// BEFORE the form is touched: `public`, `link`, `use`, `credentials` and an
+// install command containing `https` are all already on it. Unquoted, the
+// expectation was met before the agent did anything, and the workflow passed in
+// one step against a form it never submitted.
+test('a quoted expectation is not satisfied by its own words being scattered about', () => {
+  const scattered =
+    'Use the quickstart. A public repository is welcome. Link to your work. ' +
+    'curl -fsSL https://antifailure.dev/install.sh | sh. We never ask for credentials.';
+  const sentence = 'Use a public http or https link without credentials.';
+  assert.equal(judge(`"${sentence}"`, scattered), 'unmet');
+  assert.equal(judge(`"${sentence}"`, `Something. ${sentence} Try it again`), 'met');
+  // And the unquoted form is exactly the reading that made this necessary.
+  assert.equal(judge(sentence, scattered), 'met');
+});
+
+test('a quoted expectation is met across a line break and a run of spaces', () => {
+  assert.equal(judge('"It is written down."', 'Careers\nIt is\n  written   down.\nKeep this'), 'met');
+});
+
+// Never unclear. The whole point of quoting a sentence is that its absence is
+// an answer, and unclear exits zero.
+test('a quoted expectation that is absent is unmet, never unclear', () => {
+  assert.equal(judge('"It is written down."', 'Could not reach the server.'), 'unmet');
+  assert.equal(judgeAll(['"It is written down."'], 'anything else at all'), 'unmet');
+});
+
+// The page telling the agent its request never arrived is a failure signal.
+//
+// It was on no list, so `judge` returned unclear, the attempt came back
+// page-unreadable, the verdict was UNVERIFIED, and the runner exited zero over
+// a careers form that did not work.
+test('a page that says it could not reach the server is a failure, not an unreadable page', () => {
+  const banner = 'Could not reach the server. Check your connection and press it again; ' +
+    'nothing you typed is lost.';
+  assert.equal(judge('The application is recorded', banner), 'unmet');
+  assert.equal(judge('The application is recorded', 'Unable to reach the server.'), 'unmet');
+  assert.equal(judge('The application is recorded', 'A network error stopped this.'), 'unmet');
+  // The contracted forms, which are what most front ends actually write and
+  // which the "could not X" rule cannot see. Asserted separately because two
+  // patterns that both match "could not reach" make each other untestable: a
+  // mutation of either stays green while the other covers for it.
+  assert.equal(judge('The application is recorded', "We couldn't reach the server."), 'unmet');
+  assert.equal(judge('The application is recorded', 'Cannot reach the server.'), 'unmet');
+  assert.equal(judge('The application is recorded', "Can't reach the server."), 'unmet');
+});
+
+// And the sentence itself comes back, so a report can quote it.
+test('the sentence a failure signal matched is what comes back', () => {
+  const page = 'Careers\nApply to join\n' +
+    'Could not reach the server. Check your connection and press it again.\n' +
+    'Try it again';
+  assert.equal(failureSentence(page), 'Could not reach the server.');
+  assert.equal(failureSentence('Everything is fine here.'), undefined);
+});
+
+// An ordinary page must not read as a failure.
+//
+// A signal list that matches prose is a check that cannot say yes, which is
+// the same defect as one that cannot say no wearing different clothes.
+test('an ordinary page carries no failure signal', () => {
+  assert.equal(failureSentence(
+    'Two founding roles. Read the source first. Your application is in the private queue.',
+  ), undefined);
+  assert.equal(judge('The application is recorded', 'It is written down. Keep this reference.'),
+    'unclear');
+});

--- a/tools/gatecheck/main.go
+++ b/tools/gatecheck/main.go
@@ -580,6 +580,19 @@ func uncalledByGate(recipes []recipe, reachable map[string]bool) []string {
 		// the tree, hostnames.txt against the tfvars, is the `origincheck`
 		// recipe and that one is in `gate`.
 		"check-origins": true,
+		// The deployed site smoke. The same shape again, and the same reason:
+		// its answer is not a function of the tree. It opens the careers form
+		// on the hostnames people actually type, fills it in with the
+		// product's own agent, presses the button, and reads what the page
+		// says came back, so the same commit is green today and red the
+		// morning somebody binds a second custom domain the control plane has
+		// never heard of. It needs the network and a browser, neither of which
+		// `just gate` may need, and it runs on a schedule and after a deploy in
+		// sitesmoke.yml, which is where drift arriving with no deploy at all
+		// gets noticed. What IS a function of the tree is that the sentences it
+		// waits for are still the ones this repository renders, and `just
+		// sitesmoke` covers that inside `gate`.
+		"sitesmoke-deployed": true,
 	}
 
 	// Recipes that are gates rather than conveniences. A recipe that mutates

--- a/tools/sitesmoke/main.go
+++ b/tools/sitesmoke/main.go
@@ -1,0 +1,206 @@
+// Command sitesmoke drives a DEPLOYED antifailure.dev with the product's own
+// agent and fails when a person's path through it does not work.
+//
+// THE FAILURE IT WAS WRITTEN FOR. Somebody filled in the careers form on the
+// real https://antifailure.dev and was told "Could not reach the server." The
+// question that followed was the right one: this product's whole promise is
+// exploratory agents that drive an application the way a person does, and it
+// dogfoods itself on every pull request, so why did they not find it.
+//
+// The first answer was that the agents were pointed at the wrong thing. A
+// dogfood run builds a disposable stack out of ONE commit, where the front end
+// and the API necessarily agree, so the form submits and the run correctly
+// reports nothing wrong. The bug lived in the space between two independently
+// versioned deployments, and an environment built from a single commit has no
+// such space in it. That answer is true.
+//
+// It is not the whole answer, and the rest of it is the reason this tool comes
+// with changes to the runner rather than on its own. Pointed straight at the
+// deployed site, on the day it was broken, the agent would have exited zero.
+// Four things, each independent, each now fixed and each covered by a test in
+// runner/test/browser.test.ts:
+//
+//  1. A checkbox reports value="on" whether or not it is ticked, so the
+//     snapshot called the required compensation acknowledgment "filled" and
+//     the planner skipped it. So did the role radios.
+//  2. "What have you built or grown, and why this role" is required and
+//     matches no field shape the planner knows, so it stayed empty and the
+//     browser refused to submit the form at all.
+//  3. The button says "Send application", which is on no list of words that
+//     move a workflow forward, so nothing pressed it. Adding the document's
+//     own submit controls then exposed a worse one: the site header carries a
+//     "Sign in" link, the word list is consulted first, and the agent filled
+//     in the whole form and then navigated away from it.
+//  4. "Could not reach the server" was on no list of failure signals, so the
+//     page telling the agent its request never arrived was judged UNREADABLE.
+//     The verdict was unverified, and unverified exits zero.
+//
+// WHAT IT WILL NOT DO. It will not file a job application. The careers form
+// writes into a queue a person reads, and a check that runs on a schedule must
+// not put a row in it every time. The scheduled workflow answers the optional
+// work link with a URL the control plane's own validation refuses, so the
+// request reaches the handler, is refused before anything is written, and the
+// page renders the control plane's own sentence. The whole path including the
+// write is a second workflow, and it runs only when somebody passes
+// -allow-writes. See tools/sitesmoke/workflows.go, which carries the reason
+// each is inert or is not, checked against the API's source.
+//
+// WHAT IT IS NOT. It is not tools/routecheck, which asks a control plane
+// whether a route exists and merged before this. An endpoint probe reports
+// `POST /v1/applications -> 404`; a person reads "Could not reach the server."
+// Only the second is the failure anybody had, and reaching it needs the page,
+// its JavaScript, its build time configuration and a cross origin request from
+// the exact hostname somebody typed. Both halves are wanted. Neither is the
+// other.
+//
+// WHAT IT REFUSES TO GUESS. Three answers, not two. 0 is a proven pass, 1 is a
+// page that showed the wrong thing, and 2 is a run that did not find out: the
+// origin unreachable, the browser unable to drive it, or two attempts
+// disagreeing. Continuous integration treats 1 and 2 alike. Nothing here
+// returns 0 except a "pass" verdict read out of a document the runner wrote.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+)
+
+type origins []string
+
+func (o *origins) String() string     { return strings.Join(*o, ",") }
+func (o *origins) Set(v string) error { *o = append(*o, v); return nil }
+
+func main() {
+	var targets origins
+	root := flag.String("root", ".", "repository root")
+	flag.Var(&targets, "origin", "a deployed site origin to drive, for example https://antifailure.dev. Repeatable. With none, only the offline half runs.")
+	entry := flag.String("runner", "", "path to the runner's entry point. Defaults to runner/src/main.ts under -root.")
+	node := flag.String("node", "node", "the node binary to run the runner with")
+	artifacts := flag.String("artifacts", "", "where to keep screenshots, video and traces. Defaults to a temporary directory.")
+	attempts := flag.Int("attempts", 2, "how many independent browser sessions must agree before a failure is called one")
+	timeout := flag.Duration("timeout", 5*time.Minute, "per workflow timeout")
+	allowWrites := flag.Bool("allow-writes", false, "also run the workflow that files a real job application. Off by default: the careers form writes into a queue a person reads.")
+	flag.Parse()
+
+	code, err := run(*root, targets, *entry, *node, *artifacts, *attempts, *timeout, *allowWrites, os.Stdout)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "\nsitesmoke: %v\n", err)
+	}
+	os.Exit(code)
+}
+
+func run(
+	root string, targets []string, entry, node, artifacts string,
+	attempts int, timeout time.Duration, allowWrites bool, out *os.File,
+) (int, error) {
+	var report strings.Builder
+
+	// The offline half first, and it runs whether or not an origin was given.
+	// It is cheap and its failure invalidates everything below it: an
+	// expectation waiting for a sentence this repository no longer produces
+	// would fail every deployment, and one satisfied by the wrong page would
+	// pass every deployment.
+	report.WriteString("The sentences this check waits for\n")
+	if err := contractHolds(root, &report); err != nil {
+		fmt.Fprint(out, report.String())
+		return exitUndecided, err
+	}
+
+	if len(targets) == 0 {
+		fmt.Fprint(out, report.String())
+		fmt.Fprint(out, "\nNo origin was given, so NO DEPLOYMENT WAS CHECKED.\n"+
+			"This half proves only that the sentences above are still the ones this\n"+
+			"repository produces. On the day the careers form broke, this half was green:\n"+
+			"the tree was correct and production was serving a version from before the\n"+
+			"route existed. Pass -origin https://antifailure.dev to ask a deployment.\n")
+		return exitAllowed, nil
+	}
+
+	if entry == "" {
+		entry = filepath.Join(root, "runner", "src", "main.ts")
+	}
+	if _, err := os.Stat(entry); err != nil {
+		return exitUndecided, fmt.Errorf(
+			"the runner's entry point is not at %s (%v). This tool drives the product's own "+
+				"agent and will not substitute anything else for it", entry, err)
+	}
+	if artifacts == "" {
+		dir, err := os.MkdirTemp("", "sitesmoke-")
+		if err != nil {
+			return exitUndecided, fmt.Errorf("make a directory for the evidence: %w", err)
+		}
+		artifacts = dir
+	}
+	if attempts < 1 {
+		return exitUndecided, fmt.Errorf(
+			"-attempts is %d. A check that runs a workflow no times cannot fail, which is worse "+
+				"than not having it", attempts)
+	}
+
+	// Interrupted rather than killed, so a half finished browser still writes
+	// its evidence out.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	r := runner{
+		Entry: entry, Node: node, Artifacts: artifacts,
+		Attempts: attempts, Timeout: timeout,
+	}
+	workflows := workflowsFor(allowWrites)
+
+	fmt.Fprint(out, report.String())
+	fmt.Fprintf(out, "\nDriving %d %s against %d %s, %d attempts each.\n",
+		len(workflows), plural(len(workflows), "workflow", "workflows"),
+		len(targets), plural(len(targets), "origin", "origins"), attempts)
+	for _, w := range workflows {
+		if w.writes {
+			fmt.Fprintf(out, "  %s WRITES. It files a real job application into the queue a "+
+				"person reads, and it is running because -allow-writes was passed.\n", w.Name)
+		} else {
+			fmt.Fprintf(out, "  %s writes nothing. %s\n", w.Name, w.why)
+		}
+	}
+	fmt.Fprintln(out)
+
+	var findings []Finding
+	for _, origin := range targets {
+		for _, w := range workflows {
+			fmt.Fprintf(out, "  %s  %s ...\n", origin, w.Name)
+			findings = append(findings, r.drive(ctx, origin, w))
+		}
+	}
+
+	answer := verdict(findings)
+	fmt.Fprintf(out, "\n%s\n", summary(findings))
+	fmt.Fprintf(out, "Evidence is in %s\n", artifacts)
+
+	switch answer {
+	case Allowed:
+		fmt.Fprintf(out, "\nEvery origin did what a person needs it to do.\n")
+		return exitAllowed, nil
+	case Refused:
+		return exitRefused, fmt.Errorf(
+			"a person cannot complete the careers form on at least one of these hostnames right " +
+				"now. The sentence the page showed is above, and it is what somebody filling the " +
+				"form in would read")
+	default:
+		return exitUndecided, fmt.Errorf(
+			"this run did not find out. That is not a pass: it is reported as its own answer " +
+				"rather than rounded to one, because a smoke that cannot say \"I did not find " +
+				"out\" says \"fine\" instead")
+	}
+}
+
+func plural(n int, one, many string) string {
+	if n == 1 {
+		return one
+	}
+	return many
+}

--- a/tools/sitesmoke/runner.go
+++ b/tools/sitesmoke/runner.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Driving the product's own agent, through the boundary it already has.
+//
+// af-runner reads one JSON document on standard input and writes one on
+// standard output. That is the runner's documented interface and the engine is
+// simply another caller of it, so pointing it at a deployed origin needs no new
+// harness, no second browser driver, and no copy of the decision logic. The
+// engine's own caller sets base_url to the address of an environment it just
+// built; this one sets it to an address the internet already answers on.
+
+// jobDocument is what af-runner reads.
+type jobDocument struct {
+	BaseURL   string          `json:"base_url"`
+	Artifacts string          `json:"artifacts"`
+	Workflows []smokeWorkflow `json:"workflows"`
+	// Sent as an empty list rather than omitted. The runner is tolerant of a
+	// null here and the engine was not always sending one, which is how every
+	// exploration ever run died on doc.workflows.length; sending the honest
+	// empty list is the strict half of that fix and this is a caller, so it
+	// keeps it.
+	Personas []struct{} `json:"personas"`
+	Attempts int        `json:"attempts"`
+	Headless bool       `json:"headless"`
+}
+
+type outcome struct {
+	Verdict      string   `json:"verdict"`
+	Cause        string   `json:"cause"`
+	Detail       string   `json:"detail"`
+	Reproduction []string `json:"reproduction"`
+}
+
+type workflowResult struct {
+	Workflow string   `json:"workflow"`
+	Outcome  outcome  `json:"outcome"`
+	Steps    []string `json:"steps"`
+	Evidence struct {
+		Video      string `json:"video"`
+		Trace      string `json:"trace"`
+		Screenshot string `json:"screenshot"`
+	} `json:"evidence"`
+}
+
+type resultDocument struct {
+	Results []workflowResult `json:"results"`
+}
+
+// runner is how one origin is driven.
+type runner struct {
+	// Entry is the runner's entry point, which is TypeScript run by node. The
+	// engine finds this the same way, and there is deliberately no second
+	// build of it here.
+	Entry     string
+	Node      string
+	Artifacts string
+	Attempts  int
+	Timeout   time.Duration
+}
+
+// drive runs one workflow against one origin and returns what it concluded.
+//
+// EVERY WAY THIS CAN GO WRONG RETURNS Undecided, never Allowed. A runner that
+// could not start, a document that would not parse, a result list with nothing
+// in it: none of those is evidence that a person can use the site, and the
+// only thing that ever produces Allowed is a "pass" verdict read out of a
+// document the runner actually wrote.
+func (r runner) drive(ctx context.Context, origin string, workflow smokeWorkflow) Finding {
+	undecided := func(format string, args ...any) Finding {
+		return Finding{
+			Origin: origin, Workflow: workflow.Name, Answer: Undecided,
+			Said: fmt.Sprintf(format, args...),
+		}
+	}
+
+	artifacts := filepath.Join(r.Artifacts, sanitize(origin), sanitize(workflow.Name))
+	if err := os.MkdirAll(artifacts, 0o755); err != nil {
+		return undecided("could not make a place to keep the evidence: %v", err)
+	}
+	document, err := json.Marshal(jobDocument{
+		BaseURL:   strings.TrimSuffix(origin, "/"),
+		Artifacts: artifacts,
+		Workflows: []smokeWorkflow{workflow},
+		Personas:  []struct{}{},
+		Attempts:  r.Attempts,
+		Headless:  true,
+	})
+	if err != nil {
+		return undecided("could not write the job document: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, r.Timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, r.Node, r.Entry)
+	cmd.Stdin = bytes.NewReader(document)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	runErr := cmd.Run()
+
+	// The exit code is read for the record and never for the answer. The
+	// runner exits 8 on a failing workflow and 0 on a blocked one, which is
+	// right for a pull request and is not the question here: this tool has to
+	// tell "could not reach it" from "reached it and it was broken", and only
+	// the document says which.
+	var result resultDocument
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		if ctx.Err() != nil {
+			return undecided("the run against %s did not finish inside %s.", origin, r.Timeout)
+		}
+		return undecided(
+			"the runner did not return a result document (%v). It said: %s",
+			runErr, firstLine(stderr.String()))
+	}
+	if len(result.Results) == 0 {
+		return undecided(
+			"the runner returned a document with no results in it, so nothing was checked.")
+	}
+	return decide(origin, result.Results[0])
+}
+
+func firstLine(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "nothing at all"
+	}
+	lines := strings.Split(s, "\n")
+	// The last line, not the first: node prints its experimental type
+	// stripping warning before anything the runner says.
+	return strings.TrimSpace(lines[len(lines)-1])
+}
+
+func sanitize(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	return b.String()
+}

--- a/tools/sitesmoke/smoke.go
+++ b/tools/sitesmoke/smoke.go
@@ -1,0 +1,187 @@
+// Package main is shared by the files in tools/sitesmoke. This file holds the
+// part that decides, which is the part with no browser, no network and no
+// subprocess in it.
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Answer is what one origin's run concluded.
+//
+// Three, not two, and the third is the one this tool exists to keep honest. A
+// production smoke that cannot say "I did not find out" says "pass" instead,
+// because that is the answer with no work attached to it. Every path below
+// that is not a proven pass returns Refused or Undecided, and both are red.
+type Answer int
+
+const (
+	// Allowed means a person's path through this origin worked, proven by the
+	// page showing what it shows when it works.
+	Allowed Answer = iota
+	// Refused means the page showed something else. The application is broken
+	// for a person on this hostname right now.
+	Refused
+	// Undecided means this run did not find out: the origin could not be
+	// reached, the browser could not drive it, or two attempts disagreed.
+	Undecided
+)
+
+// Exit codes, and the reason there are three of them.
+//
+// `origincheck` in this repository already settled the convention and this
+// follows it: 0 allowed, 1 refused, 2 could not tell. Continuous integration
+// treats 1 and 2 alike, because both mean the run did not prove the thing it
+// was there to prove. They are separate on the command line because they need
+// different actions from whoever reads them: a 1 is a broken deployment and a
+// 2 is a broken check.
+const (
+	exitAllowed   = 0
+	exitRefused   = 1
+	exitUndecided = 2
+)
+
+func (a Answer) String() string {
+	switch a {
+	case Allowed:
+		return "allowed"
+	case Refused:
+		return "refused"
+	default:
+		return "could not tell"
+	}
+}
+
+func (a Answer) exitCode() int {
+	switch a {
+	case Allowed:
+		return exitAllowed
+	case Refused:
+		return exitRefused
+	default:
+		return exitUndecided
+	}
+}
+
+// Finding is what one workflow against one origin concluded.
+type Finding struct {
+	Origin   string
+	Workflow string
+	Answer   Answer
+	// Said is what the tool tells a person. It carries the page's own sentence
+	// whenever there was one, because "exploration failed" is a sentence
+	// nobody can act on and "It says: Could not reach the server" is one
+	// somebody can take straight to the cause.
+	Said string
+	// Steps is what the agent did, so a failure can be followed by hand.
+	Steps []string
+	// Evidence is where the screenshot, video and trace of the failure are.
+	Evidence []string
+}
+
+// decide turns one runner result into a finding.
+//
+// THE DEFECT THIS IS SHAPED AROUND. A run whose result cannot be read, whose
+// results list is empty, or whose verdict is a word this tool does not know
+// must not fall through to a pass. That failure has a name in this repository:
+// a report published as a pass over a run that failed. Every branch below
+// returns Refused or Undecided unless the verdict is literally "pass".
+func decide(origin string, result workflowResult) Finding {
+	f := Finding{Origin: origin, Workflow: result.Workflow, Steps: result.Steps}
+	f.Evidence = evidenceOf(result)
+	switch result.Outcome.Verdict {
+	case "pass":
+		f.Answer = Allowed
+		f.Said = "the page showed what it shows when this works."
+	case "fail":
+		f.Answer = Refused
+		f.Said = result.Outcome.Detail
+	case "flaky":
+		// Not a pass and not a failure, and rounding it to either would be a
+		// lie in a different direction. A form that works on one attempt and
+		// not on the next is broken for some fraction of the people using it,
+		// and this tool cannot say which fraction.
+		f.Answer = Undecided
+		f.Said = "the same workflow passed on one attempt and failed on another, so this run " +
+			"cannot say whether a person's submission works. " + result.Outcome.Detail
+	case "blocked":
+		// The agent never got far enough to have an opinion. This is the
+		// unreachable case, and it reads differently from the case above on
+		// purpose: "could not reach the origin at all" and "reached it and it
+		// showed an error" are different failures with different first steps.
+		f.Answer = Undecided
+		f.Said = "the browser could not drive " + origin + " far enough to find out. " +
+			result.Outcome.Detail
+	case "unverified":
+		f.Answer = Undecided
+		f.Said = "the run proved nothing either way. " + result.Outcome.Detail
+	case "":
+		f.Answer = Undecided
+		f.Said = "the runner returned a result with no verdict in it."
+	default:
+		f.Answer = Undecided
+		f.Said = fmt.Sprintf("the runner returned a verdict this tool does not know, %q. "+
+			"A word it cannot read is not a pass.", result.Outcome.Verdict)
+	}
+	return f
+}
+
+func evidenceOf(result workflowResult) []string {
+	var out []string
+	for _, e := range []string{result.Evidence.Screenshot, result.Evidence.Video, result.Evidence.Trace} {
+		if e != "" {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// verdict rolls a run's findings into one answer.
+//
+// The worst answer wins, and an empty set is Undecided rather than Allowed. A
+// run that checked nothing has proved nothing, and the shape of bug that
+// produces an empty set, a flag misspelled, a hostname list that failed to
+// load, is exactly the shape that would otherwise report a green production.
+func verdict(findings []Finding) Answer {
+	if len(findings) == 0 {
+		return Undecided
+	}
+	worst := Allowed
+	for _, f := range findings {
+		if f.Answer == Refused {
+			return Refused
+		}
+		if f.Answer == Undecided {
+			worst = Undecided
+		}
+	}
+	return worst
+}
+
+// summary is what the tool prints last, and it names every origin.
+func summary(findings []Finding) string {
+	var b strings.Builder
+	for _, f := range findings {
+		mark := "ok"
+		switch f.Answer {
+		case Refused:
+			mark = "REFUSED"
+		case Undecided:
+			mark = "COULD NOT TELL"
+		}
+		fmt.Fprintf(&b, "  %-9s %s  %s\n", mark, f.Origin, f.Workflow)
+		fmt.Fprintf(&b, "            %s\n", f.Said)
+		// What the agent did, on anything that is not a pass. A failure
+		// somebody cannot follow by hand is a failure somebody reruns.
+		if f.Answer != Allowed {
+			for i, s := range f.Steps {
+				fmt.Fprintf(&b, "            %2d. %s\n", i+1, s)
+			}
+		}
+		for _, e := range f.Evidence {
+			fmt.Fprintf(&b, "            evidence %s\n", e)
+		}
+	}
+	return b.String()
+}

--- a/tools/sitesmoke/smoke_test.go
+++ b/tools/sitesmoke/smoke_test.go
@@ -1,0 +1,316 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The one thing this whole file is really about.
+//
+// PR 243 in this repository fixed a report that published a failure as a pass.
+// The shape recurs because "pass" is the answer with no work attached to it:
+// every branch that forgets to decide falls into it. So every verdict this
+// tool can be handed, including the ones it has never seen, is checked here
+// against the rule that only the literal word "pass" is allowed to be a pass.
+func TestOnlyAPassIsAPass(t *testing.T) {
+	for _, tc := range []struct {
+		verdict string
+		want    Answer
+	}{
+		{"pass", Allowed},
+		{"fail", Refused},
+		{"flaky", Undecided},
+		{"blocked", Undecided},
+		{"unverified", Undecided},
+		{"", Undecided},
+		{"succeeded", Undecided},
+		{"ok", Undecided},
+		{"PASS", Undecided},
+	} {
+		got := decide("https://antifailure.dev", workflowResult{
+			Workflow: "w", Outcome: outcome{Verdict: tc.verdict, Detail: "d"},
+		})
+		if got.Answer != tc.want {
+			t.Errorf("verdict %q became %v, want %v", tc.verdict, got.Answer, tc.want)
+		}
+	}
+}
+
+// A failure has to arrive carrying the sentence the page showed.
+//
+// "exploration failed" is a red mark somebody has to reproduce. The page's own
+// words are a red mark somebody can take straight to the cause, and they are
+// the only thing that tells a control plane with no such route apart from one
+// refusing this hostname.
+func TestAFailureQuotesWhatThePageSaid(t *testing.T) {
+	said := `The page shows an error rather than what was expected. It says: "Could not reach the server."`
+	got := decide("https://www.antifailure.dev", workflowResult{
+		Workflow: "the-careers-form-reaches-the-control-plane",
+		Outcome:  outcome{Verdict: "fail", Cause: "expectation-not-met", Detail: said},
+	})
+	if got.Answer != Refused {
+		t.Fatalf("answer is %v, want refused", got.Answer)
+	}
+	if !strings.Contains(got.Said, "Could not reach the server.") {
+		t.Errorf("the finding does not quote the page: %q", got.Said)
+	}
+}
+
+// Unreachable and reached-but-broken must not read the same.
+//
+// They have different first steps: one is "is the site up", the other is "what
+// did the control plane answer". A tool that says "failed" for both sends
+// whoever reads it to the wrong place half the time.
+func TestUnreachableReadsDifferentlyFromABrokenPage(t *testing.T) {
+	unreachable := decide("https://antifailure.dev", workflowResult{
+		Outcome: outcome{
+			Verdict: "blocked", Cause: "runner-failure",
+			Detail: "page.goto: net::ERR_NAME_NOT_RESOLVED at https://antifailure.dev/careers",
+		},
+	})
+	broken := decide("https://antifailure.dev", workflowResult{
+		Outcome: outcome{
+			Verdict: "fail", Cause: "expectation-not-met",
+			Detail: `It says: "Could not reach the server."`,
+		},
+	})
+	if unreachable.Answer == broken.Answer {
+		t.Fatalf("both answered %v", unreachable.Answer)
+	}
+	if unreachable.Answer != Undecided || broken.Answer != Refused {
+		t.Fatalf("unreachable=%v broken=%v", unreachable.Answer, broken.Answer)
+	}
+	if !strings.Contains(unreachable.Said, "could not drive") {
+		t.Errorf("the unreachable message does not say the browser never got there: %q", unreachable.Said)
+	}
+	if strings.Contains(unreachable.Said, "Could not reach the server.") {
+		t.Errorf("the unreachable message quotes a page it never read: %q", unreachable.Said)
+	}
+}
+
+// A run that checked nothing has proved nothing.
+func TestNothingCheckedIsNotAPass(t *testing.T) {
+	if got := verdict(nil); got != Undecided {
+		t.Errorf("an empty run answered %v, want could not tell", got)
+	}
+	if got := verdict([]Finding{}); got != Undecided {
+		t.Errorf("an empty run answered %v, want could not tell", got)
+	}
+}
+
+// One bad origin decides the whole run, and the worst answer wins.
+func TestTheWorstAnswerWins(t *testing.T) {
+	pass := Finding{Answer: Allowed}
+	for _, tc := range []struct {
+		name     string
+		findings []Finding
+		want     Answer
+	}{
+		{"all pass", []Finding{pass, pass}, Allowed},
+		{"one refused", []Finding{pass, {Answer: Refused}}, Refused},
+		{"one undecided", []Finding{pass, {Answer: Undecided}}, Undecided},
+		{"refused outranks undecided", []Finding{{Answer: Undecided}, {Answer: Refused}}, Refused},
+	} {
+		if got := verdict(tc.findings); got != tc.want {
+			t.Errorf("%s answered %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestExitCodesAreTheDocumentedOnes(t *testing.T) {
+	for answer, want := range map[Answer]int{Allowed: 0, Refused: 1, Undecided: 2} {
+		if got := answer.exitCode(); got != want {
+			t.Errorf("%v exits %d, want %d", answer, got, want)
+		}
+	}
+}
+
+// The offline half against the real tree, and against a tree missing a sentence.
+func TestTheContractIsCheckedAgainstTheRealTree(t *testing.T) {
+	var out strings.Builder
+	if err := contractHolds(filepath.Join("..", ".."), &out); err != nil {
+		t.Fatalf("the sentences this check waits for are not in the tree: %v", err)
+	}
+	for _, c := range contracts() {
+		if !strings.Contains(out.String(), c.sentence) {
+			t.Errorf("the report does not name %q, so a reader cannot see what was checked", c.sentence)
+		}
+	}
+}
+
+func TestAMissingSentenceIsRefusedRatherThanIgnored(t *testing.T) {
+	root := t.TempDir()
+	for _, c := range contracts() {
+		path := filepath.Join(root, c.file)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		body := c.sentence
+		if c.sentence == recordedSentence {
+			// The one sentence this tree does not carry, which is the case:
+			// an expectation waiting for words the site no longer renders can
+			// never be satisfied by any deployment.
+			body = "nothing like it"
+		}
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var out strings.Builder
+	err := contractHolds(root, &out)
+	if err == nil {
+		t.Fatal("a tree missing the confirmation sentence passed the contract")
+	}
+	if !strings.Contains(err.Error(), recordedSentence) {
+		t.Errorf("the refusal does not name the missing sentence: %v", err)
+	}
+}
+
+// A file that is not there at all is refused, not skipped.
+func TestAnUnreadableFileFailsRatherThanSkips(t *testing.T) {
+	var out strings.Builder
+	if err := contractHolds(t.TempDir(), &out); err == nil {
+		t.Fatal("a tree with none of the files passed the contract")
+	}
+}
+
+// The scheduled workflow must not be able to become one that writes.
+func TestTheScheduledWorkflowWritesNothing(t *testing.T) {
+	for _, w := range workflowsFor(false) {
+		if w.writes {
+			t.Fatalf("%s writes and runs without -allow-writes", w.Name)
+		}
+		if strings.TrimSpace(w.why) == "" {
+			t.Errorf("%s claims to write nothing and gives no reason, which is an assertion "+
+				"nobody can check", w.Name)
+		}
+	}
+	names := map[string]bool{}
+	for _, w := range workflowsFor(true) {
+		names[w.Name] = true
+	}
+	if !names[applyForAFoundingRole().Name] {
+		t.Error("-allow-writes does not add the workflow that files an application")
+	}
+}
+
+// Every expectation is quoted, so every one of them can say no.
+//
+// An unquoted expectation is judged by how many of its words are somewhere on
+// the page, and the control plane's own refusal scores six of its seven words
+// against the careers page before the form is touched. One unquoted line here
+// would be an assertion that passes a broken deployment.
+func TestEveryExpectationIsVerbatim(t *testing.T) {
+	for _, w := range workflowsFor(true) {
+		if len(w.Expect) == 0 {
+			t.Errorf("%s expects nothing, so it cannot fail", w.Name)
+		}
+		for _, e := range w.Expect {
+			if !strings.HasPrefix(e, `"`) || !strings.HasSuffix(e, `"`) || len(e) < 3 {
+				t.Errorf("%s expects %q, which is judged by word overlap and not by whether "+
+					"the page says it", w.Name, e)
+			}
+		}
+	}
+}
+
+// The work link that keeps the scheduled check inert has to stay inert.
+func TestTheInertWorkLinkCarriesCredentials(t *testing.T) {
+	if !strings.Contains(inertWorkLink, "@") || !strings.Contains(inertWorkLink, ":") {
+		t.Fatalf("%q has no credentials in it, so the control plane would accept it and the "+
+			"scheduled check would file a job application every time it ran", inertWorkLink)
+	}
+	if !strings.Contains(inertWorkLink, ".test") {
+		t.Errorf("%q is not in a reserved domain", inertWorkLink)
+	}
+	w := theCareersFormReachesTheControlPlane()
+	if w.Answers["Link to your work"] != inertWorkLink {
+		t.Fatalf("the scheduled workflow answers the work link with %q, not the inert one",
+			w.Answers["Link to your work"])
+	}
+}
+
+// Driving the runner: everything that can go wrong is Undecided, never Allowed.
+func fakeRunner(t *testing.T, script string) runner {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fake-node")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+script+"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	entry := filepath.Join(dir, "main.ts")
+	if err := os.WriteFile(entry, []byte("// not read by the fake\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return runner{
+		Entry: entry, Node: path, Artifacts: filepath.Join(dir, "artifacts"),
+		Attempts: 1, Timeout: 30 * time.Second,
+	}
+}
+
+func TestARunnerThatSaysNothingIsNotAPass(t *testing.T) {
+	r := fakeRunner(t, `exit 0`)
+	got := r.drive(context.Background(), "https://antifailure.dev", theCareersFormReachesTheControlPlane())
+	if got.Answer != Undecided {
+		t.Fatalf("a runner that printed nothing answered %v", got.Answer)
+	}
+	// The message as well as the answer. Both guards below this one also
+	// return Undecided, so the answer alone cannot say which of them caught
+	// it, and a mutation that removes this check would be covered by the next
+	// one and look tested.
+	if !strings.Contains(got.Said, "did not return a result document") {
+		t.Errorf("the message does not say the runner returned nothing readable: %q", got.Said)
+	}
+}
+
+func TestARunnerThatCrashesNamesWhatItSaid(t *testing.T) {
+	// Two lines, because node prints its experimental type stripping warning
+	// before anything the runner says and the useful line is the LAST one.
+	r := fakeRunner(t, `echo "ExperimentalWarning: Type Stripping is experimental" >&2
+echo "af-runner: Cannot find package 'playwright'" >&2
+exit 1`)
+	got := r.drive(context.Background(), "https://antifailure.dev", theCareersFormReachesTheControlPlane())
+	if got.Answer != Undecided {
+		t.Fatalf("a runner that crashed answered %v", got.Answer)
+	}
+	if !strings.Contains(got.Said, "playwright") {
+		t.Errorf("the message does not carry what the runner said: %q", got.Said)
+	}
+}
+
+func TestAnEmptyResultListIsNotAPass(t *testing.T) {
+	r := fakeRunner(t, `echo '{"results":[],"passed":0,"failed":0}'`)
+	got := r.drive(context.Background(), "https://antifailure.dev", theCareersFormReachesTheControlPlane())
+	if got.Answer != Undecided {
+		t.Fatalf("a document with no results answered %v", got.Answer)
+	}
+	if !strings.Contains(got.Said, "nothing was checked") {
+		t.Errorf("the message does not say nothing was checked: %q", got.Said)
+	}
+}
+
+func TestAPassingDocumentIsRead(t *testing.T) {
+	r := fakeRunner(t, `echo '{"results":[{"workflow":"w","outcome":{"verdict":"pass","cause":"succeeded","detail":"ok"},"steps":["Open /careers"],"evidence":{"screenshot":"/tmp/a.png"}}]}'`)
+	got := r.drive(context.Background(), "https://antifailure.dev", theCareersFormReachesTheControlPlane())
+	if got.Answer != Allowed {
+		t.Fatalf("a passing document answered %v: %s", got.Answer, got.Said)
+	}
+	if len(got.Evidence) != 1 || got.Evidence[0] != "/tmp/a.png" {
+		t.Errorf("the evidence was lost: %v", got.Evidence)
+	}
+}
+
+// The runner exits 8 on a failing workflow and 0 on a blocked one. Neither
+// exit code is the answer here, and reading them instead of the document would
+// turn "could not reach the origin" into "the site is fine".
+func TestTheDocumentDecidesAndNotTheExitCode(t *testing.T) {
+	r := fakeRunner(t, `echo '{"results":[{"workflow":"w","outcome":{"verdict":"blocked","cause":"runner-failure","detail":"page.goto timed out"}}]}'; exit 0`)
+	got := r.drive(context.Background(), "https://antifailure.dev", theCareersFormReachesTheControlPlane())
+	if got.Answer != Undecided {
+		t.Fatalf("a blocked run that exited zero answered %v", got.Answer)
+	}
+}

--- a/tools/sitesmoke/workflows.go
+++ b/tools/sitesmoke/workflows.go
@@ -1,0 +1,221 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// What this tool asks the deployed site to do, and what it must say back.
+//
+// A WORKFLOW HERE IS THE PRODUCT'S OWN WORKFLOW, not a second test framework.
+// Each one below is a `Workflow` in the shape `af-runner` reads on standard
+// input: a name, a sentence, where to start, what has to be on the page at the
+// end. The runner opens Chromium, reads the accessibility tree, decides what
+// to fill and what to press, and returns a verdict. Nothing here drives a
+// browser and nothing here knows a selector.
+//
+// EVERY EXPECTATION IS QUOTED, and that is not a style. An unquoted expectation
+// is judged by how many of its meaningful words appear on the page, which is
+// right for a sentence about a product and wrong for a sentence a page either
+// renders or does not. The control plane's own refusal, "Use a public http or
+// https link without credentials", scores six of its seven words against the
+// careers page BEFORE the form is touched, because `public`, `link`, `use`,
+// `credentials` and an install command containing `https` are all already on
+// it. Quoted, it is present or it is absent, and absent is an answer.
+type smokeWorkflow struct {
+	Name        string            `json:"name"`
+	Description string            `json:"description"`
+	StartPath   string            `json:"startPath"`
+	Expect      []string          `json:"expect"`
+	Answers     map[string]string `json:"answers,omitempty"`
+
+	// writes says whether running this against a deployment puts a row in a
+	// table a person reads. Declared rather than discovered, the same way
+	// tools/routecheck declares what each of its probes costs, so a run that
+	// files a real job application is a run somebody asked for in as many
+	// words.
+	writes bool
+	// why records what makes this inert, checked against the API's source
+	// rather than assumed. Empty for a workflow that writes.
+	why string
+}
+
+// The work link that makes the scheduled check inert.
+//
+// A URL with credentials in it. `applicationInput` in the control plane refines
+// projectUrl to reject exactly that, and the refinement runs inside
+// `safeParse`, which the route calls BEFORE `recordApplication`, so the request
+// reaches the handler, is refused, and writes nothing. The browser's own
+// validation accepts it, because it is a valid absolute URL, which is the
+// property that lets the form be submitted at all.
+//
+// Verified against the deployed control plane rather than reasoned about:
+//
+//	POST https://app.antifailure.dev/v1/applications
+//	  Origin: https://antifailure.dev
+//	  -> 400 {"error":"Use a public http or https link without credentials."}
+//
+// example.test is a reserved domain under RFC 2606, so the host in it belongs
+// to nobody and can never be reached.
+const inertWorkLink = "https://smoke:smoke@example.test/"
+
+// refusalSentence is the control plane's own answer to that link.
+//
+// This tool and the control plane ship on different clocks, so this string is
+// a coupling across a deployment boundary, which is the exact hazard this
+// whole lane is about. It is not left to trust: contractHolds below reads the
+// API's source and fails when the sentence there is no longer this one.
+const refusalSentence = "Use a public http or https link without credentials."
+
+// tryAgain is the site's own label once a submission has been refused. It is
+// what proves the form was actually SENT rather than merely filled in: the
+// button says "Send application" until something comes back.
+const tryAgain = "Try it again"
+
+// recordedSentence is what the careers page says when a row exists.
+//
+// The site earns it: ApplicationForm.tsx checks that the answer carries
+// recorded:true, the submission key it sent, and a uuid, before it renders
+// this. So a workflow that ends here has proved the whole path, browser to
+// database, and not merely that something answered.
+const recordedSentence = "It is written down."
+
+// theCareersFormReachesTheControlPlane is the scheduled check.
+//
+// A PERSON'S EXPERIENCE, WHICH IS THE WHOLE POINT OF IT. An endpoint probe
+// reports `POST /v1/applications -> 404`. A person reads "Could not reach the
+// server." Those are different failures and only the second is the one anybody
+// actually had. tools/routecheck owns the first and runs before the site
+// publishes; this owns the second and runs against what browsers are pointed
+// at. Neither replaces the other: routecheck sends no Origin header and never
+// opens a page, so it cannot see the site's build time configuration, its
+// JavaScript, or a control plane that refuses this particular hostname.
+//
+// It writes nothing. See inertWorkLink.
+func theCareersFormReachesTheControlPlane() smokeWorkflow {
+	return smokeWorkflow{
+		Name: "the-careers-form-reaches-the-control-plane",
+		Description: "Fill in the careers form as a person would, press the button, and read what " +
+			"the page says came back.",
+		StartPath: "/careers",
+		Expect: []string{
+			quoted(refusalSentence),
+			quoted(tryAgain),
+		},
+		Answers: map[string]string{"Link to your work": inertWorkLink},
+		writes:  false,
+		why: "The control plane's own validation refuses a work link with credentials in it, " +
+			"in applicationInput's projectUrl refinement, and safeParse runs before " +
+			"recordApplication. Nothing is written and nothing is sent.",
+	}
+}
+
+// applyForAFoundingRole is the whole path, and it files a real application.
+//
+// It exists because the check above deliberately stops one step short: it
+// proves that a person's browser reached the deployed control plane and that
+// the control plane's own answer came back and rendered, and it does NOT prove
+// that a valid application is written to a database. Nothing else proves that
+// through a browser, so the workflow that does is kept, named, and refused
+// unless somebody asks for it by name.
+//
+// There is no staging copy of this site to run it against. antifailure.dev and
+// www.antifailure.dev are two custom domains on one Static Web App, publishing
+// on every merge to main, and there is no third. So the choice really is
+// between writing a row into the hiring queue a person reads and not proving
+// the write at all, and the answer is that a scheduled check must not file job
+// applications and a human running one deliberately may.
+func applyForAFoundingRole() smokeWorkflow {
+	return smokeWorkflow{
+		Name: "apply-for-a-founding-role",
+		Description: "Apply for a founding role and confirm the page says the application is " +
+			"recorded.",
+		StartPath: "/careers",
+		Expect:    []string{quoted(recordedSentence)},
+		writes:    true,
+	}
+}
+
+func quoted(s string) string { return `"` + s + `"` }
+
+// workflowsFor picks what this run will do.
+func workflowsFor(allowWrites bool) []smokeWorkflow {
+	if allowWrites {
+		return []smokeWorkflow{theCareersFormReachesTheControlPlane(), applyForAFoundingRole()}
+	}
+	return []smokeWorkflow{theCareersFormReachesTheControlPlane()}
+}
+
+// contract is one sentence this tool expects a deployed page to show, and the
+// file in this repository that is supposed to produce it.
+type contract struct {
+	sentence string
+	file     string
+	// why says what breaks when the file no longer carries the sentence.
+	why string
+}
+
+func contracts() []contract {
+	return []contract{
+		{
+			sentence: refusalSentence,
+			file:     filepath.Join("web", "apps", "api", "src", "recruitment", "applications.ts"),
+			why: "It is the control plane's refusal of a work link with credentials, and it is " +
+				"what the scheduled check waits for. If the API says something else now, the " +
+				"check will go red against a site that is working perfectly, on the day the " +
+				"new message is promoted to production.",
+		},
+		{
+			sentence: recordedSentence,
+			file:     filepath.Join("www", "components", "pages", "company", "ApplicationForm.tsx"),
+			why: "It is the confirmation the careers page renders once a row exists, and it is " +
+				"the only thing that tells a completed submission from a submitted one.",
+		},
+		{
+			sentence: tryAgain,
+			file:     filepath.Join("www", "components", "pages", "company", "ApplicationForm.tsx"),
+			why: "It is the button's label after a refusal, and it is what proves the form was " +
+				"sent rather than merely filled in.",
+		},
+		{
+			sentence: "compensationAcknowledged",
+			file:     filepath.Join("web", "apps", "api", "src", "recruitment", "applications.ts"),
+			why: "The form the agent drives has a required acknowledgment on it, and a control " +
+				"plane that stopped requiring one would mean the agent's tick proves nothing.",
+		},
+	}
+}
+
+// contractHolds is the OFFLINE half, and it says out loud what it did not check.
+//
+// It cannot see a deployment. On the day the careers form broke, the tree was
+// perfect: main's control plane declared the route, the form posted to it, and
+// what was wrong was that production served a version from before the route
+// existed. So this half is not evidence that the site works. It is evidence
+// that the sentences the ONLINE half waits for are still the sentences this
+// repository produces, which is the one way the online half could go quietly
+// wrong: an expectation nothing can ever satisfy passes no deployment, and an
+// expectation satisfied by the wrong page passes every one.
+func contractHolds(root string, out *strings.Builder) error {
+	var broken []string
+	for _, c := range contracts() {
+		path := filepath.Join(root, c.file)
+		source, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read %s, which is supposed to carry %q: %w", c.file, c.sentence, err)
+		}
+		if !strings.Contains(string(source), c.sentence) {
+			broken = append(broken, fmt.Sprintf("  %s\n    no longer contains %q\n    %s",
+				c.file, c.sentence, c.why))
+			continue
+		}
+		fmt.Fprintf(out, "  %s\n    still says %q\n", c.file, c.sentence)
+	}
+	if len(broken) > 0 {
+		return fmt.Errorf("%d sentence(s) this check waits for are not in the tree any more:\n%s",
+			len(broken), strings.Join(broken, "\n"))
+	}
+	return nil
+}


### PR DESCRIPTION
Somebody filled in the careers form on the real `https://antifailure.dev` and
was told "Could not reach the server." The question that followed is the one
worth answering: this product's promise is exploratory agents that drive an
application the way a person does, it dogfoods itself on every pull request, and
it found nothing.

## The first answer is true and it is not the whole answer

A dogfood run builds a disposable stack out of ONE commit, where the site and
the API necessarily agree, so the form submits and the run correctly reports
nothing wrong. The bug lived between two independently versioned deployments and
an environment built from a single commit has no such space in it. The
exploration already drives a real browser. Same agent, same Chromium, same form,
wrong target. So the fix is to point what exists at what is deployed, and not to
add a second browser harness beside the runner's own.

Pointed straight at the deployed site on the day it was broken, the agent would
still have exited zero. Five times over, and every one of them is a property of
the FORM and of the runner rather than of the target.

1. **A checkbox is never ticked.** A checkbox carries `value="on"` whether or
   not anybody ticked it and a radio carries whatever the markup gave it, so
   `filled: !!input.value` was true for every one of them, always. The planner
   skips filled fields, so the required "I understand there is no salary"
   acknowledgment was never ticked and no role was ever chosen. `filled` now
   means answered, and a radio reports whether its GROUP has a chosen member.
2. **A required field it does not recognise is left empty.** "What have you
   built or grown, and why this role" matches no shape any application shares,
   so it stayed empty and the browser refused to submit the form at all. An
   OPTIONAL one is still left alone, and so is an optional checkbox: an agent
   that ticks every box on a page has subscribed somebody to a newsletter to see
   what happens.
3. **Nothing presses "Send application".** It is on no list of words that move a
   workflow forward. The document already knows which control submits a form.
   Consulting the word list first then exposed the worse half: this site's
   header carries a "Sign in" link and `^(sign in|log in|login)$` matches it, so
   the agent filled in every field and then followed the header link. Once
   anything has been answered the submit control wins, and once it is spent the
   answer is STUCK rather than somewhere else.
4. **The failure sentence was unreadable.** "Could not reach the server" was on
   no list of failure signals, so the page telling the agent its request never
   arrived was judged unreadable. The verdict was `unverified`, and
   `unverified` exits zero.
5. **A press was read a millisecond after it landed.** The form disables its own
   fieldset while the request is in flight, so the snapshot saw no fields and a
   button labelled "Recording it". `waitForLoadState('networkidle')` cannot see
   this: it asks whether the CURRENT DOCUMENT has already reached that state,
   and a client rendered page reached it seconds ago and stays there, so every
   later call returns at once. The session now counts its in flight requests.
   This one made a working origin red about one run in ten.

## An expectation can now say no

`expect` is judged by how many of its meaningful words appear on the page. The
control plane's own refusal, "Use a public http or https link without
credentials", scores six of its seven words against the careers page BEFORE the
form is touched, because `public`, `link`, `use`, `credentials` and an install
command containing `https` are all already on it. So the expectation was
satisfied by a page the workflow had not done anything to, and the workflow
passed in one step over a form it never submitted.

An expectation in double quotes is now required character for character, and a
quoted one that is absent is `unmet` rather than `unclear`. A string is on the
page or it is not.

A workflow may also say what to type into a field it names. It is a table and
not a script: it says what an answer IS, never what order to do things in or
which control to press.

## `tools/sitesmoke`

It drives the deployed site with the product's own runner, through the job
document the runner already reads on standard input, and asserts on what a
PERSON sees. Three answers, not two: 0 is a proven pass, 1 is a page that showed
the wrong thing, 2 is a run that did not find out. Continuous integration treats
1 and 2 alike. Nothing returns 0 except the literal word `pass` read out of a
document the runner wrote.

It is not `tools/routecheck`, which merged in #249 and runs before the site
publishes. An endpoint probe reports `POST /v1/applications -> 404`; a person
reads "Could not reach the server." Reaching the second needs the real page, its
JavaScript, the control plane URL baked into the build, and a cross origin
request from the exact hostname somebody typed. Both are wanted, neither is the
other, and this one adds no tenth required context.

**It files no job applications.** The careers form writes into a queue a person
reads, and a check on a schedule must not put a row in it every time. The
scheduled workflow answers the optional work link with a URL carrying
credentials, which `applicationInput`'s `projectUrl` refinement refuses inside
`safeParse`, before `recordApplication` is reached. Measured against the
deployed control plane rather than reasoned about: `400 {"error":"Use a public
http or https link without credentials."}`. The whole path including the write
is a second workflow and it needs `-allow-writes`, which is the same shape
`routecheck -allow-write-probes` already established. There is no staging copy
of this site to run the writing half against, so the trade is real and it is
named in `tools/sitesmoke/workflows.go`: production never proves the INSERT
through a browser.

## Proving it can say no

| # | target | answer | what it said |
|---|---|---|---|
| 1 | `https://www.antifailure.dev` today | exit 1 REFUSED | `The page shows an error rather than what was expected. It says: "Could not reach the server."` |
| 2 | `https://antifailure.dev` today | exit 0 ok | the page showed what it shows when this works |
| 3 | production as recorded pre promotion | exit 1 REFUSED | the same sentence, driving the real site bundle against a control plane answering 404 on `POST /v1/applications`, which is what v1.1.1 did |
| 4 | one bad origin among two | exit 1 overall | the run goes red, not green with a line in a log |
| 5 | a hostname that does not resolve | exit 2 COULD NOT TELL | `the browser could not drive https://nothing-here.antifailure.dev far enough to find out. page.goto: net::ERR_NAME_NOT_RESOLVED` |

Rows 1, 2 and 4 are one run against both hostnames. Row 5 says something
different from row 1 on purpose: "could not reach the origin" and "reached it
and it showed an error" have different first steps.

32 mutation cells, every one RED on its intended assertion and GREEN restored.
Two stayed green on the first pass and both were the same defect in the test
rather than in the subject: two failure signal patterns both match "could not
reach", so a mutation of either was covered by the other, and the in flight wait
cannot be exercised by a server that answers instantly. The first is now
asserted through the contracted forms, "couldn't reach" and "can't reach", which
only one pattern sees. The second has a test with a control plane that takes a
second and a half to answer, which is the production race reproduced.

## `www` is red right now and that is the point

`https://www.antifailure.dev/careers` cannot submit today. #252 has merged, so
main and staging carry the fix, and production only moves when somebody promotes
a `v*` tag. Until then the scheduled job and the post publish step will both be
red on that hostname, by name, with the sentence a person would read. Do not
"fix" it here.

Signed-off-by: Vir Sanghavi <67278851+VirSanghavi@users.noreply.github.com>
