### PR TITLE
engine: a provider written outside this repository could never be selected

### DIFF
--- a/.changes/providers-that-could-not-be-registered.md
+++ b/.changes/providers-that-could-not-be-registered.md
@@ -1,0 +1,32 @@
+# added
+
+A provider written outside this repository could be implemented and never
+selected.
+
+`engine/pkg/provider` is documented as the main extension point, meant to be
+written by people outside this repository, with a conformance suite that
+decides whether an implementation is conformant. All of that was true and none
+of it was reachable. The engine chose its database provider from a switch in
+`engine/internal/env`, its runtime from another, and its golden store from a
+third, and each ended at a default that refused. Nothing consulted anything a
+build had registered, because there was nothing to register into: the only way
+to add a provider was to edit an internal package, which the Go toolchain
+refuses to let another module import. "Extensible" meant "send us a patch".
+
+`engine/pkg/extension` now carries five sockets beside the four hooks it
+already had: `DatabaseProvider`, `DatastoreProvider`, `RuntimeProvider`,
+`GoldenStore` and `Emulator`. The database, runtime and golden store switches
+consult the registry after their own cases and never before them, so a
+registration adds a choice and can never take one over, and each refusal now
+names every provider the build has rather than only the ones that ship. A
+registration under a built in name is refused at the first command instead of
+being silently unused, which is the failure that would otherwise be discovered
+as a build somebody believed replaced the Docker provider.
+
+Two of the five have no lifecycle behind them yet, and each says so in its own
+documentation rather than leaving somebody to find out. `tools/socketcheck` is
+what keeps that honest: every socket is either consulted by the engine or
+listed there with the reason, both directions fail, and the entry cannot
+outlive the gap. It was written after finding that `Registry.Audit` has no
+caller anywhere in the engine, so `audit_stream` would forward nothing even
+once somebody wrote the sinks.

--- a/.gitignore
+++ b/.gitignore
@@ -177,6 +177,7 @@ runner/artifacts/
 /schemadoc
 /sidebarcheck
 /site
+/socketcheck
 /statuscheck
 /surfacecheck
 /tagsync

--- a/docs/src/content/docs/contributing/provider-authoring.md
+++ b/docs/src/content/docs/contributing/provider-authoring.md
@@ -100,6 +100,85 @@ is the other reason it exists: a control that needs infrastructure gets
 skipped, and a skipped control is a false green rather than a proof. That is
 the subject of the next two sections.
 
+## Making the engine use it
+
+A provider nobody can select is a provider nobody has. Until a build knows the
+name `mine` means your code, `database.provider: mine` is refused, and being
+refused is the correct behaviour: falling back to `docker` would hand somebody
+an empty preview with no reason for it.
+
+Registration is how a build says so, and it needs no change to this repository.
+`engine/pkg/extension` holds the sockets and `engine/pkg/afcli` runs the same
+command tree the `af` binary runs, so your `main` is a few lines around both:
+
+```go
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/antifailure/antifailure/engine/pkg/afcli"
+	"github.com/antifailure/antifailure/engine/pkg/extension"
+	"github.com/antifailure/antifailure/engine/pkg/provider"
+)
+
+type registration struct{}
+
+func (registration) Name() string { return "mine" }
+
+func (registration) Open(
+	ctx context.Context, cfg extension.DatabaseConfig,
+) (provider.Database, error) {
+	// cfg carries the manifest's database block, the resolved Postgres major
+	// version, a state directory, the engine's clock, and Lookup, which
+	// resolves a declared credential through the engine's whole chain. Read
+	// credentials through Lookup rather than from the process environment, so
+	// that every one your provider uses is declared and auditable.
+	key, found, err := cfg.Lookup(ctx, cfg.Database.APIKeyEnv)
+	if err != nil || !found {
+		return nil, err
+	}
+	return myprovider.New(key, cfg.Database.Project)
+}
+
+func main() {
+	extension.Default.AddDatabaseProvider(registration{})
+
+	ctx, forced, stop := afcli.WithSignals(context.Background())
+	defer stop()
+	os.Exit(afcli.Run(ctx, forced, os.Args[1:], afcli.Options{}))
+}
+```
+
+Five things can be registered: `AddDatabaseProvider`, `AddDatastoreProvider`,
+`AddRuntimeProvider`, `AddGoldenStore` and `AddEmulator`. Three of them are
+selected by the engine today. `AddDatastoreProvider` and `AddEmulator` have no
+lifecycle behind them yet, because the manifest declares one datastore and no
+egress rule can name an emulator, so registering either of those does nothing
+beyond appearing in `af license status`. Each socket says so in its own
+documentation rather than leaving you to discover it.
+
+Four rules are worth knowing before you rely on this.
+
+**A registration adds a choice and never replaces one.** The engine asks its
+own providers first and the registry only afterwards, so registering under a
+name this build already has would never be used. That is refused at the first
+command rather than ignored, because a build somebody believes replaces the
+Docker provider and silently does not is worse than one that will not start.
+
+**A registered provider is checked exactly as a built in one is.** Masking,
+verification, provenance and the egress policy all live above the provider.
+Nothing here is a way around them.
+
+**A refusal names what this build does have,** registered providers included,
+so a misspelling in the manifest is answered by a message that mentions your
+provider rather than one that lists only the four that ship.
+
+**Run the conformance suite anyway.** Registration decides which provider is
+selected. It says nothing about whether that provider keeps its promises, and
+the suite is the only thing that does.
+
 ## Capabilities, and why skipping has to be loud
 
 Not every provider can do everything. A provider without copy-on-write cannot

--- a/docs/src/content/docs/providers/overview.md
+++ b/docs/src/content/docs/providers/overview.md
@@ -42,9 +42,15 @@ and the golden has to be copied in, but what you get back is a real Supabase
 project with the Auth, Storage and Realtime services your application is
 calling, which neither of the others can offer. A branch is billed by the hour.
 
-A provider named in the manifest and not built into this binary is refused at
-startup rather than substituted. Falling back to `docker` would hand somebody
-an empty preview with no reason for it.
+A provider named in the manifest and neither built into this binary nor
+registered with it is refused at startup rather than substituted. Falling back
+to `docker` would hand somebody an empty preview with no reason for it. The
+refusal names every provider the build does have, registered ones included, so
+a misspelling is answered rather than merely rejected.
+
+A build outside this repository can add its own without forking the engine.
+[Writing a provider](/docs/contributing/provider-authoring) has the
+registration, which is four lines around `engine/pkg/afcli`.
 
 ## What every provider guarantees
 

--- a/docs/src/content/docs/reference/errors.md
+++ b/docs/src/content/docs/reference/errors.md
@@ -812,6 +812,32 @@ Organization policy {policy} refuses this environment: {detail}
 | Retryable | No. Retrying the same operation unchanged will fail the same way. |
 | More | [enterprise/policy](/docs/enterprise/policy) |
 
+## Extensions
+
+### AF-EXT-001
+
+This build cannot honor one of its own extension registrations: {detail}
+
+**What to do.** Fix the registration in the binary that made it. Nothing was created.
+
+| | |
+| --- | --- |
+| Exit code | `3` |
+| Retryable | No. Retrying the same operation unchanged will fail the same way. |
+| More | [contributing/provider-authoring](/docs/contributing/provider-authoring) |
+
+### AF-EXT-002
+
+The registered {socket} {name} returned nothing and reported no error.
+
+**What to do.** Fix the registration to return either something usable or an error saying why it could not. Nothing was created.
+
+| | |
+| --- | --- |
+| Exit code | `3` |
+| Retryable | No. Retrying the same operation unchanged will fail the same way. |
+| More | [contributing/provider-authoring](/docs/contributing/provider-authoring) |
+
 ## Fidelity
 
 ### AF-FID-001

--- a/ee/engine/cmd/af/sockets_test.go
+++ b/ee/engine/cmd/af/sockets_test.go
@@ -1,0 +1,238 @@
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+
+package main_test
+
+// The proof that the engine's extension sockets can be implemented from
+// outside the engine module, made by a module that is outside it.
+//
+// It is here rather than in the engine's own test suite because the engine's
+// suite cannot make it. Inside engine/... every internal package is
+// importable, so a socket whose signature names a type from engine/internal
+// compiles there and is unimplementable everywhere else, which is exactly the
+// defect engine/api/packages.txt records against provider.Database: its
+// ConnString returned a type from engine/internal/secrets, it compiled, it
+// reviewed as correct, and no provider outside this repository could have
+// implemented it. tools/socketcheck looks for that in the syntax tree. This
+// file is the compiler saying the same thing, from the only place that can
+// say it: a separate module, which is what every provider anybody writes will
+// also be.
+//
+// The assertions below are almost beside the point. The compile is the test.
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/pkg/extension"
+	"github.com/antifailure/antifailure/engine/pkg/provider"
+	"github.com/antifailure/antifailure/engine/pkg/secret"
+)
+
+// outsideDatabase registers a database provider from this module.
+type outsideDatabase struct{ seen extension.DatabaseConfig }
+
+func (*outsideDatabase) Name() string { return "outside" }
+
+func (p *outsideDatabase) Open(
+	ctx context.Context, cfg extension.DatabaseConfig,
+) (provider.Database, error) {
+	p.seen = cfg
+	// Every field a provider is given can be named and used here, which is the
+	// half of the socket a signature check cannot prove: a credential is read
+	// through the engine's chain rather than out of the environment, and the
+	// manifest block arrives whole.
+	if cfg.Lookup != nil && cfg.Database.APIKeyEnv != "" {
+		if _, _, err := cfg.Lookup(ctx, cfg.Database.APIKeyEnv); err != nil {
+			return nil, err
+		}
+	}
+	_ = cfg.Now()
+	return nil, errors.New("outside: this fake builds no database")
+}
+
+// outsideDatastore registers a datastore provider from this module.
+type outsideDatastore struct{}
+
+func (outsideDatastore) Name() string   { return "outside-events" }
+func (outsideDatastore) Engine() string { return "clickhouse" }
+func (outsideDatastore) Open(
+	context.Context, extension.DatastoreConfig,
+) (extension.Datastore, error) {
+	return nil, extension.ErrNoGolden
+}
+
+// outsideRuntime registers a runtime from this module.
+type outsideRuntime struct{ seen extension.RuntimeConfig }
+
+func (*outsideRuntime) Name() string { return "outside-runtime" }
+
+func (p *outsideRuntime) Open(
+	ctx context.Context, cfg extension.RuntimeConfig,
+) (provider.Runtime, error) {
+	p.seen = cfg
+	// A runtime that places containers off this machine cannot build the
+	// egress sidecar and must not run without one, so the engine hands it the
+	// resolver rather than an image. Naming it here is the check that it can
+	// be called from outside the module at all.
+	if cfg.ResolveProxyImage == nil {
+		return nil, errors.New("outside: no sidecar image is obtainable")
+	}
+	_ = cfg.TTL
+	return nil, errors.New("outside: this fake places nothing")
+}
+
+// outsideStore registers a golden store from this module.
+type outsideStore struct{}
+
+func (outsideStore) Name() string { return "outside-bucket" }
+
+func (outsideStore) Open(cfg extension.ObjectStoreConfig) (extension.ObjectStore, error) {
+	return &outsideObjects{url: cfg.URL, objects: map[string][]byte{}}, nil
+}
+
+type outsideObjects struct {
+	url     string
+	objects map[string][]byte
+}
+
+func (o *outsideObjects) Name() string { return "outside-bucket at " + o.url }
+
+func (o *outsideObjects) Put(_ context.Context, name string, _ int64, body io.Reader) error {
+	b, err := io.ReadAll(body)
+	if err != nil {
+		return err
+	}
+	o.objects[name] = b
+	return nil
+}
+
+func (o *outsideObjects) Get(_ context.Context, name string) (io.ReadCloser, error) {
+	if _, ok := o.objects[name]; !ok {
+		// The sentinel this module can name. A store that could not name one
+		// would have to invent an error, and every absent golden would read
+		// as a broken store.
+		return nil, extension.ErrObjectNotFound
+	}
+	return io.NopCloser(newReader(o.objects[name])), nil
+}
+
+func (o *outsideObjects) List(context.Context, string) ([]extension.StoredObject, error) {
+	out := make([]extension.StoredObject, 0, len(o.objects))
+	for name, b := range o.objects {
+		out = append(out, extension.StoredObject{
+			Name: name, Size: int64(len(b)), Modified: time.Unix(0, 0).UTC(),
+		})
+	}
+	return out, nil
+}
+
+func (o *outsideObjects) Delete(_ context.Context, name string) error {
+	delete(o.objects, name)
+	return nil
+}
+
+func newReader(b []byte) io.Reader { return &sliceReader{b: b} }
+
+type sliceReader struct {
+	b []byte
+	n int
+}
+
+func (r *sliceReader) Read(p []byte) (int, error) {
+	if r.n >= len(r.b) {
+		return 0, io.EOF
+	}
+	n := copy(p, r.b[r.n:])
+	r.n += n
+	return n, nil
+}
+
+// outsideEmulator registers an emulator from this module.
+type outsideEmulator struct{}
+
+func (outsideEmulator) Name() string    { return "outside-s3" }
+func (outsideEmulator) Hosts() []string { return []string{"s3.amazonaws.com"} }
+func (outsideEmulator) Container() extension.EmulatorContainer {
+	return extension.EmulatorContainer{
+		Image: "localstack/localstack@sha256:" +
+			"0000000000000000000000000000000000000000000000000000000000000000",
+		Port: 4566,
+	}
+}
+
+func TestEverySocketCanBeImplementedFromOutsideTheEngineModule(t *testing.T) {
+	t.Parallel()
+
+	db := &outsideDatabase{}
+	rt := &outsideRuntime{}
+
+	r := extension.NewRegistry()
+	r.AddDatabaseProvider(db)
+	r.AddDatastoreProvider(outsideDatastore{})
+	r.AddRuntimeProvider(rt)
+	r.AddGoldenStore(outsideStore{})
+	r.AddEmulator(outsideEmulator{})
+
+	require.Equal(t, []string{
+		"database-provider:outside",
+		"datastore-provider:outside-events",
+		"emulator:outside-s3",
+		"golden-store:outside-bucket",
+		"runtime:outside-runtime",
+	}, r.Registered())
+	require.NoError(t, r.Validate(map[string][]string{
+		extension.SocketDatabaseProvider: {"docker", "neon", "supabase", "dblab"},
+		extension.SocketRuntimeProvider:  {"local", "kubernetes"},
+		extension.SocketGoldenStore:      {"local", "azure_blob", "s3"},
+	}))
+
+	found, ok := r.DatabaseProviderNamed("outside")
+	require.True(t, ok)
+	require.Equal(t, "outside", found.Name())
+
+	// The store round trips through the interface the engine holds, including
+	// the sentinel, from this module.
+	store, err := outsideStore{}.Open(extension.ObjectStoreConfig{URL: "outside://bucket"})
+	require.NoError(t, err)
+	require.NoError(t, store.Put(context.Background(), "gv_1.sql", 3, newReader([]byte("abc"))))
+	body, err := store.Get(context.Background(), "gv_1.sql")
+	require.NoError(t, err)
+	defer func() { _ = body.Close() }()
+	got, err := io.ReadAll(body)
+	require.NoError(t, err)
+	require.Equal(t, "abc", string(got))
+
+	_, err = store.Get(context.Background(), "absent")
+	require.ErrorIs(t, err, extension.ErrObjectNotFound)
+
+	// And a value the engine would hand back is nameable here too, which is
+	// the property that was broken in provider.Database once already.
+	var value secret.Value = secret.New("postgres://example")
+	require.Equal(t, secret.Redacted, value.String())
+}
+
+func TestARegistrationThisBuildCannotHonorIsRefused(t *testing.T) {
+	t.Parallel()
+	// The refusal a build gets for its own mistake, checked from the module
+	// that would make it. Registering under a name the engine already has
+	// would never be selected, because the engine asks the registry only after
+	// its own switch.
+	r := extension.NewRegistry()
+	r.AddGoldenStore(shadowingStore{})
+
+	err := r.Validate(map[string][]string{extension.SocketGoldenStore: {"local", "s3"}})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot replace")
+}
+
+type shadowingStore struct{}
+
+func (shadowingStore) Name() string { return "s3" }
+func (shadowingStore) Open(extension.ObjectStoreConfig) (extension.ObjectStore, error) {
+	return nil, errors.New("never reached")
+}

--- a/engine/internal/cli/env.go
+++ b/engine/internal/cli/env.go
@@ -178,7 +178,7 @@ type environment struct {
 }
 
 func listEnvironments(ctx context.Context, e *Env) ([]environment, error) {
-	rt, err := inventoryRuntime(e)
+	rt, err := inventoryRuntime(ctx, e)
 	if err != nil {
 		return nil, err
 	}
@@ -382,7 +382,7 @@ reaches every project's environments. For a sweep that reads each
 environment's own lifetime instead, see af env reap.`),
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			rt, err := inventoryRuntime(e)
+			rt, err := inventoryRuntime(cmd.Context(), e)
 			if err != nil {
 				return err
 			}
@@ -577,9 +577,9 @@ func contains(items []string, want string) bool {
 // runtime: with runtime.provider set to kubernetes, the environments are
 // namespaces on a cluster and there is nothing on the local daemon to find. A
 // manifest is what says which, so it is read when there is one.
-func inventoryRuntime(e *Env) (provider.Runtime, error) {
+func inventoryRuntime(ctx context.Context, e *Env) (provider.Runtime, error) {
 	if o, _, err := orchestratorWithManifest(e, ""); err == nil {
-		return o.Runtime()
+		return o.Runtime(ctx)
 	}
 	// Outside a repository there is no manifest to ask, and the only runtime
 	// that could be holding anything on this machine is the local one.

--- a/engine/internal/cli/lifecycle.go
+++ b/engine/internal/cli/lifecycle.go
@@ -455,7 +455,7 @@ interrupt at any point leaves something af down can clean up.`),
 // Silent on every failure of its own. This runs while a command is already
 // failing, and a second error about the reporter would bury the first.
 func reportStanding(ctx context.Context, e *Env, o *env.Orchestrator) {
-	rt, err := o.Runtime()
+	rt, err := o.Runtime(ctx)
 	if err != nil {
 		return
 	}

--- a/engine/internal/env/env.go
+++ b/engine/internal/env/env.go
@@ -36,6 +36,7 @@ import (
 	"github.com/antifailure/antifailure/engine/internal/envcert"
 	aferrors "github.com/antifailure/antifailure/engine/internal/errors"
 	"github.com/antifailure/antifailure/engine/internal/events"
+	"github.com/antifailure/antifailure/engine/internal/golden"
 	"github.com/antifailure/antifailure/engine/internal/journal"
 	"github.com/antifailure/antifailure/engine/internal/lock"
 	"github.com/antifailure/antifailure/engine/internal/manifest"
@@ -392,6 +393,18 @@ func (o *Orchestrator) open(ctx context.Context, command string) (*session, erro
 // environment it was most certainly meant to take. It takes a lock named for
 // the sweep instead, which also stops two sweeps from running at once.
 func (o *Orchestrator) openLocking(ctx context.Context, command, lockName string) (*session, error) {
+	// Before the lock and before anything is created, because a registration
+	// this build cannot honor is a defect in the build rather than in the run,
+	// and the cheapest moment to say so is the first command. It costs one
+	// call over empty slices in the community build, which registers nothing.
+	//
+	// Here rather than at registration time because registration is a plain
+	// Add with no error to return, and because the reserved names it is
+	// checked against are the engine's, not the registry's.
+	if err := o.extensions().Validate(reservedProviderNames()); err != nil {
+		return nil, aferrors.Coded(aferrors.AFEXT001, "detail", err.Error())
+	}
+
 	s := &session{}
 	stateDir := filepath.Join(o.opts.Root, StateDir)
 	if err := os.MkdirAll(stateDir, 0o755); err != nil {
@@ -453,7 +466,7 @@ func (o *Orchestrator) openLocking(ctx context.Context, command, lockName string
 		s.close()
 		return nil, err
 	}
-	if s.runtime, err = o.newRuntime(); err != nil {
+	if s.runtime, err = o.newRuntime(ctx); err != nil {
 		s.close()
 		return nil, err
 	}
@@ -484,6 +497,9 @@ func (o *Orchestrator) openLocking(ctx context.Context, command, lockName string
 // cannot write. Anything that can, MaskApply, DestroyGolden, MaskPreview
 // through the masking key it may mint, stays on open.
 func (o *Orchestrator) openReading(ctx context.Context) (*session, error) {
+	if err := o.extensions().Validate(reservedProviderNames()); err != nil {
+		return nil, aferrors.Coded(aferrors.AFEXT001, "detail", err.Error())
+	}
 	s := &session{}
 	stateDir := filepath.Join(o.opts.Root, StateDir)
 	if err := os.MkdirAll(stateDir, 0o755); err != nil {
@@ -515,10 +531,7 @@ func (o *Orchestrator) secretChain() *secrets.Chain {
 	if getenv == nil {
 		getenv = os.Getenv
 	}
-	registry := o.opts.Extensions
-	if registry == nil {
-		registry = extension.Default
-	}
+	registry := o.extensions()
 
 	// One constructor, shared with af explain and with model key resolution, so
 	// that a command whose job is to say where a value will come from cannot
@@ -799,7 +812,7 @@ func (o *Orchestrator) ttl() time.Duration {
 // af webhook trigger all asked this machine's Docker daemon about it and
 // found nothing. They agreed only because this function refused everything
 // except local.
-func (o *Orchestrator) newRuntime() (provider.Runtime, error) {
+func (o *Orchestrator) newRuntime(ctx context.Context) (provider.Runtime, error) {
 	kind := schema.RuntimeLocal
 	var cfg *schema.Runtime
 	if m := o.opts.Manifest; m != nil && m.Runtime != nil {
@@ -817,19 +830,95 @@ func (o *Orchestrator) newRuntime() (provider.Runtime, error) {
 	case schema.RuntimeKubernetes:
 		return o.newKubernetesRuntime(cfg)
 	default:
+		// A registered runtime is consulted here, after the built-in ones and
+		// never before them, so a registration adds a place environments can
+		// run and can never take over local or kubernetes. A registration
+		// under one of those names is refused by the registry's own validation
+		// rather than quietly losing to this switch.
+		if p, ok := o.extensions().RuntimeProviderNamed(string(kind)); ok {
+			rt, err := p.Open(ctx, extension.RuntimeConfig{
+				Root:              o.opts.Root,
+				Runtime:           runtimeConfigOf(cfg),
+				TTL:               o.ttl(),
+				StateDir:          filepath.Join(o.opts.Root, StateDir),
+				Now:               o.opts.Clock.Now,
+				Lookup:            o.lookupForProvider,
+				ResolveProxyImage: o.resolveProxyImage,
+			})
+			if err != nil {
+				return nil, err
+			}
+			if rt == nil {
+				// Assigned, checked, and returned explicitly for the reason
+				// written out over newDatabaseProvider's switch: a nil pointer
+				// in a non-nil interface passes every nil guard the caller has
+				// and crashes in Close.
+				return nil, aferrors.Coded(aferrors.AFEXT002,
+					"socket", extension.SocketRuntimeProvider, "name", string(kind))
+			}
+			return rt, nil
+		}
 		return nil, aferrors.Coded(aferrors.AFMAN002,
 			"path", filepath.Join(o.opts.Root, "antifailure.yaml"),
 			"detail", fmt.Sprintf(
-				"runtime.provider is %q, and this build has the local and kubernetes "+
-					"runtimes. Remove the field or set it to one of those", kind))
+				"runtime.provider is %q, and this build has %s. Remove the field or set "+
+					"it to one of those", kind, listNames(o.runtimeNames())))
 	}
+}
+
+// runtimeNames is every runtime this build can select, built in and registered.
+//
+// The refusal above says what there IS and not only what there is not, and it
+// has to include the registered ones or a build that registered a runtime and
+// then misspelled it in the manifest is told the name is wrong by a message
+// that does not mention the runtime it has.
+func (o *Orchestrator) runtimeNames() []string {
+	out := []string{string(schema.RuntimeLocal), string(schema.RuntimeKubernetes)}
+	return append(out, o.extensions().RuntimeProviderNames()...)
+}
+
+// runtimeConfigOf copies the manifest's runtime block for a registered runtime.
+//
+// A copy rather than the pointer, so a registration cannot edit the manifest
+// the engine goes on reading after it has been built.
+func runtimeConfigOf(cfg *schema.Runtime) schema.Runtime {
+	if cfg == nil {
+		return schema.Runtime{}
+	}
+	return *cfg
+}
+
+// listNames renders a list of names for a sentence a person reads.
+func listNames(names []string) string {
+	switch len(names) {
+	case 0:
+		return "none"
+	case 1:
+		return names[0]
+	}
+	return strings.Join(names[:len(names)-1], ", ") + " and " + names[len(names)-1]
+}
+
+// lookupForProvider resolves a declared credential for a registered provider.
+//
+// Through the engine's own chain rather than the process environment, so that
+// a registered provider's credentials are declared and auditable in exactly
+// the way a built-in provider's are, and so that a registered SecretSource
+// serves them too.
+func (o *Orchestrator) lookupForProvider(
+	ctx context.Context, name string,
+) (secrets.Value, bool, error) {
+	value, _, found, err := o.secretChain().Lookup(ctx, name)
+	return value, found, err
 }
 
 // Runtime builds the runtime this manifest asks for.
 //
 // Exported for the commands that inventory a machine rather than act on one
 // environment, which need the same selection and are not part of a lifecycle.
-func (o *Orchestrator) Runtime() (provider.Runtime, error) { return o.newRuntime() }
+func (o *Orchestrator) Runtime(ctx context.Context) (provider.Runtime, error) {
+	return o.newRuntime(ctx)
+}
 
 // newKubernetesRuntime builds the cluster runtime, including finding it a
 // sidecar image.
@@ -1024,13 +1113,55 @@ func (o *Orchestrator) newDatabaseProvider(ctx context.Context) (provider.Databa
 		})
 
 	default:
+		// A registered provider is consulted here, after every built-in one
+		// and never before them, so a registration adds a provider and can
+		// never take one over. A registration under a built-in name is refused
+		// by the registry's own validation rather than quietly losing to this
+		// switch, because a build that believes it has replaced the Docker
+		// provider and has not is worse than one that will not start.
+		if p, ok := o.extensions().DatabaseProviderNamed(string(kind)); ok {
+			db := schema.Database{}
+			if m != nil && m.Database != nil {
+				db = *m.Database
+			}
+			built, err := p.Open(ctx, extension.DatabaseConfig{
+				Root:     o.opts.Root,
+				Database: db,
+				Version:  databaseVersion(m),
+				StateDir: filepath.Join(o.opts.Root, StateDir),
+				Now:      o.opts.Clock.Now,
+				Lookup:   o.lookupForProvider,
+			})
+			if err != nil {
+				return nil, err
+			}
+			if built == nil {
+				// The same explicit nil check every case above makes, for the
+				// reason written over the switch: a nil pointer in a non-nil
+				// interface passes the caller's guard and crashes in Close.
+				return nil, aferrors.Coded(aferrors.AFEXT002,
+					"socket", extension.SocketDatabaseProvider, "name", string(kind))
+			}
+			return built, nil
+		}
 		// Named in the schema and not built here. Saying so is better than
 		// quietly falling back to Docker, which would hand somebody an empty
 		// preview and no reason for it.
 		return nil, aferrors.Coded(aferrors.AFMAN002,
 			"path", filepath.Join(o.opts.Root, "antifailure.yaml"),
-			"detail", fmt.Sprintf("database.provider is %q, which this build does not have", kind))
+			"detail", fmt.Sprintf(
+				"database.provider is %q, which this build does not have. It has %s",
+				kind, listNames(o.databaseProviderNames())))
 	}
+}
+
+// databaseProviderNames is every provider this build can select.
+func (o *Orchestrator) databaseProviderNames() []string {
+	out := []string{
+		string(schema.DBDocker), string(schema.DBNeon),
+		string(schema.DBSupabase), string(schema.DBDBLab),
+	}
+	return append(out, o.extensions().DatabaseProviderNames()...)
 }
 
 // pickGolden chooses the version a branch is made from.
@@ -1094,6 +1225,44 @@ func databaseVersion(m *schema.Manifest) int {
 	return 17
 }
 
+// extensions is the registry this orchestrator consults.
+//
+// Nil means the process wide one, which in the community build is empty, so
+// every consult costs one function call over an empty slice. One accessor
+// rather than the same three lines at each site, because a site that forgot
+// the fallback would consult a registry nothing had ever registered into and
+// report that nothing was plugged in.
+func (o *Orchestrator) extensions() *extension.Registry {
+	if o.opts.Extensions != nil {
+		return o.opts.Extensions
+	}
+	return extension.Default
+}
+
+// reservedProviderNames are the names this build already answers to.
+//
+// Passed to the registry's validation so that a registration under one of them
+// is refused rather than ignored. The engine consults the registry only after
+// its own switch, so an ignored registration is a build somebody believes
+// overrides the Docker provider and which silently does not.
+//
+// Built from the schema's constants rather than written out again, so a
+// provider added to the engine cannot be left off this list.
+func reservedProviderNames() map[string][]string {
+	return map[string][]string{
+		extension.SocketDatabaseProvider: {
+			string(schema.DBDocker), string(schema.DBNeon),
+			string(schema.DBSupabase), string(schema.DBDBLab),
+		},
+		extension.SocketRuntimeProvider: {
+			string(schema.RuntimeLocal), string(schema.RuntimeKubernetes),
+		},
+		extension.SocketGoldenStore: {
+			string(golden.KindLocal), string(golden.KindAzureBlob), string(golden.KindS3),
+		},
+	}
+}
+
 // checkPolicy asks the registered hooks whether this environment may exist.
 //
 // The community build registers nothing, so this returns nil after one call
@@ -1101,10 +1270,7 @@ func databaseVersion(m *schema.Manifest) int {
 // the socket has to be in the thing being extended, and because a hook that
 // only exists in a build nobody runs is a hook nobody has tested.
 func (o *Orchestrator) checkPolicy(ctx context.Context) error {
-	registry := o.opts.Extensions
-	if registry == nil {
-		registry = extension.Default
-	}
+	registry := o.extensions()
 	if registry.Empty() {
 		return nil
 	}
@@ -2242,10 +2408,7 @@ func (o *Orchestrator) teardown(ctx context.Context, s *session, envID string) *
 // becomes a resource leak, which is a strictly worse problem than a missing
 // meter reading.
 func (o *Orchestrator) observe(ctx context.Context, event extension.LifecycleEvent) {
-	registry := o.opts.Extensions
-	if registry == nil {
-		registry = extension.Default
-	}
+	registry := o.extensions()
 	if registry.Empty() {
 		return
 	}
@@ -2256,7 +2419,7 @@ func (o *Orchestrator) observe(ctx context.Context, event extension.LifecycleEve
 
 // Status reports what is currently running.
 func (o *Orchestrator) Status(ctx context.Context) (*Result, error) {
-	rt, err := o.newRuntime()
+	rt, err := o.newRuntime(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -2313,7 +2476,7 @@ func (o *Orchestrator) orderByManifest(running []provider.RunningService) {
 
 // Decisions returns what the environment's egress proxy has decided.
 func (o *Orchestrator) Decisions(ctx context.Context, limit int) ([]local.Decision, error) {
-	rt, err := o.sidecarRuntime()
+	rt, err := o.sidecarRuntime(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -2325,7 +2488,7 @@ func (o *Orchestrator) Decisions(ctx context.Context, limit int) ([]local.Decisi
 
 // Messages returns what the environment captured instead of sending.
 func (o *Orchestrator) Messages(ctx context.Context, limit int) ([]local.Message, error) {
-	rt, err := o.sidecarRuntime()
+	rt, err := o.sidecarRuntime(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -2337,7 +2500,7 @@ func (o *Orchestrator) Messages(ctx context.Context, limit int) ([]local.Message
 func (o *Orchestrator) WaitForMessage(
 	ctx context.Context, to, subject string, timeout time.Duration,
 ) (local.Message, error) {
-	rt, err := o.sidecarRuntime()
+	rt, err := o.sidecarRuntime(ctx)
 	if err != nil {
 		return local.Message{}, err
 	}
@@ -2367,7 +2530,7 @@ func (o *Orchestrator) WaitForMessage(
 func (o *Orchestrator) DeliverWebhook(
 	ctx context.Context, service, path string, body []byte, headers map[string]string,
 ) (local.Delivery, error) {
-	rt, err := o.sidecarRuntime()
+	rt, err := o.sidecarRuntime(ctx)
 	if err != nil {
 		return local.Delivery{}, err
 	}
@@ -2377,7 +2540,7 @@ func (o *Orchestrator) DeliverWebhook(
 
 // Logs returns recent output from the environment's services.
 func (o *Orchestrator) Logs(ctx context.Context, service string, tail int) ([]provider.LogLine, error) {
-	rt, err := o.newRuntime()
+	rt, err := o.newRuntime(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -2419,8 +2582,8 @@ type observingRuntime struct {
 
 // sidecarRuntime builds the selected runtime and requires that it can answer
 // questions about its sidecar.
-func (o *Orchestrator) sidecarRuntime() (observingRuntime, error) {
-	rt, err := o.newRuntime()
+func (o *Orchestrator) sidecarRuntime(ctx context.Context) (observingRuntime, error) {
+	rt, err := o.newRuntime(ctx)
 	if err != nil {
 		return observingRuntime{}, err
 	}

--- a/engine/internal/env/fidelity.go
+++ b/engine/internal/env/fidelity.go
@@ -53,7 +53,7 @@ func (o *Orchestrator) Fidelity(ctx context.Context) (fidelity.Inventory, error)
 
 // observeRuntime asks the runtime what is running.
 func (o *Orchestrator) observeRuntime(ctx context.Context, obs *fidelity.Observation) {
-	rt, err := o.newRuntime()
+	rt, err := o.newRuntime(ctx)
 	if err != nil {
 		obs.Runtime = "a runtime that could not be built"
 		obs.ServicesReason = "the runtime could not be reached: " + oneLine(err)

--- a/engine/internal/env/goldenstore.go
+++ b/engine/internal/env/goldenstore.go
@@ -43,7 +43,8 @@ func (o *Orchestrator) goldenStore() (golden.Store, error) {
 	if getenv == nil {
 		getenv = os.Getenv
 	}
-	s, err := golden.OpenStore(golden.Kind(db.Golden.Storage), db.Golden.StorageURL, getenv)
+	s, err := golden.OpenStore(
+		golden.Kind(db.Golden.Storage), db.Golden.StorageURL, getenv, o.extensions())
 	if err != nil {
 		return nil, aferrors.Coded(aferrors.AFDB011, "detail", err.Error())
 	}

--- a/engine/internal/env/goldenstore_test.go
+++ b/engine/internal/env/goldenstore_test.go
@@ -243,7 +243,7 @@ func TestPull_RefusesAVersionWhosePublishDidNotFinish(t *testing.T) {
 	defer cancel()
 
 	storeDir := t.TempDir()
-	store, err := golden.OpenStore(golden.KindLocal, storeDir, nil)
+	store, err := golden.OpenStore(golden.KindLocal, storeDir, nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, store.Put(ctx, golden.DumpName("gv_halfpublished"), 3,
 		strings.NewReader("abc")))

--- a/engine/internal/env/provider_selection_test.go
+++ b/engine/internal/env/provider_selection_test.go
@@ -13,6 +13,8 @@ import (
 	supabasedb "github.com/antifailure/antifailure/engine/internal/db/supabase"
 	aferrors "github.com/antifailure/antifailure/engine/internal/errors"
 	"github.com/antifailure/antifailure/engine/internal/secrets"
+	"github.com/antifailure/antifailure/engine/pkg/extension"
+	"github.com/antifailure/antifailure/engine/pkg/provider"
 	"github.com/antifailure/antifailure/engine/pkg/schema"
 )
 
@@ -238,7 +240,7 @@ func TestARuntimeThisBuildDoesNotHaveIsRefusedRatherThanSubstituted(t *testing.T
 	})
 	require.NoError(t, err)
 
-	_, err = o.newRuntime()
+	_, err = o.newRuntime(context.Background())
 	require.Error(t, err)
 	require.ErrorIs(t, err, aferrors.Coded(aferrors.AFMAN002))
 	require.Contains(t, err.Error(), "nomad")
@@ -261,7 +263,7 @@ func TestTheKubernetesRuntimeIsBuiltRatherThanRefused(t *testing.T) {
 	// nothing on the rest. What IS asserted is the thing this build changed:
 	// kubernetes is no longer refused as a runtime this build does not have.
 	// Anything else it fails with is a fact about the machine.
-	rt, err := o.newRuntime()
+	rt, err := o.newRuntime(context.Background())
 	if err != nil {
 		require.NotErrorIs(t, err, aferrors.Coded(aferrors.AFMAN002),
 			"kubernetes was refused as a runtime this build does not have, and it has it")
@@ -286,7 +288,7 @@ func TestAnUnsetRuntimeIsLocal(t *testing.T) {
 			Clock:    clock.New(),
 		})
 		require.NoError(t, err)
-		r, err := o.newRuntime()
+		r, err := o.newRuntime(context.Background())
 		if err != nil {
 			// No Docker daemon on this machine is a different failure from the
 			// manifest being refused, and only the second is under test here.
@@ -296,4 +298,123 @@ func TestAnUnsetRuntimeIsLocal(t *testing.T) {
 		require.NotNil(t, r)
 		_ = r.Close()
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Registered providers.
+//
+// Everything above this line is about the providers this build carries. These
+// are about the ones it does not: a build outside this repository registers a
+// provider through engine/pkg/extension, and the selection above has to reach
+// it. Before this the switches ended at a default that refused, so the only
+// way to add a provider was to edit this file.
+
+func TestARegisteredDatabaseProviderIsBuiltWhenTheManifestNamesIt(t *testing.T) {
+	db := newFakeDB("acmedb")
+	reg := extension.NewRegistry()
+	reg.AddDatabaseProvider(&fakeDBProvider{name: "acmedb", db: db})
+
+	o := orchestrator(t, &schema.Database{Provider: "acmedb"}, nil)
+	o.opts.Extensions = reg
+
+	p, err := o.newDatabaseProvider(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "acmedb", p.Name())
+	require.Equal(t, 1, db.opened)
+}
+
+func TestARegisteredRuntimeIsBuiltWhenTheManifestNamesIt(t *testing.T) {
+	rt := &fakeRT{name: "acmert"}
+	reg := extension.NewRegistry()
+	reg.AddRuntimeProvider(&fakeRTProvider{name: "acmert", rt: rt})
+
+	o, err := New(Options{
+		Root:     t.TempDir(),
+		Manifest: &schema.Manifest{Name: "app", Runtime: &schema.Runtime{Provider: "acmert"}},
+		Branch:   "main",
+		Clock:    clock.New(),
+	})
+	require.NoError(t, err)
+	o.opts.Extensions = reg
+
+	built, err := o.newRuntime(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "acmert", built.Name())
+}
+
+func TestARefusalNamesTheRegisteredProvidersAsWellAsTheBuiltInOnes(t *testing.T) {
+	// A build that registered a provider and then misspelled it in the
+	// manifest used to be told the name was wrong by a message that did not
+	// mention the provider the build has, which sends somebody looking for a
+	// registration that is already there.
+	// The name in the manifest is deliberately not a substring of the
+	// registered one and does not contain it. A near miss like "acmedbb"
+	// against "acmedb" passes this assertion from the quoted name alone, which
+	// is how this test first passed against a message that listed nothing.
+	reg := extension.NewRegistry()
+	reg.AddDatabaseProvider(&fakeDBProvider{name: "aurora", db: newFakeDB("aurora")})
+	reg.AddRuntimeProvider(&fakeRTProvider{name: "nomad", rt: &fakeRT{name: "nomad"}})
+
+	o := orchestrator(t, &schema.Database{Provider: "arora"}, nil)
+	o.opts.Extensions = reg
+	_, err := o.newDatabaseProvider(context.Background())
+	require.Error(t, err)
+	require.ErrorIs(t, err, aferrors.Coded(aferrors.AFMAN002))
+	require.Contains(t, err.Error(), "aurora",
+		"the refusal does not name the registered provider this build has")
+	require.Contains(t, err.Error(), "docker")
+
+	r, err := New(Options{
+		Root:     t.TempDir(),
+		Manifest: &schema.Manifest{Name: "app", Runtime: &schema.Runtime{Provider: "nmad"}},
+		Branch:   "main",
+		Clock:    clock.New(),
+	})
+	require.NoError(t, err)
+	r.opts.Extensions = reg
+	_, err = r.newRuntime(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "nomad",
+		"the refusal does not name the registered runtime this build has")
+	require.Contains(t, err.Error(), "kubernetes")
+}
+
+func TestARegistrationUnderABuiltInNameStopsTheCommandRatherThanBeingIgnored(t *testing.T) {
+	// The switches consult the registry only in their default, so a provider
+	// registered as "docker" would never be selected. Silently ignoring it is
+	// how somebody ships a build they believe replaces the Docker provider.
+	reg := extension.NewRegistry()
+	reg.AddDatabaseProvider(&fakeDBProvider{name: "docker", db: newFakeDB("docker")})
+
+	o := orchestrator(t, &schema.Database{Provider: schema.DBDocker}, nil)
+	o.opts.Extensions = reg
+
+	_, err := o.open(context.Background(), "af up")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "docker")
+	require.Contains(t, err.Error(), "cannot replace")
+}
+
+func TestAProviderThatReturnsNothingAndNoErrorIsReportedRatherThanDereferenced(t *testing.T) {
+	// The same defect the comment above newDatabaseProvider's switch describes,
+	// from the other side: a registration returning a nil interface would pass
+	// the caller's nil guard and crash in Close, and af down would segfault
+	// rather than say what was wrong.
+	reg := extension.NewRegistry()
+	reg.AddDatabaseProvider(&nilProvider{name: "hollow"})
+
+	o := orchestrator(t, &schema.Database{Provider: "hollow"}, nil)
+	o.opts.Extensions = reg
+	_, err := o.newDatabaseProvider(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "hollow")
+}
+
+type nilProvider struct{ name string }
+
+func (p *nilProvider) Name() string { return p.name }
+func (p *nilProvider) Open(
+	context.Context, extension.DatabaseConfig,
+) (provider.Database, error) {
+	return nil, nil
 }

--- a/engine/internal/env/registered_provider_test.go
+++ b/engine/internal/env/registered_provider_test.go
@@ -1,0 +1,280 @@
+package env
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/internal/clock"
+	"github.com/antifailure/antifailure/engine/internal/manifest"
+	"github.com/antifailure/antifailure/engine/internal/redact"
+	"github.com/antifailure/antifailure/engine/pkg/extension"
+	"github.com/antifailure/antifailure/engine/pkg/provider"
+	"github.com/antifailure/antifailure/engine/pkg/schema"
+	"github.com/antifailure/antifailure/engine/pkg/secret"
+)
+
+// A provider registered from outside this repository has to be a provider the
+// engine actually uses, not one it merely holds.
+//
+// The socket is worthless otherwise, and worse than worthless: a registry you
+// can add a provider to, consulted by nothing, looks exactly like a working
+// extension point from the outside and is the same shippable gap as a block
+// button that hides nothing. So this brings an environment up on a registered
+// database provider and a registered runtime, and takes it down again, which
+// is the only thing that proves the selection reaches the lifecycle.
+//
+// It needs no daemon and no database. The fakes answer for both, which is the
+// point: what is under test is the engine's selection and not a provider's own
+// behaviour, and a provider's own behaviour is what engine/conformance is for.
+
+// fakeDB is a database provider that is correct enough to bring an environment
+// up on and does nothing else.
+//
+// It does NOT call spec.Mask or spec.Verify, which a real provider must do and
+// which the conformance suite checks. Both connect to a candidate Postgres,
+// and a test that needed one would prove nothing more about the socket than
+// this does while skipping on every machine without a server.
+type fakeDB struct {
+	name     string
+	opened   int
+	goldens  []provider.GoldenVersion
+	branches map[string]provider.Branch
+	closed   bool
+}
+
+func newFakeDB(name string) *fakeDB {
+	return &fakeDB{name: name, branches: map[string]provider.Branch{}}
+}
+
+func (f *fakeDB) Name() string { return f.name }
+
+func (f *fakeDB) Capabilities() provider.Caps {
+	return provider.Caps{Branching: true, Subsetting: true, SupportedVersions: []int{16, 17}}
+}
+
+func (f *fakeDB) RefreshGolden(
+	_ context.Context, spec provider.GoldenSpec,
+) (provider.GoldenVersion, error) {
+	gv := provider.GoldenVersion{
+		ID:         fmt.Sprintf("gv_20260101000000_%08d", len(f.goldens)),
+		CreatedAt:  time.Unix(0, 0).UTC(),
+		RulesHash:  spec.RulesHash,
+		Provenance: spec.Provenance,
+		Verified:   true,
+	}
+	f.goldens = append(f.goldens, gv)
+	return gv, nil
+}
+
+func (f *fakeDB) ListGoldens(context.Context) ([]provider.GoldenVersion, error) {
+	return f.goldens, nil
+}
+
+func (f *fakeDB) DestroyGolden(context.Context, string) error { return nil }
+
+func (f *fakeDB) Branch(_ context.Context, version, envID string) (provider.Branch, error) {
+	if b, ok := f.branches[envID]; ok {
+		return b, nil
+	}
+	b := provider.Branch{EnvID: envID, From: version, ProviderRef: "branch-" + envID}
+	f.branches[envID] = b
+	return b, nil
+}
+
+func (f *fakeDB) Reset(context.Context, provider.Branch) error { return provider.ErrUnsupported }
+
+func (f *fakeDB) Destroy(_ context.Context, b provider.Branch) error {
+	delete(f.branches, b.EnvID)
+	return nil
+}
+
+func (f *fakeDB) ConnString(
+	_ context.Context, b provider.Branch, _ provider.ConnMode,
+) (secret.Value, error) {
+	return secret.New("postgres://fake/" + b.ProviderRef), nil
+}
+
+func (f *fakeDB) Inventory(context.Context) ([]provider.Resource, error) { return nil, nil }
+
+func (f *fakeDB) Health(context.Context, provider.Branch) (provider.Health, error) {
+	return provider.Health{Reachable: true}, nil
+}
+
+func (f *fakeDB) Close() error {
+	f.closed = true
+	return nil
+}
+
+// fakeDBProvider is the registration.
+type fakeDBProvider struct {
+	name string
+	db   *fakeDB
+	seen extension.DatabaseConfig
+}
+
+func (p *fakeDBProvider) Name() string { return p.name }
+
+func (p *fakeDBProvider) Open(
+	_ context.Context, cfg extension.DatabaseConfig,
+) (provider.Database, error) {
+	p.seen = cfg
+	p.db.opened++
+	return p.db, nil
+}
+
+// fakeRT is a runtime that records what it was asked to do.
+type fakeRT struct {
+	name string
+	ups  []provider.EnvSpec
+	down []string
+}
+
+func (f *fakeRT) Name() string { return f.name }
+
+func (f *fakeRT) Capabilities() provider.RuntimeCaps {
+	return provider.RuntimeCaps{Ingress: true}
+}
+
+func (f *fakeRT) Up(_ context.Context, spec provider.EnvSpec) (provider.Env, error) {
+	f.ups = append(f.ups, spec)
+	// Journalled before it is created, the same order a real runtime uses, so
+	// that an interrupt leaves something Down can remove.
+	for _, svc := range spec.Services {
+		if spec.Journal != nil {
+			if err := spec.Journal("container", spec.EnvID+"-"+svc.Name); err != nil {
+				return provider.Env{}, err
+			}
+		}
+	}
+	env := provider.Env{EnvID: spec.EnvID, ProxyReady: true}
+	for _, svc := range spec.Services {
+		env.Services = append(env.Services, provider.RunningService{
+			Name: svc.Name, Kind: svc.Kind, ContainerID: "fake-" + svc.Name,
+			URL: "http://127.0.0.1:1/" + svc.Name, Ready: true, State: "running",
+		})
+	}
+	return env, nil
+}
+
+func (f *fakeRT) Down(_ context.Context, envID string) (provider.Teardown, error) {
+	f.down = append(f.down, envID)
+	return provider.Teardown{Removed: 1}, nil
+}
+
+func (f *fakeRT) Status(_ context.Context, envID string) (provider.Env, error) {
+	return provider.Env{EnvID: envID}, nil
+}
+
+func (f *fakeRT) Inventory(context.Context) ([]provider.Resource, error) { return nil, nil }
+
+func (f *fakeRT) Close() error { return nil }
+
+// fakeRTProvider is the registration.
+type fakeRTProvider struct {
+	name string
+	rt   *fakeRT
+	seen extension.RuntimeConfig
+}
+
+func (p *fakeRTProvider) Name() string { return p.name }
+
+func (p *fakeRTProvider) Open(
+	_ context.Context, cfg extension.RuntimeConfig,
+) (provider.Runtime, error) {
+	p.seen = cfg
+	return p.rt, nil
+}
+
+const registeredManifest = `
+version: 1
+name: sockets
+services:
+  - name: web
+    kind: web
+    command: node server.js
+    port: 3000
+    build:
+      strategy: image
+      image: registry.invalid/web:1
+database:
+  provider: acmedb
+runtime:
+  provider: acmert
+  ttl: 30m
+`
+
+func registeredOrchestrator(t *testing.T, reg *extension.Registry) *Orchestrator {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "antifailure.yaml"),
+		[]byte(strings.TrimSpace(registeredManifest)+"\n"), 0o644))
+	m, err := manifest.Load(filepath.Join(dir, "antifailure.yaml"))
+	require.NoError(t, err)
+
+	o, err := New(Options{
+		Root: dir, Manifest: m, Branch: "feature/sockets",
+		Clock: clock.New(), Redactor: redact.New(),
+		Progress:   func(string) {},
+		Extensions: reg,
+		Getenv:     func(string) string { return "" },
+	})
+	require.NoError(t, err)
+	return o
+}
+
+func TestAnEnvironmentComesUpOnRegisteredProvidersAndGoesDownAgain(t *testing.T) {
+	db := newFakeDB("acmedb")
+	dbp := &fakeDBProvider{name: "acmedb", db: db}
+	rt := &fakeRT{name: "acmert"}
+	rtp := &fakeRTProvider{name: "acmert", rt: rt}
+
+	reg := extension.NewRegistry()
+	reg.AddDatabaseProvider(dbp)
+	reg.AddRuntimeProvider(rtp)
+
+	o := registeredOrchestrator(t, reg)
+	ctx := context.Background()
+
+	result, err := o.Up(ctx)
+	require.NoError(t, err)
+	require.Len(t, result.Services, 1)
+	require.Equal(t, "web", result.Services[0].Name)
+	require.NotEmpty(t, result.Golden, "the registered provider's golden was not used")
+
+	// The registered runtime is the one that ran it, not the local one.
+	require.Len(t, rt.ups, 1)
+	require.Equal(t, o.EnvID(), rt.ups[0].EnvID)
+	require.Equal(t, "registry.invalid/web:1", rt.ups[0].Services[0].Image)
+
+	// The registered database provider is the one that branched it, and the
+	// services were handed its connection string rather than a Docker one.
+	require.Len(t, db.branches, 1)
+	require.Contains(t, rt.ups[0].DatabaseURL.Reveal(), "postgres://fake/branch-")
+
+	// What the engine told each registration about itself.
+	require.Equal(t, o.opts.Root, dbp.seen.Root)
+	require.Equal(t, schema.DBProvider("acmedb"), dbp.seen.Database.Provider)
+	require.NotZero(t, dbp.seen.Version, "the Postgres major version was not resolved")
+	require.NotNil(t, dbp.seen.Lookup, "a registered provider cannot read a credential")
+	require.NotNil(t, dbp.seen.Now, "a registered provider was given no clock")
+	require.Equal(t, 30*time.Minute, rtp.seen.TTL, "runtime.ttl did not reach the runtime")
+	require.NotNil(t, rtp.seen.ResolveProxyImage,
+		"a registered runtime cannot obtain the egress sidecar, so it could only run without one")
+
+	down, err := o.Down(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, down)
+	// The environment itself, plus the two a rolling deploy check would have
+	// left beside it. Teardown asks the runtime for all three because a
+	// runtime that was only asked about the main one would strand the others.
+	require.Contains(t, rt.down, o.EnvID())
+	require.Empty(t, db.branches, "the registered provider's branch outlived the environment")
+	require.True(t, db.closed)
+}

--- a/engine/internal/errors/catalog.yaml
+++ b/engine/internal/errors/catalog.yaml
@@ -10,7 +10,8 @@
 #   area       MAN manifest, DET detection, SEC secrets, DB database,
 #              MSK masking, BLD build, RUN runtime, NET egress, AGT agent,
 #              LOD load, ORC differential oracle, GH GitHub, CP control plane,
-#              INF infrastructure, EE enterprise, SCH scheduling.
+#              INF infrastructure, EE enterprise, SCH scheduling,
+#              EXT extension registrations.
 #   message    One sentence naming what failed. Second person. {placeholders}
 #              are filled at the call site.
 #   next_step  One sentence saying what to do. Never "contact support".
@@ -1230,3 +1231,24 @@ errors:
     docs: concepts/workloads
     retryable: true
     exit_code: 9
+
+  # Extensions. A defect in the BUILD rather than in the repository being
+  # worked on: something registered a provider, a store or an emulator through
+  # engine/pkg/extension and the engine cannot honor the registration. The
+  # manifest and the environment are innocent, which is why these are not
+  # manifest codes, and the person who can fix it is whoever assembled the
+  # binary.
+  - code: AF-EXT-001
+    area: EXT
+    message: "This build cannot honor one of its own extension registrations: {detail}"
+    next_step: "Fix the registration in the binary that made it. Nothing was created."
+    docs: contributing/provider-authoring
+    retryable: false
+    exit_code: 3
+  - code: AF-EXT-002
+    area: EXT
+    message: "The registered {socket} {name} returned nothing and reported no error."
+    next_step: "Fix the registration to return either something usable or an error saying why it could not. Nothing was created."
+    docs: contributing/provider-authoring
+    retryable: false
+    exit_code: 3

--- a/engine/internal/errors/codes.gen.go
+++ b/engine/internal/errors/codes.gen.go
@@ -194,6 +194,14 @@ const (
 	// Organization policy {policy} refuses this environment: {detail}
 	AFEE010 Code = "AF-EE-010"
 
+	// Extensions
+	// This build cannot honor one of its own extension registrations:
+	// {detail}
+	AFEXT001 Code = "AF-EXT-001"
+	// The registered {socket} {name} returned nothing and reported no
+	// error.
+	AFEXT002 Code = "AF-EXT-002"
+
 	// Fidelity
 	// The environment does not reproduce {dimension}, which the manifest
 	// requires: {detail}
@@ -1091,6 +1099,24 @@ var catalog = map[Code]Entry{
 		Docs:      "enterprise/policy",
 		Retryable: false,
 		ExitCode:  ExitPolicyDenied,
+	},
+	AFEXT001: {
+		Code:      AFEXT001,
+		Area:      "EXT",
+		Message:   "This build cannot honor one of its own extension registrations: {detail}",
+		NextStep:  "Fix the registration in the binary that made it. Nothing was created.",
+		Docs:      "contributing/provider-authoring",
+		Retryable: false,
+		ExitCode:  ExitConfiguration,
+	},
+	AFEXT002: {
+		Code:      AFEXT002,
+		Area:      "EXT",
+		Message:   "The registered {socket} {name} returned nothing and reported no error.",
+		NextStep:  "Fix the registration to return either something usable or an error saying why it could not. Nothing was created.",
+		Docs:      "contributing/provider-authoring",
+		Retryable: false,
+		ExitCode:  ExitConfiguration,
 	},
 	AFFID001: {
 		Code:      AFFID001,

--- a/engine/internal/golden/store.go
+++ b/engine/internal/golden/store.go
@@ -3,10 +3,10 @@ package golden
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/url"
 	"strings"
-	"time"
+
+	"github.com/antifailure/antifailure/engine/pkg/extension"
 )
 
 // A Store is where a golden's dump and its attestation live when they live
@@ -21,31 +21,29 @@ import (
 // used. That ordering is the whole point: a dump on its own is a database
 // somebody could have put anything in, and the signed statement of what the
 // verification scan found is what makes it a golden rather than a file.
-type Store interface {
-	// Name identifies the store for a message.
-	Name() string
-	// Put writes an object, replacing one of the same name.
-	Put(ctx context.Context, name string, size int64, body io.Reader) error
-	// Get opens an object. A name that is not there returns ErrNotFound, so a
-	// caller can tell "no golden published yet" from "the store is broken",
-	// which are the same HTTP status on more than one service.
-	Get(ctx context.Context, name string) (io.ReadCloser, error)
-	// List returns the objects under a prefix.
-	List(ctx context.Context, prefix string) ([]Object, error)
-	// Delete removes an object. Removing one that is not there succeeds,
-	// because a retry after a timeout must not fail on the work it already did.
-	Delete(ctx context.Context, name string) error
-}
+//
+// The interface itself lives in engine/pkg/extension, and these are aliases
+// rather than a second declaration.
+//
+// A store is one of the things a build outside this repository may add, and an
+// interface declared in an internal package is one such a build cannot name,
+// let alone implement. Declaring it twice and adapting between them would work
+// and would be two definitions to keep in step, which is exactly how a
+// signature drifts. The alias is an alias and not a wrapper for the same
+// reason engine/internal/secrets keeps the name secrets.Value for a type that
+// lives in engine/pkg/secret: they are the same type to the compiler, so every
+// call site, struct field and type assertion in the engine keeps working and
+// no conversion exists to forget.
+type Store = extension.ObjectStore
 
 // Object is one thing in a store.
-type Object struct {
-	Name     string
-	Size     int64
-	Modified time.Time
-}
+type Object = extension.StoredObject
 
 // ErrNotFound is returned by Get for an object that is not there.
-var ErrNotFound = fmt.Errorf("golden: no such object")
+//
+// The same value a store outside this module returns, because that store
+// cannot import this package to name a sentinel declared here.
+var ErrNotFound = extension.ErrObjectNotFound
 
 // Kind names a storage backend, matching the manifest's values.
 type Kind string
@@ -69,9 +67,14 @@ const (
 // holds a credential. The credential stays in the environment: the URL names
 // the variable holding it, or carries a signature that is itself supplied
 // through one.
-func OpenStore(kind Kind, storageURL string, getenv func(string) string) (Store, error) {
+func OpenStore(
+	kind Kind, storageURL string, getenv func(string) string, reg *extension.Registry,
+) (Store, error) {
 	if getenv == nil {
 		getenv = func(string) string { return "" }
+	}
+	if reg == nil {
+		reg = extension.Default
 	}
 	raw := strings.TrimSpace(storageURL)
 	if raw == "" {
@@ -99,9 +102,41 @@ func OpenStore(kind Kind, storageURL string, getenv func(string) string) (Store,
 	case KindS3:
 		return newS3Store(raw, getenv)
 	default:
+		// Consulted after the built-in kinds and never before them, so a
+		// registration adds a place to publish and can never take over one of
+		// these. A registration under a built-in name is refused where the
+		// registry is validated rather than silently losing to this switch.
+		if s, ok := reg.GoldenStoreNamed(string(kind)); ok {
+			store, err := s.Open(extension.ObjectStoreConfig{URL: raw, Getenv: getenv})
+			if err != nil {
+				return nil, err
+			}
+			if store == nil {
+				// A nil interface here would reach every call site's nil
+				// guard as non-nil and fail inside a method. The engine's own
+				// providers assign, check and return an explicit nil for the
+				// same reason; this is that check for a store it did not
+				// write.
+				return nil, fmt.Errorf(
+					"golden: the registered store %q returned no store and no error", kind)
+			}
+			return store, nil
+		}
 		return nil, fmt.Errorf(
-			"golden: %q is not a storage kind; it is one of local, azure_blob, s3", kind)
+			"golden: %q is not a storage kind; it is one of %s",
+			kind, strings.Join(storageKinds(reg), ", "))
 	}
+}
+
+// storageKinds lists every kind this build can open, built-in and registered.
+//
+// The refusal says what there IS rather than only what there is not, because a
+// build that registered a store and then misspelled it in the manifest is
+// otherwise told the name is wrong by a message that does not mention the
+// store it has.
+func storageKinds(reg *extension.Registry) []string {
+	out := []string{string(KindLocal), string(KindAzureBlob), string(KindS3)}
+	return append(out, reg.GoldenStoreNames()...)
 }
 
 // envRef reads $NAME or ${NAME}, and reports whether the whole string was one.

--- a/engine/internal/golden/store_test.go
+++ b/engine/internal/golden/store_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -19,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/antifailure/antifailure/engine/internal/golden"
+	"github.com/antifailure/antifailure/engine/pkg/extension"
 )
 
 // Every backend runs the same suite, because the point of the interface is
@@ -129,7 +131,7 @@ func runStoreSuite(t *testing.T, open func(t *testing.T) golden.Store) {
 
 func TestLocalStore(t *testing.T) {
 	runStoreSuite(t, func(t *testing.T) golden.Store {
-		s, err := golden.OpenStore(golden.KindLocal, t.TempDir(), nil)
+		s, err := golden.OpenStore(golden.KindLocal, t.TempDir(), nil, nil)
 		require.NoError(t, err)
 		require.NotNil(t, s)
 		return s
@@ -148,11 +150,11 @@ func TestLocalStore_ReadsItsDirectoryFromTheEnvironment(t *testing.T) {
 		}
 		return ""
 	}
-	s, err := golden.OpenStore(golden.KindLocal, "$AF_GOLDEN_STORE", env)
+	s, err := golden.OpenStore(golden.KindLocal, "$AF_GOLDEN_STORE", env, nil)
 	require.NoError(t, err)
 	require.Contains(t, s.Name(), dir)
 
-	_, err = golden.OpenStore(golden.KindLocal, "$AF_NOT_SET_ANYWHERE", env)
+	_, err = golden.OpenStore(golden.KindLocal, "$AF_NOT_SET_ANYWHERE", env, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "AF_NOT_SET_ANYWHERE")
 	require.Contains(t, err.Error(), "not set on this machine")
@@ -162,11 +164,11 @@ func TestOpenStore_IsNothingWhenNothingIsConfigured(t *testing.T) {
 	t.Parallel()
 	// No storage_url means goldens live wherever the provider keeps them,
 	// which is the default and is not an error.
-	s, err := golden.OpenStore(golden.KindLocal, "", nil)
+	s, err := golden.OpenStore(golden.KindLocal, "", nil, nil)
 	require.NoError(t, err)
 	require.Nil(t, s)
 
-	_, err = golden.OpenStore("gopher_holes", "/tmp/x", nil)
+	_, err = golden.OpenStore("gopher_holes", "/tmp/x", nil, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "local, azure_blob, s3")
 }
@@ -175,17 +177,17 @@ func TestOpenStore_SaysWhatIsMissingFromARemoteURL(t *testing.T) {
 	t.Parallel()
 	// The message has to name the fix. "invalid URL" sends somebody to read
 	// the source; "the URL is the CONTAINER's" does not.
-	_, err := golden.OpenStore(golden.KindAzureBlob, "https://acct.blob.core.windows.net/", nil)
+	_, err := golden.OpenStore(golden.KindAzureBlob, "https://acct.blob.core.windows.net/", nil, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "names no container")
 
-	_, err = golden.OpenStore(golden.KindAzureBlob, "https://acct.blob.core.windows.net/goldens", nil)
+	_, err = golden.OpenStore(golden.KindAzureBlob, "https://acct.blob.core.windows.net/goldens", nil, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "shared access signature")
 
 	// And a message about a URL must not print the signature back out.
 	_, err = golden.OpenStore(golden.KindAzureBlob,
-		"ftp://acct.blob.core.windows.net/goldens?sig=SUPERSECRETSIGNATURE", nil)
+		"ftp://acct.blob.core.windows.net/goldens?sig=SUPERSECRETSIGNATURE", nil, nil)
 	require.Error(t, err)
 	require.NotContains(t, err.Error(), "SUPERSECRETSIGNATURE",
 		"a message about a URL never prints its credential")
@@ -193,7 +195,7 @@ func TestOpenStore_SaysWhatIsMissingFromARemoteURL(t *testing.T) {
 	// S3 signs with the environment's credential, and says so when it is not
 	// there rather than failing later with a 403.
 	_, err = golden.OpenStore(golden.KindS3, "s3://bucket/goldens",
-		func(string) string { return "" })
+		func(string) string { return "" }, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "AWS_ACCESS_KEY_ID")
 }
@@ -232,7 +234,7 @@ func TestS3Store(t *testing.T) {
 		// buckets is a product that quietly creates bills.
 		prefix := fmt.Sprintf("goldens-%d", time.Now().UnixNano())
 		s, err := golden.OpenStore(golden.KindS3,
-			fmt.Sprintf("%s/%s/%s", endpoint, bucket, prefix), env)
+			fmt.Sprintf("%s/%s/%s", endpoint, bucket, prefix), env, nil)
 		require.NoError(t, err)
 		return s
 	})
@@ -257,7 +259,7 @@ func TestAzureStore(t *testing.T) {
 		base := fmt.Sprintf("%s/%s/%s", endpoint, account, container)
 
 		require.NoError(t, makeContainer(base+"?restype=container&"+sas))
-		s, err := golden.OpenStore(golden.KindAzureBlob, base+"?"+sas, nil)
+		s, err := golden.OpenStore(golden.KindAzureBlob, base+"?"+sas, nil, nil)
 		require.NoError(t, err)
 		return s
 	})
@@ -346,4 +348,124 @@ func makeContainer(u string) error {
 	}
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
 	return fmt.Errorf("creating the container: %s: %s", resp.Status, body)
+}
+
+// ---------------------------------------------------------------------------
+// A store registered from outside this repository.
+
+// memStore is an object store that is not one of the three built in kinds.
+type memStore struct {
+	name    string
+	objects map[string][]byte
+}
+
+func (m *memStore) Name() string { return m.name }
+
+func (m *memStore) Put(_ context.Context, name string, _ int64, body io.Reader) error {
+	b, err := io.ReadAll(body)
+	if err != nil {
+		return err
+	}
+	m.objects[name] = b
+	return nil
+}
+
+func (m *memStore) Get(_ context.Context, name string) (io.ReadCloser, error) {
+	b, ok := m.objects[name]
+	if !ok {
+		// The sentinel a store outside this module can name, which is the
+		// same value golden.ErrNotFound is.
+		return nil, extension.ErrObjectNotFound
+	}
+	return io.NopCloser(bytes.NewReader(b)), nil
+}
+
+func (m *memStore) List(_ context.Context, prefix string) ([]golden.Object, error) {
+	var out []golden.Object
+	for name, b := range m.objects {
+		if strings.HasPrefix(name, prefix) {
+			out = append(out, golden.Object{Name: name, Size: int64(len(b))})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+func (m *memStore) Delete(_ context.Context, name string) error {
+	delete(m.objects, name)
+	return nil
+}
+
+type memStoreKind struct {
+	name string
+	seen extension.ObjectStoreConfig
+}
+
+func (k *memStoreKind) Name() string { return k.name }
+
+func (k *memStoreKind) Open(cfg extension.ObjectStoreConfig) (extension.ObjectStore, error) {
+	k.seen = cfg
+	// "registered" is in the name so that a test can tell this store from a
+	// built in one by more than the URL it was opened with, which both carry.
+	return &memStore{name: "registered " + k.name + " at " + cfg.URL, objects: map[string][]byte{}}, nil
+}
+
+func TestARegisteredStoreIsOpenedAndIsTheStoreTheEngineUses(t *testing.T) {
+	t.Parallel()
+	// The three built in kinds are the three this repository happens to have
+	// written. A fleet publishing to anything else had no way in short of
+	// editing this package, which is unimportable from outside the module.
+	kind := &memStoreKind{name: "gcs"}
+	reg := extension.NewRegistry()
+	reg.AddGoldenStore(kind)
+
+	s, err := golden.OpenStore("gcs", "gs://bucket/goldens", nil, reg)
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	require.Contains(t, s.Name(), "gs://bucket/goldens")
+	require.Equal(t, "gs://bucket/goldens", kind.seen.URL)
+
+	// And it is a golden.Store with no adapter in between: the interface is
+	// the one in engine/pkg/extension and this package's name for it is an
+	// alias, so a registered store satisfies every call site the engine has.
+	require.NoError(t, s.Put(context.Background(), "gv_1.sql", 3, strings.NewReader("abc")))
+	body, err := s.Get(context.Background(), "gv_1.sql")
+	require.NoError(t, err)
+	defer func() { _ = body.Close() }()
+	got, err := io.ReadAll(body)
+	require.NoError(t, err)
+	require.Equal(t, "abc", string(got))
+
+	_, err = s.Get(context.Background(), "missing")
+	require.ErrorIs(t, err, golden.ErrNotFound,
+		"a store outside this module cannot name golden.ErrNotFound, so every "+
+			"absent object would read as a broken store")
+}
+
+func TestAnUnregisteredKindIsRefusedAndTheRefusalListsWhatThereIs(t *testing.T) {
+	t.Parallel()
+	reg := extension.NewRegistry()
+	reg.AddGoldenStore(&memStoreKind{name: "gcs"})
+
+	_, err := golden.OpenStore("gcss", "gs://bucket/goldens", nil, reg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "local, azure_blob, s3, gcs",
+		"the refusal does not name the store this build has registered")
+}
+
+func TestABuiltInKindIsNeverTakenOverByARegistration(t *testing.T) {
+	t.Parallel()
+	// The registry is consulted after the built in kinds and never before
+	// them, so a registration cannot change where an existing manifest
+	// publishes. Registering one under a built in name is refused where the
+	// registry is validated; here what is proved is that the switch itself
+	// does not consult it first.
+	reg := extension.NewRegistry()
+	reg.AddGoldenStore(&memStoreKind{name: "local"})
+
+	dir := t.TempDir()
+	s, err := golden.OpenStore(golden.KindLocal, dir, nil, reg)
+	require.NoError(t, err)
+	require.Equal(t, "the directory "+dir, s.Name(),
+		"a registration took over the built in local store")
 }

--- a/engine/internal/mcp/tools_env.go
+++ b/engine/internal/mcp/tools_env.go
@@ -1656,7 +1656,7 @@ func (f *orchestratorFactory) inventory(ctx context.Context) ([]provider.Resourc
 	if err != nil {
 		return nil, err
 	}
-	rt, err := o.Runtime()
+	rt, err := o.Runtime(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/engine/pkg/extension/extension.go
+++ b/engine/pkg/extension/extension.go
@@ -19,8 +19,17 @@ package extension
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"io"
 	"sort"
+	"strings"
 	"sync"
+	"time"
+
+	"github.com/antifailure/antifailure/engine/pkg/provider"
+	"github.com/antifailure/antifailure/engine/pkg/schema"
+	"github.com/antifailure/antifailure/engine/pkg/secret"
 )
 
 // EnvironmentRequest is what a policy hook is asked about, before anything is
@@ -185,6 +194,306 @@ func (e *CredentialRejectedError) Error() string {
 
 func (e *CredentialRejectedError) Unwrap() error { return e.Err }
 
+// ---------------------------------------------------------------------------
+// Providers, stores and emulators.
+//
+// The four hooks above observe or refuse. The five sockets below SUPPLY: they
+// are how a build outside this repository adds a database provider, a second
+// datastore, a runtime, a place to publish goldens, or an emulated third party
+// service, without forking the engine.
+//
+// Before these existed the engine chose every one of those from a switch with
+// a default that refused, so the only way to add a provider was to edit
+// engine/internal/env, which is unimportable from outside the module and is
+// this repository's own source. "Extensible" meant "send us a patch".
+//
+// The same rule the hooks follow holds here and is the reason each socket is
+// consulted AFTER the built-in switch rather than instead of it: a
+// registration adds a choice and can never replace one. A registration whose
+// name is a built-in provider's name is refused rather than ignored, because
+// silently ignoring it is how somebody ships a build they believe overrides
+// the Docker provider and does not.
+//
+// A registered provider is subject to every check a built-in one is. Nothing
+// here is a way around masking, verification, provenance or the egress policy:
+// those live in the orchestrator, above the provider, and a provider is asked
+// for a database rather than trusted to say whether one is safe.
+
+// DatabaseConfig is what a registered database provider is given when a
+// manifest names it.
+//
+// The manifest block arrives as a COPY rather than a pointer. A provider that
+// could edit the manifest could change what an environment masks after
+// validation had already passed on it, and the engine reads these fields again
+// after the provider has been built.
+type DatabaseConfig struct {
+	// Root is the repository root, so a refusal can name the manifest that
+	// asked for this provider rather than describing it.
+	Root string
+	// Database is the manifest's database block, including Provider, Project,
+	// APIKeyEnv and MaxBranches.
+	Database schema.Database
+	// Version is the resolved Postgres major version, which is the manifest's
+	// value or the engine's default. Resolved here rather than in the provider
+	// so that two providers cannot disagree about what "unset" means.
+	Version int
+	// StateDir is where the provider may keep local files. It belongs to this
+	// repository's checkout, so a provider writing here does not leak state
+	// between projects on one machine.
+	StateDir string
+	// Now is the engine's clock. Library code in the engine never calls
+	// time.Now, so that TTLs and retries are testable without waiting for wall
+	// time, and a provider given this inherits that.
+	Now func() time.Time
+	// Lookup resolves a declared credential through the engine's whole chain:
+	// this shell's environment, .env, the encrypted local store, the keyring,
+	// and any registered SecretSource, in that order.
+	//
+	// Providers do not read the process environment themselves. That is what
+	// makes every credential a provider uses declared and auditable, and it is
+	// why found and err are separate returns: a variable that exists and is
+	// empty is not the same as one that is absent, and a store that could not
+	// be reached is neither.
+	Lookup func(ctx context.Context, name string) (secret.Value, bool, error)
+}
+
+// DatabaseProvider builds the database provider a manifest names.
+//
+// Name is the value database.provider takes. Open is called once per command,
+// and the provider it returns is closed when the command finishes.
+type DatabaseProvider interface {
+	// Name is the value database.provider takes in a manifest.
+	Name() string
+	// Open builds the provider. Returning a nil provider and a nil error is a
+	// contract violation the engine reports rather than dereferences.
+	Open(ctx context.Context, cfg DatabaseConfig) (provider.Database, error)
+}
+
+// DatastoreConfig is what a registered datastore provider is given.
+//
+// Settings rather than a manifest block, because the manifest has no
+// datastores list yet. When it gains one this grows a typed field beside
+// Settings rather than replacing it, so a provider written against this keeps
+// compiling.
+type DatastoreConfig struct {
+	// Root is the repository root.
+	Root string
+	// Name is the datastore's name in the environment, such as "events".
+	Name string
+	// StateDir is where the provider may keep local files.
+	StateDir string
+	// Settings carries provider specific values.
+	Settings map[string]string
+	// Now is the engine's clock.
+	Now func() time.Time
+	// Lookup resolves a declared credential, as DatabaseConfig.Lookup does.
+	Lookup func(ctx context.Context, name string) (secret.Value, bool, error)
+}
+
+// DatastoreCaps declares what a datastore can do, so that a suite skips a
+// behavior by name rather than passing one it never ran.
+type DatastoreCaps struct {
+	// Engine is the datastore engine, such as "clickhouse" or "redis".
+	Engine string
+	// Branching reports whether an environment can get its own copy.
+	Branching bool
+	// Golden reports whether the store can hold a masked, verified copy at
+	// all. A cache that is correct to start empty declares this false, and
+	// declaring it false is a legitimate answer rather than a missing feature.
+	Golden bool
+	// CopyOnWrite reports whether a branch shares storage with its golden, and
+	// therefore whether branch time is independent of size.
+	CopyOnWrite bool
+}
+
+// Datastore is a store other than the environment's primary Postgres.
+//
+// Deliberately smaller than provider.Database. A second datastore has no
+// pooled endpoint, no reset, and no golden pool of its own to enumerate; what
+// it has is a copy per environment and a way to say how faithful that copy is.
+//
+// It lives here rather than in engine/pkg/provider because the engine has no
+// datastore lifecycle yet: nothing in the manifest declares one and nothing in
+// the orchestrator branches one. When that lands the interface moves to
+// engine/pkg/provider beside Database and an alias stays here, the way
+// engine/internal/secrets keeps the name secrets.Value for a type that lives
+// in engine/pkg/secret. Until then, REGISTERING ONE DOES NOTHING BEYOND
+// APPEARING IN af license status: the registry holds it and no lifecycle asks
+// for it. That is said plainly because a socket nothing consults looks exactly
+// like a working feature from the outside, which is how this repository
+// shipped an audit sink that forwarded nothing.
+type Datastore interface {
+	// Name identifies the datastore in output and in errors.
+	Name() string
+	// Capabilities declares what this datastore can do.
+	Capabilities() DatastoreCaps
+	// RefreshGolden builds a new masked, verified copy. A datastore that
+	// declares Golden false returns ErrNoGolden.
+	RefreshGolden(ctx context.Context, spec provider.GoldenSpec) (provider.GoldenVersion, error)
+	// Branch creates this environment's copy. Calling it twice with the same
+	// environment identifier returns the same branch, the same idempotency
+	// contract provider.Database has and for the same reason: the engine
+	// retries after timeouts and a retry that creates a second resource is how
+	// an orphan is made.
+	Branch(ctx context.Context, version string, envID string) (provider.Branch, error)
+	// Destroy removes a branch. Removing one that is already gone succeeds.
+	Destroy(ctx context.Context, b provider.Branch) error
+	// ConnString returns how to reach a branch, as a value that renders as
+	// [redacted] everywhere text is produced.
+	ConnString(ctx context.Context, b provider.Branch) (secret.Value, error)
+	// Inventory lists everything this datastore holds, which the leak detector
+	// compares against the journal.
+	Inventory(ctx context.Context) ([]provider.Resource, error)
+	// Health reports whether a branch is reachable.
+	Health(ctx context.Context, b provider.Branch) (provider.Health, error)
+	// Close releases the datastore's own resources.
+	Close() error
+}
+
+// ErrNoGolden is returned by a datastore that holds no golden, which is a
+// declared stance rather than a failure. A cache is rebuilt from the primary
+// and a copy of one would be noise.
+var ErrNoGolden = errors.New("extension: this datastore holds no golden")
+
+// DatastoreProvider builds a datastore.
+type DatastoreProvider interface {
+	// Name is the value a manifest names this provider by.
+	Name() string
+	// Engine is the datastore engine it implements, such as "clickhouse". Two
+	// providers may implement one engine, which is why this is separate from
+	// Name.
+	Engine() string
+	// Open builds the datastore.
+	Open(ctx context.Context, cfg DatastoreConfig) (Datastore, error)
+}
+
+// RuntimeConfig is what a registered runtime is given.
+type RuntimeConfig struct {
+	// Root is the repository root.
+	Root string
+	// Runtime is the manifest's runtime block, as a copy.
+	Runtime schema.Runtime
+	// TTL is how long an environment this runtime creates may live, already
+	// parsed from the manifest. Zero means no expiry.
+	TTL time.Duration
+	// StateDir is where the runtime may keep local files.
+	StateDir string
+	// Now is the engine's clock.
+	Now func() time.Time
+	// Lookup resolves a declared credential, as DatabaseConfig.Lookup does.
+	Lookup func(ctx context.Context, name string) (secret.Value, bool, error)
+	// ResolveProxyImage produces the egress sidecar image, building it on a
+	// local container daemon or reading AF_PROXY_IMAGE.
+	//
+	// It is here because a runtime that places containers somewhere other than
+	// this machine cannot build the sidecar and must not run without it: an
+	// environment with no sidecar has no egress policy at all, which is the
+	// one thing this product refuses. It is a function rather than a string so
+	// that a command which only reads, such as af status, does not pay for a
+	// container build to answer a question.
+	ResolveProxyImage func(ctx context.Context) (string, error)
+}
+
+// RuntimeProvider builds the runtime a manifest names.
+type RuntimeProvider interface {
+	// Name is the value runtime.provider takes in a manifest.
+	Name() string
+	// Open builds the runtime.
+	Open(ctx context.Context, cfg RuntimeConfig) (provider.Runtime, error)
+}
+
+// ObjectStoreConfig is what a registered golden store is opened with.
+type ObjectStoreConfig struct {
+	// URL is database.golden.storage_url, with any $VARIABLE reference already
+	// resolved from the environment. A store never sees the variable name,
+	// only the value, which is what keeps a credential out of the manifest.
+	URL string
+	// Getenv reads the environment for anything else the store needs, such as
+	// the credential an S3 URL does not carry.
+	Getenv func(string) string
+}
+
+// StoredObject is one thing in a store.
+type StoredObject struct {
+	Name     string
+	Size     int64
+	Modified time.Time
+}
+
+// ObjectStore is where a golden's dump and its attestation live when they live
+// somewhere other than the machine that made them.
+//
+// engine/internal/golden.Store is an alias of this type, so a store registered
+// here IS the store the engine uses, with no adapter in between and no second
+// definition to drift.
+type ObjectStore interface {
+	// Name identifies the store in a message.
+	Name() string
+	// Put writes an object, replacing one of the same name.
+	Put(ctx context.Context, name string, size int64, body io.Reader) error
+	// Get opens an object. A name that is not there returns
+	// ErrObjectNotFound, so that a caller can tell "no golden published yet"
+	// from "the store is broken", which are the same HTTP status on more than
+	// one service.
+	Get(ctx context.Context, name string) (io.ReadCloser, error)
+	// List returns the objects under a prefix.
+	List(ctx context.Context, prefix string) ([]StoredObject, error)
+	// Delete removes an object. Removing one that is not there succeeds,
+	// because a retry after a timeout must not fail on the work it already did.
+	Delete(ctx context.Context, name string) error
+}
+
+// ErrObjectNotFound is what an ObjectStore returns for an object that is not
+// there.
+//
+// It lives here rather than in the engine's golden package because a store
+// written outside this repository cannot import an internal package, and a
+// sentinel a store cannot name is a sentinel it cannot return: every "no
+// golden published yet" from such a store would read as "the store is broken".
+// engine/internal/golden.ErrNotFound is this value.
+var ErrObjectNotFound = errors.New("golden: no such object")
+
+// GoldenStore opens the object store a manifest names.
+type GoldenStore interface {
+	// Name is the value database.golden.storage takes in a manifest.
+	Name() string
+	// Open builds the store for a storage URL.
+	Open(cfg ObjectStoreConfig) (ObjectStore, error)
+}
+
+// EmulatorContainer describes the container an emulator runs in.
+type EmulatorContainer struct {
+	// Image is the container image, PINNED BY DIGEST. A tag is refused,
+	// because an emulator is the thing answering for production's API and a
+	// tag that moves changes what an environment was tested against without
+	// anything in the repository changing.
+	Image string
+	// Port is the port inside the container the sidecar forwards to.
+	Port int
+	// Env is what the container is started with.
+	Env map[string]string
+}
+
+// Emulator is a third party service answered inside the environment.
+//
+// It is a declaration rather than an implementation on purpose. Antifailure
+// does not write emulators: LocalStack, Azurite and the vendors' own emulators
+// exist and carry years of fidelity work that a hand written replacement would
+// not have. What the engine adds is that the application needs no endpoint
+// override to reach one, and that is routing, which lives in the sidecar.
+//
+// The routing is not built yet, so REGISTERING AN EMULATOR TODAY DOES NOTHING
+// BEYOND APPEARING IN af license status AND BEING VALIDATED. Said plainly for
+// the same reason it is said on Datastore.
+type Emulator interface {
+	// Name is the value an egress rule will name this emulator by.
+	Name() string
+	// Hosts are the hostnames it answers for, such as s3.amazonaws.com.
+	Hosts() []string
+	// Container describes what the engine starts.
+	Container() EmulatorContainer
+}
+
 // Registry holds what has been registered.
 //
 // A value rather than only a package-level singleton, so that a test can build
@@ -195,6 +504,12 @@ type Registry struct {
 	lifecycle []LifecycleHook
 	audit     []AuditSink
 	secrets   []SecretSource
+
+	databases  []DatabaseProvider
+	datastores []DatastoreProvider
+	runtimes   []RuntimeProvider
+	stores     []GoldenStore
+	emulators  []Emulator
 }
 
 // NewRegistry returns an empty registry, which is the community behaviour.
@@ -303,6 +618,272 @@ func (r *Registry) Audit(ctx context.Context, entry AuditEntry) []error {
 	return problems
 }
 
+// AddDatabaseProvider registers a database provider a manifest can name.
+//
+// Registration order is retained and a name may be registered once. The engine
+// consults this after its own built-in providers, so a registration cannot
+// take over a name the engine already has; Validate reports that collision
+// rather than leaving it to be discovered as a provider that was quietly not
+// used.
+func (r *Registry) AddDatabaseProvider(p DatabaseProvider) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.databases = append(r.databases, p)
+}
+
+// DatabaseProviderNamed returns the provider registered under a name.
+func (r *Registry) DatabaseProviderNamed(name string) (DatabaseProvider, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, p := range r.databases {
+		if p.Name() == name {
+			return p, true
+		}
+	}
+	return nil, false
+}
+
+// DatabaseProviderNames lists what is registered, for a refusal that says what
+// this build does have.
+func (r *Registry) DatabaseProviderNames() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.databaseNames()
+}
+
+func (r *Registry) databaseNames() []string {
+	out := make([]string, 0, len(r.databases))
+	for _, p := range r.databases {
+		out = append(out, p.Name())
+	}
+	return out
+}
+
+// AddDatastoreProvider registers a provider for a store other than the
+// environment's primary Postgres.
+func (r *Registry) AddDatastoreProvider(p DatastoreProvider) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.datastores = append(r.datastores, p)
+}
+
+// DatastoreProviderNamed returns the datastore provider registered under a name.
+func (r *Registry) DatastoreProviderNamed(name string) (DatastoreProvider, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, p := range r.datastores {
+		if p.Name() == name {
+			return p, true
+		}
+	}
+	return nil, false
+}
+
+// DatastoreProviderNames lists what is registered.
+func (r *Registry) DatastoreProviderNames() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.datastoreNames()
+}
+
+func (r *Registry) datastoreNames() []string {
+	out := make([]string, 0, len(r.datastores))
+	for _, p := range r.datastores {
+		out = append(out, p.Name())
+	}
+	return out
+}
+
+// AddRuntimeProvider registers a runtime a manifest can name.
+func (r *Registry) AddRuntimeProvider(p RuntimeProvider) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.runtimes = append(r.runtimes, p)
+}
+
+// RuntimeProviderNamed returns the runtime registered under a name.
+func (r *Registry) RuntimeProviderNamed(name string) (RuntimeProvider, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, p := range r.runtimes {
+		if p.Name() == name {
+			return p, true
+		}
+	}
+	return nil, false
+}
+
+// RuntimeProviderNames lists what is registered.
+func (r *Registry) RuntimeProviderNames() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.runtimeNames()
+}
+
+func (r *Registry) runtimeNames() []string {
+	out := make([]string, 0, len(r.runtimes))
+	for _, p := range r.runtimes {
+		out = append(out, p.Name())
+	}
+	return out
+}
+
+// AddGoldenStore registers somewhere else a published golden can live.
+func (r *Registry) AddGoldenStore(s GoldenStore) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.stores = append(r.stores, s)
+}
+
+// GoldenStoreNamed returns the store registered under a name.
+func (r *Registry) GoldenStoreNamed(name string) (GoldenStore, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, s := range r.stores {
+		if s.Name() == name {
+			return s, true
+		}
+	}
+	return nil, false
+}
+
+// GoldenStoreNames lists what is registered.
+func (r *Registry) GoldenStoreNames() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.storeNames()
+}
+
+func (r *Registry) storeNames() []string {
+	out := make([]string, 0, len(r.stores))
+	for _, s := range r.stores {
+		out = append(out, s.Name())
+	}
+	return out
+}
+
+// AddEmulator registers a third party service answered inside the environment.
+func (r *Registry) AddEmulator(e Emulator) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.emulators = append(r.emulators, e)
+}
+
+// EmulatorNamed returns the emulator registered under a name.
+func (r *Registry) EmulatorNamed(name string) (Emulator, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, e := range r.emulators {
+		if e.Name() == name {
+			return e, true
+		}
+	}
+	return nil, false
+}
+
+// EmulatorNames lists what is registered.
+func (r *Registry) EmulatorNames() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.emulatorNames()
+}
+
+func (r *Registry) emulatorNames() []string {
+	out := make([]string, 0, len(r.emulators))
+	for _, e := range r.emulators {
+		out = append(out, e.Name())
+	}
+	return out
+}
+
+// The socket names Validate keys its reserved list by.
+//
+// Constants rather than the literals, because the caller supplying the
+// reserved names is the engine and the two sides agreeing on the spelling is
+// the whole of the check. A key typed differently on one side would not fail:
+// the reserved list would simply match nothing, and a registration that
+// shadows a built in provider would go back to being silently unused, which is
+// exactly the failure this refuses. They are the words a refusal is written
+// in, so they read as prose rather than as identifiers.
+const (
+	SocketDatabaseProvider  = "database provider"
+	SocketDatastoreProvider = "datastore provider"
+	SocketRuntimeProvider   = "runtime"
+	SocketGoldenStore       = "golden store"
+	SocketEmulator          = "emulator"
+)
+
+// Validate reports a registration the engine cannot honor.
+//
+// It runs before an environment is created, which is the only useful moment: a
+// build that registered a provider with no name, two providers under one name,
+// or an emulator image pinned by a tag has a configuration defect, and finding
+// it at the first af up is finding it before anybody depends on the answer.
+//
+// Reserved are the names the engine already has, which the caller supplies
+// because the engine owns that list and this package must not have to know it.
+// A registration under a reserved name is refused rather than ignored: the
+// engine consults the registry only after its own switch, so an ignored
+// registration is a build somebody believes overrides the Docker provider and
+// which silently does not.
+func (r *Registry) Validate(reserved map[string][]string) error {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	kinds := []struct {
+		socket string
+		names  []string
+	}{
+		{SocketDatabaseProvider, r.databaseNames()},
+		{SocketDatastoreProvider, r.datastoreNames()},
+		{SocketRuntimeProvider, r.runtimeNames()},
+		{SocketGoldenStore, r.storeNames()},
+		{SocketEmulator, r.emulatorNames()},
+	}
+	for _, kind := range kinds {
+		seen := make(map[string]bool, len(kind.names))
+		for _, name := range kind.names {
+			switch {
+			case strings.TrimSpace(name) == "":
+				return fmt.Errorf(
+					"a %s is registered with no name, so nothing in a manifest could ask for it",
+					kind.socket)
+			case seen[name]:
+				return fmt.Errorf(
+					"two %ss are registered as %q, and a manifest naming it would get "+
+						"whichever was registered first", kind.socket, name)
+			}
+			seen[name] = true
+			for _, taken := range reserved[kind.socket] {
+				if name == taken {
+					return fmt.Errorf(
+						"a %s is registered as %q and this build already has one by that "+
+							"name. A registration adds a choice and cannot replace one, so "+
+							"this registration would never be used; give it another name",
+						kind.socket, name)
+				}
+			}
+		}
+	}
+
+	for _, e := range r.emulators {
+		c := e.Container()
+		if len(e.Hosts()) == 0 {
+			return fmt.Errorf(
+				"the emulator %q answers for no hosts, so no request could ever reach it",
+				e.Name())
+		}
+		if !strings.Contains(c.Image, "@sha256:") {
+			return fmt.Errorf(
+				"the emulator %q is pinned by %q rather than by digest. An emulator answers "+
+					"for a production API, and a tag that moves changes what an environment "+
+					"was tested against with nothing in the repository changing",
+				e.Name(), c.Image)
+		}
+	}
+	return nil
+}
+
 // Registered names what is plugged in, for af version and af doctor.
 //
 // Worth printing: an operator debugging why an environment was refused needs to
@@ -325,6 +906,21 @@ func (r *Registry) Registered() []string {
 	for _, s := range r.secrets {
 		out = append(out, "secret-source:"+s.Name())
 	}
+	for _, p := range r.databases {
+		out = append(out, "database-provider:"+p.Name())
+	}
+	for _, p := range r.datastores {
+		out = append(out, "datastore-provider:"+p.Name())
+	}
+	for _, p := range r.runtimes {
+		out = append(out, "runtime:"+p.Name())
+	}
+	for _, st := range r.stores {
+		out = append(out, "golden-store:"+st.Name())
+	}
+	for _, e := range r.emulators {
+		out = append(out, "emulator:"+e.Name())
+	}
 	sort.Strings(out)
 	return out
 }
@@ -334,5 +930,7 @@ func (r *Registry) Empty() bool {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	return len(r.policy) == 0 && len(r.lifecycle) == 0 &&
-		len(r.audit) == 0 && len(r.secrets) == 0
+		len(r.audit) == 0 && len(r.secrets) == 0 &&
+		len(r.databases) == 0 && len(r.datastores) == 0 &&
+		len(r.runtimes) == 0 && len(r.stores) == 0 && len(r.emulators) == 0
 }

--- a/engine/pkg/extension/extension_test.go
+++ b/engine/pkg/extension/extension_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/antifailure/antifailure/engine/pkg/extension"
+	"github.com/antifailure/antifailure/engine/pkg/provider"
 )
 
 // The whole point of this package is that with nothing registered it does
@@ -266,4 +267,244 @@ func TestConcurrentRegistrationAndUseIsSafe(t *testing.T) {
 	}
 	<-done
 	<-sources
+}
+
+// ---------------------------------------------------------------------------
+// The provider sockets.
+//
+// Before these existed the engine chose a database provider, a runtime and a
+// golden store from switches whose default refused, so adding one meant
+// editing engine/internal/env, which is unimportable from outside the module.
+// These tests are about the half that lives here: what a registration is, what
+// the registry refuses, and that an empty registry still answers nothing. The
+// half that matters more, that the engine actually CONSULTS them, is tested in
+// engine/internal/env, because a socket nothing plugs into is exactly the gap
+// this package already shipped once.
+
+type fakeDatabaseProvider struct {
+	name string
+	seen extension.DatabaseConfig
+}
+
+func (f *fakeDatabaseProvider) Name() string { return f.name }
+func (f *fakeDatabaseProvider) Open(
+	_ context.Context, cfg extension.DatabaseConfig,
+) (provider.Database, error) {
+	f.seen = cfg
+	return nil, errors.New("not built in this test")
+}
+
+type fakeRuntimeProvider struct{ name string }
+
+func (f *fakeRuntimeProvider) Name() string { return f.name }
+func (f *fakeRuntimeProvider) Open(
+	context.Context, extension.RuntimeConfig,
+) (provider.Runtime, error) {
+	return nil, errors.New("not built in this test")
+}
+
+type fakeDatastoreProvider struct{ name, engine string }
+
+func (f *fakeDatastoreProvider) Name() string   { return f.name }
+func (f *fakeDatastoreProvider) Engine() string { return f.engine }
+func (f *fakeDatastoreProvider) Open(
+	context.Context, extension.DatastoreConfig,
+) (extension.Datastore, error) {
+	return nil, errors.New("not built in this test")
+}
+
+type fakeGoldenStore struct{ name string }
+
+func (f *fakeGoldenStore) Name() string { return f.name }
+func (f *fakeGoldenStore) Open(extension.ObjectStoreConfig) (extension.ObjectStore, error) {
+	return nil, errors.New("not built in this test")
+}
+
+type fakeEmulator struct {
+	name  string
+	hosts []string
+	image string
+}
+
+func (f *fakeEmulator) Name() string    { return f.name }
+func (f *fakeEmulator) Hosts() []string { return f.hosts }
+func (f *fakeEmulator) Container() extension.EmulatorContainer {
+	return extension.EmulatorContainer{Image: f.image, Port: 4566}
+}
+
+const pinnedImage = "localstack/localstack@sha256:" +
+	"0000000000000000000000000000000000000000000000000000000000000000"
+
+func TestAnEmptyRegistryHasNoProviders(t *testing.T) {
+	t.Parallel()
+	r := extension.NewRegistry()
+
+	_, ok := r.DatabaseProviderNamed("anything")
+	require.False(t, ok)
+	_, ok = r.DatastoreProviderNamed("anything")
+	require.False(t, ok)
+	_, ok = r.RuntimeProviderNamed("anything")
+	require.False(t, ok)
+	_, ok = r.GoldenStoreNamed("anything")
+	require.False(t, ok)
+	_, ok = r.EmulatorNamed("anything")
+	require.False(t, ok)
+
+	require.Empty(t, r.DatabaseProviderNames())
+	require.Empty(t, r.DatastoreProviderNames())
+	require.Empty(t, r.RuntimeProviderNames())
+	require.Empty(t, r.GoldenStoreNames())
+	require.Empty(t, r.EmulatorNames())
+	require.True(t, r.Empty())
+	require.NoError(t, r.Validate(nil))
+}
+
+func TestARegisteredProviderIsFoundByNameAndListed(t *testing.T) {
+	t.Parallel()
+	r := extension.NewRegistry()
+	r.AddDatabaseProvider(&fakeDatabaseProvider{name: "aurora"})
+	r.AddDatastoreProvider(&fakeDatastoreProvider{name: "clickhouse", engine: "clickhouse"})
+	r.AddRuntimeProvider(&fakeRuntimeProvider{name: "nomad"})
+	r.AddGoldenStore(&fakeGoldenStore{name: "gcs"})
+	r.AddEmulator(&fakeEmulator{name: "s3", hosts: []string{"s3.amazonaws.com"}, image: pinnedImage})
+
+	db, ok := r.DatabaseProviderNamed("aurora")
+	require.True(t, ok)
+	require.Equal(t, "aurora", db.Name())
+	require.Equal(t, []string{"aurora"}, r.DatabaseProviderNames())
+	require.Equal(t, []string{"clickhouse"}, r.DatastoreProviderNames())
+	require.Equal(t, []string{"nomad"}, r.RuntimeProviderNames())
+	require.Equal(t, []string{"gcs"}, r.GoldenStoreNames())
+	require.Equal(t, []string{"s3"}, r.EmulatorNames())
+
+	// af license status prints this, and an operator asking why a manifest was
+	// refused needs to see whether the provider it names is plugged in at all.
+	require.Equal(t, []string{
+		"database-provider:aurora",
+		"datastore-provider:clickhouse",
+		"emulator:s3",
+		"golden-store:gcs",
+		"runtime:nomad",
+	}, r.Registered())
+	require.False(t, r.Empty())
+}
+
+func TestARegistryWithOnlyAProviderIsNotEmpty(t *testing.T) {
+	t.Parallel()
+	// Empty() gates whole code paths, including whether the engine bothers to
+	// validate registrations at all. A registry holding only a provider that
+	// reported itself as the community no-op would have its provider silently
+	// unchecked.
+	for _, add := range []func(*extension.Registry){
+		func(r *extension.Registry) { r.AddDatabaseProvider(&fakeDatabaseProvider{name: "a"}) },
+		func(r *extension.Registry) { r.AddDatastoreProvider(&fakeDatastoreProvider{name: "b"}) },
+		func(r *extension.Registry) { r.AddRuntimeProvider(&fakeRuntimeProvider{name: "c"}) },
+		func(r *extension.Registry) { r.AddGoldenStore(&fakeGoldenStore{name: "d"}) },
+		func(r *extension.Registry) {
+			r.AddEmulator(&fakeEmulator{name: "e", hosts: []string{"h"}, image: pinnedImage})
+		},
+	} {
+		r := extension.NewRegistry()
+		add(r)
+		require.False(t, r.Empty())
+	}
+}
+
+func TestARegistrationUnderABuiltInNameIsRefusedRatherThanIgnored(t *testing.T) {
+	t.Parallel()
+	// The engine consults the registry only after its own switch, so this
+	// registration would never be used. Ignoring it silently is how somebody
+	// ships a build they believe replaces the Docker provider and does not.
+	r := extension.NewRegistry()
+	r.AddDatabaseProvider(&fakeDatabaseProvider{name: "docker"})
+
+	err := r.Validate(map[string][]string{
+		extension.SocketDatabaseProvider: {"docker", "neon"},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "docker")
+	require.Contains(t, err.Error(), "cannot replace")
+}
+
+func TestTwoProvidersUnderOneNameAreRefused(t *testing.T) {
+	t.Parallel()
+	// Whichever was registered first would answer, so the build is not the one
+	// its author is reading.
+	r := extension.NewRegistry()
+	r.AddDatabaseProvider(&fakeDatabaseProvider{name: "aurora"})
+	r.AddDatabaseProvider(&fakeDatabaseProvider{name: "aurora"})
+
+	err := r.Validate(nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "aurora")
+}
+
+func TestAProviderWithNoNameIsRefused(t *testing.T) {
+	t.Parallel()
+	// Nothing in a manifest could ask for it, so it is a registration that can
+	// only ever be dead.
+	r := extension.NewRegistry()
+	r.AddRuntimeProvider(&fakeRuntimeProvider{name: "  "})
+
+	err := r.Validate(nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no name")
+}
+
+func TestAnEmulatorPinnedByATagIsRefused(t *testing.T) {
+	t.Parallel()
+	// An emulator answers for a production API. A tag that moves changes what
+	// an environment was tested against with nothing in the repository
+	// changing, which is the whole reason every other image here is pinned.
+	r := extension.NewRegistry()
+	r.AddEmulator(&fakeEmulator{
+		name: "s3", hosts: []string{"s3.amazonaws.com"}, image: "localstack/localstack:3.4",
+	})
+
+	err := r.Validate(nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "digest")
+
+	ok := extension.NewRegistry()
+	ok.AddEmulator(&fakeEmulator{
+		name: "s3", hosts: []string{"s3.amazonaws.com"}, image: pinnedImage,
+	})
+	require.NoError(t, ok.Validate(nil))
+}
+
+func TestAnEmulatorThatAnswersForNoHostIsRefused(t *testing.T) {
+	t.Parallel()
+	// No request could ever reach it, so it is a registration that looks like
+	// coverage and is not.
+	r := extension.NewRegistry()
+	r.AddEmulator(&fakeEmulator{name: "s3", image: pinnedImage})
+
+	err := r.Validate(nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no hosts")
+}
+
+func TestConcurrentProviderRegistrationAndUseIsSafe(t *testing.T) {
+	t.Parallel()
+	// Registration happens at startup and selection happens per command. The
+	// race detector is the only thing that would catch them overlapping.
+	r := extension.NewRegistry()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range 200 {
+			r.AddDatabaseProvider(&fakeDatabaseProvider{name: "aurora"})
+			r.AddRuntimeProvider(&fakeRuntimeProvider{name: "nomad"})
+		}
+	}()
+	for range 200 {
+		_, _ = r.DatabaseProviderNamed("aurora")
+		_ = r.DatabaseProviderNames()
+		_, _ = r.RuntimeProviderNamed("nomad")
+		_ = r.RuntimeProviderNames()
+		_ = r.Registered()
+		_ = r.Empty()
+		_ = r.Validate(nil)
+	}
+	<-done
 }

--- a/justfile
+++ b/justfile
@@ -85,6 +85,7 @@ gate: _reports
     run "every manifest field is read or refused" just fieldsweep
     run "self-hosting inputs are stable" just inputcheck
     run "documented config can be set"   just wirecheck
+    run "every socket is plugged in"     just socketcheck
     run "the site calls routes that exist" just routecheck
     run "every hostname has an origin"   just origincheck
     run "the smoke waits for real sentences" just sitesmoke
@@ -1049,6 +1050,26 @@ inputcheck:
 # that has stopped being needed is reported so the file cannot rot.
 wirecheck:
     go run ./tools/wirecheck .
+
+# Every extension point in engine/pkg/extension is implementable from outside
+# the engine module, and either consulted by the engine or declared as one that
+# is not.
+#
+# A socket is a promise to two people and only one of them is visible to the
+# compiler. The implementer is outside this module and cannot import anything
+# under engine/internal, so a signature naming a type from there is a socket
+# nobody can implement; that is the defect surfacecheck was written for, in the
+# stable packages, and extension was covered by nothing. The registrant expects
+# the engine to ask, and extension.AuditSink has an interface, a registry, an
+# Add and a forwarding method that NOTHING IN THE ENGINE HAS EVER CALLED, so
+# audit_stream forwards nothing and would still forward nothing after somebody
+# wrote the sinks.
+#
+# Both directions fail: a socket that is not consulted and not listed in the
+# tool is reported, and so is one that is listed and has since been wired up,
+# so the list cannot outlive the gaps it describes.
+socketcheck:
+    go run ./tools/socketcheck .
 
 # The site does not call a control plane route that is not there.
 #

--- a/tools/errgen/main.go
+++ b/tools/errgen/main.go
@@ -66,6 +66,7 @@ var areaNames = map[string]string{
 	"FID": "Fidelity",
 	"CPL": "Control plane",
 	"WLD": "Workloads",
+	"EXT": "Extensions",
 }
 
 func main() {

--- a/tools/socketcheck/main.go
+++ b/tools/socketcheck/main.go
@@ -1,0 +1,466 @@
+// Command socketcheck holds engine/pkg/extension to the two promises that make
+// it a socket rather than a struct.
+//
+// A socket is a promise to two different people and only one of them is
+// visible in the compiler.
+//
+// THE FIRST PROMISE is to the person implementing it, who is outside this
+// module. Go's internal rule means they cannot import anything under
+// engine/internal, so a socket whose method signatures name a type from there
+// cannot be implemented from outside at all. It compiles here, it reviews as
+// correct, and it fails on the first line of the first real implementation.
+// That is not hypothetical: engine/api/packages.txt records the same defect
+// found in provider.Database, whose ConnString returned a type from
+// engine/internal/secrets, and tools/surfacecheck exists because of it. That
+// check covers the STABLE packages. extension is unstable and was not covered
+// by anything, and it is the package whose entire purpose is being implemented
+// from outside.
+//
+// THE SECOND PROMISE is to the person registering it, who expects the engine
+// to ask. This is the one that was already broken when this tool was written.
+// extension.AuditSink has an interface, a registry, an AddAuditSink and a
+// Registry.Audit that forwards to every sink, and NOTHING IN THE ENGINE HAS
+// EVER CALLED Registry.Audit. So audit_stream, a licensed feature, forwards
+// nothing, and it would still forward nothing after somebody wrote the sinks,
+// because there is no call site to hand them an entry. A hook nothing consults
+// is the same shippable gap as a block button that hides nothing: every piece
+// is there and the behaviour is absent.
+//
+// So the rule is: every socket is either CONSULTED by the engine, or listed
+// below as one that is not, with the reason. Both directions fail. A socket
+// that is not consulted and not listed fails, which is the AuditSink case. A
+// socket that is listed and IS consulted fails too, so the entry cannot
+// outlive the gap it describes and the list cannot become a set of exemptions
+// nobody rereads.
+//
+// WHAT IT DOES NOT CHECK. It reads the syntax tree rather than type checking,
+// so a type reaching a socket signature through an alias declared elsewhere is
+// invisible to it, exactly as it is to surfacecheck. It looks for a call to
+// the registry's own reader method by name, so a consultation that reached the
+// registry some other way would not count. Erring strict is the right way
+// round: the failure this exists to catch is a socket that looks plugged in
+// and is not.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+func main() {
+	flag.Parse()
+	root := "."
+	if flag.NArg() > 0 {
+		root = flag.Arg(0)
+	}
+	report, err := Check(root)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "socketcheck:", err)
+		os.Exit(1)
+	}
+	fmt.Print(report.String())
+	if len(report.Problems) > 0 {
+		os.Exit(1)
+	}
+}
+
+// notConsulted names a socket the engine does not ask, and why.
+//
+// An entry is a declaration that the gap is known, not permission for it to
+// stay. Each says what would close it, because "not implemented" without that
+// is how a list like this stops being read.
+var notConsulted = map[string]string{
+	"AuditSink": "Registry.Audit has no caller anywhere in the engine, so a registered " +
+		"sink receives nothing. Closing it means emitting the entries the audit log " +
+		"already writes through the registry as well.",
+	"DatastoreProvider": "the manifest declares one datastore and the orchestrator " +
+		"branches one, so there is no second store for a registration to be. Closing it " +
+		"means the datastores list and a lifecycle that branches each of them.",
+	"Emulator": "an egress rule cannot name an emulator yet and the sidecar has no route " +
+		"to one, so a registration describes a container nothing starts. Closing it means " +
+		"the emulate mode and the sidecar route that makes an unmodified application " +
+		"reach it.",
+}
+
+// inventoryMethods are the registry methods that walk every socket at once.
+//
+// They are excluded from counting as a consultation on purpose. Registered
+// lists what is plugged in and Empty asks whether anything is, and Validate
+// checks the registrations themselves; all three mention every field, so
+// without this exclusion every socket would look consulted the moment it had a
+// field, which is precisely the AuditSink case they would have hidden.
+var inventoryMethods = map[string]bool{"Registered": true, "Empty": true, "Validate": true}
+
+// Socket is one extension point.
+type Socket struct {
+	// Name is the interface a registration implements, such as PolicyHook.
+	Name string
+	// Add is the registry method that registers one.
+	Add string
+	// Field is the registry field it appends to.
+	Field string
+	// Readers are the registry methods that read that field, which is what a
+	// consultation has to call.
+	Readers []string
+	// ConsultedAt is where the engine calls one of them.
+	ConsultedAt string
+	// Foreign lists types in this socket's signatures that an implementation
+	// outside this module cannot name.
+	Foreign []string
+}
+
+// Report is what the check found.
+type Report struct {
+	Sockets  []Socket
+	Problems []string
+}
+
+func (r Report) String() string {
+	var b strings.Builder
+	implementable, consulted := 0, 0
+	for _, s := range r.Sockets {
+		if len(s.Foreign) == 0 {
+			implementable++
+		}
+		if s.ConsultedAt != "" {
+			consulted++
+		}
+	}
+	fmt.Fprintf(&b, "%d of %d sockets are implementable from outside the engine module\n",
+		implementable, len(r.Sockets))
+	fmt.Fprintf(&b, "%d of %d sockets are consulted by the engine\n", consulted, len(r.Sockets))
+	for _, s := range r.Sockets {
+		where := s.ConsultedAt
+		if where == "" {
+			where = "NOT CONSULTED"
+		}
+		fmt.Fprintf(&b, "  %-20s %s\n", s.Name, where)
+	}
+	for _, p := range r.Problems {
+		fmt.Fprintln(&b, "socketcheck: "+p)
+	}
+	return b.String()
+}
+
+// Check reads the extension package and the engine that consults it.
+func Check(root string) (Report, error) { return check(root, notConsulted) }
+
+// check takes the list of known gaps as an argument rather than reading the
+// package variable, so that a test can supply its own without editing global
+// state that another test running beside it is reading.
+func check(root string, unconsulted map[string]string) (Report, error) {
+	var report Report
+	dir := filepath.Join(root, "engine", "pkg", "extension")
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, dir, func(fi fs.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, parser.ParseComments)
+	if err != nil {
+		return report, fmt.Errorf("reading %s: %w", dir, err)
+	}
+	pkg, ok := pkgs["extension"]
+	if !ok {
+		return report, fmt.Errorf("no package extension in %s", dir)
+	}
+
+	interfaces := map[string]*ast.InterfaceType{}
+	structs := map[string]*ast.StructType{}
+	local := map[string]bool{}
+	// importPath is the package a file's identifier prefix refers to, per file,
+	// because two files may import the same name differently.
+	importPath := map[*ast.File]map[string]string{}
+	var addMethods, readerMethods []*ast.FuncDecl
+
+	for _, f := range pkg.Files {
+		importPath[f] = map[string]string{}
+		for _, imp := range f.Imports {
+			path, uerr := strconv.Unquote(imp.Path.Value)
+			if uerr != nil {
+				continue
+			}
+			name := path[strings.LastIndex(path, "/")+1:]
+			if imp.Name != nil {
+				name = imp.Name.Name
+			}
+			importPath[f][name] = path
+		}
+		for _, decl := range f.Decls {
+			switch d := decl.(type) {
+			case *ast.GenDecl:
+				for _, spec := range d.Specs {
+					ts, isType := spec.(*ast.TypeSpec)
+					if !isType {
+						continue
+					}
+					local[ts.Name.Name] = true
+					switch t := ts.Type.(type) {
+					case *ast.InterfaceType:
+						interfaces[ts.Name.Name] = t
+					case *ast.StructType:
+						structs[ts.Name.Name] = t
+					}
+				}
+			case *ast.FuncDecl:
+				if !isRegistryMethod(d) {
+					continue
+				}
+				if strings.HasPrefix(d.Name.Name, "Add") {
+					addMethods = append(addMethods, d)
+					continue
+				}
+				readerMethods = append(readerMethods, d)
+			}
+		}
+	}
+
+	for _, add := range addMethods {
+		socket := Socket{Add: add.Name.Name}
+		if add.Type.Params == nil || len(add.Type.Params.List) != 1 {
+			report.Problems = append(report.Problems, fmt.Sprintf(
+				"%s does not take exactly one registration, so what it registers cannot be read",
+				add.Name.Name))
+			continue
+		}
+		socket.Name = typeName(add.Type.Params.List[0].Type)
+		socket.Field = appendedField(add)
+		if socket.Field == "" {
+			report.Problems = append(report.Problems, fmt.Sprintf(
+				"%s does not append to a registry field, so nothing can find what it registered",
+				add.Name.Name))
+			continue
+		}
+		for _, reader := range readerMethods {
+			if inventoryMethods[reader.Name.Name] {
+				continue
+			}
+			if mentionsField(reader, socket.Field) {
+				socket.Readers = append(socket.Readers, reader.Name.Name)
+			}
+		}
+		sort.Strings(socket.Readers)
+		if iface, isIface := interfaces[socket.Name]; isIface {
+			socket.Foreign = foreignTypes(iface, structs, local, importPath, pkg)
+		} else {
+			report.Problems = append(report.Problems, fmt.Sprintf(
+				"%s registers %s, which is not an interface in this package",
+				add.Name.Name, socket.Name))
+		}
+		report.Sockets = append(report.Sockets, socket)
+	}
+	sort.Slice(report.Sockets, func(i, j int) bool {
+		return report.Sockets[i].Name < report.Sockets[j].Name
+	})
+
+	calls, err := engineCalls(root)
+	if err != nil {
+		return report, err
+	}
+	for i := range report.Sockets {
+		s := &report.Sockets[i]
+		if len(s.Readers) == 0 {
+			report.Problems = append(report.Problems, fmt.Sprintf(
+				"%s can be registered and never read: no registry method reads r.%s",
+				s.Name, s.Field))
+		}
+		for _, reader := range s.Readers {
+			if where, called := calls[reader]; called {
+				s.ConsultedAt = reader + ", at " + where
+				break
+			}
+		}
+		reason, listed := unconsulted[s.Name]
+		switch {
+		case s.ConsultedAt == "" && !listed:
+			report.Problems = append(report.Problems, fmt.Sprintf(
+				"%s is registered by %s and nothing in the engine calls %s. A socket "+
+					"nothing consults looks exactly like a working extension point and is "+
+					"not one. Consult it, or list it in socketcheck with the reason",
+				s.Name, s.Add, strings.Join(s.Readers, " or ")))
+		case s.ConsultedAt != "" && listed:
+			report.Problems = append(report.Problems, fmt.Sprintf(
+				"%s is listed in socketcheck as not consulted and the engine consults it "+
+					"at %s. Delete the entry: %s", s.Name, s.ConsultedAt, reason))
+		}
+		for _, foreign := range s.Foreign {
+			report.Problems = append(report.Problems, fmt.Sprintf(
+				"%s names %s, which is under engine/internal and cannot be imported from "+
+					"outside this module, so the socket cannot be implemented from outside",
+				s.Name, foreign))
+		}
+	}
+	return report, nil
+}
+
+// isRegistryMethod reports whether a function is a method on *Registry.
+func isRegistryMethod(d *ast.FuncDecl) bool {
+	if d.Recv == nil || len(d.Recv.List) != 1 {
+		return false
+	}
+	return typeName(d.Recv.List[0].Type) == "Registry"
+}
+
+// typeName renders the name of a type expression, dropping any pointer and
+// keeping the package qualifier where there is one.
+func typeName(e ast.Expr) string {
+	switch t := e.(type) {
+	case *ast.StarExpr:
+		return typeName(t.X)
+	case *ast.Ident:
+		return t.Name
+	case *ast.SelectorExpr:
+		return typeName(t.X) + "." + t.Sel.Name
+	case *ast.ArrayType:
+		return typeName(t.Elt)
+	}
+	return ""
+}
+
+// appendedField finds the registry field an Add method appends to.
+func appendedField(d *ast.FuncDecl) string {
+	field := ""
+	ast.Inspect(d.Body, func(n ast.Node) bool {
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok || len(assign.Lhs) != 1 {
+			return true
+		}
+		sel, ok := assign.Lhs[0].(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		field = sel.Sel.Name
+		return false
+	})
+	return field
+}
+
+// mentionsField reports whether a method reads a registry field.
+func mentionsField(d *ast.FuncDecl, field string) bool {
+	found := false
+	ast.Inspect(d.Body, func(n ast.Node) bool {
+		sel, ok := n.(*ast.SelectorExpr)
+		if ok && sel.Sel.Name == field {
+			found = true
+		}
+		return !found
+	})
+	return found
+}
+
+// foreignTypes lists the types in a socket's signatures that an implementation
+// outside this module cannot name.
+//
+// One level of recursion into the package's own structs, because a socket
+// whose parameter is a struct declared here carries that struct's fields
+// across the boundary too, and a single internal type in one of them is the
+// same defect one step further in.
+func foreignTypes(
+	iface *ast.InterfaceType, structs map[string]*ast.StructType, local map[string]bool,
+	importPath map[*ast.File]map[string]string, pkg *ast.Package,
+) []string {
+	seen := map[string]bool{}
+	var out []string
+	var walk func(n ast.Node, depth int)
+	walk = func(n ast.Node, depth int) {
+		ast.Inspect(n, func(node ast.Node) bool {
+			switch t := node.(type) {
+			case *ast.SelectorExpr:
+				prefix, ok := t.X.(*ast.Ident)
+				if !ok {
+					return true
+				}
+				path := lookupImport(importPath, pkg, prefix.Name)
+				if strings.Contains(path, "/engine/internal/") && !seen[path] {
+					seen[path] = true
+					out = append(out, prefix.Name+"."+t.Sel.Name)
+				}
+				return false
+			case *ast.Ident:
+				if depth > 0 || !local[t.Name] {
+					return true
+				}
+				if s, isStruct := structs[t.Name]; isStruct {
+					walk(s, depth+1)
+				}
+				return true
+			}
+			return true
+		})
+	}
+	walk(iface, 0)
+	sort.Strings(out)
+	return out
+}
+
+// lookupImport resolves an identifier prefix to an import path, in whichever
+// file of the package declares it.
+func lookupImport(importPath map[*ast.File]map[string]string, pkg *ast.Package, name string) string {
+	for _, f := range pkg.Files {
+		if path, ok := importPath[f][name]; ok {
+			return path
+		}
+	}
+	return ""
+}
+
+// engineCalls finds where the engine calls each registry reader.
+//
+// Non-test files only. A test that calls a reader proves the registry works
+// and says nothing about whether the product ever asks, which is the whole
+// question here.
+func engineCalls(root string) (map[string]string, error) {
+	calls := map[string]string{}
+	for _, tree := range []string{filepath.Join(root, "engine"), filepath.Join(root, "ee")} {
+		err := filepath.WalkDir(tree, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				if os.IsNotExist(err) {
+					return nil
+				}
+				return err
+			}
+			if d.IsDir() || !strings.HasSuffix(path, ".go") ||
+				strings.HasSuffix(path, "_test.go") ||
+				strings.Contains(filepath.ToSlash(path), "/engine/pkg/extension/") {
+				return nil
+			}
+			fset := token.NewFileSet()
+			file, perr := parser.ParseFile(fset, path, nil, 0)
+			if perr != nil {
+				return fmt.Errorf("reading %s: %w", path, perr)
+			}
+			ast.Inspect(file, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				sel, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok {
+					return true
+				}
+				if _, already := calls[sel.Sel.Name]; already {
+					return true
+				}
+				rel, rerr := filepath.Rel(root, path)
+				if rerr != nil {
+					rel = path
+				}
+				calls[sel.Sel.Name] = fmt.Sprintf("%s:%d",
+					filepath.ToSlash(rel), fset.Position(sel.Pos()).Line)
+				return true
+			})
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	return calls, nil
+}

--- a/tools/socketcheck/main.go
+++ b/tools/socketcheck/main.go
@@ -160,16 +160,30 @@ func Check(root string) (Report, error) { return check(root, notConsulted) }
 func check(root string, unconsulted map[string]string) (Report, error) {
 	var report Report
 	dir := filepath.Join(root, "engine", "pkg", "extension")
-	fset := token.NewFileSet()
-	pkgs, err := parser.ParseDir(fset, dir, func(fi fs.FileInfo) bool {
-		return !strings.HasSuffix(fi.Name(), "_test.go")
-	}, parser.ParseComments)
+	// The files are listed and parsed one at a time rather than through
+	// parser.ParseDir, which is deprecated, and collected into a slice rather
+	// than an ast.Package, which is deprecated too. Nothing here needs either:
+	// this reads one package whose name is known.
+	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return report, fmt.Errorf("reading %s: %w", dir, err)
 	}
-	pkg, ok := pkgs["extension"]
-	if !ok {
-		return report, fmt.Errorf("no package extension in %s", dir)
+	fset := token.NewFileSet()
+	var files []*ast.File
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") ||
+			strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, perr := parser.ParseFile(fset, filepath.Join(dir, name), nil, parser.ParseComments)
+		if perr != nil {
+			return report, fmt.Errorf("reading %s: %w", filepath.Join(dir, name), perr)
+		}
+		files = append(files, file)
+	}
+	if len(files) == 0 {
+		return report, fmt.Errorf("no Go files in %s", dir)
 	}
 
 	interfaces := map[string]*ast.InterfaceType{}
@@ -180,7 +194,7 @@ func check(root string, unconsulted map[string]string) (Report, error) {
 	importPath := map[*ast.File]map[string]string{}
 	var addMethods, readerMethods []*ast.FuncDecl
 
-	for _, f := range pkg.Files {
+	for _, f := range files {
 		importPath[f] = map[string]string{}
 		for _, imp := range f.Imports {
 			path, uerr := strconv.Unquote(imp.Path.Value)
@@ -248,7 +262,7 @@ func check(root string, unconsulted map[string]string) (Report, error) {
 		}
 		sort.Strings(socket.Readers)
 		if iface, isIface := interfaces[socket.Name]; isIface {
-			socket.Foreign = foreignTypes(iface, structs, local, importPath, pkg)
+			socket.Foreign = foreignTypes(iface, structs, local, importPath, files)
 		} else {
 			report.Problems = append(report.Problems, fmt.Sprintf(
 				"%s registers %s, which is not an interface in this package",
@@ -364,7 +378,7 @@ func mentionsField(d *ast.FuncDecl, field string) bool {
 // same defect one step further in.
 func foreignTypes(
 	iface *ast.InterfaceType, structs map[string]*ast.StructType, local map[string]bool,
-	importPath map[*ast.File]map[string]string, pkg *ast.Package,
+	importPath map[*ast.File]map[string]string, files []*ast.File,
 ) []string {
 	seen := map[string]bool{}
 	var out []string
@@ -377,7 +391,7 @@ func foreignTypes(
 				if !ok {
 					return true
 				}
-				path := lookupImport(importPath, pkg, prefix.Name)
+				path := lookupImport(importPath, files, prefix.Name)
 				if strings.Contains(path, "/engine/internal/") && !seen[path] {
 					seen[path] = true
 					out = append(out, prefix.Name+"."+t.Sel.Name)
@@ -402,8 +416,8 @@ func foreignTypes(
 
 // lookupImport resolves an identifier prefix to an import path, in whichever
 // file of the package declares it.
-func lookupImport(importPath map[*ast.File]map[string]string, pkg *ast.Package, name string) string {
-	for _, f := range pkg.Files {
+func lookupImport(importPath map[*ast.File]map[string]string, files []*ast.File, name string) string {
+	for _, f := range files {
 		if path, ok := importPath[f][name]; ok {
 			return path
 		}
@@ -426,9 +440,20 @@ func engineCalls(root string) (map[string]string, error) {
 				}
 				return err
 			}
+			// Relative to the root rather than a substring of the absolute
+			// path. A substring test made the answer depend on how the root
+			// was spelled: "../.." put a slash in front of "engine" and
+			// skipped the socket package, "." did not, so the same tree
+			// reported six sockets consulted from the test and eight from the
+			// command line. The eight were Validate calling its own readers,
+			// which is the inventory this gate exists to see past.
+			rel, relErr := filepath.Rel(root, path)
+			if relErr != nil {
+				rel = path
+			}
 			if d.IsDir() || !strings.HasSuffix(path, ".go") ||
 				strings.HasSuffix(path, "_test.go") ||
-				strings.Contains(filepath.ToSlash(path), "/engine/pkg/extension/") {
+				strings.HasPrefix(filepath.ToSlash(rel), "engine/pkg/extension/") {
 				return nil
 			}
 			fset := token.NewFileSet()

--- a/tools/socketcheck/main_test.go
+++ b/tools/socketcheck/main_test.go
@@ -205,6 +205,123 @@ func TestARegistrationNothingCanEvenReadIsReported(t *testing.T) {
 	}
 }
 
+const selfCallingExtension = `package extension
+
+import (
+	"context"
+	"sync"
+
+	"github.com/antifailure/antifailure/engine/pkg/provider"
+)
+
+type PolicyHook interface {
+	Name() string
+	Check(ctx context.Context) error
+}
+
+type DatabaseProvider interface {
+	Name() string
+	Open(ctx context.Context, cfg Config) (provider.Database, error)
+}
+
+type Config struct {
+	Root string
+}
+
+type Registry struct {
+	mu       sync.RWMutex
+	policy   []PolicyHook
+	database []DatabaseProvider
+}
+
+func (r *Registry) AddPolicy(h PolicyHook) { r.policy = append(r.policy, h) }
+
+func (r *Registry) CheckPolicy(ctx context.Context) error {
+	for _, h := range r.policy {
+		if err := h.Check(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *Registry) AddDatabaseProvider(p DatabaseProvider) {
+	r.database = append(r.database, p)
+}
+
+func (r *Registry) Validate() error {
+	for _, n := range r.databaseNames() {
+		_ = n
+	}
+	return nil
+}
+
+func (r *Registry) databaseNames() []string {
+	var out []string
+	for _, p := range r.database {
+		out = append(out, p.Name())
+	}
+	return out
+}
+
+func (r *Registry) Registered() []string {
+	var out []string
+	for _, h := range r.policy {
+		out = append(out, h.Name())
+	}
+	for _, p := range r.database {
+		out = append(out, p.Name())
+	}
+	return out
+}
+`
+
+func TestTheAnswerDoesNotDependOnHowTheRootIsSpelled(t *testing.T) {
+	t.Parallel()
+	// It did. The socket package was skipped by a substring test against the
+	// path, so a root of "../.." matched "/engine/pkg/extension/" and a root
+	// of "." did not. The same tree then reported six sockets consulted from
+	// the test and eight from the command line, and the two extra were the
+	// registry's own Validate calling its own readers, which is exactly the
+	// inventory this gate exists to see past. A gate whose answer depends on
+	// how it was invoked is worse than no gate.
+	root := tree(t, selfCallingExtension, goodEngine)
+
+	direct, err := check(root, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	indirect, err := check(filepath.Join(root, "..", filepath.Base(root)), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(direct.Sockets) != len(indirect.Sockets) {
+		t.Fatalf("%d sockets one way and %d the other", len(direct.Sockets), len(indirect.Sockets))
+	}
+	for i := range direct.Sockets {
+		if direct.Sockets[i].ConsultedAt != indirect.Sockets[i].ConsultedAt {
+			t.Fatalf("%s is consulted at %q one way and %q the other",
+				direct.Sockets[i].Name, direct.Sockets[i].ConsultedAt,
+				indirect.Sockets[i].ConsultedAt)
+		}
+	}
+}
+
+func TestARegistryReaderCalledOnlyByTheRegistryIsNotAConsultation(t *testing.T) {
+	t.Parallel()
+	// The same defect in its own right. A private reader called from Validate,
+	// inside the socket package, is the registry checking its own
+	// registrations rather than the engine asking for one. Counting it would
+	// report a socket as plugged in the moment it had a field, which is the
+	// AuditSink case this gate was written for.
+	engine := strings.Replace(goodEngine, "\t_, _ = r.DatabaseProviderNamed(\"docker\")", "", 1)
+
+	got := problems(t, tree(t, selfCallingExtension, engine), nil)
+	if !strings.Contains(got, "nothing in the engine calls") {
+		t.Fatalf("a socket read only by the registry itself was reported as consulted: %q", got)
+	}
+}
+
 // TestThisRepository is the gate itself.
 func TestThisRepository(t *testing.T) {
 	report, err := Check("../..")

--- a/tools/socketcheck/main_test.go
+++ b/tools/socketcheck/main_test.go
@@ -1,0 +1,218 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A gate that cannot say no is worse than no gate, so most of this file is
+// about making it say no. Each case writes a small tree with the defect in it
+// and requires the reported problem to name that defect, and then removes the
+// defect and requires the tree to pass.
+
+const goodExtension = `package extension
+
+import (
+	"context"
+	"sync"
+
+	"github.com/antifailure/antifailure/engine/pkg/provider"
+)
+
+type PolicyHook interface {
+	Name() string
+	Check(ctx context.Context) error
+}
+
+type DatabaseProvider interface {
+	Name() string
+	Open(ctx context.Context, cfg Config) (provider.Database, error)
+}
+
+type Config struct {
+	Root string
+}
+
+type Registry struct {
+	mu       sync.RWMutex
+	policy   []PolicyHook
+	database []DatabaseProvider
+}
+
+func (r *Registry) AddPolicy(h PolicyHook) { r.policy = append(r.policy, h) }
+
+func (r *Registry) CheckPolicy(ctx context.Context) error {
+	for _, h := range r.policy {
+		if err := h.Check(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *Registry) AddDatabaseProvider(p DatabaseProvider) {
+	r.database = append(r.database, p)
+}
+
+func (r *Registry) DatabaseProviderNamed(name string) (DatabaseProvider, bool) {
+	for _, p := range r.database {
+		if p.Name() == name {
+			return p, true
+		}
+	}
+	return nil, false
+}
+
+func (r *Registry) Registered() []string {
+	var out []string
+	for _, h := range r.policy {
+		out = append(out, h.Name())
+	}
+	for _, p := range r.database {
+		out = append(out, p.Name())
+	}
+	return out
+}
+`
+
+const goodEngine = `package env
+
+import "github.com/antifailure/antifailure/engine/pkg/extension"
+
+func consult(r *extension.Registry) {
+	_ = r.CheckPolicy(nil)
+	_, _ = r.DatabaseProviderNamed("docker")
+}
+`
+
+func write(t *testing.T, root, rel, body string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func tree(t *testing.T, extension, engine string) string {
+	t.Helper()
+	root := t.TempDir()
+	write(t, root, "engine/pkg/extension/extension.go", extension)
+	write(t, root, "engine/internal/env/env.go", engine)
+	return root
+}
+
+func problems(t *testing.T, root string, unconsulted map[string]string) string {
+	t.Helper()
+	report, err := check(root, unconsulted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return strings.Join(report.Problems, "\n")
+}
+
+func TestATreeWhereEverySocketIsConsultedPasses(t *testing.T) {
+	t.Parallel()
+	if got := problems(t, tree(t, goodExtension, goodEngine), nil); got != "" {
+		t.Fatalf("a correct tree was reported: %s", got)
+	}
+}
+
+func TestASocketNothingConsultsIsReported(t *testing.T) {
+	t.Parallel()
+	// The AuditSink case, which is what this gate was written for: the
+	// interface, the registry and the Add are all there, and no line of the
+	// engine ever asks.
+	engine := strings.Replace(goodEngine, `	_, _ = r.DatabaseProviderNamed("docker")`, "", 1)
+	got := problems(t, tree(t, goodExtension, engine), nil)
+	if !strings.Contains(got, "DatabaseProvider") ||
+		!strings.Contains(got, "nothing in the engine calls") {
+		t.Fatalf("an unconsulted socket was not reported: %q", got)
+	}
+}
+
+func TestASocketListedAsUnconsultedAndActuallyConsultedIsReported(t *testing.T) {
+	t.Parallel()
+	// The other direction, which is what stops the list becoming exemptions
+	// nobody rereads: when the consultation lands, the entry has to go.
+	stale := map[string]string{"DatabaseProvider": "a reason that has stopped being true"}
+
+	got := problems(t, tree(t, goodExtension, goodEngine), stale)
+	if !strings.Contains(got, "Delete the entry") {
+		t.Fatalf("a stale entry was not reported: %q", got)
+	}
+}
+
+func TestASocketNamingAnInternalTypeIsReported(t *testing.T) {
+	t.Parallel()
+	// The defect surfacecheck found in provider.Database, in the one package
+	// whose whole purpose is being implemented from outside the module. It
+	// compiles, and no implementation outside this module can name the type.
+	leaky := strings.Replace(goodExtension,
+		`	"github.com/antifailure/antifailure/engine/pkg/provider"`,
+		"\t\"github.com/antifailure/antifailure/engine/internal/secrets\"\n"+
+			"\t\"github.com/antifailure/antifailure/engine/pkg/provider\"", 1)
+	leaky = strings.Replace(leaky,
+		"	Open(ctx context.Context, cfg Config) (provider.Database, error)",
+		"	Open(ctx context.Context, cfg Config) (provider.Database, secrets.Value, error)", 1)
+
+	got := problems(t, tree(t, leaky, goodEngine), nil)
+	if !strings.Contains(got, "secrets.Value") || !strings.Contains(got, "engine/internal") {
+		t.Fatalf("a socket naming an internal type was not reported: %q", got)
+	}
+}
+
+func TestATypeCarriedInsideAConfigStructIsReportedToo(t *testing.T) {
+	t.Parallel()
+	// One level in. The signature names only Config, and Config carries the
+	// type an outside implementation cannot name, which is the same defect
+	// one step further from the interface.
+	leaky := strings.Replace(goodExtension,
+		`	"github.com/antifailure/antifailure/engine/pkg/provider"`,
+		"\t\"github.com/antifailure/antifailure/engine/internal/secrets\"\n"+
+			"\t\"github.com/antifailure/antifailure/engine/pkg/provider\"", 1)
+	leaky = strings.Replace(leaky, "type Config struct {\n\tRoot string\n}",
+		"type Config struct {\n\tRoot string\n\tKey secrets.Value\n}", 1)
+
+	got := problems(t, tree(t, leaky, goodEngine), nil)
+	if !strings.Contains(got, "secrets.Value") {
+		t.Fatalf("an internal type inside a config struct was not reported: %q", got)
+	}
+}
+
+func TestARegistrationNothingCanEvenReadIsReported(t *testing.T) {
+	t.Parallel()
+	// A registry with an Add and no reader at all. Registered() lists it, so
+	// without the inventory exclusion this would look consulted.
+	blind := strings.Replace(goodExtension, `func (r *Registry) DatabaseProviderNamed(name string) (DatabaseProvider, bool) {
+	for _, p := range r.database {
+		if p.Name() == name {
+			return p, true
+		}
+	}
+	return nil, false
+}
+`, "", 1)
+	engine := strings.Replace(goodEngine, `	_, _ = r.DatabaseProviderNamed("docker")`, "", 1)
+
+	got := problems(t, tree(t, blind, engine), nil)
+	if !strings.Contains(got, "registered and never read") {
+		t.Fatalf("a socket with no reader was not reported: %q", got)
+	}
+}
+
+// TestThisRepository is the gate itself.
+func TestThisRepository(t *testing.T) {
+	report, err := Check("../..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log("\n" + report.String())
+	if len(report.Problems) > 0 {
+		t.Fatalf("%s", strings.Join(report.Problems, "\n"))
+	}
+}

--- a/www/public/errors.v1.json
+++ b/www/public/errors.v1.json
@@ -707,6 +707,28 @@
       "planned": false
     },
     {
+      "code": "AF-EXT-001",
+      "area": "EXT",
+      "areaName": "Extensions",
+      "message": "This build cannot honor one of its own extension registrations: {detail}",
+      "resolution": "Fix the registration in the binary that made it. Nothing was created.",
+      "docs": "https://antifailure.dev/docs/contributing/provider-authoring",
+      "retryable": false,
+      "exitCode": 3,
+      "planned": false
+    },
+    {
+      "code": "AF-EXT-002",
+      "area": "EXT",
+      "areaName": "Extensions",
+      "message": "The registered {socket} {name} returned nothing and reported no error.",
+      "resolution": "Fix the registration to return either something usable or an error saying why it could not. Nothing was created.",
+      "docs": "https://antifailure.dev/docs/contributing/provider-authoring",
+      "retryable": false,
+      "exitCode": 3,
+      "planned": false
+    },
+    {
       "code": "AF-FID-001",
       "area": "FID",
       "areaName": "Fidelity",


### PR DESCRIPTION
## The failure

The documentation says providers are the main extension point and that they are
meant to be written by people outside this repository. There is a stable
interface, a conformance suite that decides whether an implementation is
conformant, and a page telling somebody they do not have to ask permission or be
a contributor here.

Every word of that was true and none of it was reachable. The engine chose its
database provider from a switch in `engine/internal/env` whose `default:`
refused anything it had no case for, its runtime from a second switch of the
same shape, and its golden store from a third. Go's internal rule means no
module but the engine can import that package, so the only way to add a case was
to edit this repository. A provider could be written, could pass the conformance
suite, and could not be selected by any build. "Extensible" meant "send us a
patch".

## What this changes

`engine/pkg/extension` gains five sockets beside the four hooks it already had:
`DatabaseProvider`, `DatastoreProvider`, `RuntimeProvider`, `GoldenStore` and
`Emulator`, each with a registration, a lookup, and a line in what
`af license status` prints.

The database provider, the runtime and the golden store now consult the registry
in the `default:` where they used to refuse, and each of those three refusals now
lists what the build does have, registered providers included. The reasoning in
the existing `default:` comments is kept rather than replaced.

The configuration each registration receives is made only of types a module
outside this one can name, including a `Lookup` that reaches the engine's whole
secret chain, so a registered provider reads its credentials the way a built in
one does rather than out of the process environment.

**A registration adds a choice and can never take one over.** The registry is
consulted after the built in cases and never before them, and a registration
under a name the engine already has is refused at the first command rather than
ignored, because a build somebody believes replaces the Docker provider and
silently does not is worse than one that will not start.

`engine/internal/golden.Store` becomes an alias of `extension.ObjectStore` rather
than a second declaration of the same interface, and `golden.ErrNotFound` becomes
`extension.ErrObjectNotFound`. A store outside this module cannot name a sentinel
declared in an internal package, so without that every absent object from a
registered store would have read as a broken store rather than as a golden that
was never published.

## Two sockets with nothing behind them, said out loud

There is no second datastore in the manifest for a `DatastoreProvider` to be,
and no egress rule can name an `Emulator`, so registering either does nothing
today beyond appearing in `af license status` and being validated. Both say so
in their own documentation.

`tools/socketcheck` is what makes that more than a comment. Every socket is
either consulted by the engine or listed in the tool with the reason, and both
directions fail: an unconsulted socket that is not listed is reported, and a
listed socket that has since been wired up is reported too, so an entry cannot
outlive the gap it describes. It also refuses a socket whose signatures name a
type under `engine/internal`, which is the defect `surfacecheck` was written for
in the stable packages and which nothing covered in the one package whose whole
purpose is being implemented from outside.

## What that gate found on its first run

`extension.AuditSink` has an interface, a registry, an `AddAuditSink`, and a
`Registry.Audit` that forwards to every sink. **Nothing in the engine has ever
called `Registry.Audit`.** `audit_stream` is a licensed feature that forwards
nothing, and it would still forward nothing after somebody wrote the sinks,
because there is no call site to hand them an entry. This pull request reports
it rather than fixing it: the fix is a decision about which actions are
forwarded and belongs with whoever makes it.

## The number

    9 of 9 sockets are implementable from outside the engine module
    6 of 9 sockets are consulted by the engine
      AuditSink            NOT CONSULTED
      DatabaseProvider     consulted
      DatastoreProvider    NOT CONSULTED
      Emulator             NOT CONSULTED
      GoldenStore          consulted
      LifecycleHook        consulted
      PolicyHook           consulted
      RuntimeProvider      consulted
      SecretSource         consulted

Measured by `just socketcheck`, whose report names the file and line of each
consultation. Before this branch there were four sockets, three of them
consulted, and none of them a provider: the number of provider shaped extension
points a build outside this repository could register and have selected was
**0 of 3**. It is now **3 of 3**, proved by an environment brought up on a
registered database provider and a registered runtime and torn down again, with
no Docker daemon and no Postgres involved.

## Two seams left open, named

**`schemas/manifest.v1.json` still enumerates only the shipped provider names.**
The engine does not read that file, so a manifest naming a registered provider
is accepted and the environment comes up; an editor validating against the
schema flags it anyway. Two things both claim to say what a valid manifest is
and they now disagree about one case. Closing it means either relaxing the enum,
which costs the typo detection it exists for, or regenerating it from what a
build has registered, which a static file cannot do. It is left for whoever adds
the first real cloud provider, and written down here so it is not discovered.

**`internal/subset` fails on the machine this branch was written on** with
`unrecognized configuration parameter "transaction_timeout"`, which is an older
local `pg_restore` reading a dump from a newer server. It was not reproduced
against pristine main. The evidence that it is not this branch is that CI runs
the same `go test ./internal/... -short` on Linux, in the edition boundary job,
and passes; and that nothing here touches `internal/subset` or anything it
imports. That is a reasonable place to rest, and saying which way it was
established is what makes it reasonable rather than an assumption.

## Tests

New behaviour tests in `engine/pkg/extension`, `engine/internal/env` and
`engine/internal/golden`, and the gate's own six cases in `tools/socketcheck`.
Every one was mutation tested: the production line it exists to catch was broken,
the test was required to go red, the line was restored, and the test was required
to go green again. Two of them did not go red the first time and were rewritten;
one was comparing a misspelled provider name against a substring of itself.
