### PR TITLE
infra: the image pins name v1.2.1, now that v1.2.1 exists

### DIFF
--- a/infra/terraform/modules/control-plane/variables.tf
+++ b/infra/terraform/modules/control-plane/variables.tf
@@ -154,7 +154,7 @@ variable "image_repository" {
 }
 variable "image_tag" {
   type    = string
-  default = "v1.1.1"
+  default = "v1.2.1"
 }
 variable "image_digest" {
   type        = string

--- a/infra/terraform/stacks/control-plane/variables.tf
+++ b/infra/terraform/stacks/control-plane/variables.tf
@@ -89,7 +89,7 @@ variable "image_repository" {
 
 variable "image_tag" {
   type    = string
-  default = "v1.1.1"
+  default = "v1.2.1"
 }
 
 variable "image_digest" {


### PR DESCRIPTION
The separate commit the v1.2.1 release notes said would follow.

```
infra/terraform/stacks/control-plane/variables.tf   default = "v1.1.1"  ->  "v1.2.1"
infra/terraform/modules/control-plane/variables.tf  default = "v1.1.1"  ->  "v1.2.1"
```

Two lines. Both said `v1.1.1`, which is **two** releases behind what production
runs.

## Why this cannot ride in the tag's own commit

`tools/tagsync` classifies these two as `live` pins: they are read by an apply
from `main` rather than from a released tree, and
`azurerm_container_app_job.maintenance` reads the value with **no
`ignore_changes`**. Pointing them at a tag before it published does not produce a
stale deployment. It produces a failed apply on the stack that runs the product.

So the bump has to happen after the tag exists, and `tagsync` refuses it if you
try to do it in the tag's commit. v1.2.1 published at 17:35:31 UTC with nine
assets, and production has been serving it since 17:47:

```
$ curl -sS https://app.antifailure.dev/readyz
{"ready":true,"version":"v1.2.1","commit":"54c03fc9b343ebbbcd04626df9d66ed10f530608"}
```

## Why they were two behind and not one

They did not move after v1.2.0 either. The v1.2.1 changelog section records that
lag in the sentence about these two pins, so the gap is written down rather than
left for somebody to notice from a diff.

`tagsync` now reports:

```
ok  v1.2.1  the control plane stack's image_tag default
ok  v1.2.1  the control plane module's image_tag default
ok  v1.2.1  the chart's appVersion, which is what image.tag defaults to
ok  v1.2.1  the tag the signature verification example checks, the release being prepared
ok  v1.2.1  the tag the rebuild example checks out, the release being prepared
ok  v1.2.1  the version the rebuild example passes to build.sh, the release being prepared
ok  v1.2.1  the archive the rebuild example hashes, the release being prepared
tagsync: every version pin names a tag that exists, or the release being prepared
```
