### PR TITLE
deploy: the one Azure call the deploy could not try again was the one that moves traffic

### DIFF
--- a/.changes/the-only-deploy-step-that-could-not-retry.md
+++ b/.changes/the-only-deploy-step-that-could-not-retry.md
@@ -1,0 +1,55 @@
+# fixed
+
+The deploy's traffic shift is tried again when Azure refuses it for a reason
+that will pass, and refused immediately when it will not.
+
+On 2026-09-06 a staging deploy printed `The containerapp 'afcp-app' does not
+exist in group 'af-cp-centralus'` while shifting traffic. The app existed. The
+same script had already run three commands against the same name and the same
+group seconds earlier, all of them successfully, and the app answered a hand
+query moments later. That is a transient ARM lookup failure reported in the
+words of a permanent one, and it was the one Azure call in the deploy with no
+way to try again: the bootstrap job is polled sixty times, the revision
+readiness is polled sixty times, every deactivate tolerates its own failure, and
+the traffic shift was a single call under `set -euo pipefail`.
+
+Staging recovers from that on its own, because the next merge deploys and takes
+traffic. A production tag has no next merge. The healthy revision sits at zero
+percent, production keeps serving the previous release, and the only signal is a
+red check nobody is watching at that hour.
+
+The shift now retries with backoff. It does not decide transient from permanent
+by reading the message, because the message is identical when the app name is
+genuinely wrong: it asks the app for its own name between attempts, waits only
+while the answer is yes, and stops on the first attempt when the answer is no,
+so a mistyped app name fails in seconds rather than after two and a half
+minutes of waiting. Throttling and gateway errors name themselves and are
+retried without the extra read. Anything the classifier does not recognise is
+not retried, because a loop that treats every unfamiliar failure as weather is a
+hang with extra steps.
+
+When the retries are exhausted the deploy says which revision is still serving
+and that the commit is not live, rather than exiting on the raw Azure message.
+It does not roll anything back, because traffic never moved and a rollback that
+puts traffic where it already is reports something that did not happen. What is
+serving is read back rather than assumed, so a call that errors after the
+weights are already written is still put through the public health gate instead
+of being reported as a deploy that never happened.
+
+The rollback's own traffic shift is retried the same way. It was a single call
+too, at the worst possible moment, and a transient failure there ended the run
+on a raw error with the unhealthy revision still serving.
+
+`docs/plan/notes/cd.md` said "any failure after step 2 puts traffic back on the
+revision that was serving". That was never true in either direction. A failure
+at the shift leaves traffic where it already was, and a failure in the
+maintenance job update or the connection budget check deliberately leaves the
+healthy release serving. Both end states are now written down, next to the
+other three.
+
+Reading what is currently serving no longer kills the deploy when Azure refuses
+the read, for the same reason: a blip on a read should not end a release before
+it starts. The cost of that tolerance lands on the reap, which compares each
+active revision against the one it must keep, and an empty name matches nothing.
+It now refuses to reap at all when it does not know which revision the deploy
+superseded, rather than deactivating the one thing a rollback would need.

--- a/deploy/cd/deploy.sh
+++ b/deploy/cd/deploy.sh
@@ -10,7 +10,10 @@
 #   2. Create the new revision with ZERO traffic. It starts, connects, and is
 #      checked on its own address while every real request still goes to the old
 #      one. A revision that cannot start never reaches a user.
-#   3. Shift traffic.
+#   3. Shift traffic. Retried with backoff while the app answers for its own
+#      name, and refused on the first attempt when it does not, because the
+#      Azure message for a transient lookup failure and for a wrong app name is
+#      the same sentence.
 #   4. Check the public origin, including which commit answers.
 #   5. Deactivate every revision this deploy superseded except one, update the
 #      scheduled job, and prove the database's connection budget still fits.
@@ -18,10 +21,39 @@
 #      failures never move traffic. Maintenance and budget failures report the
 #      unhealthy operational state while leaving the healthy app serving.
 #
+# WHAT HAPPENS WHEN EACH STEP FAILS, stated completely, because this list used
+# to name an end state for every failure except the one at step 3 and a reader
+# then had to infer it from the line ordering:
+#
+#   step 1  nothing moved, the old revision serves, the run is red
+#   step 2  the candidate is deactivated, nothing moved, the run is red
+#   step 3  traffic never left the old revision, so there is NOTHING TO ROLL
+#           BACK. The candidate stays up at zero percent and the run is red.
+#           Step 6 is not reached and must not be: putting traffic where it
+#           already is would report a rollback that never happened.
+#   step 4  step 6 runs, and traffic goes back onto the previous revision
+#   step 5  the app keeps serving the release that just passed both gates, and
+#           the run is red about the operational state rather than the app
+#
 # Step 6 is only fast because the app runs in Multiple revision mode: the old
 # revision is still up with no traffic, so the way back is one API call rather
 # than a rebuild. Step 5 exists because that is true of exactly ONE old
 # revision and this script used to keep every one of them.
+#
+# WHICH CALLS ARE RETRIED, and why the rest are not. Only the two traffic
+# shifts, because `ingress traffic set` states the weights it wants rather than
+# adjusting them, so the same call twice is the same request twice and never two
+# effects. `job start` is not repeated because a second execution runs the
+# migrations a second time; `containerapp update` is not repeated because it
+# creates a revision under a name the first attempt may already hold; every
+# `revision deactivate` is already tolerant of its own failure and the
+# connection budget check at the end is what decides whether the result of that
+# is safe; `job update` is declarative and would be safe to repeat, but both of
+# its call sites already end somewhere a person can see, one before any traffic
+# moves and one with the application still serving and the run red, so it is the
+# next candidate rather than this lane's. Each of those is a stance rather than
+# an omission, and deploy_test.sh fails when a mutating call appears here
+# without one.
 #
 # WHAT THIS DOES NOT DO. It does not roll migrations back. A schema change that
 # applied and a revision that was reverted leave the old code running against
@@ -52,6 +84,176 @@ say() { printf '\n=== %s\n' "$*"; }
 TOOL_CONNECTIONS=4
 
 # ---------------------------------------------------------------------------
+# The one call in this script that could not be tried again.
+#
+# Observed on 2026-09-06, staging cd for b63f1d16:
+#
+#   === shifting 100% of traffic to afcp-app--cb63f1d16-224417
+#   ERROR: The containerapp 'afcp-app' does not exist in group 'af-cp-centralus'
+#
+# The app existed. This same script had already run `containerapp show`,
+# `containerapp job start` and `containerapp update` against the same -n and the
+# same -g seconds earlier, all three successfully, and the app answered a hand
+# query in Multiple revision mode moments later. That message is the containerapp
+# extension reporting a transient ARM lookup failure in the words of a permanent
+# one, immediately after the resource it could not find was mutated twice.
+#
+# Everything else in this script survives that. The bootstrap job execution is
+# polled sixty times, the revision readiness is polled sixty times, every
+# deactivate is deliberately tolerant, and every read that only feeds a report
+# falls back to a stated "unchecked". The traffic shift was one shot under
+# `set -euo pipefail`, so a single transient error exited 3.
+#
+# On STAGING that self corrects: the next merge deploys and takes traffic, which
+# is exactly what happened and why staging was current an hour later. On a
+# PRODUCTION TAG there is no next merge. A transient error there leaves a healthy
+# revision at zero percent, production serving the previous release, and a red
+# check, until a person notices.
+#
+# WHY A LOOP IS NOT THE FIX ON ITS OWN. "The containerapp 'X' does not exist" is
+# also precisely what a genuinely wrong app name says. A retry that cannot tell
+# those two apart converts a real misconfiguration into a five minute hang, and
+# this repository's own rule is that a check which cannot say no is worse than no
+# check. So they are separated by ASKING A SECOND QUESTION rather than by reading
+# the sentence more closely: if the app is there when we go and look, the message
+# was a lie and we wait and try again. If it is not there either, the name is
+# wrong, and we stop on the first attempt with the message Azure gave us.
+# ---------------------------------------------------------------------------
+
+# Six attempts at 5, 10, 20, 40 and 80 seconds is a little over two and a half
+# minutes. Long enough to outlast an ARM blip, short enough that a real regional
+# outage is reported as one rather than waited out. There is deliberately no
+# environment variable here: a knob that can set the attempts to 1 is a way to
+# turn this off in the one environment that cannot self correct.
+AZURE_RETRY_ATTEMPTS=6
+AZURE_RETRY_FIRST_DELAY=5
+
+# Is the app actually there? This is the second question, and the whole
+# discrimination rests on it. `show` rather than `list`, so a subscription
+# holding many apps still costs one read, and the query is narrowed to the name
+# so nothing here can print a configuration value into a public deploy log.
+app_is_present() {
+  az containerapp show -n "$APP" -g "$RG" --query name -o tsv >/dev/null 2>&1
+}
+
+# Is this failure worth waiting on?
+#
+# Text this function does not recognise is NOT retried. A classifier that treats
+# everything unfamiliar as transient is a hang with extra steps, and the failure
+# this exists to survive already looked permanent, so guessing generously in that
+# direction is the mistake being fixed rather than a safe default.
+azure_failure_is_transient() {
+  local message="$1"
+
+  case "$message" in
+    # Nothing about a credential, a subscription, a role assignment or a
+    # mistyped argument improves by waiting. Matched FIRST, because several of
+    # these also carry the words the lookup case below matches on, and a token
+    # that expired mid deploy would otherwise be retried five times before
+    # failing with the same message anyway.
+    *AuthorizationFailed*|*AuthenticationFailed*|*ExpiredAuthenticationToken*|\
+    *InvalidAuthenticationToken*|*SubscriptionNotFound*|*"az login"*|\
+    *"unrecognized arguments"*|*"invalid choice"*|*"is not a valid"*|\
+    *"Forbidden"*|*"(403)"*|*"(401)"*)
+      return 1
+      ;;
+
+    # The observed shape, and the only one that needs the second question. These
+    # words are identical whether the resource is genuinely absent or ARM said so
+    # for a moment, which is why the sentence cannot decide it and a live read
+    # can.
+    *"does not exist"*|*ResourceNotFound*|*"could not be found"*|*"was not found"*|\
+    *"ResourceGroupNotFound"*)
+      if app_is_present; then
+        return 0
+      fi
+      return 1
+      ;;
+
+    # Throttling, gateway and transport failures. These name themselves as
+    # transient, so they cost no extra call.
+    *TooManyRequests*|*Throttl*|*ServiceUnavailable*|*GatewayTimeout*|\
+    *ServerTimeout*|*RetryableError*|*"Operation timed out"*|\
+    *"Read timed out"*|*"Connection aborted"*|*"Connection reset"*|\
+    *"temporarily unavailable"*|*"(429)"*|*"(500)"*|*"(502)"*|*"(503)"*|*"(504)")
+      return 0
+      ;;
+  esac
+
+  return 1
+}
+
+# What is carrying traffic right now.
+#
+# One reader with two callers: it captures the rollback target before anything
+# changes, and it is asked again after a shift that reported failure, because a
+# call that errors is not the same claim as a call that did nothing.
+current_serving() {
+  local serving
+
+  serving="$(az containerapp ingress traffic show -n "$APP" -g "$RG" \
+    --query "[?weight>\`0\`] | [0].revisionName" -o tsv 2>/dev/null || true)"
+  if [ -z "$serving" ] || [ "$serving" = "None" ]; then
+    # In Multiple mode with latestRevision traffic, the weight entry can name no
+    # revision. Fall back to whichever revision is actually running.
+    serving="$(az containerapp show -n "$APP" -g "$RG" \
+      --query "properties.latestReadyRevisionName" -o tsv 2>/dev/null || true)"
+  fi
+  if [ "$serving" = "None" ]; then
+    serving=""
+  fi
+
+  printf '%s' "$serving"
+}
+
+# Move all traffic onto one revision, and keep trying only while trying again is
+# the honest response.
+#
+# `ingress traffic set` is declarative: it states the weights it wants rather
+# than adjusting them, so running it twice is the same request twice and never
+# two effects. That is what makes this one safe to repeat, and it is why the
+# other mutating calls in this script are not repeated. Their stances are stated
+# beside them.
+shift_traffic() {
+  local revision="$1"
+  local attempt=1 delay="$AZURE_RETRY_FIRST_DELAY" message
+
+  while :; do
+    if message="$(az containerapp ingress traffic set -n "$APP" -g "$RG" \
+        --revision-weight "$revision=100" -o none 2>&1)"; then
+      if [ "$attempt" -gt 1 ]; then
+        say "traffic reached $revision on attempt $attempt of $AZURE_RETRY_ATTEMPTS"
+      fi
+      return 0
+    fi
+
+    printf '%s\n' "${message:-az failed and said nothing}"
+
+    if ! azure_failure_is_transient "$message"; then
+      say "THE SHIFT TO $revision FAILED AND WAITING WILL NOT HELP (attempt $attempt of $AZURE_RETRY_ATTEMPTS)."
+      echo "Azure's own message is above. Either the app named $APP in $RG is not"
+      echo "there, or the request was refused, and both of those are configuration"
+      echo "rather than weather. Nothing is retried, on purpose: a loop here would"
+      echo "turn a wrong name into a silent wait."
+      return 1
+    fi
+
+    if [ "$attempt" -ge "$AZURE_RETRY_ATTEMPTS" ]; then
+      say "THE SHIFT TO $revision DID NOT SUCCEED IN $AZURE_RETRY_ATTEMPTS ATTEMPTS."
+      echo "Every attempt looked transient and $APP answered for its own name each"
+      echo "time, so this is not a wrong name. It is a control plane that would not"
+      echo "take the write."
+      return 1
+    fi
+
+    echo "attempt $attempt of $AZURE_RETRY_ATTEMPTS looks transient and $APP is present; waiting ${delay}s"
+    sleep "$delay"
+    attempt=$((attempt + 1))
+    delay=$((delay * 2))
+  done
+}
+
+# ---------------------------------------------------------------------------
 # Reaping the revisions a deploy superseded.
 #
 # A revision at zero traffic is NOT idle, and this script used to say it was:
@@ -74,6 +276,20 @@ TOOL_CONNECTIONS=4
 # ---------------------------------------------------------------------------
 reap_superseded() {
   local keep_new="$1" keep_previous="$2" reaped=0 revision created born
+
+  # Nothing is reaped when the revision to keep is not known.
+  #
+  # The read that captures it is tolerant of a failing `az`, because an ARM blip
+  # on a read should not kill a deploy before it starts, and that is the whole
+  # argument of the retry below. The cost of that tolerance lands HERE: with an
+  # empty name to keep, the comparison below matches nothing, and this loop would
+  # deactivate the one revision step 6 exists to shift back onto. Refusing to
+  # reap leaves connections this deploy did not reclaim, and
+  # assert_connection_budget is what decides whether that is safe.
+  if [ -z "$keep_previous" ]; then
+    say "not reaping anything: this deploy never learned which revision it superseded, and the one to keep is the one it would guess wrong about"
+    return 0
+  fi
 
   # WHEN THIS DEPLOY'S REVISION WAS BORN, and why a name list is not enough.
   #
@@ -231,15 +447,12 @@ assert_connection_budget() {
 # the thing we go back to, and reading it after a failure means reading it from
 # a system that is already in the state we are trying to escape.
 # ---------------------------------------------------------------------------
-PREVIOUS="$(az containerapp ingress traffic show -n "$APP" -g "$RG" \
-  --query "[?weight>\`0\`] | [0].revisionName" -o tsv 2>/dev/null || true)"
-if [ -z "$PREVIOUS" ] || [ "$PREVIOUS" = "None" ]; then
-  # In Multiple mode with latestRevision traffic, the weight entry can name no
-  # revision. Fall back to whichever revision is actually running.
-  PREVIOUS="$(az containerapp show -n "$APP" -g "$RG" \
-    --query "properties.latestReadyRevisionName" -o tsv)"
-fi
-say "currently serving: $PREVIOUS"
+# Empty is a real answer here and it means one of two things: a first deploy with
+# nothing serving yet, or a read that failed. Both leave this deploy without a
+# rollback target, which step 6 already refuses on and reap_superseded now
+# refuses on, so it is reported and carried rather than guessed at.
+PREVIOUS="$(current_serving)"
+say "currently serving: ${PREVIOUS:-nothing this script can name}"
 
 # ---------------------------------------------------------------------------
 # 1. Migrations, before traffic.
@@ -343,7 +556,28 @@ fi
 # 4. Promote, then check the real origin.
 # ---------------------------------------------------------------------------
 say "shifting 100% of traffic to $NEW"
-az containerapp ingress traffic set -n "$APP" -g "$RG" --revision-weight "$NEW=100" -o none
+if ! shift_traffic "$NEW"; then
+  # A shift that reported failure is not the same claim as a shift that did
+  # nothing, and the difference decides which of two end states this is. The
+  # call can error after the weights are already written, so what is serving is
+  # READ BACK rather than assumed.
+  SERVING="$(current_serving)"
+  if [ "$SERVING" = "$NEW" ]; then
+    say "the shift reported failure and yet $NEW is the revision carrying traffic. Traffic HAS moved, so the public gate below is what decides whether it stays."
+  else
+    # Nothing is rolled back here, and that is the point rather than an omission.
+    # Traffic never left $PREVIOUS, so there is nowhere to go back to; putting
+    # traffic where it already is would be another write to the same API that
+    # just refused one, and it would report a rollback that never happened.
+    say "TRAFFIC NEVER MOVED. ${SERVING:-${PREVIOUS:-the previous revision}} is still serving and $NEW sits at zero percent."
+    echo "No user saw this release and no rollback is needed, because nothing"
+    echo "was promoted. What IS applied is step 1's migrations, and the candidate"
+    echo "revision is up and passed the health gate on its own address, so the"
+    echo "way forward is to run this deploy again rather than to undo anything."
+    echo "::error title=Traffic never moved::$APP is still serving ${SERVING:-${PREVIOUS:-its previous revision}}. $NEW is healthy at zero percent and $COMMIT is not live."
+    exit 1
+  fi
+fi
 
 say "post-deploy health gate on $BASE_URL"
 if "$HERE/health-gate.sh" "$BASE_URL" "$COMMIT" 40 3; then
@@ -399,7 +633,16 @@ if [ -z "$PREVIOUS" ] || [ "$PREVIOUS" = "$NEW" ]; then
   exit 1
 fi
 
-az containerapp ingress traffic set -n "$APP" -g "$RG" --revision-weight "$PREVIOUS=100" -o none
+if ! shift_traffic "$PREVIOUS"; then
+  # The worst moment to be a single shot call, which is what this used to be: a
+  # transient error during a rollback exited on a raw az message with the
+  # unhealthy revision still serving and nothing in the log saying so.
+  say "THE ROLLBACK COULD NOT MOVE TRAFFIC. $BASE_URL is unhealthy on $NEW and this needs a person now."
+  echo "$NEW failed the public health gate and is still the revision carrying"
+  echo "traffic. The revision to go back to is $PREVIOUS, and it is still up."
+  echo "::error title=Rollback did not move traffic::$APP is serving the unhealthy $NEW. Shift it onto $PREVIOUS by hand."
+  exit 1
+fi
 az containerapp revision deactivate -n "$APP" -g "$RG" --revision "$NEW" -o none || true
 
 say "rolled back; verifying $PREVIOUS is serving"

--- a/deploy/cd/deploy_test.sh
+++ b/deploy/cd/deploy_test.sh
@@ -25,18 +25,71 @@ printf 'az %s\n' "$command" >> "$log"
 name=""
 image=""
 query=""
+weight=""
 args=("$@")
 for ((i = 0; i < ${#args[@]}; i++)); do
   case "${args[$i]}" in
     -n) name="${args[$((i + 1))]}" ;;
     --image) image="${args[$((i + 1))]}" ;;
     --query) query="${args[$((i + 1))]}" ;;
+    --revision-weight) weight="${args[$((i + 1))]}" ;;
   esac
 done
 
+state="${AF_DEPLOY_TEST_STATE:?}"
+
+# How many times this exact operation has been tried in this case. Kept on disk
+# because every attempt is a separate process, and the count is the whole point:
+# a retry that fires once and a retry that fires six times are different
+# behaviours and an assertion has to be able to tell them apart.
+attempt_number() {
+  local file="$state/$1" n=0
+  if [ -f "$file" ]; then
+    n="$(cat "$file")"
+  fi
+  n=$((n + 1))
+  printf '%s' "$n" > "$file"
+  printf '%s' "$n"
+}
+
+# The message Azure actually produced on 2026-09-06 for a transient ARM lookup
+# failure, reproduced verbatim, including the fact that it is word for word what
+# a genuinely wrong app name says. The whole point of the case is that the text
+# cannot tell you which one it is.
+transient_lookup_failure() {
+  printf "ERROR: The containerapp '%s' does not exist in group 'group'\n" "$name" >&2
+  exit 3
+}
+
 case "$command" in
   "containerapp ingress traffic show"*)
-    printf 'old-revision\n'
+    if [ "${AF_DEPLOY_TEST_SERVING:-known}" = unknown ]; then
+      :
+    elif [ -f "$state/serving" ]; then
+      cat "$state/serving"
+    else
+      printf 'old-revision\n'
+    fi
+    ;;
+  "containerapp show"*)
+    # The second question the retry asks. A genuinely wrong app name answers it
+    # the same way it answered the shift, and that is what makes the shift fail
+    # fast instead of waiting.
+    case "$query" in
+      name)
+        if [ "${AF_DEPLOY_TEST_APP_PRESENT:-yes}" = no ]; then
+          transient_lookup_failure
+        fi
+        printf '%s\n' "$name"
+        ;;
+      properties.latestReadyRevisionName)
+        # An app with nothing serving yet, and an app whose read failed, are the
+        # same empty answer here. Both leave the deploy with no rollback target.
+        if [ "${AF_DEPLOY_TEST_SERVING:-known}" != unknown ]; then
+          printf 'old-revision\n'
+        fi
+        ;;
+    esac
     ;;
   "containerapp job update"*)
     printf 'job-update %s %s\n' "$name" "$image" >> "$log"
@@ -79,6 +132,54 @@ case "$command" in
     ;;
   "containerapp ingress traffic set"*)
     printf 'traffic %s\n' "$command" >> "$log"
+    target="${weight%%=*}"
+    # Which shift this is, decided by where it is pointing rather than by a
+    # counter, so that a case can break the promotion without breaking the
+    # rollback that follows it.
+    if [ "$target" = old-revision ]; then
+      mode="${AF_DEPLOY_TEST_ROLLBACK_TRAFFIC:-ok}"
+      tries="$(attempt_number rollback-attempts)"
+    else
+      mode="${AF_DEPLOY_TEST_TRAFFIC:-ok}"
+      tries="$(attempt_number promote-attempts)"
+    fi
+    case "$mode" in
+      ok)
+        printf '%s\n' "$target" > "$state/serving"
+        ;;
+      transient-then-ok)
+        # Two lookup failures and then the write lands, which is the shape the
+        # staging run had: the app was there the whole time.
+        if [ "$tries" -lt 3 ]; then
+          transient_lookup_failure
+        fi
+        printf '%s\n' "$target" > "$state/serving"
+        ;;
+      transient-forever)
+        transient_lookup_failure
+        ;;
+      throttled-then-ok)
+        # Names itself transient, so it must be retried WITHOUT the extra read.
+        if [ "$tries" -lt 3 ]; then
+          printf 'ERROR: (429) TooManyRequests: too many requests\n' >&2
+          exit 3
+        fi
+        printf '%s\n' "$target" > "$state/serving"
+        ;;
+      permanent)
+        printf 'ERROR: (403) AuthorizationFailed: the client does not have authorization\n' >&2
+        exit 3
+        ;;
+      errors-but-moved)
+        # The weights are written and the call errors anyway. A script that
+        # believes its own error message reports a deploy that never happened.
+        printf '%s\n' "$target" > "$state/serving"
+        transient_lookup_failure
+        ;;
+      missing-app)
+        transient_lookup_failure
+        ;;
+    esac
     ;;
   "containerapp revision deactivate"*)
     printf 'deactivate %s\n' "$command" >> "$log"
@@ -88,6 +189,12 @@ case "$command" in
     # ordering under test is complete before that independent check.
     ;;
   "containerapp revision list"*)
+    # Only the reap's listing is populated. The connection budget asks the same
+    # command for a different projection and is a separate check.
+    if [ "${AF_DEPLOY_TEST_REVISION_LIST:-empty}" = populated ] &&
+       [ "$query" = "[?properties.active].[name, properties.createdTime]" ]; then
+      printf 'old-revision\t2026-09-01T00:00:00Z\n'
+    fi
     ;;
 esac
 FAKE_AZ
@@ -100,8 +207,25 @@ log="${AF_DEPLOY_TEST_LOG:?}"
 url="${!#}"
 printf 'health %s\n' "$url" >> "$log"
 
-if { [[ "$url" == https://public.example/* ]] &&
-     [ "${AF_DEPLOY_TEST_PUBLIC:-ok}" = fail ]; } ||
+# The public origin answers for whichever revision is carrying traffic, which is
+# what makes a rollback provable: `fail-then-recover` is the only shape in which
+# rolling back is the right answer, a bad candidate in front of a previous
+# revision that was and still is fine.
+public_is_unhealthy() {
+  case "${AF_DEPLOY_TEST_PUBLIC:-ok}" in
+    fail) return 0 ;;
+    fail-then-recover)
+      if [ -f "${AF_DEPLOY_TEST_STATE:-}/serving" ] &&
+         grep -Fqx old-revision "${AF_DEPLOY_TEST_STATE}/serving"; then
+        return 1
+      fi
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+if { [[ "$url" == https://public.example/* ]] && public_is_unhealthy; } ||
    { [[ "$url" == https://candidate.example/* ]] &&
      [ "${AF_DEPLOY_TEST_CANDIDATE_HEALTH:-ok}" = fail ]; }; then
   case " $* " in
@@ -127,8 +251,12 @@ run_deploy() {
   shift
   CASE_LOG="$TMP/$case_name.events"
   CASE_OUT="$TMP/$case_name.out"
+  CASE_STATE="$TMP/$case_name.state"
   : > "$CASE_LOG"
-  if env PATH="$TMP/bin:$PATH" AF_DEPLOY_TEST_LOG="$CASE_LOG" "$@" \
+  rm -rf "$CASE_STATE"
+  mkdir -p "$CASE_STATE"
+  if env PATH="$TMP/bin:$PATH" AF_DEPLOY_TEST_LOG="$CASE_LOG" \
+      AF_DEPLOY_TEST_STATE="$CASE_STATE" "$@" \
       "$ROOT/deploy/cd/deploy.sh" group app bootstrap maintenance \
       ghcr.io/example/control-plane@sha256:tested abcdef123456 https://public.example \
       > "$CASE_OUT" 2>&1; then
@@ -138,8 +266,15 @@ run_deploy() {
   fi
 }
 
+# Every one of these passes the needle after `--`.
+#
+# Without it, a needle that begins with a hyphen is read by grep as an option,
+# grep exits 2 having matched nothing, and `omits` then reports success because
+# the pattern "was not found". That is a check that cannot say no, which is the
+# one thing this repository refuses to ship: the assertion that traffic never
+# touched `--revision old-revision` passed against a log that contained it.
 line_of() {
-  grep -nF "$1" "$2" | head -1 | cut -d: -f1
+  grep -nF -- "$1" "$2" | head -1 | cut -d: -f1
 }
 
 CHECKED=0
@@ -168,11 +303,11 @@ expect() {
 
 is_zero() { [ "$1" -eq 0 ]; }
 is_nonzero() { [ "$1" -ne 0 ]; }
-contains() { grep -Fq "$1" "$2"; }
-has_line() { grep -Fxq "$1" "$2"; }
-omits() { ! grep -Fq "$1" "$2"; }
+contains() { grep -Fq -- "$1" "$2"; }
+has_line() { grep -Fxq -- "$1" "$2"; }
+omits() { ! grep -Fq -- "$1" "$2"; }
 later_than() { [ "$(line_of "$1" "$3")" -gt "$(line_of "$2" "$3")" ]; }
-count_is() { [ "$(grep -Fc "$1" "$3")" -eq "$2" ]; }
+count_is() { [ "$(grep -Fc -- "$1" "$3")" -eq "$2" ]; }
 
 expect "staging passes its maintenance job to the deploy" count_is \
   '"${MAINTENANCE_JOB}"' 1 "$ROOT/.github/workflows/cd.yml"
@@ -228,6 +363,175 @@ expect "a stale maintenance read back fails the run" is_nonzero "$CASE_RC"
 expect "a stale maintenance read back names both images" contains \
   "maintenance image read back as ghcr.io/example/control-plane@sha256:old; expected ghcr.io/example/control-plane@sha256:tested" \
   "$CASE_OUT"
+
+# ---------------------------------------------------------------------------
+# The traffic shift, which was the one Azure call in this script that could not
+# be tried again.
+#
+# Both halves are proved, because a retry that cannot say no is worse than no
+# retry: it turns a wrong app name into a five minute wait and then reports the
+# same failure anyway.
+# ---------------------------------------------------------------------------
+
+run_deploy traffic-transient AF_DEPLOY_TEST_TRAFFIC=transient-then-ok
+expect "a transient lookup failure at the shift does not fail the deploy" is_zero "$CASE_RC"
+expect "a transient lookup failure at the shift is tried again" count_is \
+  "traffic containerapp ingress traffic set" 3 "$CASE_LOG"
+expect "a retried shift says which attempt carried traffic" contains \
+  "traffic reached app--" "$CASE_OUT"
+expect "a retried shift still moves the maintenance job" has_line \
+  "job-update maintenance ghcr.io/example/control-plane@sha256:tested" "$CASE_LOG"
+
+run_deploy traffic-throttled AF_DEPLOY_TEST_TRAFFIC=throttled-then-ok
+expect "a throttled shift is tried again" is_zero "$CASE_RC"
+expect "a throttled shift is retried three times" count_is \
+  "traffic containerapp ingress traffic set" 3 "$CASE_LOG"
+expect "an error that names itself transient costs no extra read" omits \
+  "az containerapp show -n app -g group --query name" "$CASE_LOG"
+
+run_deploy traffic-app-missing AF_DEPLOY_TEST_TRAFFIC=missing-app AF_DEPLOY_TEST_APP_PRESENT=no
+expect "a genuinely missing app fails the deploy" is_nonzero "$CASE_RC"
+expect "a genuinely missing app is refused on the first attempt" count_is \
+  "traffic containerapp ingress traffic set" 1 "$CASE_LOG"
+expect "a genuinely missing app is decided by asking, not by reading the message" contains \
+  "az containerapp show -n app -g group --query name" "$CASE_LOG"
+expect "a genuinely missing app says waiting will not help" contains \
+  "WAITING WILL NOT HELP" "$CASE_OUT"
+expect "a genuinely missing app is never reported as a completed deploy" omits \
+  "DEPLOYED:" "$CASE_OUT"
+
+run_deploy traffic-permanent AF_DEPLOY_TEST_TRAFFIC=permanent
+expect "a refused shift fails the deploy" is_nonzero "$CASE_RC"
+expect "a refused shift is not tried again" count_is \
+  "traffic containerapp ingress traffic set" 1 "$CASE_LOG"
+expect "a refused shift does not go looking for the app" omits \
+  "az containerapp show -n app -g group --query name" "$CASE_LOG"
+
+run_deploy traffic-exhausted AF_DEPLOY_TEST_TRAFFIC=transient-forever
+expect "a shift that never lands fails the deploy" is_nonzero "$CASE_RC"
+expect "a shift that never lands is tried the full budget" count_is \
+  "traffic containerapp ingress traffic set" 6 "$CASE_LOG"
+expect "a shift that never lands says traffic never moved" contains \
+  "TRAFFIC NEVER MOVED" "$CASE_OUT"
+expect "a shift that never lands names what is still serving" contains \
+  "old-revision is still serving" "$CASE_OUT"
+expect "a shift that never lands is never reported as a completed deploy" omits \
+  "DEPLOYED:" "$CASE_OUT"
+expect "a shift that never lands says the commit is not live" contains \
+  "::error title=Traffic never moved::" "$CASE_OUT"
+expect "a shift that never lands leaves maintenance alone" omits \
+  "job-update maintenance" "$CASE_LOG"
+
+run_deploy traffic-errors-but-moved AF_DEPLOY_TEST_TRAFFIC=errors-but-moved
+expect "a shift that errored after writing the weights is read back, not believed" contains \
+  "is the revision carrying traffic" "$CASE_OUT"
+expect "traffic that did move is still put through the public gate" contains \
+  "health https://public.example/readyz" "$CASE_LOG"
+expect "traffic that did move and passed the gate is a successful deploy" is_zero "$CASE_RC"
+
+run_deploy rollback-transient AF_DEPLOY_TEST_PUBLIC=fail-then-recover \
+  AF_DEPLOY_TEST_ROLLBACK_TRAFFIC=transient-then-ok
+expect "a transient failure during a rollback still fails the deploy" is_nonzero "$CASE_RC"
+expect "a transient failure during a rollback is tried again" count_is \
+  "traffic containerapp ingress traffic set -n app -g group --revision-weight old-revision=100" \
+  3 "$CASE_LOG"
+expect "a retried rollback reports that it restored the previous revision" contains \
+  "ROLLED BACK. https://public.example is healthy again on old-revision" "$CASE_OUT"
+expect "a retried rollback does not report that it could not move traffic" omits \
+  "THE ROLLBACK COULD NOT MOVE TRAFFIC" "$CASE_OUT"
+
+run_deploy rollback-refused AF_DEPLOY_TEST_PUBLIC=fail \
+  AF_DEPLOY_TEST_ROLLBACK_TRAFFIC=missing-app AF_DEPLOY_TEST_APP_PRESENT=no
+expect "a rollback that cannot move traffic fails the deploy" is_nonzero "$CASE_RC"
+expect "a rollback that cannot move traffic is refused on the first attempt" count_is \
+  "traffic containerapp ingress traffic set -n app -g group --revision-weight old-revision=100" \
+  1 "$CASE_LOG"
+expect "a rollback that cannot move traffic says the unhealthy revision is still serving" contains \
+  "THE ROLLBACK COULD NOT MOVE TRAFFIC" "$CASE_OUT"
+expect "a rollback that cannot move traffic raises it as an error" contains \
+  "::error title=Rollback did not move traffic::" "$CASE_OUT"
+
+# ---------------------------------------------------------------------------
+# The reap, and the rollback target it must not eat.
+#
+# The read that captures what is serving tolerates a failing az, because an ARM
+# blip on a read must not kill a deploy before it starts. The cost of that lands
+# on the reap: with no name to keep, its comparison matches nothing and it would
+# deactivate the exact revision step 6 shifts back onto.
+# ---------------------------------------------------------------------------
+
+run_deploy reap-with-a-target AF_DEPLOY_TEST_REVISION_LIST=populated
+expect "a deploy that knows what it superseded still reaps" contains \
+  "reaping revisions superseded by" "$CASE_OUT"
+expect "the reap spares the revision it would roll back onto" omits \
+  "--revision old-revision -o none" "$CASE_LOG"
+
+run_deploy reap-without-a-target AF_DEPLOY_TEST_REVISION_LIST=populated \
+  AF_DEPLOY_TEST_SERVING=unknown
+expect "a deploy with no rollback target says so before it starts" contains \
+  "currently serving: nothing this script can name" "$CASE_OUT"
+expect "a deploy that does not know what it superseded reaps nothing" contains \
+  "not reaping anything" "$CASE_OUT"
+expect "a deploy that does not know what it superseded leaves the rollback target alone" omits \
+  "--revision old-revision -o none" "$CASE_LOG"
+
+# ---------------------------------------------------------------------------
+# The number this lane owes, measured from the script rather than asserted about
+# it: every Azure call that MUTATES state either retries or says why it does not.
+#
+# The defect was never that ten operations lacked a loop. It was that the
+# absence was invisible, so nobody could tell a considered "this one must not be
+# repeated" from "nobody thought about it". This makes the difference a thing
+# the build can check.
+# ---------------------------------------------------------------------------
+
+# Every az call in the script BODY, reduced to the words before its first flag.
+# Comments are stripped first, so the paragraph that names an operation cannot
+# be mistaken for a call to it.
+mutating_call_sites() {
+  sed 's/#.*//' "$ROOT/deploy/cd/deploy.sh" \
+    | grep -o 'az [a-z][a-z-]*\( [a-z][a-z-]*\)*' \
+    | sed 's/^az //' \
+    | grep -E '(^| )(update|start|set|create|delete|deactivate|restart|stop)$'
+}
+
+# The header, which is where a stance is written.
+stance_text() {
+  sed -n '1,/^set -euo pipefail$/p' "$ROOT/deploy/cd/deploy.sh"
+}
+
+every_mutation_has_a_stance() {
+  local operation tail undeclared=""
+  while read -r operation; do
+    [ -z "$operation" ] && continue
+    # The last two words, which is how the header names an operation: `job
+    # start`, `traffic set`, `revision deactivate`, `containerapp update`.
+    tail="$(printf '%s' "$operation" | awk '{ print $(NF - 1), $NF }')"
+    if ! stance_text | grep -Fq "$tail"; then
+      undeclared="$undeclared $tail"
+    fi
+  done < <(mutating_call_sites | sort -u)
+  if [ -n "$undeclared" ]; then
+    printf 'no declared retry stance for:%s\n' "$undeclared" >&2
+    return 1
+  fi
+  return 0
+}
+
+only_one_traffic_shift_in_the_source() {
+  [ "$(mutating_call_sites | grep -Fc 'ingress traffic set')" -eq 1 ]
+}
+
+expect "every Azure call that mutates state has a declared retry stance" \
+  every_mutation_has_a_stance
+expect "the traffic shift exists in exactly one place, so it cannot be added unretried" \
+  only_one_traffic_shift_in_the_source
+
+MUTATIONS="$(mutating_call_sites | wc -l | tr -d ' ')"
+OPERATIONS="$(mutating_call_sites | sort -u | wc -l | tr -d ' ')"
+RETRIED="$(mutating_call_sites | grep -Fc 'ingress traffic set')"
+printf 'deploy retries: %s of %s state-changing az call sites retry (%s distinct operations, all %s with a declared stance)\n' \
+  "$RETRIED" "$MUTATIONS" "$OPERATIONS" "$OPERATIONS"
 
 if [ "$CHECKED" -eq 0 ]; then
   printf 'FAIL  no deployment assertions matched the selection\n' >&2

--- a/docs/plan/notes/cd.md
+++ b/docs/plan/notes/cd.md
@@ -31,10 +31,21 @@ than inside the YAML, so they can be read and run outside a CI log.
    failed migration has already broken the running application.
 2. **The new revision starts at zero traffic** and is checked on its own
    address. A revision that cannot start never receives a real request.
-3. **Traffic shifts.**
+3. **Traffic shifts**, and this one call is retried with backoff. Azure reports
+   a transient ARM lookup failure in the same sentence it uses for a genuinely
+   wrong app name, so the retry asks the app for its own name between attempts
+   and refuses immediately when the answer is that it is not there.
 4. **The public origin is checked**, including which commit answers.
-5. **Any failure after step 2 puts traffic back** on the revision that was
+5. **A failed public origin check puts traffic back** on the revision that was
    serving and deactivates the new one.
+
+Step 5 used to be written here as "any failure after step 2", and that was never
+what the script did in either direction. A failure at step 3 leaves traffic where
+it already was, so there is nothing to put back and the run is red with the
+previous release still serving. A failure after step 4, in the maintenance job
+update or the connection budget check, deliberately does NOT put traffic back,
+because the release passed both health gates and rolling it off would be trading
+a working application for an operational report.
 
 Step 5 is fast only because the app runs in Multiple revision mode: the old
 revision is still up with no traffic, so the way back is one API call. In Single


### PR DESCRIPTION
## The failure

Staging cd for `b63f1d16`, 2026-09-06:

```
=== shifting 100% of traffic to afcp-app--cb63f1d16-224417
ERROR: The containerapp 'afcp-app' does not exist in group 'af-cp-centralus'
```

The app existed. `deploy.sh` had already run `containerapp show`, `containerapp
job start` and `containerapp update` against that same `-n` and that same `-g`
seconds earlier, all three successfully, and the app answered a hand query in
Multiple revision mode moments later. That is the containerapp extension
reporting a transient ARM lookup failure in the words of a permanent one,
immediately after the resource it says is absent was mutated twice.

The traffic shift was the one call in the script with no way to try again. The
bootstrap execution is polled sixty times, the revision readiness is polled
sixty times, every `revision deactivate` tolerates its own failure, and every
read that only feeds a report falls back to a stated "unchecked". The shift was
a single call under `set -euo pipefail`, so one transient error exited 3.

Staging self corrects, and did: the next merge deployed and took traffic. A
production tag has no next merge. A transient error there leaves a revision that
passed both health gates at zero percent, production serving the previous
release, and a red check, until a person notices.

## What changed

The shift retries with backoff, six attempts at 5, 10, 20, 40 and 80 seconds,
and it does not read the message to decide. `The containerapp 'X' does not
exist` is word for word what a genuinely wrong app name says, and a loop that
cannot tell those apart turns a misconfiguration into a two and a half minute
wait ending in the same failure. So it asks a second question: the app is
queried for its own name between attempts, the wait continues only while the
answer is yes, and a name that is genuinely wrong is refused on the first
attempt. Throttling and gateway errors name themselves and cost no extra read.
Text the classifier does not recognise is not retried.

On exhaustion the deploy names the revision still serving and says the commit is
not live, instead of exiting on the raw az message. It rolls nothing back, on
purpose: traffic never left the previous revision, so a rollback would report
something that did not happen. What is serving is read back rather than assumed,
so a call that errors after the weights are already written still goes through
the public health gate.

The rollback's own shift goes through the same retry. It was a single call too,
at the worst moment.

`docs/plan/notes/cd.md` said "any failure after step 2 puts traffic back on the
revision that was serving". That was never true in either direction, and both
end states are now written down beside the other three.

Two things found on the way, both kept:

- Reading what is serving is now tolerant of a failing `az`, by the same
  argument. That cost lands on `reap_superseded`, which skips the revision it
  must keep by comparing names, and an empty name matches nothing: with an
  unknown rollback target it would have deactivated the exact revision step 6
  shifts back onto. It refuses to reap at all in that case.
- The test harness could not say no to a needle beginning with a hyphen.
  `omits() { ! grep -Fq "$1" "$2"; }` hands `--revision old-revision -o none` to
  grep as an option, grep exits 2 having matched nothing, and the negation
  reports the log is clean. The assertion that a reap left the rollback target
  alone passed against a log containing the deactivate that ate it. Every helper
  now passes its needle after a bare `--`, and the mutation run records the hole.

## The number

`./deploy/cd/deploy_test.sh`, measured from the script rather than asserted
about it, on this branch:

```
deploy retries: 1 of 11 state-changing az call sites retry (5 distinct operations, all 5 with a declared stance)
deploy ordering: 64 assertions passed
```

**Section 8's figure for this lane is wrong and this is the correction.** It
reads "Azure operations in `deploy.sh` with a retry, out of the operations that
mutate state. It is currently all of them except the one that matters most."
Measured, it was **0 of 11**. What retries in the original script are the two
READ poll loops; not one state-changing call had a retry, including
`containerapp update`, `job start` and both traffic shifts.

The useful number is therefore not the retry count. It is that all 5 distinct
mutating operations now carry a **declared stance**, checked by the build:
`ingress traffic set` retries, `job start` must not because a second execution
runs the migrations twice, `containerapp update` must not because it creates a
revision under a name the first attempt may already hold, `revision deactivate`
is already tolerant and the connection budget check decides whether that was
safe, and `job update` is safe to repeat but both call sites already end
somewhere a person can see. Two assertions enforce it: every mutating call must
be named in the header's stance, and the traffic shift must exist in exactly one
place so a second one cannot be added without the retry.

Machine: Darwin 25.3.0, arm64. Command: `./deploy/cd/deploy_test.sh`.
