### PR TITLE
engine: two goldens made in the same second were given one identifier

### DIFF
--- a/.changes/two-goldens-in-one-second-shared-an-identifier.md
+++ b/.changes/two-goldens-in-one-second-shared-an-identifier.md
@@ -1,0 +1,9 @@
+# fixed
+
+A golden version identifier carried its timestamp to the second, and the hash
+beside it is a digest of the masking rules rather than anything unique, so two
+refreshes inside one second were handed one identifier. The second `CREATE
+DATABASE` then failed with "already exists". Two test suites had already worked
+around it by minting a random rules hash per call, which left the edge in place
+for everyone else. The timestamp now carries microseconds, which is exactly the
+twenty digits the MCP server already publishes as the widest it will accept.

--- a/docs/src/content/docs/concepts/goldens.md
+++ b/docs/src/content/docs/concepts/goldens.md
@@ -24,8 +24,14 @@ A refresh produces a new version. It never rewrites an existing one.
 That is not tidiness. An environment that branched an hour ago has to keep
 seeing the data it branched from, or a test that passed becomes a test that
 fails for a reason nobody can reproduce. A version is identified by
-`gv_<timestamp>_<hash>`, so sorting by name sorts by age, and the hash makes
-two refreshes in the same second distinct.
+`gv_<timestamp>_<hash>`, so sorting by name sorts by age.
+
+The hash does not make two refreshes distinct, and this page used to say that it
+did. It is a digest of the masking rules, so two refreshes under the same rules
+carry the same hash on purpose: it tells you what a golden was made by, not
+which golden it is. Telling two apart is the timestamp's job alone, which is why
+it is written to the microsecond. At one second it was possible to refresh twice
+inside one tick and be handed one identifier for two goldens.
 
 ```sh
 af golden list          # what exists, newest first

--- a/engine/conformance/db.go
+++ b/engine/conformance/db.go
@@ -413,9 +413,11 @@ func runBehavior(ctx context.Context, t *testing.T, name string, factory Factory
 // for the same reason. Randomness cannot collide by construction, where every
 // derivation so far has collided along an axis nobody thought about.
 //
-// The one-second resolution in provider.NewGoldenVersionID is the underlying
-// sharp edge and is still there: two refreshes in one second is not something
-// only a test does. This stops the suite depending on it either way.
+// The one-second resolution in provider.NewGoldenVersionID was the underlying
+// sharp edge, and this comment used to end by saying it was still there. It is
+// not: that identifier now carries microseconds, because two refreshes in one
+// second is not something only a test does. This still stops the suite
+// depending on the timestamp either way.
 func (h *harness) rulesHash() string {
 	var b [4]byte
 	if _, err := rand.Read(b[:]); err != nil {

--- a/engine/internal/db/supabase/supabase_test.go
+++ b/engine/internal/db/supabase/supabase_test.go
@@ -51,7 +51,7 @@ func TestAGoldenVersionSurvivesTheRoundTripThroughABranchName(t *testing.T) {
 	version := provider.NewGoldenVersionID(time.Unix(1767225600, 0), "abcdef1234567890")
 	name := PrefixGolden + version
 	require.Equal(t, version, strings.TrimPrefix(name, PrefixGolden))
-	require.Equal(t, "gv_20260101000000_abcdef12", version)
+	require.Equal(t, "gv_20260101000000000000_abcdef12", version)
 }
 
 func TestAnAnnotationRoundTrips(t *testing.T) {

--- a/engine/internal/masking/sql_test.go
+++ b/engine/internal/masking/sql_test.go
@@ -103,8 +103,8 @@ func TestGoldenIDsFromThisHelperDoNotCollideWithinASecond(t *testing.T) {
 	second := provider.NewGoldenVersionID(at, "masking-test")
 	require.Equal(t, first, second,
 		"the collision this test exists for is supposed to be reproducible")
-	require.Equal(t, "gv_20260829012258_masking-", first,
-		"the id in the CI failure, reproduced exactly")
+	require.Equal(t, "gv_20260829012258000000_masking-", first,
+		"the id in the CI failure, with the microseconds this now carries")
 
 	// What it does now.
 	seen := map[string]bool{}
@@ -144,16 +144,19 @@ func requireDatabase(t *testing.T) (*pgx.Conn, func()) {
 	// A UNIQUE rules hash per call, and it has to be unique in its first eight
 	// characters.
 	//
-	// NewGoldenVersionID builds gv_<timestamp to the second>_<hash[:8]>, so a
-	// constant like "masking-test" truncates to "masking-" and every golden this
-	// helper makes inside the same second gets the SAME id. Two tests in this
-	// package that land in one second then share a golden: the first one's
-	// cleanup drops it, and the second fails with "the golden version
-	// gv_..._masking- no longer exists".
+	// NewGoldenVersionID builds gv_<timestamp>_<hash[:8]>, so a constant like
+	// "masking-test" truncates to "masking-" and every golden this helper makes
+	// at the SAME instant gets the same id. Two tests in this package that
+	// shared one then shared a golden: the first one's cleanup dropped it, and
+	// the second failed with "the golden version gv_..._masking- no longer
+	// exists".
 	//
 	// It passed locally and failed in CI for exactly that reason. The local run
-	// takes minutes and the tests fall in different seconds; a CI runner puts
-	// them in the same one.
+	// takes minutes and the tests fell in different seconds; a CI runner put
+	// them in the same one. The timestamp now carries microseconds, so the
+	// second is no longer the unit two tests have to avoid sharing, but a
+	// unique hash per call is still what this helper owes: it is the only
+	// thing that tells two goldens apart in a listing a human reads.
 	gv, err := p.RefreshGolden(ctx, provider.GoldenSpec{
 		Version: 17, RulesHash: uniqueRulesHash(),
 		Mask:   func(context.Context, secrets.Value) error { return nil },

--- a/engine/internal/mcp/tools_golden.go
+++ b/engine/internal/mcp/tools_golden.go
@@ -82,11 +82,18 @@ type prepareGolden func(ctx context.Context, action, version string) (goldenOutc
 // The pattern is the shape the engine mints, gv_ followed by a timestamp and a
 // hash, so a path, a branch name or a wildcard is refused before it reaches a
 // provider.
+//
+// Twenty is the ceiling on the timestamp and it is load bearing rather than
+// generous. provider.NewGoldenVersionID writes the timestamp to the
+// microsecond, which is exactly twenty digits, because at one second two
+// refreshes inside the same second were handed one identifier. A wider
+// timestamp would be minted by the engine and refused by this server, so
+// pkg/provider has a test that fails if it ever leaves this range.
 func goldenVersionSchema(purpose string) *Schema {
 	return &Schema{
 		Type: "string", MaxLength: 64, MinLength: 4, Pattern: `gv_[0-9]{8,20}_[0-9a-f]{4,32}`,
 		Description: purpose + " It is a version identifier inspect_goldens reports, such " +
-			"as gv_20260830044013_74234e98. It is never a pattern: this server has no " +
+			"as gv_20260830044013125431_74234e98. It is never a pattern: this server has no " +
 			"wildcard and every identifier names one version.",
 	}
 }

--- a/engine/pkg/provider/db.go
+++ b/engine/pkg/provider/db.go
@@ -294,6 +294,31 @@ type Config struct {
 // The format sorts by age as a string, which means a directory listing, a
 // database index, and a human reading a list all agree on the order without
 // parsing anything.
+//
+// The timestamp carries microseconds, and those six digits are the whole point
+// rather than precision for its own sake. The hash is a digest of the masking
+// rules, so two goldens built from the SAME rules are SUPPOSED to carry the
+// same one: it is provenance, not identity. That leaves the timestamp as the
+// only thing telling two goldens apart, and at one second resolution two
+// refreshes inside one second were handed ONE identifier. What followed
+// depended on the store: Postgres refused the second CREATE DATABASE with
+// "already exists", and a store that overwrites rather than refusing would have
+// published one golden over another.
+//
+// Two suites had already worked around it, engine/conformance and
+// internal/masking, by minting a random rules hash per call. That fixed those
+// two and left the edge exactly where it was, and conformance said so in a
+// comment: two refreshes in one second is not something only a test does. The
+// fake Postgres provider still walked into it and reddened the engine job of a
+// pull request that changed four files, none of them Go.
+//
+// Microseconds rather than milliseconds because the pattern the MCP server
+// publishes for this identifier allows eight to twenty digits, and twenty is
+// exactly a microsecond timestamp. It does not make two calls in the same
+// microsecond distinct and nothing without state could: a refresh creates a
+// database, seeds it and masks it, so consecutive ones are milliseconds apart
+// at the very least, and two of THOSE not colliding is the guarantee this
+// needs.
 func NewGoldenVersionID(at time.Time, hash string) string {
 	if len(hash) > 8 {
 		hash = hash[:8]
@@ -301,5 +326,6 @@ func NewGoldenVersionID(at time.Time, hash string) string {
 	for len(hash) < 8 {
 		hash += "0"
 	}
-	return fmt.Sprintf("gv_%s_%s", at.UTC().Format("20060102150405"), hash)
+	at = at.UTC()
+	return fmt.Sprintf("gv_%s%06d_%s", at.Format("20060102150405"), at.Nanosecond()/1000, hash)
 }

--- a/engine/pkg/provider/goldenid_test.go
+++ b/engine/pkg/provider/goldenid_test.go
@@ -1,0 +1,114 @@
+package provider_test
+
+import (
+	"regexp"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/pkg/provider"
+)
+
+// The identifier every golden is known by had no test of its own. These are
+// about the one property nothing else can supply: two goldens are two things.
+//
+// The rules hash cannot supply it. It is a digest of the masking rules, so two
+// goldens built from the same rules SHOULD carry the same one, and the two
+// suites that hit this in CI both had to mint a random hash per call to get
+// around it. That is a workaround at the caller, and it leaves every other
+// caller holding the same edge.
+
+func TestTwoGoldensRefreshedInsideOneSecondGetTwoIdentifiers(t *testing.T) {
+	t.Parallel()
+
+	// The exact shape of the failure. A refresh, then a second refresh of the
+	// same golden a moment later, both with the constant rules hash a caller is
+	// entitled to pass, both inside one second.
+	first := time.Date(2026, 9, 7, 6, 4, 45, 120_000_000, time.UTC)
+	second := first.Add(time.Microsecond)
+
+	require.NotEqual(t,
+		provider.NewGoldenVersionID(first, "abc"),
+		provider.NewGoldenVersionID(second, "abc"),
+		"two refreshes a microsecond apart were given one identifier, which is "+
+			"the CREATE DATABASE that failed with already exists")
+}
+
+func TestAGoldenIdentifierStillNamesTheSecondItWasMadeIn(t *testing.T) {
+	t.Parallel()
+
+	// The extra digits are appended, not substituted. A reader of a listing
+	// still sees the date and the time of day at the front, which is the
+	// property the format exists for.
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	require.Equal(t, "gv_20260101000000000000_abcd1234",
+		provider.NewGoldenVersionID(at, "abcd1234"),
+		"the second is still spelled out in full before the microseconds")
+}
+
+func TestGoldenIdentifiersSortByAgeAsStrings(t *testing.T) {
+	t.Parallel()
+
+	// The documented promise: a directory listing, a database index and a human
+	// reading a list all agree on the order without parsing anything. A
+	// sub-second field breaks that the moment it is not fixed width and zero
+	// padded, and a listing would then interleave two goldens made in one second
+	// with goldens made hours apart.
+	base := time.Date(2026, 9, 7, 6, 4, 45, 0, time.UTC)
+	times := []time.Time{
+		base.Add(2 * time.Second),
+		base.Add(999999 * time.Microsecond),
+		base,
+		base.Add(time.Microsecond),
+		base.Add(1500 * time.Microsecond),
+		base.Add(time.Hour),
+	}
+
+	ids := make([]string, len(times))
+	for i, at := range times {
+		ids[i] = provider.NewGoldenVersionID(at, "abcd1234")
+	}
+	byAge := append([]time.Time(nil), times...)
+	sort.Slice(byAge, func(i, j int) bool { return byAge[i].Before(byAge[j]) })
+	want := make([]string, len(byAge))
+	for i, at := range byAge {
+		want[i] = provider.NewGoldenVersionID(at, "abcd1234")
+	}
+	sort.Strings(ids)
+
+	require.Equal(t, want, ids,
+		"sorting the identifiers as strings no longer sorts the goldens by age")
+}
+
+func TestAGoldenIdentifierMatchesThePatternTheMCPServerPublishes(t *testing.T) {
+	t.Parallel()
+
+	// engine/internal/mcp/tools_golden.go publishes this pattern to every agent
+	// that calls the server, as the shape of a value it will accept. Twenty is
+	// the ceiling on the timestamp and a microsecond timestamp is exactly
+	// twenty, so this is the assertion that says no to a wider one. Nanoseconds
+	// would be twenty three and would be refused by the server that describes
+	// the identifiers this function mints.
+	published := regexp.MustCompile(`^gv_[0-9]{8,20}_[0-9a-f]{4,32}$`)
+	at := time.Date(2026, 9, 7, 6, 4, 45, 999_999_999, time.UTC)
+
+	require.Regexp(t, published, provider.NewGoldenVersionID(at, "74234e98"),
+		"the identifier no longer matches the pattern the MCP server accepts")
+}
+
+func TestAShortHashIsPaddedAndALongOneIsTruncated(t *testing.T) {
+	t.Parallel()
+
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	require.Equal(t, "gv_20260101000000000000_ab000000",
+		provider.NewGoldenVersionID(at, "ab"),
+		"a hash shorter than eight characters is padded to eight")
+
+	require.Equal(t, "gv_20260101000000000000_abcdef12",
+		provider.NewGoldenVersionID(at, "abcdef1234567890"),
+		"a hash longer than eight characters is truncated to eight")
+}


### PR DESCRIPTION
## Two goldens made in one second were given one identifier

Found by reading another pull request's red check rather than assuming it was
that pull request's fault. #280 changes `deploy/cd/deploy.sh`,
`deploy/cd/deploy_test.sh`, a note and a changelog entry. Not one of them is
Go. Its `engine` job, a required context, failed like this:

```
--- FAIL: TestThePostgresFakeIsCorrectAndItsStorageFaultsAreNot/refresh-rebuilds-existing-branches
    database_test.go:722: second refresh: create the golden candidate:
    ERROR: database "afcfe5a73bd84214_g_gv_20260907060445_abc00000" already exists (SQLSTATE 42P04)
```

Main passed the same job four minutes earlier.

## The hash was never the thing that made a golden unique

`provider.NewGoldenVersionID` built `gv_<timestamp to the second>_<hash[:8]>`.

The hash is a digest of the masking rules. Two goldens built under the same
rules are SUPPOSED to carry the same one: it says what a golden was made by,
not which golden it is. So the timestamp was the only field telling two goldens
apart, and at one second resolution a refresh followed by another refresh
inside the same second produced one identifier for two goldens. Postgres
refuses the second `CREATE DATABASE`. A store that overwrites rather than
refusing would have published one golden over another and said nothing.

That test refreshes twice in a row with a constant rules hash, which is a thing
a caller is entitled to do. It passed only when the two calls happened to
straddle a second boundary.

## The repository already knew

`engine/conformance/db.go`, in a comment ending a long explanation of an
earlier collision:

> The one-second resolution in provider.NewGoldenVersionID is the underlying
> sharp edge and is still there: two refreshes in one second is not something
> only a test does. This stops the suite depending on it either way.

Two suites had worked around it by minting a random rules hash per call,
`engine/conformance` and `internal/masking`. Both fixed themselves and left the
edge exactly where it was for every other caller, and the fake Postgres
provider walked into it.

`docs/src/content/docs/concepts/goldens.md` said the opposite of the truth:
"the hash makes two refreshes in the same second distinct". It does not and
cannot. That paragraph is rewritten.

## Microseconds, and why not more

`engine/internal/mcp/tools_golden.go` publishes this to every agent that calls
the server as the shape of a golden version it will accept:

```
gv_[0-9]{8,20}_[0-9a-f]{4,32}
```

Twenty digits is the ceiling, and a microsecond timestamp is exactly twenty. A
nanosecond one is twenty three and would be refused by our own server. So the
resolution was chosen by an existing published contract rather than by taste,
and there is a test that fails if the width ever leaves that range.

The digits are appended and zero padded, so a listing still sorts by age as a
string, which is the property the format exists for and which an unpadded
sub-second field would quietly destroy.

The comment on `goldenVersionSchema` now says why twenty is load bearing rather
than generous, and its example identifier is the shape the engine actually
mints. An agent reading that description was being shown a fourteen digit
identifier as a sample of what `inspect_goldens` reports.

What this does NOT claim: two calls inside one microsecond are still one
identifier, and nothing without state could fix that. A refresh creates a
database, seeds it and masks it. Consecutive ones are milliseconds apart at the
very least, and two of THOSE not colliding is the guarantee that was missing.

## `pkg/provider` had no test file at all

The function that mints the identity of every golden had never been tested.
There is now `pkg/provider/goldenid_test.go` with five, including a direct
reproduction of the failure above at the level it happens.

## What was deliberately not changed

Fixture identifiers across the tree, about forty of them, still carry fourteen
digit timestamps. They are strings standing for a golden in a test or a
document, not output of this function, and the tree already contains
`gv_20260101_ab12cd` with an eight digit stamp, so the width was never fixed and
nothing reads it. Changing them would be a large diff that proves nothing.

Two tests DO assert this function's own output and both were updated:
`internal/db/supabase` on the branch name round trip, and `internal/masking` on
the identifier it reproduces from a CI failure.

## Mutation table

One break per cell, because `require` stops at the first failure. Nothing was
mutated while a suite was running.

| # | what was broken | result | caught by |
| --- | --- | --- | --- |
| 1 | the timestamp goes back to one second resolution | red | `TwoGoldensRefreshedInsideOneSecondGetTwoIdentifiers` and four more |
| 2 | the microseconds stop being zero padded, so the width varies | red | `GoldenIdentifiersSortByAgeAsStrings` and four more |
| 3 | the microseconds are written before the date | red | `GoldenIdentifiersSortByAgeAsStrings` and four more |
| 4 | nanoseconds, three digits wider than the published pattern accepts | red | `AGoldenIdentifierMatchesThePatternTheMCPServerPublishes` and four more |
| 5 | a short hash stops being padded to eight characters | red | `AShortHashIsPaddedAndALongOneIsTruncated` |
| 6 | a long hash stops being truncated to eight characters | red | `AShortHashIsPaddedAndALongOneIsTruncated`, `AGoldenVersionSurvivesTheRoundTripThroughABranchName`, `GoldenIDsFromThisHelperDoNotCollideWithinASecond` |

**6 of 6.** Cell 1 is the reproduction: it restores the exact behaviour that
failed three pull requests tonight, and the test written for it is the one that
goes red.

`internal/masking` is scoped in that harness to the one test in it that reads
this identifier, rather than run whole, and the reason is written into the
harness. Its other tests stand up a Postgres container each, five minutes a
baseline, twice per cell, and none of them touches this function. Running it
whole held this machine's single build lock for twenty three minutes with three
red pull requests behind it before I stopped it. A `-run` pattern that matches
nothing exits 0 and reads exactly like a pass, so the harness counts `=== RUN`
lines and refuses a cell where the test did not run.

## Gates, run locally before pushing

```
prosecheck: 905 files, 0 places where the punctuation gives it away     exit 0
changecheck: 2 changes a user could notice, described by
             .changes/two-goldens-in-one-second-shared-an-identifier.md  exit 0
gatecheck:   84 gates in 9 pull request workflows                        exit 0
go build ./... and go vet over the five touched packages                 exit 0
```

## What was NOT checked

- **No `-race` run.** Swap on this machine has been under 1.3 GB free for most
  of the night with five lanes on one build lock, and a race build of these
  packages was not something to start into that.
- **The Docker backed half of `internal/masking` did not run in the mutation
  table**, deliberately and as described above. It runs whole in the `engine`
  required context on a clean runner, which is what should be believed about it.
- **`internal/testutil/fakes` was not run locally.** It is the package whose
  test this fixes and it needs the shared Postgres container. The proof I have
  is at the identifier level, cell 1, plus the three CI failures that named it.
