### PR TITLE
deploy: the careers smoke had no browser to drive

### DIFF
--- a/.changes/the-smoke-had-no-browser-to-drive.internal.md
+++ b/.changes/the-smoke-had-no-browser-to-drive.internal.md
@@ -1,0 +1,7 @@
+# fixed
+
+The post-publish careers smoke installed the runner's dependencies in `runner`
+and then installed its browser from the repository root, where there is no
+package.json, so npx fetched a different playwright and downloaded browsers for
+that one. The runner launched its own pinned version and found no browser. Both
+commands now run in `runner`, the way the dogfood workflow has always run them.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -495,8 +495,24 @@ jobs:
         env:
           TOKEN: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
         run: |
-          npm --prefix runner ci --no-audit --no-fund
+          # BOTH COMMANDS RUN INSIDE runner, and that is the whole of this fix.
+          #
+          # This step used to install the runner with `npm --prefix runner ci`
+          # and then run `npx playwright install` from the repository ROOT.
+          # There is no package.json at the root, so npx did not resolve the
+          # runner's pinned playwright at all: it fetched the newest one from
+          # the registry and downloaded browsers for THAT version. The runner
+          # then launched its own and looked for a revision nothing had
+          # installed, `chromium_headless_shell-1234`.
+          #
+          # The smoke reported COULD NOT TELL and exited 2 rather than passing,
+          # which is the behaviour it was built for, so this cost a red rather
+          # than a false green. dogfood.yml has run both commands with
+          # `working-directory: runner` since it was written; this matches it.
+          cd runner
+          npm ci --no-audit --no-fund
           npx playwright install --with-deps chromium
+          cd ..
           go run ./tools/sitesmoke -root . \
             -origin https://antifailure.dev \
             -origin https://www.antifailure.dev \


### PR DESCRIPTION
The new post-publish step went red on the first push to main that ran it. It
installed the runner with `npm --prefix runner ci` and then installed the
browser with `npx playwright install` from the repository ROOT.

There is no package.json at the root. So npx did not resolve the runner's
pinned playwright at all: it fetched the newest one from the registry and
downloaded browsers for that one. The runner then launched its own version and
looked for a revision nothing had installed,
`chromium_headless_shell-1234`.

Both commands now run inside `runner`, which is what dogfood.yml has done since
it was written.

WHY THIS WAS NOT CAUGHT BEFORE IT MERGED, which is the more useful half.
`deploy.yml` runs on push and not on pull_request, so the pull request that
added the step never ran it. The step was wired, reviewed, merged, and had
never once executed. That is the same shape as any other dead path: everything
about it looked right and nothing had asked it to work.

WHAT IT COST, AND WHAT IT DID NOT. The smoke reported COULD NOT TELL and exited
2 rather than reporting a pass, so this was a red rather than a false green. Its
own words: a smoke that cannot say "I did not find out" says "fine" instead.

Proved by running the step locally against the live site rather than by reading
it:

    ok        https://antifailure.dev      the page showed what it shows when
                                           this works
    REFUSED   https://www.antifailure.dev  The page shows an error rather than
                                           what was expected. It says: "Could
                                           not reach the server."

The second line is the www hostname bug. It is fixed on main and not yet in
production, because production moves only on a tag, and the smoke is right to
keep saying so until one is cut.