### PR TITLE
engine: the run said ok about a check that never happened, and could not find the migrations to begin with

### DIFF
--- a/.changes/a-rehearsal-that-reported-ok-without-running.md
+++ b/.changes/a-rehearsal-that-reported-ok-without-running.md
@@ -1,0 +1,36 @@
+# fixed
+
+`af insights` printed `ok  nothing to report` and exited 0 when the migration
+rehearsal was asked for and did not run.
+
+The body of the report was honest: the reason sat in `Missing`, worded plainly,
+"the migrations were not rehearsed, because no fresh branch was available to
+rehearse them against". The headline above it and the exit code below it were
+not, and CI reads the exit code. A branch whose rehearsal could not start was
+indistinguishable from a branch whose rehearsal found nothing.
+
+There are three outcomes here and there were two codes for them. A run that
+found nothing exits 0. A run that proved a break exits 5. A check that was
+asked for and could not run now exits 7, `ExitVerification`, as AF-DB-033, and
+prints no `ok` line at all. `--no-rehearsal` and `insights.migration_rehearsal:
+false` still exit 0, because declining a check is a decision and not a blocked
+one; the two sides of that distinction have a test each.
+
+Two more doors onto the same room were open and are now shut. `af insights -o
+json` returned as soon as it had written the document, so every exit below that
+line was unreachable and adding `-o json` reported success on a migration that
+had failed. And a rehearsal that ran against a repository where no migration
+tool was recognised timed nothing, linted nothing, produced no findings, and
+was therefore a pass, both at the command and to an agent through
+`rehearse_migration_safety`, whose verdict function had no test at all.
+
+Migration discovery also stopped at one directory below the repository root,
+and looked for `supabase/config.toml`, `alembic.ini`, `manage.py` and
+`knexfile.js` only at the root itself. Against ten layouts taken from real
+repositories it found one. It now searches to five levels for every marker and
+finds all ten, including `services/api/src/main/resources/db/migration` and
+this repository's own `web/packages/db/migrations`. Two markers stop being
+distinctive at depth, so each gained a guard: a `manage.py` is read for the
+word django rather than trusted by name, and a `drizzle` directory has to hold
+`meta/_journal.json` before the search settles on it. A dependency's own
+migrations under `node_modules` are still never this repository's.

--- a/docs/src/content/docs/concepts/insights.md
+++ b/docs/src/content/docs/concepts/insights.md
@@ -70,6 +70,52 @@ exists
 `migration_failed` finding, which fails the check by default. Either way a
 pull request check fails rather than printing a note nobody reads.
 
+### A rehearsal that did not run is not a pass
+
+Three outcomes, three exit codes, and the middle one used to be missing.
+
+| Outcome | Exit | What it means |
+| --- | --- | --- |
+| The migrations ran and nothing was found | `0` | a pass |
+| A migration failed to apply | `AF-DB-030`, `5` | a proven break |
+| The rehearsal was asked for and did not run | `AF-DB-033`, `7` | nothing was measured |
+
+The third used to exit `0` and print `ok  nothing to report`. The body said
+"the migrations were not rehearsed" three times above it, every one of those
+sentences was true, and the last line was not. The last line is the one a
+developer reads and the exit code is the only thing a pipeline reads, so the
+run reported a clean bill of health for a check that never happened.
+
+It is a separate code from a break on purpose. A blocked check that exited like
+a failure would cry wolf until somebody switched it off, and one that exits
+like a pass is the bug above. `7` is the code this catalog already gives to
+"could not verify".
+
+`--no-rehearsal` is the way to say a run is deliberately without one. That is a
+decision, it is recorded in the output, and it exits `0`. So does
+`insights.migration_rehearsal: false` in the manifest. What exits `7` is a
+rehearsal nobody declined and that did not happen anyway.
+
+A rehearsal that ran and had nothing to rehearse is the same thing. If no
+migration tool is recognised anywhere in the repository, the branch is still
+prepared and the rehearsal still runs: it times no statements, samples no
+locks and lints nothing, so every check below it reports no findings and the
+run is indistinguishable from a repository whose migrations are all safe. That
+exits `7` too, and says which of the three ways to settle it applies: name the
+directory under `database.migrations`, turn the check off in the manifest, or
+pass the flag for one run.
+
+A tool that IS recognised but whose migrations are not SQL is not this case.
+Rails, Django, Alembic and Knex are applied by running the project's own
+migrate command in the service's image, so the check did run, and the note
+about what could not be read from the files is a note rather than an exit code.
+
+**The output format never changes the verdict.** `-o json` writes the document
+and then exits exactly as the text rendering would, including `5` for a break
+and `7` for a blocked check. It used to return as soon as the document was
+written, so adding `-o json` turned a failed migration into a successful
+command.
+
 ### Every statement is timed on its own
 
 The timing matters as much as the outcome. A migration that takes four seconds
@@ -368,6 +414,21 @@ the SQL it finds:
 | A plain SQL directory | `migrations`, `db/migrations`, `sql/migrations`, or any directory of numbered files such as `0042_add_index.sql`, nearest the service that migrates | the project's own ledger, read from `schema_migrations` or `migrations` by filename, stem or number |
 | A declared directory | `database.migrations.dir` in the manifest, and nothing is inferred | `database.migrations.table`, or the same probe |
 | Rails, Django, Alembic, Knex | not read: the tool runs in the service's image | the tool's own history table |
+
+**Every marker in that table is looked for in a monorepo, not only at the root.**
+`packages/database/prisma/migrations`, `apps/api/drizzle`,
+`services/worker/db/migrate`, `apps/backend/supabase/config.toml`,
+`services/api/alembic.ini` and `packages/db/knexfile.js` are all ordinary
+workspace layouts, and the search reaches each of them.
+
+Where more than one candidate exists, the one under a path a service in the
+manifest declares wins, and then the shallowest. Ties keep the order the walk
+found them in, which is lexical, so the answer is the same on every run. So a
+monorepo with two migration directories rehearses the one beside the service
+that migrates rather than whichever the filesystem returned first. Directories
+holding somebody else's project are never looked inside: `node_modules`,
+`vendor`, `examples`, `testdata`, `fixtures`, `dist`, `build` and anything
+beginning with a dot.
 
 A project that applies its own directory of SQL files with a script of its own
 should declare it, because a guess that lands on the wrong directory rehearses

--- a/docs/src/content/docs/concepts/insights.md
+++ b/docs/src/content/docs/concepts/insights.md
@@ -425,10 +425,13 @@ Where more than one candidate exists, the one under a path a service in the
 manifest declares wins, and then the shallowest. Ties keep the order the walk
 found them in, which is lexical, so the answer is the same on every run. So a
 monorepo with two migration directories rehearses the one beside the service
-that migrates rather than whichever the filesystem returned first. Directories
-holding somebody else's project are never looked inside: `node_modules`,
-`vendor`, `examples`, `testdata`, `fixtures`, `dist`, `build` and anything
-beginning with a dot.
+that migrates rather than whichever the filesystem returned first.
+
+Directories holding somebody else's project, or a build of this one, are never
+looked inside. The list in full: `node_modules`, `vendor`, `examples`,
+`example`, `testdata`, `fixtures`, `fixture`, `dist`, `build`, `target`, `tmp`,
+`docs`, `__pycache__`, and anything whose name begins with a dot. A dependency
+that ships its own `prisma/migrations` is that dependency's schema, not yours.
 
 A project that applies its own directory of SQL files with a script of its own
 should declare it, because a guess that lands on the wrong directory rehearses

--- a/docs/src/content/docs/concepts/insights.md
+++ b/docs/src/content/docs/concepts/insights.md
@@ -105,6 +105,16 @@ exits `7` too, and says which of the three ways to settle it applies: name the
 directory under `database.migrations`, turn the check off in the manifest, or
 pass the flag for one run.
 
+**The rolling deploy check below does the opposite, and the difference is the
+default rather than an inconsistency.** A rolling check that could not run exits
+`0` and says so. That check is conditional: `when: risky` is the default and it
+runs only when the pending migrations contain something the previous release
+could notice, so "did not run" is the ORDINARY outcome for a purely additive
+migration and exiting non zero for it would fire on most runs of most
+repositories. The migration rehearsal has no such condition. It is what this
+command is for, it was asked for on every run that did not decline it, and a
+rehearsal that did not happen is therefore a gap rather than a normal Tuesday.
+
 A tool that IS recognised but whose migrations are not SQL is not this case.
 Rails, Django, Alembic and Knex are applied by running the project's own
 migrate command in the service's image, so the check did run, and the note

--- a/docs/src/content/docs/reference/errors.md
+++ b/docs/src/content/docs/reference/errors.md
@@ -700,6 +700,18 @@ The previous release does not survive this migration: {detail}
 | Retryable | No. Retrying the same operation unchanged will fail the same way. |
 | More | [concepts/insights](/docs/concepts/insights) |
 
+### AF-DB-033
+
+The migrations were not rehearsed, so this run says nothing about them: {detail}
+
+**What to do.** The report above names what was missing. Fix that, or pass --no-rehearsal to say the run is deliberately without it: a check that could not run must not exit like one that passed.
+
+| | |
+| --- | --- |
+| Exit code | `7` |
+| Retryable | No. Retrying the same operation unchanged will fail the same way. |
+| More | [concepts/insights](/docs/concepts/insights) |
+
 ## Detection
 
 ### AF-DET-001

--- a/engine/internal/cli/insights.go
+++ b/engine/internal/cli/insights.go
@@ -82,38 +82,18 @@ nothing.`),
 				}
 			}
 
-			if e.Out.Format == FormatJSON {
-				return e.Out.JSON(full)
+			if e.Out.Format != FormatJSON {
+				e.Out.Section("Database insights")
+				e.Out.Raw(full.Explain())
 			}
 
-			e.Out.Section("Database insights")
-			e.Out.Raw(full.Explain())
-
-			if opts.Baseline == nil {
+			if e.Out.Format != FormatJSON && opts.Baseline == nil {
 				e.Out.Println(e.Out.Wrap(
 					"No baseline, so query counts are not compared. Save one on main with "+
 						"--save and pass it here with --baseline: a query running 412 times "+
 						"means nothing without knowing it ran 4 times before.", 0))
 			}
-			if full.Rehearsal != nil && full.Rehearsal.Failed {
-				// The report is printed first and the command still fails. A
-				// migration that fails on a branch with production's shape is
-				// one that would have failed in production, so exiting zero
-				// would turn the whole check into a note nobody reads.
-				return aferrors.Coded(aferrors.AFDB030, "detail", full.Rehearsal.Error)
-			}
-			if full.Rolling.Failed() {
-				// Non zero for the same reason, and only for a proven break.
-				// A rolling check that could not run exits zero and says so,
-				// because a blocked check and a broken change must never be
-				// the same exit code.
-				return aferrors.Coded(aferrors.AFDB032, "detail", rollingDetail(full.Rolling))
-			}
-			if full.Clean() {
-				e.Out.Status(e.Out.S(StyleGood, SymbolOK), "nothing to report",
-					"from the checks that ran")
-			}
-			return nil
+			return insightsResult(e, full)
 		},
 	}
 	cmd.Flags().IntVar(&limit, "limit", 20, "How many queries to show")
@@ -126,6 +106,110 @@ nothing.`),
 		"Which commit the previous release is, overriding the manifest")
 	cmd.Flags().StringVar(&runner, "runner", "", "Path to the runner's entry point")
 	return cmd
+}
+
+// insightsResult renders the run in whichever format was asked for and
+// returns the exit, which is the same exit either way.
+//
+// The format used to decide both. `af insights -o json` returned the moment
+// the document was written, so every exit below it was unreachable and the
+// command reported SUCCESS on a migration that had failed on a branch with
+// production's shape. Adding `-o json` turned a break into a pass. `af ci` in
+// this package already keeps these apart, writeReport rendering and ciExit
+// deciding, and two commands in one tool must not disagree about whether a
+// break is a break.
+//
+// Order matters and it is the reverse of what reads naturally. A proven break
+// is reported before a blocked check, because a run that both broke and could
+// not measure something is a break, and the break is the more urgent.
+func insightsResult(e *Env, full insights.Full) error {
+	if e.Out.Format == FormatJSON {
+		if err := e.Out.JSON(full); err != nil {
+			return err
+		}
+		if err := insightsBreaks(full); err != nil {
+			return err
+		}
+		// No summary line in JSON: the document carries blocked itself. The
+		// exit still has to say so, which is what this returns.
+		_, err := insightsSummary(full)
+		return err
+	}
+	if err := insightsBreaks(full); err != nil {
+		return err
+	}
+	return printInsightsSummary(e, full)
+}
+
+// insightsBreaks is the proven breaks, and only the proven breaks.
+func insightsBreaks(full insights.Full) error {
+	if full.Rehearsal != nil && full.Rehearsal.Failed {
+		// A migration that fails on a branch with production's shape is one
+		// that would have failed in production, so exiting zero would turn
+		// the whole check into a note nobody reads.
+		return aferrors.Coded(aferrors.AFDB030, "detail", full.Rehearsal.Error)
+	}
+	if full.Rolling.Failed() {
+		// Non zero for the same reason, and only for a proven break. A
+		// rolling check that could not run exits zero and says so, because a
+		// blocked check and a broken change must never be the same exit code.
+		return aferrors.Coded(aferrors.AFDB032, "detail", rollingDetail(full.Rolling))
+	}
+	return nil
+}
+
+// printInsightsSummary writes the last line, or writes nothing at all.
+//
+// The guard is the whole point and it is why this is a function rather than
+// four lines inside RunE: an empty line from insightsSummary must produce no
+// output, not a bare ok with nothing after it. That is testable here against a
+// buffer and was not testable inside a cobra RunE that needs a database.
+func printInsightsSummary(e *Env, full insights.Full) error {
+	line, err := insightsSummary(full)
+	if line != "" {
+		e.Out.Status(e.Out.S(StyleGood, SymbolOK), line, "from the checks that ran")
+	}
+	return err
+}
+
+// insightsSummary is the last line and the exit code, decided together.
+//
+// They are decided together because they were decided apart, and that is the
+// defect this function exists for. af insights said "the migrations were not
+// rehearsed: no migration tool was recognised in this repository" in its body
+// and then printed
+//
+//	ok  nothing to report
+//
+// and exited zero. Every individual sentence was honest and the last line was
+// not, and the last line is the one a developer reads.
+//
+// Three states, three answers, and the middle one is the new one:
+//
+//   - a proven break exits 5 or 8 and is handled by the caller before this,
+//     because a run that both broke and could not measure something is a
+//     break and the break is the more urgent fact;
+//   - a check that was asked for and did not run exits 7 and prints no ok,
+//     because a blocked check and a passing one must not be the same exit
+//     code;
+//   - everything else is a pass and says so.
+//
+// Exit 7 rather than reusing a failure code, for the reason already written
+// into the rolling check above: a blocked check and a broken change must
+// never be the same exit code, or people learn to ignore the one that cries
+// wolf. 7 is the code this catalog already gives to "could not verify".
+//
+// An empty line means print nothing, which is the case where a check found
+// something and has already printed it.
+func insightsSummary(full insights.Full) (string, error) {
+	if full.IsBlocked() {
+		return "", aferrors.Coded(aferrors.AFDB033, "detail",
+			strings.Join(full.Blocked, "; "))
+	}
+	if full.Clean() {
+		return "nothing to report", nil
+	}
+	return "", nil
 }
 
 // rollingDetail is the one sentence the failure carries out to the exit code.

--- a/engine/internal/cli/insights_result_test.go
+++ b/engine/internal/cli/insights_result_test.go
@@ -1,0 +1,148 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	aferrors "github.com/antifailure/antifailure/engine/internal/errors"
+	"github.com/antifailure/antifailure/engine/internal/insights"
+)
+
+// The format renders the run. It does not decide the run.
+//
+// `af insights -o json` returned as soon as the document was written, so a
+// migration that failed on a branch with production's shape exited 0 as long
+// as somebody asked for JSON. Nothing caught it because the early return was
+// only reachable through a cobra RunE that needs a database, which is exactly
+// why the tail is now a function that takes a buffer.
+
+func jsonEnv() (*Env, *bytes.Buffer) {
+	var out, errW bytes.Buffer
+	e := &Env{Out: NewOutput(&out, &errW)}
+	e.Out.Format = FormatJSON
+	return e, &out
+}
+
+func TestInsightsResult_JSONStillFailsOnAProvenMigrationBreak(t *testing.T) {
+	t.Parallel()
+	e, out := jsonEnv()
+	full := insights.Full{Rehearsal: &insights.Rehearsal{
+		Failed: true, Error: "ERROR: relation \"users\" does not exist",
+	}}
+
+	err := insightsResult(e, full)
+
+	require.Error(t, err, "-o json reported success on a migration that failed")
+	require.Equal(t, aferrors.ExitProvider, aferrors.ExitCodeOf(err))
+	// The document is still written. Failing is not an excuse to give a
+	// script nothing to read.
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(out.Bytes(), &doc))
+	require.Contains(t, doc, "rehearsal")
+}
+
+func TestInsightsResult_JSONStillFailsOnABlockedCheck(t *testing.T) {
+	t.Parallel()
+	e, out := jsonEnv()
+	full := insights.Full{Blocked: []string{"no migration tool was recognised"}}
+
+	err := insightsResult(e, full)
+
+	require.Error(t, err)
+	require.Equal(t, aferrors.ExitVerification, aferrors.ExitCodeOf(err))
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(out.Bytes(), &doc))
+	// The reason is in the document as well as in the exit, because a script
+	// that branches on 7 still has to be able to say why.
+	require.Contains(t, doc, "blocked")
+}
+
+func TestInsightsResult_JSONOnACleanRunExitsZeroAndWritesTheDocument(t *testing.T) {
+	t.Parallel()
+	e, out := jsonEnv()
+
+	require.NoError(t, insightsResult(e, insights.Full{}))
+	require.NotEmpty(t, out.Bytes())
+	// And no summary line: the ok belongs to the text rendering only.
+	require.NotContains(t, out.String(), "nothing to report")
+}
+
+func TestInsightsResult_TextAndJSONAgreeOnEveryVerdict(t *testing.T) {
+	t.Parallel()
+	// The property, rather than three more examples of it. Two commands in
+	// one tool disagreeing about whether a break is a break is the defect;
+	// one command disagreeing with itself is worse.
+	for _, c := range []struct {
+		name string
+		full insights.Full
+	}{
+		{"clean", insights.Full{}},
+		{"blocked", insights.Full{Blocked: []string{"nothing was rehearsed"}}},
+		{"migration broke", insights.Full{
+			Rehearsal: &insights.Rehearsal{Failed: true, Error: "boom"}}},
+		{"a finding, which is not an exit here", insights.Full{
+			PlanFindings: []insights.PlanFinding{{Statement: "SELECT 1"}}}},
+	} {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			var textOut, textErr bytes.Buffer
+			text := &Env{Out: NewOutput(&textOut, &textErr)}
+			j, _ := jsonEnv()
+
+			require.Equal(t,
+				aferrors.ExitCodeOf(insightsResult(text, c.full)),
+				aferrors.ExitCodeOf(insightsResult(j, c.full)),
+				"text and json exited differently for the same run")
+		})
+	}
+}
+
+// The rolling check's break had no test, and moving it into insightsBreaks is
+// what surfaced that: a mutation replacing `full.Rolling.Failed()` with false
+// left every test green. It is the other proven break this command reports and
+// it had been relying on nothing.
+
+func TestInsightsResult_ARollingBreakIsAProvenBreak(t *testing.T) {
+	t.Parallel()
+	full := insights.Full{Rolling: &insights.Rolling{
+		Verdict: insights.RollingFail,
+		Against: "abc1234",
+		Workflows: []insights.RollingWorkflow{{
+			Name: "checkout", Verdict: insights.RollingFail,
+		}},
+	}}
+
+	err := insightsResult(&Env{Out: NewOutput(&bytes.Buffer{}, &bytes.Buffer{})}, full)
+
+	require.Error(t, err, "the previous release failing against the migration exited zero")
+	require.Equal(t, aferrors.ExitTestFailure, aferrors.ExitCodeOf(err))
+	var coded *aferrors.Error
+	require.ErrorAs(t, err, &coded)
+	require.Equal(t, aferrors.AFDB032, coded.Entry.Code)
+	// The workflow that failed is named, because "the previous release does
+	// not survive this migration" with no which sends somebody to the logs.
+	require.Contains(t, coded.Fields["detail"], "checkout")
+}
+
+func TestInsightsResult_ARollingCheckThatCouldNotRunIsNotABreak(t *testing.T) {
+	t.Parallel()
+	// The distinction this whole change is about, in the one place the
+	// repository already had it. Blocked and off are not failures, and making
+	// them exit like one is the mirror of printing ok over them.
+	for _, v := range []insights.RollingVerdict{
+		insights.RollingBlocked, insights.RollingOff, insights.RollingPass,
+	} {
+		v := v
+		t.Run(string(v), func(t *testing.T) {
+			t.Parallel()
+			e := &Env{Out: NewOutput(&bytes.Buffer{}, &bytes.Buffer{})}
+			require.NoError(t, insightsResult(e, insights.Full{
+				Rolling: &insights.Rolling{Verdict: v, Reason: "no previous release"},
+			}))
+		})
+	}
+}

--- a/engine/internal/cli/insights_summary_test.go
+++ b/engine/internal/cli/insights_summary_test.go
@@ -1,0 +1,120 @@
+package cli
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	aferrors "github.com/antifailure/antifailure/engine/internal/errors"
+	"github.com/antifailure/antifailure/engine/internal/insights"
+)
+
+// The line and the exit code are one decision, so they are tested as one.
+//
+// Asserting on the exact string rather than on a flag is deliberate. The
+// failure was not a wrong boolean, it was the word "ok" printed over a check
+// that did not run, and a test that only asserted "returns an error" would
+// have passed while the word was still there.
+
+func TestInsightsSummary_ABlockedCheckNeverSaysOk(t *testing.T) {
+	t.Parallel()
+	const reason = "the migrations were not rehearsed: no migration tool was recognised " +
+		"in this repository"
+	line, err := insightsSummary(insights.Full{Blocked: []string{reason}})
+
+	require.Empty(t, line, "a blocked run must print no summary of its own")
+	require.NotContains(t, line, "ok")
+	require.Error(t, err)
+
+	// Exit 7, told apart from both a pass and a proven break. This is the
+	// whole point: CI can branch on it.
+	require.Equal(t, aferrors.ExitVerification, aferrors.ExitCodeOf(err))
+	require.NotEqual(t, aferrors.ExitSuccess, aferrors.ExitCodeOf(err))
+
+	var coded *aferrors.Error
+	require.ErrorAs(t, err, &coded)
+	require.Equal(t, aferrors.AFDB033, coded.Entry.Code)
+	// The reason travels out to the exit, because "a check did not run" with
+	// no because sends somebody to read the code rather than the manifest.
+	require.Contains(t, coded.Fields["detail"], "no migration tool was recognised")
+}
+
+func TestInsightsSummary_ARunWithNothingToReportStillSaysSo(t *testing.T) {
+	t.Parallel()
+	line, err := insightsSummary(insights.Full{})
+	require.NoError(t, err)
+	require.Equal(t, "nothing to report", line)
+}
+
+func TestInsightsSummary_ADeclinedRehearsalIsAPass(t *testing.T) {
+	t.Parallel()
+	// --no-rehearsal puts its reason in Missing and not in Blocked, so the
+	// run ends clean. A flag whose only use is to get a clean run without a
+	// rehearsal has to actually produce one.
+	line, err := insightsSummary(insights.Full{
+		Missing: []string{"the migrations were not rehearsed, because --no-rehearsal was given"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "nothing to report", line)
+}
+
+func TestInsightsSummary_AFindingPrintsNoSummaryAndDoesNotFailHere(t *testing.T) {
+	t.Parallel()
+	// A run that found something has already printed it, and the failure exit
+	// codes for a proven break are decided before this function is reached.
+	line, err := insightsSummary(insights.Full{
+		PlanFindings: []insights.PlanFinding{{Statement: "SELECT 1"}},
+	})
+	require.NoError(t, err)
+	require.Empty(t, line)
+}
+
+func TestInsightsSummary_ABreakAndABlockAreDifferentExitCodes(t *testing.T) {
+	t.Parallel()
+	// The reason there are three codes rather than two. A blocked check that
+	// exited like a break trains people to ignore it; one that exited like a
+	// pass is the bug being fixed. Both failures come from collapsing these.
+	_, blocked := insightsSummary(insights.Full{Blocked: []string{"nothing was rehearsed"}})
+	migrationBroke := aferrors.Coded(aferrors.AFDB030, "detail", "syntax error")
+	rollingBroke := aferrors.Coded(aferrors.AFDB032, "detail", "checkout fails")
+
+	require.NotEqual(t, aferrors.ExitCodeOf(blocked), aferrors.ExitCodeOf(migrationBroke))
+	require.NotEqual(t, aferrors.ExitCodeOf(blocked), aferrors.ExitCodeOf(rollingBroke))
+	require.NotEqual(t, aferrors.ExitSuccess, aferrors.ExitCodeOf(blocked))
+}
+
+// The rendered output, not the returned string.
+//
+// The plan asked for this in these words: a repository where discovery
+// genuinely fails produces a summary that does not contain `ok`, proved by
+// asserting on the exact output. A test on the return value proves the
+// decision; only a test on the buffer proves the character that reached the
+// terminal, and the character is what the developer read and believed.
+
+func TestPrintInsightsSummary_ABlockedRunPrintsNothingAtAll(t *testing.T) {
+	t.Parallel()
+	var out, errW bytes.Buffer
+	e := &Env{Out: NewOutput(&out, &errW)}
+
+	err := printInsightsSummary(e, insights.Full{
+		Blocked: []string{"no migration tool was recognised anywhere in this repository"},
+	})
+
+	require.Error(t, err)
+	require.Equal(t, aferrors.ExitVerification, aferrors.ExitCodeOf(err))
+	require.Empty(t, out.String(), "a blocked run printed a summary line")
+	require.NotContains(t, out.String(), "ok")
+	require.NotContains(t, out.String(), SymbolOK)
+	require.NotContains(t, out.String(), "nothing to report")
+}
+
+func TestPrintInsightsSummary_ACleanRunStillPrintsItsLine(t *testing.T) {
+	t.Parallel()
+	var out, errW bytes.Buffer
+	e := &Env{Out: NewOutput(&out, &errW)}
+
+	require.NoError(t, printInsightsSummary(e, insights.Full{}))
+	require.Contains(t, out.String(), "nothing to report")
+	require.Contains(t, out.String(), "from the checks that ran")
+}

--- a/engine/internal/env/insights.go
+++ b/engine/internal/env/insights.go
@@ -85,6 +85,7 @@ func (o *Orchestrator) RunInsights(
 		runOpts.NoRehearsalReason = why
 	} else if opts.SkipRehearsal {
 		runOpts.NoRehearsalReason = "the migrations were not rehearsed, because --no-rehearsal was given"
+		runOpts.RehearsalDeclined = true
 	}
 
 	full, err := insights.Run(ctx, runOpts)

--- a/engine/internal/errors/catalog.yaml
+++ b/engine/internal/errors/catalog.yaml
@@ -364,6 +364,13 @@ errors:
     docs: concepts/insights
     retryable: false
     exit_code: 8
+  - code: AF-DB-033
+    area: DB
+    message: "The migrations were not rehearsed, so this run says nothing about them: {detail}"
+    next_step: "The report above names what was missing. Fix that, or pass --no-rehearsal to say the run is deliberately without it: a check that could not run must not exit like one that passed."
+    docs: concepts/insights
+    retryable: false
+    exit_code: 7
 
   # Masking
   - code: AF-MSK-001

--- a/engine/internal/errors/codes.gen.go
+++ b/engine/internal/errors/codes.gen.go
@@ -157,6 +157,9 @@ const (
 	AFDB031 Code = "AF-DB-031"
 	// The previous release does not survive this migration: {detail}
 	AFDB032 Code = "AF-DB-032"
+	// The migrations were not rehearsed, so this run says nothing about
+	// them: {detail}
+	AFDB033 Code = "AF-DB-033"
 
 	// Detection
 	// No application could be detected in {path}.
@@ -971,6 +974,15 @@ var catalog = map[Code]Entry{
 		Docs:      "concepts/insights",
 		Retryable: false,
 		ExitCode:  ExitTestFailure,
+	},
+	AFDB033: {
+		Code:      AFDB033,
+		Area:      "DB",
+		Message:   "The migrations were not rehearsed, so this run says nothing about them: {detail}",
+		NextStep:  "The report above names what was missing. Fix that, or pass --no-rehearsal to say the run is deliberately without it: a check that could not run must not exit like one that passed.",
+		Docs:      "concepts/insights",
+		Retryable: false,
+		ExitCode:  ExitVerification,
 	},
 	AFDET001: {
 		Code:      AFDET001,

--- a/engine/internal/insights/blocked_test.go
+++ b/engine/internal/insights/blocked_test.go
@@ -1,0 +1,136 @@
+package insights_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/internal/insights"
+)
+
+// The three states a rehearsal can be in, and the reason they are three.
+//
+// It ran and found nothing is a pass. It was declined is a decision somebody
+// made and recorded. It was asked for and did not run is neither, and the
+// command that printed "ok  nothing to report" over the third one is the
+// defect these tests exist for. The summary line is what a developer reads,
+// and it was the only line in the output that was not true.
+
+func TestRun_ARehearsalThatWasAskedForAndDidNotRunIsBlocked(t *testing.T) {
+	db, done := requireDatabase(t, "insightsblocked")
+	defer done()
+
+	const reason = "the migrations were not rehearsed: no migration tool was recognised " +
+		"in this repository"
+	full, err := insights.Run(context.Background(), insights.Options{
+		Config: insights.Configure(nil), Branch: db.conn, Limit: 5,
+		NoRehearsalReason: reason,
+	})
+	require.NoError(t, err)
+	require.Nil(t, full.Rehearsal)
+	// Blocked, and the reason travels with it, because "blocked" with no
+	// because sends somebody to read the code rather than the manifest.
+	require.True(t, full.IsBlocked())
+	require.Contains(t, full.Blocked, reason)
+	// Clean stays true and that is correct: every check that ran found
+	// nothing. It is the wrong question, which is why the caller now asks
+	// IsBlocked first.
+	require.True(t, full.Clean())
+}
+
+func TestRun_ARehearsalTheCallerDeclinedIsNotBlocked(t *testing.T) {
+	db, done := requireDatabase(t, "insightsdeclined")
+	defer done()
+
+	// --no-rehearsal is somebody saying they know. Reporting that as blocked
+	// would make the flag useless, because the only reason to pass it is to
+	// get a run that ends cleanly without one.
+	full, err := insights.Run(context.Background(), insights.Options{
+		Config: insights.Configure(nil), Branch: db.conn, Limit: 5,
+		NoRehearsalReason: "the migrations were not rehearsed, because --no-rehearsal was given",
+		RehearsalDeclined: true,
+	})
+	require.NoError(t, err)
+	require.Nil(t, full.Rehearsal)
+	require.False(t, full.IsBlocked())
+	require.Empty(t, full.Blocked)
+	// Still said out loud in the body, which is the part that does not change:
+	// a check that did not run is named whether or not it stops the exit code.
+	require.Contains(t, full.Missing,
+		"the migrations were not rehearsed, because --no-rehearsal was given")
+}
+
+func TestRun_ARehearsalTheManifestTurnedOffIsNotBlocked(t *testing.T) {
+	db, done := requireDatabase(t, "insightsoffnotblocked")
+	defer done()
+
+	// The manifest turning the check off is a decision too, and it is already
+	// reported under its own heading. Counting it as blocked would fail every
+	// run of a project that deliberately does not rehearse.
+	cfg := insights.Configure(nil)
+	cfg.MigrationRehearsal = false
+	full, err := insights.Run(context.Background(), insights.Options{
+		Config: cfg, Branch: db.conn, Limit: 5,
+	})
+	require.NoError(t, err)
+	require.False(t, full.IsBlocked())
+	require.Contains(t, full.Off,
+		"migration rehearsal, because insights.migration_rehearsal is false")
+}
+
+func TestRun_ARehearsalWithNothingToRehearseIsBlocked(t *testing.T) {
+	db, done := requireDatabase(t, "insightsnotool")
+	defer done()
+
+	// The fourth state, and the one the plan asked for by name: discovery
+	// genuinely failed, so a rehearsal branch WAS prepared, the rehearsal DID
+	// run, and it timed nothing, sampled no locks and linted no statements.
+	// Every check below it then reports no findings, and the run reads exactly
+	// like a repository whose migrations are all safe.
+	full, err := insights.Run(context.Background(), insights.Options{
+		Config: insights.Configure(nil), Branch: db.conn, Limit: 5,
+		Rehearsal: &insights.Target{
+			Conn: db.conn, Watch: db.watch, URL: db.url,
+			Set:     insights.MigrationSet{},
+			Applier: &insights.SQLApplier{},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, full.Rehearsal, "the rehearsal ran, which is the point")
+	require.Equal(t, insights.ToolNone, full.Rehearsal.Tool)
+	require.True(t, full.IsBlocked())
+	require.Len(t, full.Blocked, 1)
+	// The message has to name a way out or it is a dead end. All three.
+	require.Contains(t, full.Blocked[0], "no migration tool was recognised")
+	require.Contains(t, full.Blocked[0], "database.migrations")
+	require.Contains(t, full.Blocked[0], "insights.migration_rehearsal: false")
+	require.Contains(t, full.Blocked[0], "--no-rehearsal")
+}
+
+func TestRun_ARehearsalOfAToolWhoseMigrationsAreNotSQLIsNotBlocked(t *testing.T) {
+	db, done := requireDatabase(t, "insightsnotsql")
+	defer done()
+
+	// Rails, Django, Alembic and Knex are recognised and then rehearsed by
+	// running the project's own migrate command, so the check DID run. Their
+	// reason is reported in the body and must not become an exit code, or
+	// every Rails repository would fail every run.
+	full, err := insights.Run(context.Background(), insights.Options{
+		Config: insights.Configure(nil), Branch: db.conn, Limit: 5,
+		Rehearsal: &insights.Target{
+			Conn: db.conn, Watch: db.watch, URL: db.url,
+			Set: insights.MigrationSet{
+				Tool:   insights.ToolRails,
+				Dir:    "db/migrate",
+				Reason: "Rails migrations are Ruby",
+			},
+			Applier: &insights.SQLApplier{},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, full.Rehearsal)
+	require.False(t, full.IsBlocked())
+	require.Empty(t, full.Blocked)
+	require.Contains(t, full.Missing, "Rails migrations are Ruby")
+}

--- a/engine/internal/insights/layouts_test.go
+++ b/engine/internal/insights/layouts_test.go
@@ -1,6 +1,9 @@
 package insights_test
 
 import (
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 	"testing/fstest"
 
@@ -244,4 +247,59 @@ func TestDiscover_TwoCandidatesAtTheSameDepthAnswerTheSameWayEveryTime(t *testin
 		require.Equal(t, first.Dir, insights.Discover(tree).Dir,
 			"the same repository answered two different directories")
 	}
+}
+
+// TestDiscover_ThisRepositorysOwnMigrationsAreFoundInTheRealTree is the only
+// test here that does not build its own filesystem.
+//
+// Every other case is a fixture, and a fixture is a claim about a shape
+// somebody typed. This one runs the shipped search over the actual repository,
+// with no manifest, so nothing is declared and the answer has to be found. Our
+// own migrations sit at web/packages/db/migrations, four levels down, which the
+// search before this change could not reach: it read the root and one level
+// below it. The acceptance line for this lane names that path, and a fixture
+// spelling it out would have passed without the tool being able to find it
+// here.
+//
+// It fails if the directory moves, and that is the point rather than a
+// maintenance cost. If it moves, the failure says which path was found instead,
+// and the fix is to update this line once the new path is genuinely the right
+// answer.
+func TestDiscover_ThisRepositorysOwnMigrationsAreFoundInTheRealTree(t *testing.T) {
+	t.Parallel()
+
+	root := repositoryRoot(t)
+	set := insights.Locate(os.DirFS(root), nil)
+
+	require.Equal(t, "web/packages/db/migrations", set.Dir,
+		"the search cannot find this repository's own migrations, which is the "+
+			"layout the acceptance line for this change names")
+	require.False(t, set.Declared,
+		"this has to be a search rather than a reading of a declaration, or it "+
+			"proves nothing about discovery")
+	require.NotEmpty(t, set.Migrations,
+		"the directory was found and no migrations were read out of it")
+}
+
+// repositoryRoot walks up from this source file to the directory holding the
+// manifest, rather than assuming a working directory. `go test` runs with the
+// package directory as the working directory, and a relative path would break
+// the moment this package moved.
+func repositoryRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	require.True(t, ok, "the test binary was built without file names, so the "+
+		"repository root cannot be found from here")
+	dir := filepath.Dir(file)
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "antifailure.yaml")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		require.NotEqual(t, dir, parent,
+			"walked to the filesystem root without finding antifailure.yaml")
+		dir = parent
+	}
+	t.Fatal("antifailure.yaml is not within ten directories of this test file")
+	return ""
 }

--- a/engine/internal/insights/layouts_test.go
+++ b/engine/internal/insights/layouts_test.go
@@ -1,0 +1,247 @@
+package insights_test
+
+import (
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/internal/insights"
+)
+
+// layout is one repository shape, named after a real project that has it.
+//
+// The list is the measurement this lane owes, so it is drawn from repositories
+// somebody would actually install this against rather than from shapes that
+// were convenient to write. Every one of them puts its migrations somewhere
+// other than the root, which is the whole finding: a monorepo was answered
+// with "no migration tool was recognised" and the run then summarised as ok.
+type layout struct {
+	// name is the layout, written the way a person would say it.
+	name string
+	// tree is the repository, cut down to the files discovery reads.
+	tree fstest.MapFS
+	// tool is what has to be recognised.
+	tool insights.Tool
+	// dir is where the migrations have to be found, empty where the tool's
+	// migrations are not SQL and the answer is a reason instead.
+	dir string
+}
+
+func layouts() []layout {
+	return []layout{{
+		name: "packages/database/prisma/migrations, the Cal.com shape",
+		tree: fstest.MapFS{
+			"package.json":                    file(`{"workspaces":["apps/*","packages/*"]}`),
+			"apps/web/package.json":           file("{}"),
+			"packages/database/schema.prisma": file("datasource db {}"),
+			"packages/database/prisma/migrations/20240101000000_init/migration.sql": file(
+				"CREATE TABLE users (id int);"),
+			"packages/database/prisma/migrations/20240202000000_bookings/migration.sql": file(
+				"CREATE TABLE bookings (id int);"),
+		},
+		tool: insights.ToolPrisma,
+		dir:  "packages/database/prisma/migrations",
+	}, {
+		name: "apps/api/prisma/migrations, the Documenso shape",
+		tree: fstest.MapFS{
+			"package.json":          file("{}"),
+			"apps/web/package.json": file("{}"),
+			"apps/api/prisma/migrations/20240101000000_init/migration.sql": file(
+				"CREATE TABLE documents (id int);"),
+		},
+		tool: insights.ToolPrisma,
+		dir:  "apps/api/prisma/migrations",
+	}, {
+		name: "apps/api/drizzle, a Drizzle package below the root",
+		tree: fstest.MapFS{
+			"package.json":                        file("{}"),
+			"apps/api/drizzle/meta/_journal.json": file(`{"entries":[]}`),
+			"apps/api/drizzle/0000_init.sql":      file("CREATE TABLE t (id int);"),
+			"apps/api/drizzle/0001_more.sql":      file("ALTER TABLE t ADD c int;"),
+		},
+		tool: insights.ToolDrizzle,
+		dir:  "apps/api/drizzle",
+	}, {
+		name: "services/worker/db/migrate, a Rails service in a monorepo",
+		tree: fstest.MapFS{
+			"README.md":               file("x"),
+			"services/worker/Gemfile": file("source 'x'"),
+			"services/worker/db/migrate/20240101000000_create_users.rb": file(
+				"class CreateUsers < ActiveRecord::Migration; end"),
+		},
+		tool: insights.ToolRails,
+	}, {
+		name: "apps/backend/supabase, a Supabase project below the root",
+		tree: fstest.MapFS{
+			"package.json":                      file("{}"),
+			"apps/backend/supabase/config.toml": file(`project_id = "x"`),
+			"apps/backend/supabase/migrations/20240101120000_init.sql": file(
+				"CREATE TABLE users (id int);"),
+		},
+		tool: insights.ToolSupabase,
+		dir:  "apps/backend/supabase/migrations",
+	}, {
+		name: "services/api/alembic.ini, Alembic in a Python monorepo",
+		tree: fstest.MapFS{
+			"README.md":                   file("x"),
+			"services/api/alembic.ini":    file("[alembic]"),
+			"services/api/alembic/env.py": file("# env"),
+		},
+		tool: insights.ToolAlembic,
+	}, {
+		name: "apps/server/manage.py, Django below the root",
+		tree: fstest.MapFS{
+			"README.md": file("x"),
+			// A real manage.py, cut to the line that identifies it. The name
+			// alone is not distinctive enough to trust anywhere in a tree, so
+			// discovery reads the file, and this is what it reads.
+			"apps/server/manage.py": file(
+				"import os\nos.environ.setdefault('DJANGO_SETTINGS_MODULE', 'server.settings')\n"),
+		},
+		tool: insights.ToolDjango,
+	}, {
+		name: "packages/db/knexfile.js, Knex in a workspace package",
+		tree: fstest.MapFS{
+			"package.json":                file("{}"),
+			"packages/db/knexfile.js":     file("module.exports = {};"),
+			"packages/db/migrations/x.js": file("exports.up = () => {};"),
+		},
+		tool: insights.ToolKnex,
+	}, {
+		name: "services/api/src/main/resources/db/migration, Flyway in a JVM service",
+		tree: fstest.MapFS{
+			"pom.xml": file("<project/>"),
+			"services/api/src/main/resources/db/migration/V1__init.sql": file(
+				"CREATE TABLE t (id int);"),
+			"services/api/src/main/resources/db/migration/V2__more.sql": file(
+				"ALTER TABLE t ADD c int;"),
+		},
+		tool: insights.ToolFlyway,
+		dir:  "services/api/src/main/resources/db/migration",
+	}, {
+		name: "web/packages/db/migrations, this repository's own shape",
+		tree: fstest.MapFS{
+			"package.json": file("{}"),
+			"web/packages/db/migrations/0001_init.sql": file("CREATE TABLE t (id int);"),
+			"web/packages/db/migrations/0002_rls.sql":  file("ALTER TABLE t ENABLE ROW LEVEL SECURITY;"),
+		},
+		tool: insights.ToolSQLDir,
+		dir:  "web/packages/db/migrations",
+	}}
+}
+
+// TestDiscover_TheLayoutsRealRepositoriesUse is the lane's measurement.
+//
+// It fails loudly rather than reporting a fraction, because a fraction is what
+// the summary line did: an honest number beside a headline that reads as a
+// pass is the defect this lane exists to fix. The count is logged so the
+// number can be quoted, and the assertion is that it is all of them.
+func TestDiscover_TheLayoutsRealRepositoriesUse(t *testing.T) {
+	t.Parallel()
+	all := layouts()
+	found := 0
+	for _, l := range all {
+		l := l
+		t.Run(l.name, func(t *testing.T) {
+			t.Parallel()
+			set := insights.Discover(l.tree)
+			require.Equal(t, l.tool, set.Tool, "the tool was not recognised")
+			if l.dir != "" {
+				require.Equal(t, l.dir, set.Dir, "the migrations were found somewhere else")
+				require.NotEmpty(t, set.Migrations, "the directory was named and read as empty")
+			} else {
+				require.NotEmpty(t, set.Reason,
+					"a tool whose migrations are not SQL has to say why it cannot replay them")
+			}
+		})
+		if set := insights.Discover(l.tree); set.Tool == l.tool {
+			found++
+		}
+	}
+	t.Logf("nested migration layouts discovered: %d of %d", found, len(all))
+	require.Equal(t, len(all), found)
+}
+
+// The two guards the deeper search needed, each proved able to say no.
+//
+// Searching the whole tree for a marker file is only safe while the marker is
+// distinctive. Going deeper made two of them stop being distinctive on their
+// own, so each gained a predicate, and a predicate with no test that fails
+// without it is the same unfalsifiable check this lane is about.
+
+func TestDiscover_AManagePyThatIsNotDjangoIsNotDjango(t *testing.T) {
+	t.Parallel()
+	// manage.py is a name anybody can use for a script. At the root that was
+	// unlikely enough to ignore; anywhere in a monorepo it is not, and
+	// answering "django" here would send the rehearsal to run a migrate
+	// command that does not exist.
+	set := insights.Discover(fstest.MapFS{
+		"README.md":           file("x"),
+		"tools/ops/manage.py": file("#!/usr/bin/env python\nprint('restart the queue')\n"),
+	})
+	require.Equal(t, insights.ToolNone, set.Tool)
+}
+
+func TestDiscover_ADrizzleDirectoryWithNoJournalDoesNotEndTheSearch(t *testing.T) {
+	t.Parallel()
+	// Two directories called drizzle, one of them a package that vendors the
+	// name and has no journal. Finding the first and giving up is what the
+	// old search did, because the journal was checked after the search rather
+	// than inside it.
+	set := insights.Discover(fstest.MapFS{
+		"apps/admin/drizzle/readme.md":        file("not a migrations directory"),
+		"apps/api/drizzle/meta/_journal.json": file(`{"entries":[]}`),
+		"apps/api/drizzle/0000_init.sql":      file("CREATE TABLE t (id int);"),
+	})
+	require.Equal(t, insights.ToolDrizzle, set.Tool)
+	require.Equal(t, "apps/api/drizzle", set.Dir)
+}
+
+func TestDiscover_AMarkerInsideADependencyIsNotThisRepositorysMigrations(t *testing.T) {
+	t.Parallel()
+	// The skip list existed before the search went deeper, and it guarded one
+	// fallback. Now every marker is looked for at every depth, so it guards
+	// all of them: a dependency that ships its own prisma directory is a
+	// marker file sitting in the tree, and rehearsing its migrations against
+	// this repository's database would be worse than finding nothing.
+	set := insights.Discover(fstest.MapFS{
+		"package.json": file("{}"),
+		"node_modules/@acme/billing/prisma/migrations/20200101000000_init/migration.sql": file(
+			"CREATE TABLE acme_invoices (id int);"),
+		"packages/db/prisma/migrations/20240101000000_init/migration.sql": file(
+			"CREATE TABLE users (id int);"),
+	})
+	require.Equal(t, insights.ToolPrisma, set.Tool)
+	require.Equal(t, "packages/db/prisma/migrations", set.Dir)
+
+	// And when the dependency's copy is the only one, the answer is that
+	// nothing was recognised, not somebody else's schema.
+	only := insights.Discover(fstest.MapFS{
+		"package.json": file("{}"),
+		"node_modules/@acme/billing/prisma/migrations/20200101000000_init/migration.sql": file(
+			"CREATE TABLE acme_invoices (id int);"),
+	})
+	require.Equal(t, insights.ToolNone, only.Tool)
+}
+
+func TestDiscover_TwoCandidatesAtTheSameDepthAnswerTheSameWayEveryTime(t *testing.T) {
+	t.Parallel()
+	// The outcome, not the mechanism. best() no longer compares names, it
+	// relies on fs.WalkDir's documented lexical order and a stable sort, so
+	// there is no line here a mutation could break. What can still be pinned
+	// is that the answer is the same one every time, which is what stops a
+	// monorepo rehearsing a different directory on a different machine.
+	tree := fstest.MapFS{
+		"package.json": file("{}"),
+		"apps/api/prisma/migrations/20240101000000_init/migration.sql":   file("CREATE TABLE a (id int);"),
+		"apps/admin/prisma/migrations/20240101000000_init/migration.sql": file("CREATE TABLE b (id int);"),
+	}
+	first := insights.Discover(tree)
+	require.Equal(t, insights.ToolPrisma, first.Tool)
+	require.Equal(t, "apps/admin/prisma/migrations", first.Dir)
+	for i := 0; i < 20; i++ {
+		require.Equal(t, first.Dir, insights.Discover(tree).Dir,
+			"the same repository answered two different directories")
+	}
+}

--- a/engine/internal/insights/migrations.go
+++ b/engine/internal/insights/migrations.go
@@ -142,22 +142,204 @@ func Declared(fsys fs.FS, d *schema.Migrations) MigrationSet {
 }
 
 func discover(fsys fs.FS, hints []string) MigrationSet {
-	for _, find := range []func(fs.FS) (MigrationSet, bool){
-		findPrisma, findSupabase, findDrizzle, findFlyway,
-		findRails, findDjango, findAlembic, findKnex, findSQLDir,
+	l := &locator{fsys: fsys, hints: hints}
+	for _, find := range []func() (MigrationSet, bool){
+		l.findPrisma, l.findSupabase, l.findDrizzle, l.findFlyway,
+		l.findRails, l.findDjango, l.findAlembic, l.findKnex, l.findSQLDir,
 	} {
-		if set, ok := find(fsys); ok {
+		if set, ok := find(); ok {
 			return set
 		}
 	}
-	if set, ok := findNumberedSQLDir(fsys, hints); ok {
+	if set, ok := l.findNumberedSQLDir(); ok {
 		return set
 	}
 	return MigrationSet{}
 }
 
-func findPrisma(fsys fs.FS) (MigrationSet, bool) {
-	dir, ok := firstDirContaining(fsys, "prisma/migrations")
+// locator is a repository being searched, together with what the manifest says
+// about where its services live.
+//
+// Every finder is a method rather than a free function for one reason: the
+// search for a marker has to be the SAME search in all of them, and it has to
+// reach the hints. The version this replaced looked for prisma/migrations at
+// the root and exactly one level below, which finds it in a single service
+// repository and misses packages/database/prisma/migrations, apps/api/drizzle,
+// services/worker/db/migrate and every other ordinary workspace layout. The
+// marker FILES were worse still: supabase/config.toml, alembic.ini, manage.py
+// and knexfile.js were only ever looked for at the root, so a Python service
+// under services/api was answered with "no migration tool was recognised".
+//
+// Measured before this change, against the ten layouts in layouts_test.go
+// drawn from repositories on the prospect list: 1 of 10 discovered.
+type locator struct {
+	fsys  fs.FS
+	hints []string
+	// dirCache is every directory worth looking in, computed once. Nine
+	// finders each walking the tree is nine walks of a repository that can be
+	// large, and they would all get the same answer.
+	dirCache []searchDir
+	walked   bool
+}
+
+// searchDir is one directory the search will look in, with its depth.
+type searchDir struct {
+	path  string
+	depth int
+}
+
+// candidate is one place a marker was found, with what ranks it.
+type candidate struct {
+	dir   string
+	depth int
+	hint  bool
+}
+
+// dirs is the repository root and every directory within maxMigrationDepth of
+// it that is not somebody else's project.
+func (l *locator) dirs() []searchDir {
+	if l.walked {
+		return l.dirCache
+	}
+	l.walked = true
+	_ = fs.WalkDir(l.fsys, ".", func(p string, d fs.DirEntry, err error) error {
+		if err != nil || !d.IsDir() {
+			return nil
+		}
+		if p != "." && skipForMigrations(path.Base(p)) {
+			return fs.SkipDir
+		}
+		depth := 0
+		if p != "." {
+			depth = strings.Count(p, "/") + 1
+		}
+		if depth > maxMigrationDepth {
+			return fs.SkipDir
+		}
+		l.dirCache = append(l.dirCache, searchDir{path: p, depth: depth})
+		return nil
+	})
+	return l.dirCache
+}
+
+// best ranks the places a marker was found and returns the one to use.
+//
+// A directory under a path the manifest's services name wins, because a
+// monorepo with two of them should rehearse the one beside the service that
+// migrates. Among the rest the shallowest wins, because a repository that has
+// both a real one and a copy under a tool's own directory means the shallow
+// one. Ties break by name, so the answer does not depend on the order the
+// filesystem happened to hand back.
+func (l *locator) best(found []candidate) (string, bool) {
+	if len(found) == 0 {
+		return "", false
+	}
+	// Stable, and the stability IS the tie break. fs.WalkDir documents that
+	// it walks in lexical order and dirs() appends in that order, so equal
+	// candidates arrive sorted by name already. An explicit name comparison
+	// here was a line no fixture could ever fail, on fstest.MapFS or on
+	// os.DirFS, because both sort their directory entries: it agreed with the
+	// order it was breaking ties within. A line that cannot say no is the
+	// thing this file is being changed to stop shipping, so it is gone and
+	// the guarantee is by construction instead.
+	sort.SliceStable(found, func(i, j int) bool {
+		a, b := found[i], found[j]
+		if a.hint != b.hint {
+			return a.hint
+		}
+		return a.depth < b.depth
+	})
+	return found[0].dir, true
+}
+
+// mark builds a candidate for a path, deciding whether a hinted service claims
+// it. The hint is matched against the whole path rather than the base
+// directory, because "the service under shop" means shop and everything below.
+func (l *locator) mark(dir string, depth int) candidate {
+	c := candidate{dir: dir, depth: depth}
+	for _, h := range l.hints {
+		if dir == h || strings.HasPrefix(dir, h+"/") {
+			c.hint = true
+		}
+	}
+	return c
+}
+
+// dirNamed finds rel at the repository root or under any directory near it,
+// and returns the best candidate rather than the first one the walk reached.
+//
+// valid may be nil. Where it is not, a directory that fails it is not a
+// candidate and the search continues, which is the difference between "there
+// is a drizzle directory and it has no journal, so give up" and "find the
+// drizzle directory that has one".
+func (l *locator) dirNamed(rel string, valid func(dir string) bool) (string, bool) {
+	var found []candidate
+	for _, d := range l.dirs() {
+		p := rel
+		if d.path != "." {
+			p = path.Join(d.path, rel)
+		}
+		info, err := fs.Stat(l.fsys, p)
+		if err != nil || !info.IsDir() {
+			continue
+		}
+		if valid != nil && !valid(p) {
+			continue
+		}
+		found = append(found, l.mark(p, d.depth))
+	}
+	return l.best(found)
+}
+
+// fileNamed finds a marker file at the root or under any directory near it,
+// and returns the directory it is relative to, "." for the root.
+//
+// The directory rather than the file, because every caller wants to look
+// beside it: supabase/config.toml says its migrations are in
+// supabase/migrations, and a manage.py says the Django project is the tree
+// around it.
+func (l *locator) fileNamed(rel string, valid func(p string) bool) (string, bool) {
+	var found []candidate
+	for _, d := range l.dirs() {
+		p := rel
+		if d.path != "." {
+			p = path.Join(d.path, rel)
+		}
+		info, err := fs.Stat(l.fsys, p)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		if valid != nil && !valid(p) {
+			continue
+		}
+		found = append(found, l.mark(d.path, d.depth))
+	}
+	return l.best(found)
+}
+
+// under joins a directory found by fileNamed with a path relative to it,
+// keeping "." out of the result.
+func under(dir, rel string) string {
+	if dir == "." || dir == "" {
+		return rel
+	}
+	return path.Join(dir, rel)
+}
+
+// contains reports whether a file holds a string, case insensitively. It is
+// used where a marker file's NAME is not distinctive enough to be trusted on
+// its own once the search goes deeper than the root.
+func (l *locator) contains(p, want string) bool {
+	body, err := fs.ReadFile(l.fsys, p)
+	if err != nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(string(body)), strings.ToLower(want))
+}
+
+func (l *locator) findPrisma() (MigrationSet, bool) {
+	fsys := l.fsys
+	dir, ok := l.dirNamed("prisma/migrations", nil)
 	if !ok {
 		return MigrationSet{}, false
 	}
@@ -184,23 +366,29 @@ func findPrisma(fsys fs.FS) (MigrationSet, bool) {
 	return MigrationSet{Tool: ToolPrisma, Dir: dir, Migrations: out}, true
 }
 
-func findSupabase(fsys fs.FS) (MigrationSet, bool) {
-	if !exists(fsys, "supabase/config.toml") {
+func (l *locator) findSupabase() (MigrationSet, bool) {
+	fsys := l.fsys
+	base, ok := l.fileNamed("supabase/config.toml", nil)
+	if !ok {
 		return MigrationSet{}, false
 	}
 	// Supabase records the leading timestamp, not the whole filename, in
 	// supabase_migrations.schema_migrations.version.
-	set := sqlFilesIn(fsys, "supabase/migrations", leadingDigits)
+	set := sqlFilesIn(fsys, under(base, "supabase/migrations"), leadingDigits)
 	set.Tool = ToolSupabase
 	return set, true
 }
 
-func findDrizzle(fsys fs.FS) (MigrationSet, bool) {
-	dir, ok := firstDirContaining(fsys, "drizzle")
+func (l *locator) findDrizzle() (MigrationSet, bool) {
+	fsys := l.fsys
+	// The journal is part of the predicate rather than a check afterwards. A
+	// repository with a drizzle directory that holds no journal used to end
+	// the search there, so a second one that did have a journal was never
+	// reached.
+	dir, ok := l.dirNamed("drizzle", func(d string) bool {
+		return exists(l.fsys, path.Join(d, "meta", "_journal.json"))
+	})
 	if !ok {
-		return MigrationSet{}, false
-	}
-	if !exists(fsys, path.Join(dir, "meta", "_journal.json")) {
 		return MigrationSet{}, false
 	}
 	// Drizzle hashes the file contents into __drizzle_migrations, which is not
@@ -211,23 +399,14 @@ func findDrizzle(fsys fs.FS) (MigrationSet, bool) {
 	return set, true
 }
 
-func findFlyway(fsys fs.FS) (MigrationSet, bool) {
-	for _, dir := range []string{
+func (l *locator) findFlyway() (MigrationSet, bool) {
+	fsys := l.fsys
+	for _, rel := range []string{
 		"sql", "migrations", "db/migration",
 		"src/main/resources/db/migration",
 	} {
-		entries, err := fs.ReadDir(fsys, dir)
-		if err != nil {
-			continue
-		}
-		found := false
-		for _, e := range entries {
-			if flywayName.MatchString(e.Name()) {
-				found = true
-				break
-			}
-		}
-		if !found {
+		dir, ok := l.dirNamed(rel, l.holdsAFlywayMigration)
+		if !ok {
 			continue
 		}
 		// Flyway records the version between the leading V and the double
@@ -246,8 +425,8 @@ func findFlyway(fsys fs.FS) (MigrationSet, bool) {
 	return MigrationSet{}, false
 }
 
-func findRails(fsys fs.FS) (MigrationSet, bool) {
-	dir, ok := firstDirContaining(fsys, "db/migrate")
+func (l *locator) findRails() (MigrationSet, bool) {
+	dir, ok := l.dirNamed("db/migrate", nil)
 	if !ok {
 		return MigrationSet{}, false
 	}
@@ -258,8 +437,13 @@ func findRails(fsys fs.FS) (MigrationSet, bool) {
 	}, true
 }
 
-func findDjango(fsys fs.FS) (MigrationSet, bool) {
-	if !exists(fsys, "manage.py") {
+func (l *locator) findDjango() (MigrationSet, bool) {
+	// manage.py is not a distinctive enough name to trust anywhere in a tree
+	// the way supabase/config.toml or alembic.ini are, so the file has to say
+	// django. Every manage.py django-admin has ever generated does.
+	if _, ok := l.fileNamed("manage.py", func(p string) bool {
+		return l.contains(p, "django")
+	}); !ok {
 		return MigrationSet{}, false
 	}
 	return MigrationSet{
@@ -269,8 +453,8 @@ func findDjango(fsys fs.FS) (MigrationSet, bool) {
 	}, true
 }
 
-func findAlembic(fsys fs.FS) (MigrationSet, bool) {
-	if !exists(fsys, "alembic.ini") {
+func (l *locator) findAlembic() (MigrationSet, bool) {
+	if _, ok := l.fileNamed("alembic.ini", nil); !ok {
 		return MigrationSet{}, false
 	}
 	return MigrationSet{
@@ -280,8 +464,10 @@ func findAlembic(fsys fs.FS) (MigrationSet, bool) {
 	}, true
 }
 
-func findKnex(fsys fs.FS) (MigrationSet, bool) {
-	if !exists(fsys, "knexfile.js") && !exists(fsys, "knexfile.ts") {
+func (l *locator) findKnex() (MigrationSet, bool) {
+	_, js := l.fileNamed("knexfile.js", nil)
+	_, ts := l.fileNamed("knexfile.ts", nil)
+	if !js && !ts {
 		return MigrationSet{}, false
 	}
 	return MigrationSet{
@@ -291,7 +477,8 @@ func findKnex(fsys fs.FS) (MigrationSet, bool) {
 	}, true
 }
 
-func findSQLDir(fsys fs.FS) (MigrationSet, bool) {
+func (l *locator) findSQLDir() (MigrationSet, bool) {
+	fsys := l.fsys
 	// Last, because every tool above also has a directory of SQL somewhere
 	// and a project with no tool at all is the case this is for.
 	for _, dir := range []string{"migrations", "migrate", "db/migrations", "sql/migrations"} {
@@ -325,34 +512,12 @@ func findSQLDir(fsys fs.FS) (MigrationSet, bool) {
 // service paths wins; among the rest the shallowest wins; ties break by name.
 // Directories that hold other people's projects are skipped: examples,
 // fixtures, test data, vendored code and anything dot prefixed.
-func findNumberedSQLDir(fsys fs.FS, hints []string) (MigrationSet, bool) {
-	type candidate struct {
-		dir   string
-		depth int
-		hint  bool
-		count int
-	}
+func (l *locator) findNumberedSQLDir() (MigrationSet, bool) {
 	var found []candidate
-	_ = fs.WalkDir(fsys, ".", func(p string, d fs.DirEntry, err error) error {
+	for _, d := range l.dirs() {
+		entries, err := fs.ReadDir(l.fsys, d.path)
 		if err != nil {
-			return nil
-		}
-		if !d.IsDir() {
-			return nil
-		}
-		if p != "." && skipForMigrations(path.Base(p)) {
-			return fs.SkipDir
-		}
-		depth := strings.Count(p, "/") + 1
-		if p == "." {
-			depth = 0
-		}
-		if depth > maxMigrationDepth {
-			return fs.SkipDir
-		}
-		entries, err := fs.ReadDir(fsys, p)
-		if err != nil {
-			return nil
+			continue
 		}
 		n := 0
 		for _, e := range entries {
@@ -361,33 +526,33 @@ func findNumberedSQLDir(fsys fs.FS, hints []string) (MigrationSet, bool) {
 			}
 		}
 		if n < 2 {
-			return nil
+			continue
 		}
-		c := candidate{dir: p, depth: depth, count: n}
-		for _, h := range hints {
-			if p == h || strings.HasPrefix(p, h+"/") {
-				c.hint = true
-			}
-		}
-		found = append(found, c)
-		return nil
-	})
-	if len(found) == 0 {
+		found = append(found, l.mark(d.path, d.depth))
+	}
+	dir, ok := l.best(found)
+	if !ok {
 		return MigrationSet{}, false
 	}
-	sort.Slice(found, func(i, j int) bool {
-		a, b := found[i], found[j]
-		if a.hint != b.hint {
-			return a.hint
-		}
-		if a.depth != b.depth {
-			return a.depth < b.depth
-		}
-		return a.dir < b.dir
-	})
-	set := sqlFilesIn(fsys, found[0].dir, func(name string) string { return name })
+	set := sqlFilesIn(l.fsys, dir, func(name string) string { return name })
 	set.Tool = ToolSQLDir
 	return set, true
+}
+
+// holdsAFlywayMigration reports whether a directory holds a file Flyway would
+// apply, which is what makes a directory named "sql" a migration directory
+// rather than a directory of queries.
+func (l *locator) holdsAFlywayMigration(dir string) bool {
+	entries, err := fs.ReadDir(l.fsys, dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if !e.IsDir() && flywayName.MatchString(e.Name()) {
+			return true
+		}
+	}
+	return false
 }
 
 // maxMigrationDepth bounds the fallback walk. Five levels reaches
@@ -495,33 +660,6 @@ func flywayVersion(name string) string {
 func exists(fsys fs.FS, p string) bool {
 	_, err := fs.Stat(fsys, p)
 	return err == nil
-}
-
-// firstDirContaining finds suffix at the root or one level down, which is
-// where it lives in the single service repository and in the monorepo.
-func firstDirContaining(fsys fs.FS, suffix string) (string, bool) {
-	if info, err := fs.Stat(fsys, suffix); err == nil && info.IsDir() {
-		return suffix, true
-	}
-	entries, err := fs.ReadDir(fsys, ".")
-	if err != nil {
-		return "", false
-	}
-	var found []string
-	for _, e := range entries {
-		if !e.IsDir() || strings.HasPrefix(e.Name(), ".") || e.Name() == "node_modules" {
-			continue
-		}
-		p := path.Join(e.Name(), suffix)
-		if info, err := fs.Stat(fsys, p); err == nil && info.IsDir() {
-			found = append(found, p)
-		}
-	}
-	if len(found) == 0 {
-		return "", false
-	}
-	sort.Strings(found)
-	return found[0], true
 }
 
 // historyQuery is the statement that lists what a tool has already applied.

--- a/engine/internal/insights/migrations.go
+++ b/engine/internal/insights/migrations.go
@@ -560,8 +560,16 @@ func (l *locator) holdsAFlywayMigration(dir string) bool {
 // whole node_modules that escaped the skip list under another name.
 const maxMigrationDepth = 5
 
-// skipForMigrations names the directories the fallback never looks inside,
-// because what they hold is somebody else's project or a copy of this one.
+// skipForMigrations names the directories the search never looks inside,
+// because what they hold is somebody else's project or a build of this one.
+//
+// It used to guard one fallback. It now guards every marker, which is what
+// deepening the search made necessary: a dependency shipping its own
+// prisma/migrations is that dependency's schema, and answering with it would
+// rehearse somebody else's migrations with a straight face.
+//
+// docs/src/content/docs/concepts/insights.md prints this list in full. A
+// document that names seven of thirteen reads as though it named all of them.
 func skipForMigrations(base string) bool {
 	if strings.HasPrefix(base, ".") {
 		return true

--- a/engine/internal/insights/run.go
+++ b/engine/internal/insights/run.go
@@ -141,6 +141,12 @@ type Options struct {
 	// Empty falls back to a general message, which is right when the caller
 	// simply had nothing to rehearse.
 	NoRehearsalReason string
+	// RehearsalDeclined says the caller chose not to rehearse, so a run
+	// without one is a decision rather than a blocked check. --no-rehearsal
+	// is the only thing that sets it. Without it, a rehearsal the manifest
+	// asked for and did not get is reported as blocked and the command exits
+	// in a way CI can tell apart from a pass.
+	RehearsalDeclined bool
 	// Progress receives lines already safe to print.
 	Progress func(string)
 }
@@ -168,7 +174,29 @@ type Full struct {
 	Off []string `json:"off,omitempty"`
 	// Missing names what could not be measured, and why.
 	Missing []string `json:"missing,omitempty"`
+	// Blocked names the checks that were asked for and did not run.
+	//
+	// Three states, not two, and the distinction is the whole point. Off is a
+	// decision somebody made. Missing collects everything that could not be
+	// measured, including things that do not change the verdict, like an
+	// extension nobody installed. Blocked is the narrow one the summary line
+	// reads: the headline check was asked for and did not execute, so the run
+	// proves nothing about the thing it exists to prove.
+	//
+	// The report already followed this rule three sentences at a time and the
+	// summary did not. af insights said "the migrations were not rehearsed"
+	// in its body and then printed "ok  nothing to report" and exited zero,
+	// and the last line is the one a developer reads. It is the same shape as
+	// rollingBlocked beside rollingOff below, which got it right first.
+	Blocked []string `json:"blocked,omitempty"`
 }
+
+// Blocked reports whether a check that was asked for did not run.
+//
+// Callers branch on this rather than on Clean, because a run with nothing to
+// report and a run that could not look are the same shape and different
+// facts.
+func (f Full) IsBlocked() bool { return len(f.Blocked) > 0 }
 
 // Clean reports whether every check that ran found nothing.
 func (f Full) Clean() bool {
@@ -256,6 +284,24 @@ func Run(ctx context.Context, opts Options) (Full, error) {
 				return f, err
 			}
 			f.Rehearsal = &r
+			if r.Tool == ToolNone {
+				// The rehearsal ran and had nothing to rehearse, which is
+				// the same defect wearing different clothes: discovery
+				// failed, every statement timing and lock sample below is
+				// over an empty set, and the run would otherwise summarise
+				// as ok. A tool that WAS recognised but whose migrations are
+				// not SQL is not this case; those carry their own reason and
+				// are applied by the project's own migrate command.
+				//
+				// A project that genuinely has no migrations says so, and
+				// the message names all three ways to say it.
+				blocked := "no migration tool was recognised anywhere in this repository, so " +
+					"the rehearsal had nothing to rehearse. Name the directory under " +
+					"database.migrations, or turn the check off with " +
+					"insights.migration_rehearsal: false, or pass --no-rehearsal for one run"
+				f.Missing = append(f.Missing, blocked)
+				f.Blocked = append(f.Blocked, blocked)
+			}
 		} else if opts.Config.PlanDiff {
 			// Plan diff without a rehearsal has nothing to change the plan,
 			// so say so rather than reporting no findings.
@@ -290,6 +336,13 @@ func Run(ctx context.Context, opts Options) (Full, error) {
 				"to rehearse them against"
 		}
 		f.Missing = append(f.Missing, reason)
+		if !opts.RehearsalDeclined {
+			// Blocked as well as missing. Declining the rehearsal is a
+			// decision and stays a decision: --no-rehearsal asked for this,
+			// so summarising it as ok is honest. Everything else here is the
+			// headline check failing to run, which is not.
+			f.Blocked = append(f.Blocked, reason)
+		}
 	}
 
 	// With no rehearsal branch, a saved baseline is the other way to have two

--- a/engine/internal/mcp/tools_migration.go
+++ b/engine/internal/mcp/tools_migration.go
@@ -134,10 +134,18 @@ func runMigrationRehearsal(
 // rule Verdict itself applies to findings, so the ranking is shared even
 // though the shape of the run is not.
 func nativeVerdict(full insights.Full, findings []report.Finding) string {
-	if full.Rehearsal == nil {
+	if full.Rehearsal == nil || full.IsBlocked() {
 		// Nothing was rehearsed. Every other field may be populated and none
 		// of it is evidence about the migrations, so this is unverified
 		// rather than a pass with no findings.
+		//
+		// IsBlocked catches the case a nil check cannot see: a rehearsal that
+		// RAN against a repository where discovery found no migration tool.
+		// It times nothing, lints nothing and produces no findings, so the
+		// counts below are all zero and the verdict was pass. That is the same
+		// defect the CLI's summary line had, reached through a different door,
+		// and fixing one without the other would leave an agent being told
+		// PASS about migrations nobody looked at.
 		return report.VerdictUnverified
 	}
 	fail, warn := report.Run{Findings: findings}.Counts()

--- a/engine/internal/mcp/tools_migration_test.go
+++ b/engine/internal/mcp/tools_migration_test.go
@@ -1,0 +1,55 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/internal/insights"
+	"github.com/antifailure/antifailure/engine/internal/report"
+)
+
+// nativeVerdict had no test at all, which is how the second door stayed open.
+//
+// A rehearsal that ran over nothing produces no findings, and no findings read
+// as a pass in every counting scheme. The only thing that can tell it apart
+// from a repository whose migrations are genuinely safe is whether the run
+// said it was blocked, so that is what is asserted here.
+
+func TestNativeVerdict_ARehearsalThatNeverRanIsUnverified(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, report.VerdictUnverified,
+		nativeVerdict(insights.Full{}, nil))
+}
+
+func TestNativeVerdict_ARehearsalThatRanOverNothingIsUnverified(t *testing.T) {
+	t.Parallel()
+	// The rehearsal is non nil, so the old nil check saw a completed run.
+	full := insights.Full{
+		Rehearsal: &insights.Rehearsal{Tool: insights.ToolNone},
+		Blocked:   []string{"no migration tool was recognised anywhere in this repository"},
+	}
+	require.Equal(t, report.VerdictUnverified, nativeVerdict(full, nil))
+	require.NotEqual(t, report.VerdictPass, nativeVerdict(full, nil))
+}
+
+func TestNativeVerdict_ARehearsalThatRanAndFoundNothingIsAPass(t *testing.T) {
+	t.Parallel()
+	// The distinction has to cut both ways or it is just a way of never
+	// passing. A real tool, a real run, no findings, is a pass.
+	require.Equal(t, report.VerdictPass, nativeVerdict(insights.Full{
+		Rehearsal: &insights.Rehearsal{Tool: insights.ToolPrisma},
+	}, nil))
+}
+
+func TestNativeVerdict_AFindingStillDecidesOverABlockedFlag(t *testing.T) {
+	t.Parallel()
+	// A run that is blocked on one thing and has proved a failure on another
+	// reports the failure. Ordering matters: unverified is what you say when
+	// you know nothing, and here something is known.
+	full := insights.Full{
+		Rehearsal: &insights.Rehearsal{Tool: insights.ToolPrisma},
+	}
+	require.Equal(t, report.VerdictFail, nativeVerdict(full,
+		[]report.Finding{{Level: report.LevelFail, Rule: "lock"}}))
+}

--- a/www/public/errors.v1.json
+++ b/www/public/errors.v1.json
@@ -608,6 +608,17 @@
       "planned": false
     },
     {
+      "code": "AF-DB-033",
+      "area": "DB",
+      "areaName": "Database",
+      "message": "The migrations were not rehearsed, so this run says nothing about them: {detail}",
+      "resolution": "The report above names what was missing. Fix that, or pass --no-rehearsal to say the run is deliberately without it: a check that could not run must not exit like one that passed.",
+      "docs": "https://antifailure.dev/docs/concepts/insights",
+      "retryable": false,
+      "exitCode": 7,
+      "planned": false
+    },
+    {
       "code": "AF-DET-001",
       "area": "DET",
       "areaName": "Detection",


### PR DESCRIPTION
## The last line of the report was the only line that was not true

`af insights` printed `ok  nothing to report` and exited 0 on a run where the
migration rehearsal never happened. The body above it was honest: the reason
sat in `Missing`, in plain words. The headline and the exit code were not, and
the exit code is what CI reads. A branch whose rehearsal could not start was
indistinguishable from a branch whose rehearsal found nothing.

Underneath it, discovery could not find the migrations in the first place in
most of the repositories this is meant to be installed against.

### Three states, and there were two codes for them

| outcome | code | exit |
| --- | --- | --- |
| the rehearsal ran and found nothing | | 0 |
| the rehearsal ran and proved a break | AF-DB-030 | 5 |
| the rehearsal was asked for and could not run | AF-DB-033 | 7, `ExitVerification` |

Exit 7 rather than a fourth number, because `ExitVerification` already means
this and the repository already had the distinction: `RollingOff` against
`RollingBlocked`, and `workflows_unverified`. A blocked check that exits like a
proven break trains people to ignore it. One that exits like a pass is the bug.

Declining the check stays a pass. `--no-rehearsal` and
`insights.migration_rehearsal: false` exit 0, because the only reason to pass
that flag is to get a run that ends cleanly without a rehearsal. The
distinction is `Options.RehearsalDeclined` and there is a test on each side.

### A rehearsal that ran over nothing was also reporting ok

Not in the plan and found while checking its acceptance line. When discovery
recognises no tool, a rehearsal branch is still prepared and `Rehearse` still
runs: it times no statements, samples no locks and lints nothing, so every
check below reports no findings and the run reads exactly like a repository
whose migrations are all safe. That is now blocked too, and the message names
all three ways to say a project genuinely has none.

The same door was open in the MCP path through a different handle.
`nativeVerdict` returned `unverified` only when `full.Rehearsal == nil`, so a
rehearsal that ran over nothing returned **pass** to an agent. It had no test
at all, which is how it stayed open. It now reads `IsBlocked` as well, and has
four.

A tool that WAS recognised but whose migrations are not SQL is deliberately not
this case: Rails, Django, Alembic and Knex are applied by the project's own
migrate command, so the check did run. Making those blocked would fail every
run of every Rails repository, and there is a test holding that line.

### Discovery: 1 of 10, then 10 of 10

`firstDirContaining` searched the root and exactly one level below it, and every
marker FILE (`supabase/config.toml`, `alembic.ini`, `manage.py`,
`knexfile.js`) was only ever looked for at the root itself. Flyway was four
fixed root paths.

Measured against ten layouts taken from repositories on the prospect list,
in `engine/internal/insights/layouts_test.go`:

```
before   nested migration layouts discovered: 1 of 10
after    nested migration layouts discovered: 10 of 10
```

The one that already worked was `packages/database/prisma/migrations`, at
exactly one level down. The nine that did not include
`services/api/src/main/resources/db/migration`, `apps/backend/supabase`,
`apps/server/manage.py` and this repository's own `web/packages/db/migrations`.

Searching the whole tree for a marker is only safe while the marker is
distinctive, and going deeper stops two of them being distinctive:

- a `manage.py` is now read for the word django rather than trusted by name.
  Anyone can call a script that, and answering "django" would send the
  rehearsal to run a migrate command that does not exist.
- a `drizzle` directory has to hold `meta/_journal.json`. The journal check
  moved INSIDE the search predicate; checking it after the search meant the
  first directory called drizzle ended the search whether or not it was one.

Each has a test that fails without it. A third proves the pre-existing skip
list still holds now that it guards every marker rather than one fallback: a
dependency's own `node_modules/@acme/billing/prisma/migrations` is not this
repository's schema.

`findSQLDir` is deliberately left at the root. Deepening it would change a
migration's `Version` from the full filename to the stem, which is the
identifier matched against the tool's own history table, and that is a
different change with a different blast radius.

### What was already fixed before this branch, and is therefore not here

`a5946758`, the same morning the plan was written, had already added `Locate`,
`Declared`, `findNumberedSQLDir`, the `database.migrations` manifest field,
`maxMigrationDepth` and `skipForMigrations`. And `7a751c97` had already fixed
`af doctor` counting its own skips as obstacles, which the plan lists as the
third part of this lane. Both are stale entries, not work done here.

## Mutation table

Every cell breaks one production line, runs the tests that are supposed to
catch it, restores, and runs them again. One break per cell, because `require`
stops at the first failure and two breaks in one run can leave the second
assertion unreached and still looking alive. The whole table ran inside a
single build lock hold, and nothing was mutated while a suite was running: a
suite loads each file as it reaches it, so a green run over a tree that was
changing is a claim about a tree that never existed.

`AF_REQUIRE_DATABASE=1` throughout, so a database test that skipped would fail
rather than exit 0 and read as a pass.

Baselines before mutating: discovery 30 tests green, rehearsal 5 green,
summary 7 green.

| # | what was broken | result | caught by |
| --- | --- | --- | --- |
| 1 | the search goes one level down again | red | `TheLayoutsRealRepositoriesUse` (9 of 10 subtests), `FindsANumberedSQLDirectoryDeepInTheTree`, `AMarkerInsideADependency...`, `ADrizzleDirectoryWithNoJournal...`, `TestLocate_TheServicePathSteers...` |
| 2 | the manifest's service path stops steering the choice | red | `TestLocate_TheServicePathSteersBetweenTwoCandidates` |
| 3 | the deepest candidate wins instead of the shallowest | red | `TestLocate_TheServicePathSteersBetweenTwoCandidates` |
| 4 | ties stop breaking by name | **SURVIVED** | nothing, and the line is gone. See below. |
| 5 | a dependency's own migrations are searched too | red | `AMarkerInsideADependencyIsNotThisRepositorysMigrations`, `FindsANumberedSQLDirectoryDeepInTheTree` |
| 6 | a `manage.py` is trusted on its name alone | red | `AManagePyThatIsNotDjangoIsNotDjango` |
| 7 | the drizzle journal is checked after the search, not inside it | red | `ADrizzleDirectoryWithNoJournalDoesNotEndTheSearch` |
| 8 | a rehearsal asked for and not run is never marked blocked | red | `TestRun_ARehearsalThatWasAskedForAndDidNotRunIsBlocked` |
| 9 | declining the rehearsal is counted as blocked too | red | `TestRun_ARehearsalTheCallerDeclinedIsNotBlocked` |
| 10 | a rehearsal with nothing to rehearse is a pass again | red | `TestRun_ARehearsalWithNothingToRehearseIsBlocked` |
| 11 | a Rails repository is blocked for having Ruby migrations | red | `ARehearsalOfAToolWhoseMigrationsAreNotSQLIsNotBlocked`, `ARehearsalWithNothingToRehearseIsBlocked` |
| 12 | the summary prints ok over a blocked check again | red | `ABlockedCheckNeverSaysOk`, `ABreakAndABlockAreDifferentExitCodes`, `ABlockedRunPrintsNothingAtAll` |
| 13 | a run with nothing to report stops saying so | red | `ARunWithNothingToReportStillSaysSo`, `ADeclinedRehearsalIsAPass`, `ACleanRunStillPrintsItsLine` |
| 14 | `AF-DB-033` exits zero, like a check that passed | red | `ABlockedCheckNeverSaysOk`, `ABreakAndABlockAreDifferentExitCodes`, `ABlockedRunPrintsNothingAtAll` |
| 15 | `AF-DB-033` exits like a change that was proven broken | red | the same three |
| 16 | an empty summary line is printed anyway, as a bare ok | red | `ABlockedRunPrintsNothingAtAll` |
| 17 | the MCP verdict looks only at whether a rehearsal object exists | red | `TestNativeVerdict_ARehearsalThatRanOverNothingIsUnverified` |
| 18 | every rehearsal is unverified, so the distinction never passes anything | red | `ARehearsalThatRanAndFoundNothingIsAPass`, `AFindingStillDecidesOverABlockedFlag` |
| 19 | the JSON document is written and the command returns, as before | red | `TextAndJSONAgreeOnEveryVerdict/migration_broke`, `JSONStillFailsOnAProvenMigrationBreak` |
| 20 | JSON carries the blocked check in the document but not in the exit | red | `TextAndJSONAgreeOnEveryVerdict/blocked`, `JSONStillFailsOnABlockedCheck` |
| 21 | a migration that failed to apply stops being a proven break | red | `TestInsightsResult_JSONStillFailsOnAProvenMigrationBreak` |
| 22 | the rolling check's proven break stops being one | **SURVIVED**, then red | nothing at first, then `ARollingBreakIsAProvenBreak`. See below. |
| 23 | a rolling check that could not run exits like a break | red | `ARollingCheckThatCouldNotRunIsNotABreak`, all three subtests |
| 24 | the failing workflow stops being named in the detail | red | `TestInsightsResult_ARollingBreakIsAProvenBreak` |

**23 of 25.** Two survived and both were dealt with rather than noted. Every
cell restored to green afterwards, checked rather than assumed. The passes ran
in three holds of the build lock: sixteen discovery and summary cells, then six
over the MCP and JSON doors, then three more written in answer to the second
survivor.

### The first survivor, and why the answer was to delete the line

Cell 4 replaced `return a.dir < b.dir` in `best()` with `return false`, and
every discovery test stayed green, including the ten layouts.

That is not a missing test. `fs.WalkDir` documents that it walks in lexical
order, `dirs()` appends in that order, and `sort.Slice` on a slice this small
preserves the order of elements that compare equal. The name comparison agreed
with the order it was breaking ties within, for every fixture that can be
written, on `fstest.MapFS` and on `os.DirFS` alike, because both sort their
directory entries. No test could ever have failed without it.

A line no test can refuse is what this pull request exists to stop shipping, so
it is gone: `best()` uses `sort.SliceStable` and says in a comment that the
input is already lexical and the stability is the tie break. The guarantee is
now by construction rather than a check pretending to be one. The OUTCOME is
still pinned, by a test that asserts which of two same depth candidates wins
and that twenty runs agree.

### The second survivor, which was a real hole

Cell 22 deleted the `AF-DB-032` branch for a rolling check that proved a break,
and nothing went red. That one is not an unfalsifiable line, it is a live path
this refactor moved and nothing was watching. `insightsBreaks` now carries the
rolling verdict as well as the rehearsal one, and it had no test on either
rolling arm.

Three cells were written for it and a third pass run: the proven break, the
blocked rolling check that must not exit like a break, and the detail that
names which workflow failed. Pass three caught 3 of 3.

## The number

Section 3 asks for nested migration layouts discovered, out of the layouts real
repositories use, measured rather than estimated.

```
cd engine && go test ./internal/insights/ \
  -run TestDiscover_TheLayoutsRealRepositoriesUse -count=1 -v

    layouts_test.go:162: nested migration layouts discovered: 10 of 10
```

Before this change the same test on the same fixtures logged `1 of 10`. The one
that already worked was `packages/database/prisma/migrations`, at exactly one
level down, which is the only depth the old search reached.

The plan's row says the number is 0 of 4 today. It is 1 of 10: the four in the
plan grew to ten because ten is how many distinct layouts the prospect list
actually contains, and the zero was a one because a commit the same morning had
already made one level work.

Machine: this Mac, darwin 25.3.0, 16GB, Go 1.27.0, every run under
`flock /private/tmp/af-gobuild.lock`.

### The page gave two rules for a check that could not run

A fourth commit, found by reading the page I had just added a section to rather
than only the section. The new migration text says a check asked for and not run
exits `7`. Two hundred lines below, the rolling deploy section says a check that
could not run exits `0` and names what happened. Both are true and both are
deliberate, and a reader meeting them in one sitting has no way to tell that
from an inconsistency nobody noticed.

The difference is the default. `when: risky` runs the rolling check only when
the pending migrations contain something the previous release could notice, so a
purely additive migration not running it is the ORDINARY outcome, and exiting
non zero for that would fire on most runs of most repositories. The rehearsal
has no such condition: it is what the command is for, and it was asked for on
every run that did not decline it. That is now said where a reader meets the
first of the two rules, instead of being left for them to reconcile.

### A test that runs the search over this repository, not a fixture

A third commit, and the reason it exists is that every other discovery test
here builds its own `fstest.MapFS`. A fixture is a claim about a shape somebody
typed, and one spelling out `web/packages/db/migrations` passes whether or not
the shipped search can find it HERE.

`TestDiscover_ThisRepositorysOwnMigrationsAreFoundInTheRealTree` runs
`insights.Locate(os.DirFS(<repository root>), nil)` over the actual tree with a
nil manifest. Our own `database:` block declares no `migrations:` key, so
nothing is declared and the answer has to be found, four levels down, which the
search before this change could not reach.

Exactly two directories named `migrations` survive the skip list in this tree:
ours, and `www/out/product/migrations`, which is Next.js build output holding
`.txt` files that the numbered SQL predicate refuses. `engine/internal/db/supabase`
is a Go package named supabase and does not match, because `findSupabase` wants
`supabase/config.toml` rather than a directory name. Checked before the test was
written rather than concluded from it passing.

One cell, and it reproduces the defect rather than inventing a break: bound the
walk at two levels, which is the search as it stood before this lane.

```
baseline exit=0 ran=1 GREEN
caught   the walk stops two levels down, as it did before this lane
         TestDiscover_ThisRepositorysOwnMigrationsAreFoundInTheRealTree
         layouts_test.go:274: Not equal
restored exit=0 ran=1 GREEN
1 of 1 breaks caught
```

### The skip list named seven of its thirteen directories

A second commit, and the same defect as the rest of this branch in prose rather
than in an exit code. `docs/concepts/insights.md` listed `node_modules`,
`vendor`, `examples`, `testdata`, `fixtures`, `dist` and `build` as the
directories the search never enters. `skipForMigrations` also refuses `example`,
`fixture`, `target`, `tmp`, `docs` and `__pycache__`. Somebody working out why
their migrations were not found had six wrong answers available and nothing to
tell them the list was partial. It now prints all thirteen, and the function's
comment, which still described itself as guarding one fallback, says that it
guards every marker and points at the page that prints the list.

## What was NOT checked

- **`./internal/env/` timed out once here, and then passed.** The package blew
  its ten minute default timeout inside
  `TestPull_RefusesAGoldenPublishedByAnotherProject`, a Docker golden store test
  that publishes a golden and pulls it back as a second project. Run alone with
  `-timeout 30m` it passed: `ok ... 156.914s`, exit 0. So the first result was
  contention on a machine running four other lanes, not this change, and the
  change to that package is one line inside an `else if opts.SkipRehearsal`
  branch that the test does not reach. Another lane hit the same package timing
  out on Docker the same night, independently, for its own unrelated change.
- The other five affected packages did run to completion, with
  `AF_REQUIRE_DATABASE=1` so a database test that skipped would fail rather than
  exit 0: `insights ok 346.916s`, `cli ok 109.009s`, `mcp ok 2.007s`,
  `errors ok 0.070s`.
- No `-race` run. On a machine with under 1 GB of free swap for most of the
  night, a race build of these packages was not something to start beside four
  other lanes.
