### PR TITLE
infra: point the image defaults at v1.3.5, which is a separate commit on purpose

### DIFF
--- a/deploy/helm/antifailure-control-plane/Chart.yaml
+++ b/deploy/helm/antifailure-control-plane/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # of chart 1.x, tools/inputcheck holds this chart to that, and 0.1.1 would now
 # be telling an operator the opposite of what is true.
 version: 1.3.4
-appVersion: "v1.3.4"
+appVersion: "v1.3.5"
 
 home: https://antifailure.dev
 sources:

--- a/infra/terraform/modules/control-plane/variables.tf
+++ b/infra/terraform/modules/control-plane/variables.tf
@@ -154,7 +154,7 @@ variable "image_repository" {
 }
 variable "image_tag" {
   type    = string
-  default = "v1.3.4"
+  default = "v1.3.5"
 }
 variable "image_digest" {
   type        = string

--- a/infra/terraform/stacks/control-plane/variables.tf
+++ b/infra/terraform/stacks/control-plane/variables.tf
@@ -89,7 +89,7 @@ variable "image_repository" {
 
 variable "image_tag" {
   type    = string
-  default = "v1.3.4"
+  default = "v1.3.5"
 }
 
 variable "image_digest" {


### PR DESCRIPTION
The three pins that name a container image move to v1.3.5:

    infra/terraform/stacks/control-plane/variables.tf    image_tag default
    infra/terraform/modules/control-plane/variables.tf   image_tag default
    deploy/helm/antifailure-control-plane/Chart.yaml     appVersion

**This could not have been in the tag's own commit and `tools/tagsync` refuses
it there.** The maintenance container app job reads the `image_tag` default with
no `ignore_changes`, so a default naming a tag that has not been built yet points
the next apply at an image that does not exist. Inside the release commit,
v1.3.5 was not yet a tag and there was no image behind it. It is a tag now, the
`Release` workflow published nine assets, `control-plane-image` is green, and
production is serving `v1.3.5` at `4106e1ed`, so the image these defaults name is
one that exists.

That is why `tagsync` treats the two kinds of pin differently, and it is worth
saying because the same version string in the same repository means opposite
things four lines apart. The four literals in the security verification page must
name the release BEING CUT, because they tell a reader which bundle to fetch and
verify. These three must name a tag that ALREADY EXISTS, because something will
apply them. Getting either backwards is a defect, and they cannot both be
satisfied by one commit.

    tagsync, after this change:
      ok  v1.3.5  the control plane stack's image_tag default
      ok  v1.3.5  the control plane module's image_tag default
      ok  v1.3.5  the chart's appVersion, which is what image.tag defaults to
      ok  v1.3.5  the tag the signature verification example checks
      ok  v1.3.5  the tag the rebuild example checks out
      ok  v1.3.5  the version the rebuild example passes to build.sh
      ok  v1.3.5  the archive the rebuild example hashes

Changelog-None: an infrastructure default following a tag that already shipped

Signed-off-by: Vir Sanghavi <67278851+VirSanghavi@users.noreply.github.com>