### PR TITLE
engine: the report said a twin held no events while it was holding production's

### DIFF
--- a/.changes/a-report-that-understated-its-own-twin.md
+++ b/.changes/a-report-that-understated-its-own-twin.md
@@ -1,0 +1,55 @@
+# fixed
+
+The fidelity report said a twin held no events while it was holding a masked,
+verified copy of production's.
+
+The datastores dimension was built from the manifest alone. It read the stance,
+saw `golden`, and reported the store `absent` with the four things it did not
+have named: no golden, no attestation, no tables and no rows. That was the
+right answer while nothing could branch a second store, and it stopped being
+the right answer when `af golden refresh` learned to make a golden of every
+declared store and `af up` to branch each one. From then on an environment
+holding a masked, verified, branched ClickHouse was reported as one that had
+none. The product documented the defect about itself in the manifest reference,
+which is better than hiding it and is not a fix: an instrument that understates
+a twin is better than one that overstates it and it is still an instrument
+saying something untrue about what it can see, and the report is the thing this
+product asks you to trust when nothing else is.
+
+A store declared `golden` that the environment branched is now reported from
+the branch, in the two components the primary database has had all along: `data`
+says how many tables and how many rows it holds and which golden it came from,
+and `provenance` says whether that golden's signed attestation still matches
+its own signature. They are separate for the reason the database's two are
+separate, and the reason is sharper on the second store because the second
+store is where the events are: a branch full of production's shape whose
+provenance nothing can check is not the same result as one whose attestation
+verifies, and a single verdict over both would hide whichever failed.
+
+The `data` component is `unmeasured` rather than `reproduced`, and it says why.
+Nothing here records what production's second store holds, so whether the
+branch reproduces it is unknown, and calling it a reproduction would be the
+defect the primary database closed one release earlier: a branch of two hundred
+rows reported as reproducing a production of four billion, in the same words
+and with the same verdict as a full copy. The committed volume profile that
+answers this under `database.volume` has no equivalent for a second store yet.
+The report names that gap rather than counting the store as a copy of
+production nobody checked.
+
+Everything else about the dimension is unchanged, deliberately. A store
+declared `golden` that nothing branched is still `absent` with the same four
+facts named, which is the line that makes the score go down on the stack this
+was all added for. A store declared `empty`, `derived` or `topics_only` is
+still `unmeasured`, because nothing here starts one, rebuilds one or creates a
+topic in one, and a store reported reproduced on the strength of a declaration
+would be the report believing a manifest instead of an environment. A store
+that names no `source_url_env` has a golden of production's shape with none of
+its rows, and its branch is a `substitution` rather than a reproduction, so the
+fix cannot overstate in the direction the old code understated.
+
+The number, on the same manifest and the same environment, with the only
+difference being whether `af up` had branched the store: **89 percent before
+and 100 after**, with the two components that would need production's own row
+counts excluded and named. The 89 was never a twin missing a ninth of
+production. It was the report unable to see a store that was there.
+`just benchmark` runs the harness, which now prints all three rows.

--- a/docs/src/content/docs/concepts/inventory.md
+++ b/docs/src/content/docs/concepts/inventory.md
@@ -32,7 +32,7 @@ anybody.
 | `auth` | Whether each declared persona actually has a row in the branch, and whether the way it signs in can be carried out here. |
 | `runtime` | Where the environment runs. |
 | `traffic` | Where the endpoint mix comes from, through the same code the load run uses. |
-| `datastores` | Every datastore in the environment other than the primary database, and whether anything reproduced its contents. One the manifest declares `golden` is `absent`, because nothing here builds a golden for a second store. The others are `unmeasured` by name. |
+| `datastores` | Every datastore in the environment other than the primary database, and whether anything reproduced its contents. One the manifest declares `golden` and this environment branched reports what the branch holds and which golden it came from, the way `database` does. One declared `golden` that nothing branched is `absent`. The others are `unmeasured` by name. |
 | `topology` | How many instances of each service are running, against how many the manifest asked for. |
 
 Nothing is estimated and nothing is a constant somebody typed because the
@@ -117,29 +117,55 @@ created is a better reproduction than one whose pack returns canned answers,
 and both are better than a host the policy blocks. The report distinguishes
 all three rather than averaging them into one word.
 
-## A second datastore is not reproduced, and the report says so
+## A second datastore, and what the report says about it
 
-There is one golden, one masking pass, one verification scan and one branch,
-and all four are Postgres. A ClickHouse, a Redis, a Kafka or an Elasticsearch
-declared as a service starts as an empty container.
-
-For a stack shaped like an analytics product that is the whole product: the
-twin holds masked Postgres metadata and zero events, because the events are in
-ClickHouse. Every query path that matters is untested and every chart is blank.
+There was one golden, one masking pass, one verification scan and one branch,
+and all four were Postgres, so a ClickHouse, a Redis, a Kafka or an
+Elasticsearch declared as a service started as an empty container. For a stack
+shaped like an analytics product that was the whole product: the twin held
+masked Postgres metadata and zero events, because the events are in ClickHouse.
+Every query path that mattered was untested and every chart was blank.
 
 The inventory used to score that environment on its services, its branch, its
 hosts, its personas and its traffic and call it faithful, because none of its
 dimensions was looking at the second store. The `datastores` dimension is that
 absence, written down.
 
-Which state a store gets turns on what the manifest declared for it.
+A store declared `golden` is now refreshed, masked, verified and branched like
+the primary, so the twin can hold the events as well as the metadata. The
+dimension is kept and it is what tells you WHICH of the two an environment in
+front of you is.
 
-A store declared `golden` is `absent`, and it is counted. The manifest asked
-for a masked, verified copy of production in it, this build has none, and
-nothing has to read a ClickHouse to know that nothing built a golden for it.
-That is a fact about the environment rather than a gap in what can be seen, so
-it belongs in the denominator, and the report names the four things that are
-missing: no golden, no attestation, no tables and no rows.
+Which state a store gets turns on what the manifest declared for it and on what
+the environment then did about it.
+
+A store declared `golden` that this environment BRANCHED is reported from the
+branch, in two components exactly like the primary database's: `data` says how
+many tables and rows it holds and which golden it came from, and `provenance`
+says whether that golden's signed attestation still matches its own signature.
+That is the report reading the environment. It was worth writing down here
+because the dimension used to read the declaration alone, so it called a store
+holding a masked, verified copy of production `absent`, which understates a
+twin rather than overstating one and is still wrong.
+
+That `data` component is `unmeasured` rather than `reproduced`, and the report
+says why: nothing here records what production's second store holds, so
+whether the branch reproduces it is unknown. It is the rule the primary
+database already follows, arriving one dimension lower. A golden copied from
+whatever `source_url_env` names carries exactly the uncertainty that made a
+branch of two hundred rows report as reproducing a production of four billion,
+and the answer to it for the primary database, the committed volume profile
+under `database.volume`, has no equivalent for a second store yet. The report
+names that rather than counting the store as a copy of production nobody
+checked.
+
+A store declared `golden` that nothing branched is `absent`, and it is counted.
+The manifest asked for a masked, verified copy of production in it, this
+environment has none, and nothing has to read a ClickHouse to know that nothing
+branched a golden for it. That is a fact about the environment rather than a
+gap in what can be seen, so it belongs in the denominator, and the report names
+the four things that are missing: no golden, no attestation, no tables and no
+rows.
 
 A store declared `empty`, `derived` or `topics_only` is `unmeasured`, which
 keeps it out of the score in both directions. Nothing here starts a second
@@ -148,9 +174,11 @@ reported reproduced because somebody declared it empty would be the report
 believing a manifest instead of an environment.
 
 That is the number going down on purpose. A stack shaped like an analytics
-product scored 100 percent before, and scores 90 after, on the same
+product scored 100 percent before, and scores 89 after, on the same
 observation, because the one store the product is about is now in the
-denominator. `just benchmark` runs the harness that produced both numbers.
+denominator. The same stack with that store actually branched scores 100 again,
+with the two components that would need production's own row counts excluded
+and named. `just benchmark` runs the harness that produced all three.
 
 A store is recognised two ways. A [declared datastore](/docs/reference/manifest)
 is the better one, because it carries the stance somebody chose for it and the
@@ -219,12 +247,14 @@ the first is how a check stops being believed.
 manifest says what production runs on, so there is no other side to the
 comparison. Requiring it fails with `AF-FID-002` saying so.
 
-`datastores` is measurable only as far as the stances go. A store declared
-`golden` is `absent`, so requiring the dimension on a manifest whose stores are
-all `golden` fails with `AF-FID-001`, which is a fact about the environment.
-Any store on another stance is unmeasured, and one of those in the manifest
-takes the whole dimension to `AF-FID-002` naming it, which is the honest answer
-rather than a pass.
+`datastores` is measurable for a store declared `golden`, and only as far as
+the stances go for the rest. A store nothing branched is `absent`, so requiring
+the dimension before an `af up` that branches it fails with `AF-FID-001`, which
+is a fact about the environment. A store the environment did branch has its
+provenance measured and its data reported as an unknown, so requiring the
+dimension takes it to `AF-FID-002` naming the `data` component, which is the
+honest answer rather than a pass. Any store on another stance is unmeasured and
+takes the whole dimension to `AF-FID-002` naming it, for the same reason.
 
 `topology` is measurable for every service that names an instance count, and a
 count that is short fails with `AF-FID-001`. A manifest where some service

--- a/docs/src/content/docs/reference/manifest.md
+++ b/docs/src/content/docs/reference/manifest.md
@@ -344,13 +344,21 @@ validator refuses a store with no stance and the
 starts an `empty` store, runs a `derived` rebuild or creates a topic. A store
 whose engine this build cannot mask is REFUSED rather than published unmasked.
 
-**The fidelity report has not caught up with the branching**, and that is worth
-knowing before you read one. The datastores dimension is built from the
-manifest alone, so it reports a store declared `golden` as absent and names the
-golden, the attestation, the tables and the rows it cannot see, whether or not
-`af up` branched one. What would close it is the dimension reading the branch
-that now exists rather than the declaration, and until it does, the report
-understates a twin that holds a masked second store.
+**The fidelity report reads the branch**, not the declaration. A store declared
+`golden` that this environment branched is reported the way the primary
+database is, with its golden, its attestation, its tables and its rows; one the
+environment has not branched is `absent`, and the report names those same four
+things as the ones it does not have. Until that was true the dimension was
+built from the manifest alone, so it said `absent` about a store holding a
+masked, verified copy of production, which understated a twin rather than
+overstating one and was still an instrument saying something untrue about what
+it could see.
+
+What the report still cannot tell you about a branched store is whether what it
+holds is what production holds. Nothing here records a second store's
+production row counts, so that half is reported as an unknown with the reason
+named rather than as a copy of production, which is the same rule
+`database.volume` applies to the primary.
 
 ### Reaching a store from a service
 

--- a/engine/internal/datastore/clickhouse/clickhouse.go
+++ b/engine/internal/datastore/clickhouse/clickhouse.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -563,6 +564,14 @@ func (p *Provider) branchName(ctx context.Context, b provider.Branch) (string, e
 // Databases with this provider's marker in their comment and nothing else,
 // which is what keeps a leak report from proposing to drop a developer's own
 // database on a server they also use for something real.
+//
+// A branch also carries what it HOLDS, and that is what the fidelity report
+// reads. The alternative was a method of its own on the datastore interface,
+// and this is the smaller change for the same answer: the engine already asks
+// every provider for an inventory, the primary database already reports which
+// golden a branch came from through a label of exactly this kind, and a
+// provider that cannot say gets a report that says so rather than one that
+// guesses.
 func (p *Provider) Inventory(ctx context.Context) ([]provider.Resource, error) {
 	list, err := p.ours(ctx)
 	if err != nil {
@@ -576,6 +585,12 @@ func (p *Provider) Inventory(ctx context.Context) ([]provider.Resource, error) {
 		}
 		if d.meta.From != "" {
 			labels["golden"] = d.meta.From
+		}
+		if d.meta.Kind == "branch" {
+			if tables, rows, ok := p.contentsOf(ctx, d.name); ok {
+				labels["tables"] = strconv.Itoa(tables)
+				labels["rows"] = strconv.FormatInt(rows, 10)
+			}
 		}
 		out = append(out, provider.Resource{
 			Kind:      "database/" + d.meta.Kind,
@@ -626,6 +641,51 @@ func (p *Provider) dropDatabase(ctx context.Context, name string) error {
 		return fmt.Errorf("datastore.clickhouse: dropping %s: %w", name, err)
 	}
 	return nil
+}
+
+// contentsOf reports the tables a branch holds and the rows in them, and false
+// when the server would not say.
+//
+// Read from the server rather than from the metadata the branch was created
+// with. That metadata records the tables the golden had at the moment they
+// were attached, and a branch is a database an environment then writes to, so
+// a report built from it would keep printing the golden's numbers over a store
+// whose contents had moved. That is the same defect one level down as the one
+// that made a full store read as absent.
+//
+// Both numbers or neither, because a table count with no row count renders as
+// a store that came up empty and the reader cannot tell that from a store that
+// really did. Answering false leaves the report saying the provider does not
+// record it, which is a sentence somebody can act on.
+//
+// total_rows is what the server keeps for a MergeTree, exact from its parts,
+// so nothing here walks the rows. A table whose engine keeps none, a view or a
+// Dictionary, is not counted as a table either: a branch holds the golden's
+// MergeTree tables, and a view is a statement rather than data.
+func (p *Provider) contentsOf(ctx context.Context, name string) (tables int, rows int64, ok bool) {
+	var found bool
+	err := p.server.rows(ctx,
+		"SELECT toString(count()), toString(ifNull(sum(total_rows), 0)) FROM system.tables "+
+			"WHERE database = {db:String} AND total_rows IS NOT NULL",
+		map[string]string{"db": name}, func(r [][]byte) error {
+			if len(r) != 2 {
+				return nil
+			}
+			t, convErr := strconv.Atoi(strings.TrimSpace(string(r[0])))
+			if convErr != nil {
+				return convErr
+			}
+			n, convErr := strconv.ParseInt(strings.TrimSpace(string(r[1])), 10, 64)
+			if convErr != nil {
+				return convErr
+			}
+			tables, rows, found = t, n, true
+			return nil
+		})
+	if err != nil || !found {
+		return 0, 0, false
+	}
+	return tables, rows, true
 }
 
 // sizeOf reports the bytes a database occupies, and zero when it cannot be

--- a/engine/internal/datastore/clickhouse/refresh_live_test.go
+++ b/engine/internal/datastore/clickhouse/refresh_live_test.go
@@ -136,12 +136,29 @@ func TestRefreshLive_AGoldenIsCopiedMaskedVerifiedAndBranched(t *testing.T) {
 	require.Empty(t, env.column(
 		"SELECT name FROM system.tables WHERE database = currentDatabase() AND name = 'recent'"))
 
+	// What the branch HOLDS, which is what the fidelity report reads and what
+	// it could not read before: the dimension was built from the manifest
+	// alone, so a store declared golden was reported absent whether or not
+	// anything had branched one.
+	heldTables, heldRows := branchContents(t, ctx, p, branch.EnvID)
+	require.Equal(t, "2", heldTables, "the inventory does not say how many tables the branch holds")
+	require.Equal(t, "4", heldRows,
+		"the inventory does not say how many rows the branch holds: 3 events and 1 session")
+
 	// A branch is the environment's own. Writing into it changes nothing
 	// anybody else can see, which is what makes two environments of one golden
 	// independent.
 	env.exec("INSERT INTO events (uuid, event, distinct_id, properties, ts) VALUES " +
 		"('01890fa1-9e40-7d3c-8b9a-2f5c6d7e8a09', 'pageview', 'someone', '{}', now64(6))")
 	require.Equal(t, []string{"4"}, env.column("SELECT toString(count()) FROM events"))
+
+	// And it is read from the server rather than from the metadata the branch
+	// was created with. The environment wrote a row, so the count moved; a
+	// count taken from the declaration would still say 3, which is the same
+	// defect as reporting a full store absent one level down.
+	_, afterWrite := branchContents(t, ctx, p, branch.EnvID)
+	require.Equal(t, "5", afterWrite,
+		"the inventory reports the golden's row count rather than the branch's")
 	second, err := p.Branch(ctx, gv.ID, "env_l42_refresh_two")
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, p.Destroy(context.Background(), second)) })
@@ -194,3 +211,25 @@ func errFindings(report verify.Report) error {
 type errString string
 
 func (e errString) Error() string { return string(e) }
+
+// branchContents reads what the provider says one environment's branch holds.
+//
+// Through Inventory, because that is the socket the engine asks and therefore
+// the only place an answer can reach a report from. A helper that queried the
+// server itself would prove the server knows and say nothing about whether the
+// provider passes it on.
+func branchContents(
+	t *testing.T, ctx context.Context, p *clickhouse.Provider, envID string,
+) (tables, rows string) {
+	t.Helper()
+	inventory, err := p.Inventory(ctx)
+	require.NoError(t, err)
+	for _, r := range inventory {
+		if r.EnvID != envID {
+			continue
+		}
+		return r.Labels["tables"], r.Labels["rows"]
+	}
+	t.Fatalf("the inventory holds nothing for %s, so there is nothing to read", envID)
+	return "", ""
+}

--- a/engine/internal/env/datastore_up_live_test.go
+++ b/engine/internal/env/datastore_up_live_test.go
@@ -19,10 +19,12 @@ import (
 	"github.com/antifailure/antifailure/engine/internal/clock"
 	"github.com/antifailure/antifailure/engine/internal/datastore/clickhouse"
 	"github.com/antifailure/antifailure/engine/internal/dockerutil"
+	"github.com/antifailure/antifailure/engine/internal/fidelity"
 	"github.com/antifailure/antifailure/engine/internal/manifest"
 	"github.com/antifailure/antifailure/engine/internal/redact"
 	"github.com/antifailure/antifailure/engine/internal/secrets"
 	"github.com/antifailure/antifailure/engine/pkg/provider"
+	"github.com/antifailure/antifailure/engine/pkg/schema"
 )
 
 // The lane's second acceptance, and the sentence the whole wave was added for:
@@ -105,7 +107,25 @@ func TestUpLive_AnEnvironmentHoldsAMaskedPostgresAndAMaskedClickHouse(t *testing
 	if os.Getenv("AF_SKIP_DOCKER") != "" {
 		t.Skip("skipped: AF_SKIP_DOCKER is set and this brings an environment up")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+	// Forty rather than twenty, and the budget is here to stop a hang rather
+	// than to police the clock.
+	//
+	// This test now takes two full inventories as well as an environment,
+	// before the up and after it, and each of those asks the runtime what is
+	// running, the database provider where the branch came from and the store
+	// provider what its branch holds. A CI runner does the whole thing in
+	// minutes. A laptop running several Docker suites at once has taken this
+	// test twenty six minutes on its own, and the twenty minute budget then
+	// expired in the middle of a query that had nothing to do with anything
+	// already proved, which reads as a broken twin rather than as a slow
+	// machine.
+	//
+	// It is deliberately above the engine suite's own thirty minute timeout,
+	// which means a genuine hang on CI is caught by the suite rather than by
+	// this deadline. That is the right way round: the suite's timeout is the
+	// one that cannot be outrun, and this one exists so that a developer
+	// waiting on a loaded machine gets a result rather than a deadline.
+	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Minute)
 	defer cancel()
 
 	pgSource := productionPostgres(t)
@@ -169,9 +189,48 @@ func TestUpLive_AnEnvironmentHoldsAMaskedPostgresAndAMaskedClickHouse(t *testing
 	require.False(t, golden.Datastores[0].Empty)
 	require.Positive(t, golden.Datastores[0].Columns)
 
+	// The report BEFORE the environment exists, on this manifest, with a
+	// golden of the events already made and nothing branched. This is the
+	// first half of the pair: the store is absent, and the report names the
+	// four things it does not have.
+	beforeInv, err := o.Fidelity(ctx)
+	require.NoError(t, err)
+	beforeReport := beforeInv.Explain()
+	t.Log("the report with no branch\n\n" + beforeReport)
+	beforeStore := datastoreComponent(t, beforeInv, "events")
+	require.Equal(t, fidelity.Absent, beforeStore.State,
+		"a store nothing branched is not reported as one the environment does not hold")
+	require.Contains(t, beforeStore.Detail, "no golden, no attestation, no tables and no rows")
+
 	result, err := o.Up(ctx)
 	require.NoError(t, err)
 	require.NotEmpty(t, result.Golden)
+
+	// And the report AFTER, on the same manifest and the same command. The
+	// defect this pair is the check for: the datastores dimension was built
+	// from the manifest alone, so both halves of this pair used to be the
+	// first one, and the instrument said absent about a store holding a
+	// masked, verified copy of production.
+	afterInv, err := o.Fidelity(ctx)
+	require.NoError(t, err)
+	afterReport := afterInv.Explain()
+	t.Log("the report after af up\n\n" + afterReport)
+
+	afterData := datastoreComponent(t, afterInv, "events data")
+	require.Contains(t, afterData.Detail, "1 table over 3 rows",
+		"the environment holds a masked ClickHouse and the report does not say what is in it")
+	require.Contains(t, afterData.Detail, "branched from "+golden.Datastores[0].Version)
+	// Unmeasured rather than reproduced, and the report says why: nothing here
+	// records what production's events store holds, so the branch has not been
+	// shown to reproduce it. The primary database's data component is the same
+	// unknown for the same reason on a manifest with no volume profile.
+	require.Equal(t, fidelity.Unmeasured, afterData.State)
+	require.Contains(t, afterData.Detail, "nothing here says what production's events holds")
+
+	afterProvenance := datastoreComponent(t, afterInv, "events provenance")
+	require.Equal(t, fidelity.Reproduced, afterProvenance.State)
+	require.Contains(t, afterProvenance.Detail, "golden "+golden.Datastores[0].Version)
+	require.Contains(t, afterProvenance.Detail, "still matching its signature")
 
 	// The store the environment provides is not also started as a service, so
 	// there is one ClickHouse on the network and it is the one holding a
@@ -491,4 +550,20 @@ func stripDockerFrames(body []byte) string {
 		body = body[8+size:]
 	}
 	return b.String()
+}
+
+// datastoreComponent pulls one component out of the datastores dimension.
+func datastoreComponent(
+	t *testing.T, inv fidelity.Inventory, name string,
+) fidelity.Component {
+	t.Helper()
+	d, ok := inv.Dimension(schema.FidelityDatastores)
+	require.True(t, ok, "the inventory has no datastores dimension")
+	for _, c := range d.Components {
+		if c.Name == name {
+			return c
+		}
+	}
+	t.Fatalf("the datastores dimension has no component %q: %+v", name, d.Components)
+	return fidelity.Component{}
 }

--- a/engine/internal/env/fidelity.go
+++ b/engine/internal/env/fidelity.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"unicode/utf8"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/antifailure/antifailure/engine/internal/personas"
 	"github.com/antifailure/antifailure/engine/internal/verify"
 	"github.com/antifailure/antifailure/engine/internal/volume"
+	"github.com/antifailure/antifailure/engine/pkg/provider"
 	"github.com/antifailure/antifailure/engine/pkg/schema"
 )
 
@@ -47,6 +49,7 @@ func (o *Orchestrator) Fidelity(ctx context.Context) (fidelity.Inventory, error)
 	obs := fidelity.Observation{EnvID: o.envID, Manifest: o.opts.Manifest}
 	o.observeRuntime(ctx, &obs)
 	o.observeDatabase(ctx, s, &obs)
+	o.observeDatastores(ctx, s, &obs)
 	o.observeHosts(&obs)
 	o.observeTraffic(&obs)
 	return fidelity.Build(obs), nil
@@ -144,6 +147,18 @@ func (o *Orchestrator) observeAttestation(
 		obs.GoldenReason = "the provider could not list its goldens: " + oneLine(err)
 		return
 	}
+	obs.Attested, obs.Attestation = attestationOf(goldens, version)
+}
+
+// attestationOf reads back one golden's signed statement and says what it
+// covered, or why it cannot be trusted.
+//
+// One function for the primary database and for every declared datastore,
+// rather than the same six checks written twice. This is the product's central
+// guarantee arriving in a report, and a second copy of it is a second thing to
+// keep in step: the copy that forgets to call Verify still prints a confident
+// sentence about a golden somebody edited after it was signed.
+func attestationOf(goldens []provider.GoldenVersion, version string) (attested bool, detail string) {
 	for _, g := range goldens {
 		if g.ID != version {
 			continue
@@ -154,38 +169,168 @@ func (o *Orchestrator) observeAttestation(
 			// lookup. A golden that lost its verification is the one case
 			// somebody has to act on, and an unknown is the one result nobody
 			// acts on.
-			obs.Attestation = "golden " + version + " is no longer marked verified"
-			return
+			return false, "golden " + version + " is no longer marked verified"
 		}
 		if g.Attestation == "" {
-			obs.Attestation = "golden " + version + " carries no attestation, so nothing here can " +
+			return false, "golden " + version + " carries no attestation, so nothing here can " +
 				"check that its data was masked and read back"
-			return
 		}
 		var a verify.Attestation
 		if err := json.Unmarshal([]byte(g.Attestation), &a); err != nil {
-			obs.Attestation = "the attestation on golden " + version + " could not be read: " + oneLine(err)
-			return
+			return false, "the attestation on golden " + version + " could not be read: " + oneLine(err)
 		}
 		if !a.Verify() {
-			obs.Attestation = "the attestation on golden " + version +
+			return false, "the attestation on golden " + version +
 				" does not match its own signature, so it was changed after it was signed"
-			return
 		}
-		obs.Attested = true
-		obs.Attestation = fmt.Sprintf(
+		out := fmt.Sprintf(
 			"%d columns read back over %d rows sampled, signed and still matching its signature",
 			a.Report.Columns, a.Report.RowsSampled)
 		if n := len(a.Report.Skipped); n > 0 {
-			obs.Attestation += fmt.Sprintf(", with %d columns the scan could not read", n)
+			out += fmt.Sprintf(", with %d columns the scan could not read", n)
 		}
-		return
+		return true, out
 	}
 	// Absent rather than unknown for the same reason: the provider was asked
 	// and answered, and the answer is that the golden this branch came from is
 	// gone, so nothing can check what was done to the data in it.
-	obs.Attestation = "golden " + version + " is the one this branch came from and the provider " +
+	return false, "golden " + version + " is the one this branch came from and the provider " +
 		"no longer lists it"
+}
+
+// observeDatastores asks each store the manifest declares golden what its
+// branch holds.
+//
+// The second store, arriving in the report. `af golden refresh` makes a golden
+// of every declared store and `af up` branches each one, and until this the
+// datastores dimension was built from the manifest alone: it read the stance,
+// saw golden, and reported absent whether or not the environment held a masked
+// copy. So an environment that genuinely held a masked, verified, branched
+// ClickHouse was reported as not holding one. That understates rather than
+// overstates, which is the better of the two directions and is still an
+// instrument saying something untrue about what it can see.
+//
+// Only the golden stance is asked about, and that is deliberate rather than
+// unfinished. Nothing here starts an empty store, runs a derived rebuild or
+// creates a topic, so a store declared any of those three stays unmeasured:
+// reporting one reproduced because somebody declared it empty would be the
+// report believing a manifest instead of an environment.
+func (o *Orchestrator) observeDatastores(
+	ctx context.Context, s *session, obs *fidelity.Observation,
+) {
+	golden := make([]schema.Datastore, 0, len(o.opts.Manifest.Datastores))
+	for _, ds := range datastoreDeclarations(o.opts.Manifest) {
+		if ds.Stance == schema.StanceGolden {
+			golden = append(golden, ds)
+		}
+	}
+	if len(golden) == 0 {
+		return
+	}
+	// mustExist, so that taking an inventory never STARTS a datastore. Opening
+	// a ClickHouse provider brings the machine's server up when it is not
+	// running, and a read only command that waits a minute on a container it
+	// then asks nothing is the behaviour openDatastores' own comment warns
+	// about. A store whose server is not there is one this environment does
+	// not hold, which is what the dimension already reports.
+	if err := o.openDatastores(ctx, s, true); err != nil {
+		reason := "the datastore providers could not be opened: " + oneLine(err)
+		for _, ds := range golden {
+			obs.Stores = append(obs.Stores, fidelity.Store{
+				Name: ds.Name, GoldenReason: reason, BranchReason: reason,
+			})
+		}
+		return
+	}
+	for _, h := range s.stores {
+		if h.decl.Stance != schema.StanceGolden {
+			continue
+		}
+		if store, branched := o.observeDatastore(ctx, h); branched {
+			obs.Stores = append(obs.Stores, store)
+		}
+	}
+}
+
+// observeDatastore asks one store's provider about this environment's branch,
+// and reports false when there is no branch to ask about.
+//
+// False rather than a Store carrying nothing, because the two mean different
+// things to the dimension and only one of them is this environment's answer. A
+// store nothing branched is ABSENT with the four missing facts named, which is
+// the sentence the manifest earns by declaring golden; a store that WAS
+// branched is reported from what the branch holds. Returning an empty Store
+// here would turn the first case into a report of a branch with no golden and
+// no rows, which reads as a broken twin rather than as an absent one.
+func (o *Orchestrator) observeDatastore(
+	ctx context.Context, h *datastoreHandle,
+) (fidelity.Store, bool) {
+	store := fidelity.Store{Name: h.decl.Name}
+	inventory, err := h.prov.Inventory(ctx)
+	if err != nil {
+		reason := "the " + h.decl.Name + " datastore could not be asked what it holds: " + oneLine(err)
+		store.GoldenReason, store.BranchReason = reason, reason
+		return store, true
+	}
+
+	var branch provider.Resource
+	found := false
+	for _, r := range inventory {
+		if r.EnvID == o.envID {
+			branch, found = r, true
+			break
+		}
+	}
+	if !found {
+		return fidelity.Store{}, false
+	}
+
+	store.Golden = branch.Labels["golden"]
+	if store.Golden == "" {
+		store.GoldenReason = "this provider does not record which golden the " + h.decl.Name +
+			" datastore's branch came from"
+	} else {
+		goldens, listErr := h.prov.ListGoldens(ctx)
+		if listErr != nil {
+			store.GoldenReason = "the " + h.decl.Name + " datastore could not list its goldens: " +
+				oneLine(listErr)
+		} else {
+			store.Attested, store.Attestation = attestationOf(goldens, store.Golden)
+		}
+	}
+
+	tables, rows, ok := branchContents(branch.Labels)
+	if !ok {
+		store.BranchReason = "this provider does not record what the " + h.decl.Name +
+			" datastore's branch holds"
+		return store, true
+	}
+	store.Tables, store.Rows = tables, rows
+	return store, true
+}
+
+// branchContents reads what a provider says its branch holds.
+//
+// Both labels or neither. A count of tables with no count of rows would render
+// as "12 tables over 0 rows", which is a store somebody would read as empty,
+// and a report that turns a missing number into a zero is the failure this
+// package exists to refuse. A provider that records neither gets the sentence
+// saying so, in the exclusions list, rather than a figure.
+func branchContents(labels map[string]string) (tables int, rows int64, ok bool) {
+	t, hasTables := labels["tables"]
+	r, hasRows := labels["rows"]
+	if !hasTables || !hasRows {
+		return 0, 0, false
+	}
+	tables, err := strconv.Atoi(t)
+	if err != nil {
+		return 0, 0, false
+	}
+	rows, err = strconv.ParseInt(r, 10, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+	return tables, rows, true
 }
 
 // branchSize counts what the branch holds.

--- a/engine/internal/fidelity/branch_test.go
+++ b/engine/internal/fidelity/branch_test.go
@@ -1,0 +1,238 @@
+package fidelity_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/internal/fidelity"
+	"github.com/antifailure/antifailure/engine/pkg/schema"
+)
+
+// The report reading the branch rather than the declaration.
+//
+// The defect these are the check for is one the product documented about
+// itself: the datastores dimension was built from the manifest alone, so it
+// reported a store declared golden as absent and named the golden, the
+// attestation, the tables and the rows it could not see, whether or not the
+// environment had branched one. An instrument that understates a twin holding
+// a masked, verified second store is better than one that overstates it and is
+// still an instrument saying something untrue about what it can see.
+
+// branchedEvents is the store an environment holds once af up has branched it.
+func branchedEvents() fidelity.Store {
+	return fidelity.Store{
+		Name:     "events",
+		Golden:   "gv_20260907101500_9f3c2b71",
+		Attested: true,
+		Attestation: "6 columns read back over 1000 rows sampled, signed and still " +
+			"matching its signature",
+		Tables: 4,
+		Rows:   1000000,
+	}
+}
+
+// branchedTwin is the analytics twin AFTER af up, which is the only thing that
+// separates it from the observation the score benchmark measures.
+func branchedTwin(t *testing.T) fidelity.Observation {
+	t.Helper()
+	obs := analyticsTwin(t)
+	obs.Stores = []fidelity.Store{branchedEvents()}
+	return obs
+}
+
+func TestABranchedGoldenStoreReportsWhatTheBranchHolds(t *testing.T) {
+	t.Parallel()
+	inv := fidelity.Build(branchedTwin(t))
+
+	data := componentState(t, inv, schema.FidelityDatastores, "events data")
+	require.Contains(t, data.Detail, "4 tables over 1000000 rows",
+		"the environment holds a masked copy of production's events and the report does not say what it holds")
+	require.Contains(t, data.Detail, "branched from gv_20260907101500_9f3c2b71")
+	// Unmeasured rather than reproduced, and this is the primary database's
+	// own rule arriving for the second store: a branch nothing was compared
+	// against production has not been shown to reproduce it. The report says
+	// what the branch holds and says what nothing here knows about production,
+	// which is two facts rather than a verdict with no denominator.
+	require.Equal(t, fidelity.Unmeasured, data.State)
+	require.Contains(t, data.Detail, "nothing here says what production's events holds")
+
+	prov := componentState(t, inv, schema.FidelityDatastores, "events provenance")
+	require.Equal(t, fidelity.Reproduced, prov.State)
+	require.Contains(t, prov.Detail, "golden gv_20260907101500_9f3c2b71")
+	require.Contains(t, prov.Detail, "6 columns read back over 1000 rows sampled")
+}
+
+func TestAGoldenStoreNothingBranchedIsStillAbsentWithTheFourFactsNamed(t *testing.T) {
+	t.Parallel()
+	// The line the lane that wrote this dimension put there, and it has to
+	// survive. An environment that has not branched its second store is not a
+	// twin of a stack whose events are the product, and the report saying so
+	// is the number going down on purpose.
+	inv := fidelity.Build(analyticsTwin(t))
+
+	events := componentState(t, inv, schema.FidelityDatastores, "events")
+	require.Equal(t, fidelity.Absent, events.State)
+	require.Contains(t, events.Detail, "no golden, no attestation, no tables and no rows")
+
+	d, ok := inv.Dimension(schema.FidelityDatastores)
+	require.True(t, ok)
+	for _, c := range d.Components {
+		require.NotContains(t, c.Name, " data",
+			"a store nothing branched is reported as if something had")
+	}
+}
+
+func TestAStoreOnAnotherStanceIsNotReportedFromABranch(t *testing.T) {
+	t.Parallel()
+	// The narrowness of this change, asserted rather than described. A store
+	// declared empty, derived or topics_only stays unmeasured whatever arrives
+	// in the observation, because nothing in this build starts one, rebuilds
+	// one or creates a topic in one, and a store reported reproduced on the
+	// strength of a declaration is the report believing a manifest instead of
+	// an environment.
+	obs := analyticsTwin(t)
+	obs.Stores = []fidelity.Store{{
+		Name: "cache", Golden: "gv_20260907101500_9f3c2b71", Attested: true,
+		Attestation: "signed and still matching its signature", Tables: 1, Rows: 5,
+	}}
+	inv := fidelity.Build(obs)
+
+	cache := componentState(t, inv, schema.FidelityDatastores, "cache")
+	require.Equal(t, fidelity.Unmeasured, cache.State)
+	require.Contains(t, cache.Detail, "a redis declared empty")
+}
+
+func TestABranchWhoseGoldenLostItsAttestationFailsProvenanceAndNotData(t *testing.T) {
+	t.Parallel()
+	// Two components rather than one verdict over both, which is the reason
+	// the database dimension has two. The branch holds production's rows and
+	// nothing can show what was done to them before they arrived, and a single
+	// verdict would hide whichever of those failed.
+	obs := branchedTwin(t)
+	obs.Stores[0].Attested = false
+	obs.Stores[0].Attestation = "golden gv_20260907101500_9f3c2b71 is no longer marked verified"
+	inv := fidelity.Build(obs)
+
+	require.Equal(t, fidelity.Absent,
+		componentState(t, inv, schema.FidelityDatastores, "events provenance").State)
+	require.Contains(t,
+		componentState(t, inv, schema.FidelityDatastores, "events provenance").Detail,
+		"no longer marked verified")
+	require.Equal(t, "4 tables over 1000000 rows, branched from gv_20260907101500_9f3c2b71"+
+		", and nothing here says what production's events holds, so whether this branch "+
+		"reproduces it is unknown. The volume profile that answers that for the primary "+
+		"database, under database.volume, has no equivalent for a second store yet",
+		componentState(t, inv, schema.FidelityDatastores, "events data").Detail,
+		"a golden that lost its attestation changed what the report says the branch holds")
+}
+
+func TestAStoreTheProviderCouldNotBeAskedAboutIsExcludedAndNamed(t *testing.T) {
+	t.Parallel()
+	// Unmeasured, in neither half of the number, and named in the exclusions
+	// list the headline points at. A store nothing could read is not a store
+	// shown to be missing, and reporting the second as the first is how a
+	// report stops being believed.
+	obs := branchedTwin(t)
+	obs.Stores[0].BranchReason = "the events datastore could not be asked what it holds: connection refused"
+	obs.Stores[0].GoldenReason = "the events datastore could not list its goldens: connection refused"
+	inv := fidelity.Build(obs)
+
+	require.Equal(t, fidelity.Unmeasured,
+		componentState(t, inv, schema.FidelityDatastores, "events data").State)
+	require.Equal(t, fidelity.Unmeasured,
+		componentState(t, inv, schema.FidelityDatastores, "events provenance").State)
+
+	var named int
+	for _, e := range inv.Score().Excluded {
+		if e.Dimension == schema.FidelityDatastores && strings.HasPrefix(e.Component, "events ") {
+			require.Contains(t, e.Because, "connection refused")
+			named++
+		}
+	}
+	require.Equal(t, 2, named, "a store nothing could read was dropped from the report rather than named")
+}
+
+func TestAStoreWithNoSourceIsASubstitutionRatherThanAReproduction(t *testing.T) {
+	t.Parallel()
+	// The overstating half of the same defect. A golden built with no source
+	// has production's shape and none of its rows, and a branch of one is not
+	// a copy of production however many tables it carries.
+	obs := branchedTwin(t)
+	for i := range obs.Manifest.Datastores {
+		if obs.Manifest.Datastores[i].Name == "events" {
+			obs.Manifest.Datastores[i].SourceURLEnv = ""
+		}
+	}
+	obs.Stores[0].Rows = 0
+	inv := fidelity.Build(obs)
+
+	data := componentState(t, inv, schema.FidelityDatastores, "events data")
+	require.Equal(t, fidelity.Substituted, data.State,
+		"a store with no source was improved to a reproduction, or lost to an unknown")
+	require.Contains(t, data.Detail, "production's shape with none of its rows")
+}
+
+func TestEveryBranchedStoreIsReportedSeparately(t *testing.T) {
+	t.Parallel()
+	// Two golden stores in one environment, which is what a stack with events
+	// and a search index looks like. Four components, all distinct, because a
+	// name collision here would silently drop one store's answer out of the
+	// score.
+	obs := branchedTwin(t)
+	obs.Manifest.Datastores = append(obs.Manifest.Datastores, schema.Datastore{
+		Name: "search", Engine: "elasticsearch", Stance: schema.StanceGolden,
+		SourceURLEnv: "PRODUCTION_SEARCH_URL",
+	})
+	obs.Stores = append(obs.Stores, fidelity.Store{
+		Name: "search", Golden: "gv_20260907101500_11223344", Attested: true,
+		Attestation: "2 columns read back over 40 rows sampled", Tables: 1, Rows: 40,
+	})
+	d, ok := fidelity.Build(obs).Dimension(schema.FidelityDatastores)
+	require.True(t, ok)
+
+	seen := map[string]int{}
+	for _, c := range d.Components {
+		seen[c.Name]++
+	}
+	require.Equal(t, map[string]int{
+		"cache": 1, "events data": 1, "events provenance": 1,
+		"search data": 1, "search provenance": 1,
+	}, seen)
+}
+
+func TestTheRenderedReportNamesTheGoldenTheAttestationTheTablesAndTheRows(t *testing.T) {
+	t.Parallel()
+	// The four facts the documented defect said the report named as missing
+	// from a store that had them, in the block a reader with thirty seconds
+	// actually sees. Asserted against the datastores block rather than the
+	// whole report, because the database dimension above it says four things
+	// of exactly the same shape about the primary Postgres.
+	block := datastoresBlock(t, fidelity.Build(branchedTwin(t)).Explain())
+	for _, want := range []string{
+		"gv_20260907101500_9f3c2b71",
+		"6 columns read back over 1000 rows sampled",
+		"4 tables",
+		"1000000 rows",
+	} {
+		require.Containsf(t, block, want, "the datastores block does not say %q:\n%s", want, block)
+	}
+}
+
+// The number this lane owes, and the proof that the old one was wrong.
+//
+// The same manifest, the same environment, and the only difference is whether
+// af up branched the store the manifest declares golden. 90 percent was not a
+// twin missing ten percent of production; it was the report unable to see a
+// store that was there.
+func TestATwinThatHoldsItsSecondStoreScoresTheStoreItHolds(t *testing.T) {
+	t.Parallel()
+	before := measureScore(t, fidelity.Build(analyticsTwin(t)))
+	after := measureScore(t, fidelity.Build(branchedTwin(t)))
+
+	require.Equal(t, scoreOf{reproduced: 8, counted: 9, percent: 89}, before)
+	require.Equal(t, scoreOf{reproduced: 9, counted: 9, percent: 100}, after)
+	require.Greater(t, after.percent, before.percent,
+		"the report reads the branch and still scores the environment as if it had none")
+}

--- a/engine/internal/fidelity/build.go
+++ b/engine/internal/fidelity/build.go
@@ -81,6 +81,16 @@ type Observation struct {
 	// says why the configured source produced nothing.
 	Traffic       string
 	TrafficReason string
+
+	// Stores describes each declared datastore this environment BRANCHED, as
+	// that store's own provider answered for it.
+	//
+	// A store nothing branched is not in here at all, and the absence is load
+	// bearing: it is what leaves the datastores dimension reporting a store
+	// declared golden as absent, which is the answer for an environment that
+	// has none. Only a store the environment actually holds appears, and only
+	// then does the dimension report what is in it.
+	Stores []Store
 }
 
 // Host is one third party host the egress policy names.
@@ -117,6 +127,50 @@ type Persona struct {
 	// a magic link or a one time code needs to arrive.
 	Deliverable bool
 }
+
+// Store is one declared datastore's branch, as its provider answered for it.
+//
+// The same two questions the database dimension asks about the primary, asked
+// of the second store: which golden this branch came from and whether that
+// golden's attestation still checks out, and what the branch holds. A separate
+// type rather than a second set of fields on Observation, because a datastore
+// has no pooled endpoint, no subset, no personas and no source of traffic, and
+// a struct carrying fields nothing ever fills is one a reader has to check
+// against the code before believing.
+type Store struct {
+	// Name is the store's name in the manifest, which is what the manifest
+	// declared and what its components are named after.
+	Name string
+	// Golden is the golden this branch came from, and GoldenReason says why
+	// the provider could not say.
+	Golden       string
+	GoldenReason string
+	// Attested reports whether that golden is verified and its attestation
+	// parsed and matched its own signature. Attestation describes what the
+	// attestation covered when it did, and says which of those failed when it
+	// did not, so an absence always carries the reason for it.
+	Attested    bool
+	Attestation string
+	// Tables and Rows are what the branch holds, read from the branch.
+	// BranchReason says why they could not be read.
+	//
+	// There is no floor here, unlike the primary database's count. That one
+	// stops a live count at a ceiling because counting every row of a
+	// production sized Postgres to print one number would take minutes; a
+	// store that reports what it holds from its own metadata answers exactly
+	// or does not answer at all, and a provider that cannot answer sets
+	// BranchReason rather than a number somebody would quote.
+	Tables       int
+	Rows         int64
+	BranchReason string
+}
+
+// There is deliberately no Empty field here, unlike the primary database's.
+// Whether a store declares a source is in its own manifest entry, the manifest
+// is part of this observation, and the dimension reads it from there. A copy
+// of a fact the report already holds is a second thing to keep in step, and
+// this is the file whose whole claim is that the inventory is a pure function
+// of what was observed.
 
 // Build turns an observation into an inventory.
 //

--- a/engine/internal/fidelity/datastores.go
+++ b/engine/internal/fidelity/datastores.go
@@ -1,6 +1,7 @@
 package fidelity
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 
@@ -25,14 +26,31 @@ import (
 // called it faithful. The instrument whose entire job is to say "this is not
 // production" was the last thing that would have told anybody.
 //
-// So the dimension reports these rather than leaving them out, and which of
-// two states each gets turns on what the manifest declared for it.
+// So the dimension reports these rather than leaving them out, and what each
+// gets turns on what the manifest declared for it and on what the environment
+// then did about it.
 //
-// A store the manifest declares golden is ABSENT, and it is counted. The
-// manifest asked for a masked, verified copy of production in it and this
-// build has none, which is a fact about the environment and not a gap in what
-// can be seen. That is the line that makes the score go down on exactly the
-// stack this dimension was added for.
+// A store the manifest declares golden AND the environment branched is
+// reported the way the primary database is: one component for what the branch
+// holds and one for where it came from, carrying the golden, the attestation,
+// the tables and the rows. That half of this file was written when nothing
+// could branch a second store, so the dimension read the declaration alone and
+// called a full store absent, which is a lie in the generous direction and is
+// still a lie. An instrument that understates the twin is not the instrument
+// this repository argues for.
+//
+// What the branch holds is an UNKNOWN rather than a reproduction, and it says
+// why. Nothing here records what production's second store holds, so nothing
+// can say whether the branch reproduces it, and the primary database learned
+// that lesson first: a branch of two hundred rows was reported as reproducing
+// a production of four billion. The tables and the rows are still in the
+// report, and the verdict over them is the one nobody has earned yet.
+//
+// A store declared golden that nothing branched is ABSENT, and it is counted.
+// The manifest asked for a masked, verified copy of production in it and this
+// environment has none, which is a fact about the environment and not a gap in
+// what can be seen. That is the line that makes the score go down on exactly
+// the stack this dimension was added for.
 //
 // A store recognised from a service image, or declared with any other stance,
 // is UNMEASURED, which keeps it out of the score in both directions: nothing
@@ -52,6 +70,14 @@ import (
 func datastores(obs Observation) Dimension {
 	d := Dimension{Name: schema.FidelityDatastores}
 
+	// The stores this environment holds, by name. A store that is not in here
+	// was not branched, and the declaration is then the only thing there is to
+	// report about it.
+	branched := make(map[string]Store, len(obs.Stores))
+	for _, st := range obs.Stores {
+		branched[st.Name] = st
+	}
+
 	found := make([]Component, 0, len(obs.Manifest.Datastores)+len(obs.Manifest.Services))
 	declared := map[string]bool{}
 	for _, ds := range obs.Manifest.Datastores {
@@ -65,6 +91,18 @@ func datastores(obs Observation) Dimension {
 			continue
 		}
 		declared[ds.Name] = true
+		// GOLDEN AND BRANCHED, both. The stance alone is a declaration and an
+		// observation alone is a store nobody asked for a copy of production
+		// in, and neither on its own is grounds for reporting what a branch
+		// holds. A store declared empty, derived or topics_only stays
+		// unmeasured whatever arrives here, which is the rule the lane that
+		// wrote this dimension established and the one this change is
+		// deliberately narrower than.
+		if st, ok := branched[ds.Name]; ok && ds.Stance == schema.StanceGolden {
+			found = append(found, storeDataComponent(ds, st),
+				storeProvenanceComponent(ds.Name, st))
+			continue
+		}
 		found = append(found, declaredComponent(ds))
 	}
 
@@ -99,21 +137,127 @@ func datastores(obs Observation) Dimension {
 	return d
 }
 
-// declaredComponent is one store the manifest declares, in the state the
-// declaration and this build together put it in.
+// storeDataComponent answers whether one store's branch holds production's
+// data.
 //
-// TWO STATES, and which one a stance gets is the whole of this function.
+// dataComponent in build.go with one arm fewer, and it is dropped because a
+// datastore has no such thing rather than because this does not look for it.
+// There is no subset of a second store: the slice is configured for the
+// primary database and taken from it. Nothing here reads a floor either,
+// because the count is what the store says it holds rather than a walk over
+// its rows.
+//
+// The empty arm is the manifest's own entry rather than an observed fact,
+// which is the one place this reads a declaration on purpose. A store that
+// names no source variable gets a golden of production's shape with none of
+// its rows, and that is decided by the manifest before anything runs.
+//
+// Kept beside declaredComponent rather than folded into build.go's version.
+// The two answer about different providers from different observations. What
+// they must agree on is the rule below rather than the code: a component is
+// not called a reproduction until something has compared it against
+// production, and neither of them can call one that on its own.
+func storeDataComponent(ds schema.Datastore, s Store) Component {
+	c := Component{Name: ds.Name + " data"}
+	switch {
+	case s.BranchReason != "":
+		// The branch could not be counted, so there is nothing to hold
+		// against production either. One unknown, reported once.
+		c.State, c.Detail = Unmeasured, s.BranchReason
+		return c
+	case ds.SourceURLEnv == "":
+		// A golden built with no source has production's shape and none of its
+		// rows, and reporting that as a copy of production would be this
+		// dimension overstating in exactly the way it was changed to stop
+		// understating. The refresh says the same sentence out loud when it
+		// makes one.
+		c.State = Substituted
+		c.Detail = describeStore(s) +
+			", and the store declares no source, so this is production's shape with none of its rows"
+	default:
+		c.State = Reproduced
+		c.Detail = describeStore(s) + ", branched from " + orUnknown(s.Golden)
+	}
+	return withoutAVolumeProfile(c, ds)
+}
+
+// withoutAVolumeProfile applies the primary database's own rule to a second
+// store: a branch nothing was compared against has not been shown to reproduce
+// anything.
+//
+// againstProduction in build.go makes that rule for the database, because a
+// golden built from a staging server holding two hundred rows was reported as
+// reproducing a production holding four billion, in the same words and with
+// the same verdict as a full copy. The second store is copied from whatever
+// address source_url_env names, so it carries the identical uncertainty, and
+// reporting it reproduced three hours after that was closed for the primary
+// would be the same defect one dimension lower.
+//
+// So the verdict is downgraded and the reason names what is missing. It does
+// NOT name a command to run, because there is not one: database.volume records
+// what production's Postgres holds and there is no equivalent for a second
+// store yet. Naming a fix that does not exist would be worse than naming the
+// gap, and the report telling somebody what this product cannot yet answer is
+// the thing it is for.
+//
+// It never improves a verdict, exactly as againstProduction never does. A
+// store with no source is still production's shape with none of its rows.
+func withoutAVolumeProfile(c Component, ds schema.Datastore) Component {
+	if c.State == Reproduced {
+		c.State = Unmeasured
+	}
+	c.Detail += ", and nothing here says what production's " + ds.Name +
+		" holds, so whether this branch reproduces it is unknown. The volume profile that " +
+		"answers that for the primary database, under database.volume, has no equivalent " +
+		"for a second store yet"
+	return c
+}
+
+// storeProvenanceComponent answers whether one store's branch can be shown to
+// have come from a golden that was masked and verified.
+//
+// Separate from the data for the reason provenanceComponent is separate from
+// it: a branch full of production's shape whose provenance nothing can check
+// is not the same result as one whose attestation verifies, and a single
+// verdict over both would hide whichever failed. On the second store that
+// distinction is sharper rather than softer, because the second store is
+// where the events are.
+func storeProvenanceComponent(name string, s Store) Component {
+	c := Component{Name: name + " provenance"}
+	switch {
+	case s.GoldenReason != "":
+		c.State, c.Detail = Unmeasured, s.GoldenReason
+	case !s.Attested:
+		c.State, c.Detail = Absent, orUnknown(s.Attestation)
+	default:
+		c.State = Reproduced
+		c.Detail = "golden " + s.Golden + ", " + s.Attestation
+	}
+	return c
+}
+
+// describeStore renders what one store's branch holds.
+func describeStore(s Store) string {
+	return fmt.Sprintf("%s over %s",
+		plural(int64(s.Tables), "table", "tables"), plural(s.Rows, "row", "rows"))
+}
+
+// declaredComponent is one store the manifest declares and this environment
+// does NOT hold a branch of, in the state the declaration puts it in.
+//
+// TWO STATES, and which one a stance gets is the whole of this function. A
+// store the environment branched never reaches here: it is reported by the two
+// components above, from what the branch holds.
 //
 // A stance of golden is ABSENT. The manifest asked for a masked, verified copy
-// of production in this store, this build has no such thing, and that is a
-// fact about the environment rather than a gap in what can be seen: there is
-// one golden, one masking pass, one verification scan and one branch, and all
-// four are the primary Postgres. Nothing has to read a ClickHouse to know that
-// nothing built a golden for it. So it is counted, in the denominator, and the
-// score goes down, which is the point: an analytics product's twin holding
-// masked Postgres metadata and zero events must not score as a faithful twin,
-// and until this it did, because unmeasured kept the one store the product is
-// about out of the number in both directions.
+// of production in this store, this environment has no such thing, and that is
+// a fact about the environment rather than a gap in what can be seen: nothing
+// branched one, so there is nothing to read. So it is counted, in the
+// denominator, and the score goes down, which is the point: an analytics
+// product's twin holding masked Postgres metadata and zero events must not
+// score as a faithful twin, and until the lane that wrote this it did, because
+// unmeasured kept the one store the product is about out of the number in both
+// directions.
 //
 // Every other stance stays UNMEASURED. Nothing in this build starts a second
 // store, rebuilds one from the branch or creates a topic in one, so whether an
@@ -171,8 +315,8 @@ func stanceGap(stance schema.DatastoreStance) string {
 		// is what tells somebody which four things would have to appear before
 		// this line changes.
 		return "nothing here built one: no golden, no attestation, no tables and no rows. " +
-			"There is one golden, one masking pass, one verification scan and one branch, " +
-			"and all four are the primary Postgres"
+			"af golden refresh makes a golden of this store and af up branches it, and " +
+			"this environment holds neither"
 	default:
 		// A stance no build of this engine knows. Validation refuses one, so
 		// reaching here means a manifest parsed by a newer engine than the one

--- a/engine/internal/fidelity/score_test.go
+++ b/engine/internal/fidelity/score_test.go
@@ -222,9 +222,16 @@ func TestBenchmarkTheFidelityScoreBeforeAndAfter(t *testing.T) {
 	require.Equal(t, fidelity.Absent, web.State)
 	require.Contains(t, web.Detail, "1 of 3 instances")
 
+	// The third row: the same manifest with the store it declares golden
+	// actually branched. Not a different environment, the same one after an
+	// af up that branches the store, which the report used to describe
+	// identically to one that had none.
+	branched := measureScore(t, fidelity.Build(branchedTwin(t)))
+	require.Equal(t, scoreOf{reproduced: 9, counted: 9, percent: 100}, branched)
+
 	report := renderScoreBenchmark(
 		headlineOf(t, beforeHealthyText), healthy,
-		headlineOf(t, beforeHalfText), half)
+		headlineOf(t, beforeHalfText), half, branched)
 	t.Log("\n" + report)
 	if out := os.Getenv(scoreBenchmarkOutEnv); out != "" {
 		require.NoError(t, os.MkdirAll(filepath.Dir(out), 0o750))
@@ -238,7 +245,9 @@ const scoreBenchmarkOutEnv = "AF_SCORE_BENCHMARK_OUT"
 
 // renderScoreBenchmark writes the report, dated, because a number older than
 // the code that produced it is withdrawn rather than rounded.
-func renderScoreBenchmark(beforeOne string, one scoreOf, beforeTwo string, two scoreOf) string {
+func renderScoreBenchmark(
+	beforeOne string, one scoreOf, beforeTwo string, two scoreOf, branched scoreOf,
+) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "# The fidelity score, before and after\n\nMeasured %s by\n",
 		time.Now().UTC().Format("2006-01-02"))
@@ -257,6 +266,8 @@ func renderScoreBenchmark(beforeOne string, one scoreOf, beforeTwo string, two s
 		quoteScore(beforeOne), renderScore(one))
 	fmt.Fprintf(&b, "| The same, running one instance of each multi instance service | %s | %s |\n",
 		quoteScore(beforeTwo), renderScore(two))
+	fmt.Fprintf(&b, "| The first row again, with the golden ClickHouse actually branched | %s | %s |\n",
+		quoteScore(beforeOne), renderScore(branched))
 
 	b.WriteString("\nThe second row is the environment every user of this engine had until\n")
 	b.WriteString("c2233c50: both runtimes hardcoded one instance, so a manifest asking for\n")
@@ -265,15 +276,24 @@ func renderScoreBenchmark(beforeOne string, one scoreOf, beforeTwo string, two s
 	b.WriteString("absent rather than excluded as unmeasured, because nothing here built a\n")
 	b.WriteString("golden for it and that is a fact about the environment; and the topology\n")
 	b.WriteString("dimension counts instances against the count each service asked for.\n\n")
-	b.WriteString("What would move it back up, honestly: L4.2 filling the ClickHouse with a\n")
-	b.WriteString("masked, verified copy, which is the one component holding the first row\n")
-	b.WriteString("below 100.\n\n")
-	b.WriteString("The denominator here is 9 rather than the 10 this report first carried.\n")
-	b.WriteString("The database dimension's data component became an unknown rather than a\n")
-	b.WriteString("reproduction for an environment with no volume profile, because nothing\n")
-	b.WriteString("had ever compared the branch against production, and an unmeasured\n")
-	b.WriteString("component is in neither half of the score. benchmark-volume-share is the\n")
-	b.WriteString("same twin with a profile, where the component is measured and fails.\n")
+	b.WriteString("The third row is what moved it back up, and it is the same manifest: a\n")
+	b.WriteString("ClickHouse refreshed, masked, verified and branched, reported from what\n")
+	b.WriteString("the branch holds rather than from the declaration. The 90 in the first row\n")
+	b.WriteString("was never a twin missing a tenth of production. It was the report unable\n")
+	b.WriteString("to see a store that was there, which is an understatement rather than an\n")
+	b.WriteString("overstatement and is still a number that was wrong.\n\n")
+	b.WriteString("The third row's two numbers agree and they do not mean the same thing.\n")
+	b.WriteString("The left one is an instrument that was not looking at the second store\n")
+	b.WriteString("at all. The right one is an instrument that read it, named the golden it\n")
+	b.WriteString("came from, checked that golden's signature and counted what the branch\n")
+	b.WriteString("holds.\n")
+	b.WriteString("\nThe denominator in the first two rows is 9 rather than the 10 this\n")
+	b.WriteString("report first carried. The database dimension's data component became an\n")
+	b.WriteString("unknown rather than a reproduction for an environment with no volume\n")
+	b.WriteString("profile, because nothing had ever compared the branch against production,\n")
+	b.WriteString("and an unmeasured component is in neither half of the score.\n")
+	b.WriteString("benchmark-volume-share is the same twin with a profile, where the\n")
+	b.WriteString("component is measured and fails.\n")
 	return b.String()
 }
 

--- a/engine/internal/fidelity/testdata/product-analytics.yaml
+++ b/engine/internal/fidelity/testdata/product-analytics.yaml
@@ -37,6 +37,11 @@ datastores:
   - name: events
     engine: clickhouse
     stance: golden
+    # The variable holding production's address, because a store that names
+    # none gets a golden of production's shape with none of its rows, and this
+    # stack is the one whose events ARE the product. The report says which of
+    # the two a branch is, so the fixture has to choose.
+    source_url_env: PRODUCTION_CLICKHOUSE_URL
 
   - name: cache
     engine: redis


### PR DESCRIPTION

## The failure

The datastores dimension was built from the manifest alone. It read the stance,
saw `golden`, and reported the store `absent` with the four things it did not
have named: no golden, no attestation, no tables and no rows. That was the
right answer while nothing could branch a second store, and it stopped being
right the moment `af golden refresh` learned to make a golden of every declared
store and `af up` to branch each one. From then on an environment holding a
masked, verified, branched ClickHouse was reported as one that had none.

The product documented the defect about itself, in the manifest reference,
under a heading reading "The fidelity report has not caught up with the
branching". Documenting it is better than hiding it and it is not a fix. An
instrument that understates a twin is better than one that overstates it and it
is still an instrument saying something untrue about what it can see, and the
report is the one thing this product asks you to trust when nothing else is.

## What this does

A store declared `golden` that the environment branched is reported from the
branch, in the two components the primary database has had all along:

    events data  unmeasured   1 table over 3 rows, branched from gv_..., and
                              nothing here says what production's events holds
    events prov… reproduced   golden gv_..., 3 columns read back over 9 rows
                              sampled, signed and still matching its signature

They are separate for the reason the database's two are separate, and the
reason is sharper on the second store because the second store is where the
events are: a branch full of production's shape whose provenance nothing can
check is not the same result as one whose attestation verifies, and a single
verdict over both would hide whichever failed.

The data half is an UNKNOWN rather than a reproduction, and it says why.
`#295` closed exactly this for the primary database three hours before this
branch was written: a golden built from a staging server holding two hundred
rows was reported as reproducing a production holding four billion, in the same
words and with the same verdict as a full copy, because nothing in the engine
had ever been told what production holds. A second store is copied from
whatever address `source_url_env` names, so it carries the identical
uncertainty, and reporting it `reproduced` here would be the same defect one
dimension lower. The committed volume profile that answers this under
`database.volume` has no equivalent for a second store yet, so the reason names
the gap rather than naming a command that cannot close it. The report telling
somebody what this product cannot answer yet is the thing it is for.

The observation comes from the store's own provider through the socket the
engine already asks. `Inventory` labels a branch with what it holds, read from
the server rather than from the metadata the branch was created with, because a
branch is a database an environment then writes to and a count taken from the
declaration would keep printing the golden's numbers. The alternative was a
method of its own on `provider.Datastore`, which is a wider change for the same
answer; a provider that records neither label gets a report saying so rather
than a figure.

`attestationOf` is now one function for the primary database and for every
declared datastore, rather than the same six checks written twice. It is the
product's central guarantee arriving in a report, and the second copy is the
one that forgets to check the signature.

## What deliberately did not change

- A store declared `golden` that nothing branched is still `absent`, with the
  same four facts named. That is the line that makes the score go down on the
  stack this was all added for, and it is asserted rather than assumed.
- A store declared `empty`, `derived` or `topics_only` is still `unmeasured`,
  whatever arrives in the observation. Nothing here starts one, rebuilds one or
  creates a topic in one, and a store reported reproduced on the strength of a
  declaration would be the report believing a manifest instead of an
  environment. There is a test that feeds a branch observation for a store
  declared `empty` and requires the report to ignore it.
- A store that names no `source_url_env` has a golden of production's shape
  with none of its rows, so its branch is a `substitution` rather than a
  reproduction, and the unknown above never erases that verdict or improves it.

## The number

**89 percent before and 100 after**, on the same manifest and the same
environment, the only difference being whether `af up` had branched the store,
with the two components that would need production's own row counts excluded
and named.

The 89 was never a twin missing a ninth of production. It was the report unable
to see a store that was there. `just benchmark` runs the harness and now prints
all three rows: 100 before the dimension existed, 89 with an unbranched store,
100 with the store the environment actually holds.

## The evidence

One live environment, reported twice, on one manifest, either side of one
`af up`, from `TestUpLive_AnEnvironmentHoldsAMaskedPostgresAndAMaskedClickHouse`
against a real Postgres, a real ClickHouse, the Docker database provider and
the local runtime. Before:

    datastores     absent (1 absent)
      events       absent       a clickhouse declared golden, and nothing here
                                built one: no golden, no attestation, no tables
                                and no rows. af golden refresh makes a golden of
                                this store and af up branches it, and this
                                environment holds neither

After:

    datastores     reproduced (1 reproduced, 1 unmeasured)
      events data  unmeasured   1 table over 3 rows, branched from
                                gv_20260908001700012144_08f6b759, and nothing
                                here says what production's events holds, so
                                whether this branch reproduces it is unknown.
                                The volume profile that answers that for the
                                primary database, under database.volume, has no
                                equivalent for a second store yet
      events prov… reproduced   golden gv_20260908001700012144_08f6b759, 3
                                columns read back over 9 rows sampled, signed
                                and still matching its signature

The database dimension in that same report reads the same way about the primary
Postgres, which is the check that the second store is being held to the rule
rather than to a softer one.

The before report in that run is also the negative control for the wiring: a
call site nothing reaches cannot produce two different answers from one
command.

The live test's budget went from twenty minutes to forty. It now takes two full
inventories as well as an environment, and on a laptop running several Docker
suites at once the twenty minute budget expired in the middle of a query that
had nothing to do with anything already proved, which reads as a broken twin
rather than as a slow machine. It is above the engine suite's own thirty minute
timeout on purpose: the suite's is the deadline that cannot be outrun, and this
one exists so that somebody waiting on a loaded machine gets a result.
