### PR TITLE
www: the film was served as a file of unknown type

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -566,6 +566,36 @@ jobs:
   # ---------------------------------------------------------------------------
   origins:
     name: origins
+    # THE GRANT THIS JOB NEEDS, AND WHERE IT IS, because the job cannot run
+    # without it and nothing in the tree said so.
+    #
+    # `origincheck` asks Azure which custom domains are actually bound to the
+    # Static Web App rather than trusting a list in this repository, and the
+    # app is `af-site` in `af-web`, which is NOT either control plane's group.
+    # `af-infra-ci` held Contributor on af-cp-centralus and af-cp-prod-centralus
+    # and nothing at all on af-web, so `az staticwebapp hostname list` returned
+    # AuthorizationFailed and the middle of three stages could not run.
+    #
+    # The tool did the right thing with that: it printed
+    # "origincheck: NOT CHECKED. This is not a pass." and exited 2, rather than
+    # reporting a pass over a question it never asked. So this was a red on
+    # main that named its own cause, which is the only reason it took minutes
+    # rather than a morning.
+    #
+    # af-infra-ci now holds READER on the af-web resource group. Read only, and
+    # af-web holds the public marketing site and the public DNS zone, so there
+    # is nothing there this identity can see that a visitor cannot. It is a
+    # role assignment made by hand, like the DNS Zone Contributor grant that
+    # domain.tf documents and deliberately does not create, and for the same
+    # reason: a stack scoped to its own group that could grant itself access to
+    # another group would defeat the point of scoping it. Both grants are
+    # therefore written down here and in domain.tf rather than expressed in
+    # Terraform, which is a trade this project has made twice now.
+    #
+    #   az role assignment create --role Reader \
+    #     --assignee-object-id <af-infra-ci object id> \
+    #     --assignee-principal-type ServicePrincipal \
+    #     --scope /subscriptions/<id>/resourceGroups/af-web
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: site

--- a/www/public/staticwebapp.config.json
+++ b/www/public/staticwebapp.config.json
@@ -137,6 +137,7 @@
     ".xml": "application/xml; charset=utf-8",
     ".avif": "image/avif",
     ".webp": "image/webp",
+    ".mp4": "video/mp4",
     ".webmanifest": "application/manifest+json"
   }
 }


### PR DESCRIPTION
One line. `.mp4` was the only extension this site serves that is not in the
`mimeTypes` list, so the launch film went out as:

```
content-type: application/octet-stream
x-content-type-options: nosniff
```

## Nothing is broken by it, and this says so rather than overselling the fix

Checked on both engines rather than reasoned about, against the live site:

| | Chromium 1440x900 | WebKit, iPhone 14 profile |
| --- | --- | --- |
| `readyState` | 4 | 4 |
| playing | yes, 8.58s of 85.504 | yes, 8.48s of 85.5 |
| `video.error` | null | null |
| console errors | none | none |
| `canPlayType("video/mp4")` | | `"maybe"` |

Range requests already worked, which is the half of this that genuinely would
have broken seeking on iOS:

```
$ curl -r 0-99 -D- https://www.antifailure.dev/home/launch-film.mp4
HTTP/2 206
content-range: bytes 0-99/10285851
accept-ranges: bytes
```

So this is correctness, not a repair. A video declared as a stream of bytes is a
thing that bites later rather than now: a proxy that will not range over an
opaque type, a download prompt instead of a player, a future CDN that declines to
cache or compress by class. The six entries already in that list are there for
the same reason.

## The machinery was already expecting it

`tools/site/assemble.sh` names `mimeTypes` explicitly in its post-merge
assertion, checks every entry survived into the shipped config, and prints the
count. The key was anticipated; the list simply had no video in it.

## One thing I got wrong on the way

My first reading of this file was of a **different file**.
`find -name staticwebapp.config.json | head -1` returns
`deploy/blog-redirect/`'s, not `www/public/`'s, and that one genuinely has no
`mimeTypes` at all. I reported "no mimeTypes" off the wrong config and was about
to add a block that already existed with six entries in it. Two configs share a
name in this tree. Name the path.
