### PR TITLE
build: the gates were the least linted code in the tree

### DIFF
--- a/.changes/the-gates-were-the-least-linted-code-in-the-tree.internal.md
+++ b/.changes/the-gates-were-the-least-linted-code-in-the-tree.internal.md
@@ -1,0 +1,22 @@
+# fixed
+
+CI linted the engine and nothing else.
+
+`tools/` holds prosecheck, gatecheck, changecheck, routecheck, wirecheck,
+claimcheck and every other instrument this repository trusts to say no, and no
+workflow had ever pointed a linter at it. Held to the same set the engine is
+kept at zero on, it carried 122 findings.
+
+The count matters as much as the fix. The first look reported 27, and 27 was
+the number a plan was built on. golangci-lint caps its output by default at
+three of any repeated issue and fifty per linter, so the run that said 27 had
+seen 122 and printed a sample. Both caps are now off, in the shared config, so
+a future regression is reported at its real size.
+
+Every finding is fixed rather than suppressed and no rule is disabled. The
+prints that deliberately ignore a failed write to a report stream now say so at
+the call site, in the form the engine already uses. Deferred closes on read
+handles take the engine's idiom too. Two format verbs that dropped a wrapped
+error, three error strings ending in punctuation, a deprecated parser call, a
+hand-rolled type assertion on an error, and two dead test helpers are all
+corrected.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,6 +367,24 @@ jobs:
           working-directory: engine
           args: --timeout 15m
 
+      - name: Lint the gates
+        # The step above lints the engine and, until this one existed, that was
+        # the whole of it. tools/ holds prosecheck, gatecheck, changecheck,
+        # routecheck, wirecheck, claimcheck and every other instrument this
+        # repository trusts to say no, and it was the least linted code in the
+        # tree: 122 findings, on the same linter set the engine is held to at
+        # zero.
+        #
+        # Same action, same version, same config, a different working
+        # directory. Two invocations rather than one run over both modules
+        # because they are separate Go modules joined by a workspace, and
+        # golangci-lint runs against one module's package graph at a time.
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+        with:
+          version: v2.13.1
+          working-directory: tools
+          args: --timeout 15m
+
       - name: The gates themselves
         # errcheck, ldcheck and the generators decide whether a build is
         # allowed to ship, and their own tests were never run here. A gate

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -72,6 +72,22 @@ linters:
         linters:
           - bodyclose
 
+# Report every finding, not a sample of them.
+#
+# golangci-lint caps output by default: max-same-issues is 3 and
+# max-issues-per-linter is 50. A run that says "27 issues" when there are 122
+# is not a smaller version of the truth, it is a number that cannot be used.
+# The tools module was measured at 27 with the defaults and at 122 without
+# them, and the plan built on the first number was wrong about how much work
+# there was and about which packages carried it.
+#
+# The engine has been at zero since this file existed, so this changes nothing
+# there today. It changes what the first regression looks like, which is the
+# only moment the cap could ever matter.
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
 formatters:
   enable:
     - gofmt

--- a/justfile
+++ b/justfile
@@ -109,6 +109,7 @@ gate: _reports
     run "typecheck"                      just typecheck
     run "format"                         just fmt-check
     run "lint"                           just lint
+    run "the gates lint too"             just lint-tools
     run "the gates themselves"           just test-tools
     run "coverage"                       just coverage
     run "engine"                         just test-engine
@@ -1367,6 +1368,28 @@ generate:
 # certifies this machine's keychain works, by not looking at the keychain.
 keyring:
     cd engine && go test ./internal/secrets/ -count=1
+
+# The same linter set, pointed at the module that decides what ships.
+#
+# tools/ holds prosecheck, gatecheck, changecheck, routecheck, wirecheck,
+# claimcheck and every other instrument this repository trusts to say no, and
+# until this recipe existed CI linted the engine only. The gates were the least
+# linted code in the tree. It carried 122 findings when somebody finally looked,
+# and the count had been reported as 27 because golangci-lint caps repeated
+# issues by default; see the issues block in .golangci.yml.
+lint-tools:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if ! command -v golangci-lint > /dev/null; then
+      echo "golangci-lint is not installed. brew install golangci-lint"
+      exit 1
+    fi
+    cd tools
+    # verify before run, for the reason the engine recipe gives: `run` does not
+    # validate the config, so an invalid one passes locally and fails the moment
+    # CI's action verifies it.
+    golangci-lint config verify
+    golangci-lint run --timeout 15m ./...
 
 # Lint the code the other platforms compile.
 #

--- a/tools/azguard/region.go
+++ b/tools/azguard/region.go
@@ -197,6 +197,6 @@ func cmdRegion(args []string) int {
 		report(errs)
 		return 1
 	}
-	fmt.Fprintf(os.Stdout, "azguard: %s can create PostgreSQL %s on %s\n", strings.Join(locations, ", "), version, azureSku)
+	_, _ = fmt.Fprintf(os.Stdout, "azguard: %s can create PostgreSQL %s on %s\n", strings.Join(locations, ", "), version, azureSku)
 	return 0
 }

--- a/tools/changecheck/main.go
+++ b/tools/changecheck/main.go
@@ -189,7 +189,7 @@ func validateFragments(dir string) error {
 		"The first line is one of \"# added\", \"# fixed\", \"# changed\" or \"# security\",\n"+
 		"and every heading is followed by prose. www/lib/changelog.ts reads this\n"+
 		"grammar and nothing else, so a fragment outside it is one the published\n"+
-		"changelog silently drops.",
+		"changelog silently drops",
 		len(problems), plural(len(problems), "fragment", "fragments"),
 		strings.Join(problems, "\n  "))
 }

--- a/tools/cigate/main.go
+++ b/tools/cigate/main.go
@@ -296,13 +296,13 @@ func poll(c client, sha, workflow string, attempts int, interval time.Duration, 
 				return refuse, stop.Error(), nil
 			}
 			lastErr = err
-			fmt.Fprintf(out, "attempt %d: could not read the run list: %v\n", attempt, err)
+			_, _ = fmt.Fprintf(out, "attempt %d: could not read the run list: %v\n", attempt, err)
 			sleep(interval, attempt, attempts)
 			continue
 		}
 		lastErr = nil
 		v, why, r := decide(found, workflow)
-		fmt.Fprintf(out, "attempt %d: %s (%s)%s\n", attempt, why, v, link(r))
+		_, _ = fmt.Fprintf(out, "attempt %d: %s (%s)%s\n", attempt, why, v, link(r))
 		if v != wait {
 			return v, why, r
 		}
@@ -386,8 +386,8 @@ func summarise(line string) {
 	if err != nil {
 		return
 	}
-	defer f.Close()
-	fmt.Fprintln(f, line)
+	defer func() { _ = f.Close() }()
+	_, _ = fmt.Fprintln(f, line)
 }
 
 func fail(format string, args ...any) {

--- a/tools/classcheck/main.go
+++ b/tools/classcheck/main.go
@@ -413,9 +413,10 @@ func parseCSS(src string) map[string]rule {
 		k := j + 1
 		braces := 1
 		for k < len(src) && braces > 0 {
-			if src[k] == '{' {
+			switch src[k] {
+			case '{':
 				braces++
-			} else if src[k] == '}' {
+			case '}':
 				braces--
 			}
 			k++
@@ -540,7 +541,7 @@ func readExemptions(path string) ([]*exemption, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	var out []*exemption
 	sc := bufio.NewScanner(f)
 	n := 0

--- a/tools/conflictcheck/main.go
+++ b/tools/conflictcheck/main.go
@@ -121,7 +121,7 @@ func main() {
 		if err != nil {
 			return nil
 		}
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 
 		files++
 		s := bufio.NewScanner(f)

--- a/tools/docs/forbidden_test.go
+++ b/tools/docs/forbidden_test.go
@@ -6,6 +6,7 @@ package docs_test
 // does rather than what it is meant to do.
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -40,20 +41,12 @@ func scan(t *testing.T, env []string, args ...string) run {
 	code := 0
 	var exit *exec.ExitError
 	if err != nil {
-		if !asExit(err, &exit) {
+		if !errors.As(err, &exit) {
 			t.Fatalf("running the scan: %v\n%s", err, out)
 		}
 		code = exit.ExitCode()
 	}
 	return run{code: code, output: string(out)}
-}
-
-func asExit(err error, target **exec.ExitError) bool {
-	e, ok := err.(*exec.ExitError)
-	if ok {
-		*target = e
-	}
-	return ok
 }
 
 // write puts one document in a scratch directory and returns the directory.

--- a/tools/dogfood/main.go
+++ b/tools/dogfood/main.go
@@ -729,7 +729,7 @@ func (r *runner) capture(name string, args ...string) string {
 }
 
 func (run *Run) print(w *os.File) {
-	fmt.Fprintf(w, "\ndogfood: %s run on %s, %s\n",
+	_, _ = fmt.Fprintf(w, "\ndogfood: %s run on %s, %s\n",
 		run.Mode, shortCommit(run.Commit), duration(run.Seconds))
 	for _, s := range run.Steps {
 		mark := "ok"
@@ -739,7 +739,7 @@ func (run *Run) print(w *os.File) {
 		case s.Over:
 			mark = fmt.Sprintf("OVER BUDGET (%s)", duration(s.Budget))
 		}
-		fmt.Fprintf(w, "  %-16s %8s  %s\n", s.Name, duration(s.Seconds), mark)
+		_, _ = fmt.Fprintf(w, "  %-16s %8s  %s\n", s.Name, duration(s.Seconds), mark)
 	}
 	if len(run.Verdicts) > 0 {
 		// Beside the timings, because a run that took four minutes and reached
@@ -750,20 +750,20 @@ func (run *Run) print(w *os.File) {
 			kinds = append(kinds, fmt.Sprintf("%d %s", n, v))
 		}
 		sort.Strings(kinds)
-		fmt.Fprintf(w, "  %-16s %8s  %s\n", "workflows", "", strings.Join(kinds, ", "))
+		_, _ = fmt.Fprintf(w, "  %-16s %8s  %s\n", "workflows", "", strings.Join(kinds, ", "))
 	}
 	if len(run.Findings) > 0 {
-		fmt.Fprintf(w, "\n%s to classify as a product bug, a CI defect, or a docs gap:\n",
+		_, _ = fmt.Fprintf(w, "\n%s to classify as a product bug, a CI defect, or a docs gap:\n",
 			plural(len(run.Findings), "thing", "things"))
 		for _, f := range run.Findings {
-			fmt.Fprintf(w, "  - %s\n", f)
+			_, _ = fmt.Fprintf(w, "  - %s\n", f)
 		}
 	}
 	if run.Green {
-		fmt.Fprintf(w, "\ngreen\n")
+		_, _ = fmt.Fprintf(w, "\ngreen\n")
 		return
 	}
-	fmt.Fprintf(w, "\nnot green\n")
+	_, _ = fmt.Fprintf(w, "\nnot green\n")
 }
 
 func writeRecord(path string, run *Run) error {

--- a/tools/figurecheck/main.go
+++ b/tools/figurecheck/main.go
@@ -291,7 +291,7 @@ func readExemptions(path string) (map[key]string, error) {
 		}
 		return nil, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	s := bufio.NewScanner(f)
 	for n := 1; s.Scan(); n++ {

--- a/tools/gatecheck/main_test.go
+++ b/tools/gatecheck/main_test.go
@@ -15,17 +15,6 @@ import (
 // A check nobody has proved can fail is a check that passes everything the day
 // it breaks. These build small pairs of files with a known answer.
 
-func write(t *testing.T, root, rel, body string) {
-	t.Helper()
-	full := filepath.Join(root, filepath.FromSlash(rel))
-	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(full, []byte(body), 0o600); err != nil {
-		t.Fatal(err)
-	}
-}
-
 // ciGates reads a workflow fragment the way main does: as steps of a file.
 func ciGates(t *testing.T, yaml string) map[string]*entry {
 	t.Helper()

--- a/tools/inputcheck/main.go
+++ b/tools/inputcheck/main.go
@@ -354,11 +354,11 @@ func shortName(dir string) string {
 func valuesInputs(path string) ([]input, error) {
 	source, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("reading the chart's values, which is half of what this checks: %v", err)
+		return nil, fmt.Errorf("reading the chart's values, which is half of what this checks: %w", err)
 	}
 	var doc yaml.Node
 	if err := yaml.Unmarshal(source, &doc); err != nil {
-		return nil, fmt.Errorf("%s is not valid YAML: %v", path, err)
+		return nil, fmt.Errorf("%s is not valid YAML: %w", path, err)
 	}
 	if len(doc.Content) == 0 {
 		return nil, fmt.Errorf("%s is empty", path)
@@ -442,7 +442,7 @@ var (
 func blockInputs(path, source, want string) ([]input, error) {
 	raw, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("reading %s, which declares part of what this promises: %v", path, err)
+		return nil, fmt.Errorf("reading %s, which declares part of what this promises: %w", path, err)
 	}
 
 	var cleaned []string
@@ -587,7 +587,7 @@ func writeGolden(root string, inputs []input) error {
 func readGolden(root string) ([]input, error) {
 	source, err := os.ReadFile(filepath.Join(root, goldenPath))
 	if err != nil {
-		return nil, fmt.Errorf("reading the snapshot of the v1.0.0 surface: %v", err)
+		return nil, fmt.Errorf("reading the snapshot of the v1.0.0 surface: %w", err)
 	}
 	var out []input
 	for n, line := range strings.Split(string(source), "\n") {

--- a/tools/installcheck/main.go
+++ b/tools/installcheck/main.go
@@ -173,7 +173,7 @@ func report(errOut, out io.Writer, findings []finding, driftOnly bool) int {
 		}
 	}
 	if len(bad) == 0 {
-		fmt.Fprintf(out, "installcheck: %d installed %s the lockfile\n",
+		_, _ = fmt.Fprintf(out, "installcheck: %d installed %s the lockfile\n",
 			len(findings), plural(len(findings), "tree matches", "trees match"))
 		return 0
 	}
@@ -201,43 +201,43 @@ func report(errOut, out io.Writer, findings []finding, driftOnly bool) int {
 	}
 
 	if len(stale) > 0 {
-		fmt.Fprintf(errOut, "installcheck: %d installed %s not what the lockfile says:\n",
+		_, _ = fmt.Fprintf(errOut, "installcheck: %d installed %s not what the lockfile says:\n",
 			len(stale), plural(len(stale), "tree is", "trees are"))
 		for _, f := range stale {
-			fmt.Fprintf(errOut, "  %s\n", f.dir)
+			_, _ = fmt.Fprintf(errOut, "  %s\n", f.dir)
 			for _, d := range f.details {
-				fmt.Fprintf(errOut, "      %s\n", d)
+				_, _ = fmt.Fprintf(errOut, "      %s\n", d)
 			}
 		}
-		fmt.Fprintf(errOut, "\nEverything checked against that tree answered about the wrong "+
+		_, _ = fmt.Fprintf(errOut, "\nEverything checked against that tree answered about the wrong "+
 			"versions, and said so in good faith.\n")
 	}
 	if len(ordered) > 0 {
-		fmt.Fprintf(errOut, "\ninstallcheck: %d %s installed before the workspace it links into:\n",
+		_, _ = fmt.Fprintf(errOut, "\ninstallcheck: %d %s installed before the workspace it links into:\n",
 			len(ordered), plural(len(ordered), "tree was", "trees were"))
 		for _, f := range ordered {
-			fmt.Fprintf(errOut, "  %s\n", f.dir)
+			_, _ = fmt.Fprintf(errOut, "  %s\n", f.dir)
 			for _, d := range f.details {
-				fmt.Fprintf(errOut, "      %s\n", d)
+				_, _ = fmt.Fprintf(errOut, "      %s\n", d)
 			}
 		}
-		fmt.Fprintf(errOut, "\n`npm ci` succeeds in that order and leaves a tree that does not work: "+
+		_, _ = fmt.Fprintf(errOut, "\n`npm ci` succeeds in that order and leaves a tree that does not work: "+
 			"the\nfile: links resolve to source directories whose own dependencies are absent, "+
 			"so\nthe errors land in a file nobody touched.\n")
 	}
 	if len(never) > 0 {
-		fmt.Fprintf(errOut, "\ninstallcheck: %d %s no node_modules at all:\n",
+		_, _ = fmt.Fprintf(errOut, "\ninstallcheck: %d %s no node_modules at all:\n",
 			len(never), plural(len(never), "workspace has", "workspaces have"))
 		for _, f := range never {
-			fmt.Fprintf(errOut, "  %s\n", f.dir)
+			_, _ = fmt.Fprintf(errOut, "  %s\n", f.dir)
 		}
-		fmt.Fprintf(errOut, "\nThat is a fresh checkout rather than drift. `just deps` installs "+
+		_, _ = fmt.Fprintf(errOut, "\nThat is a fresh checkout rather than drift. `just deps` installs "+
 			"every workspace in the tree.\n")
 	}
 
-	fmt.Fprintf(errOut, "\nFix:\n")
+	_, _ = fmt.Fprintf(errOut, "\nFix:\n")
 	for _, f := range bad {
-		fmt.Fprintf(errOut, "  %s\n", f.fixCommand())
+		_, _ = fmt.Fprintf(errOut, "  %s\n", f.fixCommand())
 	}
 	if driftOnly && len(stale) == 0 && len(ordered) == 0 {
 		return 0

--- a/tools/ldcheck/main.go
+++ b/tools/ldcheck/main.go
@@ -205,38 +205,33 @@ func packageDir(root, modulePath, moduleDir, pkg string) (string, error) {
 // constant is the same silent no-op as -X against a missing symbol. Neither
 // does a variable of another type, for the same reason.
 func hasStringVar(dir, name string) error {
-	fset := token.NewFileSet()
-	pkgs, err := parser.ParseDir(fset, dir, func(fi os.FileInfo) bool {
-		return !strings.HasSuffix(fi.Name(), "_test.go")
-	}, 0)
+	files, err := parseNonTestFiles(dir)
 	if err != nil {
-		return fmt.Errorf("parsing %s: %w", dir, err)
+		return err
 	}
 
-	for _, pkg := range pkgs {
-		for _, file := range pkg.Files {
-			for _, decl := range file.Decls {
-				gen, ok := decl.(*ast.GenDecl)
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			gen, ok := decl.(*ast.GenDecl)
+			if !ok {
+				continue
+			}
+			for _, spec := range gen.Specs {
+				value, ok := spec.(*ast.ValueSpec)
 				if !ok {
 					continue
 				}
-				for _, spec := range gen.Specs {
-					value, ok := spec.(*ast.ValueSpec)
-					if !ok {
+				for _, ident := range value.Names {
+					if ident.Name != name {
 						continue
 					}
-					for _, ident := range value.Names {
-						if ident.Name != name {
-							continue
-						}
-						if gen.Tok == token.CONST {
-							return fmt.Errorf("%s is a constant; the linker cannot write to one", name)
-						}
-						if !isStringVar(value) {
-							return fmt.Errorf("%s is not a string; -X only writes strings", name)
-						}
-						return nil
+					if gen.Tok == token.CONST {
+						return fmt.Errorf("%s is a constant; the linker cannot write to one", name)
 					}
+					if !isStringVar(value) {
+						return fmt.Errorf("%s is not a string; -X only writes strings", name)
+					}
+					return nil
 				}
 			}
 		}
@@ -274,30 +269,25 @@ func isStringVar(value *ast.ValueSpec) bool {
 // fixed at compile time, and demanding a flag for it would ask for the one thing
 // that silently does nothing.
 func unstamped(dir string, stamped map[string]bool) ([]string, error) {
-	fset := token.NewFileSet()
-	pkgs, err := parser.ParseDir(fset, dir, func(fi os.FileInfo) bool {
-		return !strings.HasSuffix(fi.Name(), "_test.go")
-	}, 0)
+	files, err := parseNonTestFiles(dir)
 	if err != nil {
-		return nil, fmt.Errorf("parsing %s: %w", dir, err)
+		return nil, err
 	}
 
 	var found []string
-	for _, pkg := range pkgs {
-		for _, file := range pkg.Files {
-			for _, decl := range file.Decls {
-				gen, ok := decl.(*ast.GenDecl)
-				if !ok || gen.Tok != token.VAR {
-					continue
-				}
-				names, strings := groupNames(gen)
-				if !anyStamped(names, stamped) {
-					continue
-				}
-				for _, name := range strings {
-					if !stamped[name] {
-						found = append(found, name)
-					}
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			gen, ok := decl.(*ast.GenDecl)
+			if !ok || gen.Tok != token.VAR {
+				continue
+			}
+			names, strings := groupNames(gen)
+			if !anyStamped(names, stamped) {
+				continue
+			}
+			for _, name := range strings {
+				if !stamped[name] {
+					found = append(found, name)
 				}
 			}
 		}
@@ -345,4 +335,40 @@ func sorted(set map[string]bool) []string {
 func fail(format string, args ...any) {
 	fmt.Fprintf(os.Stderr, "ldcheck: "+format+"\n", args...)
 	os.Exit(1)
+}
+
+// parseNonTestFiles parses every non-test Go file in one directory.
+//
+// This was parser.ParseDir, which Go 1.25 deprecated. The replacement is
+// deliberately the same reading rather than a better one: it parses the files
+// on disk, in name order, with no type checking and no build context.
+//
+// SO IT STILL DOES NOT UNDERSTAND BUILD TAGS, which is the reason ParseDir was
+// deprecated, and saying so is the point of this comment. A package level
+// string behind a //go:build tag is counted here on every platform. The fix
+// for that is golang.org/x/tools/go/packages, which type checks and therefore
+// needs the tree to compile; this gate runs over directories to answer whether
+// a symbol is declared, and a gate that can only answer about a tree that
+// already builds is a gate that goes quiet exactly when a build is broken.
+// Nothing in this repository declares a version string behind a build tag, and
+// if something ever does, this is where the answer becomes wrong.
+func parseNonTestFiles(dir string) ([]*ast.File, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", dir, err)
+	}
+	fset := token.NewFileSet()
+	var out []*ast.File
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, filepath.Join(dir, name), nil, 0)
+		if err != nil {
+			return nil, fmt.Errorf("parsing %s: %w", filepath.Join(dir, name), err)
+		}
+		out = append(out, file)
+	}
+	return out, nil
 }

--- a/tools/manifestcheck/main.go
+++ b/tools/manifestcheck/main.go
@@ -177,7 +177,7 @@ func run(root string, out *os.File) error {
 			checked, plural(checked, "manifest", "manifests"))
 		return fmt.Errorf("the documentation shows a manifest the engine would refuse")
 	}
-	fmt.Fprintf(out, "manifestcheck: %d %s in the documentation, every key is one the engine accepts\n",
+	_, _ = fmt.Fprintf(out, "manifestcheck: %d %s in the documentation, every key is one the engine accepts\n",
 		checked, plural(checked, "manifest", "manifests"))
 	return nil
 }

--- a/tools/notices/main.go
+++ b/tools/notices/main.go
@@ -98,10 +98,10 @@ func replace(path, content string) error {
 	if err != nil {
 		return fmt.Errorf("writing %s: %w", path, err)
 	}
-	defer os.Remove(tmp.Name())
+	defer func() { _ = os.Remove(tmp.Name()) }()
 
 	if _, err := tmp.WriteString(content); err != nil {
-		tmp.Close()
+		_ = tmp.Close()
 		return fmt.Errorf("writing %s: %w", path, err)
 	}
 	if err := tmp.Close(); err != nil {

--- a/tools/planguard/main.go
+++ b/tools/planguard/main.go
@@ -343,10 +343,10 @@ func readPlan(path string) (*planFile, error) {
 	}
 	var p planFile
 	if err := json.Unmarshal(raw, &p); err != nil {
-		return nil, fmt.Errorf("parsing %s: %w\n\nThis wants the output of `terraform show -json <planfile>`, not the plan file itself and not the human readable plan.", path, err)
+		return nil, fmt.Errorf("parsing %s: %w\n\nThis wants the output of `terraform show -json <planfile>`, not the plan file itself and not the human readable plan", path, err)
 	}
 	if p.FormatVersion == "" {
-		return nil, fmt.Errorf("%s has no format_version, so it is not a `terraform show -json` document. Refusing to report zero destroys from a file this tool did not understand.", path)
+		return nil, fmt.Errorf("%s has no format_version, so it is not a `terraform show -json` document. Refusing to report zero destroys from a file this tool did not understand", path)
 	}
 	return &p, nil
 }

--- a/tools/prmerge/main.go
+++ b/tools/prmerge/main.go
@@ -194,9 +194,9 @@ func (local) run(name string, args ...string) ([]byte, error) {
 		// The message matters more than the exit code here: `gh` puts the
 		// reason a merge was refused on stderr and nothing else says it.
 		if said := strings.TrimSpace(stderr.String()); said != "" {
-			return out, fmt.Errorf("%s %s: %v: %s", name, strings.Join(args, " "), err, said)
+			return out, fmt.Errorf("%s %s: %w: %s", name, strings.Join(args, " "), err, said)
 		}
-		return out, fmt.Errorf("%s %s: %v", name, strings.Join(args, " "), err)
+		return out, fmt.Errorf("%s %s: %w", name, strings.Join(args, " "), err)
 	}
 	return out, nil
 }
@@ -616,7 +616,7 @@ func contexts(sha string, all []check, out io.Writer) []string {
 					"nothing ran, and cancelled is how GitHub spells a timeout, a stopped run "+
 					"and a superseded run alike", name, c.Conclusion, sha))
 		default:
-			fmt.Fprintf(out, "ok  %-40s success\n", name)
+			_, _ = fmt.Fprintf(out, "ok  %-40s success\n", name)
 		}
 	}
 	return problems
@@ -690,7 +690,7 @@ func confirm(h hub, number int, own string, attempts int, interval time.Duration
 					"the merge base of every open pull request. Push a signed commit on top "+
 					"instead", p.MergeCommit.Oid, own)
 			}
-			fmt.Fprintf(out, "ok  %-40s %s\n", "the commit carries the sign-off", p.MergeCommit.Oid)
+			_, _ = fmt.Fprintf(out, "ok  %-40s %s\n", "the commit carries the sign-off", p.MergeCommit.Oid)
 			return nil
 		} else if !p.merged() && p.Closed {
 			return fmt.Errorf("pull request %d is closed and not merged. Nothing landed", number)
@@ -823,39 +823,39 @@ func checkFields(h hub, number int, out io.Writer) error {
 	if drift := fieldDrift(pullFieldNames(), structFieldNames()); len(drift) > 0 {
 		problems = append(problems, drift...)
 	} else {
-		fmt.Fprintf(out, "ok  %-44s %d fields\n", "the request and the struct ask the same", len(pullFieldNames()))
+		_, _ = fmt.Fprintf(out, "ok  %-44s %d fields\n", "the request and the struct ask the same", len(pullFieldNames()))
 	}
 
 	raw, err := h.gh(pullArgs(h.repo, number)...)
 	if err != nil {
 		// gh names the field it does not recognise, which is the whole point.
-		return fmt.Errorf("the pull request field list was refused: %v", err)
+		return fmt.Errorf("the pull request field list was refused: %w", err)
 	}
 	keys, err := keysOf(raw)
 	if err != nil {
-		return fmt.Errorf("reading pull request %d: %v", number, err)
+		return fmt.Errorf("reading pull request %d: %w", number, err)
 	}
 	if absent := missing(keys, pullFieldNames()); len(absent) > 0 {
 		problems = append(problems, fmt.Sprintf(
 			"gh accepted %v and the response carries no such key", absent))
 	} else {
-		fmt.Fprintf(out, "ok  %-44s #%d\n", "gh has every field pullFields asks for", number)
+		_, _ = fmt.Fprintf(out, "ok  %-44s #%d\n", "gh has every field pullFields asks for", number)
 	}
 
 	var p pull
 	if err := json.Unmarshal(raw, &p); err != nil {
-		return fmt.Errorf("reading pull request %d: %v", number, err)
+		return fmt.Errorf("reading pull request %d: %w", number, err)
 	}
 
 	raw, err = h.gh(checkRunArgs(h.repo, p.HeadRefOid)...)
 	if err != nil {
-		return fmt.Errorf("reading the check runs on %s: %v", p.HeadRefOid, err)
+		return fmt.Errorf("reading the check runs on %s: %w", p.HeadRefOid, err)
 	}
 	var runs struct {
 		CheckRuns []map[string]json.RawMessage `json:"check_runs"`
 	}
 	if err := json.Unmarshal(raw, &runs); err != nil {
-		return fmt.Errorf("reading the check runs on %s: %v", p.HeadRefOid, err)
+		return fmt.Errorf("reading the check runs on %s: %w", p.HeadRefOid, err)
 	}
 	switch {
 	case len(runs.CheckRuns) == 0:
@@ -874,19 +874,19 @@ func checkFields(h hub, number int, out io.Writer) error {
 			problems = append(problems, fmt.Sprintf(
 				"a check run carries none of %v, and this command reads them", sortedKeys(absent)))
 		} else {
-			fmt.Fprintf(out, "ok  %-44s %d runs\n", "a check run carries the five fields read", len(runs.CheckRuns))
+			_, _ = fmt.Fprintf(out, "ok  %-44s %d runs\n", "a check run carries the five fields read", len(runs.CheckRuns))
 		}
 	}
 
 	raw, err = h.gh(statusArgs(h.repo, p.HeadRefOid)...)
 	if err != nil {
-		return fmt.Errorf("reading the commit statuses on %s: %v", p.HeadRefOid, err)
+		return fmt.Errorf("reading the commit statuses on %s: %w", p.HeadRefOid, err)
 	}
 	var statuses struct {
 		Statuses []map[string]json.RawMessage `json:"statuses"`
 	}
 	if err := json.Unmarshal(raw, &statuses); err != nil {
-		return fmt.Errorf("reading the commit statuses on %s: %v", p.HeadRefOid, err)
+		return fmt.Errorf("reading the commit statuses on %s: %w", p.HeadRefOid, err)
 	}
 	if keys, err := keysOf(raw); err == nil && !keys["statuses"] {
 		problems = append(problems, "the commit status response carries no `statuses` key, and "+
@@ -895,7 +895,7 @@ func checkFields(h hub, number int, out io.Writer) error {
 		unchecked = append(unchecked, fmt.Sprintf(
 			"the shape of a commit status, because %s carries none. Every required context "+
 				"on this repository is a check run", p.HeadRefOid))
-		fmt.Fprintf(out, "ok  %-44s\n", "the commit status response has its list")
+		_, _ = fmt.Fprintf(out, "ok  %-44s\n", "the commit status response has its list")
 	} else {
 		absent := map[string]bool{}
 		for _, st := range statuses.Statuses {
@@ -909,7 +909,7 @@ func checkFields(h hub, number int, out io.Writer) error {
 			problems = append(problems, fmt.Sprintf(
 				"a commit status carries none of %v, and this command reads them", sortedKeys(absent)))
 		} else {
-			fmt.Fprintf(out, "ok  %-44s %d statuses\n", "a commit status carries the four fields read", len(statuses.Statuses))
+			_, _ = fmt.Fprintf(out, "ok  %-44s %d statuses\n", "a commit status carries the four fields read", len(statuses.Statuses))
 		}
 	}
 
@@ -934,13 +934,13 @@ func checkFields(h hub, number int, out io.Writer) error {
 				"`required_status_checks.contexts`, and that is the list this command refuses on. "+
 				"An empty one would let every merge past the context check")
 		} else {
-			fmt.Fprintf(out, "ok  %-44s %d contexts\n",
+			_, _ = fmt.Fprintf(out, "ok  %-44s %d contexts\n",
 				"protection carries the required list", len(body.RequiredStatusChecks.Contexts))
 		}
 	}
 
 	for _, u := range unchecked {
-		fmt.Fprintf(out, "not checked  %s\n", u)
+		_, _ = fmt.Fprintf(out, "not checked  %s\n", u)
 	}
 	if len(problems) > 0 {
 		return fmt.Errorf("the field names this command uses do not match the API.\n  %s",
@@ -1055,7 +1055,7 @@ func merge(h hub, r runner, number int, given string, dry bool, attempts int, in
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(out, "prmerge: #%d %q\n  head %s on %s, base %s, mergeStateStatus %s\n",
+	_, _ = fmt.Fprintf(out, "prmerge: #%d %q\n  head %s on %s, base %s, mergeStateStatus %s\n",
 		p.Number, p.Title, p.HeadRefOid, p.HeadRefName, p.BaseRefName, p.MergeStateStatus)
 
 	var problems []string
@@ -1078,7 +1078,7 @@ func merge(h hub, r runner, number int, given string, dry bool, attempts int, in
 	if drift := listDrift(live); len(drift) > 0 {
 		problems = append(problems, drift...)
 	} else {
-		fmt.Fprintf(out, "ok  %-40s %d contexts on %s\n", "the required list is the live one", len(required), p.BaseRefName)
+		_, _ = fmt.Fprintf(out, "ok  %-40s %d contexts on %s\n", "the required list is the live one", len(required), p.BaseRefName)
 	}
 
 	all, err := h.checks(p.HeadRefOid)
@@ -1088,7 +1088,7 @@ func merge(h hub, r runner, number int, given string, dry bool, attempts int, in
 	problems = append(problems, contexts(p.HeadRefOid, all, out)...)
 
 	if why, ok := willMerge[p.MergeStateStatus]; ok {
-		fmt.Fprintf(out, "ok  %-40s %s, %s\n", "mergeStateStatus", p.MergeStateStatus, why)
+		_, _ = fmt.Fprintf(out, "ok  %-40s %s, %s\n", "mergeStateStatus", p.MergeStateStatus, why)
 	} else if why, known := willNotMerge[p.MergeStateStatus]; known {
 		problems = append(problems, fmt.Sprintf("mergeStateStatus is %s: %s", p.MergeStateStatus, why))
 	} else {
@@ -1121,7 +1121,7 @@ func merge(h hub, r runner, number int, given string, dry bool, attempts int, in
 	}
 
 	if noted := unrequired(all); len(noted) > 0 {
-		fmt.Fprintf(out, "    not required by protection, and not blocking: %s\n", strings.Join(noted, ", "))
+		_, _ = fmt.Fprintf(out, "    not required by protection, and not blocking: %s\n", strings.Join(noted, ", "))
 	}
 
 	if len(problems) > 0 {
@@ -1129,13 +1129,13 @@ func merge(h hub, r runner, number int, given string, dry bool, attempts int, in
 	}
 
 	if dry {
-		fmt.Fprintf(out, "\nwould run: gh %s\n", strings.Join(args, " "))
-		fmt.Fprintf(out, "dry run, so nothing was merged\n")
+		_, _ = fmt.Fprintf(out, "\nwould run: gh %s\n", strings.Join(args, " "))
+		_, _ = fmt.Fprintf(out, "dry run, so nothing was merged\n")
 		return nil
 	}
 
 	if _, err := h.gh(args...); err != nil {
-		return fmt.Errorf("the merge was refused: %v", err)
+		return fmt.Errorf("the merge was refused: %w", err)
 	}
 	if err := confirm(h, number, own, attempts, interval, out); err != nil {
 		return err
@@ -1146,8 +1146,8 @@ func merge(h hub, r runner, number int, given string, dry bool, attempts int, in
 	// the pull request, so one refusal discards the work. The merge is confirmed
 	// by the time this prints, which is the only point at which deleting is
 	// safe, and a person does it.
-	fmt.Fprintf(out, "\nmerged #%d. The branch is still there, on purpose.\n", number)
-	fmt.Fprintf(out, "  Delete it when you are satisfied: git push origin --delete %s\n", p.HeadRefName)
+	_, _ = fmt.Fprintf(out, "\nmerged #%d. The branch is still there, on purpose.\n", number)
+	_, _ = fmt.Fprintf(out, "  Delete it when you are satisfied: git push origin --delete %s\n", p.HeadRefName)
 	return nil
 }
 

--- a/tools/prosecheck/main.go
+++ b/tools/prosecheck/main.go
@@ -245,7 +245,7 @@ func run(root string, out io.Writer) error {
 	// Write errors are ignored explicitly, once, with a reason: the verdict of
 	// this tool is its exit code, not its report, so a broken pipe on stdout
 	// changes what a person can read and not whether the build should fail.
-	report := func(format string, args ...any) { fmt.Fprintf(out, format, args...) }
+	report := func(format string, args ...any) { _, _ = fmt.Fprintf(out, format, args...) }
 
 	for _, f := range found {
 		report("%s:%d  %s. Write %s.\n    %s\n", f.file, f.num, f.what, f.instead, strings.TrimSpace(f.line))

--- a/tools/prosecheck/main.go
+++ b/tools/prosecheck/main.go
@@ -245,7 +245,7 @@ func run(root string, out io.Writer) error {
 	// Write errors are ignored explicitly, once, with a reason: the verdict of
 	// this tool is its exit code, not its report, so a broken pipe on stdout
 	// changes what a person can read and not whether the build should fail.
-	report := func(format string, args ...any) { _, _ = fmt.Fprintf(out, format, args...) }
+	report := func(format string, args ...any) { fmt.Fprintf(out, format, args...) }
 
 	for _, f := range found {
 		report("%s:%d  %s. Write %s.\n    %s\n", f.file, f.num, f.what, f.instead, strings.TrimSpace(f.line))

--- a/tools/readability/main.go
+++ b/tools/readability/main.go
@@ -103,16 +103,16 @@ func run(root string, max float64, out *os.File) error {
 	// past the first screen.
 	sort.Slice(reports, func(i, j int) bool { return reports[i].Mean > reports[j].Mean })
 
-	fmt.Fprintf(out, "%-58s %6s %6s %7s %7s\n", "page", "words", "mean", "longest", "flesch")
+	_, _ = fmt.Fprintf(out, "%-58s %6s %6s %7s %7s\n", "page", "words", "mean", "longest", "flesch")
 	over := 0
 	for _, r := range reports {
-		fmt.Fprintf(out, "%-58s %6d %6.1f %7d %7.1f\n", r.Path, r.Words, r.Mean, r.Longest, r.Flesch)
+		_, _ = fmt.Fprintf(out, "%-58s %6d %6.1f %7d %7.1f\n", r.Path, r.Words, r.Mean, r.Longest, r.Flesch)
 		if max > 0 && r.Mean > max {
 			over++
 		}
 	}
 
-	fmt.Fprintf(out, "\nreadability: %d pages, mean sentence %.1f words, hardest page %s\n",
+	_, _ = fmt.Fprintf(out, "\nreadability: %d pages, mean sentence %.1f words, hardest page %s\n",
 		len(reports), overallMean(reports), reports[0].Path)
 	if over > 0 {
 		return fmt.Errorf("%d pages have a mean sentence longer than %.0f words", over, max)

--- a/tools/releasecheck/main.go
+++ b/tools/releasecheck/main.go
@@ -189,7 +189,7 @@ func check(source []byte, out io.Writer) ([]string, error) {
 	problems = append(problems, checkBundlesArePublished(publish, assets, out)...)
 
 	if len(problems) == 0 {
-		fmt.Fprintf(out, "releasecheck: %d assets, every one named before it is published, "+
+		_, _ = fmt.Fprintf(out, "releasecheck: %d assets, every one named before it is published, "+
 			"every signature published, and the signing job holds an OIDC token\n", len(assets))
 	}
 	return problems, nil
@@ -259,7 +259,7 @@ func checkSigningToken(wf workflow, out io.Writer) []string {
 				name, describe(granted)))
 			continue
 		}
-		fmt.Fprintf(out, "ok  the %q job signs and holds `id-token: write`\n", name)
+		_, _ = fmt.Fprintf(out, "ok  the %q job signs and holds `id-token: write`\n", name)
 	}
 	return problems
 }
@@ -343,7 +343,7 @@ func checkUnmatchedFiles(publishing *step, out io.Writer) []string {
 				"not told was absent",
 			publishing.label(), value)}
 	}
-	fmt.Fprintf(out, "ok  a `files:` pattern that matches nothing stops the release\n")
+	_, _ = fmt.Fprintf(out, "ok  a `files:` pattern that matches nothing stops the release\n")
 	return nil
 }
 
@@ -413,7 +413,7 @@ func checkAssetsAreNamedEarlier(publish *job, index int, assets []string, out io
 					pattern, dir))
 				continue
 			}
-			fmt.Fprintf(out, "ok  %-36s named into %s\n", pattern, dir)
+			_, _ = fmt.Fprintf(out, "ok  %-36s named into %s\n", pattern, dir)
 			continue
 		}
 		if !names(corpus, pattern) {
@@ -423,7 +423,7 @@ func checkAssetsAreNamedEarlier(publish *job, index int, assets []string, out io
 				pattern))
 			continue
 		}
-		fmt.Fprintf(out, "ok  %-36s named before it is published\n", pattern)
+		_, _ = fmt.Fprintf(out, "ok  %-36s named before it is published\n", pattern)
 	}
 	return problems
 }
@@ -462,7 +462,7 @@ func checkBundlesArePublished(publish *job, assets []string, out io.Writer) []st
 					"the runner and nobody can fetch it", path))
 			continue
 		}
-		fmt.Fprintf(out, "ok  %-36s signed and published\n", path)
+		_, _ = fmt.Fprintf(out, "ok  %-36s signed and published\n", path)
 	}
 	return problems
 }

--- a/tools/reltar/main.go
+++ b/tools/reltar/main.go
@@ -119,14 +119,14 @@ func write(root, name, out string, when time.Time) error {
 	if err != nil {
 		return err
 	}
-	defer os.Remove(tmp)
+	defer func() { _ = os.Remove(tmp) }()
 
 	// BestCompression rather than the default, named rather than inherited: the
 	// level is part of the output bytes, so leaving it implicit would make the
 	// archive depend on a default that a Go release is free to change.
 	zw, err := gzip.NewWriterLevel(f, gzip.BestCompression)
 	if err != nil {
-		f.Close()
+		_ = f.Close()
 		return err
 	}
 	// Left at its zero value on purpose. gzip's header carries a modification
@@ -138,16 +138,16 @@ func write(root, name, out string, when time.Time) error {
 	tw := tar.NewWriter(zw)
 	for _, p := range paths {
 		if err := add(tw, root, p, when); err != nil {
-			f.Close()
+			_ = f.Close()
 			return fmt.Errorf("%s: %w", p, err)
 		}
 	}
 	if err := tw.Close(); err != nil {
-		f.Close()
+		_ = f.Close()
 		return err
 	}
 	if err := zw.Close(); err != nil {
-		f.Close()
+		_ = f.Close()
 		return err
 	}
 	if err := f.Close(); err != nil {
@@ -248,7 +248,7 @@ func add(tw *tar.Writer, root, rel string, when time.Time) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	written, err := io.Copy(tw, f)
 	if err != nil {
 		return err

--- a/tools/routecheck/inventory.go
+++ b/tools/routecheck/inventory.go
@@ -66,7 +66,7 @@ func ParseInventory(path string) ([]Route, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot read the route inventory: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	var (
 		routes  []Route

--- a/tools/routecheck/main.go
+++ b/tools/routecheck/main.go
@@ -102,7 +102,7 @@ func run(root, origin string, allowWrites bool, timeout time.Duration, attempts 
 		b.WriteString("from that module instead of building the URL here.")
 		return errors.New(b.String())
 	}
-	fmt.Fprintf(out, "the site builds control plane URLs in one place, and declares %d route(s) there\n", len(routes))
+	_, _ = fmt.Fprintf(out, "the site builds control plane URLs in one place, and declares %d route(s) there\n", len(routes))
 
 	served, err := ParseBoundaryRegister(filepath.Join(root, boundaryPath))
 	if err != nil {
@@ -118,10 +118,10 @@ func run(root, origin string, allowWrites bool, timeout time.Duration, attempts 
 		sort.Strings(undeclared)
 		return fmt.Errorf("the site calls %d route(s) this repository's control plane does not serve at all:\n  %s\n\n%s classifies every route the router mounts, and route-boundary.test.ts\nfails on one that is missing from it, so a route absent from that register is a\nroute absent from the server", len(undeclared), strings.Join(undeclared, "\n  "), boundaryPath)
 	}
-	fmt.Fprintf(out, "every route it declares is one this repository's control plane mounts\n")
+	_, _ = fmt.Fprintf(out, "every route it declares is one this repository's control plane mounts\n")
 
 	if origin == "" {
-		fmt.Fprintf(out, "\nno -origin given, so what is DEPLOYED was not checked. The offline half cannot\nsee the failure this command exists for: it passed on the day the careers form\nbroke, because main's API did declare the route.\n")
+		_, _ = fmt.Fprintf(out, "\nno -origin given, so what is DEPLOYED was not checked. The offline half cannot\nsee the failure this command exists for: it passed on the day the careers form\nbroke, because main's API did declare the route.\n")
 		return nil
 	}
 	return probeAll(origin, routes, allowWrites, timeout, attempts, out)

--- a/tools/routecheck/probe.go
+++ b/tools/routecheck/probe.go
@@ -45,7 +45,7 @@ func probeAll(origin string, routes []Route, allowWrites bool, timeout time.Dura
 		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
 	}
 
-	fmt.Fprintf(out, "\nasking %s what it actually serves\n\n", origin)
+	_, _ = fmt.Fprintf(out, "\nasking %s what it actually serves\n\n", origin)
 	results := make([]Result, 0, len(routes))
 	for _, r := range routes {
 		results = append(results, probeOne(client, origin, r, allowWrites, attempts))
@@ -62,7 +62,7 @@ func probeAll(origin string, routes []Route, allowWrites bool, timeout time.Dura
 		if res.Status != 0 {
 			status = fmt.Sprintf("%4d", res.Status)
 		}
-		fmt.Fprintf(out, "  %-*s  %s  %-10s  %s\n", width, res.Route.Method+" "+res.Route.Path, status, res.Verdict, res.Detail)
+		_, _ = fmt.Fprintf(out, "  %-*s  %s  %-10s  %s\n", width, res.Route.Method+" "+res.Route.Path, status, res.Verdict, res.Detail)
 	}
 
 	var absent, unknown, notProbed []Result
@@ -108,7 +108,7 @@ func probeAll(origin string, routes []Route, allowWrites bool, timeout time.Dura
 	if b.Len() > 0 {
 		return errors.New(b.String())
 	}
-	fmt.Fprintf(out, "\nall %d route(s) the site calls are served by %s\n", len(results), origin)
+	_, _ = fmt.Fprintf(out, "\nall %d route(s) the site calls are served by %s\n", len(results), origin)
 	return nil
 }
 

--- a/tools/routecheck/probe_test.go
+++ b/tools/routecheck/probe_test.go
@@ -185,7 +185,7 @@ func TestARedirectIsTheAnswerAndIsNotFollowed(t *testing.T) {
 	var hits int
 	srv := controlPlaneLike(func(w http.ResponseWriter, r *http.Request) {
 		hits++
-		http.Redirect(w, r, "https://github.example/login", 302)
+		http.Redirect(w, r, "https://github.example/login", http.StatusFound)
 	})
 	defer srv.Close()
 

--- a/tools/routecheck/strays.go
+++ b/tools/routecheck/strays.go
@@ -77,7 +77,7 @@ func FindStrayCallSites(wwwRoot string) ([]Stray, error) {
 		if openErr != nil {
 			return openErr
 		}
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 
 		scan := bufio.NewScanner(f)
 		scan.Buffer(make([]byte, 0, 64*1024), 1024*1024)

--- a/tools/sbomcheck/main.go
+++ b/tools/sbomcheck/main.go
@@ -122,7 +122,7 @@ func check(sbomPath, artifacts, name string, minPackages int, out io.Writer) ([]
 	if err := validateAgainstSchema(body); err != nil {
 		return []string{fmt.Sprintf("it is not a valid SPDX 2.3 document: %v", err)}, nil
 	}
-	fmt.Fprintf(out, "ok  %s validates against the SPDX 2.3 schema\n", filepath.Base(sbomPath))
+	_, _ = fmt.Fprintf(out, "ok  %s validates against the SPDX 2.3 schema\n", filepath.Base(sbomPath))
 
 	var doc document
 	if err := json.Unmarshal(body, &doc); err != nil {
@@ -176,11 +176,11 @@ func check(sbomPath, artifacts, name string, minPackages int, out io.Writer) ([]
 				b.rel, sum, b.rel))
 			continue
 		}
-		fmt.Fprintf(out, "ok  %s is described, sha256 %s\n", b.rel, sum)
+		_, _ = fmt.Fprintf(out, "ok  %s is described, sha256 %s\n", b.rel, sum)
 	}
 
 	if len(problems) == 0 {
-		fmt.Fprintf(out, "sbomcheck: %d packages, %d binaries, every one described\n",
+		_, _ = fmt.Fprintf(out, "sbomcheck: %d packages, %d binaries, every one described\n",
 			len(doc.Packages), len(binaries))
 	}
 	return problems, nil
@@ -255,7 +255,7 @@ func sha256File(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	h := sha256.New()
 	if _, err := io.Copy(h, f); err != nil {
 		return "", err

--- a/tools/sitesmoke/main.go
+++ b/tools/sitesmoke/main.go
@@ -109,13 +109,13 @@ func run(
 	// pass every deployment.
 	report.WriteString("The sentences this check waits for\n")
 	if err := contractHolds(root, &report); err != nil {
-		fmt.Fprint(out, report.String())
+		_, _ = fmt.Fprint(out, report.String())
 		return exitUndecided, err
 	}
 
 	if len(targets) == 0 {
-		fmt.Fprint(out, report.String())
-		fmt.Fprint(out, "\nNo origin was given, so NO DEPLOYMENT WAS CHECKED.\n"+
+		_, _ = fmt.Fprint(out, report.String())
+		_, _ = fmt.Fprint(out, "\nNo origin was given, so NO DEPLOYMENT WAS CHECKED.\n"+
 			"This half proves only that the sentences above are still the ones this\n"+
 			"repository produces. On the day the careers form broke, this half was green:\n"+
 			"the tree was correct and production was serving a version from before the\n"+
@@ -155,35 +155,35 @@ func run(
 	}
 	workflows := workflowsFor(allowWrites)
 
-	fmt.Fprint(out, report.String())
-	fmt.Fprintf(out, "\nDriving %d %s against %d %s, %d attempts each.\n",
+	_, _ = fmt.Fprint(out, report.String())
+	_, _ = fmt.Fprintf(out, "\nDriving %d %s against %d %s, %d attempts each.\n",
 		len(workflows), plural(len(workflows), "workflow", "workflows"),
 		len(targets), plural(len(targets), "origin", "origins"), attempts)
 	for _, w := range workflows {
 		if w.writes {
-			fmt.Fprintf(out, "  %s WRITES. It files a real job application into the queue a "+
+			_, _ = fmt.Fprintf(out, "  %s WRITES. It files a real job application into the queue a "+
 				"person reads, and it is running because -allow-writes was passed.\n", w.Name)
 		} else {
-			fmt.Fprintf(out, "  %s writes nothing. %s\n", w.Name, w.why)
+			_, _ = fmt.Fprintf(out, "  %s writes nothing. %s\n", w.Name, w.why)
 		}
 	}
-	fmt.Fprintln(out)
+	_, _ = fmt.Fprintln(out)
 
 	var findings []Finding
 	for _, origin := range targets {
 		for _, w := range workflows {
-			fmt.Fprintf(out, "  %s  %s ...\n", origin, w.Name)
+			_, _ = fmt.Fprintf(out, "  %s  %s ...\n", origin, w.Name)
 			findings = append(findings, r.drive(ctx, origin, w))
 		}
 	}
 
 	answer := verdict(findings)
-	fmt.Fprintf(out, "\n%s\n", summary(findings))
-	fmt.Fprintf(out, "Evidence is in %s\n", artifacts)
+	_, _ = fmt.Fprintf(out, "\n%s\n", summary(findings))
+	_, _ = fmt.Fprintf(out, "Evidence is in %s\n", artifacts)
 
 	switch answer {
 	case Allowed:
-		fmt.Fprintf(out, "\nEvery origin did what a person needs it to do.\n")
+		_, _ = fmt.Fprintf(out, "\nEvery origin did what a person needs it to do.\n")
 		return exitAllowed, nil
 	case Refused:
 		return exitRefused, fmt.Errorf(

--- a/tools/surfacecheck/main.go
+++ b/tools/surfacecheck/main.go
@@ -119,13 +119,13 @@ func run(root string, updateBaseline bool, out *os.File) (int, error) {
 	if updateBaseline {
 		if len(problems) > 0 {
 			report(out, problems)
-			fmt.Fprintln(out, "\nThe baseline was not rewritten: the surface it would record is not one that passes the checks above.")
+			_, _ = fmt.Fprintln(out, "\nThe baseline was not rewritten: the surface it would record is not one that passes the checks above.")
 			return 1, nil
 		}
 		if err := WriteBaseline(filepath.Join(root, baselineFile), packages, classes); err != nil {
 			return 0, err
 		}
-		fmt.Fprintf(out, "surfacecheck: wrote %s\n", baselineFile)
+		_, _ = fmt.Fprintf(out, "surfacecheck: wrote %s\n", baselineFile)
 		return 0, nil
 	}
 
@@ -149,7 +149,7 @@ func run(root string, updateBaseline bool, out *os.File) (int, error) {
 			exported += len(pkg.Exports())
 		}
 	}
-	fmt.Fprintf(out, "surfacecheck: %d importable packages, %d stable holding %d exports, %d additions since v1.0.0\n",
+	_, _ = fmt.Fprintf(out, "surfacecheck: %d importable packages, %d stable holding %d exports, %d additions since v1.0.0\n",
 		len(packages), stable, exported, additions)
 	return 0, nil
 }
@@ -163,14 +163,14 @@ func report(out *os.File, problems []Problem) {
 		}
 		byKind[p.Kind] = append(byKind[p.Kind], p)
 	}
-	fmt.Fprintf(out, "surfacecheck: %d problems\n", len(problems))
+	_, _ = fmt.Fprintf(out, "surfacecheck: %d problems\n", len(problems))
 	for _, kind := range kinds {
-		fmt.Fprintf(out, "\n%s\n", kind)
+		_, _ = fmt.Fprintf(out, "\n%s\n", kind)
 		list := byKind[kind]
 		sort.Slice(list, func(i, j int) bool { return list[i].Message < list[j].Message })
 		for _, p := range list {
-			fmt.Fprintf(out, "  %s\n", p.Message)
+			_, _ = fmt.Fprintf(out, "  %s\n", p.Message)
 		}
-		fmt.Fprintf(out, "\n  %s\n", strings.ReplaceAll(byKind[kind][0].Remedy, "\n", "\n  "))
+		_, _ = fmt.Fprintf(out, "\n  %s\n", strings.ReplaceAll(byKind[kind][0].Remedy, "\n", "\n  "))
 	}
 }

--- a/tools/tagsync/main.go
+++ b/tools/tagsync/main.go
@@ -212,7 +212,7 @@ func main() {
 func read(root string, p pin) (string, error) {
 	source, err := os.ReadFile(filepath.Join(root, p.file))
 	if err != nil {
-		return "", fmt.Errorf("%s is a version pin this check watches and cannot be read: %v", p.file, err)
+		return "", fmt.Errorf("%s is a version pin this check watches and cannot be read: %w", p.file, err)
 	}
 	found := p.pattern.FindAllStringSubmatch(string(source), -1)
 	if len(found) != 1 {
@@ -249,7 +249,7 @@ func tags(root string) (map[string]bool, error) {
 func preparing(root string) (string, error) {
 	file, err := os.Open(filepath.Join(root, "CHANGELOG.md"))
 	if err != nil {
-		return "", fmt.Errorf("reading CHANGELOG.md, which says which release is being prepared: %v", err)
+		return "", fmt.Errorf("reading CHANGELOG.md, which says which release is being prepared: %w", err)
 	}
 	defer func() { _ = file.Close() }()
 

--- a/tools/tagsync/main_test.go
+++ b/tools/tagsync/main_test.go
@@ -227,12 +227,12 @@ func TestAWorkedExampleMayNotNameAnOlderPublishedTag(t *testing.T) {
 	const pending = "v1.0.0"
 
 	// Named as `released`, an older published tag is acceptable.
-	if !(published["v0.1.0"] || "v0.1.0" == pending) {
+	if !published["v0.1.0"] && pending != "v0.1.0" {
 		t.Fatal("v0.1.0 should be acceptable to a released pin, and is not")
 	}
 
 	// Named as `current`, only the release being prepared is.
-	if "v0.1.0" == pending {
+	if pending == "v0.1.0" {
 		t.Fatal("the fixture is wrong: v0.1.0 must not equal the pending release")
 	}
 	for _, p := range pins {

--- a/tools/tfsecignores/main.go
+++ b/tools/tfsecignores/main.go
@@ -348,14 +348,14 @@ func decideAt(directives []directive, failing map[string]map[string]bool, out io
 
 		switch {
 		case expired:
-			fmt.Fprintf(out, "EXPIRED  %s  %s  accepted until %s\n", d.where(), d.Rule, d.Expires)
+			_, _ = fmt.Fprintf(out, "EXPIRED  %s  %s  accepted until %s\n", d.where(), d.Rule, d.Expires)
 			problems = append(problems, fmt.Sprintf(
 				"the decision to accept %s at %s expired on %s. tfsec has already stopped honouring it, "+
 					"so the finding is back; reread the reason written above it and either fix the "+
 					"configuration or set a new date on purpose",
 				d.Rule, d.where(), d.Expires))
 		case !used:
-			fmt.Fprintf(out, "STALE    %s  %s  nothing in this file breaks that rule\n", d.where(), d.Rule)
+			_, _ = fmt.Fprintf(out, "STALE    %s  %s  nothing in this file breaks that rule\n", d.where(), d.Rule)
 			problems = append(problems, fmt.Sprintf(
 				"the ignore for %s at %s suppressed nothing: with every ignore disabled, that rule is "+
 					"not failing in that file. So either the finding was fixed and this comment now "+
@@ -367,7 +367,7 @@ func decideAt(directives []directive, failing map[string]map[string]bool, out io
 		}
 	}
 
-	fmt.Fprintf(out, "\n%d ignores, %d live, %d expired or stale\n",
+	_, _ = fmt.Fprintf(out, "\n%d ignores, %d live, %d expired or stale\n",
 		len(directives), live, len(directives)-live)
 
 	if len(problems) > 0 {

--- a/tools/tfsecignores/main_test.go
+++ b/tools/tfsecignores/main_test.go
@@ -225,9 +225,6 @@ func fakeTfsec(t *testing.T, stdout string, code int) string {
 }
 
 func shellQuote(s string) string { return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'" }
-func itoa(i int) string {
-	return strings.TrimSpace(strings.Fields(strings.Repeat(" ", 0) + string(rune('0'+i)))[0])
-}
 
 // THE FAILURE THAT STARTED ALL OF THIS. A scanner that did not run must not
 // read as a scanner that found nothing.

--- a/tools/vulncheck/main.go
+++ b/tools/vulncheck/main.go
@@ -141,7 +141,7 @@ func run(args []string, out io.Writer) error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(out, "scanning %d modules: %s\n\n", len(modules), strings.Join(modules, ", "))
+	_, _ = fmt.Fprintf(out, "scanning %d modules: %s\n\n", len(modules), strings.Join(modules, ", "))
 
 	// Built once, then run in each module's own directory rather than driven
 	// with govulncheck's -C flag. Building once is the cheaper shape when there
@@ -235,7 +235,7 @@ func buildScanner(root string) (string, func(), error) {
 	if err != nil {
 		return "", func() {}, err
 	}
-	cleanup := func() { os.RemoveAll(dir) }
+	cleanup := func() { _ = os.RemoveAll(dir) }
 
 	bin := filepath.Join(dir, "govulncheck")
 	cmd := exec.Command("go", "build", "-o", bin, "golang.org/x/vuln/cmd/govulncheck")
@@ -389,26 +389,26 @@ func decideAt(findings []*finding, summaries map[string]string, pol *policy, out
 	var problems []string
 
 	for _, k := range uncovered {
-		fmt.Fprintf(out, "REACHABLE  %s  %s\n", k.id, k.module)
+		_, _ = fmt.Fprintf(out, "REACHABLE  %s  %s\n", k.id, k.module)
 		if s := summaries[k.id]; s != "" {
-			fmt.Fprintf(out, "           %s\n", s)
+			_, _ = fmt.Fprintf(out, "           %s\n", s)
 		}
-		fmt.Fprintf(out, "           https://pkg.go.dev/vuln/%s\n", k.id)
+		_, _ = fmt.Fprintf(out, "           https://pkg.go.dev/vuln/%s\n", k.id)
 		problems = append(problems, fmt.Sprintf("%s is reachable in %s and is not accepted in %s", k.id, k.module, policyFile))
 	}
 
 	for _, e := range expired {
-		fmt.Fprintf(out, "EXPIRED    %s  %s  accepted until %s\n", e.ID, e.Module, e.Expires)
+		_, _ = fmt.Fprintf(out, "EXPIRED    %s  %s  accepted until %s\n", e.ID, e.Module, e.Expires)
 		problems = append(problems, fmt.Sprintf("the decision to accept %s in %s expired on %s and needs rereading", e.ID, e.Module, e.Expires))
 	}
 
 	for _, e := range unused {
-		fmt.Fprintf(out, "STALE      %s  %s  matches nothing\n", e.ID, e.Module)
+		_, _ = fmt.Fprintf(out, "STALE      %s  %s  matches nothing\n", e.ID, e.Module)
 		problems = append(problems, fmt.Sprintf("%s in %s is accepted in %s but nothing reaches it any more, so the entry is claiming to protect against something that is not there", e.ID, e.Module, policyFile))
 	}
 
 	covered := len(seen) - len(uncovered)
-	fmt.Fprintf(out, "\n%d reachable, %d accepted, %d unaccepted, %d expired, %d stale\n",
+	_, _ = fmt.Fprintf(out, "\n%d reachable, %d accepted, %d unaccepted, %d expired, %d stale\n",
 		len(seen), covered, len(uncovered), len(expired), len(unused))
 
 	if len(problems) > 0 {


### PR DESCRIPTION
## The failure

CI lints `engine` and nothing else. `tools/` holds `prosecheck`, `gatecheck`,
`changecheck`, `routecheck`, `wirecheck`, `claimcheck` and every other
instrument this repository trusts to say no, and no workflow had ever pointed a
linter at it. Held to the same set the engine is kept at zero on, it carried
**122** findings.

## The count is part of the finding

The brief said 26. The first run I did said 27. Both were samples.

`golangci-lint` caps its own output by default: `max-same-issues: 3` and
`max-issues-per-linter: 50`. With the caps off the same tree reports 122. The
sample was not representative either: errcheck showed 12 of 94, and the two
packages carrying the most findings, `prmerge` with 17 and `installcheck` with
14, did not appear in it at all.

Both caps are now off in the shared `.golangci.yml`, with the measurement in the
comment. The engine has been at zero since that file existed so this changes
nothing there today; it changes what the first regression looks like, which is
the only moment a cap could ever matter.

## All 122 by category, and what was done to each

**No rule is disabled. Nothing is suppressed. Every finding is fixed.**

### errcheck, 94

| what | count | disposition |
| --- | --- | --- |
| `fmt.Fprintf` / `fmt.Fprintln` to a report writer | 78 | `_, _ = fmt.Fprintf(out, ...)` at the call site |
| deferred `Close` on a read handle | 8 | `defer func() { _ = f.Close() }()` |
| best effort `Close` on an error path (`reltar`, `notices`, `cigate`) | 5 | `_ = f.Close()` |
| temporary file and directory removal (`reltar`, `notices`, `vulncheck`) | 3 | `_ = os.Remove(...)` / `_ = os.RemoveAll(...)` |

The prints are the interesting one, and **the fix is deliberately not an
`exclude-functions` entry**. errcheck's default exclusions already cover
`os.Stdout`, `os.Stderr`, `bytes.Buffer` and `strings.Builder`, which is exactly
why the engine passes with 322 `fmt.Fprint*` call sites of its own. These tools
write to an injected `io.Writer` so they can be tested, which is right, and it
takes them out of the default exclusions. Widening the exclusion to any
`io.Writer` would stop the engine noticing an unchecked write to a socket:
`cmd/af-proxy/transparent.go` writes to a `net.Conn` and says `_, _ =` at the
call site for exactly this reason. So the tools say it at the call site too.

The deferred closes are worth a second look, because **the config's own comment
did not match its own rule**. It says "Deferred Close on a read-only handle is
the one place ignoring an error is conventional and correct" and excludes
`(io.Closer).Close`. These call sites are `(*os.File).Close`, so the exclusion
never matched what the comment meant. Rather than widen it (which would also
hide a write handle, where a failed `Close` loses data), they take the engine's
idiom.

### errorlint, 17

Sixteen `%v` where an error is being formatted, which breaks `errors.Is` and
`errors.As` for every caller: `inputcheck` 4, `prmerge` 10, `tagsync` 2. All
`%w` now. One hand rolled type assertion on an error in `tools/docs`, replaced
with `errors.As` and the helper deleted.

### staticcheck, 9

| finding | disposition |
| --- | --- |
| `SA1019` `parser.ParseDir` deprecated, `ldcheck` x2 | replaced with a `ReadDir` + `ParseFile` loop |
| `ST1005` error string ends in punctuation, `changecheck` x1 `planguard` x2 | trailing full stop removed |
| `QF1003` if/else chain is a tagged switch, `classcheck` | made a `switch` |
| `ST1013` literal `302`, `routecheck/probe_test.go` | `http.StatusFound` |
| `ST1017` Yoda condition, `tagsync/main_test.go` x2 | reversed |

The `ParseDir` replacement is **deliberately the same reading and not a better
one**, and the new function says so: it is still blind to build tags, which is
the reason `ParseDir` was deprecated. The alternative is `golang.org/x/tools/go/packages`,
which type checks and therefore needs the tree to compile, and a gate that can
only answer about a tree that already builds goes quiet exactly when a build is
broken. The comment records where the answer becomes wrong if this repository
ever puts a version string behind a build tag.

Fixing the two Yoda conditions **exposed a tenth finding**, `QF1001` De Morgan's
law on the same line, which staticcheck had been reporting one issue for. Fixed
too, which is why the staticcheck total moved from 9 to 10 findings for 9
reported lines.

### unused, 2

Both superseded rather than half finished, so both deleted rather than wired up:

- `gatecheck/main_test.go` `write`, replaced by `writeWorkflows`, which four
  tests use to build workflows on disk.
- `tfsecignores/main_test.go` `itoa`, replaced by `strconv.Itoa`, which the same
  file already imports and uses two lines above it.

## Can it say no

Real output, in both directions, against `just lint-tools`, which is what the
new CI step runs.

```
--- FIXED TREE ---
exit=0
0 issues.
--- ONE FINDING REINTRODUCED (the `_, _ =` removed from one line of prosecheck) ---
exit=1
tools/prosecheck/main.go:248:58: Error return value of `fmt.Fprintf` is not checked (errcheck)
	report := func(format string, args ...any) { fmt.Fprintf(out, format, args...) }
	                                                        ^
1 issues:
* errcheck: 1
error: recipe `lint-tools` failed with exit code 1
--- RESTORED ---
exit=0
0 issues.
```

It names the file, the line, the column, the rule and the expression. And the
caps change has its own before and after: the same pre-fix tree reported
`27 issues` with the defaults and `122 issues` with `--max-issues-per-linter=0
--max-same-issues=0`.

## The gate

Same pinned action, same version, same config, `working-directory: tools`. Two
invocations rather than one run over both modules, because the engine and the
tools are separate Go modules joined by a workspace and `golangci-lint` runs
against one module's package graph at a time.

`just lint-tools` is the matching recipe, and `just gate` calls it beside
`just lint`.

**What this does not cover, said plainly.** `gatecheck` reads `run:` steps and
cannot see a `uses:` action, so neither lint step is inside its reach: the
engine's has never been either. The recipe is here because the rule requires it
and because local and CI parity is real, not because `gatecheck` is enforcing
the pair. `go run ./tools/gatecheck .` passes: 80 gates, 69 paired, 2 paired by
command only, 9 exempt.

## The gate watched failing, in CI, and not only locally

A gate nobody has seen fail is decoration, so this branch pushed a deliberate
break and watched GitHub refuse it, then reverted it.

`82d975e9` removed one `_, _ =` in `prosecheck`. Run `33966...`, job `engine`:
`Lint` over the engine stayed **green** in the same job while **`Lint the gates`
went red**:

```
##[error]/home/runner/work/antifailure/antifailure/tools/prosecheck/main.go:248:58: Error return value of `fmt.Fprintf` is not checked (errcheck)
	report := func(format string, args ...any) { fmt.Fprintf(out, format, args...) }
1 issues:
* errcheck: 1
##[error]issues found
```

The revert restored the tree exactly (`git diff` between the two green commits
is empty) and the step went back to `0 issues`.

**One thing the CI log does not print** is the config path it resolved. The
action logs `golangci-lint config path` and `config verify` running in
`tools/`, and both succeed, but not the answer. Locally, with the same binary at
the same version, `golangci-lint config path` in `tools/` prints
`../.golangci.yml`, which is the shared config this branch edits.

## It caught something on its first day

`tools/sitesmoke` landed on main in #262 while this branch was open, carrying
twelve unchecked writes to its report stream. A pull request builds the merge of
the branch with main, so this job ran against a tree neither side had linted and
went red on a package this branch had never seen. That is the gate finding a
real thing in a package written, reviewed and merged by people with no linter
pointed at the module, which is the whole argument for adding it. Fixed the same
way as the other seventy eight.

That also moves the totals: **134 findings fixed**, 122 on the tree as it was
when this branch opened plus the 12 that arrived during it.

## Local runs

- `golangci-lint run --timeout 15m ./...` in `tools`: **0 issues**
- `go test ./... -count=1 -timeout 20m` in `tools`: every package ok
- `gofmt -l .` in `tools`: clean
- `go run ./tools/gatecheck .`: exit 0
- `go run ./tools/prosecheck .`: 814 files, 0 findings
- `go run ./tools/changecheck .`: 35 changed paths, described by the internal fragment
