### PR TITLE
engine: one identity masked into two people, the moment a twin held two stores

### DIFF
--- a/.changes/one-user-masked-into-two-people.md
+++ b/.changes/one-user-masked-into-two-people.md
@@ -1,0 +1,50 @@
+# changed
+
+Masking held one guarantee above all the others: the same customer maps to the
+same fake customer in every table and every refresh, so a foreign key still
+joins after the data is rewritten. It held that guarantee inside one Postgres,
+and it had never been asked to hold it anywhere else.
+
+Every part of the pipeline that touches an engine was Postgres and said so
+nowhere. The classifier matched a rule's `type:` against Postgres type names, so
+a rule saying `type: text` could not match a ClickHouse `String`. Nothing then
+decided what happened to that column, so it was copied unchanged, while the
+Postgres column beside it holding the same address was masked. One person, two
+answers, and no error anywhere: the Postgres store holds a fake address and the
+analytics store holds the real one. A join across the two returns nothing or
+returns somebody else, every report built on it is plausible, and the fidelity
+report calls the environment faithful.
+
+That is worse than the empty ClickHouse the previous change is about. An empty
+store is visible within a minute of opening a chart. A store masked into a
+different person is confidently wrong.
+
+So there is now a dialect boundary, and it is deliberately narrow: an engine's
+type names, its identifier quoting, its statement parameters, the read that
+takes a chunk, and the rewrite that puts one back. Everything else was already
+engine independent and stays that way. The transforms are pure functions of a
+key that never reaches the database, computed in Go, so what a value masks to
+never depended on which store it came out of.
+
+Each engine's type names map onto the POSTGRES names rather than onto a third
+vocabulary, so one `masking.yaml` covers every store and a rule anybody has
+already written keeps meaning what it meant. A type an engine's dialect does not
+recognise comes back unchanged, which lands it in the branch that reports a
+column rather than deciding about it. An engine nobody has a dialect for is
+refused at planning time rather than treated as Postgres, and a ClickHouse table
+with no sorting key is refused for the same reason a half masked table is never
+started: ClickHouse has no physical row identifier, so there is no statement
+that means one row.
+
+The verification scanner gains the same boundary and keeps its own copy of the
+type table, because it must not import the thing it checks. A test requires the
+two to agree, which is how the Postgres lists have been kept in step and is now
+how the ClickHouse ones are.
+
+**And the guarantee is now checked rather than argued.** `CrossStoreCheck` takes
+two stores' plans, finds every identifier that appears in both, masks probe
+values through each side, and reports the share that come out identical. A
+column masked in one store and copied in the other is a leak; two columns masked
+with different transforms, or under different links, are one identity becoming
+two people. Anything below 100 percent is a bug, there is deliberately no way to
+mark a pair exempt, and a report that compared nothing is not a pass.

--- a/benchmarks/2026-09-07-1307-crossstore.md
+++ b/benchmarks/2026-09-07-1307-crossstore.md
@@ -1,0 +1,25 @@
+# Cross store join keys, before and after the dialect boundary
+
+Run on 2026-09-07T13:07:43Z.
+
+- Machine: darwin arm64, 8 cores.
+- Stores: a Postgres holding people and a ClickHouse 25.3.14.14 holding the events about them.
+- Harness: `just benchmark`, which is `engine/internal/masking/benchmark_test.go` in this repository.
+- Rules: one `masking.yaml` for both stores, two rules and the built in defaults under them.
+
+| | Candidate join keys | Verified identical | Share |
+| --- | --- | --- | --- |
+| Before | 6 | 3 | 50.0% |
+| After | 6 | 6 | 100.0% |
+
+A candidate join key is a column name that appears in both stores, or two columns a rule gave the same link, where at least one side is masked. Anything below 100 percent is a bug rather than a score: a join key that masks to two different values is a broken join, and a join key masked in one store and copied in the other is also a leak.
+
+What the before figure was, column by column:
+
+- `events.af_masking.bench_events.name` and `primary.public.bench_person.name`: primary.public.bench_person.name is masked with name and events.af_masking.bench_events.name is copied unchanged, so one store holds a fake value for this identifier and the other holds the real one
+- `events.af_masking.bench_events.properties` and `primary.public.bench_person.properties`: primary.public.bench_person.properties is masked with empty_json and events.af_masking.bench_events.properties is copied unchanged, so one store holds a fake value for this identifier and the other holds the real one
+- `events.af_masking.bench_events.session_note` and `primary.public.bench_person.session_note`: primary.public.bench_person.session_note is masked with nullify and events.af_masking.bench_events.session_note is copied unchanged, so one store holds a fake value for this identifier and the other holds the real one
+
+The before figure is not a simulation. The classifier decides on a canonical type name, and before the dialect boundary it compared a rule's `type:` against whatever the catalog reported. This run reproduces that by labelling the ClickHouse catalog as Postgres, so no translation happens and the raw ClickHouse type names are matched against Postgres ones, which is the code that used to run.
+
+The after figure is the one to read as a pass, and only at 100 percent. A report that found nothing to compare is not a pass either: this run requires the candidate count to be positive.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -60,3 +60,24 @@ golden and nothing is copied. A provider that copies files, which `pgurl` does,
 shows a branch time proportional to the database. Both are legitimate. Only one
 of them is what somebody with a terabyte should buy, and telling them which
 before they run their own trial is why the slow numbers are published here too.
+
+## Cross store join keys
+
+A different question again, and the only figure here that is not a time. An
+environment holds more than one store and the same person is usually in several
+of them, joined on an identifier that is in both. **Of the identifiers that
+appear in more than one store, how many mask to the same value in all of them?**
+
+| Stores | Candidate join keys | Verified identical | Share | Run |
+| --- | --- | --- | --- | --- |
+| Postgres and ClickHouse | 6 | 6 | 100% | `2026-09-07-1307` |
+
+Anything below 100 percent is a bug rather than a slower number. A join key that
+masks to two different values is a join that returns nothing, and a join key
+masked in one store and copied in the other is also a leak. That is what makes
+this worth quoting: it is a figure that can only be said out loud when it is
+perfect, and the same run publishes what it was before the dialect boundary
+existed, which was 3 of 6.
+
+A report that found nothing to compare is not a pass either, and the harness
+refuses one.

--- a/docs/src/content/docs/concepts/masking.md
+++ b/docs/src/content/docs/concepts/masking.md
@@ -45,9 +45,11 @@ rules:
     why: "keeps foreign keys joinable after remapping"
 ```
 
-`table` and `column` accept `*`. `type` matches the Postgres type. `why` is one
-sentence, printed by `af mask plan` beside the column it applies to, so a
-decision made months ago is readable when somebody questions it.
+`table` and `column` accept `*`. `type` matches the type name, written in the
+Postgres vocabulary whichever store the column is in: see [more than one
+store](#more-than-one-store). `why` is one sentence, printed by `af mask plan`
+beside the column it applies to, so a decision made months ago is readable when
+somebody questions it.
 
 ### `link` is the one that catches people
 
@@ -68,6 +70,90 @@ returns nothing. `link` groups them:
 Without the link, `users.id` and `orders.user_id` get different new UUIDs, every
 order becomes an orphan, and the environment looks like a customer base with no
 orders. Nothing errors. That is why it is worth stating explicitly.
+
+## More than one store
+
+An environment can hold more than one datastore, and the same person is usually
+in several of them: a Postgres holding accounts and a ClickHouse holding the
+events about them, joined on an identifier that is in both.
+
+**One identity has to mask to one person across every store.** If it does not,
+a join across the two returns nothing or returns somebody else, every report
+built on it is plausible, and nothing anywhere says so. That is worse than a
+store nobody copied at all, because an empty store is visible within a minute of
+opening a chart.
+
+It is one `masking.yaml` for every store, and the `type` in a rule is written in
+the Postgres vocabulary whatever the store is. Each engine's own type names are
+mapped onto the Postgres ones before a rule is matched, so `type: text` means
+Postgres `text` and ClickHouse `String` and nobody writes the rule twice. A
+rules file per engine would be a rules file that goes stale for one engine and
+not the other, and the failure mode of that is a column masked in one store and
+real in the next.
+
+Two refusals follow from the same principle:
+
+- A store whose engine this build has no dialect for is refused when the plan is
+  made. Guessing at Postgres would mean matching a rule against a vocabulary the
+  store does not have, so nothing would match, so every column would fall
+  through to the branch that says nobody decided. A column that looks classified
+  and was not is the failure this whole page is about.
+- A ClickHouse table with no sorting key is refused for the same reason a half
+  masked table is never started. ClickHouse has no physical row identifier, so
+  there is no statement that means one row. Postgres always has `ctid`, so the
+  refusal is the engine's rather than a new rule about keys.
+
+The transforms themselves never needed a store. Every one is a pure function of
+the project key, the column identity, and the input value, computed on the
+machine running the refresh and never in the database, so what a value masks to
+has never depended on which store it came out of. What did depend on the store
+was the classifier deciding what to do with a column, and that is what the
+dialect settles.
+
+### The check that says the two stores agree
+
+The guarantee is checked rather than argued. The check takes two stores' plans,
+finds every identifier that appears in both, masks probe values through each
+side, and reports the share that come out identical:
+
+```
+join keys verified identical across primary and events: 4 of 4 (100.0%)
+```
+
+Anything below 100 percent is a bug, and there are three ways to get there:
+
+- one side is masked and the other is copied unchanged, which is a leak as well
+  as a broken join
+- the two sides are masked with different transforms
+- the two sides are masked under different links, so each derives its own subkey
+  and one input produces two different outputs
+
+There is deliberately no way to mark a pair exempt. Two columns with one name in
+two stores that genuinely mean different things is a real thing to look at, and
+the cost of looking at it is a rule; the cost of silencing it is a twin that is
+wrong in a way nobody can see. A report that found nothing to compare is not a
+pass either.
+
+The commonest thing it finds is a blob that is `jsonb` on one side and a
+`String` holding JSON on the other. Nothing leaks, and the two stores still hold
+different values for one field. A rule settles it:
+
+```yaml
+  - table: "*"
+    column: properties
+    type: text
+    transform: empty_json
+    why: "the analytics store keeps this JSON in a String"
+```
+
+### What is not built yet
+
+The dialect boundary is the classification, the statements and the verification
+scan. Nothing yet refreshes a golden for a second store, branches one, or opens
+a connection to one: there is no ClickHouse provider, and `datastores` entries
+other than `primary` are reported with their declared stance rather than
+measured. Said here rather than left to be discovered, because a boundary that
+looks complete from outside is how somebody ends up trusting one.
 
 ## Writing the rules from the schema
 

--- a/engine/internal/masking/benchmark_test.go
+++ b/engine/internal/masking/benchmark_test.go
@@ -1,0 +1,190 @@
+package masking_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/internal/masking"
+)
+
+// The lane's number, produced by a harness in this repository so that anybody
+// can run it against their own two stores and get their own.
+//
+// It is the one number in the table that can only be quoted when it is perfect,
+// which is what makes quoting it worth something: a join key that masks to two
+// different values is a broken join and a leak, so anything below 100 percent
+// is a bug rather than a score.
+//
+// The BEFORE figure is not a simulation. The classifier decides on a canonical
+// type, and before this existed it compared a rule's `type:` against whatever
+// name the catalog reported. Labelling the ClickHouse catalog as Postgres is
+// exactly that: no translation happens, the raw ClickHouse names are matched
+// against Postgres type names, and the result is the code that used to run.
+
+// The two schemas the number is measured on.
+//
+// Shaped like the product this wave exists for, and carrying the three ways a
+// join key diverges when the classifier speaks one engine's vocabulary. `name`
+// is matched by a built in rule that names a TYPE, `session_note` is matched by
+// no rule at all and is classified from its type, and `properties` is the same
+// blob under two type names. Nothing is inserted: this measures what the
+// classifier decides, which is a property of the schema.
+const benchmarkPerson = `
+CREATE TABLE bench_person (
+  id           bigserial PRIMARY KEY,
+  distinct_id  text NOT NULL UNIQUE,
+  email        text NOT NULL,
+  name         text NOT NULL,
+  session_note text,
+  properties   jsonb
+);`
+
+const benchmarkEvents = `
+CREATE TABLE bench_events (
+  uuid         UUID,
+  distinct_id  String,
+  email        Nullable(String),
+  name         String,
+  session_note Nullable(String),
+  properties   String,
+  ts           DateTime64(6)
+) ENGINE = MergeTree ORDER BY uuid`
+
+func TestBenchmarkCrossStoreJoinKeys(t *testing.T) {
+	if os.Getenv("AF_BENCHMARK") == "" {
+		t.Skip("skipped: set AF_BENCHMARK=1, or run just benchmark")
+	}
+	conn, done := requireDatabase(t)
+	defer done()
+	ch := requireClickHouse(t)
+	ctx := context.Background()
+
+	_, err := conn.Exec(ctx, benchmarkPerson)
+	require.NoError(t, err)
+	ch.exec(t, benchmarkEvents, nil)
+
+	rules, err := masking.NewRuleSet([]masking.Rule{
+		{Column: "distinct_id", Transform: "email", Link: "email",
+			Why: "This product's distinct id is the person's address."},
+		{Column: "properties", Type: "text", Transform: "empty_json",
+			Why: "ClickHouse holds this JSON in a String."},
+	})
+	require.NoError(t, err)
+
+	pgTables, err := masking.ReadCatalog(ctx, conn)
+	require.NoError(t, err)
+	chTables := ch.catalog(t)
+
+	after, err := masking.CrossStoreCheck(testKey(t), []masking.StoreAssignments{
+		{Store: "primary", Assignments: rules.Assign(pgTables)},
+		{Store: "events", Assignments: rules.Assign(chTables)},
+	}, nil)
+	require.NoError(t, err)
+
+	// The same catalogs, with the second store's engine unset, which is the
+	// code that ran before this change: every type name compared as though it
+	// were already a Postgres one.
+	untranslated := make([]masking.Table, 0, len(chTables))
+	for _, tb := range chTables {
+		tb.Engine = "postgres"
+		untranslated = append(untranslated, tb)
+	}
+	before, err := masking.CrossStoreCheck(testKey(t), []masking.StoreAssignments{
+		{Store: "primary", Assignments: rules.Assign(pgTables)},
+		{Store: "events", Assignments: rules.Assign(untranslated)},
+	}, nil)
+	require.NoError(t, err)
+
+	report := crossStoreReportFile(t, ch, before, after)
+	t.Log("\n" + report)
+
+	out := os.Getenv("AF_BENCHMARK_OUT")
+	if out == "" {
+		out = filepath.Join("..", "..", "..", "benchmarks",
+			time.Now().UTC().Format("2006-01-02-1504")+"-crossstore.md")
+	}
+	require.NoError(t, os.MkdirAll(filepath.Dir(out), 0o755))
+	require.NoError(t, os.WriteFile(out, []byte(report), 0o644))
+	t.Logf("wrote %s", out)
+
+	// The run is also the check. A benchmark that recorded a number nobody
+	// looked at would be a report, and this one refuses.
+	require.True(t, after.OK(), "the number this run produced is a bug:\n%s", after.Summary())
+	require.Less(t, before.Percent(), after.Percent(),
+		"the before figure is not worse than the after figure, so either the fixture no "+
+			"longer reaches the defect or the defect was never there")
+}
+
+func crossStoreReportFile(
+	t *testing.T, ch *chServer, before, after masking.CrossStoreReport,
+) string {
+	t.Helper()
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Cross store join keys, before and after the dialect boundary\n\n")
+	fmt.Fprintf(&b, "Run on %s.\n\n", time.Now().UTC().Format(time.RFC3339))
+	fmt.Fprintf(&b, "- Machine: %s %s, %d cores.\n", runtime.GOOS, runtime.GOARCH, runtime.NumCPU())
+	fmt.Fprintf(&b, "- Stores: a Postgres holding people and a %s holding the events about them.\n",
+		serverVersion(t, ch))
+	fmt.Fprintf(&b, "- Harness: `just benchmark`, which is "+
+		"`engine/internal/masking/benchmark_test.go` in this repository.\n")
+	fmt.Fprintf(&b, "- Rules: one `masking.yaml` for both stores, two rules and the built in "+
+		"defaults under them.\n\n")
+
+	fmt.Fprintf(&b, "| | Candidate join keys | Verified identical | Share |\n")
+	fmt.Fprintf(&b, "| --- | --- | --- | --- |\n")
+	fmt.Fprintf(&b, "| Before | %d | %d | %.1f%% |\n",
+		before.Checked, before.Identical, before.Percent())
+	fmt.Fprintf(&b, "| After | %d | %d | %.1f%% |\n\n",
+		after.Checked, after.Identical, after.Percent())
+
+	fmt.Fprintf(&b, "A candidate join key is a column name that appears in both stores, or two "+
+		"columns a rule gave the same link, where at least one side is masked. Anything below "+
+		"100 percent is a bug rather than a score: a join key that masks to two different "+
+		"values is a broken join, and a join key masked in one store and copied in the other "+
+		"is also a leak.\n\n")
+
+	if mismatches := before.Mismatches(); len(mismatches) > 0 {
+		fmt.Fprintf(&b, "What the before figure was, column by column:\n\n")
+		for _, p := range mismatches {
+			fmt.Fprintf(&b, "- `%s` and `%s`: %s\n", p.A, p.B, p.Reason)
+		}
+		b.WriteString("\n")
+	}
+
+	fmt.Fprintf(&b, "The before figure is not a simulation. The classifier decides on a "+
+		"canonical type name, and before the dialect boundary it compared a rule's `type:` "+
+		"against whatever the catalog reported. This run reproduces that by labelling the "+
+		"ClickHouse catalog as Postgres, so no translation happens and the raw ClickHouse "+
+		"type names are matched against Postgres ones, which is the code that used to run.\n\n")
+
+	fmt.Fprintf(&b, "The after figure is the one to read as a pass, and only at 100 percent. "+
+		"A report that found nothing to compare is not a pass either: this run requires the "+
+		"candidate count to be positive.\n")
+	return b.String()
+}
+
+// serverVersion names the second store, so a report says which build it is about.
+func serverVersion(t *testing.T, ch *chServer) string {
+	t.Helper()
+	rows, err := ch.rows(context.Background(), "SELECT version()")
+	if err != nil || len(rows) == 0 {
+		return "ClickHouse"
+	}
+	return "ClickHouse " + string(rows[0][0])
+}
+
+// The load average is deliberately NOT recorded here, where the database
+// provider benchmark next door does record it.
+//
+// That one measures times, and a time measured on a laptop under load is partly
+// about the laptop. This measures a count of columns that agree, which does not
+// move with load at all, and printing a figure that cannot affect the result
+// would invite somebody to explain a mismatch with it.

--- a/engine/internal/masking/catalog.go
+++ b/engine/internal/masking/catalog.go
@@ -21,6 +21,12 @@ import (
 
 // Table is one table and its columns.
 type Table struct {
+	// Engine is the datastore engine this table was read from, which decides
+	// what its type names mean and how a statement addresses a row in it. Set
+	// by whatever read the catalog. Empty means Postgres, which is what a
+	// Table meant before there was a second engine, and an engine nobody has a
+	// dialect for is refused rather than treated as Postgres.
+	Engine string
 	Schema string
 	Name   string
 	// Columns are in ordinal order, which is the order a person reading the
@@ -131,7 +137,10 @@ ORDER BY c.table_schema, c.table_name, c.ordinal_position`
 		}
 		key := schema + "." + table
 		if _, ok := byTable[key]; !ok {
-			byTable[key] = &Table{Schema: schema, Name: table}
+			// Stamped rather than left to the empty default, so that a table
+			// read from Postgres says so and the compatibility case in
+			// DialectFor covers only values nothing read from a database.
+			byTable[key] = &Table{Engine: enginePostgres, Schema: schema, Name: table}
 			order = append(order, key)
 		}
 		byTable[key].Columns = append(byTable[key].Columns, ColumnInfo{

--- a/engine/internal/masking/clickhouse.go
+++ b/engine/internal/masking/clickhouse.go
@@ -1,0 +1,276 @@
+package masking
+
+import (
+	"fmt"
+	"strings"
+)
+
+// engineClickHouse is the engine name a manifest datastore declares for
+// ClickHouse.
+const engineClickHouse = "clickhouse"
+
+func init() { RegisterDialect(clickhouseDialect{}) }
+
+// clickhouseDialect is the second engine, and the reason the boundary above it
+// exists.
+//
+// It is the store an analytics product keeps its events in, which is where
+// every row about a person actually lives: the Postgres beside it holds teams,
+// dashboards and feature flags. A twin that masks the Postgres and leaves the
+// events alone has masked the metadata and published the data.
+//
+// WHAT THIS DOES AND DOES NOT DO TODAY, said plainly, because a dialect that
+// looks complete from outside is exactly how somebody ends up trusting one.
+//
+//   - The type vocabulary is real and is checked against a live server: the
+//     conformance test reads system.columns from a running ClickHouse and
+//     requires this mapping to place every type it finds.
+//   - The read and the rewrite are real statements and the live test runs
+//     them, so they are not text nobody has executed.
+//   - Nothing here refreshes a golden, branches a store or opens a connection.
+//     There is no ClickHouse provider yet and this is not one.
+//   - Update emits the per row mutation form. A ClickHouse mutation is
+//     asynchronous and rewrites whole parts, so one per row is correct and slow
+//     in a way an UPDATE is not, and a bulk refresh will want an INSERT into a
+//     shadow table followed by EXCHANGE TABLES. That shape is the provider's
+//     and not this file's: it is a plan for a whole table, where everything
+//     here is a statement for one row.
+type clickhouseDialect struct{}
+
+func (clickhouseDialect) Engine() string { return engineClickHouse }
+
+// clickhouseTypes maps ClickHouse's own type names onto the Postgres names the
+// classifier, the rules and the verification scanner all speak.
+//
+// Keyed on the base name, so that FixedString(16), DateTime64(3),
+// DateTime('UTC') and Decimal(10, 2) are one entry each rather than one entry
+// per parameter anybody might write.
+//
+// A type NOT in this table comes back unchanged, which lands it in the
+// classifier's "this does not recognise the type, so nothing decided what
+// happens to this column" branch. That is the fail visible answer and it is
+// deliberate: a wrong guess here is a column that looks classified, and the
+// list a person has to work through is the one thing that finds it.
+var clickhouseTypes = map[string]string{
+	"string":      "text",
+	"fixedstring": "text",
+	"uuid":        "uuid",
+	"int8":        "smallint",
+	"int16":       "smallint",
+	"uint8":       "smallint",
+	"uint16":      "integer",
+	"int32":       "integer",
+	"uint32":      "bigint",
+	"int64":       "bigint",
+	"uint64":      "bigint",
+	"int128":      "numeric",
+	"uint128":     "numeric",
+	"int256":      "numeric",
+	"uint256":     "numeric",
+	"float32":     "real",
+	"float64":     "double precision",
+	"decimal":     "numeric",
+	"decimal32":   "numeric",
+	"decimal64":   "numeric",
+	"decimal128":  "numeric",
+	"decimal256":  "numeric",
+	"bool":        "boolean",
+	"boolean":     "boolean",
+	"date":        "date",
+	"date32":      "date",
+	"datetime":    "timestamp with time zone",
+	"datetime64":  "timestamp with time zone",
+	"json":        "jsonb",
+	"object":      "jsonb",
+	// Postgres reports every array as ARRAY and every enum, extension and
+	// domain type as USER-DEFINED, and both land in the branch that reports a
+	// column rather than masking it. The same shapes here are given the same
+	// two names so that one classifier reaches the same conclusion about both
+	// stores.
+	"array":   "ARRAY",
+	"enum8":   "USER-DEFINED",
+	"enum16":  "USER-DEFINED",
+	"enum":    "USER-DEFINED",
+	"map":     "USER-DEFINED",
+	"tuple":   "USER-DEFINED",
+	"nested":  "USER-DEFINED",
+	"variant": "USER-DEFINED",
+	"dynamic": "USER-DEFINED",
+	// An IP address locates a person. Postgres calls it inet, the scanner
+	// reads inet through its text form, and the ip transform is the rule that
+	// covers it in both stores.
+	"ipv4": "inet",
+	"ipv6": "inet",
+}
+
+// clickhouseWrappers are the type constructors that decorate another type
+// without changing what it holds.
+var clickhouseWrappers = []string{"Nullable", "LowCardinality"}
+
+// Canonical maps a ClickHouse type name onto the Postgres name for the same
+// kind of value.
+func (clickhouseDialect) Canonical(dataType string) string {
+	base := strings.TrimSpace(dataType)
+	for {
+		inner, unwrapped := unwrapClickHouse(base)
+		if !unwrapped {
+			break
+		}
+		base = inner
+	}
+	// The parameters of a parameterised type say how wide or how precise it
+	// is, never what kind of thing it holds, so the base name is the whole
+	// question. Array(String) is the exception that proves it: an array of
+	// anything is an array, and Postgres reports it as ARRAY for the same
+	// reason.
+	if i := strings.IndexByte(base, '('); i >= 0 {
+		base = base[:i]
+	}
+	if canon, ok := clickhouseTypes[strings.ToLower(strings.TrimSpace(base))]; ok {
+		return canon
+	}
+	return dataType
+}
+
+// unwrapClickHouse removes one decorating constructor, and reports whether it
+// removed anything.
+func unwrapClickHouse(t string) (string, bool) {
+	for _, w := range clickhouseWrappers {
+		if len(t) > len(w)+2 && strings.EqualFold(t[:len(w)], w) &&
+			t[len(w)] == '(' && t[len(t)-1] == ')' {
+			return strings.TrimSpace(t[len(w)+1 : len(t)-1]), true
+		}
+	}
+	return t, false
+}
+
+// QuoteIdent quotes an identifier in backticks, doubling any it contains.
+//
+// ClickHouse accepts a doubled backtick inside a backtick quoted identifier as
+// one literal backtick, the same rule Postgres has for the double quote. The
+// live conformance test creates a column whose name contains one and reads it
+// back, because a quoting rule nobody has executed is a guess.
+func (clickhouseDialect) QuoteIdent(name string) string {
+	return "`" + strings.ReplaceAll(name, "`", "``") + "`"
+}
+
+// Qualify renders a table as db.table, or as the table alone when the catalog
+// did not name a database.
+func (d clickhouseDialect) Qualify(t Table) string {
+	if t.Schema == "" {
+		return d.QuoteIdent(t.Name)
+	}
+	return d.QuoteIdent(t.Schema) + "." + d.QuoteIdent(t.Name)
+}
+
+// Unaddressable refuses a table with no sorting key.
+//
+// ClickHouse has no ctid and no other physical row identifier, so a table with
+// no key has no way to say which row a statement means. Postgres masks such a
+// table in one unchunked statement; here there is no such statement, and the
+// refusal is at planning time because a masking run that fails halfway leaves a
+// table neither real nor safe.
+func (clickhouseDialect) Unaddressable(t Table) string {
+	if len(t.PrimaryKey) == 0 {
+		return "ClickHouse has no physical row identifier, so a table with no sorting key " +
+			"cannot be rewritten one row at a time; give the table a sorting key or a rule " +
+			"that leaves it alone"
+	}
+	return ""
+}
+
+// RowKey addresses one row through the first column of the sorting key.
+//
+// Rendered through toString for the same reason Postgres casts to text: one
+// comparison covers an integer key, a UUID and whatever else somebody sorted
+// on, and the order only has to be total and stable rather than natural.
+func (d clickhouseDialect) RowKey(tp TablePlan) string {
+	if len(tp.OrderBy) == 0 {
+		// Unreachable through a plan, because Unaddressable refuses the table
+		// before one is built. Written rather than left to panic, because a
+		// TablePlan is a public value somebody can build by hand.
+		return "toString(tuple())"
+	}
+	return "toString(" + d.QuoteIdent(tp.OrderBy[0]) + ")"
+}
+
+// SelectChunk reads one chunk of a table, every column rendered as text.
+//
+// A transform takes a string and returns one, and the Postgres path gets that
+// from its driver: pgx decodes a uuid or a timestamp into something whose text
+// form the executor takes. Rendering here instead means a ClickHouse reader
+// needs no decoder per type, which matters more than it sounds: ClickHouse has
+// Map, Tuple, Nested, Variant and a UUID that is sixteen bytes on the wire, and
+// a reader that got one of them wrong would hand a transform bytes it would
+// mask as though they were a value.
+//
+// toString propagates null, so a null column still arrives as a null and the
+// transform still sees the absence rather than an empty string. That is the
+// first of the three properties this package is built on and it does not get to
+// change per engine.
+func (d clickhouseDialect) SelectChunk(tp TablePlan, after string) Query {
+	key := d.RowKey(tp)
+	cols := make([]string, 0, len(tp.Columns)+1)
+	cols = append(cols, key)
+	for _, c := range tp.Columns {
+		cols = append(cols, "toString("+d.QuoteIdent(c.Column.Name)+")")
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "SELECT %s FROM %s", strings.Join(cols, ", "), d.Qualify(tp.Table))
+	var args []any
+	if after != "" {
+		fmt.Fprintf(&b, " WHERE %s > %s", key, (clickhouseDialect{}).Placeholder(1))
+		args = append(args, after)
+	}
+	fmt.Fprintf(&b, " ORDER BY %s", key)
+	if tp.ChunkSize > 0 {
+		fmt.Fprintf(&b, " LIMIT %d", tp.ChunkSize)
+	}
+	return Query{SQL: b.String(), Args: args}
+}
+
+// Update rewrites the planned columns of one row.
+//
+// The parameters are numbered the way the Postgres statement numbers them, the
+// row key first and the values after it in column order, because that ordering
+// is the executor's contract rather than either engine's.
+func (d clickhouseDialect) Update(tp TablePlan) Statement {
+	names := make([]string, 0, len(tp.Columns))
+	sets := make([]string, 0, len(tp.Columns))
+	for i, c := range tp.Columns {
+		names = append(names, c.Column.Name)
+		sets = append(sets, fmt.Sprintf("%s = %s",
+			d.QuoteIdent(c.Column.Name), clickhouseValue(c.Column, i+2)))
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "ALTER TABLE %s UPDATE %s WHERE %s = %s",
+		d.Qualify(tp.Table), strings.Join(sets, ", "), d.RowKey(tp), (clickhouseDialect{}).Placeholder(1))
+	return Statement{
+		SQL: b.String(), Table: tp.Table.String(), Columns: names,
+		Keyed: len(tp.OrderBy) > 0,
+	}
+}
+
+// Placeholder renders a ClickHouse server side query parameter.
+//
+// Every masked value arrives as a string, because that is what a transform
+// produces, so every parameter is declared String and the assignment casts
+// where the column is something else.
+func (clickhouseDialect) Placeholder(n int) string { return fmt.Sprintf("{p%d:String}", n) }
+
+// clickhouseValue renders the assigned value for one column.
+//
+// ClickHouse will not put a String into a UUID column on its own, where
+// Postgres infers the column's type from the assignment. So a column whose
+// canonical type is not text carries an explicit cast to the type the catalog
+// reported, which is the only place in this file the RAW type is used rather
+// than the canonical one: a cast has to name the type the server has.
+func clickhouseValue(c ColumnInfo, n int) string {
+	param := (clickhouseDialect{}).Placeholder(n)
+	if strings.EqualFold((clickhouseDialect{}).Canonical(c.Type), "text") || c.Type == "" {
+		return param
+	}
+	return fmt.Sprintf("CAST(%s AS %s)", param, c.Type)
+}

--- a/engine/internal/masking/clickhouse_live_test.go
+++ b/engine/internal/masking/clickhouse_live_test.go
@@ -1,0 +1,584 @@
+package masking_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/client"
+	"github.com/docker/go-connections/nat"
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/internal/dockerutil"
+	"github.com/antifailure/antifailure/engine/internal/masking"
+	"github.com/antifailure/antifailure/engine/internal/verify"
+)
+
+// These run against a real ClickHouse, because the thing being checked is a
+// vocabulary and a statement shape, and neither can be checked against a
+// fixture written by the same person who wrote the code.
+//
+// A type table tested only against type names somebody typed into a test file
+// proves that the two agree with each other. What it has to agree with is the
+// server: system.columns is what a catalog reader will actually see, and a name
+// this build spells differently is a column nothing classifies. The same goes
+// for the statements. Text that has never been executed is a guess about a
+// grammar, and this repository has shipped a host pattern that did not compile
+// and an audit sink nothing called.
+//
+// They skip by name when no ClickHouse is reachable, the way every cloud
+// conformance test here does, so the community suite needs nothing installed.
+// AF_TEST_CLICKHOUSE_URL points them at a server somebody already has;
+// otherwise one container is started and removed.
+
+// clickhouseImage is the server these run against.
+//
+// Pinned to a minor version rather than latest, because a type this dialect
+// places is a claim about a version and "whatever was newest that morning" is
+// not a version anybody can reproduce.
+const clickhouseImage = "clickhouse/clickhouse-server:25.3-alpine"
+
+// chServer is a ClickHouse reachable over its HTTP interface.
+//
+// HTTP rather than a driver, and deliberately in the test rather than in the
+// package. A ClickHouse client is a dependency decision that belongs with the
+// provider that will need one, which is the lane after this. What this lane
+// owes is that the statements and the type mapping are right, and the HTTP
+// interface proves both without adding a module to the engine.
+type chServer struct {
+	base     string
+	user     string
+	password string
+	database string
+	// client is this server's own, rather than http.DefaultClient, so that the
+	// connections it keeps alive can be closed when the test that made them
+	// finishes. The package's TestMain checks for leaked goroutines, and a
+	// pooled connection's read loop is one.
+	client *http.Client
+}
+
+func (c *chServer) do(
+	ctx context.Context, sql string, params, settings map[string]string,
+) ([]byte, error) {
+	q := url.Values{}
+	q.Set("database", c.database)
+	for k, v := range params {
+		q.Set("param_"+k, v)
+	}
+	for k, v := range settings {
+		q.Set(k, v)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		c.base+"/?"+q.Encode(), strings.NewReader(sql))
+	if err != nil {
+		return nil, err
+	}
+	req.SetBasicAuth(c.user, c.password)
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("clickhouse said %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return body, nil
+}
+
+// exec runs a statement that returns nothing.
+//
+// mutations_sync makes an ALTER UPDATE wait for its own mutation. A ClickHouse
+// mutation is asynchronous by default, so without this the statement returns
+// before it has rewritten anything and a test that read the rows back would be
+// reading whichever half of the truth arrived first.
+func (c *chServer) exec(t *testing.T, sql string, params map[string]string) {
+	t.Helper()
+	_, err := c.do(context.Background(), sql, params, map[string]string{"mutations_sync": "2"})
+	require.NoError(t, err, sql)
+}
+
+// rows runs a statement and decodes RowBinaryWithNamesAndTypes.
+//
+// Binary rather than TSV, because a String in ClickHouse is bytes and the
+// verification scanner's whole opinion about that type is that bytes which do
+// not decode as text are bytes it could not read. A transport that escaped them
+// would decide that question before the scanner saw it.
+func (c *chServer) rows(ctx context.Context, sql string) ([]verify.Row, error) {
+	body, err := c.do(ctx, sql+" FORMAT RowBinaryWithNamesAndTypes", nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return decodeRowBinary(body)
+}
+
+// decodeRowBinary reads the header and then the rows.
+//
+// It handles String and Nullable(String) and REFUSES anything else rather than
+// guessing at a width, because a decoder that skipped an unexpected type would
+// silently misalign every column after it.
+func decodeRowBinary(body []byte) ([]verify.Row, error) {
+	buf := bytes.NewBuffer(body)
+	n, err := binary.ReadUvarint(buf)
+	if err != nil {
+		return nil, fmt.Errorf("reading the column count: %w", err)
+	}
+	for i := uint64(0); i < n; i++ {
+		if _, err := readCHString(buf); err != nil {
+			return nil, fmt.Errorf("reading column name %d: %w", i, err)
+		}
+	}
+	nullable := make([]bool, n)
+	for i := uint64(0); i < n; i++ {
+		typ, err := readCHString(buf)
+		if err != nil {
+			return nil, fmt.Errorf("reading column type %d: %w", i, err)
+		}
+		switch string(typ) {
+		case "String":
+		case "Nullable(String)":
+			nullable[i] = true
+		default:
+			return nil, fmt.Errorf(
+				"column %d came back as %s and this decoder reads String and "+
+					"Nullable(String) only; a statement that returns anything else has to "+
+					"render it, because guessing at a width misaligns every column after it",
+				i, typ)
+		}
+	}
+
+	var out []verify.Row
+	for buf.Len() > 0 {
+		row := make(verify.Row, 0, n)
+		for i := uint64(0); i < n; i++ {
+			if nullable[i] {
+				flag, err := buf.ReadByte()
+				if err != nil {
+					return nil, err
+				}
+				if flag == 1 {
+					row = append(row, nil)
+					continue
+				}
+			}
+			v, err := readCHString(buf)
+			if err != nil {
+				return nil, err
+			}
+			row = append(row, v)
+		}
+		out = append(out, row)
+	}
+	return out, nil
+}
+
+func readCHString(buf *bytes.Buffer) ([]byte, error) {
+	n, err := binary.ReadUvarint(buf)
+	if err != nil {
+		return nil, err
+	}
+	v := make([]byte, n)
+	if _, err := io.ReadFull(buf, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+// source is the verification source for this server.
+//
+// The rows are decoded from one response body, so this hands them on one at a
+// time rather than streaming from the wire. That is the test harness being
+// simple, not the interface: a provider reading the native protocol yields as
+// it reads, and the scan holds one value whichever it is.
+func (c *chServer) source() verify.Source {
+	return verify.NewSource(verify.ClickHouse,
+		func(ctx context.Context, sql string, yield func(verify.Row) error) error {
+			rows, err := c.rows(ctx, sql)
+			if err != nil {
+				return err
+			}
+			for _, r := range rows {
+				if err := yield(r); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+}
+
+// catalog reads the tables and columns, the way a ClickHouse provider will.
+//
+// In the test rather than in the package for the reason the HTTP client is: the
+// catalog reader belongs with the provider that opens the connection. What it
+// is here for is to feed the dialect the server's OWN type names rather than
+// ones written into a fixture.
+func (c *chServer) catalog(t *testing.T) []masking.Table {
+	t.Helper()
+	ctx := context.Background()
+
+	keys, err := c.rows(ctx, `
+SELECT database, name, sorting_key FROM system.tables
+WHERE database = currentDatabase() AND engine NOT LIKE '%View'`)
+	require.NoError(t, err)
+	sortingKey := map[string][]string{}
+	for _, r := range keys {
+		var cols []string
+		for _, part := range strings.Split(string(r[2]), ",") {
+			if part = strings.TrimSpace(part); part != "" {
+				cols = append(cols, part)
+			}
+		}
+		sortingKey[string(r[0])+"."+string(r[1])] = cols
+	}
+
+	cols, err := c.rows(ctx, `
+SELECT database, table, name, type FROM system.columns
+WHERE database = currentDatabase() ORDER BY database, table, position`)
+	require.NoError(t, err)
+
+	byTable := map[string]*masking.Table{}
+	var order []string
+	for _, r := range cols {
+		schema, table := string(r[0]), string(r[1])
+		key := schema + "." + table
+		if _, ok := sortingKey[key]; !ok {
+			continue
+		}
+		if _, ok := byTable[key]; !ok {
+			byTable[key] = &masking.Table{
+				Engine: "clickhouse", Schema: schema, Name: table,
+				PrimaryKey: sortingKey[key],
+			}
+			order = append(order, key)
+		}
+		typ := string(r[3])
+		byTable[key].Columns = append(byTable[key].Columns, masking.ColumnInfo{
+			Name: string(r[2]), Type: typ,
+			Nullable: strings.HasPrefix(typ, "Nullable(") ||
+				strings.Contains(typ, "(Nullable("),
+		})
+	}
+	out := make([]masking.Table, 0, len(order))
+	for _, key := range order {
+		out = append(out, *byTable[key])
+	}
+	return out
+}
+
+// requireClickHouse returns a server, starting one when the environment does
+// not name one, and skipping by name when neither is possible.
+func requireClickHouse(t *testing.T) *chServer {
+	t.Helper()
+	transport := &http.Transport{}
+	t.Cleanup(transport.CloseIdleConnections)
+	client := &http.Client{Transport: transport, Timeout: 2 * time.Minute}
+
+	if u := os.Getenv("AF_TEST_CLICKHOUSE_URL"); u != "" {
+		parsed, err := url.Parse(u)
+		require.NoError(t, err, "AF_TEST_CLICKHOUSE_URL is not a URL")
+		password, _ := parsed.User.Password()
+		db := strings.TrimPrefix(parsed.Path, "/")
+		if db == "" {
+			db = "default"
+		}
+		return &chServer{
+			base:     parsed.Scheme + "://" + parsed.Host,
+			user:     parsed.User.Username(),
+			password: password,
+			database: db,
+			client:   client,
+		}
+	}
+	if os.Getenv("AF_SKIP_DOCKER") != "" {
+		t.Skip("skipped: AF_SKIP_DOCKER is set and AF_TEST_CLICKHOUSE_URL names no server")
+	}
+
+	cli, err := dockerutil.Client()
+	if err != nil {
+		t.Skipf("skipped: no Docker daemon is reachable: %v", err)
+	}
+	// Closed, because the daemon client holds an idle connection whose read
+	// loop is a goroutine, and this package checks for leaked goroutines. It is
+	// registered before the container cleanup so that it runs after it.
+	t.Cleanup(func() { _ = cli.Close() })
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	t.Cleanup(cancel)
+
+	if _, err := cli.ImageInspect(ctx, clickhouseImage); err != nil {
+		rc, pullErr := cli.ImagePull(ctx, clickhouseImage, image.PullOptions{})
+		if pullErr != nil {
+			t.Skipf("skipped: %s could not be pulled: %v", clickhouseImage, pullErr)
+		}
+		dockerutil.Discard(rc)
+	}
+
+	port := freePort(t)
+	name := fmt.Sprintf("af-mask-ch-%d", time.Now().UnixNano()%1e9)
+	const password = "af-masking-test"
+	httpPort := nat.Port("8123/tcp")
+	resp, err := cli.ContainerCreate(ctx,
+		&container.Config{
+			Image: clickhouseImage,
+			// Labelled as ours, and that is not cosmetic: RemoveContainer
+			// REFUSES a container it cannot see a label on, so an unlabelled
+			// one is created, used, and then left running. Nine of them
+			// accumulated on this machine in three runs, four were killed for
+			// memory, and the two tests that came after them skipped with a
+			// timeout that said nothing about the cause. The cleanup below
+			// reports its own failure for the same reason.
+			Labels: dockerutil.Managed("masking-test", name, time.Now()),
+			Env: []string{
+				"CLICKHOUSE_PASSWORD=" + password,
+				"CLICKHOUSE_DB=af_masking",
+			},
+			ExposedPorts: nat.PortSet{httpPort: struct{}{}},
+		},
+		&container.HostConfig{
+			PortBindings: nat.PortMap{httpPort: []nat.PortBinding{{
+				// Loopback only, which is what makes a fixed password
+				// acceptable: the server is unreachable from anywhere but
+				// this machine.
+				HostIP: "127.0.0.1", HostPort: strconv.Itoa(port),
+			}}},
+			RestartPolicy: container.RestartPolicy{Name: "no"},
+		}, nil, nil, name)
+	if err != nil {
+		t.Skipf("skipped: no ClickHouse container could be created: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := dockerutil.RemoveContainer(context.WithoutCancel(ctx), cli, resp.ID); err != nil {
+			t.Errorf("the ClickHouse container %s was left behind: %v", name, err)
+		}
+	})
+	require.NoError(t, cli.ContainerStart(ctx, resp.ID, container.StartOptions{}))
+
+	server := &chServer{
+		base:     "http://127.0.0.1:" + strconv.Itoa(port),
+		user:     "default",
+		password: password,
+		database: "af_masking",
+		client:   client,
+	}
+	deadline := time.Now().Add(90 * time.Second)
+	for {
+		if _, err = server.do(ctx, "SELECT 1", nil, nil); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			// The server's own last words rather than only the connection
+			// error. A container killed for memory and a container still
+			// starting produce the same EOF from here, and skipping on the
+			// EOF alone is how a real failure reads as an absent dependency.
+			t.Skipf("skipped: ClickHouse did not answer in ninety seconds: %v\ncontainer log:\n%s",
+				err, containerLog(ctx, cli, resp.ID))
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	return server
+}
+
+// eventsSchema is the shape this whole wave exists for: an events table with
+// the identifier that joins it to the Postgres beside it, and the properties
+// blob an analytics product keeps its per person fields in.
+const eventsSchema = `
+CREATE TABLE events (
+  uuid        UUID,
+  event       String,
+  distinct_id String,
+  email       Nullable(String),
+  person_id   Nullable(UUID),
+  properties  String,
+  ip          Nullable(String),
+  ts          DateTime64(6)
+) ENGINE = MergeTree ORDER BY uuid`
+
+func insertEvents(t *testing.T, ch *chServer) {
+	t.Helper()
+	ch.exec(t, `INSERT INTO events VALUES
+  ('01890fa1-9e40-7d3c-8b9a-2f5c6d7e8a01', 'pageview', 'ada@lovelace-analytics.co.uk',
+   'ada@lovelace-analytics.co.uk', '01890fa1-9e40-7d3c-8b9a-2f5c6d7e8b01',
+   '{"plan":"team"}', '81.2.69.142', '2026-09-07 10:00:00'),
+  ('01890fa1-9e40-7d3c-8b9a-2f5c6d7e8a02', 'pageview', 'grace@hopper-systems.io',
+   'grace@hopper-systems.io', '01890fa1-9e40-7d3c-8b9a-2f5c6d7e8b02',
+   '{"plan":"free"}', '81.2.69.160', '2026-09-07 10:01:00')`, nil)
+}
+
+// TestClickHouseLive_TheDialectPlacesEveryTypeTheServerReports is the external
+// grader for the type table.
+//
+// Every type name here is read back out of system.columns rather than written
+// into the test, so the mapping is checked against the spelling the server
+// actually uses. A table agreeing with a fixture proves the fixture.
+func TestClickHouseLive_TheDialectPlacesEveryTypeTheServerReports(t *testing.T) {
+	ch := requireClickHouse(t)
+	d := clickhouse(t)
+
+	var cols []string
+	for i, c := range clickhouseTypeCases {
+		if strings.HasPrefix(c.raw, "AggregateFunction") {
+			// Needs an aggregating engine to hold one, and it is here for the
+			// opposite reason to the others: it is the row that must NOT be
+			// placed.
+			continue
+		}
+		cols = append(cols, fmt.Sprintf("c%d %s", i, c.raw))
+	}
+	ch.exec(t, "CREATE TABLE every_type (id String, "+strings.Join(cols, ", ")+
+		") ENGINE = MergeTree ORDER BY id", nil)
+
+	rows, err := ch.rows(context.Background(),
+		"SELECT name, type FROM system.columns WHERE database = currentDatabase() "+
+			"AND table = 'every_type'")
+	require.NoError(t, err)
+	reported := map[string]string{}
+	for _, r := range rows {
+		reported[string(r[0])] = string(r[1])
+	}
+
+	for i, c := range clickhouseTypeCases {
+		if strings.HasPrefix(c.raw, "AggregateFunction") {
+			continue
+		}
+		name := fmt.Sprintf("c%d", i)
+		serverType, ok := reported[name]
+		require.True(t, ok, "the server did not report %s at all", name)
+
+		require.Equal(t, c.canonical, d.Canonical(serverType),
+			"the server calls this %q and the masking dialect places it somewhere else; "+
+				"a type nothing places is a column nothing classifies", serverType)
+		require.Equal(t, c.canonical, verify.ClickHouse.Canonical(serverType),
+			"the server calls this %q and the scanner places it somewhere else", serverType)
+	}
+}
+
+// TestClickHouseLive_TheSameDetectorsFindRealDataInASecondStore is the scanning
+// half of the lane, end to end against a server.
+func TestClickHouseLive_TheSameDetectorsFindRealDataInASecondStore(t *testing.T) {
+	ch := requireClickHouse(t)
+	ch.exec(t, eventsSchema, nil)
+	insertEvents(t, ch)
+
+	report, err := verify.ScanSource(context.Background(), ch.source(), verify.Options{
+		SampleSize: 100,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "clickhouse", report.Engine,
+		"a report that does not say which store it read cannot be told from another store's")
+	require.Empty(t, report.Skipped, "%v", report.Skipped)
+	require.False(t, report.Clean(),
+		"a ClickHouse holding real addresses came back clean, so the golden it gates "+
+			"would be published")
+
+	found := map[string][]string{}
+	for _, f := range report.Findings {
+		found[f.Column] = append(found[f.Column], f.Detector)
+	}
+	require.Contains(t, found, "email", "the address column produced no finding: %+v", report.Findings)
+	require.Contains(t, found, "distinct_id",
+		"an identifier that is an address produced no finding, and it is the column the "+
+			"join is on")
+	// A routable address, deliberately not one of the documentation ranges the
+	// ip transform produces: the detector does not fire on those, which is what
+	// makes it able to tell a masked address from a real one.
+	require.Contains(t, found, "ip")
+
+	// And nothing was quietly passed over. Every column is either read or
+	// listed as unread, which is the property the Postgres scanner had to
+	// learn the hard way.
+	require.Positive(t, report.Columns)
+	require.Positive(t, report.RowsSampled)
+}
+
+// TestClickHouseLive_TheStatementsTheDialectCompilesRun is the other half: the
+// text is not a guess about a grammar.
+func TestClickHouseLive_TheStatementsTheDialectCompilesRun(t *testing.T) {
+	ch := requireClickHouse(t)
+	ch.exec(t, eventsSchema, nil)
+	insertEvents(t, ch)
+
+	rs, err := masking.NewRuleSet([]masking.Rule{
+		{Column: "distinct_id", Transform: "email", Link: "email",
+			Why: "This product's distinct id is the person's address."},
+		{Column: "properties", Type: "text", Transform: "empty_json",
+			Why: "Free form JSON in a String."},
+		// A masked column that is NOT a String, so the cast the dialect writes
+		// for one is executed rather than only compared as text. Postgres
+		// infers the column's type from the assignment and ClickHouse does not.
+		{Column: "person_id", Transform: "uuid_remap",
+			Why: "The person a row is about."},
+	})
+	require.NoError(t, err)
+
+	tables := ch.catalog(t)
+	plan := masking.BuildPlan(tables, rs.Assign(tables), "live")
+	require.True(t, plan.Runnable(), masking.DescribeProblems(plan.Problems))
+	require.Len(t, plan.Tables, 1)
+	tp := plan.Tables[0]
+
+	// The read the dialect compiles, run against the server.
+	d := clickhouse(t)
+	read := d.SelectChunk(tp, "")
+	rows, err := ch.rows(context.Background(), read.SQL)
+	require.NoError(t, err, read.SQL)
+	require.Len(t, rows, 2, "the compiled read did not return the rows")
+
+	// And the rewrite, applied one row at a time exactly as the executor
+	// would, with the values computed in Go from a key the server never sees.
+	key := testKey(t)
+	stmt := tp.Compile()
+	for _, row := range rows {
+		params := map[string]string{"p1": string(row[0])}
+		for i, c := range tp.Columns {
+			transform, ok := masking.Lookup(c.Transform)
+			require.True(t, ok, c.Transform)
+			in := string(row[1+i])
+			out, applyErr := transform.Apply(key, masking.Column{
+				Schema: tp.Table.Schema, Table: tp.Table.Name,
+				Name: c.Column.Name, Link: c.Link,
+			}, &in)
+			require.NoError(t, applyErr)
+			require.NotNil(t, out)
+			params[fmt.Sprintf("p%d", i+2)] = *out
+		}
+		ch.exec(t, stmt.SQL, params)
+	}
+
+	after, err := verify.ScanSource(context.Background(), ch.source(), verify.Options{
+		SampleSize: 100,
+	})
+	require.NoError(t, err)
+	require.Empty(t, after.Findings,
+		"the masked store still holds something that looks real: %v", after.Findings)
+	require.True(t, after.Clean(), "%v %v", after.Findings, after.Skipped)
+}
+
+// containerLog returns the tail of a container's output, for a message that
+// would otherwise say only that nothing answered.
+func containerLog(ctx context.Context, cli *client.Client, id string) string {
+	rc, err := cli.ContainerLogs(ctx, id, container.LogsOptions{
+		ShowStdout: true, ShowStderr: true, Tail: "20",
+	})
+	if err != nil {
+		return "unavailable: " + err.Error()
+	}
+	defer func() { _ = rc.Close() }()
+	body, err := io.ReadAll(rc)
+	if err != nil {
+		return "unreadable: " + err.Error()
+	}
+	return string(body)
+}

--- a/engine/internal/masking/clickhouse_test.go
+++ b/engine/internal/masking/clickhouse_test.go
@@ -1,0 +1,239 @@
+package masking_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/internal/masking"
+	"github.com/antifailure/antifailure/engine/internal/verify"
+)
+
+func clickhouse(t *testing.T) masking.Dialect {
+	t.Helper()
+	d, err := masking.DialectFor("clickhouse")
+	require.NoError(t, err)
+	return d
+}
+
+// clickhouseTypeCases are the type names a real ClickHouse reports, with the
+// Postgres name each has to become.
+//
+// Every row is a type that appears in an analytics schema. The last four are
+// the ones that must NOT be given a meaning: a Map or a Tuple holds whatever
+// somebody put in it and no transform here can rewrite one, so it lands in the
+// branch that reports a column rather than deciding about it, exactly as
+// Postgres does with an array and a user defined type.
+var clickhouseTypeCases = []struct{ raw, canonical string }{
+	{"String", "text"},
+	{"Nullable(String)", "text"},
+	{"LowCardinality(String)", "text"},
+	{"LowCardinality(Nullable(String))", "text"},
+	{"FixedString(16)", "text"},
+	{"UUID", "uuid"},
+	{"Nullable(UUID)", "uuid"},
+	{"Int64", "bigint"},
+	{"UInt8", "smallint"},
+	{"Int32", "integer"},
+	{"Float64", "double precision"},
+	{"Decimal(10, 2)", "numeric"},
+	{"Bool", "boolean"},
+	{"Date", "date"},
+	{"DateTime64(6)", "timestamp with time zone"},
+	{"DateTime('UTC')", "timestamp with time zone"},
+	{"IPv4", "inet"},
+	{"IPv6", "inet"},
+	{"JSON", "jsonb"},
+	{"Array(String)", "ARRAY"},
+	{"Map(String, String)", "USER-DEFINED"},
+	{"Tuple(String, UInt8)", "USER-DEFINED"},
+	{"Enum8('a' = 1, 'b' = 2)", "USER-DEFINED"},
+	{"AggregateFunction(sum, UInt64)", "AggregateFunction(sum, UInt64)"},
+}
+
+// TestClickHouseTypes_AgreeWithTheScanner is the same check the Postgres type
+// lists have already, applied to the second engine.
+//
+// The masking classifier and the verification scanner each carry their own
+// table of what a ClickHouse type means, and they carry it twice on purpose:
+// verify must not import masking, because it is the check on masking. This is
+// what keeps the two tables the same table. A type one calls text and the other
+// calls unreadable is a column one instrument is silent about while the other
+// speaks, which is exactly the state that let a bytea holding a private key be
+// reported clean.
+func TestClickHouseTypes_AgreeWithTheScanner(t *testing.T) {
+	t.Parallel()
+	d := clickhouse(t)
+	for _, c := range clickhouseTypeCases {
+		require.Equal(t, c.canonical, d.Canonical(c.raw),
+			"masking reads %s as something else", c.raw)
+		require.Equal(t, c.canonical, verify.ClickHouse.Canonical(c.raw),
+			"the scanner reads %s as something else", c.raw)
+	}
+}
+
+// TestClickHouse_ReadsAStringAsBytesRatherThanText is the one place the two
+// packages deliberately differ, recorded so it reads as a decision.
+//
+// A ClickHouse String is a byte string. It is where an analytics schema keeps
+// its JSON and it is also where a ciphertext would go. The scanner reads one as
+// bytes and decodes it where it decodes, so a column of encrypted bytes is
+// counted as unread rather than handed to the detectors as mojibake, matching
+// nothing, and reported as clean.
+func TestClickHouse_ReadsAStringAsBytesRatherThanText(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "bytea", verify.ClickHouse.Kind("String"))
+	require.Equal(t, "bytea", verify.ClickHouse.Kind("LowCardinality(Nullable(String))"))
+	require.Equal(t, "text", verify.ClickHouse.Kind("Array(String)"))
+	require.Equal(t, "structural", verify.ClickHouse.Kind("DateTime64(6)"))
+	// And Postgres text stays text, because a Postgres text column in a UTF-8
+	// database is text by construction.
+	require.Equal(t, "text", verify.Postgres.Kind("text"))
+	require.Equal(t, "bytea", verify.Postgres.Kind("bytea"))
+}
+
+// TestAssign_AClickHouseStringIsClassifiedLikeAPostgresText is the defect this
+// lane closes, stated as the two stores agreeing.
+//
+// Before the dialect existed, a rule saying `type: text` could not match a
+// ClickHouse String, so the built in rule for a name column matched nothing,
+// so nothing decided what happened to the column, so it was copied. The
+// Postgres column beside it was masked. One person, two answers.
+func TestAssign_AClickHouseStringIsClassifiedLikeAPostgresText(t *testing.T) {
+	t.Parallel()
+	rs, err := masking.NewRuleSet(nil)
+	require.NoError(t, err)
+
+	pg := rs.Assign([]masking.Table{{
+		Engine: "postgres", Schema: "public", Name: "person", PrimaryKey: []string{"id"},
+		Columns: []masking.ColumnInfo{
+			{Name: "id", Type: "bigint"},
+			{Name: "name", Type: "text", Nullable: true},
+		},
+	}})
+	ch := rs.Assign([]masking.Table{{
+		Engine: "clickhouse", Schema: "default", Name: "person", PrimaryKey: []string{"id"},
+		Columns: []masking.ColumnInfo{
+			{Name: "id", Type: "Int64"},
+			{Name: "name", Type: "String", Nullable: true},
+		},
+	}})
+
+	require.Equal(t, "name", assignmentFor(t, pg, "name").Transform)
+	require.Equal(t, "name", assignmentFor(t, ch, "name").Transform,
+		"the built in rule for a name on a text type did not reach the ClickHouse column, "+
+			"so nothing decided about it and it keeps what production had")
+	require.Equal(t,
+		assignmentFor(t, pg, "name").Link, assignmentFor(t, ch, "name").Link,
+		"two links means two subkeys means one person masked into two")
+
+	// The raw type still travels, because a person reading the plan is looking
+	// at their own schema and String is what they will find in it.
+	require.Equal(t, "String", assignmentFor(t, ch, "name").Column.Type)
+	require.Equal(t, "text", assignmentFor(t, pg, "name").Column.Type)
+}
+
+// TestAssign_RefusesAnEngineNobodyHasADialectFor is the fail closed half.
+//
+// Falling back to Postgres would mean classifying a store with the wrong type
+// vocabulary, and the result of that is not an error, it is a column that looks
+// classified and was not.
+func TestAssign_RefusesAnEngineNobodyHasADialectFor(t *testing.T) {
+	t.Parallel()
+	rs, err := masking.NewRuleSet(nil)
+	require.NoError(t, err)
+
+	tables := []masking.Table{{
+		Engine: "cassandra", Schema: "app", Name: "person", PrimaryKey: []string{"id"},
+		Columns: []masking.ColumnInfo{{Name: "email", Type: "text", Nullable: true}},
+	}}
+	plan := masking.BuildPlan(tables, rs.Assign(tables), "h")
+	require.False(t, plan.Runnable(), "a store nobody has a dialect for was planned anyway")
+	require.Contains(t, masking.DescribeProblems(plan.Problems), "no dialect for the engine")
+	require.Contains(t, masking.DescribeProblems(plan.Problems), "cassandra")
+}
+
+// TestAssign_RefusesAClickHouseTableWithNoSortingKey is the other refusal, and
+// it is at planning time for the reason every refusal in this package is: a
+// masking run that fails halfway leaves a table neither real nor safe.
+//
+// Postgres has ctid, so it can address any row of any table. ClickHouse has no
+// row identifier at all.
+func TestAssign_RefusesAClickHouseTableWithNoSortingKey(t *testing.T) {
+	t.Parallel()
+	rs, err := masking.NewRuleSet(nil)
+	require.NoError(t, err)
+
+	tables := []masking.Table{{
+		Engine: "clickhouse", Schema: "default", Name: "log",
+		Columns: []masking.ColumnInfo{{Name: "email", Type: "String", Nullable: true}},
+	}}
+	plan := masking.BuildPlan(tables, rs.Assign(tables), "h")
+	require.False(t, plan.Runnable())
+	require.Contains(t, masking.DescribeProblems(plan.Problems), "no physical row identifier")
+
+	// And the same table in Postgres is planned, because there it can be
+	// addressed. The refusal is the engine's, not a new rule about keys.
+	pgTables := []masking.Table{{
+		Engine: "postgres", Schema: "public", Name: "log",
+		Columns: []masking.ColumnInfo{{Name: "email", Type: "text", Nullable: true}},
+	}}
+	pgPlan := masking.BuildPlan(pgTables, rs.Assign(pgTables), "h")
+	require.True(t, pgPlan.Runnable(), masking.DescribeProblems(pgPlan.Problems))
+}
+
+// TestClickHouse_StatementsAreClickHouseAndNotPostgres is the text itself.
+//
+// Checked here as well as through the conformance suite because the suite
+// checks properties every dialect shares, and these are the specifics: a
+// ClickHouse rewrite is a mutation, its parameters are named and typed, and a
+// value going into a column that is not a String needs a cast that Postgres
+// infers on its own.
+func TestClickHouse_StatementsAreClickHouseAndNotPostgres(t *testing.T) {
+	t.Parallel()
+	d := clickhouse(t)
+	tables := []masking.Table{{
+		Engine: "clickhouse", Schema: "default", Name: "events",
+		PrimaryKey: []string{"uuid"},
+		Columns: []masking.ColumnInfo{
+			{Name: "uuid", Type: "UUID"},
+			{Name: "email", Type: "String", Nullable: true},
+			{Name: "person_id", Type: "Nullable(UUID)", Nullable: true},
+		},
+	}}
+	rs, err := masking.NewRuleSet([]masking.Rule{
+		{Column: "person_id", Transform: "uuid_remap", Why: "The person a row is about."},
+	})
+	require.NoError(t, err)
+	plan := masking.BuildPlan(tables, rs.Assign(tables), "h")
+	require.True(t, plan.Runnable(), masking.DescribeProblems(plan.Problems))
+	require.Len(t, plan.Tables, 1)
+
+	stmt := plan.Tables[0].Compile()
+	require.Contains(t, stmt.SQL, "ALTER TABLE `default`.`events` UPDATE",
+		"a ClickHouse rewrite is a mutation, not an UPDATE statement")
+	require.NotContains(t, stmt.SQL, "$1", "the Postgres parameter shape reached ClickHouse")
+	require.Contains(t, stmt.SQL, "{p1:String}")
+	require.Contains(t, stmt.SQL, "WHERE toString(`uuid`) = {p1:String}")
+	// The plan orders columns by name, so email is the second argument and
+	// person_id the third.
+	require.Contains(t, stmt.SQL, "`email` = {p2:String}")
+	require.NotContains(t, stmt.SQL, "CAST({p2", "a String column needs no cast")
+	require.Contains(t, stmt.SQL, "CAST({p3:String} AS Nullable(UUID))",
+		"a String going into a UUID column needs the cast Postgres infers for itself")
+
+	read := d.SelectChunk(plan.Tables[0], "")
+	require.Contains(t, read.SQL, "SELECT toString(`uuid`)")
+	require.NotContains(t, read.SQL, "::text", "the Postgres cast reached ClickHouse")
+}
+
+func assignmentFor(t *testing.T, in []masking.Assignment, column string) masking.Assignment {
+	t.Helper()
+	for _, a := range in {
+		if a.Column.Name == column {
+			return a
+		}
+	}
+	t.Fatalf("no assignment for %s", column)
+	return masking.Assignment{}
+}

--- a/engine/internal/masking/crossstore.go
+++ b/engine/internal/masking/crossstore.go
@@ -1,0 +1,355 @@
+package masking
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// The cross store check answers one question: does a value that identifies one
+// person in two stores mask to the same thing in both?
+//
+// It is here because the answer being NO is the worst failure this package can
+// have, and it is silent. An empty ClickHouse beside a masked Postgres is a
+// twin that is visibly incomplete, and somebody notices within a minute of
+// opening a chart. One identity masked into two different fake people is a twin
+// that is confidently wrong: every join across the two stores returns nothing
+// or returns the wrong person, every report built on it is plausible, and
+// nothing anywhere says so.
+//
+// Determinism inside one store has been enforced since the beginning, by the
+// key derivation: a transform is a pure function of a subkey derived from the
+// column identity, and two columns that must agree are given the same identity
+// through their link. Nothing extended that across stores, because there was
+// only ever one. The identity deliberately does NOT include the store, which is
+// what makes the guarantee possible at all, and this file is what proves the
+// guarantee holds rather than assuming it from the construction.
+//
+// It is deliberately strict. A pair it cannot verify counts as a pair it did
+// not verify, never as one that passed, and OK is false for a report that
+// found no join keys at all. A check that cannot come back unflattering is not
+// a check.
+
+// JoinColumn is one side of a candidate join key.
+type JoinColumn struct {
+	// Store is the datastore's name in the manifest.
+	Store string
+	// Table and Column are where it lives.
+	Table  string
+	Column string
+	// Transform is what masks it, empty when nothing does.
+	Transform string
+	// Link is the identity its subkey is derived from.
+	Link string
+	// Identity is the column identity the executor would use, which is what
+	// actually decides the output.
+	Identity Column
+}
+
+// String names the column the way a person would.
+func (j JoinColumn) String() string { return j.Store + "." + j.Table + "." + j.Column }
+
+// Masked reports whether anything rewrites this column.
+func (j JoinColumn) Masked() bool { return j.Transform != "" }
+
+// JoinPair is one candidate join key: the same identifier, in two stores.
+type JoinPair struct {
+	// Key is what paired them, either a shared column name or a shared link.
+	Key string
+	A   JoinColumn
+	B   JoinColumn
+	// Identical reports whether every applicable probe masked to the same
+	// value on both sides.
+	Identical bool
+	// Probes is how many probe values were applicable to both sides. A pair
+	// where nothing was applicable is not a pair that passed.
+	Probes int
+	// Reason says why the pair is not identical, and is empty when it is.
+	Reason string
+}
+
+// CrossStoreReport is what the check found.
+type CrossStoreReport struct {
+	// Stores are the datastores compared, in the order they were given.
+	Stores []string
+	// Pairs are the candidate join keys, sorted.
+	Pairs []JoinPair
+	// Checked and Identical are the denominator and the numerator of the
+	// number this check exists to produce.
+	Checked   int
+	Identical int
+}
+
+// Percent is the share of candidate join keys that mask identically in every
+// store they appear in.
+//
+// Zero for a report with nothing in it, which is not a pass and is not meant to
+// read as one. Use OK.
+func (r CrossStoreReport) Percent() float64 {
+	if r.Checked == 0 {
+		return 0
+	}
+	return float64(r.Identical) * 100 / float64(r.Checked)
+}
+
+// OK reports whether every candidate join key was verified identical.
+//
+// False when a pair disagreed AND false when there was nothing to compare. A
+// report over two stores that share no identifier has not proved anything, and
+// returning true for it would be a check that cannot say no.
+func (r CrossStoreReport) OK() bool { return r.Checked > 0 && r.Identical == r.Checked }
+
+// Mismatches returns the pairs that are not identical.
+func (r CrossStoreReport) Mismatches() []JoinPair {
+	var out []JoinPair
+	for _, p := range r.Pairs {
+		if !p.Identical {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// Summary is the one line a person quotes, and the lines under it that say why
+// when the number is not 100.
+func (r CrossStoreReport) Summary() string {
+	var b strings.Builder
+	if r.Checked == 0 {
+		fmt.Fprintf(&b, "no column identifies the same thing in more than one of %s, "+
+			"so nothing was compared and nothing is proved\n", strings.Join(r.Stores, " and "))
+		return b.String()
+	}
+	fmt.Fprintf(&b, "join keys verified identical across %s: %d of %d (%.1f%%)\n",
+		strings.Join(r.Stores, " and "), r.Identical, r.Checked, r.Percent())
+	for _, p := range r.Mismatches() {
+		fmt.Fprintf(&b, "  %s and %s: %s\n", p.A, p.B, p.Reason)
+	}
+	return b.String()
+}
+
+// StoreAssignments is one store's masking decisions, as its plan made them.
+type StoreAssignments struct {
+	// Store is the datastore's name in the manifest.
+	Store string
+	// Assignments is what Assign decided for that store's catalog.
+	Assignments []Assignment
+}
+
+// DefaultProbes are the values the check masks through both sides.
+//
+// Spread across the shapes the transforms accept, because several of them
+// refuse a value that is not what they are for: uuid_remap refuses anything
+// that is not a UUID, credit_card refuses anything that is not a card, and
+// date_shift refuses anything that is not a date. A probe set of email
+// addresses alone would leave a pair of UUID columns with nothing applicable to
+// compare, and a pair with nothing applicable is reported as unverified rather
+// than counted as identical.
+//
+// Every one of them is a reserved name or a documentation range, which is not
+// only tidiness. This list ships in the product and its values appear in the
+// report it prints, so an address here that could belong to somebody is an
+// address this repository publishes. contactcheck said so, by name, on the
+// first version of this file.
+func DefaultProbes() []string {
+	return []string{
+		"ada@example.com",
+		"01890fa1-9e40-7d3c-8b9a-2f5c6d7e8a90",
+		"+14155550123",
+		"4111111111111111",
+		"2026-09-07",
+		"1234567",
+		"Ada Lovelace",
+		"https://example.com/report?tab=usage",
+		"198.51.100.24",
+		"A sentence somebody typed into a notes field.",
+	}
+}
+
+// CrossStoreCheck compares what two or more stores do to the same identifier.
+//
+// A candidate join key is a column name that appears in more than one store, or
+// two columns in different stores that a rule gave the same EXPLICIT link.
+// Either is a join somebody could write, and either breaks if the two sides do
+// not mask identically. The default link, which Assign fills in as the
+// transform's own name, does not count: it would pair every nullified column
+// with every other one and pass every time.
+//
+// There is deliberately no way to declare a candidate exempt. Two columns with
+// one name in two stores that mean different things is a real thing to look at,
+// and the cost of looking at it is a rule; the cost of silencing it is a twin
+// that is wrong in a way nobody can see. A false positive here costs somebody a
+// minute, and a false negative costs somebody their data.
+func CrossStoreCheck(key *Key, stores []StoreAssignments, probes []string) (CrossStoreReport, error) {
+	if key == nil {
+		return CrossStoreReport{}, fmt.Errorf("masking: the cross store check needs a key")
+	}
+	if len(stores) < 2 {
+		return CrossStoreReport{}, fmt.Errorf(
+			"masking: the cross store check compares stores and it was given %d", len(stores))
+	}
+	if len(probes) == 0 {
+		probes = DefaultProbes()
+	}
+
+	report := CrossStoreReport{}
+	columns := map[string][]JoinColumn{}
+	links := map[string][]JoinColumn{}
+	for _, s := range stores {
+		report.Stores = append(report.Stores, s.Store)
+		for _, a := range s.Assignments {
+			j := JoinColumn{
+				Store: s.Store, Table: a.Table.String(), Column: a.Column.Name,
+				Transform: a.Transform, Link: a.Link,
+				Identity: Column{
+					Schema: a.Table.Schema, Table: a.Table.Name,
+					Name: a.Column.Name, Link: a.Link,
+				},
+			}
+			if a.Problem != "" {
+				// An assignment that cannot be carried out is not a decision
+				// about what the column holds, and a plan carrying one is
+				// refused before anything runs. Comparing it would report a
+				// difference that no environment can reach.
+				continue
+			}
+			columns[a.Column.Name] = append(columns[a.Column.Name], j)
+			if a.Link != "" && a.Link != a.Transform {
+				// Only a link somebody WROTE. Assign fills in the transform's
+				// own name as the default link, so every nullified column in
+				// one store would otherwise pair with every nullified column
+				// in the other: pairs that share an identity by construction,
+				// that pass by construction, and that would pad the
+				// denominator of this check with agreement it did not have to
+				// find. A check whose number is mostly free passes is a check
+				// nobody should quote. An explicit link is the opposite: it is
+				// somebody saying these two are the same thing.
+				links[a.Link] = append(links[a.Link], j)
+			}
+		}
+	}
+
+	seen := map[string]bool{}
+	add := func(keyName string, a, b JoinColumn) {
+		if a.Store == b.Store {
+			return
+		}
+		if !a.Masked() && !b.Masked() {
+			// Neither side is rewritten, so there is nothing here that could
+			// diverge. Both hold what production held, which is a different
+			// problem and one the plan already reports as copied unchanged.
+			return
+		}
+		id := a.String() + "|" + b.String()
+		if b.String() < a.String() {
+			id = b.String() + "|" + a.String()
+			a, b = b, a
+		}
+		if seen[id] {
+			return
+		}
+		seen[id] = true
+		report.Pairs = append(report.Pairs, comparePair(key, keyName, a, b, probes))
+	}
+
+	for name, cols := range columns {
+		for i := range cols {
+			for j := i + 1; j < len(cols); j++ {
+				add(name, cols[i], cols[j])
+			}
+		}
+	}
+	for link, cols := range links {
+		for i := range cols {
+			for j := i + 1; j < len(cols); j++ {
+				add("link "+link, cols[i], cols[j])
+			}
+		}
+	}
+
+	sort.Slice(report.Pairs, func(i, j int) bool {
+		if report.Pairs[i].A.String() != report.Pairs[j].A.String() {
+			return report.Pairs[i].A.String() < report.Pairs[j].A.String()
+		}
+		return report.Pairs[i].B.String() < report.Pairs[j].B.String()
+	})
+	report.Checked = len(report.Pairs)
+	for _, p := range report.Pairs {
+		if p.Identical {
+			report.Identical++
+		}
+	}
+	return report, nil
+}
+
+// comparePair masks the probes through both sides and reports what happened.
+func comparePair(key *Key, keyName string, a, b JoinColumn, probes []string) JoinPair {
+	pair := JoinPair{Key: keyName, A: a, B: b}
+
+	switch {
+	case a.Masked() != b.Masked():
+		unmasked, masked := a, b
+		if a.Masked() {
+			unmasked, masked = b, a
+		}
+		pair.Reason = fmt.Sprintf(
+			"%s is masked with %s and %s is copied unchanged, so one store holds a fake "+
+				"value for this identifier and the other holds the real one",
+			masked, masked.Transform, unmasked)
+		return pair
+	case a.Transform != b.Transform:
+		pair.Reason = fmt.Sprintf(
+			"the two are masked with different transforms, %s and %s, so one identity "+
+				"becomes two people",
+			a.Transform, b.Transform)
+		return pair
+	case a.Identity.String() != b.Identity.String():
+		pair.Reason = fmt.Sprintf(
+			"the two derive their subkey from different identities, %s and %s, so the same "+
+				"input masks to two different outputs; give them one link",
+			a.Identity, b.Identity)
+		return pair
+	}
+
+	transform, ok := Lookup(a.Transform)
+	if !ok {
+		pair.Reason = "there is no transform called " + a.Transform
+		return pair
+	}
+
+	for _, probe := range probes {
+		value := probe
+		left, leftErr := transform.Apply(key, a.Identity, &value)
+		right, rightErr := transform.Apply(key, b.Identity, &value)
+		if leftErr != nil || rightErr != nil {
+			// A transform refuses a value that is not what it is for, and
+			// refusing the same value on both sides is agreement rather than
+			// disagreement: this probe simply does not apply to this pair.
+			// One side refusing and the other not would be a real difference,
+			// and is why this compares the errors rather than skipping on the
+			// first one.
+			if (leftErr == nil) != (rightErr == nil) {
+				pair.Reason = fmt.Sprintf(
+					"%s accepted a value that %s refused, which cannot happen for two "+
+						"columns masked the same way", a, b)
+				return pair
+			}
+			continue
+		}
+		pair.Probes++
+		if orNull(left) != orNull(right) {
+			pair.Reason = fmt.Sprintf(
+				"the same input masks to different values in the two stores, which is the " +
+					"failure this check exists for")
+			return pair
+		}
+	}
+
+	if pair.Probes == 0 {
+		pair.Reason = fmt.Sprintf(
+			"no probe value was applicable to %s, so nothing was compared and this pair "+
+				"is not verified", a.Transform)
+		return pair
+	}
+	pair.Identical = true
+	return pair
+}

--- a/engine/internal/masking/crossstore_live_test.go
+++ b/engine/internal/masking/crossstore_live_test.go
@@ -1,0 +1,207 @@
+package masking_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/internal/masking"
+	"github.com/antifailure/antifailure/engine/internal/verify"
+)
+
+// The lane's acceptance, run against two real servers.
+//
+// Everything else about cross store determinism can be argued from the
+// construction: the subkey comes from the column identity, the identity does
+// not name the store, so the same identity gives the same output. This is the
+// argument being checked rather than repeated. Two databases, two engines, one
+// key, one rules file, and the address that identifies one person read back out
+// of both of them afterwards.
+
+// personTable is the Postgres side of the pair, added beside the fixture the
+// rest of this package's live tests use.
+const personTable = `
+CREATE TABLE person (
+  id          bigserial PRIMARY KEY,
+  distinct_id text NOT NULL UNIQUE,
+  email       text NOT NULL,
+  properties  jsonb
+);
+INSERT INTO person (distinct_id, email, properties) VALUES
+  ('ada@lovelace-analytics.co.uk',  'ada@lovelace-analytics.co.uk',  '{"plan":"team"}'),
+  ('grace@hopper-systems.io', 'grace@hopper-systems.io', '{"plan":"free"}'),
+  ('alan@turing-labs.net',  'alan@turing-labs.net',  '{"plan":"team"}');
+`
+
+// eventsForThosePeople is the ClickHouse side, holding the same three people.
+const eventsForThosePeople = `
+CREATE TABLE events (
+  uuid        UUID,
+  event       String,
+  distinct_id String,
+  email       Nullable(String),
+  properties  String,
+  ts          DateTime64(6)
+) ENGINE = MergeTree ORDER BY uuid`
+
+const insertThosePeople = `INSERT INTO events VALUES
+  ('01890fa1-9e40-7d3c-8b9a-2f5c6d7e8a01', 'pageview', 'ada@lovelace-analytics.co.uk',
+   'ada@lovelace-analytics.co.uk', '{"plan":"team"}', '2026-09-07 10:00:00'),
+  ('01890fa1-9e40-7d3c-8b9a-2f5c6d7e8a02', 'pageview', 'grace@hopper-systems.io',
+   'grace@hopper-systems.io', '{"plan":"free"}', '2026-09-07 10:01:00'),
+  ('01890fa1-9e40-7d3c-8b9a-2f5c6d7e8a03', 'pageview', 'alan@turing-labs.net',
+   'alan@turing-labs.net', '{"plan":"team"}', '2026-09-07 10:02:00')`
+
+// TestCrossStoreLive_OneIdentityMasksToOnePersonInBothStores is the lane's
+// number, measured rather than argued.
+func TestCrossStoreLive_OneIdentityMasksToOnePersonInBothStores(t *testing.T) {
+	conn, done := requireDatabase(t)
+	defer done()
+	ch := requireClickHouse(t)
+	ctx := context.Background()
+
+	_, err := conn.Exec(ctx, personTable)
+	require.NoError(t, err)
+	ch.exec(t, eventsForThosePeople, nil)
+	ch.exec(t, insertThosePeople, nil)
+
+	// One rules file, both stores. The properties rule is the one a person has
+	// to write: the same blob is jsonb on one side and a String on the other,
+	// and without it the classifier empties one as JSON and the other as text.
+	rules, err := masking.NewRuleSet([]masking.Rule{
+		{Column: "distinct_id", Transform: "email", Link: "email",
+			Why: "This product's distinct id is the person's address."},
+		{Column: "properties", Type: "text", Transform: "empty_json",
+			Why: "ClickHouse holds this JSON in a String."},
+	})
+	require.NoError(t, err)
+
+	pgTables, err := masking.ReadCatalog(ctx, conn)
+	require.NoError(t, err)
+	require.NotEmpty(t, pgTables)
+	for _, tb := range pgTables {
+		require.Equal(t, "postgres", tb.Engine,
+			"a table read from Postgres does not say so, so the empty compatibility case "+
+				"in DialectFor covers something a catalog reader produced")
+	}
+	chTables := ch.catalog(t)
+	require.NotEmpty(t, chTables)
+
+	// The number.
+	key := testKey(t)
+	report, err := masking.CrossStoreCheck(key, []masking.StoreAssignments{
+		{Store: "primary", Assignments: rules.Assign(pgTables)},
+		{Store: "events", Assignments: rules.Assign(chTables)},
+	}, nil)
+	require.NoError(t, err)
+	t.Log("\n" + report.Summary())
+	require.True(t, report.OK(), "the two stores do not agree:\n%s", report.Summary())
+	require.Equal(t, 100.0, report.Percent())
+
+	// And then the same claim one level down, from the rows themselves. The
+	// report compares what the transforms WOULD do; this masks both stores and
+	// reads the values back out of two different servers.
+	pgPlan := masking.BuildPlan(pgTables, rules.Assign(pgTables), "live")
+	require.True(t, pgPlan.Runnable(), masking.DescribeProblems(pgPlan.Problems))
+	exec, err := masking.NewExecutor(masking.ExecutorOptions{Key: key})
+	require.NoError(t, err)
+	_, err = exec.Apply(ctx, conn, pgPlan)
+	require.NoError(t, err)
+
+	chPlan := masking.BuildPlan(chTables, rules.Assign(chTables), "live")
+	require.True(t, chPlan.Runnable(), masking.DescribeProblems(chPlan.Problems))
+	maskClickHouse(t, ch, chPlan, key)
+
+	pgEmails := postgresEmails(t, conn)
+	chEmails := clickhouseEmails(t, ch)
+	require.Len(t, pgEmails, 3)
+	require.Equal(t, pgEmails, chEmails,
+		"the same three people masked into six; a join between the two stores now "+
+			"returns nothing and every report built on it is confidently wrong")
+
+	for _, address := range []string{
+		"ada@lovelace-analytics.co.uk", "grace@hopper-systems.io", "alan@turing-labs.net",
+	} {
+		require.NotContains(t, pgEmails, address, "an address survived masking")
+	}
+
+	// Both stores read back with the same detectors, and both clean. The
+	// guarantee does not move: a golden that fails here is never published.
+	pgReport, err := verify.Scan(ctx, conn, verify.Options{SampleSize: 200})
+	require.NoError(t, err)
+	require.Empty(t, pgReport.Findings, "%v", pgReport.Findings)
+	chReport, err := verify.ScanSource(ctx, ch.source(), verify.Options{SampleSize: 200})
+	require.NoError(t, err)
+	require.Empty(t, chReport.Findings, "%v", chReport.Findings)
+	require.Equal(t, "postgres", pgReport.Engine)
+	require.Equal(t, "clickhouse", chReport.Engine)
+}
+
+// maskClickHouse runs the plan the dialect compiled, one row at a time, exactly
+// as the executor does against Postgres: read a chunk, compute in Go, write the
+// values back as parameters.
+func maskClickHouse(t *testing.T, ch *chServer, plan masking.Plan, key *masking.Key) {
+	t.Helper()
+	d, err := masking.DialectFor("clickhouse")
+	require.NoError(t, err)
+	for _, tp := range plan.Tables {
+		read := d.SelectChunk(tp, "")
+		rows, rowsErr := ch.rows(context.Background(), read.SQL)
+		require.NoError(t, rowsErr, read.SQL)
+		stmt := tp.Compile()
+		for _, row := range rows {
+			params := map[string]string{"p1": string(row[0])}
+			for i, c := range tp.Columns {
+				transform, ok := masking.Lookup(c.Transform)
+				require.True(t, ok, c.Transform)
+				in := string(row[1+i])
+				out, applyErr := transform.Apply(key, masking.Column{
+					Schema: tp.Table.Schema, Table: tp.Table.Name,
+					Name: c.Column.Name, Link: c.Link,
+				}, &in)
+				require.NoError(t, applyErr)
+				require.NotNil(t, out, "this fixture holds no nulls")
+				params[fmt.Sprintf("p%d", i+2)] = *out
+			}
+			ch.exec(t, stmt.SQL, params)
+		}
+	}
+}
+
+// postgresEmails reads the masked addresses back out of Postgres.
+//
+// Ordered by distinct_id, which after masking is the same value as email: both
+// carry the link email, so both derive the same subkey and one address masks to
+// one address whichever column it was in. That is the within store half of the
+// same guarantee, and it is what makes the two lists comparable row by row.
+func postgresEmails(t *testing.T, conn *pgx.Conn) []string {
+	t.Helper()
+	rows, err := conn.Query(context.Background(),
+		"SELECT email FROM person ORDER BY distinct_id")
+	require.NoError(t, err)
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var email string
+		require.NoError(t, rows.Scan(&email))
+		out = append(out, email)
+	}
+	require.NoError(t, rows.Err())
+	return out
+}
+
+// clickhouseEmails reads the same addresses out of the other server.
+func clickhouseEmails(t *testing.T, ch *chServer) []string {
+	t.Helper()
+	rows, err := ch.rows(context.Background(),
+		"SELECT assumeNotNull(email) FROM events ORDER BY distinct_id")
+	require.NoError(t, err)
+	var out []string
+	for _, r := range rows {
+		out = append(out, string(r[0]))
+	}
+	return out
+}

--- a/engine/internal/masking/crossstore_test.go
+++ b/engine/internal/masking/crossstore_test.go
@@ -1,0 +1,348 @@
+package masking_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/internal/masking"
+)
+
+// The two stores here are shaped like the product this wave exists for: a
+// Postgres holding people and a ClickHouse holding the events about them, with
+// the identifier that joins the two present in both.
+//
+// The column names and types are the ones that shape appears with in the wild.
+// distinct_id is text in Postgres and String in ClickHouse; properties is jsonb
+// on one side and a String holding JSON on the other, which is the case that
+// makes the check earn its keep.
+
+func postgresPeople() []masking.Table {
+	return []masking.Table{{
+		Engine: "postgres", Schema: "public", Name: "person",
+		PrimaryKey: []string{"id"},
+		Columns: []masking.ColumnInfo{
+			{Name: "id", Type: "bigint"},
+			{Name: "uuid", Type: "uuid"},
+			{Name: "distinct_id", Type: "text", Nullable: true},
+			{Name: "email", Type: "text", Nullable: true},
+			{Name: "properties", Type: "jsonb", Nullable: true},
+			{Name: "created_at", Type: "timestamp with time zone"},
+		},
+	}}
+}
+
+func clickhouseEvents() []masking.Table {
+	return []masking.Table{{
+		Engine: "clickhouse", Schema: "default", Name: "events",
+		PrimaryKey: []string{"uuid"},
+		Columns: []masking.ColumnInfo{
+			{Name: "uuid", Type: "UUID"},
+			{Name: "event", Type: "String"},
+			{Name: "distinct_id", Type: "String", Nullable: true},
+			{Name: "email", Type: "Nullable(String)", Nullable: true},
+			{Name: "properties", Type: "String", Nullable: true},
+			{Name: "timestamp", Type: "DateTime64(6)"},
+		},
+	}}
+}
+
+// oneRulesFile is the point: ONE file, covering both stores, with the types
+// written in the Postgres vocabulary because that is the vocabulary every rule
+// anybody has already written is in.
+func oneRulesFile(t *testing.T) *masking.RuleSet {
+	t.Helper()
+	rs, err := masking.NewRuleSet([]masking.Rule{
+		{Column: "distinct_id", Transform: "hash_hex", Link: "person",
+			Why: "The identifier that joins a person to their events."},
+		{Column: "properties", Type: "text", Transform: "empty_json",
+			Why: "ClickHouse holds this JSON in a String, and it is the same blob " +
+				"the Postgres jsonb holds."},
+	})
+	require.NoError(t, err)
+	return rs
+}
+
+func stores(t *testing.T, rs *masking.RuleSet) []masking.StoreAssignments {
+	t.Helper()
+	pg, ch := postgresPeople(), clickhouseEvents()
+	return []masking.StoreAssignments{
+		{Store: "primary", Assignments: rs.Assign(pg)},
+		{Store: "events", Assignments: rs.Assign(ch)},
+	}
+}
+
+// TestCrossStore_TheSameIdentityMasksToTheSamePersonInBothStores is the lane's
+// acceptance and the number it publishes.
+func TestCrossStore_TheSameIdentityMasksToTheSamePersonInBothStores(t *testing.T) {
+	t.Parallel()
+	report, err := masking.CrossStoreCheck(testKey(t), stores(t, oneRulesFile(t)), nil)
+	require.NoError(t, err)
+
+	require.True(t, report.OK(), "the report is not clean:\n%s", report.Summary())
+	require.Equal(t, 100.0, report.Percent(), report.Summary())
+	require.Positive(t, report.Checked, "nothing was compared, which is not a pass")
+	t.Log("\n" + report.Summary())
+
+	// And the value itself, not only the verdict. The check compares outputs,
+	// so this asserts the same thing one level down: a person's address masks
+	// to one address in both stores.
+	pg := maskedValue(t, report, "primary", "public.person", "email")
+	ch := maskedValue(t, report, "events", "default.events", "email")
+	require.Equal(t, pg, ch,
+		"one address masked into two people, which is the failure this lane exists for")
+	require.NotEqual(t, "ada@lovelace-analytics.co.uk", pg, "the address was not masked at all")
+}
+
+// maskedValue masks one probe through one side of a reported pair, so a test
+// can assert the value rather than only the verdict.
+func maskedValue(t *testing.T, r masking.CrossStoreReport, store, table, column string) string {
+	t.Helper()
+	for _, p := range r.Pairs {
+		for _, side := range []masking.JoinColumn{p.A, p.B} {
+			if side.Store != store || side.Table != table || side.Column != column {
+				continue
+			}
+			transform, ok := masking.Lookup(side.Transform)
+			require.True(t, ok, side.Transform)
+			in := "ada@lovelace-analytics.co.uk"
+			out, err := transform.Apply(testKey(t), side.Identity, &in)
+			require.NoError(t, err)
+			require.NotNil(t, out)
+			return *out
+		}
+	}
+	t.Fatalf("%s.%s.%s is not in any reported pair", store, table, column)
+	return ""
+}
+
+// TestCrossStore_CatchesAJoinKeyMaskedInOneStoreAndCopiedInTheOther is the
+// defect the whole lane is named after.
+//
+// The second store's column is left with no transform, which is exactly what
+// happened before the dialect existed: a ClickHouse String matched no rule
+// carrying a Postgres type name, so nothing decided about the column and it was
+// copied. The Postgres side then holds a fake address and the ClickHouse side
+// holds the real one.
+func TestCrossStore_CatchesAJoinKeyMaskedInOneStoreAndCopiedInTheOther(t *testing.T) {
+	t.Parallel()
+	rs := oneRulesFile(t)
+	all := stores(t, rs)
+	all[1].Assignments = withoutTransform(all[1].Assignments, "email")
+
+	report, err := masking.CrossStoreCheck(testKey(t), all, nil)
+	require.NoError(t, err)
+	require.False(t, report.OK(), "a copied join key was reported as verified:\n%s", report.Summary())
+	require.Less(t, report.Percent(), 100.0)
+
+	// Which side is which, not only that a sentence was produced. The first
+	// version of this named them the wrong way round, said the copied column
+	// was "masked with" an empty transform, and passed: the assertions were
+	// about the words rather than about the columns they were attached to.
+	require.Contains(t, report.Summary(),
+		"primary.public.person.email is masked with email and "+
+			"events.default.events.email is copied unchanged")
+	require.Contains(t, report.Summary(), "the other holds the real one")
+	require.Contains(t, mismatchedColumns(report), "events.default.events.email")
+}
+
+// TestCrossStore_CatchesTwoStoresMaskedWithDifferentTransforms covers the
+// subtler half: both sides are masked, so nothing leaks, and the join is still
+// broken because the two outputs are different values.
+func TestCrossStore_CatchesTwoStoresMaskedWithDifferentTransforms(t *testing.T) {
+	t.Parallel()
+	rs := oneRulesFile(t)
+	all := stores(t, rs)
+	all[1].Assignments = withTransform(all[1].Assignments, "email", "hash_hex", "hash_hex")
+
+	report, err := masking.CrossStoreCheck(testKey(t), all, nil)
+	require.NoError(t, err)
+	require.False(t, report.OK(), report.Summary())
+	require.Contains(t, report.Summary(), "different transforms")
+	require.Contains(t, report.Summary(), "one identity becomes two people")
+}
+
+// TestCrossStore_CatchesTwoStoresMaskedUnderDifferentLinks is the one a reader
+// would not predict: the same transform on both sides is not enough.
+//
+// The subkey is derived from the column identity, and the link IS the identity
+// when one is set. Two columns masked by the same transform under different
+// links draw from two different subkeys and produce two different fake people
+// out of one real one.
+func TestCrossStore_CatchesTwoStoresMaskedUnderDifferentLinks(t *testing.T) {
+	t.Parallel()
+	rs := oneRulesFile(t)
+	all := stores(t, rs)
+	all[1].Assignments = withTransform(all[1].Assignments, "email", "email", "events_email")
+
+	report, err := masking.CrossStoreCheck(testKey(t), all, nil)
+	require.NoError(t, err)
+	require.False(t, report.OK(), report.Summary())
+	require.Contains(t, report.Summary(), "different identities")
+	require.Contains(t, report.Summary(), "give them one link")
+}
+
+// TestCrossStore_TheDivergenceARulesFileHasToSettle is the case that made the
+// rules file above carry a rule for properties.
+//
+// jsonb in Postgres and a String holding JSON in ClickHouse are the same blob
+// under two type names, and without a rule the classifier empties one as JSON
+// and the other as text. Nothing leaks, and the two stores still hold different
+// values for one field. Reported rather than tolerated, because the same shape
+// with an identifier in it is a broken join.
+func TestCrossStore_TheDivergenceARulesFileHasToSettle(t *testing.T) {
+	t.Parallel()
+	bare, err := masking.NewRuleSet(nil)
+	require.NoError(t, err)
+
+	report, err := masking.CrossStoreCheck(testKey(t), stores(t, bare), nil)
+	require.NoError(t, err)
+	require.False(t, report.OK(),
+		"properties is jsonb on one side and String on the other and this was called clean:\n%s",
+		report.Summary())
+	require.Contains(t, mismatchedColumns(report), "events.default.events.properties")
+
+	// And with the rule, it settles. The escape hatch is a rule that says what
+	// the column is, never a way to silence the report.
+	settled, err := masking.CrossStoreCheck(testKey(t), stores(t, oneRulesFile(t)), nil)
+	require.NoError(t, err)
+	require.True(t, settled.OK(), settled.Summary())
+}
+
+// TestCrossStore_NothingToCompareIsNotAPass is the check on the check.
+//
+// A report over two stores that share no identifier has proved nothing, and a
+// percentage over an empty set is the shape every vacuous green check has.
+func TestCrossStore_NothingToCompareIsNotAPass(t *testing.T) {
+	t.Parallel()
+	rs, err := masking.NewRuleSet(nil)
+	require.NoError(t, err)
+	left := []masking.Table{{
+		Engine: "postgres", Schema: "public", Name: "a", PrimaryKey: []string{"id"},
+		Columns: []masking.ColumnInfo{
+			{Name: "id", Type: "bigint"},
+			{Name: "left_note", Type: "text", Nullable: true},
+		},
+	}}
+	right := []masking.Table{{
+		Engine: "clickhouse", Schema: "default", Name: "b", PrimaryKey: []string{"id"},
+		Columns: []masking.ColumnInfo{
+			{Name: "id", Type: "Int64"},
+			{Name: "right_note", Type: "String", Nullable: true},
+		},
+	}}
+	report, err := masking.CrossStoreCheck(testKey(t), []masking.StoreAssignments{
+		{Store: "primary", Assignments: rs.Assign(left)},
+		{Store: "events", Assignments: rs.Assign(right)},
+	}, nil)
+	require.NoError(t, err)
+	require.Zero(t, report.Checked)
+	require.False(t, report.OK(), "a report that compared nothing came back as a pass")
+	require.Equal(t, 0.0, report.Percent())
+	require.Contains(t, report.Summary(), "nothing is proved")
+}
+
+// TestCrossStore_APairWithNoApplicableProbeIsNotVerified covers the other way a
+// check like this goes quietly vacuous: every probe is refused by the
+// transform, nothing is compared, and the pair passes anyway.
+//
+// The first version of this test was itself the failure it describes. It ran
+// the ordinary fixture with one nonsense probe and asserted a property of pairs
+// whose probe count was zero, and every transform in that fixture accepts any
+// string, so no pair had one and the loop body never ran. Removing the guard in
+// the production code left it green. It now builds a pair that CAN have nothing
+// applicable, and asserts that one did before asserting anything about it.
+func TestCrossStore_APairWithNoApplicableProbeIsNotVerified(t *testing.T) {
+	t.Parallel()
+	rs, err := masking.NewRuleSet([]masking.Rule{
+		{Column: "person_id", Transform: "uuid_remap", Link: "person",
+			Why: "The person a row is about."},
+	})
+	require.NoError(t, err)
+
+	left := []masking.Table{{
+		Engine: "postgres", Schema: "public", Name: "person", PrimaryKey: []string{"id"},
+		Columns: []masking.ColumnInfo{
+			{Name: "id", Type: "bigint"},
+			{Name: "person_id", Type: "uuid", Nullable: true},
+		},
+	}}
+	right := []masking.Table{{
+		Engine: "clickhouse", Schema: "default", Name: "events", PrimaryKey: []string{"uuid"},
+		Columns: []masking.ColumnInfo{
+			{Name: "uuid", Type: "UUID"},
+			{Name: "person_id", Type: "Nullable(UUID)", Nullable: true},
+		},
+	}}
+	all := []masking.StoreAssignments{
+		{Store: "primary", Assignments: rs.Assign(left)},
+		{Store: "events", Assignments: rs.Assign(right)},
+	}
+
+	// uuid_remap refuses anything that is not a UUID, and neither probe is one,
+	// so both sides refuse both probes and nothing is compared.
+	report, err := masking.CrossStoreCheck(testKey(t), all,
+		[]string{"not a uuid", "still not a uuid"})
+	require.NoError(t, err)
+
+	require.Equal(t, 1, report.Checked, "the fixture did not produce the pair this is about")
+	require.Zero(t, report.Pairs[0].Probes,
+		"a probe was applicable after all, so this test would pass whatever the "+
+			"production code did with a pair that has none")
+	require.False(t, report.Pairs[0].Identical)
+	require.Contains(t, report.Pairs[0].Reason, "not verified")
+	require.False(t, report.OK())
+
+	// And the same pair with a probe that IS a UUID is verified, which is what
+	// stops the assertion above from being satisfied by a check that refuses
+	// everything.
+	verified, err := masking.CrossStoreCheck(testKey(t), all,
+		[]string{"01890fa1-9e40-7d3c-8b9a-2f5c6d7e8a90"})
+	require.NoError(t, err)
+	require.True(t, verified.OK(), verified.Summary())
+	require.Equal(t, 1, verified.Pairs[0].Probes)
+}
+
+// TestCrossStore_RefusesToCompareOneStore is the argument check, and it is a
+// real one: a cross store report over one store would be a perfect score every
+// time.
+func TestCrossStore_RefusesToCompareOneStore(t *testing.T) {
+	t.Parallel()
+	all := stores(t, oneRulesFile(t))
+	_, err := masking.CrossStoreCheck(testKey(t), all[:1], nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "compares stores")
+
+	_, err = masking.CrossStoreCheck(nil, all, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "needs a key")
+}
+
+func withoutTransform(in []masking.Assignment, column string) []masking.Assignment {
+	out := append([]masking.Assignment(nil), in...)
+	for i := range out {
+		if out[i].Column.Name == column {
+			out[i].Transform, out[i].Link = "", ""
+		}
+	}
+	return out
+}
+
+func withTransform(in []masking.Assignment, column, transform, link string) []masking.Assignment {
+	out := append([]masking.Assignment(nil), in...)
+	for i := range out {
+		if out[i].Column.Name == column {
+			out[i].Transform, out[i].Link = transform, link
+		}
+	}
+	return out
+}
+
+func mismatchedColumns(r masking.CrossStoreReport) string {
+	var names []string
+	for _, p := range r.Mismatches() {
+		names = append(names, p.A.String(), p.B.String())
+	}
+	return strings.Join(names, " ")
+}

--- a/engine/internal/masking/dialect.go
+++ b/engine/internal/masking/dialect.go
@@ -1,0 +1,186 @@
+package masking
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// A dialect is the part of masking that knows one datastore engine.
+//
+// Everything else in this package is deliberately engine independent and was
+// already: a transform is a pure function of the project key, the column
+// identity and the input value, computed in Go and never in the database, and
+// that property does not care which store the value came out of. Three things
+// do care, and all three were Postgres without saying so.
+//
+//  1. The name an engine gives a type. `text` in Postgres is `String` in
+//     ClickHouse, and the classifier, the rules people write and the
+//     verification scanner all speak the Postgres name.
+//  2. The way an identifier is quoted.
+//  3. The statement that rewrites a row.
+//
+// The first of those is the one that leaks data. A ClickHouse column of type
+// String matched no rule carrying `type: text`, so nothing in the classifier
+// recognised it, so nothing decided what happened to it and it was copied
+// unchanged. The same person is then a fake customer in Postgres and a real
+// one in ClickHouse, and a join across the two produces two different people
+// for one user. That is worse than an empty store, because an empty store is
+// visible and this is not.
+//
+// So an engine's type names are mapped onto the POSTGRES names rather than
+// onto a third vocabulary invented here. There are already two independent
+// tables of Postgres type names in this repository, this package's and the
+// verification scanner's, kept in step by a test rather than by sharing code,
+// because verify must not import masking. A third vocabulary would mean three
+// tables to keep in step instead of two, and the failure mode of a stale one
+// is a column nobody classified.
+
+// Query is a statement and the arguments it is run with.
+type Query struct {
+	SQL  string
+	Args []any
+}
+
+// Dialect is everything masking needs to know about one datastore engine.
+//
+// Deliberately small, and deliberately not an execution surface. Nothing here
+// opens a connection or runs a statement: the executor holds a Postgres
+// connection and runs a chunk inside a transaction, which is what ctid
+// addressing requires and what a ClickHouse mutation is not. Widening this
+// interface until it could execute against both would weaken the contract the
+// Postgres path depends on to accommodate an engine whose write path is not a
+// transaction at all. The second engine's execution loop belongs with the
+// second engine's provider.
+type Dialect interface {
+	// Engine is the name a manifest datastore declares, such as postgres or
+	// clickhouse.
+	Engine() string
+	// Canonical maps one of this engine's own type names onto the Postgres
+	// name for the same kind of value, which is the vocabulary the rules and
+	// both classifiers speak. It is a projection: a name that is already
+	// canonical comes back unchanged, so feeding the output back in is safe.
+	// A type this dialect does not recognise comes back as it went in, which
+	// is what lands it in the classifier's "nobody has decided about this"
+	// branch rather than in a silently wrong one.
+	Canonical(dataType string) string
+	// QuoteIdent quotes an identifier so that a name carrying the quote
+	// character cannot end the quoting early.
+	QuoteIdent(name string) string
+	// Placeholder renders the nth statement parameter, counting from one.
+	//
+	// The numbering is the executor's contract rather than either engine's:
+	// the row key is always the first argument and the masked values follow in
+	// the plan's column order. Two engines write a parameter differently and
+	// neither gets to reorder them.
+	Placeholder(n int) string
+	// Qualify renders a table the way a statement addresses it.
+	Qualify(t Table) string
+	// Unaddressable says why this engine cannot rewrite one row of this table
+	// at a time, and returns empty when it can. Postgres can always: a table
+	// with no primary key is addressed by ctid. An engine with no physical row
+	// identifier says so here, at planning time, because a masking run that
+	// fails halfway leaves a table neither real nor safe.
+	Unaddressable(t Table) string
+	// RowKey is the expression that addresses one row.
+	RowKey(tp TablePlan) string
+	// SelectChunk reads one chunk of a table, resuming after a key when one is
+	// given.
+	SelectChunk(tp TablePlan, after string) Query
+	// Update rewrites the planned columns of one row, with the values as
+	// parameters rather than interpolated: they are computed in Go from a key
+	// the database never sees, and a value carrying a quote must not be able
+	// to change what the statement means.
+	Update(tp TablePlan) Statement
+}
+
+// dialects is the registry, keyed by engine name.
+var (
+	dialectMu sync.RWMutex
+	dialects  = map[string]Dialect{}
+)
+
+// RegisterDialect adds a dialect. Registering two under one name panics, the
+// same way two transforms under one name do: it is a programming error visible
+// at startup rather than a behaviour that changes with link order.
+func RegisterDialect(d Dialect) {
+	dialectMu.Lock()
+	defer dialectMu.Unlock()
+	name := d.Engine()
+	if _, dup := dialects[name]; dup {
+		panic("masking: two dialects are registered as " + name)
+	}
+	dialects[name] = d
+}
+
+// DialectFor returns the dialect for an engine.
+//
+// An empty engine is Postgres. That is a compatibility case and not a default
+// anybody should rely on: a Table read from a database carries the engine that
+// produced it, and every catalog reader sets it. The empty case exists because
+// a Table value written before this field did, in a test or in a caller that
+// only ever had one engine, means the one engine there was.
+//
+// An engine nobody has a dialect for is an ERROR rather than Postgres. Guessing
+// would mean classifying a ClickHouse schema with Postgres type names, and the
+// result of that is not a failure, it is a column that looks classified and
+// was not.
+func DialectFor(engine string) (Dialect, error) {
+	if engine == "" {
+		engine = enginePostgres
+	}
+	dialectMu.RLock()
+	defer dialectMu.RUnlock()
+	d, ok := dialects[engine]
+	if !ok {
+		return nil, fmt.Errorf(
+			"masking: there is no dialect for the engine %q, so nothing here knows what its "+
+				"type names mean or how to address a row in it; there is %s",
+			engine, strings.Join(dialectNamesLocked(), ", "))
+	}
+	return d, nil
+}
+
+// DialectNames returns every registered engine, sorted.
+func DialectNames() []string {
+	dialectMu.RLock()
+	defer dialectMu.RUnlock()
+	return dialectNamesLocked()
+}
+
+func dialectNamesLocked() []string {
+	out := make([]string, 0, len(dialects))
+	for name := range dialects {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// dialect returns the table's dialect, or Postgres when the engine is unknown.
+//
+// Used only where an error cannot be reported and where the caller has already
+// been refused: Assign records a Problem on every column of a table whose
+// engine has no dialect, BuildPlan skips a table with problems, and the
+// executor refuses a plan that has any. So a statement is never compiled for an
+// engine nobody recognised. The fallback is here rather than a panic because a
+// TablePlan built by hand in a test is a legitimate value.
+func (t Table) dialect() Dialect {
+	d, err := DialectFor(t.Engine)
+	if err != nil {
+		return postgresDialect{}
+	}
+	return d
+}
+
+// canonical returns the column with its type renamed into the Postgres
+// vocabulary the classifier and the rules speak.
+//
+// The RAW name is what the plan prints and what an error message names, because
+// a person reading it is looking at their own store's schema and "String" is
+// what they will find there. The canonical name is what decides.
+func canonical(t Table, c ColumnInfo) ColumnInfo {
+	c.Type = t.dialect().Canonical(c.Type)
+	return c
+}

--- a/engine/internal/masking/dialect_broken_test.go
+++ b/engine/internal/masking/dialect_broken_test.go
@@ -1,0 +1,347 @@
+package masking
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// The broken fakes, one per behaviour, and the self test that watches each one
+// go red.
+//
+// Every fake wraps a correct dialect and breaks exactly one thing, which is
+// what makes it a control: a fake that was broken in five ways would fail the
+// suite for reasons nobody could attribute. The Postgres dialect is the one
+// wrapped because it is the one with a live suite behind it.
+
+// brokenDialect is a correct dialect with one method replaced.
+type brokenDialect struct {
+	Dialect
+	engine      func() string
+	canonical   func(string) string
+	quoteIdent  func(string) string
+	placeholder func(int) string
+	qualify     func(Table) string
+	rowKey      func(TablePlan) string
+	selectChunk func(TablePlan, string) Query
+	update      func(TablePlan) Statement
+	addressable func(Table) string
+}
+
+func (b brokenDialect) Engine() string {
+	if b.engine != nil {
+		return b.engine()
+	}
+	return b.Dialect.Engine()
+}
+
+func (b brokenDialect) Canonical(t string) string {
+	if b.canonical != nil {
+		return b.canonical(t)
+	}
+	return b.Dialect.Canonical(t)
+}
+
+func (b brokenDialect) QuoteIdent(name string) string {
+	if b.quoteIdent != nil {
+		return b.quoteIdent(name)
+	}
+	return b.Dialect.QuoteIdent(name)
+}
+
+func (b brokenDialect) Placeholder(n int) string {
+	if b.placeholder != nil {
+		return b.placeholder(n)
+	}
+	return b.Dialect.Placeholder(n)
+}
+
+func (b brokenDialect) Qualify(t Table) string {
+	if b.qualify != nil {
+		return b.qualify(t)
+	}
+	return b.Dialect.Qualify(t)
+}
+
+func (b brokenDialect) RowKey(tp TablePlan) string {
+	if b.rowKey != nil {
+		return b.rowKey(tp)
+	}
+	return b.Dialect.RowKey(tp)
+}
+
+func (b brokenDialect) SelectChunk(tp TablePlan, after string) Query {
+	if b.selectChunk != nil {
+		return b.selectChunk(tp, after)
+	}
+	return b.Dialect.SelectChunk(tp, after)
+}
+
+func (b brokenDialect) Update(tp TablePlan) Statement {
+	if b.update != nil {
+		return b.update(tp)
+	}
+	return b.Dialect.Update(tp)
+}
+
+func (b brokenDialect) Unaddressable(t Table) string {
+	if b.addressable != nil {
+		return b.addressable(t)
+	}
+	return b.Dialect.Unaddressable(t)
+}
+
+func sound() Dialect { return postgresDialect{} }
+
+// dialectControls pairs each injected defect with the behaviour that has to
+// notice it, and with every other behaviour it reds.
+//
+// The `also` column is exact rather than a note. The self test requires the set
+// of behaviours that went red to be precisely the named one plus these, so an
+// overlap is something a reader can see rather than something the table quietly
+// tolerates. Three defects red more than one behaviour because the row key
+// appears in every statement built from it, and a dialect that addresses the
+// wrong row writes the wrong statement everywhere.
+var dialectControls = []struct {
+	flaw      string
+	behaviour string
+	also      []string
+	dialect   Dialect
+}{
+	{
+		flaw:      "a dialect registered under a name it does not answer to",
+		behaviour: "Engine_IsNamedAndRegistered",
+		dialect:   brokenDialect{Dialect: sound(), engine: func() string { return "not-registered" }},
+	},
+	{
+		flaw:      "a canonical mapping that moves again when it is applied twice",
+		behaviour: "Canonical_IsAProjection",
+		dialect: brokenDialect{Dialect: sound(), canonical: func(t string) string {
+			switch t {
+			case "text":
+				return "json"
+			case "json":
+				return "jsonb"
+			}
+			return t
+		}},
+	},
+	{
+		flaw:      "a dialect that guesses text for a type it has never heard of",
+		behaviour: "Canonical_LeavesATypeItDoesNotKnowAlone",
+		dialect: brokenDialect{Dialect: sound(), canonical: func(t string) string {
+			if sound().Canonical(t) == t {
+				return "text"
+			}
+			return sound().Canonical(t)
+		}},
+	},
+	{
+		flaw:      "an identifier quoted without doubling the quote inside it",
+		behaviour: "QuoteIdent_CannotBeEndedEarly",
+		dialect: brokenDialect{Dialect: sound(), quoteIdent: func(name string) string {
+			return `"` + name + `"`
+		}},
+	},
+	{
+		flaw:      "a table addressed without its schema",
+		behaviour: "Qualify_NamesTheSchemaAndTheTable",
+		dialect: brokenDialect{Dialect: sound(), qualify: func(t Table) string {
+			return sound().QuoteIdent(t.Name)
+		}},
+	},
+	{
+		flaw:      "two argument positions that render as one placeholder",
+		behaviour: "Placeholder_IsDistinctPerPosition",
+		dialect: brokenDialect{Dialect: sound(), placeholder: func(n int) string {
+			if n == 2 {
+				return "$1"
+			}
+			return fmt.Sprintf("$%d", n)
+		}},
+	},
+	{
+		flaw:      "a row addressed by the second key column instead of the first",
+		behaviour: "RowKey_AddressesTheFirstKeyColumn",
+		also: []string{
+			// The row key is what every statement compares and orders on, so a
+			// dialect whose RowKey disagrees with its own statements disagrees
+			// with them everywhere at once.
+			"Update_SendsEveryValueAsAParameter",
+			"SelectChunk_ReadsTheKeyAndEveryPlannedColumn",
+			"SelectChunk_OrdersByTheRowKey",
+		},
+		dialect: brokenDialect{Dialect: sound(), rowKey: func(tp TablePlan) string {
+			return sound().QuoteIdent(tp.OrderBy[1])
+		}},
+	},
+	{
+		flaw:      "a statement that reports fewer columns than it rewrites",
+		behaviour: "Update_RewritesEveryPlannedColumn",
+		dialect: brokenDialect{Dialect: sound(), update: func(tp TablePlan) Statement {
+			s := sound().Update(tp)
+			s.Columns = s.Columns[:len(s.Columns)-1]
+			return s
+		}},
+	},
+	{
+		flaw:      "a statement that reports its columns in the wrong order",
+		behaviour: "Update_RewritesEveryPlannedColumn",
+		dialect: brokenDialect{Dialect: sound(), update: func(tp TablePlan) Statement {
+			s := sound().Update(tp)
+			for i, j := 0, len(s.Columns)-1; i < j; i, j = i+1, j-1 {
+				s.Columns[i], s.Columns[j] = s.Columns[j], s.Columns[i]
+			}
+			return s
+		}},
+	},
+	{
+		flaw:      "a masked value built into the statement text instead of sent as an argument",
+		behaviour: "Update_SendsEveryValueAsAParameter",
+		dialect: brokenDialect{Dialect: sound(), update: func(tp TablePlan) Statement {
+			s := sound().Update(tp)
+			last := sound().Placeholder(len(tp.Columns) + 1)
+			s.SQL = strings.Replace(s.SQL, last, "'a literal'", 1)
+			return s
+		}},
+	},
+	{
+		flaw:      "a read with no chunk limit, which takes the whole table at once",
+		behaviour: "SelectChunk_ReadsTheKeyAndEveryPlannedColumn",
+		dialect: brokenDialect{Dialect: sound(), selectChunk: func(tp TablePlan, after string) Query {
+			q := sound().SelectChunk(tp, after)
+			q.SQL = strings.Replace(q.SQL, fmt.Sprintf(" LIMIT %d", tp.ChunkSize), "", 1)
+			return q
+		}},
+	},
+	{
+		flaw:      "a resume point interpolated into the text instead of sent as an argument",
+		behaviour: "SelectChunk_ResumesAfterAKey",
+		dialect: brokenDialect{Dialect: sound(), selectChunk: func(tp TablePlan, after string) Query {
+			q := sound().SelectChunk(tp, after)
+			if after != "" {
+				q.SQL = strings.Replace(q.SQL, sound().Placeholder(1), "'"+after+"'", 1)
+				q.Args = nil
+			}
+			return q
+		}},
+	},
+	{
+		flaw:      "a read in no order, which can visit one row twice and another never",
+		behaviour: "SelectChunk_OrdersByTheRowKey",
+		dialect: brokenDialect{Dialect: sound(), selectChunk: func(tp TablePlan, after string) Query {
+			q := sound().SelectChunk(tp, after)
+			if at := strings.Index(q.SQL, " ORDER BY "); at >= 0 {
+				end := strings.Index(q.SQL[at+1:], " LIMIT ")
+				if end < 0 {
+					q.SQL = q.SQL[:at]
+				} else {
+					q.SQL = q.SQL[:at] + q.SQL[at+1+end:]
+				}
+			}
+			return q
+		}},
+	},
+	{
+		flaw:      "a statement that is different text every time it is compiled",
+		behaviour: "Statements_AreTheSameTextTwice",
+		dialect:   &driftingDialect{Dialect: sound()},
+	},
+	{
+		flaw:      "a table with a key refused as though it had none",
+		behaviour: "Unaddressable_AcceptsATableWithAKey",
+		dialect: brokenDialect{Dialect: sound(), addressable: func(Table) string {
+			return "this dialect refuses everything"
+		}},
+	},
+}
+
+// driftingDialect compiles a different statement every time, which is the one
+// defect a stateless fake cannot express.
+type driftingDialect struct {
+	Dialect
+	n int
+}
+
+func (d *driftingDialect) Update(tp TablePlan) Statement {
+	d.n++
+	s := d.Dialect.Update(tp)
+	s.SQL = fmt.Sprintf("%s /* %d */", s.SQL, d.n)
+	return s
+}
+
+// redBehaviours runs every behaviour against a dialect and names the ones that
+// failed.
+func redBehaviours(d Dialect) []string {
+	var out []string
+	for _, b := range dialectBehaviours() {
+		if err := b.Check(d); err != nil {
+			out = append(out, b.Name)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestDialectSuite_FailsEachBrokenDialect is the claim the suite makes about
+// itself, checked.
+func TestDialectSuite_FailsEachBrokenDialect(t *testing.T) {
+	t.Parallel()
+	for _, control := range dialectControls {
+		control := control
+		t.Run(control.flaw, func(t *testing.T) {
+			t.Parallel()
+			red := redBehaviours(control.dialect)
+			want := append([]string{control.behaviour}, control.also...)
+			sort.Strings(want)
+
+			if len(red) == 0 {
+				t.Fatalf("%s passed every behaviour, so nothing in the suite can catch it "+
+					"and %s asserts something that cannot go red",
+					control.flaw, control.behaviour)
+			}
+			if strings.Join(red, ",") != strings.Join(want, ",") {
+				t.Errorf("%s reddened %v and the table says it reddens %v; a behaviour "+
+					"failing for a reason nobody wrote down is not a control",
+					control.flaw, red, want)
+			}
+		})
+	}
+}
+
+// TestDialectSuite_EveryBehaviourHasABrokenFake keeps the table honest as
+// behaviours are added.
+//
+// A behaviour with no defect pointed at it has never been shown to go red,
+// which is the state every assertion is in until somebody proves otherwise.
+func TestDialectSuite_EveryBehaviourHasABrokenFake(t *testing.T) {
+	t.Parallel()
+	covered := map[string]bool{}
+	for _, control := range dialectControls {
+		covered[control.behaviour] = true
+	}
+	for _, b := range dialectBehaviours() {
+		if !covered[b.Name] {
+			t.Errorf("no broken dialect is pointed at %s, so it has never been seen to "+
+				"fail and there is nothing to say it can", b.Name)
+		}
+	}
+}
+
+// TestDialectSuite_PassesACorrectDialect is the positive control.
+//
+// Without it the fakes above prove only that the suite can fail, which a suite
+// that failed on everything would also satisfy.
+func TestDialectSuite_PassesACorrectDialect(t *testing.T) {
+	t.Parallel()
+	for _, name := range DialectNames() {
+		d, err := DialectFor(name)
+		if err != nil {
+			t.Fatalf("DialectFor(%q): %v", name, err)
+		}
+		if red := redBehaviours(d); len(red) > 0 {
+			t.Errorf("the %s dialect fails %v", name, red)
+		}
+	}
+}

--- a/engine/internal/masking/dialect_conformance_test.go
+++ b/engine/internal/masking/dialect_conformance_test.go
@@ -1,0 +1,378 @@
+package masking
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// The conformance suite for a dialect, with a broken fake per behaviour and a
+// self test that watches each one go red.
+//
+// The rule this follows is the one L0.1 exists to enforce: every new interface
+// ships with a broken fake and a self test in the same commit. The database
+// conformance suite in this repository declared twenty four behaviours and had
+// never been shown to fail a single one, and a behaviour that has never gone
+// red is a function call, not a check.
+//
+// A behaviour here returns an error rather than calling t.Error, which is what
+// lets the self test watch a red without a subprocess: a failure is a value
+// rather than a state of the test binary. The datastore suite next door needs
+// the subprocess because its behaviours use require; these are pure functions
+// over a plan and do not.
+
+// dialectBehaviour is one property every dialect must have.
+type dialectBehaviour struct {
+	Name  string
+	Check func(d Dialect) error
+}
+
+// probeTable is the table every behaviour reasons about.
+//
+// Three columns so that "every column" can differ from "the first column", a
+// two column key so that "the first key column" can differ from "the key", and
+// a chunk size so that the limit is visible in the read.
+func probeTable() TablePlan {
+	t := Table{
+		Schema: "app", Name: "people",
+		PrimaryKey: []string{"id", "tenant"},
+		Columns: []ColumnInfo{
+			{Name: "id", Type: "uuid"},
+			{Name: "tenant", Type: "text"},
+			{Name: "email", Type: "text", Nullable: true},
+			{Name: "full_name", Type: "text", Nullable: true},
+			{Name: "note", Type: "text", Nullable: true},
+		},
+	}
+	return TablePlan{
+		Table: t,
+		Columns: []Assignment{
+			{Table: t, Column: t.ColumnNamed("email"), Transform: "email", Link: "email"},
+			{Table: t, Column: t.ColumnNamed("full_name"), Transform: "name", Link: "name"},
+			{Table: t, Column: t.ColumnNamed("note"), Transform: "free_text", Link: "free_text"},
+		},
+		ChunkSize: 20000,
+		OrderBy:   []string{"id", "tenant"},
+	}
+}
+
+// awkwardNames are identifiers that end the quoting early when nobody escapes
+// them. A store whose table names come from a manifest is a store where these
+// are reachable, which is why quoteIdent is unconditional rather than reasoned
+// about per call site.
+var awkwardNames = []string{`a"b`, "a`b", "a'b", `a\b`, "a b", "select"}
+
+func dialectBehaviours() []dialectBehaviour {
+	return []dialectBehaviour{
+		{
+			Name: "Engine_IsNamedAndRegistered",
+			Check: func(d Dialect) error {
+				if strings.TrimSpace(d.Engine()) == "" {
+					return fmt.Errorf("the dialect has no engine name, so no manifest can " +
+						"select it and no error message can say which store it was about")
+				}
+				found, err := DialectFor(d.Engine())
+				if err != nil {
+					return fmt.Errorf("the dialect calls itself %q and DialectFor does not "+
+						"know that name: %w", d.Engine(), err)
+				}
+				if found.Engine() != d.Engine() {
+					return fmt.Errorf("DialectFor(%q) returned the dialect for %q",
+						d.Engine(), found.Engine())
+				}
+				return nil
+			},
+		},
+		{
+			Name: "Canonical_IsAProjection",
+			Check: func(d Dialect) error {
+				// The canonical vocabulary is the Postgres one, so every one
+				// of these must come back as itself. Without that law, the
+				// classifier's own type lists would be reachable only from
+				// Postgres and a second engine would map onto names nothing
+				// recognises.
+				for _, name := range []string{
+					"text", "character varying", "json", "jsonb", "uuid", "bigint",
+					"boolean", "timestamp with time zone", "ARRAY", "USER-DEFINED",
+					"bytea", "inet", "numeric", "date",
+				} {
+					once := d.Canonical(name)
+					twice := d.Canonical(once)
+					if once != twice {
+						return fmt.Errorf("Canonical(%q) is %q and Canonical of that is %q, "+
+							"so the mapping is not stable and a name that has already been "+
+							"canonicalised changes meaning when it is seen again",
+							name, once, twice)
+					}
+				}
+				return nil
+			},
+		},
+		{
+			Name: "Canonical_LeavesATypeItDoesNotKnowAlone",
+			Check: func(d Dialect) error {
+				const unknown = "a_type_this_build_has_never_heard_of"
+				if got := d.Canonical(unknown); got != unknown {
+					return fmt.Errorf("Canonical(%q) is %q, and a type nobody recognises has "+
+						"to come back unchanged so the classifier reports it rather than "+
+						"deciding something about it", unknown, got)
+				}
+				return nil
+			},
+		},
+		{
+			Name: "QuoteIdent_CannotBeEndedEarly",
+			Check: func(d Dialect) error {
+				for _, name := range awkwardNames {
+					quoted := d.QuoteIdent(name)
+					if len(quoted) < len(name)+2 {
+						return fmt.Errorf("QuoteIdent(%q) is %q, which is not quoted at all",
+							name, quoted)
+					}
+					delim := quoted[0]
+					if quoted[len(quoted)-1] != delim {
+						return fmt.Errorf("QuoteIdent(%q) is %q, which does not open and "+
+							"close with the same character", name, quoted)
+					}
+					body := quoted[1 : len(quoted)-1]
+					for i := 0; i < len(body); i++ {
+						if body[i] != delim {
+							continue
+						}
+						if i+1 >= len(body) || body[i+1] != delim {
+							return fmt.Errorf("QuoteIdent(%q) is %q, where a %c inside the "+
+								"name is not doubled, so the identifier ends early and "+
+								"whatever follows it in the statement is no longer a name",
+								name, quoted, delim)
+						}
+						i++
+					}
+				}
+				return nil
+			},
+		},
+		{
+			Name: "Qualify_NamesTheSchemaAndTheTable",
+			Check: func(d Dialect) error {
+				tp := probeTable()
+				got := d.Qualify(tp.Table)
+				for _, part := range []string{tp.Table.Schema, tp.Table.Name} {
+					if !strings.Contains(got, d.QuoteIdent(part)) {
+						return fmt.Errorf("Qualify is %q and does not carry the quoted %q, so "+
+							"a statement built from it addresses a table in whichever "+
+							"schema the session happens to be in", got, part)
+					}
+				}
+				return nil
+			},
+		},
+		{
+			Name: "Placeholder_IsDistinctPerPosition",
+			Check: func(d Dialect) error {
+				seen := map[string]int{}
+				for n := 1; n <= 5; n++ {
+					p := d.Placeholder(n)
+					if p == "" {
+						return fmt.Errorf("Placeholder(%d) is empty, so a value would have to "+
+							"be interpolated and a masked value carrying a quote would "+
+							"change what the statement means", n)
+					}
+					if prev, dup := seen[p]; dup {
+						return fmt.Errorf("Placeholder(%d) and Placeholder(%d) are both %q, "+
+							"so two arguments address one slot and the values land in the "+
+							"wrong columns", prev, n, p)
+					}
+					seen[p] = n
+				}
+				return nil
+			},
+		},
+		{
+			Name: "RowKey_AddressesTheFirstKeyColumn",
+			Check: func(d Dialect) error {
+				tp := probeTable()
+				got := d.RowKey(tp)
+				if !strings.Contains(got, d.QuoteIdent(tp.OrderBy[0])) {
+					return fmt.Errorf("RowKey is %q and does not name the key column %q, so "+
+						"the statement does not say which row it means",
+						got, tp.OrderBy[0])
+				}
+				return nil
+			},
+		},
+		{
+			Name: "Update_RewritesEveryPlannedColumn",
+			Check: func(d Dialect) error {
+				tp := probeTable()
+				stmt := d.Update(tp)
+				if !strings.Contains(stmt.SQL, d.Qualify(tp.Table)) {
+					return fmt.Errorf("the update does not name the table: %s", stmt.SQL)
+				}
+				if len(stmt.Columns) != len(tp.Columns) {
+					return fmt.Errorf("the plan rewrites %d columns and the statement reports "+
+						"%d, so the executor sends a different number of values than the "+
+						"statement expects", len(tp.Columns), len(stmt.Columns))
+				}
+				for i, c := range tp.Columns {
+					if stmt.Columns[i] != c.Column.Name {
+						return fmt.Errorf("the statement reports column %d as %q and the plan "+
+							"has %q there; the values are positional, so a different order "+
+							"writes each column's value into another column",
+							i, stmt.Columns[i], c.Column.Name)
+					}
+					if !strings.Contains(stmt.SQL, d.QuoteIdent(c.Column.Name)) {
+						return fmt.Errorf("the update does not rewrite %q, so that column "+
+							"keeps whatever production had in it: %s",
+							c.Column.Name, stmt.SQL)
+					}
+				}
+				if !stmt.Keyed {
+					return fmt.Errorf("the plan has a key and the statement says it is not " +
+						"keyed, so the executor will not checkpoint it and an interrupted " +
+						"run starts over")
+				}
+				return nil
+			},
+		},
+		{
+			Name: "Update_SendsEveryValueAsAParameter",
+			Check: func(d Dialect) error {
+				tp := probeTable()
+				stmt := d.Update(tp)
+				for n := 1; n <= len(tp.Columns)+1; n++ {
+					if !strings.Contains(stmt.SQL, d.Placeholder(n)) {
+						return fmt.Errorf("the update has no %s, so argument %d has nowhere "+
+							"to land: %s", d.Placeholder(n), n, stmt.SQL)
+					}
+				}
+				if !strings.Contains(stmt.SQL, d.RowKey(tp)) {
+					return fmt.Errorf("the update does not compare the row key, so it "+
+						"rewrites every row of the table at once: %s", stmt.SQL)
+				}
+				return nil
+			},
+		},
+		{
+			Name: "SelectChunk_ReadsTheKeyAndEveryPlannedColumn",
+			Check: func(d Dialect) error {
+				tp := probeTable()
+				q := d.SelectChunk(tp, "")
+				if !strings.Contains(q.SQL, d.RowKey(tp)) {
+					return fmt.Errorf("the read does not select the row key, so the update "+
+						"that follows has nothing to address a row with: %s", q.SQL)
+				}
+				for _, c := range tp.Columns {
+					if !strings.Contains(q.SQL, d.QuoteIdent(c.Column.Name)) {
+						return fmt.Errorf("the read does not select %q, so its transform is "+
+							"applied to nothing: %s", c.Column.Name, q.SQL)
+					}
+				}
+				if !strings.Contains(q.SQL, fmt.Sprintf("%d", tp.ChunkSize)) {
+					return fmt.Errorf("the read carries no chunk limit, so one statement "+
+						"reads the whole table: %s", q.SQL)
+				}
+				if len(q.Args) != 0 {
+					return fmt.Errorf("the first read takes %d arguments and there is no "+
+						"resume point yet", len(q.Args))
+				}
+				return nil
+			},
+		},
+		{
+			Name: "SelectChunk_ResumesAfterAKey",
+			Check: func(d Dialect) error {
+				tp := probeTable()
+				const after = "0189-resume-point"
+				q := d.SelectChunk(tp, after)
+				if len(q.Args) != 1 || q.Args[0] != after {
+					return fmt.Errorf("a resumed read takes %v as arguments and it has to "+
+						"take exactly the resume point, or the bound is interpolated "+
+						"into the text", q.Args)
+				}
+				if !strings.Contains(q.SQL, d.Placeholder(1)) {
+					return fmt.Errorf("a resumed read has no %s, so the resume point has "+
+						"nowhere to land: %s", d.Placeholder(1), q.SQL)
+				}
+				if !strings.Contains(q.SQL, ">") {
+					return fmt.Errorf("a resumed read does not bound the key, so it reads "+
+						"the rows it has already masked again: %s", q.SQL)
+				}
+				return nil
+			},
+		},
+		{
+			Name: "SelectChunk_OrdersByTheRowKey",
+			Check: func(d Dialect) error {
+				tp := probeTable()
+				q := d.SelectChunk(tp, "")
+				at := strings.Index(strings.ToUpper(q.SQL), "ORDER BY")
+				if at < 0 {
+					return fmt.Errorf("the read has no order, so two chunks can return the "+
+						"same row and skip another: %s", q.SQL)
+				}
+				if !strings.Contains(q.SQL[at:], d.RowKey(tp)) {
+					return fmt.Errorf("the read is not ordered by the key it resumes on, so "+
+						"the resume point does not mean what the next chunk assumes: %s",
+						q.SQL)
+				}
+				return nil
+			},
+		},
+		{
+			Name: "Statements_AreTheSameTextTwice",
+			Check: func(d Dialect) error {
+				tp := probeTable()
+				if a, b := d.Update(tp).SQL, d.Update(tp).SQL; a != b {
+					return fmt.Errorf("two updates for one plan differ:\n%s\n%s", a, b)
+				}
+				if a, b := d.SelectChunk(tp, "x").SQL, d.SelectChunk(tp, "x").SQL; a != b {
+					return fmt.Errorf("two reads for one plan differ:\n%s\n%s", a, b)
+				}
+				return nil
+			},
+		},
+		{
+			Name: "Unaddressable_AcceptsATableWithAKey",
+			Check: func(d Dialect) error {
+				if why := d.Unaddressable(probeTable().Table); why != "" {
+					return fmt.Errorf("a table with a primary key is refused as "+
+						"unaddressable: %s", why)
+				}
+				return nil
+			},
+		},
+	}
+}
+
+// runDialect is the suite.
+func runDialect(t *testing.T, d Dialect) {
+	t.Helper()
+	for _, b := range dialectBehaviours() {
+		t.Run(b.Name, func(t *testing.T) {
+			if err := b.Check(d); err != nil {
+				t.Errorf("%s: %v", d.Engine(), err)
+			}
+		})
+	}
+}
+
+// TestDialects_EveryRegisteredDialectPassesTheSuite is the positive control.
+//
+// Over the registry rather than over a list written here, so that a dialect
+// added later is covered by everything below without anybody remembering to
+// add it.
+func TestDialects_EveryRegisteredDialectPassesTheSuite(t *testing.T) {
+	t.Parallel()
+	names := DialectNames()
+	if len(names) < 2 {
+		t.Fatalf("there are %d dialects registered and a boundary with one implementation "+
+			"has never been shown to be a boundary at all: %v", len(names), names)
+	}
+	for _, name := range names {
+		d, err := DialectFor(name)
+		if err != nil {
+			t.Fatalf("DialectFor(%q): %v", name, err)
+		}
+		t.Run(name, func(t *testing.T) { runDialect(t, d) })
+	}
+}

--- a/engine/internal/masking/draft.go
+++ b/engine/internal/masking/draft.go
@@ -66,16 +66,22 @@ func linkFor(a Assignment) string {
 }
 
 // unmatchedRule is the rule for a column the classifier could not place.
+//
+// Classified on the canonical type for the same reason Assign is: this file
+// writes down what Assign decided, and a draft that disagreed with the plan it
+// describes would be a rules file that changes the plan the moment somebody
+// applies it.
 func unmatchedRule(a Assignment) Rule {
 	c := a.Column
+	cc := canonical(a.Table, c)
 	r := Rule{Table: a.Table.String(), Column: c.Name}
 	const because = "Nothing recognised this column, so it is emptied until somebody says otherwise."
 	switch {
-	case isJSON(c):
+	case isJSON(cc):
 		r.Transform, r.Why = "empty_json", because
 	case c.Nullable && !c.Unique:
 		r.Transform, r.Why = "nullify", because
-	case !looksSensitive(c):
+	case !looksSensitive(cc):
 		// Not a type this package can rewrite, so no transform would run.
 		// Preserved and said so, which is the one line in the file that is
 		// a question rather than an answer.

--- a/engine/internal/masking/execute.go
+++ b/engine/internal/masking/execute.go
@@ -270,35 +270,10 @@ func (e *Executor) applyChunk(
 	return int64(len(batch)), last, nil
 }
 
-// selectChunk builds the read for one chunk.
+// selectChunk builds the read for one chunk, in the table's own dialect.
 func (tp TablePlan) selectChunk(after string) (string, []any) {
-	key := tp.keyExpr()
-	cols := make([]string, 0, len(tp.Columns)+1)
-	// Cast on the way out, so every key type arrives as a string. A ctid read
-	// natively comes back as a struct that formats as nothing the WHERE clause
-	// will match, which produced an update that silently changed no rows.
-	cols = append(cols, key+"::text")
-	for _, c := range tp.Columns {
-		cols = append(cols, quoteIdent(c.Column.Name))
-	}
-
-	var b strings.Builder
-	fmt.Fprintf(&b, "SELECT %s FROM %s", strings.Join(cols, ", "), tp.Table.Qualified())
-	var args []any
-	if after != "" && len(tp.OrderBy) > 0 {
-		// Compared as text, so one code path covers integer keys, uuids, and
-		// anything else somebody used. The order is not the key's natural
-		// order for an integer, and it does not need to be: it only has to be
-		// total and stable, so every row is visited once and a resume picks up
-		// where the last chunk stopped.
-		fmt.Fprintf(&b, " WHERE %s::text > $1", key)
-		args = append(args, after)
-	}
-	fmt.Fprintf(&b, " ORDER BY %s::text", key)
-	if tp.ChunkSize > 0 {
-		fmt.Fprintf(&b, " LIMIT %d", tp.ChunkSize)
-	}
-	return b.String(), args
+	q := tp.Table.dialect().SelectChunk(tp, after)
+	return q.SQL, q.Args
 }
 
 // toStringPtr converts a scanned value to the shape a transform takes.

--- a/engine/internal/masking/plan.go
+++ b/engine/internal/masking/plan.go
@@ -178,34 +178,12 @@ type Statement struct {
 // that never goes near the database, so the database cannot compute them. And
 // a statement that interpolated values would be a statement where a masked
 // value containing a quote changes what the statement means.
-func (tp TablePlan) Compile() Statement {
-	names := make([]string, 0, len(tp.Columns))
-	sets := make([]string, 0, len(tp.Columns))
-	for i, c := range tp.Columns {
-		names = append(names, c.Column.Name)
-		sets = append(sets, fmt.Sprintf("%s = $%d", quoteIdent(c.Column.Name), i+2))
-	}
-
-	var b strings.Builder
-	fmt.Fprintf(&b, "UPDATE %s SET %s WHERE %s::text = $1",
-		tp.Table.Qualified(), strings.Join(sets, ", "), tp.keyExpr())
-	return Statement{
-		SQL: b.String(), Table: tp.Table.String(), Columns: names,
-		Keyed: len(tp.OrderBy) > 0,
-	}
-}
-
-// keyExpr is what addresses one row.
 //
-// A primary key when there is one. Otherwise ctid, the physical row
-// identifier, which every table has and which is only meaningful inside the
-// transaction that read it. That is why a table with no key cannot be
-// resumed: nothing about a ctid survives the run that saw it.
-func (tp TablePlan) keyExpr() string {
-	if len(tp.OrderBy) > 0 {
-		return quoteIdent(tp.OrderBy[0])
-	}
-	return "ctid"
+// The text itself comes from the table's dialect, because the two engines
+// disagree about all three of quoting, casting and the shape of a rewrite,
+// and about nothing else here.
+func (tp TablePlan) Compile() Statement {
+	return tp.Table.dialect().Update(tp)
 }
 
 // Explain renders a plan for a person.

--- a/engine/internal/masking/postgres.go
+++ b/engine/internal/masking/postgres.go
@@ -1,0 +1,107 @@
+package masking
+
+import (
+	"fmt"
+	"strings"
+)
+
+// enginePostgres is the engine name a manifest datastore declares for the
+// store this package was written against.
+const enginePostgres = "postgres"
+
+func init() { RegisterDialect(postgresDialect{}) }
+
+// postgresDialect is the dialect every statement in this package used to be,
+// written down rather than assumed.
+//
+// Nothing about the Postgres path changed when it moved here. The statements
+// are the same text, the type vocabulary is the identity mapping because
+// Postgres names are the canonical ones, and the row key is still ctid when
+// there is no primary key. That is the point: the Postgres path is the one
+// with a live suite behind it, so it is the one the boundary has to leave
+// alone.
+type postgresDialect struct{}
+
+func (postgresDialect) Engine() string { return enginePostgres }
+
+// Canonical is the identity, because the canonical vocabulary IS the Postgres
+// one. Written out rather than left implicit so that the projection law the
+// conformance suite checks holds here too.
+func (postgresDialect) Canonical(dataType string) string { return dataType }
+
+func (postgresDialect) QuoteIdent(name string) string { return quoteIdent(name) }
+
+func (postgresDialect) Qualify(t Table) string { return t.Qualified() }
+
+// Placeholder is Postgres's own positional parameter.
+func (postgresDialect) Placeholder(n int) string { return fmt.Sprintf("$%d", n) }
+
+// Unaddressable is always empty for Postgres.
+//
+// Every table has a ctid, so every table can be rewritten one row at a time.
+// A table with no primary key cannot be RESUMED, which is a different fact and
+// the plan already says it: the chunk size is zero and the plan prints "in one
+// statement (no primary key to chunk on)".
+func (postgresDialect) Unaddressable(Table) string { return "" }
+
+// RowKey is what addresses one row.
+//
+// A primary key when there is one. Otherwise ctid, the physical row
+// identifier, which every table has and which is only meaningful inside the
+// transaction that read it. That is why a table with no key cannot be
+// resumed: nothing about a ctid survives the run that saw it.
+func (postgresDialect) RowKey(tp TablePlan) string {
+	if len(tp.OrderBy) > 0 {
+		return quoteIdent(tp.OrderBy[0])
+	}
+	return "ctid"
+}
+
+// SelectChunk builds the read for one chunk.
+func (d postgresDialect) SelectChunk(tp TablePlan, after string) Query {
+	key := d.RowKey(tp)
+	cols := make([]string, 0, len(tp.Columns)+1)
+	// Cast on the way out, so every key type arrives as a string. A ctid read
+	// natively comes back as a struct that formats as nothing the WHERE clause
+	// will match, which produced an update that silently changed no rows.
+	cols = append(cols, key+"::text")
+	for _, c := range tp.Columns {
+		cols = append(cols, quoteIdent(c.Column.Name))
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "SELECT %s FROM %s", strings.Join(cols, ", "), d.Qualify(tp.Table))
+	var args []any
+	if after != "" && len(tp.OrderBy) > 0 {
+		// Compared as text, so one code path covers integer keys, uuids, and
+		// anything else somebody used. The order is not the key's natural
+		// order for an integer, and it does not need to be: it only has to be
+		// total and stable, so every row is visited once and a resume picks up
+		// where the last chunk stopped.
+		fmt.Fprintf(&b, " WHERE %s::text > %s", key, d.Placeholder(1))
+		args = append(args, after)
+	}
+	fmt.Fprintf(&b, " ORDER BY %s::text", key)
+	if tp.ChunkSize > 0 {
+		fmt.Fprintf(&b, " LIMIT %d", tp.ChunkSize)
+	}
+	return Query{SQL: b.String(), Args: args}
+}
+
+// Update rewrites the planned columns of one row.
+func (d postgresDialect) Update(tp TablePlan) Statement {
+	names := make([]string, 0, len(tp.Columns))
+	sets := make([]string, 0, len(tp.Columns))
+	for i, c := range tp.Columns {
+		names = append(names, c.Column.Name)
+		sets = append(sets, fmt.Sprintf("%s = %s", quoteIdent(c.Column.Name), d.Placeholder(i+2)))
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "UPDATE %s SET %s WHERE %s::text = %s",
+		d.Qualify(tp.Table), strings.Join(sets, ", "), d.RowKey(tp), d.Placeholder(1))
+	return Statement{
+		SQL: b.String(), Table: tp.Table.String(), Columns: names,
+		Keyed: len(tp.OrderBy) > 0,
+	}
+}

--- a/engine/internal/masking/rules.go
+++ b/engine/internal/masking/rules.go
@@ -25,7 +25,15 @@ type Rule struct {
 	Table string `json:"table,omitempty" yaml:"table,omitempty"`
 	// Column matches the column name, with * as a wildcard.
 	Column string `json:"column,omitempty" yaml:"column,omitempty"`
-	// Type matches the Postgres type name. Empty matches every type.
+	// Type matches the type name, in the Postgres vocabulary, whichever store
+	// the column is in. Empty matches every type.
+	//
+	// One rule file covers every store because each engine's names are mapped
+	// onto the Postgres ones before a rule is matched, so `type: text` means
+	// Postgres text and ClickHouse String and nobody writes the rule twice.
+	// The alternative was a rules file per engine, which is a rules file that
+	// goes stale for one engine and not the other, and the failure mode of
+	// that is a column masked in one store and real in the next.
 	Type string `json:"type,omitempty" yaml:"type,omitempty"`
 	// Transform is the name of the transform to apply.
 	Transform string `json:"transform" yaml:"transform"`
@@ -242,12 +250,38 @@ func (rs *RuleSet) Assign(tables []Table) []Assignment {
 
 	var out []Assignment
 	for _, t := range tables {
+		// The dialect is looked up once per table and its failure is carried
+		// onto every column of that table rather than reported once and
+		// forgotten. An engine nobody has a dialect for is refused: guessing
+		// Postgres would mean matching `type: text` against a vocabulary that
+		// does not have the word, so nothing would match, so every column
+		// would fall through to a branch that says nobody decided. A column
+		// that looks classified and was not is the failure this whole file is
+		// written against.
+		d, dialectErr := DialectFor(t.Engine)
+		unaddressable := ""
+		if dialectErr == nil {
+			unaddressable = d.Unaddressable(t)
+		}
+
 		for _, c := range t.Columns {
 			a := Assignment{Table: t, Column: c}
+			if dialectErr != nil {
+				a.Problem = dialectErr.Error()
+				out = append(out, a)
+				continue
+			}
+
+			// Matched and classified on the CANONICAL type, so that one
+			// masking.yaml covers both stores: a rule saying `type: text`
+			// means the same thing whether the column is Postgres text or
+			// ClickHouse String. Every message below still names the RAW type,
+			// because a person reading it is looking at their own schema.
+			cc := canonical(t, c)
 
 			best := -1
 			for _, r := range rs.rules {
-				score, ok := r.matches(t, c)
+				score, ok := r.matches(t, cc)
 				if !ok || score <= best {
 					continue
 				}
@@ -271,10 +305,10 @@ func (rs *RuleSet) Assign(tables []Table) []Assignment {
 			// Only the types that can hold a sentence. A bigint called quantity
 			// needs no rule and emptying it would break every environment for
 			// nothing, which is how a fail-closed default gets turned off.
-			if a.Transform == "" && !knownStructural(c) {
+			if a.Transform == "" && !knownStructural(cc) {
 				a.Unmatched = true
 				switch {
-				case !looksSensitive(c):
+				case !looksSensitive(cc):
 					// A THIRD ANSWER, and the reason it exists.
 					//
 					// looksSensitive is a known-yes list of six types and there
@@ -294,7 +328,7 @@ func (rs *RuleSet) Assign(tables []Table) []Assignment {
 						", so nothing decided what happens to this column and it is " +
 						"copied unchanged. The verification scan does not read this " +
 						"type either. Give it a transform, or a rule saying it is fine."
-				case isJSON(c):
+				case isJSON(cc):
 					// A JSON column is emptied whether or not it can hold
 					// null, because `empty_json` writes a value rather than
 					// removing one. That matters: `jsonb NOT NULL DEFAULT '{}'`
@@ -345,7 +379,16 @@ func (rs *RuleSet) Assign(tables []Table) []Assignment {
 			if a.Transform != "" && a.Link == "" {
 				a.Link = a.Transform
 			}
-			out = append(out, checkFeasible(a))
+			a = checkFeasible(a)
+			if a.Problem == "" && a.Masked() && unaddressable != "" {
+				// The engine cannot say which row a statement means, so the
+				// rewrite cannot be carried out. Refused here with every other
+				// infeasible assignment rather than discovered by the executor,
+				// for the reason above checkFeasible: a run that fails halfway
+				// leaves a table neither real nor safe.
+				a.Problem = unaddressable
+			}
+			out = append(out, a)
 		}
 	}
 	return out

--- a/engine/internal/verify/dialect.go
+++ b/engine/internal/verify/dialect.go
@@ -1,0 +1,328 @@
+package verify
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// A dialect is the part of verification that knows one datastore engine, and a
+// source is the part that can talk to one.
+//
+// The scan itself is engine independent and always was: the detectors run over
+// text, and text out of ClickHouse is the same text as out of Postgres. What
+// was Postgres and did not say so was the query that lists the columns, the
+// query that samples one, and the table of type names that decides which
+// columns are worth reading at all.
+//
+// The type table here is a SECOND copy of the one in the masking package, and
+// it is a copy on purpose. This package must not import that one, because it
+// is the check on it: an instrument that shares its opinion of what a type
+// means with the thing it is checking cannot disagree with it. Two independent
+// tables that a test in the other package requires to agree can. That was
+// already true of the Postgres names and it is now true of the ClickHouse ones.
+//
+// Both tables are written in the POSTGRES vocabulary, and each engine's names
+// are mapped onto it. A third vocabulary would mean three tables to keep in
+// step rather than two.
+
+// Dialect is what a scan needs to know about one datastore engine.
+type Dialect interface {
+	// Engine is the name a manifest datastore declares.
+	Engine() string
+	// Canonical maps one of this engine's type names onto the Postgres name
+	// for the same kind of value. A name it does not recognise comes back
+	// unchanged, which lands the column in the list of things the scanner says
+	// it could not read rather than in a wrong answer.
+	Canonical(dataType string) string
+	// Kind is how the scanner reads a column of this engine's type: "text"
+	// through a text form, "bytea" as raw bytes decoded where they decode,
+	// "structural" for a type that cannot carry a sentence, and "unread" for
+	// one the scanner has no way to read.
+	Kind(dataType string) string
+	// Columns is the statement listing every column of every ordinary table,
+	// as schema, table, column, type.
+	Columns() string
+	// Sample is the statement reading up to limit non null values of one
+	// column.
+	Sample(c Column, limit int) string
+}
+
+// Column is one column the scan has an opinion about.
+type Column struct {
+	Schema string
+	Table  string
+	Name   string
+	// Type is the engine's own name for the type, which is what the report
+	// prints: a person reading it is looking at their own schema.
+	Type string
+	// kind is how this column is read, decided from the type by the dialect.
+	kind columnKind
+}
+
+// Row is one row of a result, one entry per selected column, holding the bytes
+// the engine returned. A null is a nil entry.
+//
+// Valid until the function it was handed to returns. Nothing keeps one, which
+// is what lets a sample of two thousand values of a column holding documents
+// cost one value at a time rather than all of them at once.
+type Row [][]byte
+
+// Exec runs one statement and hands each row to a function.
+//
+// The extension point for a second engine. A ClickHouse provider supplies this
+// and nothing else: the statements come from the dialect, the classification
+// from the shared table, and the detectors are the same detectors.
+//
+// Bytes rather than strings, so that a column holding something that is not
+// text is recognised as such instead of being silently mangled into one. A
+// callback rather than a slice, so that the scan holds one value at a time: it
+// samples two thousand rows per column and a column can hold a document, and
+// the first shape of this returned them all at once.
+type Exec func(ctx context.Context, sql string, yield func(Row) error) error
+
+// Source is a datastore a scan can read.
+type Source interface {
+	// Engine names the datastore engine, for the report.
+	Engine() string
+	// Columns lists every column the scan has an opinion about. The list is a
+	// schema rather than data, so it is small and is returned whole.
+	Columns(ctx context.Context) ([]Column, error)
+	// Sample reads up to limit non null values of one column, one at a time.
+	Sample(ctx context.Context, c Column, limit int, yield func(Row) error) error
+}
+
+// NewSource pairs a dialect with something that can run its statements.
+func NewSource(d Dialect, exec Exec) Source { return &sqlSource{d: d, exec: exec} }
+
+type sqlSource struct {
+	d    Dialect
+	exec Exec
+}
+
+func (s *sqlSource) Engine() string { return s.d.Engine() }
+
+func (s *sqlSource) Columns(ctx context.Context) ([]Column, error) {
+	var out []Column
+	err := s.exec(ctx, s.d.Columns(), func(r Row) error {
+		if len(r) < 4 {
+			return fmt.Errorf(
+				"listing columns returned %d values for a row and this needs "+
+					"the schema, the table, the column and the type", len(r))
+		}
+		c := Column{
+			Schema: string(r[0]), Table: string(r[1]),
+			Name: string(r[2]), Type: string(r[3]),
+		}
+		switch s.d.Kind(c.Type) {
+		case "structural":
+			// Not read and not listed. A listing of every bigint in the schema
+			// as "not readable" is a listing nobody reads, which is the same
+			// as no listing.
+			return nil
+		case "bytea":
+			c.kind = kindBytea
+		case "unread":
+			c.kind = kindUnread
+		default:
+			c.kind = kindText
+		}
+		out = append(out, c)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("verify: listing columns: %w", err)
+	}
+	return out, nil
+}
+
+func (s *sqlSource) Sample(ctx context.Context, c Column, limit int, yield func(Row) error) error {
+	return s.exec(ctx, s.d.Sample(c, limit), yield)
+}
+
+// postgresDialect is what every statement in this package used to be.
+type postgresDialect struct{}
+
+func (postgresDialect) Engine() string { return "postgres" }
+
+// Canonical is the identity: the canonical vocabulary is the Postgres one.
+func (postgresDialect) Canonical(dataType string) string { return dataType }
+
+func (postgresDialect) Kind(dataType string) string { return KindOf(dataType) }
+
+// Columns lists every column of every ordinary table.
+//
+// Everything, with the structural types dropped afterwards rather than in the
+// statement. This used to be six text types named in the WHERE clause, and the
+// cost of that was not the columns it skipped, it was that the report did not
+// say it had skipped them: a bytea holding a sealed private key and an enum
+// were equally invisible, and "clean" covered both.
+func (postgresDialect) Columns() string {
+	return `
+SELECT c.table_schema, c.table_name, c.column_name, c.data_type
+FROM information_schema.columns c
+JOIN information_schema.tables t
+  ON t.table_schema = c.table_schema AND t.table_name = c.table_name
+WHERE t.table_type = 'BASE TABLE'
+  AND c.table_schema NOT IN ('pg_catalog', 'information_schema')
+  AND c.table_schema NOT LIKE 'pg_toast%'
+ORDER BY c.table_schema, c.table_name, c.ordinal_position`
+}
+
+func (postgresDialect) Sample(c Column, limit int) string {
+	expr := quoteIdent(c.Name) + "::text"
+	if c.kind == kindBytea {
+		// Raw, not cast. A bytea cast to text is its hex form, "\x6162",
+		// which no detector matches, and which is how a secret in a bytea
+		// column would have passed a scan that read it.
+		expr = quoteIdent(c.Name)
+	}
+	return fmt.Sprintf(
+		`SELECT %s FROM %s.%s WHERE %s IS NOT NULL LIMIT %d`,
+		expr, quoteIdent(c.Schema), quoteIdent(c.Table),
+		quoteIdent(c.Name), limit)
+}
+
+// clickhouseTypes maps ClickHouse's type names onto the Postgres ones this
+// scanner classifies by.
+//
+// Independently written from the table in the masking package and required to
+// agree with it by a test that lives over there, for the reason at the top of
+// this file: the check must not take its opinion from the thing it checks.
+var clickhouseTypes = map[string]string{
+	"string": "text", "fixedstring": "text",
+	"uuid": "uuid",
+	"int8": "smallint", "int16": "smallint", "uint8": "smallint",
+	"uint16": "integer", "int32": "integer",
+	"uint32": "bigint", "int64": "bigint", "uint64": "bigint",
+	"int128": "numeric", "uint128": "numeric",
+	"int256": "numeric", "uint256": "numeric",
+	"float32": "real", "float64": "double precision",
+	"decimal": "numeric", "decimal32": "numeric", "decimal64": "numeric",
+	"decimal128": "numeric", "decimal256": "numeric",
+	"bool": "boolean", "boolean": "boolean",
+	"date": "date", "date32": "date",
+	"datetime": "timestamp with time zone", "datetime64": "timestamp with time zone",
+	"json": "jsonb", "object": "jsonb",
+	"array":   "ARRAY",
+	"enum8":   "USER-DEFINED",
+	"enum16":  "USER-DEFINED",
+	"enum":    "USER-DEFINED",
+	"map":     "USER-DEFINED",
+	"tuple":   "USER-DEFINED",
+	"nested":  "USER-DEFINED",
+	"variant": "USER-DEFINED", "dynamic": "USER-DEFINED",
+	"ipv4": "inet", "ipv6": "inet",
+}
+
+// clickhouseDialect reads a ClickHouse.
+//
+// Nothing in the engine opens a ClickHouse connection yet. This is the half of
+// a second store's verification that does not need one: the statements and the
+// type vocabulary. A provider supplies the Exec, and the detectors, the sample
+// size, the unread list and the attestation are then the same ones the
+// Postgres golden is published on.
+type clickhouseDialect struct{}
+
+func (clickhouseDialect) Engine() string { return "clickhouse" }
+
+func (clickhouseDialect) Canonical(dataType string) string {
+	base := strings.TrimSpace(dataType)
+	for {
+		inner, unwrapped := unwrapClickHouse(base)
+		if !unwrapped {
+			break
+		}
+		base = inner
+	}
+	if i := strings.IndexByte(base, '('); i >= 0 {
+		base = base[:i]
+	}
+	if canon, ok := clickhouseTypes[strings.ToLower(strings.TrimSpace(base))]; ok {
+		return canon
+	}
+	return dataType
+}
+
+func unwrapClickHouse(t string) (string, bool) {
+	for _, w := range []string{"Nullable", "LowCardinality"} {
+		if len(t) > len(w)+2 && strings.EqualFold(t[:len(w)], w) &&
+			t[len(w)] == '(' && t[len(t)-1] == ')' {
+			return strings.TrimSpace(t[len(w)+1 : len(t)-1]), true
+		}
+	}
+	return t, false
+}
+
+// Kind reads a ClickHouse String as bytes rather than as text, which is the
+// one place the shared classification is not the whole answer.
+//
+// A Postgres text column in a UTF-8 database is text by construction. A
+// ClickHouse String is a byte string: it is where an analytics schema puts
+// JSON, and it is also where it would put a ciphertext. Read as text, a
+// column of encrypted bytes would be handed to the detectors as mojibake,
+// match nothing, and be counted as read and clean. Read as bytes it is
+// decoded where it decodes and counted as unread where it does not, which is
+// the same treatment bytea gets and for the same reason.
+func (d clickhouseDialect) Kind(dataType string) string {
+	canon := d.Canonical(dataType)
+	if strings.EqualFold(canon, "text") {
+		return "bytea"
+	}
+	return KindOf(canon)
+}
+
+// Columns lists every column of every ordinary table.
+//
+// system.columns is ClickHouse's own catalog. The engine filter drops views
+// and the dictionary and merge engines, which have no rows of their own, and
+// the database filter drops the server's own catalogs the way the Postgres
+// statement drops pg_catalog.
+func (clickhouseDialect) Columns() string {
+	return `
+SELECT c.database, c.table, c.name, c.type
+FROM system.columns c
+INNER JOIN system.tables t ON t.database = c.database AND t.name = c.table
+WHERE c.database NOT IN ('system', 'INFORMATION_SCHEMA', 'information_schema')
+  AND t.engine NOT LIKE '%View'
+  AND t.engine NOT IN ('Dictionary', 'Merge', 'Distributed')
+ORDER BY c.database, c.table, c.position`
+}
+
+// Sample reads one column, with the nullability stripped from the type rather
+// than from the values.
+//
+// assumeNotNull rather than the bare column, so that the result type is String
+// and not Nullable(String). The rows are already filtered to the ones that are
+// not null, so nothing is being asserted that the statement has not already
+// enforced, and what it buys is a result a reader does not have to decode a
+// null flag out of. A scan reads values to look at them; the null it might have
+// found is the one thing it has no opinion about.
+func (d clickhouseDialect) Sample(c Column, limit int) string {
+	inner := "assumeNotNull(" + d.quoteIdent(c.Name) + ")"
+	expr := "toString(" + inner + ")"
+	if c.kind == kindBytea {
+		// Raw, not rendered. A ClickHouse String is bytes, and rendering one
+		// through toString would still be bytes, but the point of the bytes
+		// path is that what comes back is decoded here rather than by the
+		// server.
+		expr = inner
+	}
+	return fmt.Sprintf(
+		`SELECT %s FROM %s.%s WHERE isNotNull(%s) LIMIT %d`,
+		expr, d.quoteIdent(c.Schema), d.quoteIdent(c.Table),
+		d.quoteIdent(c.Name), limit)
+}
+
+func (clickhouseDialect) quoteIdent(name string) string {
+	return "`" + strings.ReplaceAll(name, "`", "``") + "`"
+}
+
+// Postgres and ClickHouse name the two dialects for a caller assembling a
+// source. They are values rather than a registry because this package has no
+// manifest to read an engine name out of: whatever chose the engine is the
+// thing holding the connection.
+var (
+	Postgres   Dialect = postgresDialect{}
+	ClickHouse Dialect = clickhouseDialect{}
+)

--- a/engine/internal/verify/scan.go
+++ b/engine/internal/verify/scan.go
@@ -111,6 +111,14 @@ type Report struct {
 	// Scanner names what produced this, so an attestation can be read by
 	// something that did not produce it.
 	Scanner string `json:"scanner"`
+	// Engine names the datastore this report is about.
+	//
+	// An environment holds more than one store, each with its own golden and
+	// its own attestation, and two reports that do not say which store they
+	// read are two reports nobody can tell apart. Omitted when empty so that
+	// an attestation written before this field existed still verifies against
+	// its own signature, the same reason Provenance is.
+	Engine string `json:"engine,omitempty"`
 	// StartedAt and FinishedAt bound the scan.
 	StartedAt  time.Time `json:"started_at"`
 	FinishedAt time.Time `json:"finished_at"`
@@ -196,8 +204,62 @@ type Options struct {
 	Unruled []string
 }
 
-// Scan reads back a database and reports what still looks real.
+// Scan reads back a Postgres database and reports what still looks real.
+//
+// The engine's own callers all hold a pgx connection, so this is the shape
+// they keep. It is a thin wrapper over ScanSource, and going through the same
+// generic path the second engine uses is deliberate: a boundary that the
+// tested path routes around is a boundary that rots.
 func Scan(ctx context.Context, conn *pgx.Conn, opts Options) (Report, error) {
+	return ScanSource(ctx, PostgresSource(conn), opts)
+}
+
+// PostgresSource reads a Postgres through a pgx connection.
+func PostgresSource(conn *pgx.Conn) Source {
+	return NewSource(Postgres, func(ctx context.Context, sql string, yield func(Row) error) error {
+		rows, err := conn.Query(ctx, sql)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			values, valErr := rows.Values()
+			if valErr != nil {
+				return valErr
+			}
+			row := make(Row, 0, len(values))
+			for _, v := range values {
+				row = append(row, asBytes(v))
+			}
+			if err := yield(row); err != nil {
+				return err
+			}
+		}
+		return rows.Err()
+	})
+}
+
+// asBytes renders one scanned value as the bytes the detectors read.
+//
+// A text cast arrives as a string and a bytea as bytes, which is the whole
+// distinction the scan makes. Anything else is rendered the way it prints,
+// rather than dropped: a value nobody anticipated is still worth showing the
+// detectors.
+func asBytes(v any) []byte {
+	switch value := v.(type) {
+	case nil:
+		return nil
+	case []byte:
+		return value
+	case string:
+		return []byte(value)
+	default:
+		return []byte(fmt.Sprint(value))
+	}
+}
+
+// ScanSource reads back a datastore and reports what still looks real.
+func ScanSource(ctx context.Context, src Source, opts Options) (Report, error) {
 	if opts.SampleSize <= 0 {
 		opts.SampleSize = DefaultSampleSize
 	}
@@ -205,11 +267,12 @@ func Scan(ctx context.Context, conn *pgx.Conn, opts Options) (Report, error) {
 		opts.Now = time.Now
 	}
 	report := Report{
-		Scanner: "antifailure/verify/2", StartedAt: opts.Now().UTC(),
+		Scanner: "antifailure/verify/2", Engine: src.Engine(),
+		StartedAt:  opts.Now().UTC(),
 		SampleSize: opts.SampleSize,
 	}
 
-	columns, err := scannableColumns(ctx, conn)
+	columns, err := src.Columns(ctx)
 	if err != nil {
 		return report, err
 	}
@@ -222,25 +285,25 @@ func Scan(ctx context.Context, conn *pgx.Conn, opts Options) (Report, error) {
 
 	seenTables := map[string]bool{}
 	for _, c := range columns {
-		seenTables[c.schema+"."+c.table] = true
-		ruled := !unruled[c.schema+"."+c.table+"."+c.column]
+		seenTables[c.Schema+"."+c.Table] = true
+		ruled := !unruled[c.Schema+"."+c.Table+"."+c.Name]
 
 		if c.kind == kindUnread {
 			// Known from the type alone, before a row is read. Said in the
 			// report rather than passed over, and turned into a finding when
 			// the column is one that nothing masked and whose name says what
 			// it holds.
-			report.noteUnread(c, "not readable by the scanner: "+c.typ, ruled)
+			report.noteUnread(c, "not readable by the scanner: "+c.Type, ruled)
 			continue
 		}
 		report.Columns++
 
-		rows, sampled, opaque, scanErr := scanColumn(ctx, conn, c, opts.SampleSize)
+		rows, sampled, opaque, scanErr := scanColumn(ctx, src, c, opts.SampleSize)
 		if scanErr != nil {
 			// A column that could not be read is recorded rather than ignored.
 			// Ignoring it would let an unreadable column count as a clean one.
 			report.Skipped = append(report.Skipped,
-				fmt.Sprintf("%s.%s.%s: %v", c.schema, c.table, c.column, scanErr))
+				fmt.Sprintf("%s.%s.%s: %v", c.Schema, c.Table, c.Name, scanErr))
 			continue
 		}
 		report.RowsSampled += int64(sampled)
@@ -292,11 +355,6 @@ const (
 	// listed rather than passed over.
 	kindUnread
 )
-
-type columnRef struct {
-	schema, table, column, typ string
-	kind                       columnKind
-}
 
 // structuralTypes are the types whose text form cannot carry a sentence
 // somebody typed: numbers, times, booleans, and identifiers the database
@@ -355,44 +413,6 @@ func classify(dataType string) columnKind {
 	return kindUnread
 }
 
-// scannableColumns lists every column the scan has an opinion about.
-//
-// Everything that is not structural. This used to be six text types and
-// nothing else, and the cost of that was not the columns it skipped, it was
-// that the report did not say it had skipped them: a bytea holding a sealed
-// private key and an enum were equally invisible, and "clean" covered both.
-func scannableColumns(ctx context.Context, conn *pgx.Conn) ([]columnRef, error) {
-	const query = `
-SELECT c.table_schema, c.table_name, c.column_name, c.data_type
-FROM information_schema.columns c
-JOIN information_schema.tables t
-  ON t.table_schema = c.table_schema AND t.table_name = c.table_name
-WHERE t.table_type = 'BASE TABLE'
-  AND c.table_schema NOT IN ('pg_catalog', 'information_schema')
-  AND c.table_schema NOT LIKE 'pg_toast%'
-ORDER BY c.table_schema, c.table_name, c.ordinal_position`
-
-	rows, err := conn.Query(ctx, query)
-	if err != nil {
-		return nil, fmt.Errorf("verify: listing columns: %w", err)
-	}
-	defer rows.Close()
-
-	var out []columnRef
-	for rows.Next() {
-		var c columnRef
-		if err := rows.Scan(&c.schema, &c.table, &c.column, &c.typ); err != nil {
-			return nil, fmt.Errorf("verify: listing columns: %w", err)
-		}
-		if structuralTypes[strings.ToLower(c.typ)] {
-			continue
-		}
-		c.kind = classify(c.typ)
-		out = append(out, c)
-	}
-	return out, rows.Err()
-}
-
 // sensitiveNameWords are the words in a table or column name that say the
 // column holds something that grants access. The list is the one the built in
 // masking rules and the credential detector already act on, written down once
@@ -416,67 +436,50 @@ func SensitiveName(table, column string) bool {
 
 // noteUnread records a column the scan could not read, and raises a finding
 // when it is also unmasked and named like a secret.
-func (r *Report) noteUnread(c columnRef, reason string, ruled bool) {
+func (r *Report) noteUnread(c Column, reason string, ruled bool) {
 	r.Unread = append(r.Unread, UnreadColumn{
-		Schema: c.schema, Table: c.table, Column: c.column, Type: c.typ,
+		Schema: c.Schema, Table: c.Table, Column: c.Name, Type: c.Type,
 		Reason: reason, Ruled: ruled,
 	})
-	if ruled || !SensitiveName(c.table, c.column) {
+	if ruled || !SensitiveName(c.Table, c.Name) {
 		return
 	}
 	r.Findings = append(r.Findings, Finding{
-		Schema: c.schema, Table: c.table, Column: c.column,
-		Detector: DetectorUnreadSensitive, Example: c.typ,
+		Schema: c.Schema, Table: c.Table, Column: c.Name,
+		Detector: DetectorUnreadSensitive, Example: c.Type,
 	})
 }
 
 // scanColumn reads a sample of one column and runs the detectors over it.
 //
 // It returns the findings, how many rows it sampled, and how many of those it
-// could not turn into text, which is only ever non zero for bytea.
+// could not turn into text, which is only ever non zero for a column read as
+// bytes.
+//
+// The reading is here and the statement is in the dialect, which is the whole
+// division: what counts as a leak is the same question in every store, and
+// how to ask for the values is not.
 func scanColumn(
-	ctx context.Context, conn *pgx.Conn, c columnRef, limit int,
+	ctx context.Context, src Source, c Column, limit int,
 ) ([]Finding, int, int, error) {
-	expr := quoteIdent(c.column) + "::text"
-	if c.kind == kindBytea {
-		// Raw, not cast. A bytea cast to text is its hex form, "\x6162",
-		// which no detector matches, and which is how a secret in a bytea
-		// column would have passed a scan that read it.
-		expr = quoteIdent(c.column)
-	}
-	sql := fmt.Sprintf(
-		`SELECT %s FROM %s.%s WHERE %s IS NOT NULL LIMIT %d`,
-		expr, quoteIdent(c.schema), quoteIdent(c.table),
-		quoteIdent(c.column), limit)
-
-	rows, err := conn.Query(ctx, sql)
-	if err != nil {
-		return nil, 0, 0, err
-	}
-	defer rows.Close()
-
 	counts := map[string]int{}
 	examples := map[string]string{}
 	sampled, opaque := 0, 0
-	for rows.Next() {
+	err := src.Sample(ctx, c, limit, func(row Row) error {
+		if len(row) == 0 {
+			return nil
+		}
+		sampled++
 		var value string
 		if c.kind == kindBytea {
-			var raw []byte
-			if err := rows.Scan(&raw); err != nil {
-				return nil, sampled, opaque, err
-			}
-			sampled++
-			decoded, ok := decodeText(raw)
+			decoded, ok := decodeText(row[0])
 			if !ok {
 				opaque++
-				continue
+				return nil
 			}
 			value = decoded
 		} else {
-			if err := rows.Scan(&value); err != nil {
-				return nil, sampled, opaque, err
-			}
-			sampled++
+			value = string(row[0])
 		}
 		for _, d := range Detectors() {
 			if d.Match(value) {
@@ -486,15 +489,16 @@ func scanColumn(
 				}
 			}
 		}
-	}
-	if err := rows.Err(); err != nil {
+		return nil
+	})
+	if err != nil {
 		return nil, sampled, opaque, err
 	}
 
 	var out []Finding
 	for name, n := range counts {
 		out = append(out, Finding{
-			Schema: c.schema, Table: c.table, Column: c.column,
+			Schema: c.Schema, Table: c.Table, Column: c.Name,
 			Detector: name, Example: examples[name], Rows: n,
 		})
 	}

--- a/justfile
+++ b/justfile
@@ -518,6 +518,15 @@ benchmark:
     # number a customer is quoted has to be readable without running anything,
     # and the datastore half writes into {{reports}}/, which is gitignored.
     AF_BENCHMARK=1 go test ./internal/db/pgurl -run TestBenchmark -v -count=1 -timeout 60m
+    # The cross store number, which is a third question again: of the
+    # identifiers that appear in more than one of an environment's stores, how
+    # many mask to the same value in all of them. It writes into benchmarks/
+    # for the same reason the provider half does, and it is the one figure here
+    # that is only quotable at 100 percent, because anything less is a broken
+    # join rather than a slower one. It needs a ClickHouse; without one, and
+    # without AF_TEST_CLICKHOUSE_URL, it starts and removes a container.
+    AF_BENCHMARK=1 go test ./internal/masking -run TestBenchmarkCrossStoreJoinKeys \
+      -v -count=1 -timeout 30m
 
 # The fast ones, for a tight loop.
 test-short:

--- a/web/apps/api/test/legal-facts.test.ts
+++ b/web/apps/api/test/legal-facts.test.ts
@@ -1171,6 +1171,7 @@ describe('the terms describe guards that are really in the engine', () => {
       'internal/dockerutil/dockerutil.go',
       'internal/masking/rules.go',
       'internal/verify/scan.go',
+      'internal/verify/dialect.go',
       'internal/env/golden.go',
     ]) {
       const source = await engine(file).catch(() => '')
@@ -1261,24 +1262,41 @@ describe('the terms describe guards that are really in the engine', () => {
    * is still not a proof that no personal data survives.
    */
   it('pins the mechanism the verification scan uses, which the terms describe as a limit', async () => {
-    const source = await engine('internal/verify/scan.go')
+    // The classification moved when the scanner gained a second engine: it
+    // used to be one Postgres query in scan.go and it is now the shared step
+    // every source goes through, in dialect.go. The claim did not move, so
+    // this follows the code rather than being relaxed, and it is pinned two
+    // ways instead of one.
+    const source = await engine('internal/verify/dialect.go')
     // Not an allowlist of readable types any more. Every column is listed and
     // classified, and only the structural types, the numbers, times, booleans
-    // and uuids that cannot hold a sentence at all, are dropped before the
-    // classification. Narrowing this back to a literal type list is what this
-    // catches.
+    // and uuids that cannot hold a sentence at all, are dropped. Every other
+    // answer assigns a kind rather than skipping, which is what makes the
+    // page's "names the ones it cannot" true.
     assert.match(
       source,
-      /if structuralTypes\[strings\.ToLower\(c\.typ\)\] \{\n\t\t\tcontinue\n\t\t\}\n\t\tc\.kind = classify\(c\.typ\)/,
+      /switch s\.d\.Kind\(c\.Type\) \{\n\t\tcase "structural":[\s\S]{0,400}?return nil\n\t\tcase "bytea":[\s\S]{0,200}?default:\n\t\t\tc\.kind = kindText/,
       'the verification scan no longer lists every column and classifies it. The terms page says ' +
         'it reads every column it can read as text and names the ones it cannot, and that ' +
         'sentence is only true while the column listing drops nothing but the structural types.',
     )
+    // The narrowing this exists to catch, stated as the thing that must NOT
+    // come back. The original defect was a literal six type allowlist in the
+    // listing statement, and a statement that filters by type again is how the
+    // page starts overstating the product without any assertion above noticing.
+    assert.doesNotMatch(
+      source,
+      /data_type IN \(/,
+      'the column listing statement filters by type again. That is the allowlist the scan was ' +
+        'widened away from after it said clean about a bytea holding sealed key material, and ' +
+        'the terms page describes the wider mechanism.',
+    )
     // The half that turns "I could not read it" into a refusal. Without this
     // the page's second sentence, that such a column fails rather than passes,
     // is false.
+    const scan = await engine('internal/verify/scan.go')
     assert.match(
-      source,
+      scan,
       /const DetectorUnreadSensitive = "unread-sensitive-name"/,
       'the finding raised for a column the scan cannot read, that nothing masks, and whose name ' +
         'says it holds a secret is gone. The terms page says that column fails the scan.',


### PR DESCRIPTION
## The failure

Masking has held one guarantee above every other since it was written: the same
customer maps to the same fake customer in every table and in every refresh, so
a foreign key still joins after the data is rewritten. It held that guarantee
inside one Postgres, and it had never been asked to hold it anywhere else.

Every part of the pipeline that touches an engine was Postgres and said so
nowhere. The classifier matched a rule's `type:` against Postgres type names, so
a rule saying `type: text` could not match a ClickHouse `String`. Nothing then
decided what happened to that column, so it was copied unchanged, while the
Postgres column beside it holding the same address was masked. One person, two
answers, and no error anywhere: the metadata store holds a fake address and the
analytics store holds the real one. A join across the two returns nothing or
returns somebody else, every report built on it is plausible, and the fidelity
report calls the environment faithful.

That is worse than the empty ClickHouse #285 is about. An empty store is visible
within a minute of opening a chart. A store masked into a different person is
confidently wrong, which is why section 10 of the plan calls this the sharpest
correctness risk in the file.

## The boundary

`masking.Dialect` is deliberately narrow: an engine's type names, its identifier
quoting, its statement parameters, the read that takes a chunk, and the rewrite
that puts one back. Everything else was already engine independent and stays
that way. A transform is a pure function of the project key, the column identity
and the input value, computed in Go from a key the database never sees, so what
a value masks to never depended on which store it came out of. What did depend
on the store was the classifier deciding what to do with a column at all.

Each engine's type names map onto the POSTGRES names rather than onto a third
vocabulary. One `masking.yaml` therefore covers every store and a rule anybody
has already written keeps meaning what it meant: `type: text` is Postgres `text`
and ClickHouse `String` and nobody writes the rule twice. There were already two
independent tables of Postgres type names in this repository, this package's and
the verification scanner's, kept in step by a test rather than by shared code
because verify must not import the thing it checks. A third vocabulary would
have meant three tables to keep in step instead of two.

Two refusals follow from the same principle, both at planning time because a
masking run that fails halfway leaves a table neither real nor safe:

- An engine nobody has a dialect for is refused rather than treated as Postgres.
  Guessing would mean matching rules against a vocabulary the store does not
  have, so nothing would match, so every column would fall through to the branch
  that says nobody decided. A column that looks classified and was not is the
  failure this whole change is about.
- A ClickHouse table with no sorting key is refused, because ClickHouse has no
  physical row identifier and there is no statement that means one row. Postgres
  always has `ctid`, so this is the engine's refusal rather than a new rule.

The Postgres path did not change. Its statements are the same text, its type
vocabulary is the identity mapping because the canonical names are the Postgres
ones, and its suite is untouched: not one existing test file in either package
was edited.

## The scanner

The same boundary, with its own copy of the type table, and a test in the
masking package requires the two to agree for ClickHouse the way one already
does for Postgres.

`verify.Scan` keeps its signature and every caller, and now runs through the
generic source that a second engine uses, because a boundary the tested path
routes around is a boundary that rots. One place the two engines deliberately
differ is recorded rather than smoothed over: a ClickHouse `String` is read as
BYTES. It is a byte string, it is where an analytics schema keeps its JSON and
it is where a ciphertext would go, and read as text a column of encrypted bytes
would be handed to the detectors as mojibake, match nothing, and be counted as
read and clean.

`Report` gains `Engine`, omitted when empty so an attestation written before
this field still verifies against its own signature. An environment holds more
than one store, each with its own golden and attestation, and two reports that
do not say which store they read are two reports nobody can tell apart.

## The guarantee is now checked, not argued

`CrossStoreCheck` takes two stores' plans, finds every identifier that appears in
both, masks probe values through each side, and reports the share that come out
identical. Three ways to fail, all of them silent in production: one side masked
and the other copied, which is a leak as well as a broken join; two sides masked
with different transforms; two sides masked under different links, so each
derives its own subkey and one input produces two outputs.

Anything below 100 percent is a bug. There is deliberately no way to mark a pair
exempt: two columns with one name in two stores that mean different things is a
real thing to look at, and the cost of looking is a rule, where the cost of
silencing it is a twin that is wrong in a way nobody can see. A report that
found nothing to compare is not a pass either, and neither is a pair no probe
was applicable to.

## The number

`just benchmark` gains a third half, writing a dated report into `benchmarks/`
beside the provider timings. On a Postgres and a ClickHouse holding the same six
identifiers:

    before  3 of 6 join keys verified identical  (50%)
    after   6 of 6                               (100%)

The before figure is not a simulation. The classifier decides on a canonical
type name, and before this it compared a rule's `type:` against whatever the
catalog reported; the run reproduces that by labelling the ClickHouse catalog as
Postgres, so no translation happens. All three of the columns it names were
copied unchanged into the second store while the Postgres column beside them was
masked, which is a leak as well as a broken join.

## Two things outside these two packages

`web/apps/api/test/legal-facts.test.ts` pins the mechanism the terms page
describes as a limit, and it pinned the literal text of the column listing in
`verify/scan.go`. That listing moved into the shared step every source now goes
through, so the pin follows it into `verify/dialect.go` rather than being
relaxed, and it is now pinned two ways: the switch that drops only the
structural types and assigns a kind to every other answer, and a
`doesNotMatch` on `data_type IN (`, which is the literal allowlist the scan was
widened away from and the exact narrowing that would make the page overstate
the product. Both halves were mutation tested against the engine source.

`contactcheck` refused the first version of the probe list, because
`DefaultProbes` ships in the product and its values are printed in the report
it produces, so an address there that could belong to somebody is an address
this repository publishes. Every probe is now a reserved name or a
documentation range.

## What is proved and what is not

The dialect ships with a conformance suite of fourteen behaviours, a broken fake
per behaviour, and a self test that requires the set of behaviours each fake
reddens to be exactly the set the table names. That is L0.1's rule followed
rather than cited.

The ClickHouse half is checked against a running server, not against a fixture:
the type mapping is read back out of `system.columns`, the compiled read and the
compiled rewrite are executed, and the same detectors find real addresses in a
ClickHouse and then do not. The tests skip by name when no server is reachable
and `AF_TEST_CLICKHOUSE_URL` points them at one somebody already has.

Nothing here refreshes a golden for a second store, branches one, or opens a
connection to one. There is no ClickHouse provider and this is not one. The
ClickHouse client that the live tests use is in the test rather than in the
package, because a driver is a dependency decision that belongs with the
provider that will need it. Said in the code, in the changelog and in the docs,
because a boundary that looks complete from outside is how somebody ends up
trusting one.

## Acceptance, as the lane row asks for it

The cross store determinism test, run against two real servers:

```
--- PASS: TestCrossStoreLive_OneIdentityMasksToOnePersonInBothStores (39.58s)
        join keys verified identical across primary and events: 4 of 4 (100.0%)
```

It reads both catalogs live, runs one rules file over both, masks the Postgres
with the existing executor and the ClickHouse with the statements the dialect
compiles, and then reads the addresses back out of the two servers and requires
them to be the same three values.

The existing Postgres masking suite, unchanged and green. Not one existing test
file in either package is edited, which is checkable from the diff:

```
ok  github.com/antifailure/antifailure/engine/internal/masking  411.033s
ok  github.com/antifailure/antifailure/engine/internal/verify      5.665s
```

## Mutation table

Sixteen cells, each breaking one production line and requiring the test that
names it to go red and then green. The driver counts the RUN line for the test
it names, because a `-run` pattern that matches nothing exits 0 and reads
exactly like a pass.

| Broken | Test that went red |
| --- | --- |
| canonicalisation removed from Assign | `TestAssign_AClickHouseStringIsClassifiedLikeAPostgresText` |
| the refusal of an engine with no dialect | `TestAssign_RefusesAnEngineNobodyHasADialectFor` |
| the refusal of a table with no row identifier | `TestAssign_RefusesAClickHouseTableWithNoSortingKey` |
| the cast into a column that is not a String | `TestClickHouse_StatementsAreClickHouseAndNotPostgres` |
| unwrapping Nullable and LowCardinality in masking | `TestClickHouseTypes_AgreeWithTheScanner` |
| reading a ClickHouse String as bytes | `TestClickHouse_ReadsAStringAsBytesRatherThanText` |
| the scanner's own entry for String | `TestClickHouseTypes_AgreeWithTheScanner` |
| the masked against copied comparison | `TestCrossStore_CatchesAJoinKeyMaskedInOneStoreAndCopiedInTheOther` |
| the transform comparison | `TestCrossStore_CatchesTwoStoresMaskedWithDifferentTransforms` |
| the identity comparison | `TestCrossStore_CatchesTwoStoresMaskedUnderDifferentLinks` |
| OK refusing a report that compared nothing | `TestCrossStore_NothingToCompareIsNotAPass` |
| a pair no probe was applicable to | `TestCrossStore_APairWithNoApplicableProbeIsNotVerified` |
| pairing only on a link somebody wrote | `TestCrossStore_NothingToCompareIsNotAPass` |
| dropping the structural types from the scan | `TestScan_ArraysAndEnumsAreReadThroughTheirTextForm` |
| the engine the report says it read | `TestClickHouseLive_TheSameDetectorsFindRealDataInASecondStore` |
| the Postgres statement's argument numbering | `TestApply_MasksTheDataAndKeepsTheJoins` |

**One cell found a vacuous test of mine and it is worth recording.** Removing the
guard for a pair no probe applies to left
`TestCrossStore_APairWithNoApplicableProbeIsNotVerified` green: it asserted a
property of pairs whose probe count was zero, and every transform in the fixture
it used accepts any string, so no pair had one and the loop body never ran. It
now builds a pair that can have nothing applicable and asserts that one did
before asserting anything about it.

The dialect suite's fifteen broken fakes are the same discipline running on
every build rather than by hand, and its self test requires the set of
behaviours each fake reddens to be exactly the set the table names.

## What was NOT checked

- **No ClickHouse provider exists, so nothing refreshes a golden for a second
  store or branches one.** The dialect boundary is the classification, the
  statements and the scan. Said in the package doc, the changelog and the docs.
- **The bulk rewrite shape is not settled here.** `Update` emits the per row
  mutation form and the live test runs it. A ClickHouse mutation is asynchronous
  and rewrites whole parts, so a refresh over a real events table will want an
  INSERT into a shadow table and an EXCHANGE TABLES, and that is a plan for a
  whole table where everything in the dialect is a statement for one row.
- **Writing a NULL to ClickHouse is not exercised.** The parameters are declared
  String, the live fixtures hold no nulls in the masked columns, and expressing
  a null through a server side parameter is the writer's problem.
- **The engine's other packages were not all run here.** `mcp`, `report`, the
  three `TestSeededGolden` tests in `env` and the linter were, and everything
  builds and vets. CI runs the rest.
- **The ClickHouse client in the live tests is a test harness**, not a provider,
  and it speaks the HTTP interface rather than the native protocol.

## A line of section 1 to correct

Nothing in section 1 was found wrong. One line of the L4.3 lane row was
imprecise and the plan should say the narrower thing: it reads "the masking
engine compiles rules to Postgres SQL", and the values were never computed in
SQL. They are computed in Go from a key the database never sees, which is what
made cross store determinism possible at all; what was Postgres was the
classifier's type vocabulary, the identifier quoting, and the read and rewrite
statements. The correction makes the lane's premise stronger rather than weaker.
