### PR TITLE
ee: the credential path was written once per store and needed by six lanes

### DIFF
--- a/.changes/three-clouds-signed-three-ways.md
+++ b/.changes/three-clouds-signed-three-ways.md
@@ -1,0 +1,26 @@
+# changed
+
+The credential path was written once per secret store and needed by six lanes.
+
+AWS Signature Version 4, the Google metadata server plus the service account
+JWT exchange, and the Microsoft Entra client credentials flow all lived inside
+`ee/engine/secrets`, next to the store that first needed them. None of them is
+about reading a secret. Every managed database provider and every runtime that
+reaches a cloud API proves who it is the same way, against a different
+endpoint, so the next six of those would each have grown their own copy of a
+signer where one wrong byte is a 403 that reads like a wrong password. Two
+signers that agree today are indistinguishable from one signer until a fix
+lands in only one of them.
+
+They now live in `ee/engine/cloudauth`, with the AWS credential chain, both
+Google token paths, both Entra token paths and the one bounded HTTP client they
+share. The secret sources call it and print exactly the messages they printed
+before, including which of the four places AWS credentials were looked for and
+which identity a refusal was refused for.
+
+Nothing else about the behaviour moved. The rejected and not-configured
+sentinels are the same values rather than two declarations with the same words,
+which is what keeps the one-refresh rule working across the boundary, and the
+Azure scope is still the vault resource with `/.default` after it, pinned in a
+test against the literal string rather than against the constant that derives
+it.

--- a/ee/engine/cloudauth/aws.go
+++ b/ee/engine/cloudauth/aws.go
@@ -1,0 +1,346 @@
+package cloudauth
+
+// AWS credentials and Signature Version 4.
+//
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+//
+// The credential chain is deliberately short: the environment, the ECS
+// credential endpoint, and EC2 instance metadata. Those are what a CI runner, a
+// task, and an instance actually have. What is missing is named rather than
+// silently absent, because "no credentials were found" without saying which
+// four places were looked in is the message this whole area exists to avoid. A
+// profile in ~/.aws/credentials is deliberately not read, and the refusal says
+// so, because a tool that quietly picked up whichever profile happened to be
+// exported would sign against an account nobody chose.
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// AWSCredentials are what a request is signed with.
+type AWSCredentials struct {
+	AccessKeyID     string
+	SecretAccessKey string
+	// SessionToken is present for temporary credentials, which is what an
+	// assumed role, an ECS task and an EC2 instance all have. Its absence is
+	// what distinguishes a long-lived user key.
+	SessionToken string
+	// Expires is when they stop working. Zero means they do not, which is only
+	// true of a long-lived user key.
+	Expires time.Time
+	// Source names where they came from, for the message that says why a
+	// request was refused.
+	Source string
+}
+
+// AWSChain finds credentials and holds on to them until they expire.
+//
+// One instance per caller rather than a package level cache, because two
+// sources may be configured for two accounts and a shared cache would hand the
+// second one the first one's keys.
+type AWSChain struct {
+	getenv func(string) string
+
+	mu    sync.Mutex
+	creds *AWSCredentials
+}
+
+// NewAWSChain builds a chain.
+//
+// getenv is injected so a test does not have to mutate the process environment,
+// and so that af explain can resolve against a different one. supplied may be
+// nil; when it is not, those credentials are used as they are and the chain is
+// never walked.
+func NewAWSChain(getenv func(string) string, supplied *AWSCredentials) *AWSChain {
+	return &AWSChain{getenv: getenv, creds: supplied}
+}
+
+// Credentials finds or renews the keys.
+func (c *AWSChain) Credentials(ctx context.Context) (AWSCredentials, error) {
+	c.mu.Lock()
+	current := c.creds
+	c.mu.Unlock()
+
+	// Renewed a minute early. Temporary credentials that expire between being
+	// read and being used produce a rejection that a refresh would have
+	// avoided, and a minute is longer than any request here takes.
+	if current != nil && (current.Expires.IsZero() || time.Now().Add(time.Minute).Before(current.Expires)) {
+		return *current, nil
+	}
+
+	found, err := c.discover(ctx)
+	if err != nil {
+		return AWSCredentials{}, err
+	}
+	c.mu.Lock()
+	c.creds = &found
+	c.mu.Unlock()
+	return found, nil
+}
+
+// Reset discards the credentials so the next lookup finds new ones.
+//
+// Which is the whole mechanism for every AWS credential that can be renewed: a
+// container endpoint and an instance role both hand out fresh temporary keys on
+// request. Long-lived keys from the environment come back identical, and the
+// second rejection is then correctly reported as a credential that is wrong
+// rather than one that expired.
+func (c *AWSChain) Reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.creds = nil
+}
+
+// discover walks the credential chain, in the order AWS's own tooling does.
+func (c *AWSChain) discover(ctx context.Context) (AWSCredentials, error) {
+	if id := c.getenv("AWS_ACCESS_KEY_ID"); id != "" {
+		secret := c.getenv("AWS_SECRET_ACCESS_KEY")
+		if secret == "" {
+			return AWSCredentials{}, Wrap(ErrNotConfigured,
+				"AWS_ACCESS_KEY_ID is set and AWS_SECRET_ACCESS_KEY is not")
+		}
+		return AWSCredentials{
+			AccessKeyID: id, SecretAccessKey: secret,
+			SessionToken: c.getenv("AWS_SESSION_TOKEN"),
+			Source:       "the environment",
+		}, nil
+	}
+
+	// An ECS task. The relative URI is set by the agent and the full URI form
+	// is what EKS Pod Identity uses.
+	if uri := c.getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"); uri != "" {
+		return c.fromEndpoint(ctx, "http://169.254.170.2"+uri,
+			c.getenv("AWS_CONTAINER_AUTHORIZATION_TOKEN"), "the ECS credential endpoint", 0)
+	}
+	if uri := c.getenv("AWS_CONTAINER_CREDENTIALS_FULL_URI"); uri != "" {
+		return c.fromEndpoint(ctx, uri,
+			c.getenv("AWS_CONTAINER_AUTHORIZATION_TOKEN"), "the container credential endpoint", 0)
+	}
+
+	if creds, err := c.fromInstanceMetadata(ctx); err == nil {
+		return creds, nil
+	}
+
+	// Named rather than silently absent. A message that says only "no
+	// credentials" leaves somebody guessing which of four mechanisms was meant
+	// to supply them, and the answer is usually that the one they configured is
+	// not one of these.
+	return AWSCredentials{}, Wrap(ErrNotConfigured,
+		"no AWS credentials were found: AWS_ACCESS_KEY_ID is unset, no container "+
+			"credential endpoint is configured, and instance metadata did not answer. "+
+			"A profile in ~/.aws/credentials and a web identity token file are not read "+
+			"by this source; export the keys, or use a role the runtime already provides")
+}
+
+// fromEndpoint reads credentials from the ECS or Pod Identity agent.
+func (c *AWSChain) fromEndpoint(ctx context.Context, url, token, source string, timeout time.Duration) (AWSCredentials, error) {
+	headers := map[string]string{"Accept": "application/json"}
+	if token != "" {
+		headers["Authorization"] = token
+	}
+	resp, err := Do(ctx, Request{Method: "GET", URL: url, Headers: headers, Timeout: timeout})
+	if err != nil {
+		return AWSCredentials{}, fmt.Errorf("%s could not be reached: %s", source, err)
+	}
+	if resp.Status != 200 {
+		return AWSCredentials{}, fmt.Errorf("%s answered %d", source, resp.Status)
+	}
+	var payload struct {
+		AccessKeyID     string `json:"AccessKeyId"`
+		SecretAccessKey string `json:"SecretAccessKey"`
+		Token           string `json:"Token"`
+		Expiration      string `json:"Expiration"`
+	}
+	if err := resp.Decode(&payload); err != nil {
+		return AWSCredentials{}, err
+	}
+	expires, _ := time.Parse(time.RFC3339, payload.Expiration)
+	return AWSCredentials{
+		AccessKeyID: payload.AccessKeyID, SecretAccessKey: payload.SecretAccessKey,
+		SessionToken: payload.Token, Expires: expires, Source: source,
+	}, nil
+}
+
+// fromInstanceMetadata reads an EC2 instance role, through IMDSv2.
+//
+// Version 2 only. Version 1 answers an unauthenticated GET, which is what makes
+// a server-side request forgery in an application on the instance into a
+// credential disclosure, and reading it here would mean this tool works on
+// instances configured the way nobody should configure them.
+func (c *AWSChain) fromInstanceMetadata(ctx context.Context) (AWSCredentials, error) {
+	const base = "http://169.254.169.254"
+	// A second, not the shared ten. This address is link-local: on an instance
+	// it answers in single-digit milliseconds, and on a laptop nothing answers
+	// and the connection hangs rather than being refused. At the shared timeout
+	// every af up on every machine that is not an EC2 instance would wait ten
+	// seconds here to learn something it could have learned in one.
+	const metadataTimeout = time.Second
+	tokenResp, err := Do(ctx, Request{
+		Method: "PUT", URL: base + "/latest/api/token",
+		Headers: map[string]string{"X-aws-ec2-metadata-token-ttl-seconds": "60"},
+		Timeout: metadataTimeout,
+	})
+	if err != nil || tokenResp.Status != 200 {
+		return AWSCredentials{}, fmt.Errorf("instance metadata did not answer")
+	}
+	imds := map[string]string{"X-aws-ec2-metadata-token": string(tokenResp.Body)}
+
+	roleResp, err := Do(ctx, Request{
+		Method: "GET", URL: base + "/latest/meta-data/iam/security-credentials/",
+		Headers: imds, Timeout: metadataTimeout,
+	})
+	if err != nil || roleResp.Status != 200 {
+		return AWSCredentials{}, fmt.Errorf("this instance has no role attached")
+	}
+	role := strings.TrimSpace(strings.Split(string(roleResp.Body), "\n")[0])
+	if role == "" {
+		return AWSCredentials{}, fmt.Errorf("this instance has no role attached")
+	}
+	return c.fromEndpoint(ctx,
+		base+"/latest/meta-data/iam/security-credentials/"+role, "",
+		"the EC2 instance role "+role, metadataTimeout)
+}
+
+// ---------------------------------------------------------------------------
+// Signature Version 4
+// ---------------------------------------------------------------------------
+
+// SigV4Request is one request to sign.
+type SigV4Request struct {
+	Method      string
+	URL         string
+	Body        []byte
+	Headers     map[string]string
+	Region      string
+	Service     string
+	Credentials AWSCredentials
+	Now         time.Time
+}
+
+// SignV4 returns the headers a request needs, including Authorization.
+//
+// Implemented rather than imported, and verified against the canonical example
+// AWS publishes for this purpose rather than against our own idea of it. The
+// algorithm is fixed, published, and has not changed since 2012; the SDK that
+// would supply it is a hundred packages inside the module that holds the
+// credentials.
+//
+// The parts that are easy to get wrong, and which the test pins: the signed
+// header list is sorted and lowercased and must match the canonical headers
+// exactly; the payload hash is of the body even when the body is empty; and the
+// session token is signed rather than merely sent, so a temporary credential
+// whose token is added after signing is refused.
+func SignV4(req SigV4Request) (map[string]string, error) {
+	host, path, query, err := splitURL(req.URL)
+	if err != nil {
+		return nil, err
+	}
+
+	stamp := req.Now.Format("20060102T150405Z")
+	day := req.Now.Format("20060102")
+
+	payloadHash := sha256Hex(req.Body)
+
+	signed := map[string]string{
+		"host":       host,
+		"x-amz-date": stamp,
+		// Signed rather than merely sent. It is optional for most services and
+		// required by S3, and signing it always means one code path and one
+		// thing to be right about, which is also what lets this be verified
+		// against the canonical example AWS publishes, since that example is an
+		// S3 request.
+		"x-amz-content-sha256": payloadHash,
+	}
+	for k, v := range req.Headers {
+		signed[strings.ToLower(k)] = v
+	}
+	if req.Credentials.SessionToken != "" {
+		// Inside the signature, not merely alongside it. AWS includes this
+		// header in the canonical request, so adding it afterwards produces a
+		// signature over a different request and a refusal that reads as a
+		// wrong secret key.
+		signed["x-amz-security-token"] = req.Credentials.SessionToken
+	}
+
+	names := make([]string, 0, len(signed))
+	for k := range signed {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+
+	var canonicalHeaders strings.Builder
+	for _, k := range names {
+		canonicalHeaders.WriteString(k)
+		canonicalHeaders.WriteByte(':')
+		// Values are trimmed and internal runs of spaces collapsed, which is
+		// part of the specification and not tidying.
+		canonicalHeaders.WriteString(strings.Join(strings.Fields(signed[k]), " "))
+		canonicalHeaders.WriteByte('\n')
+	}
+	signedHeaders := strings.Join(names, ";")
+
+	canonical := strings.Join([]string{
+		req.Method, path, query, canonicalHeaders.String(), signedHeaders, payloadHash,
+	}, "\n")
+
+	scope := strings.Join([]string{day, req.Region, req.Service, "aws4_request"}, "/")
+	toSign := strings.Join([]string{
+		"AWS4-HMAC-SHA256", stamp, scope, sha256Hex([]byte(canonical)),
+	}, "\n")
+
+	key := hmacSHA256([]byte("AWS4"+req.Credentials.SecretAccessKey), day)
+	key = hmacSHA256(key, req.Region)
+	key = hmacSHA256(key, req.Service)
+	key = hmacSHA256(key, "aws4_request")
+	signature := hex.EncodeToString(hmacSHA256(key, toSign))
+
+	out := map[string]string{}
+	for k, v := range req.Headers {
+		out[k] = v
+	}
+	out["X-Amz-Date"] = stamp
+	out["X-Amz-Content-Sha256"] = payloadHash
+	if req.Credentials.SessionToken != "" {
+		out["X-Amz-Security-Token"] = req.Credentials.SessionToken
+	}
+	out["Authorization"] = fmt.Sprintf(
+		"AWS4-HMAC-SHA256 Credential=%s/%s, SignedHeaders=%s, Signature=%s",
+		req.Credentials.AccessKeyID, scope, signedHeaders, signature)
+	return out, nil
+}
+
+// splitURL returns the host, the canonical path, and the canonical query.
+func splitURL(raw string) (host, path, query string, err error) {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return "", "", "", err
+	}
+	path = parsed.EscapedPath()
+	if path == "" {
+		// An empty path canonicalises to "/", and signing "" produces a
+		// signature the service does not agree with.
+		path = "/"
+	}
+	// Query parameters are sorted by name, and Encode does that.
+	return parsed.Host, path, parsed.Query().Encode(), nil
+}
+
+func sha256Hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+func hmacSHA256(key []byte, data string) []byte {
+	h := hmac.New(sha256.New, key)
+	h.Write([]byte(data))
+	return h.Sum(nil)
+}

--- a/ee/engine/cloudauth/aws_test.go
+++ b/ee/engine/cloudauth/aws_test.go
@@ -1,0 +1,223 @@
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+
+package cloudauth
+
+// The signing, against the example AWS publishes.
+//
+// This is the part of the AWS credential path that is worth proving without an
+// AWS account, and it is also the part most likely to be wrong: a signature is
+// either exactly right or it is a 403 that reads like a bad secret key. AWS
+// publishes a worked example with the inputs, the intermediate strings and the
+// final signature, precisely so an implementation can be checked against
+// something other than itself. Checking against our own idea of the algorithm
+// would prove only that the code agrees with the code.
+//
+// It matters more here than it did in ee/engine/secrets, where this used to
+// live. One store signed with it there. Every managed database provider and
+// every runtime that reaches an AWS API signs with it now, so a regression
+// would be one commit breaking all of them at once, in a way that reads to each
+// of them as somebody else's credentials being wrong.
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The credentials in this file are AWS's own published example values. They are
+// documented as examples, they authenticate nothing, and they are the only
+// values that produce the published signature, so the vector cannot be checked
+// without them.
+const (
+	exampleKeyID  = "AKIA" + "IOSFODNN7EXAMPLE"
+	exampleSecret = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+)
+
+func TestSigV4MatchesTheCanonicalExample(t *testing.T) {
+	// AWS General Reference, Signature Version 4 signing examples: a GET of an
+	// S3 object with a Range header, on 24 May 2013.
+	signed, err := SignV4(SigV4Request{
+		Method: "GET",
+		URL:    "https://examplebucket.s3.amazonaws.com/test.txt",
+		Body:   nil,
+		Headers: map[string]string{
+			"Range": "bytes=0-9",
+		},
+		Region:  "us-east-1",
+		Service: "s3",
+		Credentials: AWSCredentials{
+			AccessKeyID: exampleKeyID, SecretAccessKey: exampleSecret,
+		},
+		Now: time.Date(2013, 5, 24, 0, 0, 0, 0, time.UTC),
+	})
+	require.NoError(t, err)
+
+	authorization := signed["Authorization"]
+	require.Contains(t, authorization,
+		"Credential="+exampleKeyID+"/20130524/us-east-1/s3/aws4_request")
+	require.Contains(t, authorization,
+		"SignedHeaders=host;range;x-amz-content-sha256;x-amz-date")
+	require.Contains(t, authorization,
+		"Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41",
+		"the signature does not match the published example, so every real request would be refused")
+
+	// The empty body hashes to the published value, which is the constant every
+	// AWS example carries and the easiest thing to get wrong by hashing nothing
+	// rather than hashing the empty string.
+	require.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		signed["X-Amz-Content-Sha256"])
+	require.Equal(t, "20130524T000000Z", signed["X-Amz-Date"])
+}
+
+func TestSigV4SignsTheSessionTokenRatherThanOnlySendingIt(t *testing.T) {
+	// A temporary credential whose token is attached after signing produces a
+	// signature over a different request, and the refusal that comes back reads
+	// like a wrong secret key rather than like a signing mistake. Every
+	// credential the chain finds except a long-lived user key is temporary, so
+	// this is the common case and not the exotic one.
+	with, err := SignV4(SigV4Request{
+		Method: "POST", URL: "https://secretsmanager.eu-west-1.amazonaws.com/",
+		Body: []byte(`{"SecretId":"x"}`), Region: "eu-west-1", Service: "secretsmanager",
+		Credentials: AWSCredentials{
+			AccessKeyID: exampleKeyID, SecretAccessKey: exampleSecret,
+			SessionToken: "a-temporary-token",
+		},
+		Now: time.Date(2026, 8, 27, 0, 0, 0, 0, time.UTC),
+	})
+	require.NoError(t, err)
+	require.Contains(t, with["Authorization"], "x-amz-security-token",
+		"the session token is not in the signed header list")
+	require.Equal(t, "a-temporary-token", with["X-Amz-Security-Token"])
+
+	// And the signature actually differs, rather than the header merely being
+	// listed. Listing a header and not hashing it is the same bug wearing a
+	// disguise.
+	without, err := SignV4(SigV4Request{
+		Method: "POST", URL: "https://secretsmanager.eu-west-1.amazonaws.com/",
+		Body: []byte(`{"SecretId":"x"}`), Region: "eu-west-1", Service: "secretsmanager",
+		Credentials: AWSCredentials{AccessKeyID: exampleKeyID, SecretAccessKey: exampleSecret},
+		Now:         time.Date(2026, 8, 27, 0, 0, 0, 0, time.UTC),
+	})
+	require.NoError(t, err)
+	require.NotEqual(t, signatureOf(t, with), signatureOf(t, without))
+}
+
+func TestSigV4SignsTheBody(t *testing.T) {
+	// Two requests differing only in their body must sign differently, or the
+	// signature is not protecting the thing being asked for.
+	one := mustSign(t, []byte(`{"SecretId":"one"}`))
+	two := mustSign(t, []byte(`{"SecretId":"two"}`))
+	require.NotEqual(t, signatureOf(t, one), signatureOf(t, two))
+}
+
+func TestSigV4CanonicalisesAnEmptyPath(t *testing.T) {
+	// An endpoint written without a trailing slash has an empty path, and an
+	// empty path canonicalises to "/". Signing "" produces a signature the
+	// service does not agree with, and the endpoint is written both ways in the
+	// wild.
+	withSlash, err := SignV4(SigV4Request{
+		Method: "POST", URL: "https://secretsmanager.eu-west-1.amazonaws.com/",
+		Body: []byte(`{}`), Region: "eu-west-1", Service: "secretsmanager",
+		Credentials: AWSCredentials{AccessKeyID: exampleKeyID, SecretAccessKey: exampleSecret},
+		Now:         time.Date(2026, 8, 27, 0, 0, 0, 0, time.UTC),
+	})
+	require.NoError(t, err)
+	without, err := SignV4(SigV4Request{
+		Method: "POST", URL: "https://secretsmanager.eu-west-1.amazonaws.com",
+		Body: []byte(`{}`), Region: "eu-west-1", Service: "secretsmanager",
+		Credentials: AWSCredentials{AccessKeyID: exampleKeyID, SecretAccessKey: exampleSecret},
+		Now:         time.Date(2026, 8, 27, 0, 0, 0, 0, time.UTC),
+	})
+	require.NoError(t, err)
+	require.Equal(t, signatureOf(t, withSlash), signatureOf(t, without))
+}
+
+func mustSign(t *testing.T, body []byte) map[string]string {
+	t.Helper()
+	signed, err := SignV4(SigV4Request{
+		Method: "POST", URL: "https://secretsmanager.eu-west-1.amazonaws.com/",
+		Body: body, Region: "eu-west-1", Service: "secretsmanager",
+		Credentials: AWSCredentials{AccessKeyID: exampleKeyID, SecretAccessKey: exampleSecret},
+		Now:         time.Date(2026, 8, 27, 0, 0, 0, 0, time.UTC),
+	})
+	require.NoError(t, err)
+	return signed
+}
+
+func signatureOf(t *testing.T, headers map[string]string) string {
+	t.Helper()
+	_, after, found := strings.Cut(headers["Authorization"], "Signature=")
+	require.True(t, found, "no signature in %q", headers["Authorization"])
+	return after
+}
+
+// ---------------------------------------------------------------------------
+
+func TestAWSChainNamesEveryPlaceItLookedForCredentials(t *testing.T) {
+	// The message somebody reads when nothing answered. "No credentials" on its
+	// own leaves them guessing which of four mechanisms was supposed to supply
+	// them, and the answer is usually that the one they configured, a profile
+	// or a web identity token file, is not one this chain reads.
+	//
+	// An environment with nothing in it and no metadata service to reach, which
+	// is what a laptop looks like.
+	chain := NewAWSChain(func(string) string { return "" }, nil)
+	_, err := chain.Credentials(t.Context())
+	require.ErrorIs(t, err, ErrNotConfigured)
+	require.Contains(t, err.Error(), "AWS_ACCESS_KEY_ID")
+	require.Contains(t, err.Error(), "~/.aws/credentials")
+}
+
+func TestAWSChainHoldsSuppliedCredentialsWithoutWalkingTheChain(t *testing.T) {
+	// Supplied credentials are used as they are. Walking the chain anyway would
+	// mean an explicit key in a manifest silently losing to whatever the
+	// environment happened to export.
+	supplied := &AWSCredentials{
+		AccessKeyID: exampleKeyID, SecretAccessKey: exampleSecret, Source: "the manifest",
+	}
+	chain := NewAWSChain(func(string) string {
+		t.Fatal("the environment was read even though credentials were supplied")
+		return ""
+	}, supplied)
+	got, err := chain.Credentials(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "the manifest", got.Source)
+}
+
+func TestAWSChainReadsTheEnvironmentBeforeAnyEndpoint(t *testing.T) {
+	// Order matters and it is AWS's own: an exported key wins over a container
+	// endpoint, so somebody debugging against another account by exporting keys
+	// is not silently signed as the task's role.
+	chain := NewAWSChain(func(name string) string {
+		switch name {
+		case "AWS_ACCESS_KEY_ID":
+			return exampleKeyID
+		case "AWS_SECRET_ACCESS_KEY":
+			return exampleSecret
+		case "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI":
+			return "/v2/credentials/should-not-be-read"
+		}
+		return ""
+	}, nil)
+	got, err := chain.Credentials(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "the environment", got.Source)
+	require.Equal(t, exampleKeyID, got.AccessKeyID)
+}
+
+func TestAWSChainNamesAHalfSuppliedEnvironmentRatherThanIgnoringIt(t *testing.T) {
+	// A key id with no secret is a mistake somebody made, not an absence. Left
+	// to fall through it would look identical to having configured nothing.
+	chain := NewAWSChain(func(name string) string {
+		if name == "AWS_ACCESS_KEY_ID" {
+			return exampleKeyID
+		}
+		return ""
+	}, nil)
+	_, err := chain.Credentials(t.Context())
+	require.ErrorIs(t, err, ErrNotConfigured)
+	require.Contains(t, err.Error(), "AWS_SECRET_ACCESS_KEY")
+	require.NotContains(t, err.Error(), exampleKeyID, "a message must not quote a key id")
+}

--- a/ee/engine/cloudauth/azure.go
+++ b/ee/engine/cloudauth/azure.go
@@ -1,0 +1,217 @@
+package cloudauth
+
+// Microsoft Entra tokens, two ways.
+//
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+//
+// A service principal, which is a tenant, a client id and a client secret
+// exchanged for a bearer token, and is what a CI runner outside Azure has. Or
+// the managed identity the host provides, read from the same link-local address
+// every Azure VM and container app carries, which needs no secret at all.
+//
+// The authority is a field rather than a constant, and that is not a
+// generalisation for its own sake. Azure Government obtains tokens from
+// login.microsoftonline.us and the China cloud from
+// login.partner.microsoftonline.cn, and data residency is one of the reasons a
+// customer asks for any of this, so a host compiled in would refuse exactly the
+// customers the feature exists for.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// AzureKeyVaultResource is the resource a Key Vault token is minted for.
+const AzureKeyVaultResource = "https://vault.azure.net"
+
+// PublicAzureAuthority is where a token comes from in the public cloud.
+const PublicAzureAuthority = "https://login.microsoftonline.com"
+
+// AzureTokenSource hands out a bearer token and holds it until it expires.
+type AzureTokenSource struct {
+	// TenantID, ClientID and ClientSecret authenticate a service principal.
+	// Leave ClientSecret empty to use the managed identity the host provides,
+	// in which case ClientID still names which of several identities to use.
+	TenantID     string
+	ClientID     string
+	ClientSecret string
+	// Authority is where a token is obtained. Empty means the public cloud.
+	Authority string
+	// Resource is what the token is for, as https://vault.azure.net. The v2
+	// scope a service principal asks for is this with "/.default" appended,
+	// which is how Entra names the same thing on its two endpoints, so there is
+	// one field rather than two that have to agree.
+	Resource string
+
+	mu      sync.Mutex
+	token   string
+	expires time.Time
+	// how names where the token came from, for the refusal message.
+	how string
+}
+
+// authority is the token host, defaulted here as well as by a caller so that a
+// source built directly in a test is not pointed at nothing.
+func (s *AzureTokenSource) authority() string {
+	if s.Authority == "" {
+		return PublicAzureAuthority
+	}
+	return strings.TrimRight(s.Authority, "/")
+}
+
+func (s *AzureTokenSource) resource() string {
+	if s.Resource == "" {
+		return AzureKeyVaultResource
+	}
+	return strings.TrimRight(s.Resource, "/")
+}
+
+// How names where the current token came from, for a refusal message.
+func (s *AzureTokenSource) How() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.how
+}
+
+// Reset discards the token so the next call acquires a new one.
+func (s *AzureTokenSource) Reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.token, s.expires = "", time.Time{}
+}
+
+// Token returns a bearer token, acquiring one when the held token is missing or
+// nearly expired.
+func (s *AzureTokenSource) Token(ctx context.Context) (string, error) {
+	s.mu.Lock()
+	token, expires := s.token, s.expires
+	s.mu.Unlock()
+	// A minute early, so a token that expires between being read and being used
+	// does not produce a rejection a renewal would have avoided.
+	if token != "" && time.Now().Add(time.Minute).Before(expires) {
+		return token, nil
+	}
+
+	got, lifetime, how, err := s.acquire(ctx)
+	if err != nil {
+		return "", err
+	}
+	s.mu.Lock()
+	s.token, s.expires, s.how = got, time.Now().Add(lifetime), how
+	s.mu.Unlock()
+	return got, nil
+}
+
+func (s *AzureTokenSource) acquire(ctx context.Context) (token string, lifetime time.Duration, how string, err error) {
+	if s.ClientSecret != "" {
+		return s.fromServicePrincipal(ctx)
+	}
+	return s.fromManagedIdentity(ctx)
+}
+
+func (s *AzureTokenSource) fromServicePrincipal(ctx context.Context) (string, time.Duration, string, error) {
+	form := url.Values{
+		"grant_type":    {"client_credentials"},
+		"client_id":     {s.ClientID},
+		"client_secret": {s.ClientSecret},
+		"scope":         {s.resource() + "/.default"},
+	}
+	resp, err := Do(ctx, Request{
+		Method: "POST",
+		URL:    s.authority() + "/" + s.TenantID + "/oauth2/v2.0/token",
+		Body:   []byte(form.Encode()),
+		Headers: map[string]string{
+			"Content-Type": "application/x-www-form-urlencoded",
+			"Accept":       "application/json",
+		},
+	})
+	if err != nil {
+		return "", 0, "", fmt.Errorf("Microsoft Entra could not be reached: %s", err)
+	}
+	if resp.Status != 200 {
+		// A wrong client secret and a wrong tenant both land here, and Entra's
+		// own error code is the part that tells them apart, so it is passed
+		// through. The description is not: it embeds the request and can run to
+		// several lines.
+		return "", 0, "", Wrap(ErrRejected,
+			"Microsoft Entra refused the service principal with %d %s",
+			resp.Status, AzureErrorCode(resp.Body))
+	}
+	var payload struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int    `json:"expires_in"`
+	}
+	if err := resp.Decode(&payload); err != nil {
+		return "", 0, "", err
+	}
+	if payload.AccessToken == "" {
+		return "", 0, "", fmt.Errorf("Microsoft Entra answered 200 and returned no token")
+	}
+	return payload.AccessToken, time.Duration(payload.ExpiresIn) * time.Second,
+		"the service principal " + s.ClientID, nil
+}
+
+func (s *AzureTokenSource) fromManagedIdentity(ctx context.Context) (string, time.Duration, string, error) {
+	query := map[string]string{"api-version": "2018-02-01", "resource": s.resource()}
+	if s.ClientID != "" {
+		// A user-assigned identity has to be named, because a host may carry
+		// several and the service will not guess between them.
+		query["client_id"] = s.ClientID
+	}
+	resp, err := Do(ctx, Request{
+		Method: "GET", URL: "http://169.254.169.254/metadata/identity/oauth2/token",
+		Query: query, Headers: map[string]string{"Metadata": "true"},
+		// The same second the AWS instance metadata gets, for the same reason:
+		// this is a link-local address that answers immediately on a host that
+		// has one and hangs on a laptop that does not.
+		Timeout: time.Second,
+	})
+	if err != nil {
+		return "", 0, "", Wrap(ErrNotConfigured,
+			"no Azure credentials: AZURE_CLIENT_SECRET is unset and no managed identity "+
+				"answered on this host. Set AZURE_TENANT_ID, AZURE_CLIENT_ID and "+
+				"AZURE_CLIENT_SECRET, or run somewhere with an identity assigned")
+	}
+	if resp.Status != 200 {
+		return "", 0, "", fmt.Errorf(
+			"the managed identity endpoint answered %d; this host may have no identity assigned",
+			resp.Status)
+	}
+	var payload struct {
+		AccessToken string `json:"access_token"`
+		// Returned as a string of seconds by this endpoint, unlike Entra's,
+		// which returns a number. Two shapes for one field on two endpoints of
+		// one product, so it is decoded as text and converted.
+		ExpiresIn string `json:"expires_in"`
+	}
+	if err := resp.Decode(&payload); err != nil {
+		return "", 0, "", err
+	}
+	seconds, _ := strconv.Atoi(payload.ExpiresIn)
+	if seconds <= 0 {
+		seconds = 3600
+	}
+	return payload.AccessToken, time.Duration(seconds) * time.Second, "this host's managed identity", nil
+}
+
+// AzureErrorCode reads the code out of an Azure error document.
+//
+// The code and never the message. Azure's message embeds the request, and the
+// request names the secret and the vault.
+func AzureErrorCode(body []byte) string {
+	var payload struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if json.Unmarshal(body, &payload) != nil || payload.Error.Code == "" {
+		return "with no error code"
+	}
+	return payload.Error.Code
+}

--- a/ee/engine/cloudauth/azure_test.go
+++ b/ee/engine/cloudauth/azure_test.go
@@ -63,7 +63,13 @@ func TestAzureDefaultsTheResourceToKeyVault(t *testing.T) {
 	}
 	_, err := source.Token(t.Context())
 	require.NoError(t, err)
-	require.Equal(t, AzureKeyVaultResource+"/.default", gotScope)
+	// The literal, not AzureKeyVaultResource+"/.default", which would compare
+	// the derivation against itself. This exact string was a constant in
+	// ee/engine/secrets before the credential path moved, and the extraction is
+	// only behaviour preserving if it still comes out byte for byte.
+	require.Equal(t, "https://vault.azure.net/.default", gotScope)
+	require.Equal(t, "https://vault.azure.net", AzureKeyVaultResource)
+	require.Equal(t, "https://login.microsoftonline.com", PublicAzureAuthority)
 }
 
 func TestAzureReportsARefusalAsARejectedCredential(t *testing.T) {

--- a/ee/engine/cloudauth/azure_test.go
+++ b/ee/engine/cloudauth/azure_test.go
@@ -1,0 +1,116 @@
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+
+package cloudauth
+
+// The Entra exchange, against a local server speaking the documented form.
+//
+// This proves what the code sends and what it does with each answer. It does
+// not prove that Entra accepts the request, and nothing without a tenant can.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAzureAsksTheAuthorityItIsGivenForTheResourceScope(t *testing.T) {
+	// Two things at once and both have burned somebody. The authority, because
+	// Azure Government and the China cloud mint tokens on different hosts and a
+	// compiled in host refuses exactly the customers who ask for this. And the
+	// scope, because Entra's v2 endpoint wants the resource with "/.default"
+	// appended, and a resource sent bare comes back as an error about the
+	// scope rather than about the resource.
+	var gotPath, gotScope, gotGrant string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		gotPath, gotScope, gotGrant = r.URL.Path, r.Form.Get("scope"), r.Form.Get("grant_type")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"a-token","expires_in":3600}`))
+	}))
+	t.Cleanup(server.Close)
+
+	source := &AzureTokenSource{
+		TenantID: "a-tenant", ClientID: "a-client",
+		ClientSecret: "assembled-at-run-time",
+		Authority:    server.URL,
+		Resource:     "https://ossrdbms-aad.database.windows.net",
+	}
+	token, err := source.Token(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "a-token", token)
+	require.Equal(t, "/a-tenant/oauth2/v2.0/token", gotPath)
+	require.Equal(t, "https://ossrdbms-aad.database.windows.net/.default", gotScope)
+	require.Equal(t, "client_credentials", gotGrant)
+	require.Equal(t, "the service principal a-client", source.How())
+}
+
+func TestAzureDefaultsTheResourceToKeyVault(t *testing.T) {
+	// The one caller today is the Key Vault source, and a zero Resource that
+	// silently signed for nothing would produce a token the vault refuses.
+	var gotScope string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		gotScope = r.Form.Get("scope")
+		_, _ = w.Write([]byte(`{"access_token":"a-token","expires_in":3600}`))
+	}))
+	t.Cleanup(server.Close)
+
+	source := &AzureTokenSource{
+		TenantID: "t", ClientID: "c", ClientSecret: "assembled-at-run-time",
+		Authority: server.URL,
+	}
+	_, err := source.Token(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, AzureKeyVaultResource+"/.default", gotScope)
+}
+
+func TestAzureReportsARefusalAsARejectedCredential(t *testing.T) {
+	// The distinction the one-refresh rule is built on. A refused client secret
+	// reported as an unreachable host sends somebody to the network for a
+	// credential problem, and it never gets its one renewal.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"code":"invalid_client","message":"..."}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	source := &AzureTokenSource{
+		TenantID: "t", ClientID: "c", ClientSecret: "assembled-at-run-time",
+		Authority: server.URL,
+	}
+	_, err := source.Token(t.Context())
+	require.ErrorIs(t, err, ErrRejected)
+	require.Contains(t, err.Error(), "invalid_client")
+	require.NotContains(t, err.Error(), "assembled-at-run-time",
+		"a refusal must not quote the secret it was refused for")
+}
+
+func TestAzureHoldsTheTokenRatherThanMintingOnePerCall(t *testing.T) {
+	// A token minted per lookup turns twenty variables into twenty exchanges,
+	// which Entra rate limits, and it is the mistake the expiry field exists to
+	// prevent.
+	exchanges := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		exchanges++
+		_, _ = w.Write([]byte(`{"access_token":"a-token","expires_in":3600}`))
+	}))
+	t.Cleanup(server.Close)
+
+	source := &AzureTokenSource{
+		TenantID: "t", ClientID: "c", ClientSecret: "assembled-at-run-time",
+		Authority: server.URL,
+	}
+	for range 3 {
+		_, err := source.Token(t.Context())
+		require.NoError(t, err)
+	}
+	require.Equal(t, 1, exchanges)
+
+	// And Reset actually discards it, which is what the one refresh spends.
+	source.Reset()
+	_, err := source.Token(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, 2, exchanges)
+}

--- a/ee/engine/cloudauth/cloudauth.go
+++ b/ee/engine/cloudauth/cloudauth.go
@@ -1,0 +1,59 @@
+// Package cloudauth holds the three ways this product proves who it is to a
+// cloud, with no vendor SDK anywhere in the credential path.
+//
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+//
+// It was extracted from ee/engine/secrets, where AWS Signature Version 4, the
+// Google metadata and service account exchange, and the Microsoft Entra client
+// credentials flow were written once each for the three secret stores. Nothing
+// about any of them is specific to reading a secret. A managed Postgres
+// provider signs the same way, a runtime that pulls an image signs the same
+// way, and every one of those lanes would otherwise write a fourth, a fifth and
+// a sixth copy of a signing algorithm where a single wrong byte is a 403 that
+// reads like a wrong password.
+//
+// The reason there is no SDK here is the same reason there was none there.
+// Reading a secret, or minting a database token, is one signed request to one
+// endpoint. The SDK that would do it brings roughly a hundred packages into a
+// module whose whole purpose is holding credentials, and every one of them is
+// code with access to them. Signature Version 4 is about a hundred lines of a
+// documented algorithm that has not changed since 2012, and it is verified here
+// against the worked example AWS publishes rather than against our own idea of
+// it. The equivalent for Google and for Azure is an OAuth exchange over forms.
+//
+// Everything in this package is standard library only, and there is a test that
+// fails if that stops being true.
+package cloudauth
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrRejected reports that the far end refused the credential rather than
+// refusing the request.
+//
+// The distinction is what drives the one refresh rule in ee/engine/secrets: a
+// 404 is a miss, a 500 is a service having a bad day, and a 401 is the one case
+// where trying again with the same credential is pointless and trying again
+// with a new one might work.
+//
+// The wording is load bearing and is not to be tidied. ee/engine/secrets
+// re-exports this exact value so that errors.Is keeps working across the
+// package boundary, and it trims this sentence off the front of the detail it
+// renders as AF-SEC-002, by matching the text.
+var ErrRejected = errors.New("the store rejected the credential")
+
+// ErrNotConfigured reports a credential source that was asked for and never
+// given what it needs.
+//
+// Carried separately so that a caller can say "no key was found in any of the
+// four places" rather than reporting a connection failure to an empty host.
+var ErrNotConfigured = errors.New("not configured")
+
+// Wrap is the shape every credential path uses to report a refusal, so the
+// distinction between a rejected credential and an unreachable service is made
+// in one place rather than once per cloud.
+func Wrap(kind error, format string, args ...any) error {
+	return fmt.Errorf("%w: %s", kind, fmt.Sprintf(format, args...))
+}

--- a/ee/engine/cloudauth/gcp.go
+++ b/ee/engine/cloudauth/gcp.go
@@ -1,0 +1,275 @@
+package cloudauth
+
+// Google access tokens, two ways.
+//
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+//
+// Two ways, matching where this actually runs. The metadata server, which is
+// what a Cloud Run service, a GKE workload and a Compute Engine instance all
+// have and which needs no key material at all. And a service account key,
+// signed here into a JWT assertion and exchanged, which is what a CI runner
+// outside Google has. The second is a key on disk and is worth avoiding where
+// the first is available; the message says which one was used when a request is
+// refused, so that nobody has to guess.
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net/url"
+	"sync"
+	"time"
+)
+
+// ScopeGoogleCloudPlatform is the scope an assertion asks for.
+//
+// The broad one, because the permission that decides what may be read is the
+// IAM role on the service account rather than the scope, and a narrower scope
+// here would only add a second place to get it wrong.
+const ScopeGoogleCloudPlatform = "https://www.googleapis.com/auth/cloud-platform"
+
+// GCPServiceAccount is a parsed service account key.
+type GCPServiceAccount struct {
+	Type        string `json:"type"`
+	ProjectID   string `json:"project_id"`
+	PrivateKey  string `json:"private_key"`
+	ClientEmail string `json:"client_email"`
+	TokenURI    string `json:"token_uri"`
+
+	key *rsa.PrivateKey
+}
+
+// ParseGCPServiceAccount reads a service account key document.
+func ParseGCPServiceAccount(raw []byte) (*GCPServiceAccount, error) {
+	var account GCPServiceAccount
+	if err := json.Unmarshal(raw, &account); err != nil {
+		return nil, fmt.Errorf("it is not JSON")
+	}
+	if account.Type != "service_account" {
+		return nil, fmt.Errorf("it is a %q key and only a service_account key is read here", account.Type)
+	}
+	if account.ClientEmail == "" || account.PrivateKey == "" {
+		return nil, fmt.Errorf("it has no client_email or no private_key")
+	}
+	if account.TokenURI == "" {
+		account.TokenURI = "https://oauth2.googleapis.com/token"
+	}
+
+	block, _ := pem.Decode([]byte(account.PrivateKey))
+	if block == nil {
+		return nil, fmt.Errorf("its private_key is not PEM")
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("its private_key is not a PKCS#8 key")
+	}
+	key, ok := parsed.(*rsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("its private_key is not RSA")
+	}
+	account.key = key
+	// The PEM is dropped now that the key is parsed, so the plaintext of a
+	// private key is not held in a struct for the life of the process.
+	account.PrivateKey = ""
+	return &account, nil
+}
+
+// SignAssertion builds the JWT a service account exchanges for a token.
+//
+// RS256 over a fixed header and a claim set with a one hour life. The audience
+// is the token endpoint itself, which is what stops an assertion minted for one
+// service being replayed against another.
+func (a *GCPServiceAccount) SignAssertion(now time.Time, scope string) (string, error) {
+	if scope == "" {
+		scope = ScopeGoogleCloudPlatform
+	}
+	header := base64url([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	claims, err := json.Marshal(map[string]any{
+		"iss":   a.ClientEmail,
+		"scope": scope,
+		"aud":   a.TokenURI,
+		"iat":   now.Unix(),
+		"exp":   now.Add(time.Hour).Unix(),
+	})
+	if err != nil {
+		return "", err
+	}
+	signing := header + "." + base64url(claims)
+	digest := sha256.Sum256([]byte(signing))
+	signature, err := rsa.SignPKCS1v15(rand.Reader, a.key, crypto.SHA256, digest[:])
+	if err != nil {
+		return "", err
+	}
+	return signing + "." + base64url(signature), nil
+}
+
+// GCPTokenSource hands out an access token and holds it until it expires.
+type GCPTokenSource struct {
+	// account is the parsed service account key, nil when the metadata server
+	// is used.
+	account *GCPServiceAccount
+	scope   string
+
+	mu      sync.Mutex
+	token   string
+	expires time.Time
+	how     string
+}
+
+// NewGCPTokenSource builds a token source. A nil account takes the metadata
+// server path, which is the better one wherever it exists.
+func NewGCPTokenSource(account *GCPServiceAccount, scope string) *GCPTokenSource {
+	if scope == "" {
+		scope = ScopeGoogleCloudPlatform
+	}
+	return &GCPTokenSource{account: account, scope: scope}
+}
+
+// Account returns the parsed key, or nil when the metadata server is used.
+func (s *GCPTokenSource) Account() *GCPServiceAccount { return s.account }
+
+// How names where the current token came from, for a refusal message.
+func (s *GCPTokenSource) How() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.how
+}
+
+// Reset discards the token so the next call acquires a new one.
+func (s *GCPTokenSource) Reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.token, s.expires = "", time.Time{}
+}
+
+// Token returns an access token, acquiring one when the held token is missing
+// or nearly expired.
+func (s *GCPTokenSource) Token(ctx context.Context) (string, error) {
+	s.mu.Lock()
+	token, expires := s.token, s.expires
+	s.mu.Unlock()
+	// A minute early, so a token that expires between being read and being used
+	// does not produce a rejection a renewal would have avoided.
+	if token != "" && time.Now().Add(time.Minute).Before(expires) {
+		return token, nil
+	}
+
+	var (
+		got      string
+		lifetime time.Duration
+		how      string
+		err      error
+	)
+	if s.account != nil {
+		got, lifetime, how, err = s.fromServiceAccount(ctx)
+	} else {
+		got, lifetime, how, err = s.fromMetadataServer(ctx)
+	}
+	if err != nil {
+		return "", err
+	}
+
+	s.mu.Lock()
+	s.token, s.expires, s.how = got, time.Now().Add(lifetime), how
+	s.mu.Unlock()
+	return got, nil
+}
+
+// fromServiceAccount signs a JWT and exchanges it for an access token.
+func (s *GCPTokenSource) fromServiceAccount(ctx context.Context) (string, time.Duration, string, error) {
+	assertion, err := s.account.SignAssertion(time.Now(), s.scope)
+	if err != nil {
+		return "", 0, "", err
+	}
+	form := url.Values{
+		"grant_type": {"urn:ietf:params:oauth:grant-type:jwt-bearer"},
+		"assertion":  {assertion},
+	}
+	resp, err := Do(ctx, Request{
+		Method: "POST", URL: s.account.TokenURI, Body: []byte(form.Encode()),
+		Headers: map[string]string{
+			"Content-Type": "application/x-www-form-urlencoded",
+			"Accept":       "application/json",
+		},
+	})
+	if err != nil {
+		return "", 0, "", fmt.Errorf("Google's token endpoint could not be reached: %s", err)
+	}
+	if resp.Status != 200 {
+		return "", 0, "", Wrap(ErrRejected,
+			"Google refused the service account assertion with %d %s",
+			resp.Status, GCPErrorStatus(resp.Body))
+	}
+	var payload struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int    `json:"expires_in"`
+	}
+	if err := resp.Decode(&payload); err != nil {
+		return "", 0, "", err
+	}
+	if payload.AccessToken == "" {
+		return "", 0, "", fmt.Errorf("Google answered 200 and returned no token")
+	}
+	return payload.AccessToken, time.Duration(payload.ExpiresIn) * time.Second,
+		"the service account " + s.account.ClientEmail, nil
+}
+
+// fromMetadataServer reads the token the platform already holds.
+func (s *GCPTokenSource) fromMetadataServer(ctx context.Context) (string, time.Duration, string, error) {
+	resp, err := Do(ctx, Request{
+		Method: "GET",
+		URL:    "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token",
+		// Required, and its absence is the whole anti-forgery mechanism: the
+		// metadata server refuses any request without it, so a browser or a
+		// naive server-side fetch cannot reach it.
+		Headers: map[string]string{"Metadata-Flavor": "Google"},
+		// A second, like the other two link-local metadata services. Off
+		// Google this name does not resolve, and waiting the shared ten seconds
+		// to learn that would be ten seconds on every af up.
+		Timeout: time.Second,
+	})
+	if err != nil {
+		return "", 0, "", Wrap(ErrNotConfigured,
+			"no Google credentials: GOOGLE_APPLICATION_CREDENTIALS is unset and the "+
+				"metadata server did not answer, so this is not running on Google Cloud. "+
+				"Point GOOGLE_APPLICATION_CREDENTIALS at a service account key, or run "+
+				"somewhere with a service account attached")
+	}
+	if resp.Status != 200 {
+		return "", 0, "", fmt.Errorf("the metadata server answered %d", resp.Status)
+	}
+	var payload struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int    `json:"expires_in"`
+	}
+	if err := resp.Decode(&payload); err != nil {
+		return "", 0, "", err
+	}
+	return payload.AccessToken, time.Duration(payload.ExpiresIn) * time.Second,
+		"this host's attached service account", nil
+}
+
+func base64url(b []byte) string { return base64.RawURLEncoding.EncodeToString(b) }
+
+// GCPErrorStatus reads the status out of a Google error document.
+//
+// The status and never the message. Google's message quotes the resource name,
+// and the resource name is the secret.
+func GCPErrorStatus(body []byte) string {
+	var payload struct {
+		Error struct {
+			Status string `json:"status"`
+		} `json:"error"`
+	}
+	if json.Unmarshal(body, &payload) != nil || payload.Error.Status == "" {
+		return "with no status"
+	}
+	return payload.Error.Status
+}

--- a/ee/engine/cloudauth/gcp_test.go
+++ b/ee/engine/cloudauth/gcp_test.go
@@ -1,0 +1,125 @@
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+
+package cloudauth
+
+// The Google assertion, signed with a real key and verified with its public
+// half, so RS256, the base64url encoding of each segment and the exact bytes
+// that are signed are proved rather than assumed. A signature Google refuses
+// looks identical to a wrong service account from the outside.
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGCPAssertionCarriesTheScopeItIsAskedFor(t *testing.T) {
+	// The scope is a parameter because a database provider asks for a different
+	// one from a secret store. A signer that ignored it and signed the constant
+	// would produce an assertion Google accepts and a token that cannot reach
+	// the thing the caller asked about, which is a permission error somebody
+	// would look for in IAM.
+	key, keyJSON := serviceAccountKey(t)
+	account, err := ParseGCPServiceAccount(keyJSON)
+	require.NoError(t, err)
+
+	const scope = "https://www.googleapis.com/auth/sqlservice.admin"
+	assertion, err := account.SignAssertion(time.Now(), scope)
+	require.NoError(t, err)
+
+	parts := strings.Split(assertion, ".")
+	require.Len(t, parts, 3, "a JWT is three segments")
+
+	signature, err := base64.RawURLEncoding.DecodeString(parts[2])
+	require.NoError(t, err)
+	digest := sha256.Sum256([]byte(parts[0] + "." + parts[1]))
+	require.NoError(t,
+		rsa.VerifyPKCS1v15(&key.PublicKey, crypto.SHA256, digest[:], signature),
+		"the assertion does not verify against its own key, so Google would refuse it")
+
+	var claims struct {
+		Iss   string `json:"iss"`
+		Aud   string `json:"aud"`
+		Scope string `json:"scope"`
+		Exp   int64  `json:"exp"`
+		Iat   int64  `json:"iat"`
+	}
+	requireSegment(t, parts[1], &claims)
+	require.Equal(t, scope, claims.Scope)
+	require.Equal(t, "af-test@example.iam.gserviceaccount.com", claims.Iss)
+	// The audience is the token endpoint, which is what stops an assertion
+	// minted for one service being replayed against another.
+	require.Equal(t, "https://oauth2.googleapis.com/token", claims.Aud)
+	require.Equal(t, int64(3600), claims.Exp-claims.Iat)
+}
+
+func TestGCPAssertionFallsBackToTheCloudPlatformScope(t *testing.T) {
+	// An empty scope is the common case and must not sign an empty claim, which
+	// Google refuses with a message about the assertion rather than about the
+	// scope.
+	_, keyJSON := serviceAccountKey(t)
+	account, err := ParseGCPServiceAccount(keyJSON)
+	require.NoError(t, err)
+
+	assertion, err := account.SignAssertion(time.Now(), "")
+	require.NoError(t, err)
+	var claims struct {
+		Scope string `json:"scope"`
+	}
+	requireSegment(t, strings.Split(assertion, ".")[1], &claims)
+	require.Equal(t, ScopeGoogleCloudPlatform, claims.Scope)
+}
+
+func TestGCPDropsThePrivateKeyPEMOnceItIsParsed(t *testing.T) {
+	// The plaintext of a private key should not sit in a struct for the life of
+	// the process when the parsed form is what is used.
+	_, keyJSON := serviceAccountKey(t)
+	account, err := ParseGCPServiceAccount(keyJSON)
+	require.NoError(t, err)
+	require.Empty(t, account.PrivateKey)
+}
+
+// serviceAccountKey builds a real key at run time.
+//
+// Generated rather than written into the repository. A private key in a test
+// fixture is a private key in a repository, and the rule about that has no
+// exception for keys that guard nothing: a scanner cannot tell, and a person
+// skimming a diff cannot either.
+func serviceAccountKey(t *testing.T) (*rsa.PrivateKey, []byte) {
+	t.Helper()
+	// 2048 rather than 4096, because this is generated on every run and the
+	// difference is a second of test time for no additional proof.
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	encoded := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+
+	document, err := json.Marshal(map[string]string{
+		"type":         "service_account",
+		"project_id":   "af-test",
+		"client_email": "af-test@example.iam.gserviceaccount.com",
+		"private_key":  string(encoded),
+		"token_uri":    "https://oauth2.googleapis.com/token",
+	})
+	require.NoError(t, err)
+	return key, document
+}
+
+func requireSegment(t *testing.T, segment string, into any) {
+	t.Helper()
+	raw, err := base64.RawURLEncoding.DecodeString(segment)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(raw, into))
+}

--- a/ee/engine/cloudauth/gcp_test.go
+++ b/ee/engine/cloudauth/gcp_test.go
@@ -77,7 +77,12 @@ func TestGCPAssertionFallsBackToTheCloudPlatformScope(t *testing.T) {
 		Scope string `json:"scope"`
 	}
 	requireSegment(t, strings.Split(assertion, ".")[1], &claims)
-	require.Equal(t, ScopeGoogleCloudPlatform, claims.Scope)
+	// The literal, for the same reason the Azure scope is pinned to one: this
+	// string was a constant in ee/engine/secrets before the credential path
+	// moved, and comparing the default against the constant that defines it
+	// would prove nothing about whether the value changed.
+	require.Equal(t, "https://www.googleapis.com/auth/cloud-platform", claims.Scope)
+	require.Equal(t, "https://www.googleapis.com/auth/cloud-platform", ScopeGoogleCloudPlatform)
 }
 
 func TestGCPDropsThePrivateKeyPEMOnceItIsParsed(t *testing.T) {

--- a/ee/engine/cloudauth/http.go
+++ b/ee/engine/cloudauth/http.go
@@ -1,24 +1,24 @@
-package secrets
+package cloudauth
 
-// One HTTP client for four stores, so that the parts every adapter gets wrong
-// are got right once.
+// One HTTP client for every cloud call, so that the parts every adapter gets
+// wrong are got right once.
 //
 // Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
 //
 // Three of those parts are worth naming.
 //
 // A timeout that is on the request rather than only on the client, because a
-// store that accepts a connection and then never answers is the failure mode
+// service that accepts a connection and then never answers is the failure mode
 // that hangs an af up for ever, and a client timeout does not cover a body that
 // arrives one byte at a time.
 //
-// A bounded read of the response, because these are secret stores and a
-// response is a JSON document with one value in it. An unbounded ReadAll is how
-// a misconfigured address pointed at something that streams turns a lookup into
-// an out of memory kill.
+// A bounded read of the response, because these are credential and secret
+// endpoints and a response is a JSON document with one value in it. An
+// unbounded ReadAll is how a misconfigured address pointed at something that
+// streams turns a lookup into an out of memory kill.
 //
 // A body that never reaches an error message. Every one of these responses can
-// contain the secret, so the errors here carry the status and the store's own
+// contain the secret, so the errors here carry the status and the service's own
 // error field and never the document. That is the same rule the dotenv parser
 // follows when it refuses to quote a line it could not parse.
 
@@ -36,9 +36,9 @@ import (
 // httpTimeout bounds a single request.
 //
 // Ten seconds, because this is on the path of af up and a developer waiting for
-// an environment should be told a store is unreachable rather than watching a
-// spinner. A store that needs longer than ten seconds to return one secret is a
-// store that is already failing.
+// an environment should be told a service is unreachable rather than watching a
+// spinner. A service that needs longer than ten seconds to return one secret is
+// a service that is already failing.
 const httpTimeout = 10 * time.Second
 
 // maxBody bounds the response.
@@ -55,16 +55,16 @@ const maxBody = 1 << 20
 // that fired first would produce a less specific error.
 var client = &http.Client{Timeout: 30 * time.Second}
 
-// request is one call to a store.
-type request struct {
-	method  string
-	url     string
-	headers map[string]string
-	// body is sent as-is when set. Nil means no body.
-	body []byte
-	// query is appended when set.
-	query map[string]string
-	// timeout overrides httpTimeout for one call.
+// Request is one call to a cloud endpoint.
+type Request struct {
+	Method  string
+	URL     string
+	Headers map[string]string
+	// Body is sent as-is when set. Nil means no body.
+	Body []byte
+	// Query is appended when set.
+	Query map[string]string
+	// Timeout overrides httpTimeout for one call.
 	//
 	// It exists for one case and it is worth its weight: the EC2 instance
 	// metadata address is a link-local address that nothing answers on a
@@ -72,23 +72,23 @@ type request struct {
 	// timeout that is ten seconds added to every af up on every machine that is
 	// not an EC2 instance, to discover something that a machine either is or is
 	// not within a few milliseconds.
-	timeout time.Duration
+	Timeout time.Duration
 }
 
-// response is what came back, with the body already bounded.
-type response struct {
-	status int
-	body   []byte
+// Response is what came back, with the body already bounded.
+type Response struct {
+	Status int
+	Body   []byte
 }
 
-// do makes the call.
+// Do makes the call.
 //
-// It returns an error only for a failure to complete the exchange. A store that
-// answers with 403 is a successful exchange carrying a refusal, and the caller
-// decides what a status means, because "404" means "no such secret" to one
-// store and "no such vault" to another.
-func do(ctx context.Context, req request) (*response, error) {
-	timeout := req.timeout
+// It returns an error only for a failure to complete the exchange. A service
+// that answers with 403 is a successful exchange carrying a refusal, and the
+// caller decides what a status means, because "404" means "no such secret" to
+// one service and "no such vault" to another.
+func Do(ctx context.Context, req Request) (*Response, error) {
+	timeout := req.Timeout
 	if timeout <= 0 {
 		timeout = httpTimeout
 	}
@@ -96,28 +96,29 @@ func do(ctx context.Context, req request) (*response, error) {
 	defer cancel()
 
 	var body io.Reader
-	if req.body != nil {
-		body = bytes.NewReader(req.body)
+	if req.Body != nil {
+		body = bytes.NewReader(req.Body)
 	}
-	httpReq, err := http.NewRequestWithContext(ctx, req.method, req.url, body)
+	httpReq, err := http.NewRequestWithContext(ctx, req.Method, req.URL, body)
 	if err != nil {
 		return nil, err
 	}
-	if len(req.query) > 0 {
+	if len(req.Query) > 0 {
 		q := httpReq.URL.Query()
-		for k, v := range req.query {
+		for k, v := range req.Query {
 			q.Set(k, v)
 		}
 		httpReq.URL.RawQuery = q.Encode()
 	}
-	for k, v := range req.headers {
+	for k, v := range req.Headers {
 		httpReq.Header.Set(k, v)
 	}
 
 	resp, err := client.Do(httpReq)
 	if err != nil {
 		// The URL is in this error and the URL can carry a token in a query
-		// string for some stores, so it is stripped rather than passed through.
+		// string for some services, so it is stripped rather than passed
+		// through.
 		return nil, fmt.Errorf("%s", scrubURL(err.Error()))
 	}
 	defer func() {
@@ -131,37 +132,37 @@ func do(ctx context.Context, req request) (*response, error) {
 	if err != nil {
 		return nil, fmt.Errorf("reading the response failed after %d bytes", len(read))
 	}
-	return &response{status: resp.StatusCode, body: read}, nil
+	return &Response{Status: resp.StatusCode, Body: read}, nil
 }
 
-// decode reads a JSON response into v.
+// Decode reads a JSON response into v.
 //
-// The error deliberately does not quote the document. A store returns the
+// The error deliberately does not quote the document. A service returns the
 // secret in the same shape it returns an error, so a decode failure that
 // printed what it was given would print the secret exactly when something is
 // already going wrong.
-func (r *response) decode(v any) error {
-	if err := json.Unmarshal(r.body, v); err != nil {
+func (r *Response) Decode(v any) error {
+	if err := json.Unmarshal(r.Body, v); err != nil {
 		return fmt.Errorf("the store answered %d with %d bytes that are not the JSON expected",
-			r.status, len(r.body))
+			r.Status, len(r.Body))
 	}
 	return nil
 }
 
-// rejected reports whether a status means the credential was refused rather
+// Rejected reports whether a status means the credential was refused rather
 // than the request.
 //
 // 401 and 403 only. A 400 is a request this code built wrongly and retrying
 // with a fresh token changes nothing, and a 429 is a rate limit that a refresh
 // would make worse.
-func (r *response) rejected() bool {
-	return r.status == http.StatusUnauthorized || r.status == http.StatusForbidden
+func (r *Response) Rejected() bool {
+	return r.Status == http.StatusUnauthorized || r.Status == http.StatusForbidden
 }
 
 // scrubURL removes a query string from a message.
 //
-// Some stores take a token as a query parameter, and a transport error quotes
-// the URL it failed on. Rather than deciding per store which parameters are
+// Some services take a token as a query parameter, and a transport error quotes
+// the URL it failed on. Rather than deciding per service which parameters are
 // safe, everything after the question mark goes.
 func scrubURL(s string) string {
 	var out strings.Builder

--- a/ee/engine/cloudauth/surface_test.go
+++ b/ee/engine/cloudauth/surface_test.go
@@ -1,0 +1,159 @@
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+
+package cloudauth
+
+// The lane's number, measured rather than asserted: three clouds, one auth
+// implementation, no vendor SDK in the credential path.
+//
+// Two of those three are claims about the whole enterprise module rather than
+// about this package, which is why they are checked by reading the tree instead
+// of by reading this file. A package can say "no SDK" in a comment for years
+// after somebody added one, and "one implementation" stops being true the first
+// time a lane copies a signer rather than importing it. Both of those are how
+// this repository has been wrong before, so both get an instrument that fails.
+//
+// What this cannot see: a transitive dependency that pulls an SDK in without a
+// direct import, and a second implementation written without any of the three
+// protocol strings below. The first is covered by the module graph having no
+// SDK in it at all, which the go.mod half checks. The second is not covered and
+// is named here rather than pretended away.
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTheCredentialPathCarriesNoVendorSDK(t *testing.T) {
+	// Every import this package makes, read off the source rather than off a
+	// list somebody maintains. A standard library path has no dot in its first
+	// segment, because a module path begins with a domain and a standard
+	// library path does not.
+	entries, err := os.ReadDir(".")
+	require.NoError(t, err)
+
+	fset := token.NewFileSet()
+	files, imports := 0, 0
+	var foreign []string
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		files++
+		parsed, parseErr := parser.ParseFile(fset, name, nil, parser.ImportsOnly)
+		// A file that cannot be parsed is not a file with no imports, and
+		// counting it as one is how a check reports clean because it could not
+		// look.
+		require.NoError(t, parseErr, "%s could not be parsed, so its imports were not read", name)
+		for _, spec := range parsed.Imports {
+			path := strings.Trim(spec.Path.Value, `"`)
+			imports++
+			if strings.Contains(strings.Split(path, "/")[0], ".") {
+				foreign = append(foreign, name+" imports "+path)
+			}
+		}
+	}
+
+	require.NotZero(t, files, "no source files were read, so nothing was checked")
+	require.Empty(t, foreign, "the credential path must be standard library only")
+	t.Logf("credential path: %d files, %d imports, %d outside the standard library",
+		files, imports, len(foreign))
+}
+
+func TestTheEnterpriseModuleDeclaresNoCloudSDK(t *testing.T) {
+	// The module graph, not just this package. An SDK reached through another
+	// package is still an SDK in the module that holds the credentials.
+	raw, err := os.ReadFile(filepath.Join("..", "go.mod"))
+	require.NoError(t, err)
+
+	sdks := []string{
+		"github.com/aws/aws-sdk-go",
+		"cloud.google.com/go",
+		"google.golang.org/api",
+		"github.com/Azure/azure-sdk-for-go",
+		"github.com/AzureAD/microsoft-authentication-library-for-go",
+	}
+	var found []string
+	for _, sdk := range sdks {
+		if strings.Contains(string(raw), sdk) {
+			found = append(found, sdk)
+		}
+	}
+	require.Empty(t, found, "a cloud SDK entered the module that holds the credentials")
+	t.Logf("ee/engine go.mod: 0 of %d cloud SDKs present", len(sdks))
+}
+
+// theThreeProtocols are the strings only an implementation of each cloud's
+// authentication can contain. One per cloud, and each is the part that cannot
+// be written any other way.
+var theThreeProtocols = map[string]string{
+	"AWS Signature Version 4":    "AWS4-HMAC-SHA256",
+	"Google JWT bearer exchange": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+	"Entra client credentials":   "client_credentials",
+}
+
+func TestThreeCloudsAreSignedByOneImplementation(t *testing.T) {
+	// Here, and nowhere else in the enterprise module. The day a database
+	// provider copies the signer instead of importing it, this fails and names
+	// the file, which is the only moment anybody would notice: two signers that
+	// agree today look exactly like one signer, right up until a fix lands in
+	// one of them.
+	for cloud, marker := range theThreeProtocols {
+		require.True(t, markerIsInThisPackage(t, marker),
+			"%s: the protocol string is not in cloudauth, so this check is watching nothing", cloud)
+	}
+
+	elsewhere := map[string][]string{}
+	err := filepath.Walk("..", func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			if info.Name() == "cloudauth" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		raw, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		for cloud, marker := range theThreeProtocols {
+			if strings.Contains(string(raw), marker) {
+				elsewhere[cloud] = append(elsewhere[cloud], path)
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	require.Empty(t, elsewhere, "a second implementation of a cloud's authentication exists")
+	t.Logf("%d clouds, 1 auth implementation, 0 copies elsewhere in ee/engine",
+		len(theThreeProtocols))
+}
+
+func markerIsInThisPackage(t *testing.T, marker string) bool {
+	t.Helper()
+	entries, err := os.ReadDir(".")
+	require.NoError(t, err)
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") ||
+			strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+		raw, readErr := os.ReadFile(entry.Name())
+		require.NoError(t, readErr)
+		if strings.Contains(string(raw), marker) {
+			return true
+		}
+	}
+	return false
+}

--- a/ee/engine/secrets/aws.go
+++ b/ee/engine/secrets/aws.go
@@ -4,34 +4,33 @@ package secrets
 //
 // Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
 //
-// Without the AWS SDK, which is the largest single decision in this file and
-// the one most likely to be questioned. Reading a secret is one signed POST to
-// one endpoint. The SDK that does that for you brings roughly a hundred
+// Without the AWS SDK, which is the largest single decision behind this file
+// and the one most likely to be questioned. Reading a secret is one signed POST
+// to one endpoint. The SDK that does that for you brings roughly a hundred
 // packages into a module whose whole purpose is holding credentials, and every
 // one of them is code with access to them. Signature Version 4 is a documented
-// algorithm of about a hundred lines, it is verified here against the canonical
+// algorithm of about a hundred lines, it is verified against the canonical
 // example AWS publishes for exactly this purpose, and it does not change.
 //
-// The credential chain is deliberately short: the environment, the ECS
-// credential endpoint, and EC2 instance metadata. Those are what a CI runner, a
-// task, and an instance actually have. What is missing is named rather than
-// silently absent, because "no credentials were found" without saying which
-// four places were looked in is the message this whole package exists to avoid.
+// The signing and the credential chain now live in ee/engine/cloudauth,
+// because a managed Postgres provider and a runtime that pulls an image sign
+// the same way and must not each grow their own copy. What is left here is the
+// one API call this store makes and what it does with each answer. The chain
+// itself is unchanged and is still deliberately short: the environment, the ECS
+// credential endpoint, and EC2 instance metadata, with what is missing named
+// rather than silently absent.
 
 import (
 	"context"
-	"crypto/hmac"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 	"os"
-	"sort"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/antifailure/antifailure/ee/engine/cloudauth"
 )
 
 // AWSConfig is what a Secrets Manager source needs.
@@ -59,27 +58,18 @@ type AWSConfig struct {
 }
 
 // AWSCredentials are what a request is signed with.
-type AWSCredentials struct {
-	AccessKeyID     string
-	SecretAccessKey string
-	// SessionToken is present for temporary credentials, which is what an
-	// assumed role, an ECS task and an EC2 instance all have. Its absence is
-	// what distinguishes a long-lived user key.
-	SessionToken string
-	// Expires is when they stop working. Zero means they do not, which is only
-	// true of a long-lived user key.
-	Expires time.Time
-	// Source names where they came from, for the message that says why a
-	// request was refused.
-	Source string
-}
+//
+// An alias rather than a second declaration, so that a caller which built one
+// of these before the credential path moved to ee/engine/cloudauth still names
+// the same type and there is no conversion to forget.
+type AWSCredentials = cloudauth.AWSCredentials
 
 // AWSBackend reads from Secrets Manager.
 type AWSBackend struct {
-	cfg AWSConfig
+	cfg   AWSConfig
+	chain *cloudauth.AWSChain
 
 	mu     sync.Mutex
-	creds  *AWSCredentials
 	cached map[string]string
 	loaded bool
 }
@@ -100,7 +90,15 @@ func NewAWSSecretsManager(cfg AWSConfig) (*Source, error) {
 			"AWS Secrets Manager needs a region (AWS_REGION); a secret is regional "+
 				"and one in eu-west-1 does not exist in us-east-1")
 	}
-	return New(&AWSBackend{cfg: cfg, creds: cfg.Credentials}), nil
+	return New(newAWSBackend(cfg)), nil
+}
+
+// newAWSBackend wires the config to a credential chain.
+func newAWSBackend(cfg AWSConfig) *AWSBackend {
+	if cfg.Getenv == nil {
+		cfg.Getenv = os.Getenv
+	}
+	return &AWSBackend{cfg: cfg, chain: cloudauth.NewAWSChain(cfg.Getenv, cfg.Credentials)}
 }
 
 func (a *AWSBackend) Describe() string {
@@ -125,141 +123,8 @@ func (a *AWSBackend) Describe() string {
 // is that no credentials could be found at all, and it says which places were
 // looked in.
 func (a *AWSBackend) Reach(ctx context.Context) error {
-	_, err := a.credentials(ctx)
+	_, err := a.chain.Credentials(ctx)
 	return err
-}
-
-// credentials finds or renews the keys.
-func (a *AWSBackend) credentials(ctx context.Context) (AWSCredentials, error) {
-	a.mu.Lock()
-	current := a.creds
-	a.mu.Unlock()
-
-	// Renewed a minute early. Temporary credentials that expire between being
-	// read and being used produce a rejection that a refresh would have
-	// avoided, and a minute is longer than any request here takes.
-	if current != nil && (current.Expires.IsZero() || time.Now().Add(time.Minute).Before(current.Expires)) {
-		return *current, nil
-	}
-
-	found, err := a.discover(ctx)
-	if err != nil {
-		return AWSCredentials{}, err
-	}
-	a.mu.Lock()
-	a.creds = &found
-	a.mu.Unlock()
-	return found, nil
-}
-
-// discover walks the credential chain, in the order AWS's own tooling does.
-func (a *AWSBackend) discover(ctx context.Context) (AWSCredentials, error) {
-	if id := a.cfg.Getenv("AWS_ACCESS_KEY_ID"); id != "" {
-		secret := a.cfg.Getenv("AWS_SECRET_ACCESS_KEY")
-		if secret == "" {
-			return AWSCredentials{}, wrap(ErrNotConfigured,
-				"AWS_ACCESS_KEY_ID is set and AWS_SECRET_ACCESS_KEY is not")
-		}
-		return AWSCredentials{
-			AccessKeyID: id, SecretAccessKey: secret,
-			SessionToken: a.cfg.Getenv("AWS_SESSION_TOKEN"),
-			Source:       "the environment",
-		}, nil
-	}
-
-	// An ECS task. The relative URI is set by the agent and the full URI form
-	// is what EKS Pod Identity uses.
-	if uri := a.cfg.Getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"); uri != "" {
-		return a.fromEndpoint(ctx, "http://169.254.170.2"+uri,
-			a.cfg.Getenv("AWS_CONTAINER_AUTHORIZATION_TOKEN"), "the ECS credential endpoint", 0)
-	}
-	if uri := a.cfg.Getenv("AWS_CONTAINER_CREDENTIALS_FULL_URI"); uri != "" {
-		return a.fromEndpoint(ctx, uri,
-			a.cfg.Getenv("AWS_CONTAINER_AUTHORIZATION_TOKEN"), "the container credential endpoint", 0)
-	}
-
-	if creds, err := a.fromInstanceMetadata(ctx); err == nil {
-		return creds, nil
-	}
-
-	// Named rather than silently absent. A message that says only "no
-	// credentials" leaves somebody guessing which of four mechanisms was meant
-	// to supply them, and the answer is usually that the one they configured is
-	// not one of these.
-	return AWSCredentials{}, wrap(ErrNotConfigured,
-		"no AWS credentials were found: AWS_ACCESS_KEY_ID is unset, no container "+
-			"credential endpoint is configured, and instance metadata did not answer. "+
-			"A profile in ~/.aws/credentials and a web identity token file are not read "+
-			"by this source; export the keys, or use a role the runtime already provides")
-}
-
-// fromEndpoint reads credentials from the ECS or Pod Identity agent.
-func (a *AWSBackend) fromEndpoint(ctx context.Context, url, token, source string, timeout time.Duration) (AWSCredentials, error) {
-	headers := map[string]string{"Accept": "application/json"}
-	if token != "" {
-		headers["Authorization"] = token
-	}
-	resp, err := do(ctx, request{method: "GET", url: url, headers: headers, timeout: timeout})
-	if err != nil {
-		return AWSCredentials{}, fmt.Errorf("%s could not be reached: %s", source, err)
-	}
-	if resp.status != 200 {
-		return AWSCredentials{}, fmt.Errorf("%s answered %d", source, resp.status)
-	}
-	var payload struct {
-		AccessKeyID     string `json:"AccessKeyId"`
-		SecretAccessKey string `json:"SecretAccessKey"`
-		Token           string `json:"Token"`
-		Expiration      string `json:"Expiration"`
-	}
-	if err := resp.decode(&payload); err != nil {
-		return AWSCredentials{}, err
-	}
-	expires, _ := time.Parse(time.RFC3339, payload.Expiration)
-	return AWSCredentials{
-		AccessKeyID: payload.AccessKeyID, SecretAccessKey: payload.SecretAccessKey,
-		SessionToken: payload.Token, Expires: expires, Source: source,
-	}, nil
-}
-
-// fromInstanceMetadata reads an EC2 instance role, through IMDSv2.
-//
-// Version 2 only. Version 1 answers an unauthenticated GET, which is what makes
-// a server-side request forgery in an application on the instance into a
-// credential disclosure, and reading it here would mean this tool works on
-// instances configured the way nobody should configure them.
-func (a *AWSBackend) fromInstanceMetadata(ctx context.Context) (AWSCredentials, error) {
-	const base = "http://169.254.169.254"
-	// A second, not the shared ten. This address is link-local: on an instance
-	// it answers in single-digit milliseconds, and on a laptop nothing answers
-	// and the connection hangs rather than being refused. At the shared timeout
-	// every af up on every machine that is not an EC2 instance would wait ten
-	// seconds here to learn something it could have learned in one.
-	const metadataTimeout = time.Second
-	tokenResp, err := do(ctx, request{
-		method: "PUT", url: base + "/latest/api/token",
-		headers: map[string]string{"X-aws-ec2-metadata-token-ttl-seconds": "60"},
-		timeout: metadataTimeout,
-	})
-	if err != nil || tokenResp.status != 200 {
-		return AWSCredentials{}, fmt.Errorf("instance metadata did not answer")
-	}
-	imds := map[string]string{"X-aws-ec2-metadata-token": string(tokenResp.body)}
-
-	roleResp, err := do(ctx, request{
-		method: "GET", url: base + "/latest/meta-data/iam/security-credentials/",
-		headers: imds, timeout: metadataTimeout,
-	})
-	if err != nil || roleResp.status != 200 {
-		return AWSCredentials{}, fmt.Errorf("this instance has no role attached")
-	}
-	role := strings.TrimSpace(strings.Split(string(roleResp.body), "\n")[0])
-	if role == "" {
-		return AWSCredentials{}, fmt.Errorf("this instance has no role attached")
-	}
-	return a.fromEndpoint(ctx,
-		base+"/latest/meta-data/iam/security-credentials/"+role, "",
-		"the EC2 instance role "+role, metadataTimeout)
 }
 
 // Refresh discards the credentials so the next lookup finds new ones.
@@ -275,7 +140,7 @@ func (a *AWSBackend) Refresh(context.Context) error {
 	if a.cfg.Credentials != nil {
 		return fmt.Errorf("these credentials were supplied directly and cannot be renewed")
 	}
-	a.creds = nil
+	a.chain.Reset()
 	a.cached, a.loaded = nil, false
 	return nil
 }
@@ -316,7 +181,7 @@ func (a *AWSBackend) Fetch(ctx context.Context, name string) (string, bool, erro
 
 // getSecret makes the one API call this adapter needs.
 func (a *AWSBackend) getSecret(ctx context.Context, id string) (string, bool, error) {
-	creds, err := a.credentials(ctx)
+	creds, err := a.chain.Credentials(ctx)
 	if err != nil {
 		return "", false, err
 	}
@@ -334,44 +199,45 @@ func (a *AWSBackend) getSecret(ctx context.Context, id string) (string, bool, er
 		"Content-Type": "application/x-amz-json-1.1",
 		"X-Amz-Target": "secretsmanager.GetSecretValue",
 	}
-	signed, err := signV4(sigV4Request{
-		method: "POST", url: endpoint, body: body, headers: headers,
-		region: a.cfg.Region, service: "secretsmanager",
-		credentials: creds, now: time.Now().UTC(),
+	signed, err := cloudauth.SignV4(cloudauth.SigV4Request{
+		Method: "POST", URL: endpoint, Body: body, Headers: headers,
+		Region: a.cfg.Region, Service: "secretsmanager",
+		Credentials: creds, Now: time.Now().UTC(),
 	})
 	if err != nil {
 		return "", false, err
 	}
 
-	resp, err := do(ctx, request{method: "POST", url: endpoint, body: body, headers: signed})
+	resp, err := cloudauth.Do(ctx, cloudauth.Request{
+		Method: "POST", URL: endpoint, Body: body, Headers: signed})
 	if err != nil {
 		return "", false, fmt.Errorf("cannot be reached: %s", err)
 	}
 
 	switch {
-	case resp.status == 200:
-	case resp.status == http.StatusBadRequest && awsErrorType(resp.body) == "ResourceNotFoundException":
+	case resp.Status == 200:
+	case resp.Status == http.StatusBadRequest && awsErrorType(resp.Body) == "ResourceNotFoundException":
 		// A secret that is not there is a miss, so the chain falls through.
 		// Secrets Manager reports it as a 400 with a type rather than a 404,
 		// which is why the type has to be read: treating every 400 as a miss
 		// would swallow a malformed request and treating it as a failure would
 		// make every variable this store does not hold fatal.
 		return "", false, nil
-	case resp.rejected(),
-		awsErrorType(resp.body) == "AccessDeniedException",
-		awsErrorType(resp.body) == "ExpiredTokenException",
-		awsErrorType(resp.body) == "UnrecognizedClientException":
+	case resp.Rejected(),
+		awsErrorType(resp.Body) == "AccessDeniedException",
+		awsErrorType(resp.Body) == "ExpiredTokenException",
+		awsErrorType(resp.Body) == "UnrecognizedClientException":
 		return "", false, wrap(ErrRejected, "AWS answered %d %s, using credentials from %s",
-			resp.status, awsErrorType(resp.body), creds.Source)
+			resp.Status, awsErrorType(resp.Body), creds.Source)
 	default:
-		return "", false, fmt.Errorf("AWS answered %d %s", resp.status, awsErrorType(resp.body))
+		return "", false, fmt.Errorf("AWS answered %d %s", resp.Status, awsErrorType(resp.Body))
 	}
 
 	var payload struct {
 		SecretString string `json:"SecretString"`
 		SecretBinary string `json:"SecretBinary"`
 	}
-	if err := resp.decode(&payload); err != nil {
+	if err := resp.Decode(&payload); err != nil {
 		return "", false, err
 	}
 	if payload.SecretString == "" && payload.SecretBinary != "" {
@@ -398,138 +264,4 @@ func awsErrorType(body []byte) string {
 		return payload.Type[i+1:]
 	}
 	return payload.Type
-}
-
-// ---------------------------------------------------------------------------
-// Signature Version 4
-// ---------------------------------------------------------------------------
-
-type sigV4Request struct {
-	method      string
-	url         string
-	body        []byte
-	headers     map[string]string
-	region      string
-	service     string
-	credentials AWSCredentials
-	now         time.Time
-}
-
-// signV4 returns the headers a request needs, including Authorization.
-//
-// Implemented rather than imported, and verified against the canonical example
-// AWS publishes for this purpose rather than against our own idea of it. The
-// algorithm is fixed, published, and has not changed since 2012; the SDK that
-// would supply it is a hundred packages inside the module that holds the
-// credentials.
-//
-// The parts that are easy to get wrong, and which the test pins: the signed
-// header list is sorted and lowercased and must match the canonical headers
-// exactly; the payload hash is of the body even when the body is empty; and the
-// session token is signed rather than merely sent, so a temporary credential
-// whose token is added after signing is refused.
-func signV4(req sigV4Request) (map[string]string, error) {
-	host, path, query, err := splitURL(req.url)
-	if err != nil {
-		return nil, err
-	}
-
-	stamp := req.now.Format("20060102T150405Z")
-	day := req.now.Format("20060102")
-
-	payloadHash := sha256Hex(req.body)
-
-	signed := map[string]string{
-		"host":       host,
-		"x-amz-date": stamp,
-		// Signed rather than merely sent. It is optional for most services and
-		// required by S3, and signing it always means one code path and one
-		// thing to be right about, which is also what lets this be verified
-		// against the canonical example AWS publishes, since that example is an
-		// S3 request.
-		"x-amz-content-sha256": payloadHash,
-	}
-	for k, v := range req.headers {
-		signed[strings.ToLower(k)] = v
-	}
-	if req.credentials.SessionToken != "" {
-		// Inside the signature, not merely alongside it. AWS includes this
-		// header in the canonical request, so adding it afterwards produces a
-		// signature over a different request and a refusal that reads as a
-		// wrong secret key.
-		signed["x-amz-security-token"] = req.credentials.SessionToken
-	}
-
-	names := make([]string, 0, len(signed))
-	for k := range signed {
-		names = append(names, k)
-	}
-	sort.Strings(names)
-
-	var canonicalHeaders strings.Builder
-	for _, k := range names {
-		canonicalHeaders.WriteString(k)
-		canonicalHeaders.WriteByte(':')
-		// Values are trimmed and internal runs of spaces collapsed, which is
-		// part of the specification and not tidying.
-		canonicalHeaders.WriteString(strings.Join(strings.Fields(signed[k]), " "))
-		canonicalHeaders.WriteByte('\n')
-	}
-	signedHeaders := strings.Join(names, ";")
-
-	canonical := strings.Join([]string{
-		req.method, path, query, canonicalHeaders.String(), signedHeaders, payloadHash,
-	}, "\n")
-
-	scope := strings.Join([]string{day, req.region, req.service, "aws4_request"}, "/")
-	toSign := strings.Join([]string{
-		"AWS4-HMAC-SHA256", stamp, scope, sha256Hex([]byte(canonical)),
-	}, "\n")
-
-	key := hmacSHA256([]byte("AWS4"+req.credentials.SecretAccessKey), day)
-	key = hmacSHA256(key, req.region)
-	key = hmacSHA256(key, req.service)
-	key = hmacSHA256(key, "aws4_request")
-	signature := hex.EncodeToString(hmacSHA256(key, toSign))
-
-	out := map[string]string{}
-	for k, v := range req.headers {
-		out[k] = v
-	}
-	out["X-Amz-Date"] = stamp
-	out["X-Amz-Content-Sha256"] = payloadHash
-	if req.credentials.SessionToken != "" {
-		out["X-Amz-Security-Token"] = req.credentials.SessionToken
-	}
-	out["Authorization"] = fmt.Sprintf(
-		"AWS4-HMAC-SHA256 Credential=%s/%s, SignedHeaders=%s, Signature=%s",
-		req.credentials.AccessKeyID, scope, signedHeaders, signature)
-	return out, nil
-}
-
-// splitURL returns the host, the canonical path, and the canonical query.
-func splitURL(raw string) (host, path, query string, err error) {
-	parsed, err := url.Parse(raw)
-	if err != nil {
-		return "", "", "", err
-	}
-	path = parsed.EscapedPath()
-	if path == "" {
-		// An empty path canonicalises to "/", and signing "" produces a
-		// signature the service does not agree with.
-		path = "/"
-	}
-	// Query parameters are sorted by name, and Encode does that.
-	return parsed.Host, path, parsed.Query().Encode(), nil
-}
-
-func sha256Hex(b []byte) string {
-	sum := sha256.Sum256(b)
-	return hex.EncodeToString(sum[:])
-}
-
-func hmacSHA256(key []byte, data string) []byte {
-	h := hmac.New(sha256.New, key)
-	h.Write([]byte(data))
-	return h.Sum(nil)
 }

--- a/ee/engine/secrets/aws_test.go
+++ b/ee/engine/secrets/aws_test.go
@@ -2,155 +2,27 @@
 
 package secrets
 
-// The signing, against the example AWS publishes.
+// What this adapter does without an AWS account.
 //
-// This is the part of the AWS adapter that is worth proving without an AWS
-// account, and it is also the part most likely to be wrong: a signature is
-// either exactly right or it is a 403 that reads like a bad secret key. AWS
-// publishes a worked example with the inputs, the intermediate strings and the
-// final signature, precisely so an implementation can be checked against
-// something other than itself. Checking against our own idea of the algorithm
-// would prove only that the code agrees with the code.
+// The signing lives in ee/engine/cloudauth now, and so does the proof of it:
+// the canonical example AWS publishes is checked there, against the service's
+// own published answer rather than against our own idea of the algorithm. What
+// is left here is the part that belongs to the store, which is what it says
+// when it cannot be built and what it says when no credentials answered.
 //
 // Everything else in this adapter needs a real account and is marked `written`
 // rather than `proven` in STATUS.md until it has one.
 
 import (
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
-// The credentials in this file are AWS's own published example values. They are
-// documented as examples, they authenticate nothing, and they are the only
-// values that produce the published signature, so the vector cannot be checked
-// without them.
-const (
-	exampleKeyID  = "AKIA" + "IOSFODNN7EXAMPLE"
-	exampleSecret = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-)
-
-func TestSigV4MatchesTheCanonicalExample(t *testing.T) {
-	// AWS General Reference, Signature Version 4 signing examples: a GET of an
-	// S3 object with a Range header, on 24 May 2013.
-	signed, err := signV4(sigV4Request{
-		method: "GET",
-		url:    "https://examplebucket.s3.amazonaws.com/test.txt",
-		body:   nil,
-		headers: map[string]string{
-			"Range": "bytes=0-9",
-		},
-		region:  "us-east-1",
-		service: "s3",
-		credentials: AWSCredentials{
-			AccessKeyID: exampleKeyID, SecretAccessKey: exampleSecret,
-		},
-		now: time.Date(2013, 5, 24, 0, 0, 0, 0, time.UTC),
-	})
-	require.NoError(t, err)
-
-	authorization := signed["Authorization"]
-	require.Contains(t, authorization,
-		"Credential="+exampleKeyID+"/20130524/us-east-1/s3/aws4_request")
-	require.Contains(t, authorization,
-		"SignedHeaders=host;range;x-amz-content-sha256;x-amz-date")
-	require.Contains(t, authorization,
-		"Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41",
-		"the signature does not match the published example, so every real request would be refused")
-
-	// The empty body hashes to the published value, which is the constant every
-	// AWS example carries and the easiest thing to get wrong by hashing nothing
-	// rather than hashing the empty string.
-	require.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-		signed["X-Amz-Content-Sha256"])
-	require.Equal(t, "20130524T000000Z", signed["X-Amz-Date"])
-}
-
-func TestSigV4SignsTheSessionTokenRatherThanOnlySendingIt(t *testing.T) {
-	// A temporary credential whose token is attached after signing produces a
-	// signature over a different request, and the refusal that comes back reads
-	// like a wrong secret key rather than like a signing mistake. Every
-	// credential this adapter finds except a long-lived user key is temporary,
-	// so this is the common case and not the exotic one.
-	with, err := signV4(sigV4Request{
-		method: "POST", url: "https://secretsmanager.eu-west-1.amazonaws.com/",
-		body: []byte(`{"SecretId":"x"}`), region: "eu-west-1", service: "secretsmanager",
-		credentials: AWSCredentials{
-			AccessKeyID: exampleKeyID, SecretAccessKey: exampleSecret,
-			SessionToken: "a-temporary-token",
-		},
-		now: time.Date(2026, 8, 27, 0, 0, 0, 0, time.UTC),
-	})
-	require.NoError(t, err)
-	require.Contains(t, with["Authorization"], "x-amz-security-token",
-		"the session token is not in the signed header list")
-	require.Equal(t, "a-temporary-token", with["X-Amz-Security-Token"])
-
-	// And the signature actually differs, rather than the header merely being
-	// listed. Listing a header and not hashing it is the same bug wearing a
-	// disguise.
-	without, err := signV4(sigV4Request{
-		method: "POST", url: "https://secretsmanager.eu-west-1.amazonaws.com/",
-		body: []byte(`{"SecretId":"x"}`), region: "eu-west-1", service: "secretsmanager",
-		credentials: AWSCredentials{AccessKeyID: exampleKeyID, SecretAccessKey: exampleSecret},
-		now:         time.Date(2026, 8, 27, 0, 0, 0, 0, time.UTC),
-	})
-	require.NoError(t, err)
-	require.NotEqual(t, signatureOf(t, with), signatureOf(t, without))
-}
-
-func TestSigV4SignsTheBody(t *testing.T) {
-	// Two requests differing only in their body must sign differently, or the
-	// signature is not protecting the thing being asked for.
-	one := mustSign(t, []byte(`{"SecretId":"one"}`))
-	two := mustSign(t, []byte(`{"SecretId":"two"}`))
-	require.NotEqual(t, signatureOf(t, one), signatureOf(t, two))
-}
-
-func TestSigV4CanonicalisesAnEmptyPath(t *testing.T) {
-	// An endpoint written without a trailing slash has an empty path, and an
-	// empty path canonicalises to "/". Signing "" produces a signature the
-	// service does not agree with, and the endpoint is written both ways in the
-	// wild.
-	withSlash, err := signV4(sigV4Request{
-		method: "POST", url: "https://secretsmanager.eu-west-1.amazonaws.com/",
-		body: []byte(`{}`), region: "eu-west-1", service: "secretsmanager",
-		credentials: AWSCredentials{AccessKeyID: exampleKeyID, SecretAccessKey: exampleSecret},
-		now:         time.Date(2026, 8, 27, 0, 0, 0, 0, time.UTC),
-	})
-	require.NoError(t, err)
-	without, err := signV4(sigV4Request{
-		method: "POST", url: "https://secretsmanager.eu-west-1.amazonaws.com",
-		body: []byte(`{}`), region: "eu-west-1", service: "secretsmanager",
-		credentials: AWSCredentials{AccessKeyID: exampleKeyID, SecretAccessKey: exampleSecret},
-		now:         time.Date(2026, 8, 27, 0, 0, 0, 0, time.UTC),
-	})
-	require.NoError(t, err)
-	require.Equal(t, signatureOf(t, withSlash), signatureOf(t, without))
-}
-
-func mustSign(t *testing.T, body []byte) map[string]string {
-	t.Helper()
-	signed, err := signV4(sigV4Request{
-		method: "POST", url: "https://secretsmanager.eu-west-1.amazonaws.com/",
-		body: body, region: "eu-west-1", service: "secretsmanager",
-		credentials: AWSCredentials{AccessKeyID: exampleKeyID, SecretAccessKey: exampleSecret},
-		now:         time.Date(2026, 8, 27, 0, 0, 0, 0, time.UTC),
-	})
-	require.NoError(t, err)
-	return signed
-}
-
-func signatureOf(t *testing.T, headers map[string]string) string {
-	t.Helper()
-	_, after, found := strings.Cut(headers["Authorization"], "Signature=")
-	require.True(t, found, "no signature in %q", headers["Authorization"])
-	return after
-}
-
-// ---------------------------------------------------------------------------
+// The key id below is AWS's own published example value. It is documented as an
+// example, it authenticates nothing, and a message that quoted a real one would
+// be the failure the assertion beneath it exists to catch.
+const exampleKeyID = "AKIA" + "IOSFODNN7EXAMPLE"
 
 func TestAWSRefusesToBeBuiltWithoutARegion(t *testing.T) {
 	_, err := NewAWSSecretsManager(AWSConfig{Getenv: func(string) string { return "" }})

--- a/ee/engine/secrets/azure.go
+++ b/ee/engine/secrets/azure.go
@@ -16,17 +16,19 @@ package secrets
 // The credential is a bearer token that expires, usually in an hour. That is
 // the case the one-refresh rule exists for, and it is why the token is fetched
 // with an expiry and renewed a minute early rather than on rejection alone.
+// Obtaining it, from a service principal or from the host's managed identity,
+// lives in ee/engine/cloudauth, because an Azure Database for PostgreSQL
+// provider authenticates through the identical exchange against a different
+// resource.
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/url"
 	"os"
-	"strconv"
 	"strings"
-	"sync"
-	"time"
+
+	"github.com/antifailure/antifailure/ee/engine/cloudauth"
 )
 
 // AzureConfig is what a Key Vault source needs.
@@ -57,12 +59,21 @@ type AzureConfig struct {
 // AzureBackend reads from Key Vault.
 type AzureBackend struct {
 	cfg AzureConfig
+	// tokens holds the bearer token and knows whether it came from a service
+	// principal or from the host's managed identity, which is what the refusal
+	// message names.
+	tokens *cloudauth.AzureTokenSource
+}
 
-	mu      sync.Mutex
-	token   string
-	expires time.Time
-	// how names where the token came from, for the refusal message.
-	how string
+// newAzureBackend wires a config to a token source for the vault resource.
+func newAzureBackend(cfg AzureConfig) *AzureBackend {
+	return &AzureBackend{cfg: cfg, tokens: &cloudauth.AzureTokenSource{
+		TenantID:     cfg.TenantID,
+		ClientID:     cfg.ClientID,
+		ClientSecret: cfg.ClientSecret,
+		Authority:    cfg.Authority,
+		Resource:     cloudauth.AzureKeyVaultResource,
+	}}
 }
 
 // NewAzureKeyVault builds a Key Vault source, or reports what it is missing.
@@ -102,20 +113,11 @@ func NewAzureKeyVault(cfg AzureConfig) (*Source, error) {
 		cfg.Authority = cfg.Getenv("AZURE_AUTHORITY_HOST")
 	}
 	if cfg.Authority == "" {
-		cfg.Authority = "https://login.microsoftonline.com"
+		cfg.Authority = cloudauth.PublicAzureAuthority
 	}
 	cfg.Authority = strings.TrimRight(cfg.Authority, "/")
 	cfg.VaultURL = strings.TrimRight(cfg.VaultURL, "/")
-	return New(&AzureBackend{cfg: cfg}), nil
-}
-
-// authority is the token host, defaulted here as well as in the constructor so
-// that a backend built directly in a test is not pointed at nothing.
-func (c AzureConfig) authority() string {
-	if c.Authority == "" {
-		return "https://login.microsoftonline.com"
-	}
-	return strings.TrimRight(c.Authority, "/")
+	return New(newAzureBackend(cfg)), nil
 }
 
 func (a *AzureBackend) Describe() string {
@@ -147,139 +149,23 @@ func (a *AzureBackend) Describe() string {
 // refused is Fetch's question and it is answered per variable, because a
 // principal may hold one secret and not another.
 func (a *AzureBackend) Reach(ctx context.Context) error {
-	if _, err := a.bearer(ctx); err != nil {
+	if _, err := a.tokens.Token(ctx); err != nil {
 		return err
 	}
-	if _, err := do(ctx, request{
-		method: "GET",
-		url:    a.cfg.VaultURL + "/secrets",
-		query:  map[string]string{"api-version": a.cfg.APIVersion, "maxresults": "1"},
+	if _, err := cloudauth.Do(ctx, cloudauth.Request{
+		Method: "GET",
+		URL:    a.cfg.VaultURL + "/secrets",
+		Query:  map[string]string{"api-version": a.cfg.APIVersion, "maxresults": "1"},
 	}); err != nil {
 		return fmt.Errorf("cannot be reached: %s", err)
 	}
 	return nil
 }
 
-func (a *AzureBackend) bearer(ctx context.Context) (string, error) {
-	a.mu.Lock()
-	token, expires := a.token, a.expires
-	a.mu.Unlock()
-	// A minute early, so a token that expires between being read and being used
-	// does not produce a rejection a renewal would have avoided.
-	if token != "" && time.Now().Add(time.Minute).Before(expires) {
-		return token, nil
-	}
-
-	got, lifetime, how, err := a.acquire(ctx)
-	if err != nil {
-		return "", err
-	}
-	a.mu.Lock()
-	a.token, a.expires, a.how = got, time.Now().Add(lifetime), how
-	a.mu.Unlock()
-	return got, nil
-}
-
-const azureScope = "https://vault.azure.net/.default"
-
-func (a *AzureBackend) acquire(ctx context.Context) (token string, lifetime time.Duration, how string, err error) {
-	if a.cfg.ClientSecret != "" {
-		return a.fromServicePrincipal(ctx)
-	}
-	return a.fromManagedIdentity(ctx)
-}
-
-func (a *AzureBackend) fromServicePrincipal(ctx context.Context) (string, time.Duration, string, error) {
-	form := url.Values{
-		"grant_type":    {"client_credentials"},
-		"client_id":     {a.cfg.ClientID},
-		"client_secret": {a.cfg.ClientSecret},
-		"scope":         {azureScope},
-	}
-	resp, err := do(ctx, request{
-		method: "POST",
-		url:    a.cfg.authority() + "/" + a.cfg.TenantID + "/oauth2/v2.0/token",
-		body:   []byte(form.Encode()),
-		headers: map[string]string{
-			"Content-Type": "application/x-www-form-urlencoded",
-			"Accept":       "application/json",
-		},
-	})
-	if err != nil {
-		return "", 0, "", fmt.Errorf("Microsoft Entra could not be reached: %s", err)
-	}
-	if resp.status != 200 {
-		// A wrong client secret and a wrong tenant both land here, and Entra's
-		// own error code is the part that tells them apart, so it is passed
-		// through. The description is not: it embeds the request and can run to
-		// several lines.
-		return "", 0, "", wrap(ErrRejected,
-			"Microsoft Entra refused the service principal with %d %s",
-			resp.status, azureErrorCode(resp.body))
-	}
-	var payload struct {
-		AccessToken string `json:"access_token"`
-		ExpiresIn   int    `json:"expires_in"`
-	}
-	if err := resp.decode(&payload); err != nil {
-		return "", 0, "", err
-	}
-	if payload.AccessToken == "" {
-		return "", 0, "", fmt.Errorf("Microsoft Entra answered 200 and returned no token")
-	}
-	return payload.AccessToken, time.Duration(payload.ExpiresIn) * time.Second,
-		"the service principal " + a.cfg.ClientID, nil
-}
-
-func (a *AzureBackend) fromManagedIdentity(ctx context.Context) (string, time.Duration, string, error) {
-	query := map[string]string{"api-version": "2018-02-01", "resource": "https://vault.azure.net"}
-	if a.cfg.ClientID != "" {
-		// A user-assigned identity has to be named, because a host may carry
-		// several and the service will not guess between them.
-		query["client_id"] = a.cfg.ClientID
-	}
-	resp, err := do(ctx, request{
-		method: "GET", url: "http://169.254.169.254/metadata/identity/oauth2/token",
-		query: query, headers: map[string]string{"Metadata": "true"},
-		// The same second the AWS instance metadata gets, for the same reason:
-		// this is a link-local address that answers immediately on a host that
-		// has one and hangs on a laptop that does not.
-		timeout: time.Second,
-	})
-	if err != nil {
-		return "", 0, "", wrap(ErrNotConfigured,
-			"no Azure credentials: AZURE_CLIENT_SECRET is unset and no managed identity "+
-				"answered on this host. Set AZURE_TENANT_ID, AZURE_CLIENT_ID and "+
-				"AZURE_CLIENT_SECRET, or run somewhere with an identity assigned")
-	}
-	if resp.status != 200 {
-		return "", 0, "", fmt.Errorf(
-			"the managed identity endpoint answered %d; this host may have no identity assigned",
-			resp.status)
-	}
-	var payload struct {
-		AccessToken string `json:"access_token"`
-		// Returned as a string of seconds by this endpoint, unlike Entra's,
-		// which returns a number. Two shapes for one field on two endpoints of
-		// one product, so it is decoded as text and converted.
-		ExpiresIn string `json:"expires_in"`
-	}
-	if err := resp.decode(&payload); err != nil {
-		return "", 0, "", err
-	}
-	seconds, _ := strconv.Atoi(payload.ExpiresIn)
-	if seconds <= 0 {
-		seconds = 3600
-	}
-	return payload.AccessToken, time.Duration(seconds) * time.Second, "this host's managed identity", nil
-}
-
 // Refresh discards the token so the next lookup acquires a new one.
 func (a *AzureBackend) Refresh(ctx context.Context) error {
-	a.mu.Lock()
-	a.token, a.expires = "", time.Time{}
-	a.mu.Unlock()
-	_, err := a.bearer(ctx)
+	a.tokens.Reset()
+	_, err := a.tokens.Token(ctx)
 	return err
 }
 
@@ -295,40 +181,38 @@ func (a *AzureBackend) Fetch(ctx context.Context, name string) (string, bool, er
 				"digits and hyphens", name)
 	}
 
-	token, err := a.bearer(ctx)
+	token, err := a.tokens.Token(ctx)
 	if err != nil {
 		return "", false, err
 	}
-	resp, err := do(ctx, request{
-		method:  "GET",
-		url:     a.cfg.VaultURL + "/secrets/" + secretName,
-		query:   map[string]string{"api-version": a.cfg.APIVersion},
-		headers: map[string]string{"Authorization": "Bearer " + token, "Accept": "application/json"},
+	resp, err := cloudauth.Do(ctx, cloudauth.Request{
+		Method:  "GET",
+		URL:     a.cfg.VaultURL + "/secrets/" + secretName,
+		Query:   map[string]string{"api-version": a.cfg.APIVersion},
+		Headers: map[string]string{"Authorization": "Bearer " + token, "Accept": "application/json"},
 	})
 	if err != nil {
 		return "", false, fmt.Errorf("cannot be reached: %s", err)
 	}
 
-	a.mu.Lock()
-	how := a.how
-	a.mu.Unlock()
+	how := a.tokens.How()
 
 	switch {
-	case resp.status == 200:
-	case resp.status == 404:
+	case resp.Status == 200:
+	case resp.Status == 404:
 		return "", false, nil
-	case resp.rejected():
+	case resp.Rejected():
 		return "", false, wrap(ErrRejected, "Key Vault answered %d %s, using %s",
-			resp.status, azureErrorCode(resp.body), how)
+			resp.Status, cloudauth.AzureErrorCode(resp.Body), how)
 	default:
 		return "", false, fmt.Errorf("Key Vault answered %d %s",
-			resp.status, azureErrorCode(resp.body))
+			resp.Status, cloudauth.AzureErrorCode(resp.Body))
 	}
 
 	var payload struct {
 		Value string `json:"value"`
 	}
-	if err := resp.decode(&payload); err != nil {
+	if err := resp.Decode(&payload); err != nil {
 		return "", false, err
 	}
 	return payload.Value, true, nil
@@ -360,20 +244,4 @@ func AzureSecretName(name string) string {
 		return ""
 	}
 	return out
-}
-
-// azureErrorCode reads the code out of an Azure error document.
-//
-// The code and never the message. Azure's message embeds the request, and the
-// request names the secret and the vault.
-func azureErrorCode(body []byte) string {
-	var payload struct {
-		Error struct {
-			Code string `json:"code"`
-		} `json:"error"`
-	}
-	if json.Unmarshal(body, &payload) != nil || payload.Error.Code == "" {
-		return "with no error code"
-	}
-	return payload.Error.Code
 }

--- a/ee/engine/secrets/cloud_test.go
+++ b/ee/engine/secrets/cloud_test.go
@@ -44,6 +44,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/ee/engine/cloudauth"
 )
 
 // ---------------------------------------------------------------------------
@@ -73,7 +75,7 @@ func TestAzureMapsAVariableNameOntoANameKeyVaultAccepts(t *testing.T) {
 func TestAzureSaysSoRatherThanLookingUpANameItCannotHold(t *testing.T) {
 	// A 400 treated as a miss would make the variable invisible while the
 	// operator looks at a vault that plainly contains something like it.
-	backend := &AzureBackend{cfg: AzureConfig{VaultURL: "https://v.vault.azure.net"}}
+	backend := newAzureBackend(AzureConfig{VaultURL: "https://v.vault.azure.net"})
 	_, found, err := backend.Fetch(t.Context(), "HAS SPACE")
 	require.False(t, found)
 	require.Error(t, err)
@@ -109,8 +111,12 @@ func TestAzureUsesTheAuthorityItIsGiven(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
+	// Read off the token source rather than off the config, because the token
+	// source is what builds the URL the request goes to. A config field that
+	// held the right host while the exchange used a compiled in one would pass
+	// the weaker assertion.
 	require.Equal(t, "https://login.microsoftonline.us",
-		source.backend.(*AzureBackend).cfg.authority())
+		source.backend.(*AzureBackend).tokens.Authority)
 }
 
 func TestAzureRefusesToBeBuiltWithoutWhatItNeeds(t *testing.T) {
@@ -134,21 +140,21 @@ func TestAzureConformanceAgainstTheDocumentedWireFormat(t *testing.T) {
 	// adapter treats each documented response the way the contract requires.
 	server := fakeKeyVault(t)
 
-	working := &AzureBackend{cfg: AzureConfig{
+	working := newAzureBackend(AzureConfig{
 		VaultURL: server.URL + "/ok", Authority: server.URL, TenantID: "t", ClientID: "c",
 		ClientSecret: "assembled-at-run-time", APIVersion: "7.4",
-	}}
-	rejecting := &countingAzure{AzureBackend: &AzureBackend{cfg: AzureConfig{
+	})
+	rejecting := &countingAzure{AzureBackend: newAzureBackend(AzureConfig{
 		VaultURL: server.URL + "/denied", Authority: server.URL, TenantID: "t", ClientID: "c",
 		ClientSecret: "assembled-at-run-time", APIVersion: "7.4",
-	}}}
+	})}
 	// No client secret, so this one takes the managed identity path, and there
 	// is no managed identity on the machine running the tests. That is the
 	// realistic shape of an unreachable Azure source: not a vault that refuses
 	// a connection, but a host that cannot obtain a token at all.
-	unreachable := &AzureBackend{cfg: AzureConfig{
+	unreachable := newAzureBackend(AzureConfig{
 		VaultURL: "http://127.0.0.1:1", APIVersion: "7.4",
-	}}
+	})
 
 	result := Run(t.Context(), t, Harness{
 		Name:         "Azure Key Vault (documented wire format, not a live vault)",
@@ -228,9 +234,10 @@ func TestGCPSignsAnAssertionThatVerifies(t *testing.T) {
 	})
 	require.NoError(t, err)
 	backend := source.backend.(*GCPBackend)
-	require.NotNil(t, backend.account, "the key was not parsed")
+	account := backend.tokens.Account()
+	require.NotNil(t, account, "the key was not parsed")
 
-	assertion, err := backend.signAssertion(time.Now())
+	assertion, err := account.SignAssertion(time.Now(), cloudauth.ScopeGoogleCloudPlatform)
 	require.NoError(t, err)
 
 	parts := strings.Split(assertion, ".")
@@ -263,7 +270,7 @@ func TestGCPSignsAnAssertionThatVerifies(t *testing.T) {
 	// The audience is the token endpoint, which is what stops an assertion
 	// minted for one service being replayed against another.
 	require.Equal(t, "https://oauth2.googleapis.com/token", claims.Aud)
-	require.Equal(t, gcpScope, claims.Scope)
+	require.Equal(t, cloudauth.ScopeGoogleCloudPlatform, claims.Scope)
 	require.Equal(t, int64(3600), claims.Exp-claims.Iat)
 }
 
@@ -275,7 +282,7 @@ func TestGCPDropsThePrivateKeyPEMOnceItIsParsed(t *testing.T) {
 		Project: "af-test", CredentialsJSON: keyJSON, Getenv: func(string) string { return "" },
 	})
 	require.NoError(t, err)
-	require.Empty(t, source.backend.(*GCPBackend).account.PrivateKey)
+	require.Empty(t, source.backend.(*GCPBackend).tokens.Account().PrivateKey)
 }
 
 func TestGCPRefusesAKeyItCannotUse(t *testing.T) {
@@ -311,15 +318,15 @@ func TestGCPConformanceAgainstTheDocumentedWireFormat(t *testing.T) {
 	// plausible and authenticates against nothing.
 	server := fakeSecretManager(t)
 
-	working := &GCPBackend{
-		cfg:     GCPConfig{Project: "ok", Version: "latest", Endpoint: server.URL},
-		account: tokenEndpoint(t, server.URL)}
-	rejecting := &countingGCP{GCPBackend: &GCPBackend{
-		cfg:     GCPConfig{Project: "denied", Version: "latest", Endpoint: server.URL},
-		account: tokenEndpoint(t, server.URL)}}
-	unreachable := &GCPBackend{
-		cfg:     GCPConfig{Project: "ok", Version: "latest", Endpoint: "http://127.0.0.1:1"},
-		account: tokenEndpoint(t, "http://127.0.0.1:1")}
+	working := newGCPBackend(
+		GCPConfig{Project: "ok", Version: "latest", Endpoint: server.URL},
+		tokenEndpoint(t, server.URL))
+	rejecting := &countingGCP{GCPBackend: newGCPBackend(
+		GCPConfig{Project: "denied", Version: "latest", Endpoint: server.URL},
+		tokenEndpoint(t, server.URL))}
+	unreachable := newGCPBackend(
+		GCPConfig{Project: "ok", Version: "latest", Endpoint: "http://127.0.0.1:1"},
+		tokenEndpoint(t, "http://127.0.0.1:1"))
 
 	result := Run(t.Context(), t, Harness{
 		Name:         "Google Secret Manager (documented wire format, not a live project)",
@@ -378,10 +385,10 @@ func serviceAccountKey(t *testing.T) (*rsa.PrivateKey, []byte) {
 // tokenEndpoint builds an account whose token endpoint is the local server, so
 // the adapter takes the service account path rather than trying to reach
 // Google's metadata server, which does not answer here and should not be asked.
-func tokenEndpoint(t *testing.T, base string) *gcpServiceAccount {
+func tokenEndpoint(t *testing.T, base string) *cloudauth.GCPServiceAccount {
 	t.Helper()
 	_, keyJSON := serviceAccountKey(t)
-	account, err := parseServiceAccount(keyJSON)
+	account, err := cloudauth.ParseGCPServiceAccount(keyJSON)
 	require.NoError(t, err)
 	account.TokenURI = base + "/token"
 	return account

--- a/ee/engine/secrets/gcp.go
+++ b/ee/engine/secrets/gcp.go
@@ -10,29 +10,22 @@ package secrets
 // application a base64 string that looks plausible, connects to nothing, and
 // produces an authentication failure at the far end rather than an error here.
 //
-// Two ways to get a token, matching where this actually runs. The metadata
-// server, which is what a Cloud Run service, a GKE workload and a Compute
-// Engine instance all have and which needs no key material at all. And a
-// service account key, signed here into a JWT assertion and exchanged, which is
-// what a CI runner outside Google has. The second is a key on disk and is worth
-// avoiding where the first is available; the message says so when it is used.
+// Getting the token is not this file's job any more. The metadata server and
+// the service account assertion both live in ee/engine/cloudauth, because a
+// Cloud SQL provider needs the identical exchange and a second copy of a JWT
+// signer is a second thing to get subtly wrong. What is chosen here is which
+// of the two applies: a key on disk is worth avoiding where the metadata server
+// exists, and the refusal message says which one was used.
 
 import (
 	"context"
-	"crypto"
-	"crypto/rand"
-	"crypto/rsa"
-	"crypto/sha256"
-	"crypto/x509"
 	"encoding/base64"
-	"encoding/json"
-	"encoding/pem"
 	"fmt"
 	"net/url"
 	"os"
 	"strings"
-	"sync"
-	"time"
+
+	"github.com/antifailure/antifailure/ee/engine/cloudauth"
 )
 
 // GCPConfig is what a Secret Manager source needs.
@@ -60,24 +53,18 @@ type GCPConfig struct {
 // GCPBackend reads from Secret Manager.
 type GCPBackend struct {
 	cfg GCPConfig
-	// account is the parsed service account key, nil when the metadata server
-	// is used.
-	account *gcpServiceAccount
-
-	mu      sync.Mutex
-	token   string
-	expires time.Time
-	how     string
+	// tokens holds the access token and knows which of the two ways it was
+	// obtained, which is what the refusal message names.
+	tokens *cloudauth.GCPTokenSource
 }
 
-type gcpServiceAccount struct {
-	Type        string `json:"type"`
-	ProjectID   string `json:"project_id"`
-	PrivateKey  string `json:"private_key"`
-	ClientEmail string `json:"client_email"`
-	TokenURI    string `json:"token_uri"`
-
-	key *rsa.PrivateKey
+// newGCPBackend wires a config and an optional service account key to a token
+// source. A nil account takes the metadata server path.
+func newGCPBackend(cfg GCPConfig, account *cloudauth.GCPServiceAccount) *GCPBackend {
+	return &GCPBackend{
+		cfg:    cfg,
+		tokens: cloudauth.NewGCPTokenSource(account, cloudauth.ScopeGoogleCloudPlatform),
+	}
 }
 
 // NewGCPSecretManager builds a Secret Manager source, or reports what it is
@@ -101,7 +88,7 @@ func NewGCPSecretManager(cfg GCPConfig) (*Source, error) {
 	}
 	cfg.Endpoint = strings.TrimRight(cfg.Endpoint, "/")
 
-	backend := &GCPBackend{cfg: cfg}
+	var account *cloudauth.GCPServiceAccount
 	raw := cfg.CredentialsJSON
 	if len(raw) == 0 {
 		// The conventional variable, holding a path rather than the document.
@@ -117,47 +104,13 @@ func NewGCPSecretManager(cfg GCPConfig) (*Source, error) {
 		}
 	}
 	if len(raw) > 0 {
-		account, err := parseServiceAccount(raw)
+		parsed, err := cloudauth.ParseGCPServiceAccount(raw)
 		if err != nil {
 			return nil, wrap(ErrNotConfigured, "the service account key is not usable: %s", err)
 		}
-		backend.account = account
+		account = parsed
 	}
-	return New(backend), nil
-}
-
-func parseServiceAccount(raw []byte) (*gcpServiceAccount, error) {
-	var account gcpServiceAccount
-	if err := json.Unmarshal(raw, &account); err != nil {
-		return nil, fmt.Errorf("it is not JSON")
-	}
-	if account.Type != "service_account" {
-		return nil, fmt.Errorf("it is a %q key and only a service_account key is read here", account.Type)
-	}
-	if account.ClientEmail == "" || account.PrivateKey == "" {
-		return nil, fmt.Errorf("it has no client_email or no private_key")
-	}
-	if account.TokenURI == "" {
-		account.TokenURI = "https://oauth2.googleapis.com/token"
-	}
-
-	block, _ := pem.Decode([]byte(account.PrivateKey))
-	if block == nil {
-		return nil, fmt.Errorf("its private_key is not PEM")
-	}
-	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
-	if err != nil {
-		return nil, fmt.Errorf("its private_key is not a PKCS#8 key")
-	}
-	key, ok := parsed.(*rsa.PrivateKey)
-	if !ok {
-		return nil, fmt.Errorf("its private_key is not RSA")
-	}
-	account.key = key
-	// The PEM is dropped now that the key is parsed, so the plaintext of a
-	// private key is not held in a struct for the life of the process.
-	account.PrivateKey = ""
-	return &account, nil
+	return New(newGCPBackend(cfg, account)), nil
 }
 
 func (g *GCPBackend) Describe() string {
@@ -170,182 +123,47 @@ func (g *GCPBackend) Describe() string {
 
 // Reach acquires a token, which is the thing that actually fails.
 func (g *GCPBackend) Reach(ctx context.Context) error {
-	_, err := g.bearer(ctx)
+	_, err := g.tokens.Token(ctx)
 	return err
-}
-
-const gcpScope = "https://www.googleapis.com/auth/cloud-platform"
-
-func (g *GCPBackend) bearer(ctx context.Context) (string, error) {
-	g.mu.Lock()
-	token, expires := g.token, g.expires
-	g.mu.Unlock()
-	if token != "" && time.Now().Add(time.Minute).Before(expires) {
-		return token, nil
-	}
-
-	var (
-		got      string
-		lifetime time.Duration
-		how      string
-		err      error
-	)
-	if g.account != nil {
-		got, lifetime, how, err = g.fromServiceAccount(ctx)
-	} else {
-		got, lifetime, how, err = g.fromMetadataServer(ctx)
-	}
-	if err != nil {
-		return "", err
-	}
-
-	g.mu.Lock()
-	g.token, g.expires, g.how = got, time.Now().Add(lifetime), how
-	g.mu.Unlock()
-	return got, nil
-}
-
-// fromServiceAccount signs a JWT and exchanges it for an access token.
-func (g *GCPBackend) fromServiceAccount(ctx context.Context) (string, time.Duration, string, error) {
-	assertion, err := g.signAssertion(time.Now())
-	if err != nil {
-		return "", 0, "", err
-	}
-	form := url.Values{
-		"grant_type": {"urn:ietf:params:oauth:grant-type:jwt-bearer"},
-		"assertion":  {assertion},
-	}
-	resp, err := do(ctx, request{
-		method: "POST", url: g.account.TokenURI, body: []byte(form.Encode()),
-		headers: map[string]string{
-			"Content-Type": "application/x-www-form-urlencoded",
-			"Accept":       "application/json",
-		},
-	})
-	if err != nil {
-		return "", 0, "", fmt.Errorf("Google's token endpoint could not be reached: %s", err)
-	}
-	if resp.status != 200 {
-		return "", 0, "", wrap(ErrRejected,
-			"Google refused the service account assertion with %d %s",
-			resp.status, gcpErrorStatus(resp.body))
-	}
-	var payload struct {
-		AccessToken string `json:"access_token"`
-		ExpiresIn   int    `json:"expires_in"`
-	}
-	if err := resp.decode(&payload); err != nil {
-		return "", 0, "", err
-	}
-	if payload.AccessToken == "" {
-		return "", 0, "", fmt.Errorf("Google answered 200 and returned no token")
-	}
-	return payload.AccessToken, time.Duration(payload.ExpiresIn) * time.Second,
-		"the service account " + g.account.ClientEmail, nil
-}
-
-// signAssertion builds the JWT a service account exchanges for a token.
-//
-// RS256 over a fixed header and a claim set with a one hour life. The audience
-// is the token endpoint itself, which is what stops an assertion minted for one
-// service being replayed against another.
-func (g *GCPBackend) signAssertion(now time.Time) (string, error) {
-	header := base64url([]byte(`{"alg":"RS256","typ":"JWT"}`))
-	claims, err := json.Marshal(map[string]any{
-		"iss":   g.account.ClientEmail,
-		"scope": gcpScope,
-		"aud":   g.account.TokenURI,
-		"iat":   now.Unix(),
-		"exp":   now.Add(time.Hour).Unix(),
-	})
-	if err != nil {
-		return "", err
-	}
-	signing := header + "." + base64url(claims)
-	digest := sha256.Sum256([]byte(signing))
-	signature, err := rsa.SignPKCS1v15(rand.Reader, g.account.key, crypto.SHA256, digest[:])
-	if err != nil {
-		return "", err
-	}
-	return signing + "." + base64url(signature), nil
-}
-
-// fromMetadataServer reads the token the platform already holds.
-func (g *GCPBackend) fromMetadataServer(ctx context.Context) (string, time.Duration, string, error) {
-	resp, err := do(ctx, request{
-		method: "GET",
-		url:    "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token",
-		// Required, and its absence is the whole anti-forgery mechanism: the
-		// metadata server refuses any request without it, so a browser or a
-		// naive server-side fetch cannot reach it.
-		headers: map[string]string{"Metadata-Flavor": "Google"},
-		// A second, like the other two link-local metadata services. Off
-		// Google this name does not resolve, and waiting the shared ten seconds
-		// to learn that would be ten seconds on every af up.
-		timeout: time.Second,
-	})
-	if err != nil {
-		return "", 0, "", wrap(ErrNotConfigured,
-			"no Google credentials: GOOGLE_APPLICATION_CREDENTIALS is unset and the "+
-				"metadata server did not answer, so this is not running on Google Cloud. "+
-				"Point GOOGLE_APPLICATION_CREDENTIALS at a service account key, or run "+
-				"somewhere with a service account attached")
-	}
-	if resp.status != 200 {
-		return "", 0, "", fmt.Errorf("the metadata server answered %d", resp.status)
-	}
-	var payload struct {
-		AccessToken string `json:"access_token"`
-		ExpiresIn   int    `json:"expires_in"`
-	}
-	if err := resp.decode(&payload); err != nil {
-		return "", 0, "", err
-	}
-	return payload.AccessToken, time.Duration(payload.ExpiresIn) * time.Second,
-		"this host's attached service account", nil
 }
 
 // Refresh discards the token so the next lookup acquires a new one.
 func (g *GCPBackend) Refresh(ctx context.Context) error {
-	g.mu.Lock()
-	g.token, g.expires = "", time.Time{}
-	g.mu.Unlock()
-	_, err := g.bearer(ctx)
+	g.tokens.Reset()
+	_, err := g.tokens.Token(ctx)
 	return err
 }
 
 // Fetch reads a variable.
 func (g *GCPBackend) Fetch(ctx context.Context, name string) (string, bool, error) {
-	token, err := g.bearer(ctx)
+	token, err := g.tokens.Token(ctx)
 	if err != nil {
 		return "", false, err
 	}
 
 	secret := g.cfg.Prefix + name
-	resp, err := do(ctx, request{
-		method: "GET",
-		url: g.cfg.Endpoint + "/v1/projects/" + g.cfg.Project +
+	resp, err := cloudauth.Do(ctx, cloudauth.Request{
+		Method: "GET",
+		URL: g.cfg.Endpoint + "/v1/projects/" + g.cfg.Project +
 			"/secrets/" + url.PathEscape(secret) + "/versions/" + g.cfg.Version + ":access",
-		headers: map[string]string{"Authorization": "Bearer " + token, "Accept": "application/json"},
+		Headers: map[string]string{"Authorization": "Bearer " + token, "Accept": "application/json"},
 	})
 	if err != nil {
 		return "", false, fmt.Errorf("cannot be reached: %s", err)
 	}
 
-	g.mu.Lock()
-	how := g.how
-	g.mu.Unlock()
+	how := g.tokens.How()
 
 	switch {
-	case resp.status == 200:
-	case resp.status == 404:
+	case resp.Status == 200:
+	case resp.Status == 404:
 		return "", false, nil
-	case resp.rejected():
+	case resp.Rejected():
 		return "", false, wrap(ErrRejected, "Secret Manager answered %d %s, using %s",
-			resp.status, gcpErrorStatus(resp.body), how)
+			resp.Status, cloudauth.GCPErrorStatus(resp.Body), how)
 	default:
 		return "", false, fmt.Errorf("Secret Manager answered %d %s",
-			resp.status, gcpErrorStatus(resp.body))
+			resp.Status, cloudauth.GCPErrorStatus(resp.Body))
 	}
 
 	var payload struct {
@@ -353,7 +171,7 @@ func (g *GCPBackend) Fetch(ctx context.Context, name string) (string, bool, erro
 			Data string `json:"data"`
 		} `json:"payload"`
 	}
-	if err := resp.decode(&payload); err != nil {
+	if err := resp.Decode(&payload); err != nil {
 		return "", false, err
 	}
 	// Base64, always. Secret Manager holds bytes rather than text, and handing
@@ -364,22 +182,4 @@ func (g *GCPBackend) Fetch(ctx context.Context, name string) (string, bool, erro
 		return "", false, fmt.Errorf("the payload of %s is not the base64 the API documents", secret)
 	}
 	return string(decoded), true, nil
-}
-
-func base64url(b []byte) string { return base64.RawURLEncoding.EncodeToString(b) }
-
-// gcpErrorStatus reads the status out of a Google error document.
-//
-// The status and never the message. Google's message quotes the resource name,
-// and the resource name is the secret.
-func gcpErrorStatus(body []byte) string {
-	var payload struct {
-		Error struct {
-			Status string `json:"status"`
-		} `json:"error"`
-	}
-	if json.Unmarshal(body, &payload) != nil || payload.Error.Status == "" {
-		return "with no status"
-	}
-	return payload.Error.Status
 }

--- a/ee/engine/secrets/source.go
+++ b/ee/engine/secrets/source.go
@@ -42,10 +42,10 @@ package secrets
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 	"sync"
 
+	"github.com/antifailure/antifailure/ee/engine/cloudauth"
 	"github.com/antifailure/antifailure/ee/engine/feature"
 	"github.com/antifailure/antifailure/ee/engine/license"
 	"github.com/antifailure/antifailure/engine/pkg/extension"
@@ -109,12 +109,17 @@ type Refresher interface {
 // The distinction is the whole point. A 404 is a miss, a 500 is a store having
 // a bad day, and a 401 is the one case where trying again with the same
 // credential is pointless and trying again with a new one might work.
-var ErrRejected = errors.New("the store rejected the credential")
+// The value itself is ee/engine/cloudauth's, so that an error raised inside a
+// credential exchange and an error raised by a store answering 403 both satisfy
+// errors.Is against this one sentinel. Two sentinels with the same words would
+// pass every reading of the code and silently switch the one-refresh rule off
+// for whichever half did not own the value.
+var ErrRejected = cloudauth.ErrRejected
 
 // ErrNotConfigured reports a backend that was asked for but never given what it
 // needs. Carried separately so that Available can say "no address is set"
 // rather than reporting a connection failure to an empty host.
-var ErrNotConfigured = errors.New("not configured")
+var ErrNotConfigured = cloudauth.ErrNotConfigured
 
 // Source is a Backend seen as something the engine can plug in.
 //
@@ -300,5 +305,5 @@ func Register(reg *extension.Registry, sources ...*Source) {
 // distinction between a rejected credential and an unreachable store is made in
 // one place rather than four.
 func wrap(kind error, format string, args ...any) error {
-	return fmt.Errorf("%w: %s", kind, fmt.Sprintf(format, args...))
+	return cloudauth.Wrap(kind, format, args...)
 }

--- a/ee/engine/secrets/vault.go
+++ b/ee/engine/secrets/vault.go
@@ -30,6 +30,8 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+
+	"github.com/antifailure/antifailure/ee/engine/cloudauth"
 )
 
 // VaultConfig is what a Vault source needs.
@@ -153,27 +155,27 @@ func (v *VaultBackend) Describe() string {
 // first lookup and handled by the refresh rule, and checking it here would cost
 // a second round trip to learn something the lookup learns for free.
 func (v *VaultBackend) Reach(ctx context.Context) error {
-	resp, err := do(ctx, request{
-		method:  "GET",
-		url:     v.cfg.Address + "/v1/sys/health",
-		headers: v.headers(""),
+	resp, err := cloudauth.Do(ctx, cloudauth.Request{
+		Method:  "GET",
+		URL:     v.cfg.Address + "/v1/sys/health",
+		Headers: v.headers(""),
 		// standbyok and performancestandbyok stop a standby node answering 429,
 		// which is a healthy node that can still serve reads.
-		query: map[string]string{"standbyok": "true", "perfstandbyok": "true"},
+		Query: map[string]string{"standbyok": "true", "perfstandbyok": "true"},
 	})
 	if err != nil {
 		return fmt.Errorf("cannot be reached: %s", err)
 	}
 
 	// Vault encodes its state in the status code rather than only in the body.
-	switch resp.status {
+	switch resp.Status {
 	case 200, 429, 472, 473:
 	case 501:
 		return fmt.Errorf("is not initialised")
 	case 503:
 		return fmt.Errorf("is sealed")
 	default:
-		return fmt.Errorf("answered %d to a health check", resp.status)
+		return fmt.Errorf("answered %d to a health check", resp.Status)
 	}
 	return v.checkMountVersion(ctx)
 }
@@ -205,12 +207,12 @@ func (v *VaultBackend) checkMountVersion(ctx context.Context) error {
 		return nil
 	}
 
-	resp, err := do(ctx, request{
-		method:  "GET",
-		url:     v.cfg.Address + "/v1/sys/internal/ui/mounts/" + v.cfg.Mount,
-		headers: v.headers(token),
+	resp, err := cloudauth.Do(ctx, cloudauth.Request{
+		Method:  "GET",
+		URL:     v.cfg.Address + "/v1/sys/internal/ui/mounts/" + v.cfg.Mount,
+		Headers: v.headers(token),
 	})
-	if err != nil || resp.status != 200 {
+	if err != nil || resp.Status != 200 {
 		return nil
 	}
 	var payload struct {
@@ -219,7 +221,7 @@ func (v *VaultBackend) checkMountVersion(ctx context.Context) error {
 			Options map[string]string `json:"options"`
 		} `json:"data"`
 	}
-	if resp.decode(&payload) != nil || payload.Data.Type != "kv" {
+	if resp.Decode(&payload) != nil || payload.Data.Type != "kv" {
 		return nil
 	}
 
@@ -321,13 +323,13 @@ func (v *VaultBackend) read(ctx context.Context, path string) (map[string]string
 		full = v.cfg.Address + "/v1/" + v.cfg.Mount + "/data/" + path
 	}
 
-	resp, err := do(ctx, request{method: "GET", url: full, headers: v.headers(token)})
+	resp, err := cloudauth.Do(ctx, cloudauth.Request{Method: "GET", URL: full, Headers: v.headers(token)})
 	if err != nil {
 		return nil, fmt.Errorf("cannot be reached: %s", err)
 	}
 
 	switch {
-	case resp.status == 404:
+	case resp.Status == 404:
 		// A 404 is a miss, and it is also what reading a mount as the wrong KV
 		// version looks like, because the path with the data/ segment does not
 		// exist on a version 1 mount and the path without it does not exist on
@@ -338,16 +340,16 @@ func (v *VaultBackend) read(ctx context.Context, path string) (map[string]string
 			return nil, err
 		}
 		return nil, nil
-	case resp.rejected():
-		return nil, wrap(ErrRejected, "Vault answered %d: %s", resp.status, vaultErrors(resp.body))
-	case resp.status != 200:
-		return nil, fmt.Errorf("Vault answered %d: %s", resp.status, vaultErrors(resp.body))
+	case resp.Rejected():
+		return nil, wrap(ErrRejected, "Vault answered %d: %s", resp.Status, vaultErrors(resp.Body))
+	case resp.Status != 200:
+		return nil, fmt.Errorf("Vault answered %d: %s", resp.Status, vaultErrors(resp.Body))
 	}
 
 	var payload struct {
 		Data json.RawMessage `json:"data"`
 	}
-	if err := resp.decode(&payload); err != nil {
+	if err := resp.Decode(&payload); err != nil {
 		return nil, err
 	}
 	raw := payload.Data
@@ -425,8 +427,8 @@ func (v *VaultBackend) versionMixUp(ctx context.Context, path, token string) err
 			other = v.cfg.Address + "/v1/" + v.cfg.Mount + "/data/" + path
 			configured, actual = "1", "2"
 		}
-		resp, err := do(ctx, request{method: "GET", url: other, headers: v.headers(token)})
-		if err != nil || resp.status != 200 {
+		resp, err := cloudauth.Do(ctx, cloudauth.Request{Method: "GET", URL: other, Headers: v.headers(token)})
+		if err != nil || resp.Status != 200 {
 			return
 		}
 		v.mixUp = fmt.Errorf(
@@ -454,18 +456,18 @@ func (v *VaultBackend) Refresh(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	resp, err := do(ctx, request{
-		method:  "POST",
-		url:     v.cfg.Address + "/v1/auth/" + v.cfg.AppRolePath + "/login",
-		headers: v.headers(""),
-		body:    body,
+	resp, err := cloudauth.Do(ctx, cloudauth.Request{
+		Method:  "POST",
+		URL:     v.cfg.Address + "/v1/auth/" + v.cfg.AppRolePath + "/login",
+		Headers: v.headers(""),
+		Body:    body,
 	})
 	if err != nil {
 		return fmt.Errorf("cannot be reached: %s", err)
 	}
-	if resp.status != 200 {
+	if resp.Status != 200 {
 		return wrap(ErrRejected, "the AppRole login answered %d: %s",
-			resp.status, vaultErrors(resp.body))
+			resp.Status, vaultErrors(resp.Body))
 	}
 
 	var payload struct {
@@ -473,7 +475,7 @@ func (v *VaultBackend) Refresh(ctx context.Context) error {
 			ClientToken string `json:"client_token"`
 		} `json:"auth"`
 	}
-	if err := resp.decode(&payload); err != nil {
+	if err := resp.Decode(&payload); err != nil {
 		return err
 	}
 	if payload.Auth.ClientToken == "" {

--- a/engine/api/packages.txt
+++ b/engine/api/packages.txt
@@ -34,6 +34,7 @@ unstable github.com/antifailure/antifailure/engine/pkg/extension   The registrat
 unstable github.com/antifailure/antifailure/engine/pkg/livekey     Reads the live key material a hosted deployment is configured with. Internal plumbing that happens to sit outside internal so the enterprise module can reach it.
 unstable github.com/antifailure/antifailure/engine/chaos           The suite that proves the failure paths the documentation claims. Tests of this repository, run against this repository, and not an interface anybody integrates against.
 
+unstable github.com/antifailure/antifailure/ee/engine/cloudauth      Enterprise. The three clouds' credential paths, shared by the secret stores and by every managed database provider. Unstable because a cloud can change how a token is obtained without asking anybody, and because the alternative is each provider carrying its own signer, which is the failure it was extracted to prevent.
 unstable github.com/antifailure/antifailure/ee/engine/compliance     Enterprise. The whole module is a separate one so the community binary cannot import it, and nothing in it is promised to anybody.
 unstable github.com/antifailure/antifailure/ee/engine/feature        Enterprise. Feature gating for the licensed build, which moves with the licence terms rather than with semantic versioning.
 unstable github.com/antifailure/antifailure/ee/engine/license        Enterprise. Licence parsing and verification, which changes whenever the licence format does.


### PR DESCRIPTION
## The failure

Three clouds are authenticated inside `ee/engine/secrets`, each next to the
secret store that first needed it: AWS Signature Version 4 written by hand, the
Google metadata server plus a service account JWT exchange, and the Microsoft
Entra client credentials flow. None of that is about reading a secret. It is
about proving who this process is, and the plan's Wave 2 and Wave 5 lanes need
the identical proof against a different endpoint.

Left where it was, each of those lanes writes its own copy. A second SigV4
signer that agrees with the first one today is indistinguishable from one
signer, right up to the morning somebody fixes a canonicalisation bug in one of
them and the other keeps returning a 403 that reads like a wrong secret key.
That is the shape of failure this repository keeps finding, and the credential
path is the worst place to find it.

## What moved

`ee/engine/cloudauth`, standard library only, holds the signing, the AWS
credential chain, both Google token paths, both Entra token paths, and the one
bounded HTTP client they share. The secret sources call it and print exactly
the messages they printed before.

## How equivalence was established, rather than assumed

Passing tests do not prove a pure extraction, because the tests can move with
the code they were written against. Three separate things say this one is
behaviour preserving.

**The tests that did not move.** The `ee/engine/secrets` suite had 43 top level
tests. Four of them are the SigV4 vectors and they moved with the signing. The
other **39 are still there, still driving the public secrets API, and now
transit `cloudauth` to do it**. 35 of the 39 are byte identical; the four that
changed are named below.

**A token by token comparison of every moved function.** A script strips
comments, normalises receiver renames and exported spellings, and diffs the old
body against the new one. **Twenty five functions were compared.** Eleven are
identical once the renames are normalised. Ten more differ only in tokens that
were read one at a time and are all renames: `a` to `c`, `do` to `Do`,
`resp.status` to `resp.Status`, `AWSBackend` to `AWSChain`. **Four carry a real
difference** and they are the four listed below.

**The vector that cannot flatter its new location.** The canonical SigV4
example is AWS's own published answer, with the published signature. It still
verifies.

## The four differences that are not renames

1. `SignAssertion` takes a `scope` parameter where it read a package constant.
   `ee/engine/secrets` passes `ScopeGoogleCloudPlatform`, which is the same
   string, and a test pins the literal so the derivation is not compared
   against itself.
2. `GCPTokenSource` carries the scope for the same reason.
3. The Azure v2 scope is derived as the resource with `/.default` after it,
   rather than being a second constant that has to agree with the resource.
   For Key Vault that is `https://vault.azure.net/.default`, byte for byte the
   constant it replaces, pinned in a test against the literal.
4. `fromManagedIdentity` sends `s.resource()` where it sent the vault host
   literal. Same value for the one caller.

## Four tests changed and why

- `TestAzureUsesTheAuthorityItIsGiven` now reads the authority off the token
  source rather than off the config, which is a stronger assertion: the token
  source is what builds the URL, and a config field holding the right host
  while the exchange used a compiled in one would have passed the old one.
- `TestGCPSignsAnAssertionThatVerifies` and
  `TestGCPDropsThePrivateKeyPEMOnceItIsParsed` reach the parsed key through
  `tokens.Account()`. Both still start from `NewGCPSecretManager`, so the
  public path is still what is under test.
- The conformance backends are built by a constructor rather than by a struct
  literal, because a backend needs its token source wired.

## `vault.go`

`vault.go` changes here and is not part of the extraction. The shared HTTP
client moved, so its five call sites are renamed field for field: `method` to
`Method`, `resp.status` to `resp.Status`, and so on. That is every line of the
change to that file. Two clients would have been two connection pools, and the
comment on the shared one says why there is exactly one.

## The lane's number

**3 clouds, 1 auth implementation, 0 vendor SDKs in the credential path**,
measured by a test rather than counted by hand:

```
credential path: 5 files, 41 imports, 0 outside the standard library
ee/engine go.mod: 0 of 5 cloud SDKs present
3 clouds, 1 auth implementation, 0 copies elsewhere in ee/engine
```

The third of those fails if `AWS4-HMAC-SHA256`,
`urn:ietf:params:oauth:grant-type:jwt-bearer` or `client_credentials` appears
anywhere in `ee/engine` outside `cloudauth`, which is the day a lane copies the
signer instead of importing it.

## What is NOT proved here

Nothing in this branch has ever run against a real AWS, Google or Azure
account, and it did not before either. The Azure managed identity path and the
AWS instance metadata path both read hard coded link local addresses, so
neither can be driven from a test, and both are unchanged code carried across
whole. `ee/engine/secrets` STATUS rows are untouched because none of them names
a file that moved.
