### PR TITLE
deploy: origincheck needed a grant nobody had written down

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -566,6 +566,36 @@ jobs:
   # ---------------------------------------------------------------------------
   origins:
     name: origins
+    # THE GRANT THIS JOB NEEDS, AND WHERE IT IS, because the job cannot run
+    # without it and nothing in the tree said so.
+    #
+    # `origincheck` asks Azure which custom domains are actually bound to the
+    # Static Web App rather than trusting a list in this repository, and the
+    # app is `af-site` in `af-web`, which is NOT either control plane's group.
+    # `af-infra-ci` held Contributor on af-cp-centralus and af-cp-prod-centralus
+    # and nothing at all on af-web, so `az staticwebapp hostname list` returned
+    # AuthorizationFailed and the middle of three stages could not run.
+    #
+    # The tool did the right thing with that: it printed
+    # "origincheck: NOT CHECKED. This is not a pass." and exited 2, rather than
+    # reporting a pass over a question it never asked. So this was a red on
+    # main that named its own cause, which is the only reason it took minutes
+    # rather than a morning.
+    #
+    # af-infra-ci now holds READER on the af-web resource group. Read only, and
+    # af-web holds the public marketing site and the public DNS zone, so there
+    # is nothing there this identity can see that a visitor cannot. It is a
+    # role assignment made by hand, like the DNS Zone Contributor grant that
+    # domain.tf documents and deliberately does not create, and for the same
+    # reason: a stack scoped to its own group that could grant itself access to
+    # another group would defeat the point of scoping it. Both grants are
+    # therefore written down here and in domain.tf rather than expressed in
+    # Terraform, which is a trade this project has made twice now.
+    #
+    #   az role assignment create --role Reader \
+    #     --assignee-object-id <af-infra-ci object id> \
+    #     --assignee-principal-type ServicePrincipal \
+    #     --scope /subscriptions/<id>/resourceGroups/af-web
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: site


### PR DESCRIPTION
A comment. The change that made the `origins` job green was a role assignment in
Azure, and nothing in the tree said the job needed one.

## What went red, and what said so

```
origincheck: could not enumerate the custom domains on af-site in af-web, so
NOTHING here was checked: az staticwebapp hostname list -n af-site -g af-web:
ERROR: (AuthorizationFailed) ... does not have authorization to perform action
'Microsoft.Web/staticSites/customDomains/read' ...
origincheck: NOT CHECKED. This is not a pass.
```

`origincheck` asks Azure which custom domains are actually **bound** to the
Static Web App rather than trusting a list in this repository. That is the whole
point of the stage. The app is `af-site` in `af-web`, which is neither control
plane's resource group, and `af-infra-ci` held Contributor on
`af-cp-centralus` and `af-cp-prod-centralus` and **nothing at all** on `af-web`.

Its other two stages had already passed, which is worth saying: the tfvars allow
both hostnames, and production answers both on all three cross origin routes.
Only the middle one could not run, and the tool refused to report a pass over a
question it never asked. That refusal is why this was a red on `main` that named
its own cause instead of a green over a blind spot.

## The grant

`af-infra-ci` now holds **Reader** on the `af-web` resource group. Read only, and
`af-web` holds the public marketing site and the public DNS zone, so there is
nothing there this identity can see that a visitor to the site cannot.

## Why the grant is by hand and this comment is the record

`infra/terraform/modules/control-plane/domain.tf` already makes exactly this
trade, and says so: `antifailure.dev` is in `af-web` too, the identity applying
the control plane stack needs DNS Zone Contributor there, and that file
deliberately does not create it, because *a stack that could grant itself write
access to a zone in another group would defeat the point of scoping it.*

That argument holds for a Reader grant as much as for a Contributor one. So this
is written where the job that needs it lives, rather than expressed in Terraform,
and the repository now records both of the two grants it depends on and does not
create.

## Green, all three stages

```
origincheck origins: every hostname has an allowed origin in every control plane tfvars
  ok   antifailure.dev is bound to af-site and tools/site/hostnames.txt names it (status Ready)
  ok   www.antifailure.dev is bound to af-site and tools/site/hostnames.txt names it (status Ready)
  ok   agreeable-hill-09b250510.7.azurestaticapps.net is bound and deliberately not an allowed origin
origincheck domains: the 3 domain(s) bound to af-site are exactly what tools/site/hostnames.txt claims
  ok    https://antifailure.dev      /v1/site/events  /v1/leads  /v1/applications: 204, allow-origin echoes this origin
  ok    https://www.antifailure.dev  /v1/site/events  /v1/leads  /v1/applications: 204, allow-origin echoes this origin
origincheck live: https://app.antifailure.dev answers every hostname on every cross origin route listed above
```

Deploy run [33982237656](https://github.com/antifailure/antifailure/actions/runs/33982237656): `site` success, `origins` success.
