### PR TITLE
docs: the stale scan runbook knew one of the two ways it happens

### DIFF
--- a/.changes/a-runbook-that-knew-one-of-two-causes.md
+++ b/.changes/a-runbook-that-knew-one-of-two-causes.md
@@ -1,0 +1,32 @@
+# fixed
+
+The runbook for a stale vulnerability scan named one cause, and the case that
+happened was the other one.
+
+It said a scan goes stale because GitHub disables a scheduled workflow in a
+repository nobody has touched for sixty days, and sent you to
+`gh workflow enable`. On 2026-09-05 the scan went stale for a different reason
+entirely: the schedule fired 21 seconds after a merge to `main` and a
+concurrency group cancelled it 17 seconds later, before it reached a single job.
+`gh workflow list --all` said `active`, which is where that page runs out of
+advice.
+
+The two look identical from outside, because the watchdog reports the same
+sentence for both: the newest completed scheduled run is too old. The page now
+opens with the query that tells them apart, a gap with no rows in it against a
+row that says `cancelled`, and gives the remedy for each. For a cancellation the
+remedy is re-running that run rather than starting a new one, because only a run
+of the `schedule` event counts and `gh workflow run` produces a
+`workflow_dispatch` one the watchdog deliberately ignores.
+
+It also says to check whether a fix is already in the tree and simply was not
+live yet. `security.yml` gives the schedule its own concurrency group precisely
+so activity on `main` cannot reach it, and that change had landed 83 minutes
+after the run that was cancelled. A scheduled run cancelled after it is a
+regression; one cancelled before it is not, and the difference is two commit
+timestamps rather than a judgement.
+
+The worked example is dated and kept in its failed state, with a note that the
+run it names now reads `completed/success` because following this page is what
+somebody did to it. A runbook whose example shows the healthy state teaches
+nothing about the sick one.

--- a/docs/src/content/docs/self-hosting/runbooks/security-workflow.md
+++ b/docs/src/content/docs/self-hosting/runbooks/security-workflow.md
@@ -11,7 +11,7 @@ issue titled "The vulnerability scan is not protecting this repository".
 `.github/workflows/security.yml` runs `govulncheck` daily at 07:00 UTC.
 `.github/workflows/security-watch.yml` watches it and is what opened the issue.
 
-## The two failures it covers, which are different
+## The three failures it covers, which are different
 
 **The scan ran and failed.** `govulncheck` found a known vulnerability that is
 reachable from this code, or an entry in `.govulncheck.yaml` expired or stopped
@@ -27,7 +27,18 @@ Scheduled runs only, and that is the part that is easy to get wrong. The scan
 also runs on every pull request, so counting runs of any kind would let a busy
 afternoon make a dead schedule look fresh.
 
-The issue body says which of the two happened.
+**The scan was cancelled before it started.** This one is new, it has happened,
+and it looks exactly like the case above from the outside. A scheduled run that
+a concurrency group cancels never reaches a job, so it completes in seconds with
+a `cancelled` conclusion and nothing in its log. The watchdog skips a cancelled
+run rather than reading it as a failure, correctly, so the newest run it counts
+is yesterday's and it ages out at 26 hours. On 2026-09-05 the schedule fired at
+11:11:27Z, 21 seconds after a merge to `main`, and was cancelled 17 seconds
+later with zero jobs.
+
+The issue body says which of the three happened, except that it cannot tell the
+second from the third: both read as a scan that is too old. The next section
+tells them apart in one command.
 
 ## If the scan failed
 
@@ -41,15 +52,76 @@ Three honest outcomes, in order of preference: upgrade the dependency, prove the
 path is unreachable and record it with an expiry, or accept it deliberately with
 a date to look again.
 
+## If the scan is too old, find out which of the two reasons it is
+
+**Look at the scheduled runs before touching anything.** This is the step that
+was missing, and without it the section below sends you to re-enable a workflow
+that was never disabled.
+
+```sh
+gh api "repos/antifailure/antifailure/actions/workflows/security.yml/runs?event=schedule&per_page=10" \
+  --jq '.workflow_runs[] | "\(.created_at)  \(.status)/\(.conclusion)  \(.id)"'
+```
+
+A gap with **no rows at all** in it is the schedule not firing, which is the
+next section. A row that is there and says `cancelled` is the third case. This
+is what that looked like on 2026-09-05, before it was remedied:
+
+```
+2026-09-05T11:11:27Z  completed/cancelled  33962658928
+2026-09-04T12:02:16Z  completed/success    33870767538
+```
+
+**That run now reads `completed/success`, because re-running it is what this
+section tells you to do and somebody did.** The example is kept as it was rather
+than refreshed, because a runbook whose worked example shows the healthy state
+teaches nothing about the sick one. Do not expect that id to reproduce the row
+above.
+
+Confirm the diagnosis by asking whether the run reached a job. A concurrency
+cancellation reaches none:
+
+```sh
+gh api repos/antifailure/antifailure/actions/runs/<id>/jobs --jq '.jobs | length'
+```
+
+Zero, and a `created_at` to `updated_at` gap of seconds rather than minutes,
+means the run was superseded before it began. Against 33962658928 that command
+answers `2` today, for the same reason: the second attempt ran the jobs. Ask it
+of the run your own issue names, not of this one. **Re-run it.** The remedy is
+that run, not a new one, because only a run of the `schedule` event counts:
+
+```sh
+gh run rerun <id>
+```
+
+The second attempt keeps `event: schedule`, so the watchdog sees a fresh
+completed scheduled run and goes green. `gh workflow run security.yml` does not
+help here; it produces a `workflow_dispatch` run, which the watchdog
+deliberately ignores for the same reason it ignores pull request runs.
+
+Then ask why it was cancelled, because a fix may already be in the tree and not
+yet in effect. `security.yml` gives the schedule its own concurrency group so
+that activity on `main` cannot reach it. A scheduled run STILL cancelled after
+that is a real regression in the group expression. A scheduled run cancelled
+*before* that change reached `main` is not: on 2026-09-05 the fix landed at
+12:34:27Z and the cancelled run had fired at 11:11:27Z, 83 minutes earlier.
+Compare the fix's commit time against the run's, rather than assuming the guard
+was live.
+
 ## If the scan stopped running
 
-Check the workflow's state, and re-enable it:
+Only after the section above shows a gap with no scheduled rows in it. Check the
+workflow's state, and re-enable it:
 
 ```sh
 gh workflow list --all
 gh workflow enable security.yml
 gh workflow run security.yml
 ```
+
+`gh workflow list --all` reporting `active` means this is NOT the case you have,
+and the section above is where to look.
 
 Then look at what the gap was. A repository that has had no push for two months
 is dormant, and the right response is to run the scan by hand before picking the


### PR DESCRIPTION
The page for a stale vulnerability scan named one cause. The case that happened
today was the other one, and the page's advice for it was a dead end.

## What it said, and what happened

It said GitHub disables a scheduled workflow in a repository nobody has touched
for sixty days, and sent the reader to:

```sh
gh workflow list --all
gh workflow enable security.yml
```

What actually happened on 2026-09-05: the schedule fired at **11:11:27Z**, 21
seconds after a merge to `main`, and a concurrency group cancelled it 17 seconds
later with **zero jobs**. The watchdog skips a cancelled run rather than reading
it as a failure, which is correct, so the newest run it counted was the previous
day's and it aged out at 26 hours.

`gh workflow list --all` said **`active`**. That is exactly where the page ran
out of advice.

## Why this is worth more than a paragraph

The two cases are indistinguishable from the alarm, because the watchdog says
the same sentence for both. And **the remedies are different in a way that
matters**:

`gh workflow run security.yml` produces a `workflow_dispatch` run, and the
watchdog ignores those deliberately, for the same reason it ignores pull request
runs: a busy afternoon must not make a dead schedule look fresh. So dispatching
a scan **does not clear the alarm**. Re-running the cancelled run does, because
the second attempt keeps `event: schedule`.

The page now opens with the query that separates the two before either remedy,
then a second command that confirms it: a concurrency cancellation reaches no
job at all, and a `created_at` to `updated_at` gap of seconds says the same
thing.

## And whether the fix is already in the tree

`security.yml` gives the schedule its own concurrency group precisely so
activity on `main` cannot reach it. That change landed at **12:34:27Z**, which
is **83 minutes after** the run that was cancelled. So a scheduled run cancelled
after that commit is a regression in the group expression, and one cancelled
before it is not. The page says to compare those two timestamps rather than
assume the guard was live, which is the difference between "the fix does not
work" and "the fix was not there yet".

## The worked example needed a paragraph of its own

Both commands on the page were run verbatim before this was committed, and that
is how this came up: **re-running `33962658928` is what the page tells you to
do, somebody did it, and that run now answers `completed/success` with 2 jobs
rather than `cancelled` with 0.**

The example is kept in its failed state and dated, with the drift explained,
rather than refreshed to what the command prints today. A runbook whose worked
example shows the healthy state teaches nothing about the sick one.

```
prosecheck    826 files, 0 places where the punctuation gives it away
runbookcheck  1 numbered runbooks, every step number agrees
claimcheck    317 site files, 8 claim rules, 0 contradicted
changecheck   2 changed paths, described by .changes/a-runbook-that-knew-one-of-two-causes.md
```
