### PR TITLE
engine: the guard asked over HTTP and the test then asked over HTTPS

### DIFF
--- a/.changes/a-guard-that-checked-a-protocol-the-test-did-not-use.internal.md
+++ b/.changes/a-guard-that-checked-a-protocol-the-test-did-not-use.internal.md
@@ -1,0 +1,23 @@
+# fixed
+
+A required context went red because a guard asked a different question than the
+test.
+
+The egress tests skip when the machine cannot reach the host they decide about,
+so a laptop with no network reports a skip rather than a failure that looks like
+a broken containment control. That guard made a plain HTTP request. Six of the
+tests behind it require HTTPS. HTTP answered, nothing skipped, and the HTTPS
+request then failed into `engine`, which gates every merge, on a pull request
+that touched no engine file at all.
+
+The guard now takes the origins the test actually depends on, spelled the way
+the probe spells them, and the first one is a plain parameter rather than part
+of the variadic so a call that guards on nothing does not compile.
+
+A probe that did not get out also used to mean two things at once and say the
+more alarming one. The sidecar has always written one decision per request,
+allowed or not, so a failed probe now reads that log and reports whether the
+sidecar refused a host the policy allows, which is a containment regression, or
+allowed it and the connection failed anyway, which is the network. Only one
+combination skips, and it needs the sidecar's own record AND a second probe from
+the test process to agree the host is unreachable.

--- a/engine/conformance/runtime.go
+++ b/engine/conformance/runtime.go
@@ -1174,7 +1174,7 @@ func (h *rtHarness) inventoryAttributesResources(ctx context.Context) {
 // guarantee the whole thing is sold on.
 
 func (h *rtHarness) egressNoPolicyMeansNothingGetsOut(ctx context.Context) {
-	h.requireInternet(ctx)
+	h.requireInternet(ctx, "http://"+h.opts.AllowedHost)
 	// A manifest with no egress section is valid. It must mean nothing gets
 	// out, not that the sidecar failed to parse a policy and let everything
 	// through, and not that the environment refused to start.
@@ -1188,7 +1188,7 @@ func (h *rtHarness) egressNoPolicyMeansNothingGetsOut(ctx context.Context) {
 }
 
 func (h *rtHarness) egressAllowedHostIsReached(ctx context.Context) {
-	h.requireInternet(ctx)
+	h.requireInternet(ctx, "http://"+h.opts.AllowedHost)
 	code := h.probe(ctx, h.envID("eg2"), h.allowOnly(),
 		"wget -T 20 -q -O - http://"+h.opts.AllowedHost+"/")
 	if code != reached {
@@ -1200,7 +1200,21 @@ func (h *rtHarness) egressAllowedHostIsReached(ctx context.Context) {
 }
 
 func (h *rtHarness) egressHostWithNoRuleIsRefused(ctx context.Context) {
-	h.requireInternet(ctx)
+	// The ALLOWED host only, and RefusedHost deliberately not, which is the
+	// opposite of what the equivalent test in the local runtime's own suite
+	// does. This assertion is that a request FAILED, and a host that is merely
+	// down satisfies it, so guarding on RefusedHost looks like the obvious
+	// improvement. It is wrong here and runtime_selftest_test.go said so
+	// within one run: that self-test drives a FAKE runtime that touches no
+	// network, and it sets RefusedHost to "refused.invalid" precisely so the
+	// name can never resolve. Probing it from the test process skipped two
+	// behaviors, and the self-test reported them as behaviors that could no
+	// longer go red, which is exactly what it exists to catch.
+	//
+	// RefusedHost is a caller's option, and a caller may legitimately give an
+	// unroutable name. Only AllowedHost is something this harness can insist
+	// on being reachable.
+	h.requireInternet(ctx, "http://"+h.opts.AllowedHost)
 	code := h.probe(ctx, h.envID("eg3"), h.allowOnly(),
 		"wget -T 20 -q -O - http://"+h.opts.RefusedHost+"/")
 	if code != refused {
@@ -1209,7 +1223,8 @@ func (h *rtHarness) egressHostWithNoRuleIsRefused(ctx context.Context) {
 }
 
 func (h *rtHarness) egressAppliesWithoutProxyVariables(ctx context.Context) {
-	h.requireInternet(ctx)
+	// AllowedHost only, for the reason on egressHostWithNoRuleIsRefused above.
+	h.requireInternet(ctx, "http://"+h.opts.AllowedHost)
 	// The property the whole design rests on. Proxy variables are a request,
 	// and a great many clients ignore them: Node has no proxy support at all,
 	// and plenty of SDKs bundle a client that does the same. An egress control
@@ -1229,7 +1244,7 @@ func (h *rtHarness) egressAppliesWithoutProxyVariables(ctx context.Context) {
 }
 
 func (h *rtHarness) egressCannotBeBypassedByAddress(ctx context.Context) {
-	h.requireInternet(ctx)
+	h.requireInternet(ctx, "http://"+h.opts.AllowedHost)
 	// Interception is by DNS, so the obvious way around it is to skip DNS.
 	// That has to fail for a reason that has nothing to do with DNS: the
 	// environment has no route out, so a packet addressed straight at the
@@ -1259,7 +1274,7 @@ func (h *rtHarness) egressCannotReachMetadata(ctx context.Context) {
 }
 
 func (h *rtHarness) egressCannotBeBypassedByUDP(ctx context.Context) {
-	h.requireInternet(ctx)
+	h.requireInternet(ctx, "http://"+h.opts.AllowedHost)
 	// DNS is the one thing the environment is allowed to speak to the sidecar,
 	// so UDP straight past it to somebody else's resolver is the obvious
 	// tunnel: a name lookup carries whatever the client puts in it.
@@ -1398,27 +1413,40 @@ func shortLivedClient(timeout time.Duration) *http.Client {
 	}
 }
 
-// requireInternet skips when this machine cannot reach the host the egress
-// behaviors decide about.
+// requireInternet skips when this machine cannot reach what an egress behavior
+// depends on.
 //
 // A laptop on a plane should report a skip, not a failure that looks exactly
 // like a broken egress control. The check is deliberately made from the test
 // process rather than from inside an environment: what it is asking is whether
 // the machine has internet at all, and asking from inside would be asking the
 // question the behavior itself exists to answer.
-func (h *rtHarness) requireInternet(ctx context.Context) {
+//
+// IT TAKES THE ORIGINS RATHER THAN ASSUMING THEM. Every behavior below happens
+// to use plain HTTP today, so this harness has never had the defect its twin in
+// engine/internal/runtime/local did, where the guard probed HTTP and six tests
+// then required HTTPS, and a required context went red on an unrelated pull
+// request because HTTP answered and nothing skipped. The parameter is here so
+// that adding an HTTPS behavior cannot quietly reintroduce it: an origin that is
+// not named is not guarded, and naming it is the same string the probe uses.
+//
+// The first origin is a plain parameter and not part of the variadic, so a call
+// that guards on nothing does not compile.
+func (h *rtHarness) requireInternet(ctx context.Context, origin string, more ...string) {
 	h.t.Helper()
 	c := shortLivedClient(10 * time.Second)
 	defer c.CloseIdleConnections()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+h.opts.AllowedHost+"/", nil)
-	if err != nil {
-		h.t.Fatalf("building the reachability request: %v", err)
+	for _, origin := range append([]string{origin}, more...) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, origin+"/", nil)
+		if err != nil {
+			h.t.Fatalf("building the reachability request for %s: %v", origin, err)
+		}
+		resp, err := c.Do(req)
+		if err != nil {
+			h.t.Skipf("skipped: %s is not reachable from this machine: %v", origin, err)
+		}
+		_ = resp.Body.Close()
 	}
-	resp, err := c.Do(req)
-	if err != nil {
-		h.t.Skipf("skipped: %s is not reachable from this machine: %v", h.opts.AllowedHost, err)
-	}
-	_ = resp.Body.Close()
 }
 
 // httpGet reads a URL and returns its body.

--- a/engine/internal/runtime/local/containment_test.go
+++ b/engine/internal/runtime/local/containment_test.go
@@ -223,7 +223,12 @@ func containedPolicy() *schema.Egress {
 
 func TestContainment_NothingEscapesAContainedEnvironment(t *testing.T) {
 	r := requireRuntime(t)
-	requireInternet(t)
+	// The escape script's controls reach http://example.com/ and one of its
+	// attacks reaches http://www.iana.org/, so both are named. The second
+	// matters for the same reason it does in local_test.go: "a-host-with-no-rule"
+	// is an attack that must FAIL, and a host that is merely down makes it fail
+	// for a reason that has nothing to do with containment.
+	requireInternet(t, "http://"+allowedHost, "http://"+refusedHost)
 
 	res := runEscapeProbe(t, r, envID(t, r, "containescape"), containedPolicy(), escapeScript)
 
@@ -246,7 +251,7 @@ func TestContainment_TheSameProbeEscapesWithoutIt(t *testing.T) {
 	// without one skips it out loud rather than leaving the contained run
 	// above with no control.
 	requireRuntime(t)
-	requireInternet(t)
+	requireInternet(t, "http://"+allowedHost, "http://"+refusedHost)
 
 	cli, err := dockerutil.Client()
 	require.NoError(t, err)
@@ -337,7 +342,7 @@ func awaitLooseProbe(t *testing.T, ctx context.Context, id string) string {
 // in sandbox mode, and the decision log recorded it as allowed.
 func TestContainment_ALiveCredentialOverPlainHTTPTripsTheWire(t *testing.T) {
 	r := requireRuntime(t)
-	requireInternet(t)
+	requireInternet(t, "http://"+allowedHost)
 	id := envID(t, r, "containtrip")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
@@ -408,7 +413,7 @@ func TestContainment_ALiveCredentialOverPlainHTTPTripsTheWire(t *testing.T) {
 // and the link local range is not on it.
 func TestContainment_TheMetadataEndpointIsRefusedUnderDefaultAllow(t *testing.T) {
 	r := requireRuntime(t)
-	requireInternet(t)
+	requireInternet(t, "http://"+allowedHost)
 	id := envID(t, r, "containmeta")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)

--- a/engine/internal/runtime/local/egress_verdict_test.go
+++ b/engine/internal/runtime/local/egress_verdict_test.go
@@ -1,0 +1,285 @@
+package local_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/antifailure/antifailure/engine/internal/runtime/local"
+)
+
+// Exit 9 meant two completely different things and the test said neither.
+//
+// THE FAILURE. On 2026-09-05, `engine`, which is a required context, went red
+// on a pull request that touched no file under engine/ at all:
+//
+//	--- FAIL: TestEgress_HTTPSIsDecidedByHost (2.94s)
+//	    expected: 0
+//	    actual  : 9
+//	    Messages: an allowed host was not reachable over HTTPS
+//
+// The probe is `curl ... && exit 0 || exit 9`, so every way of not getting out
+// arrives as the same number: the sidecar refused a host the policy allows,
+// which is the containment regression the test exists to catch, and the host
+// simply did not answer, which is the weather. The message names the first and
+// the second is far more likely, so a transient external failure reads as the
+// most alarming result this suite can produce.
+//
+// THE SIDECAR ALREADY KNOWS WHICH. It writes one decision record per request,
+// allowed or not, and Runtime.Decisions reads them; the capture test in this
+// same package has been asserting on that log for as long as it existed. The
+// reachability tests never asked. So these two functions turn the log into the
+// answer, and they are pure so that the discrimination itself is proved on a
+// machine with no Docker daemon and no network.
+//
+// The rule they encode, in one sentence: a probe that did not get out is OURS
+// unless the sidecar's own record says it allowed the connection AND this
+// machine independently cannot reach the host either. Only that row skips, and
+// it needs positive evidence from two places that do not share a cause.
+
+// sidecarVerdict is what the sidecar's own record says about a probe that did
+// not get out.
+type sidecarVerdict string
+
+const (
+	// verdictRefused: the sidecar decided against a connection. When the
+	// policy allowed the host, this is the regression the suite is for.
+	verdictRefused sidecarVerdict = "refused"
+	// verdictAllowedAndFailed: the sidecar let the connection through and it
+	// failed anyway, so the failure is past the sidecar.
+	verdictAllowedAndFailed sidecarVerdict = "allowed-and-failed"
+	// verdictNoDecision: nothing about this host reached the sidecar at all.
+	//
+	// Not a network excuse. Every external name inside an environment resolves
+	// to the sidecar, so a request that produced no decision did not get as
+	// far as the thing that decides, and the DNS that failed is the sidecar's
+	// own.
+	verdictNoDecision sidecarVerdict = "no-decision"
+)
+
+// readVerdict reports what the sidecar's log says about one host.
+//
+// The LAST decision naming the host, because a probe may retry and the answer
+// that matters is the one it ended on. Decisions arrive oldest first, which is
+// the order Runtime.Decisions returns them in.
+func readVerdict(decisions []local.Decision, host string) (sidecarVerdict, local.Decision) {
+	var last local.Decision
+	var found bool
+	for _, d := range decisions {
+		if d.Host == host {
+			last, found = d, true
+		}
+	}
+	switch {
+	case !found:
+		return verdictNoDecision, local.Decision{}
+	case last.Allowed:
+		return verdictAllowedAndFailed, last
+	default:
+		return verdictRefused, last
+	}
+}
+
+// unreachableIsOurs decides whether a probe that did not get out is this
+// product's failure or the network's, and writes the sentence for either.
+//
+// reachableFromHere is the second, independent piece of evidence: the test
+// process asking the same host over the same scheme at the moment of failure.
+// It is what stops this becoming "the test tolerates an unreachable host". A
+// sidecar that logs an allow and then drops the bytes still fails here,
+// because the machine outside it can still reach the host.
+func unreachableIsOurs(
+	v sidecarVerdict, d local.Decision, host, origin string, reachableFromHere bool,
+) (ours bool, message string) {
+	switch v {
+	case verdictRefused:
+		return true, fmt.Sprintf(
+			"the sidecar REFUSED %s, which the policy allows. mode=%q rule=%q reason=%q status=%d error=%q. "+
+				"This is the containment regression this test exists to catch, not the network.",
+			host, d.Mode, d.Rule, d.Reason, d.Status, d.Error)
+	case verdictNoDecision:
+		return true, fmt.Sprintf(
+			"the probe did not get out and the sidecar recorded no decision about %s at all. "+
+				"Every external name in an environment resolves to the sidecar, so the request "+
+				"never reached the thing that decides: the sidecar's DNS, the network, or the "+
+				"probe container itself. None of those is the host being down.",
+			host)
+	case verdictAllowedAndFailed:
+		if reachableFromHere {
+			return true, fmt.Sprintf(
+				"the sidecar ALLOWED %s and the request failed anyway, while this machine reaches "+
+					"%s right now. The failure is between the sidecar and the host. "+
+					"mode=%q rule=%q status=%d error=%q",
+				host, origin, d.Mode, d.Rule, d.Status, d.Error)
+		}
+		return false, fmt.Sprintf(
+			"the sidecar allowed %s and neither the environment nor this machine could reach %s. "+
+				"Two independent probes agree the host is unreachable, so this run says nothing "+
+				"about containment. sidecar error=%q",
+			host, origin, d.Error)
+	default:
+		// A verdict nothing produces. Failing is right: a classification this
+		// does not understand must not become a skip.
+		return true, fmt.Sprintf("unrecognised sidecar verdict %q about %s", v, host)
+	}
+}
+
+func TestReadVerdict_TellsTheThreeCasesApart(t *testing.T) {
+	const host = "example.com"
+	cases := []struct {
+		name      string
+		decisions []local.Decision
+		want      sidecarVerdict
+	}{
+		{
+			name:      "nothing about this host reached the sidecar",
+			decisions: []local.Decision{{Host: "other.test", Allowed: true}},
+			want:      verdictNoDecision,
+		},
+		{
+			name:      "an empty log is not an allow",
+			decisions: nil,
+			want:      verdictNoDecision,
+		},
+		{
+			name:      "the sidecar decided against it",
+			decisions: []local.Decision{{Host: host, Allowed: false, Mode: "block"}},
+			want:      verdictRefused,
+		},
+		{
+			name:      "the sidecar let it through",
+			decisions: []local.Decision{{Host: host, Allowed: true, Mode: "allow"}},
+			want:      verdictAllowedAndFailed,
+		},
+		{
+			// A retry that ends on a refusal is a refusal. Reading the first
+			// record would report the opposite of what happened.
+			name: "the last decision wins",
+			decisions: []local.Decision{
+				{Host: host, Allowed: true, Mode: "allow"},
+				{Host: host, Allowed: false, Mode: "block"},
+			},
+			want: verdictRefused,
+		},
+		{
+			name: "and it wins in the other direction too",
+			decisions: []local.Decision{
+				{Host: host, Allowed: false, Mode: "block"},
+				{Host: host, Allowed: true, Mode: "allow"},
+			},
+			want: verdictAllowedAndFailed,
+		},
+		{
+			// Another host's refusal must not be read as this host's.
+			name: "a decision about a different host decides nothing here",
+			decisions: []local.Decision{
+				{Host: "www.iana.org", Allowed: false, Mode: "block"},
+			},
+			want: verdictNoDecision,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, _ := readVerdict(c.decisions, host)
+			if got != c.want {
+				t.Errorf("readVerdict = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestUnreachableIsOurs_OnlyOneRowIsTheWeather(t *testing.T) {
+	const host = "example.com"
+	const origin = "https://example.com"
+	cases := []struct {
+		name      string
+		verdict   sidecarVerdict
+		decision  local.Decision
+		reachable bool
+		wantOurs  bool
+		says      string
+	}{
+		{
+			name:     "a refusal of an allowed host is ours whatever the network is doing",
+			verdict:  verdictRefused,
+			decision: local.Decision{Mode: "block", Rule: "", Reason: "no rule"},
+			// The network is fine, and it would not matter if it were not.
+			reachable: true,
+			wantOurs:  true,
+			says:      "REFUSED",
+		},
+		{
+			name:      "and still ours when the host is down as well",
+			verdict:   verdictRefused,
+			decision:  local.Decision{Mode: "block"},
+			reachable: false,
+			wantOurs:  true,
+			says:      "REFUSED",
+		},
+		{
+			name:      "a request that never reached the sidecar is ours",
+			verdict:   verdictNoDecision,
+			reachable: false,
+			wantOurs:  true,
+			says:      "recorded no decision",
+		},
+		{
+			// THE ROW THE WHOLE DESIGN TURNS ON. A sidecar that logs an allow
+			// and then drops the bytes must not be able to skip, and this is
+			// what stops it: the machine outside can still reach the host.
+			name:      "an allow that failed while the host answers here is ours",
+			verdict:   verdictAllowedAndFailed,
+			decision:  local.Decision{Mode: "allow", Error: "upstream reset"},
+			reachable: true,
+			wantOurs:  true,
+			says:      "ALLOWED",
+		},
+		{
+			// The only skip, and it needs both pieces of evidence.
+			name:      "an allow that failed while nothing here can reach it either is the weather",
+			verdict:   verdictAllowedAndFailed,
+			decision:  local.Decision{Mode: "allow", Error: "dial tcp: i/o timeout"},
+			reachable: false,
+			wantOurs:  false,
+			says:      "neither the environment nor this machine",
+		},
+		{
+			name:      "a classification nothing produces fails rather than skips",
+			verdict:   sidecarVerdict("something new"),
+			reachable: false,
+			wantOurs:  true,
+			says:      "unrecognised",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ours, msg := unreachableIsOurs(c.verdict, c.decision, host, origin, c.reachable)
+			if ours != c.wantOurs {
+				t.Errorf("ours = %v, want %v (message: %s)", ours, c.wantOurs, msg)
+			}
+			if !strings.Contains(msg, c.says) {
+				t.Errorf("message %q does not say %q", msg, c.says)
+			}
+			if !strings.Contains(msg, host) {
+				t.Errorf("message %q does not name the host it is about", msg)
+			}
+		})
+	}
+}
+
+// TestUnreachableIsOurs_SkipsExactlyOnce is the counting check. A rule with
+// two ways to skip is a rule that will grow a third.
+func TestUnreachableIsOurs_SkipsExactlyOnce(t *testing.T) {
+	skips := 0
+	for _, v := range []sidecarVerdict{verdictRefused, verdictNoDecision, verdictAllowedAndFailed} {
+		for _, reachable := range []bool{true, false} {
+			if ours, _ := unreachableIsOurs(v, local.Decision{}, "example.com", "https://example.com", reachable); !ours {
+				skips++
+			}
+		}
+	}
+	if skips != 1 {
+		t.Errorf("%d of the six combinations skip, want exactly 1: the sidecar allowed it and "+
+			"this machine cannot reach the host either", skips)
+	}
+}

--- a/engine/internal/runtime/local/local_test.go
+++ b/engine/internal/runtime/local/local_test.go
@@ -392,6 +392,26 @@ func TestUp_StopsWhenAMigrationFails(t *testing.T) {
 // policy, and a direct connection that bypasses the proxy entirely. Together
 // they answer the only question that matters about an egress control: does it
 // decide, and can it be walked around.
+//
+// BOTH HOSTS ARE ONE ORGANISATION'S, AND THAT IS A DEPENDENCY WORTH SAYING OUT
+// LOUD. example.com is a reserved domain ICANN and IANA operate, and
+// www.iana.org is IANA's own site. So `engine`, a required context on every
+// pull request in this repository, cannot go green without one organisation
+// being up, and the two fixtures do not fail independently: an IANA outage
+// moves the allowed host and the refused host together.
+//
+// Kept rather than changed, and the reasons are worth having written down.
+// Both are chosen precisely because they are boring, stable and nobody's
+// production service, and a refused host has to be one nothing in any policy
+// here ever names. What the choice costs is measured elsewhere in this file:
+// a guard that skips when either is unreachable, and, for the reachability
+// assertions, a failure that reads the sidecar's own decision log rather than
+// blaming containment for the network.
+//
+// If the coupling is ever worth removing, the change is to move refusedHost to
+// a second organisation's domain, so the two fixtures fail independently. That
+// is a decision about which third parties this repository's merge gate depends
+// on, not a cleanup, which is why it is written here rather than done.
 const (
 	allowedHost = "example.com"
 	refusedHost = "www.iana.org"
@@ -479,42 +499,125 @@ func parseInt(t *testing.T, re *regexp.Regexp, s string) int {
 	return n
 }
 
-// requireInternet skips when the machine cannot reach the hosts these tests
-// decide about, so a laptop on a plane reports a skip rather than a failure
-// that looks like a broken egress control.
-func requireInternet(t *testing.T) {
+// requireInternet skips when the machine cannot reach what these tests depend
+// on, so a laptop on a plane reports a skip rather than a failure that looks
+// like a broken egress control.
+//
+// IT TAKES THE ORIGINS RATHER THAN ASSUMING THEM, and that is the whole point
+// of the parameter. It used to probe `http://example.com/` unconditionally,
+// while TestEgress_HTTPSIsDecidedByHost and five others need HTTPS. On
+// 2026-09-05 `engine`, a required context, went red on a pull request touching
+// no file under engine/: HTTP answered, so nothing skipped, and the HTTPS
+// request then failed. A guard that checks a protocol the test does not use
+// answers a question nobody asked.
+//
+// Pass every origin the test actually depends on, spelled the way the probe
+// spells it, so a copy of the string is what keeps the two in step. A test that
+// needs a host to be UP in order for its refusal to mean anything names that
+// host too: an assertion that a request failed is satisfied by a host that is
+// merely down, which is a pass for the wrong reason and nothing would say so.
+//
+// WHAT IT DELIBERATELY STILL DOES NOT DO. The probe is made from the test
+// process; the test's request is made from inside a container, through the
+// sidecar. Making the guard identical would mean building the environment to
+// decide whether to run the test, and worse, it would make the guard
+// indistinguishable from the assertion, so a real egress regression would
+// report as a skip. The conformance harness states the same reasoning on its
+// own copy. Closing the scheme gap does not close that one, and a probe that
+// fails past the sidecar is told apart by unreachableIsOurs instead.
+//
+// The first origin is a plain parameter and not part of the variadic, so a call
+// that guards on nothing does not compile. A runtime check would have been a
+// check; this is the compiler.
+func requireInternet(t *testing.T, origin string, more ...string) {
 	t.Helper()
-	// Its own transport, closed on the way out. The default one keeps the
-	// connection idle for a minute and a half, and its reader and writer
-	// goroutines are what goleak finds at the end of a run where this was the
-	// only outbound call anything made.
+	for _, origin := range append([]string{origin}, more...) {
+		if err := reachErr(origin); err != nil {
+			// Counted as a skip for the same reason the daemon ones are. A
+			// laptop with no network would otherwise run every containment
+			// test, reach nothing, skip everything and print ok.
+			skipped.Add(1)
+			t.Skipf("skipped: %s is not reachable from this machine: %v", origin, err)
+		}
+	}
+}
+
+// reachErr is one GET, and nil when the origin answered at all.
+//
+// Its own transport, closed on the way out. The default one keeps the
+// connection idle for a minute and a half, and its reader and writer goroutines
+// are what goleak finds at the end of a run where this was the only outbound
+// call anything made.
+//
+// The status is not read. This asks whether the machine can reach the host over
+// this scheme, and a 500 from a host that answered is a reachable host.
+func reachErr(origin string) error {
 	tr := &http.Transport{}
 	defer tr.CloseIdleConnections()
 	c := &http.Client{Timeout: 10 * time.Second, Transport: tr}
-	resp, err := c.Get("http://" + allowedHost + "/")
+	resp, err := c.Get(origin + "/")
 	if err != nil {
-		// Counted as a skip for the same reason the daemon ones are. A laptop
-		// with no network would otherwise run every containment test, reach
-		// nothing, skip everything and print ok.
-		skipped.Add(1)
-		t.Skipf("skipped: %s is not reachable from this machine: %v", allowedHost, err)
+		return err
 	}
 	_ = resp.Body.Close()
+	return nil
+}
+
+// requireGotOut asserts a probe reached a host the policy allows, and when it
+// did not, says which of two very different things happened.
+//
+// `curl ... && exit 0 || exit 9` collapses "the sidecar refused a host the
+// policy allows" and "the host did not answer" into one number, and the message
+// beside it named the first. The sidecar has always known which: it writes one
+// decision per request, allowed or not, and Runtime.Decisions reads them.
+// TestCapture_SendsNothingToTheRealProvider in this file has asserted on that
+// log since it was written. The reachability tests never asked.
+//
+// The rule is in unreachableIsOurs and it is proved there, on fabricated
+// records, without a daemon. Only one of its six rows is the weather, and that
+// row needs the sidecar's own log to say it allowed the connection AND this
+// machine to be unable to reach the host at that moment. A sidecar that logs an
+// allow and then drops the bytes still fails, because the machine outside it
+// can still reach the host.
+func requireGotOut(t *testing.T, r *local.Runtime, id, host, origin string, code int) {
+	t.Helper()
+	if code == 0 {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	decisions, err := r.Decisions(ctx, id, 200)
+	require.NoError(t, err, "the probe exited %d and the sidecar's log could not be read", code)
+
+	verdict, d := readVerdict(decisions, host)
+	ours, message := unreachableIsOurs(verdict, d, host, origin, reachErr(origin) == nil)
+	if ours {
+		t.Fatalf("the probe exited %d and %s", code, message)
+	}
+	skipped.Add(1)
+	t.Skipf("skipped: %s", message)
 }
 
 func TestEgress_AllowedHostIsReached(t *testing.T) {
 	r := requireRuntime(t)
-	requireInternet(t)
-	code := probe(t, r, envID(t, r, "egallow"), &schema.Egress{
+	requireInternet(t, "http://"+allowedHost)
+	id := envID(t, r, "egallow")
+	code := probe(t, r, id, &schema.Egress{
 		Default: schema.ModeBlock,
 		Rules:   []schema.EgressRule{{Host: allowedHost, Mode: schema.ModeAllow}},
 	}, "wget -T 20 -q -O - http://"+allowedHost+"/ >/dev/null 2>&1 && exit 0 || exit 9")
+	requireGotOut(t, r, id, allowedHost, "http://"+allowedHost, code)
 	require.Equal(t, 0, code, "a host the policy allows was not reached through the proxy")
 }
 
 func TestEgress_HostWithNoRuleIsRefused(t *testing.T) {
 	r := requireRuntime(t)
-	requireInternet(t)
+	// The refused host is named here as well as the allowed one, and that is
+	// not belt and braces. The assertion below is that a request FAILED, and a
+	// host that is merely down satisfies it: the test would pass, for entirely
+	// the wrong reason, and nothing would say so. Guarding on it turns that
+	// into a skip.
+	requireInternet(t, "http://"+allowedHost, "http://"+refusedHost)
 	// The default is block, and the point of this test is that the refusal
 	// comes from the policy rather than from the host being unreachable, which
 	// is why the allowed host in the test above is a real one too.
@@ -531,7 +634,7 @@ const noProxyVars = "env -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PRO
 
 func TestEgress_AppliesToAClientThatIgnoresProxyVariables(t *testing.T) {
 	r := requireRuntime(t)
-	requireInternet(t)
+	requireInternet(t, "http://"+allowedHost, "http://"+refusedHost)
 	// The property the whole design rests on. Proxy variables are a request,
 	// and a great many clients ignore them: Node has no proxy support at all,
 	// and plenty of SDKs bundle a client that does the same. An egress control
@@ -543,8 +646,10 @@ func TestEgress_AppliesToAClientThatIgnoresProxyVariables(t *testing.T) {
 		Default: schema.ModeBlock,
 		Rules:   []schema.EgressRule{{Host: allowedHost, Mode: schema.ModeAllow}},
 	}
-	allowed := probe(t, r, envID(t, r, "egnovars1"), rules,
+	allowedID := envID(t, r, "egnovars1")
+	allowed := probe(t, r, allowedID, rules,
 		noProxyVars+"wget -T 20 -q -O - http://"+allowedHost+"/ >/dev/null 2>&1 && exit 0 || exit 9")
+	requireGotOut(t, r, allowedID, allowedHost, "http://"+allowedHost, allowed)
 	require.Equal(t, 0, allowed,
 		"a client with no proxy support could not reach a host the policy allows")
 
@@ -556,7 +661,7 @@ func TestEgress_AppliesToAClientThatIgnoresProxyVariables(t *testing.T) {
 
 func TestEgress_CannotBeBypassedByConnectingToAnAddress(t *testing.T) {
 	r := requireRuntime(t)
-	requireInternet(t)
+	requireInternet(t, "http://"+allowedHost)
 	// Interception happens through DNS, so the obvious way around it is to
 	// skip DNS. That has to fail, and it does for a reason that has nothing to
 	// do with DNS: the service's network has no route out, so a packet
@@ -570,7 +675,10 @@ func TestEgress_CannotBeBypassedByConnectingToAnAddress(t *testing.T) {
 
 func TestEgress_HTTPSIsDecidedByHost(t *testing.T) {
 	r := requireRuntime(t)
-	requireInternet(t)
+	// HTTPS, because that is what the probe below asks for. This guard read
+	// http://example.com/ until 2026-09-05, when HTTP answered, nothing
+	// skipped, and the HTTPS request failed into a required context.
+	requireInternet(t, "https://"+allowedHost)
 	img := curlImage(t)
 	cmd := "curl -sS -o /dev/null --max-time 20 https://" + allowedHost + "/ && exit 0 || exit 9"
 
@@ -579,10 +687,12 @@ func TestEgress_HTTPSIsDecidedByHost(t *testing.T) {
 	// whether the connection happens at all. A rule that names paths or
 	// methods cannot be enforced on HTTPS until the environment certificate
 	// lands, and that limit is stated in the docs rather than papered over.
-	allowed := probeWith(t, r, envID(t, r, "eghttps1"), &schema.Egress{
+	allowedID := envID(t, r, "eghttps1")
+	allowed := probeWith(t, r, allowedID, &schema.Egress{
 		Default: schema.ModeBlock,
 		Rules:   []schema.EgressRule{{Host: allowedHost, Mode: schema.ModeAllow}},
 	}, img, cmd)
+	requireGotOut(t, r, allowedID, allowedHost, "https://"+allowedHost, allowed)
 	require.Equal(t, 0, allowed, "an allowed host was not reachable over HTTPS")
 
 	refused := probeWith(t, r, envID(t, r, "eghttps2"), &schema.Egress{
@@ -593,7 +703,7 @@ func TestEgress_HTTPSIsDecidedByHost(t *testing.T) {
 
 func TestEgress_NoPolicyMeansBlockEverything(t *testing.T) {
 	r := requireRuntime(t)
-	requireInternet(t)
+	requireInternet(t, "http://"+allowedHost)
 	// A manifest with no egress section is valid, and it must not mean the
 	// sidecar fails to parse its policy and the environment fails to start.
 	code := probe(t, r, envID(t, r, "egnone"), nil,
@@ -714,7 +824,7 @@ func get(t *testing.T, url string) string {
 
 func TestEgress_HTTPSPathRulesAreEnforcedWhenTheCertificateIsIssued(t *testing.T) {
 	r := requireRuntime(t)
-	requireInternet(t)
+	requireInternet(t, "https://"+allowedHost)
 	img := curlImage(t)
 
 	// The thing a host level tunnel cannot do. A rule naming a path needs the
@@ -731,14 +841,16 @@ func TestEgress_HTTPSPathRulesAreEnforcedWhenTheCertificateIsIssued(t *testing.T
 	}
 	// The rule allows every path under root, so this is the positive case and
 	// proves the certificate is trusted and the request is re-originated.
-	code := probeInspected(t, r, envID(t, r, "insp1"), rules, ca, img,
+	id := envID(t, r, "insp1")
+	code := probeInspected(t, r, id, rules, ca, img,
 		"curl -sS -o /dev/null --max-time 25 https://"+allowedHost+"/ && exit 0 || exit 9")
+	requireGotOut(t, r, id, allowedHost, "https://"+allowedHost, code)
 	require.Equal(t, 0, code, "an inspected HTTPS request to an allowed path did not complete")
 }
 
 func TestEgress_HTTPSPathOutsideTheRuleIsRefused(t *testing.T) {
 	r := requireRuntime(t)
-	requireInternet(t)
+	requireInternet(t, "https://"+allowedHost)
 	img := curlImage(t)
 
 	ca, err := envcert.Generate("test-inspect2", time.Now())
@@ -840,7 +952,7 @@ func TestCapture_RecordsAMessageAndAnswersAsTheProviderWould(t *testing.T) {
 
 func TestCapture_SendsNothingToTheRealProvider(t *testing.T) {
 	r := requireRuntime(t)
-	requireInternet(t)
+	requireInternet(t, "https://"+allowedHost)
 	img := curlImage(t)
 	id := envID(t, r, "capture2")
 
@@ -893,7 +1005,7 @@ func fakeLiveKey() string {
 
 func TestTripwire_RefusesARequestCarryingALiveCredential(t *testing.T) {
 	r := requireRuntime(t)
-	requireInternet(t)
+	requireInternet(t, "https://"+allowedHost)
 	img := curlImage(t)
 	id := envID(t, r, "tripwire1")
 
@@ -947,7 +1059,7 @@ func TestTripwire_RefusesARequestCarryingALiveCredential(t *testing.T) {
 
 func TestSandbox_SubstitutesTheCredentialOnTheWayOut(t *testing.T) {
 	r := requireRuntime(t)
-	requireInternet(t)
+	requireInternet(t, "https://"+allowedHost)
 	img := curlImage(t)
 	id := envID(t, r, "sandbox1")
 

--- a/engine/internal/runtime/local/local_test.go
+++ b/engine/internal/runtime/local/local_test.go
@@ -693,7 +693,7 @@ func TestEgress_HTTPSIsDecidedByHost(t *testing.T) {
 		Rules:   []schema.EgressRule{{Host: allowedHost, Mode: schema.ModeAllow}},
 	}, img, cmd)
 	requireGotOut(t, r, allowedID, allowedHost, "https://"+allowedHost, allowed)
-	require.Equal(t, 0, allowed, "an allowed host was not reachable over HTTPS")
+	require.Equal(t, 4242, allowed, "TEMPORARY: proving this test ran rather than skipping past the new guard")
 
 	refused := probeWith(t, r, envID(t, r, "eghttps2"), &schema.Egress{
 		Default: schema.ModeBlock,

--- a/engine/internal/runtime/local/local_test.go
+++ b/engine/internal/runtime/local/local_test.go
@@ -693,7 +693,7 @@ func TestEgress_HTTPSIsDecidedByHost(t *testing.T) {
 		Rules:   []schema.EgressRule{{Host: allowedHost, Mode: schema.ModeAllow}},
 	}, img, cmd)
 	requireGotOut(t, r, allowedID, allowedHost, "https://"+allowedHost, allowed)
-	require.Equal(t, 4242, allowed, "TEMPORARY: proving this test ran rather than skipping past the new guard")
+	require.Equal(t, 0, allowed, "an allowed host was not reachable over HTTPS")
 
 	refused := probeWith(t, r, envID(t, r, "eghttps2"), &schema.Egress{
 		Default: schema.ModeBlock,


### PR DESCRIPTION
## The failure

`engine` is a required context. It went red on #256, a pull request that touches
no file under `engine/`:

```
--- FAIL: TestEgress_HTTPSIsDecidedByHost (2.94s)
    expected: 0
    actual  : 9
    Messages: an allowed host was not reachable over HTTPS
```

`requireInternet` skips these tests when the machine cannot reach the host they
decide about, so a laptop on a plane reports a skip rather than a failure that
reads as broken containment. It made a plain **HTTP** GET to
`http://example.com/`, from the test process. The test then required **HTTPS**
to `https://example.com/`, from inside a container, through the sidecar. HTTP
answered, so nothing skipped, and the HTTPS request failed.

Confirmed from the log of attempt 1 of run `33963140205`, not from the report:
`33 of 34 daemon tests ran`, so nothing skipped.

## The siblings, counted

**Six of twenty one guarded tests** sat behind a guard checking a protocol they
do not use. All six are in `internal/runtime/local`:

| test | guard checked | test uses |
| --- | --- | --- |
| `TestEgress_HTTPSIsDecidedByHost` | http | **https** |
| `TestEgress_HTTPSPathRulesAreEnforcedWhenTheCertificateIsIssued` | http | **https** |
| `TestEgress_HTTPSPathOutsideTheRuleIsRefused` | http | **https** |
| `TestCapture_SendsNothingToTheRealProvider` | http | **https** |
| `TestTripwire_RefusesARequestCarryingALiveCredential` | http | **https** |
| `TestSandbox_SubstitutesTheCredentialOnTheWayOut` | http | **https** |

The other fifteen were already correct and are recorded as checked rather than
left for the next reader: five HTTP tests in `local_test.go`, four in
`containment_test.go` (whose escape script's controls use `http://example.com/`),
and the six behaviors in `engine/conformance`, which has its own `requireInternet`
and no HTTPS behavior today.

`containment_test.go` is also the one place that already told its two failure
modes apart: `"a control failed, so the attacks in this run prove nothing"`. The
egress tests did not.

## Should the guard probe the same thing the test uses

**Scheme: yes, and it now does.** The guard takes the origins the test depends
on, spelled the way the probe spells them, so a copy of the string keeps them in
step. The first origin is a plain parameter rather than part of the variadic, so
a call that guards on nothing **does not compile** — a runtime check would have
been a check; this is the compiler.

**Location: no, and deliberately not.** The guard runs from the test process and
the test runs from inside a container through the sidecar. Making them identical
means building the environment to decide whether to run the test, and worse, it
makes the guard indistinguishable from the assertion, so a real egress
regression would report as a skip. The conformance harness already states that
reasoning on its own copy; this change keeps it and says that closing the scheme
gap does not close it.

## Can the test tell its two failure modes apart

**Yes, and the mechanism already existed.** The sidecar writes one decision per
request, allowed or not; `Runtime.Decisions` reads them; and
`TestCapture_SendsNothingToTheRealProvider`, in this same file, has asserted on
that log since it was written. The reachability tests never asked.

A failed probe now reads the log through two pure functions with their own table
tests, so the discrimination is proved on a machine with no daemon and no
network:

| the sidecar's own record | this machine reaches the host now | verdict |
| --- | --- | --- |
| refused | yes | **fail** — the containment regression |
| refused | no | **fail** — still ours |
| no decision at all | either | **fail** — it never reached the thing that decides |
| allowed, connection failed | yes | **fail** — the failure is between the sidecar and the host |
| allowed, connection failed | no | **skip**, with the reason |
| anything unrecognised | either | **fail** |

One of six rows skips, and it needs two pieces of evidence that do not share a
cause. **This is not "tolerate an unreachable host":** a sidecar that logs an
allow and then drops the bytes still fails, because the machine outside it can
still reach the host. `TestUnreachableIsOurs_SkipsExactlyOnce` counts the rows,
so a second way to skip cannot be added quietly.

## A refusal that passes for the wrong reason

An assertion that a request FAILED is satisfied by a host that is merely down.
`refusedHost` is now named in the guard for the local tests that need it up, so
that becomes a skip instead of a green tick.

**I tried the same thing in the conformance harness and its self test refused
it, correctly, inside one run.** `runtime_selftest_test.go` drives a fake
runtime and sets `RefusedHost` to `refused.invalid` precisely so the name never
resolves. Guarding on it skipped two behaviors, and the self test reported them
as behaviors that could no longer go red, which is exactly what it is for.
`RefusedHost` is a caller's option and a caller may legitimately give an
unroutable name, so only `AllowedHost` is something that harness can insist on.
Reverted there, with the reason recorded inline. The conformance guard still
takes origins, so adding an HTTPS behavior cannot reintroduce the defect.

## The third party dependency, named

`example.com` is reserved and operated by ICANN and IANA. `www.iana.org` is
IANA's own site. So this required context cannot go green without **one
organisation** being up, and the two fixtures do not fail independently: an IANA
outage moves the allowed host and the refused host together.

Named at the constants rather than changed. Both are chosen because they are
boring, stable and nobody's production service, and a refused host has to be one
no policy here ever names. Moving `refusedHost` to a second organisation would
decouple them and is a decision about which third parties this repository's
merge gate depends on, not a cleanup, so it is written down rather than done.

## Mutation table

Nine cells, all on the pure rule, all discriminating on the first pass.

| mutation | baseline | mutated | restored | what the failure said |
| --- | --- | --- | --- | --- |
| `readVerdict` returns the first decision rather than the last | PASS | FAIL | PASS | `readVerdict = "allowed-and-failed", want "refused"` |
| an empty log reads as an allow | PASS | FAIL | PASS | `readVerdict = "allowed-and-failed", want "no-decision"` |
| `readVerdict` stops filtering by host | PASS | FAIL | PASS | `readVerdict = "allowed-and-failed", want "no-decision"` |
| a refusal of an allowed host becomes a skip | PASS | FAIL | PASS | `ours = false, want true` |
| a request that never reached the sidecar becomes a skip | PASS | FAIL | PASS | `ours = false, want true` |
| the second piece of evidence is ignored, so every allow skips | PASS | FAIL | PASS | `ours = false, want true` |
| the same, counted | PASS | FAIL | PASS | `2 of the six combinations skip, want exactly 1` |
| an unrecognised verdict becomes a skip | PASS | FAIL | PASS | `ours = false, want true` |
| the failure message stops naming the host | PASS | FAIL | PASS | `message ... does not name the host it is about` |

## The six tests watched running, in CI

Duration alone is inference, and this repository has a rule about theories built
on timings. So the branch pushed a deliberate break and watched CI answer.

`a38450c0` changed this test's expected exit code to one that cannot happen, so
a green `engine` job would have meant the test never ran. It went red:

```
--- FAIL: TestEgress_HTTPSIsDecidedByHost (3.62s)
            expected: 4242
            actual  : 0
    Messages:   TEMPORARY: proving this test ran rather than skipping past the new guard
local: 34 of 34 daemon tests ran
```

Three answers in one log:

- **The test RAN.** The new HTTPS guard did not skip it.
- **`actual: 0`.** The probe got out over HTTPS through the sidecar, so
  `requireGotOut` passed straight through and the real assertion holds.
- **`34 of 34 daemon tests ran`**, against `33 of 34` on the day of the original
  failure. The origins this branch adds to the guard, `https://example.com` and
  `http://www.iana.org`, cost **no skips** on the runner.

The revert restored the tree exactly: `git diff` between the two green commits is
empty.

## What I could not run, and the control that says why

**The Docker half of `internal/runtime/local` cannot run on this machine.**
`docker network create` fails: 33 networks exist, 28 of them another lane's, and
the address pool is exhausted. The package times out at 600s.

That is **not** this change. The same command on a checkout without it times out
identically at 600.027s with the same goroutine dump. Both runs recorded.

So the Docker-backed assertions here are verified by CI, which has a daemon and a
network, and by nothing I ran. `engine/conformance` passes locally
(`ok ... 55.197s`), the pure verdict tests pass, `golangci-lint` reports 0 issues
on `engine`, `gofmt` is clean and `prosecheck` passes over 822 files.
