### PR TITLE
engine: copy on write was a capability five providers declared and nothing could refuse

### DIFF
--- a/.changes/copy-on-write-was-a-claim-nothing-could-refuse.md
+++ b/.changes/copy-on-write-was-a-claim-nothing-could-refuse.md
@@ -20,13 +20,20 @@ of the whole cloud database wave, the sentence the product is sold on is a
 sentence about seconds, and the number a buyer is given comes from it.
 
 `CopyOnWrite_BranchTimeMatchesTheDeclaration` measures it, in the units the
-claim is made in. Two goldens are built, one with a gibibyte of ballast the
-suite writes through the mask callback every provider already calls, and both
-are branched several times alternately, taking the fastest of each. A provider
-declaring copy on write must not have grown; a provider declaring it false
-must have. Those two requirements are complementary, so one of the two possible
-declarations is refused on every run whatever the stopwatch says, and there is
-no reading under which both pass.
+claim is made in. Two goldens are built, one carrying half a gibibyte of
+ballast the suite writes through the mask callback every provider already
+calls, and both are branched several times alternately, taking the fastest of
+each. A provider declaring copy on write must not have grown; a provider
+declaring it false must have. Those two requirements are complementary, so one
+of the two possible declarations is refused on every run whatever the stopwatch
+says, and there is no reading under which both pass.
+
+The boundary is measured rather than fixed: twice the spread the small golden's
+own branch times showed during that run, floored at a quarter of a second. So
+the check is sharper on a quiet machine and refuses to accuse an honest
+provider on a loaded one, and every run prints the copy rate it was actually
+able to refuse, because a pass whose bound is invisible is a pass nobody can
+weigh.
 
 The false side is enforced as hard as the true side. A provider that understates
 its own branching is wrong in the same published table as one that invents it,

--- a/.changes/copy-on-write-was-a-claim-nothing-could-refuse.md
+++ b/.changes/copy-on-write-was-a-claim-nothing-could-refuse.md
@@ -1,0 +1,44 @@
+# fixed
+
+`Caps.CopyOnWrite` says a branch shares storage with its golden, and therefore
+that branch time does not grow with the database. Five providers declared a
+value for it. Nothing in the repository could tell whether any of them was
+telling the truth.
+
+The database conformance suite never read the field at all. Its
+`Capabilities_AreSelfConsistent` behaviour reads `Branching`,
+`SupportedVersions`, `ExpectedBranchLatency`, `MaxConcurrentBranches` and
+`Name`, and stops. The datastore suite beside it reads the same field twice,
+and both reads are about self consistency: copy on write without branching,
+copy on write without a golden. Neither asks whether the claim is true. So a
+provider could declare copy on write alongside branching and a golden, copy
+every byte on every branch, and pass both suites, which is exactly the defect
+this repository keeps finding in its own instruments.
+
+It is not a small field. Copy on write is the distinguishing commercial claim
+of the whole cloud database wave, the sentence the product is sold on is a
+sentence about seconds, and the number a buyer is given comes from it.
+
+`CopyOnWrite_BranchTimeMatchesTheDeclaration` measures it, in the units the
+claim is made in. Two goldens are built, one with a gibibyte of ballast the
+suite writes through the mask callback every provider already calls, and both
+are branched several times alternately, taking the fastest of each. A provider
+declaring copy on write must not have grown; a provider declaring it false
+must have. Those two requirements are complementary, so one of the two possible
+declarations is refused on every run whatever the stopwatch says, and there is
+no reading under which both pass.
+
+The false side is enforced as hard as the true side. A provider that understates
+its own branching is wrong in the same published table as one that invents it,
+and a check that only fires in one direction cannot tell a correct declaration
+from an unexamined one, because both look like the absence of a complaint.
+
+`Caps.ExpectedBranchLatency` had the same shape of hole and it is closed in the
+same commit. Its documentation has always said "the suite asserts against it, so
+a provider that gets slower fails rather than quietly degrading", and what the
+suite asserted was that the number is greater than zero. A provider could
+declare eight seconds, take three minutes, and stay green.
+`Branch_IsWithinTheDeclaredLatency` makes the sentence true.
+
+Both behaviours ship with the broken fakes that prove they can say no, in the
+same commit, on both sides of each boundary.

--- a/docs/src/content/docs/contributing/provider-authoring.md
+++ b/docs/src/content/docs/contributing/provider-authoring.md
@@ -195,6 +195,42 @@ against reality. A silent skip is how a provider ends up claiming conformance
 it does not have, so the suite is built to make skipping visible rather than
 convenient.
 
+### Copy on write, which is measured rather than believed
+
+`CopyOnWrite` says a branch shares storage with its golden, so branch time does
+not grow with the database. It is the claim a customer is really buying, so the
+suite does not take your word for it.
+
+`CopyOnWrite_BranchTimeMatchesTheDeclaration` builds two goldens, one of them a
+gibibyte larger than the other, branches each of them several times alternately,
+and takes the fastest of each. Then it asks one question in two directions:
+
+- Declared `true`, and the larger golden branched measurably slower: **fail**.
+  You are copying, and whoever waits for an environment is paying for it.
+- Declared `false`, and the larger golden branched no slower: **fail**. You have
+  a flat branch time and are not saying so, which puts the wrong row in the
+  comparison table a buyer chooses from.
+
+Those two are complementary, so one of the two possible declarations is refused
+on every run. There is no reading of the stopwatch that lets both pass, which is
+the property a check needs before a green one means anything.
+
+The suite makes a golden large by writing ballast into it from inside the `Mask`
+callback, so a provider needs no extra method: hand `Mask` a connection string
+that works, which every other behaviour needs anyway, and the sizing takes care
+of itself. `Options.CopyOnWriteSmallBytes`, `CopyOnWriteLargeBytes` and
+`CopyOnWriteSamples` tune it for a provider that bills by the gibibyte. They
+have floors, and the floors are the point: below them, copying the extra data
+costs less than the measurement gives to noise, and the behaviour would pass
+every declaration rather than refuse one.
+
+`ExpectedBranchLatency` is checked the same way.
+`Branch_IsWithinTheDeclaredLatency` times the fastest of three branches of the
+conformance dataset against the number you declared. Declare what your service
+does, not what you hope it does: the number is what the engine plans an
+environment around, and a provider that has got slower has to fail here rather
+than degrade quietly.
+
 ## Proving the suite can fail
 
 A green conformance run is worth exactly as much as your confidence that the

--- a/docs/src/content/docs/contributing/provider-authoring.md
+++ b/docs/src/content/docs/contributing/provider-authoring.md
@@ -201,9 +201,10 @@ convenient.
 not grow with the database. It is the claim a customer is really buying, so the
 suite does not take your word for it.
 
-`CopyOnWrite_BranchTimeMatchesTheDeclaration` builds two goldens, one of them a
-gibibyte larger than the other, branches each of them several times alternately,
-and takes the fastest of each. Then it asks one question in two directions:
+`CopyOnWrite_BranchTimeMatchesTheDeclaration` builds two goldens, one of them
+half a gibibyte larger than the other, branches each of them several times
+alternately, and takes the fastest of each. Then it asks one question in two
+directions:
 
 - Declared `true`, and the larger golden branched measurably slower: **fail**.
   You are copying, and whoever waits for an environment is paying for it.
@@ -218,11 +219,36 @@ the property a check needs before a green one means anything.
 The suite makes a golden large by writing ballast into it from inside the `Mask`
 callback, so a provider needs no extra method: hand `Mask` a connection string
 that works, which every other behaviour needs anyway, and the sizing takes care
-of itself. `Options.CopyOnWriteSmallBytes`, `CopyOnWriteLargeBytes` and
-`CopyOnWriteSamples` tune it for a provider that bills by the gibibyte. They
-have floors, and the floors are the point: below them, copying the extra data
-costs less than the measurement gives to noise, and the behaviour would pass
-every declaration rather than refuse one.
+of itself. It also weighs the last branch it makes, because a branch that is
+fast because it is EMPTY would otherwise read as one that is fast because it
+shares storage.
+
+### What the check can and cannot see, printed every time
+
+The allowance the growth is measured against is not a constant. It is twice the
+spread the small golden's own branch times showed during this run, floored at a
+quarter of a second: the machine saying how far its readings travel while the
+data is held still. On a quiet machine that collapses and the check sharpens;
+under load it widens rather than accusing an honest provider of copying.
+
+So the power of the check varies, and every run prints it:
+
+```
+  this run could refuse    a copy slower than 0.49 seconds per GiB, and nothing faster
+```
+
+Read that line before believing a pass. It is the bound on what the run was
+able to see, and a provider whose branch times are erratic gets a weaker bound
+than one whose are steady. Raise `Options.CopyOnWriteLargeBytes` if you want a
+stronger statement than the one your run printed.
+
+`CopyOnWriteSmallBytes`, `CopyOnWriteLargeBytes` and `CopyOnWriteSamples` tune
+the cost for a provider that bills by the gibibyte, and
+`AF_CONFORMANCE_COW_LARGE_BYTES` and its two siblings do the same from the
+environment for a machine that cannot afford the default. Both have floors, and
+both make the run say it was tuned. There is deliberately no way to skip the
+behaviour: a run that shrank says how far it shrank and what it could still
+refuse, and that can be read, where a run that skipped cannot.
 
 `ExpectedBranchLatency` is checked the same way.
 `Branch_IsWithinTheDeclaredLatency` times the fastest of three branches of the

--- a/engine/conformance/cow.go
+++ b/engine/conformance/cow.go
@@ -172,6 +172,48 @@ const (
 	copyOnWriteBallastRowBytes = 1024
 )
 
+// copyOnWriteAllowance is the boundary both sides of the assertion are
+// measured against: how much extra branch time is attributable to noise rather
+// than to the extra data. Three terms, and the largest wins.
+//
+// The OBSERVED SPREAD of the small arm is the one that matters most and it is
+// the one a fixed number cannot supply. It is this machine, during this run,
+// telling the measurement how much its own timings move when nothing about the
+// data has changed. On a quiet machine it collapses and the instrument gets
+// sharper; under load it widens and stops accusing an honest provider of
+// copying. Taken from the small arm rather than the large one because the
+// minimum already absorbs a slow large sample, and what inflates the growth is
+// an anomalously FAST small one.
+//
+// The ABSOLUTE FLOOR covers a provider whose branching is quick and whose
+// spread is therefore a few milliseconds, where any hiccup would clear it. A
+// quarter of a second is longer than a scheduling hiccup that survives taking
+// the minimum of several alternating samples, and it is a small fraction of
+// what moving a gibibyte costs on any storage that exists.
+//
+// The PROPORTIONAL term covers the case three samples are too few to reveal:
+// a spread that came out near zero by luck on a provider whose timings do in
+// fact move by seconds. Half is deliberately generous.
+//
+// The cost of that generosity is a real limit and is stated rather than
+// hidden. A provider whose branch takes eight seconds could copy up to four
+// seconds worth of data and still be called copy on write here. Sensitivity is
+// bounded by the provider's OWN fixed cost, so the instrument is sharp on a
+// fast provider and blunt on a slow one, and the remedy is a larger large
+// size rather than a smaller allowance. The failure messages say so, with the
+// size that would have been needed, computed from what was measured.
+func copyOnWriteAllowance(smallTimes []time.Duration) time.Duration {
+	best, worst := minDuration(smallTimes), maxDuration(smallTimes)
+	allowance := worst - best
+	if proportional := time.Duration(float64(best) * copyOnWriteJitterFraction); proportional > allowance {
+		allowance = proportional
+	}
+	if allowance < copyOnWriteNoiseFloor {
+		allowance = copyOnWriteNoiseFloor
+	}
+	return allowance
+}
+
 // ballastTable is the table the suite fills to make a golden large.
 //
 // Nothing else in the suite reads it. It exists to occupy storage, so its
@@ -192,11 +234,22 @@ func (h *harness) copyOnWriteMatchesTheDeclaration(ctx context.Context) {
 	smallV, smallBytes := h.refreshWithBallast(ctx, small)
 	largeV, largeBytes := h.refreshWithBallast(ctx, large)
 
-	if largeBytes <= smallBytes {
-		h.t.Fatalf("the ballast did not grow the golden: the small one carries %s and the "+
-			"large one %s. Nothing about copy on write can be read from two goldens of the "+
-			"same size, and a verdict from them would be a coin toss printed as a check.",
-			bytesText(smallBytes), bytesText(largeBytes))
+	// What the goldens ACTUALLY carry, against what was asked for. The sizes
+	// are configured but they are not guaranteed: a Postgres that decided to
+	// compress the ballast, or a provider that dropped part of it, leaves two
+	// goldens closer together than the configuration intended, and every
+	// number below would then be computed from a delta that is real but too
+	// small to decide anything. Measured rather than assumed is the whole
+	// reason pg_total_relation_size is read at all, and reading it is only
+	// worth doing if the answer can refuse the run.
+	delta := largeBytes - smallBytes
+	if want := large - small; delta < want/2 {
+		h.t.Fatalf("the two goldens were asked to differ by %s and they differ by %s. The "+
+			"ballast did not reach the size this measurement needs, so the extra data may "+
+			"cost less to copy than the machine's own noise, and a verdict read off it would "+
+			"be a coin toss printed as a check. Either the store compressed the ballast or "+
+			"the provider did not carry all of it.",
+			bytesText(want), bytesText(delta))
 	}
 
 	smallTimes := make([]time.Duration, 0, samples)
@@ -210,8 +263,8 @@ func (h *harness) copyOnWriteMatchesTheDeclaration(ctx context.Context) {
 
 	ts, tl := minDuration(smallTimes), minDuration(largeTimes)
 	grown := tl - ts
-	allowance := copyOnWriteAllowance(ts)
-	deltaGiB := float64(largeBytes-smallBytes) / float64(1<<30)
+	allowance := copyOnWriteAllowance(smallTimes)
+	deltaGiB := float64(delta) / float64(1<<30)
 	marginal := grown.Seconds() / deltaGiB
 
 	// The measurement is logged whatever the verdict, because the number is
@@ -227,7 +280,7 @@ func (h *harness) copyOnWriteMatchesTheDeclaration(ctx context.Context) {
 		h.p.Name(), caps.CopyOnWrite,
 		bytesText(smallBytes), durationsText(smallTimes), ts.Round(time.Millisecond),
 		bytesText(largeBytes), durationsText(largeTimes), tl.Round(time.Millisecond),
-		bytesText(largeBytes-smallBytes),
+		bytesText(delta),
 		grown.Round(time.Millisecond), allowance.Round(time.Millisecond),
 		marginal)
 
@@ -240,7 +293,7 @@ func (h *harness) copyOnWriteMatchesTheDeclaration(ctx context.Context) {
 				"being made and charged to whoever waits for the environment. Either the "+
 				"provider copies and the declaration is wrong, or it shares storage and "+
 				"something else in Branch scales with size.",
-				bytesText(largeBytes-smallBytes), grown.Round(time.Millisecond),
+				bytesText(delta), grown.Round(time.Millisecond),
 				allowance.Round(time.Millisecond), marginal)
 		}
 		// The declared latency, checked at the LARGE size, which is where the
@@ -263,14 +316,20 @@ func (h *harness) copyOnWriteMatchesTheDeclaration(ctx context.Context) {
 	if grown <= allowance {
 		h.t.Fatalf("this provider declares CopyOnWrite FALSE, and branching the golden with %s "+
 			"more data in it took only %s longer, inside the %s this machine's noise can "+
-			"account for. Branch time that does not grow with the data is what copy on write "+
-			"IS, so either the capability is understated or the branch is not carrying the "+
-			"golden's data. Understating it is not the safe direction: the wave publishes one "+
-			"table of branch time per provider, a buyer chooses from that table, and a "+
-			"provider that hides a flat branch time is as wrong in that table as one that "+
-			"invents it.",
-			bytesText(largeBytes-smallBytes), grown.Round(time.Millisecond),
-			allowance.Round(time.Millisecond))
+			"account for. "+
+			"Branch time that does not grow with the data is what copy on write IS, so either "+
+			"the capability is understated or the branch is not carrying the golden's data. "+
+			"Understating it is not the safe direction: the wave publishes one table of branch "+
+			"time per provider, a buyer chooses from that table, and a provider that hides a "+
+			"flat branch time is as wrong in that table as one that invents it. "+
+			"The other reading, and the suite cannot tell them apart from one measurement: this "+
+			"provider's branch already costs %s before any of the extra data, and a copy that "+
+			"is small beside its own fixed cost is invisible whatever it is. %s That is a "+
+			"property of the configuration rather than of the provider, and the fix is a larger "+
+			"golden rather than a looser threshold.",
+			bytesText(delta), grown.Round(time.Millisecond),
+			allowance.Round(time.Millisecond), ts.Round(time.Millisecond),
+			neededSizeAdvice(grown, allowance, delta))
 	}
 }
 
@@ -481,6 +540,25 @@ func copyOnWriteAllowance(small time.Duration) time.Duration {
 	return copyOnWriteNoiseFloor
 }
 
+// neededSizeAdvice turns the reading into the size that would have decided it.
+//
+// A failure that only says the growth was too small leaves the reader guessing
+// how much larger is large enough, and guessing there produces either another
+// failed run or a size chosen to make the red go away.
+func neededSizeAdvice(grown, allowance time.Duration, delta int64) string {
+	if grown <= 0 {
+		return "The extra data cost no measurable time at all, so no size derived from this " +
+			"reading would mean anything; if this provider does copy, raise the large size " +
+			"until the copy is visible and read the number again."
+	}
+	// Linear in the data, which is what the false declaration asserts. Doubled,
+	// so the answer clears the allowance rather than landing on it.
+	need := float64(delta) * (float64(allowance) / float64(grown)) * 2
+	return fmt.Sprintf("At the rate this run measured, the extra data would have to be about "+
+		"%s for the copy to clear the allowance, which is what Options.CopyOnWriteLargeBytes "+
+		"is for.", bytesText(int64(need)))
+}
+
 func minDuration(ds []time.Duration) time.Duration {
 	best := ds[0]
 	for _, d := range ds[1:] {
@@ -489,6 +567,16 @@ func minDuration(ds []time.Duration) time.Duration {
 		}
 	}
 	return best
+}
+
+func maxDuration(ds []time.Duration) time.Duration {
+	worst := ds[0]
+	for _, d := range ds[1:] {
+		if d > worst {
+			worst = d
+		}
+	}
+	return worst
 }
 
 func durationsText(ds []time.Duration) string {

--- a/engine/conformance/cow.go
+++ b/engine/conformance/cow.go
@@ -101,6 +101,17 @@ const (
 	DefaultCopyOnWriteLargeBytes int64 = 1 << 30
 	// DefaultCopyOnWriteSamples is how many branches are timed per size.
 	DefaultCopyOnWriteSamples = 3
+	// DefaultCopyOnWriteTimeout bounds this behaviour alone.
+	//
+	// Half an hour, which is long by the standards of every other behaviour in
+	// the suite and is what the work actually is on the slowest provider that
+	// runs it. The docker provider's golden is a committed IMAGE, so a
+	// gibibyte of ballast is a gibibyte written into a container and then
+	// tarred into a layer, twice, before any branch is timed at all. A
+	// behaviour bounded at the suite's usual few minutes would report that
+	// provider as hung rather than as slow, and the difference matters: one is
+	// a defect and the other is the cost of the measurement.
+	DefaultCopyOnWriteTimeout = 30 * time.Minute
 
 	// MinCopyOnWriteRatio is the least the two sizes may differ by.
 	//

--- a/engine/conformance/cow.go
+++ b/engine/conformance/cow.go
@@ -1,0 +1,500 @@
+package conformance
+
+// Copy on write is the distinguishing commercial claim of every cloud database
+// in this category, and until this file existed nothing could refuse it.
+//
+// Caps.CopyOnWrite said "a branch shares storage with its golden, and
+// therefore branch time is independent of database size", five providers
+// declared a value for it, and the database suite never read the field. The
+// datastore suite beside it read the field twice and both reads were about
+// self consistency: copy on write without branching, copy on write without a
+// golden. Neither asks whether the claim is TRUE. So a provider could declare
+// CopyOnWrite alongside Branching and Golden, copy every byte on every branch,
+// and pass both suites, which is the defect this repository keeps finding in
+// its own instruments: a declaration nothing can refuse.
+//
+// WHAT IS MEASURED, AND WHY IT IS TIME RATHER THAN BYTES.
+//
+// The claim's customer visible meaning is a sentence about seconds: the same
+// command takes the same time on a hundred rows and on a terabyte. That is the
+// sentence the plan sells the wave on, so it is the sentence the suite checks.
+// Asking a provider how many bytes a branch occupies would be checking a
+// second declaration with the first, and it would need an interface method
+// several real services cannot answer honestly: Aurora reports clone storage
+// with lag, Neon reports logical size rather than shared extents. Wall clock
+// needs no new method and no cloud account, and a provider cannot answer it
+// with an opinion.
+//
+// THE SHAPE OF THE MEASUREMENT.
+//
+// Two goldens are built, one small and one large, and the large one is large
+// because the suite put ballast in it through the Mask callback the provider
+// must call anyway. Each is branched several times, alternating between them,
+// and the MINIMUM per size is taken. Minimum rather than mean because load
+// only ever makes an operation slower: on a machine running fifteen other
+// lanes the mean measures the machine and the minimum measures the provider.
+// Alternating rather than running all of one size then all of the other
+// because load drifts, and a drift that lands on one arm reads exactly like
+// the effect being measured.
+//
+// THE ASSERTION IS TWO SIDED ON PURPOSE, AND THE TWO SIDES ARE COMPLEMENTARY.
+//
+//	CopyOnWrite true   requires  grown <= allowance
+//	CopyOnWrite false  requires  grown >  allowance
+//
+// where grown is the extra branch time the extra bytes cost. Exactly one of
+// those holds for any measurement whatsoever, so the suite refuses one of the
+// two possible declarations every single time it runs. There is no reading of
+// the stopwatch under which both declarations pass, which is the property a
+// check needs before anybody should believe a green one.
+//
+// The false side matters as much as the true side. A provider that understates
+// its own capability is lying about what the buyer is paying for in the other
+// direction, it makes the wave's comparison table wrong, and a check that only
+// fires one way is half an instrument.
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/antifailure/antifailure/engine/internal/secrets"
+	"github.com/antifailure/antifailure/engine/pkg/provider"
+)
+
+// The default sizes, and how they were chosen.
+//
+// Discriminating power here is physical rather than statistical: a provider
+// that copies must move the bytes, so the signal is the copy time and there is
+// no sample count that manufactures it from a delta too small to see. The
+// large size is therefore set from the FASTEST copy anybody could plausibly
+// be doing, not the slowest, because the failure that matters is calling a
+// fast copy "shared storage".
+//
+// A local NVMe file copy runs at roughly two gigabytes a second at the very
+// best. One gibibyte of ballast therefore costs an honest copier at least half
+// a second even on the best hardware this suite will ever meet, and on the
+// machine this was written on, at load twenty six with a hundred foreign
+// containers, Postgres CREATE DATABASE moved it far slower than that. Against
+// an allowance whose absolute floor is a quarter of a second, that is the
+// margin: the fastest plausible honest copy is still twice the allowance, and
+// the realistic one is an order of magnitude past it.
+//
+// The small size is not zero. A golden with no ballast at all measures the
+// provider's fixed cost plus whatever a bare Postgres cluster costs to
+// duplicate, and the difference between the two arms would then include the
+// base cluster as well as the ballast. Eight mebibytes is small enough to
+// vanish against a gibibyte and large enough that the small arm is a real
+// branch of a real golden rather than a special case.
+//
+// Both are overridable, because a provider that bills per gibibyte or per
+// second has a legitimate reason to choose differently and the alternative is
+// a lane quietly dropping the behaviour. What is NOT overridable is the ratio
+// floor below: sizes a provider could set equal would turn the instrument off
+// while leaving it in the output as though it had run.
+const (
+	// DefaultCopyOnWriteSmallBytes is the ballast in the small golden.
+	DefaultCopyOnWriteSmallBytes int64 = 8 << 20
+	// DefaultCopyOnWriteLargeBytes is the ballast in the large golden.
+	DefaultCopyOnWriteLargeBytes int64 = 1 << 30
+	// DefaultCopyOnWriteSamples is how many branches are timed per size.
+	DefaultCopyOnWriteSamples = 3
+
+	// MinCopyOnWriteRatio is the least the two sizes may differ by.
+	//
+	// It exists because the one way to make this behaviour vacuous without
+	// deleting it is to configure the two goldens to be the same size, after
+	// which the measurement is noise and the verdict is a coin toss that reads
+	// like a check.
+	MinCopyOnWriteRatio = 16
+	// MinCopyOnWriteSamples is the least number of timings per size. Two,
+	// because a minimum of one is a single reading and a single reading on a
+	// loaded machine is not a measurement.
+	MinCopyOnWriteSamples = 2
+
+	// MinCopyOnWriteLargeBytes is the least ballast the large golden may
+	// carry, and it is a derived number rather than a taste.
+	//
+	// The ratio floor above stops a run making the two goldens the same size,
+	// but it does not stop a run making them BOTH small, and small is the
+	// direction that grants a free pass to the declaration this behaviour
+	// exists to refuse. A provider claiming copy on write passes trivially
+	// when the extra data costs less to copy than the allowance, so the large
+	// size has to be big enough that copying it costs more than the
+	// allowance's absolute floor even on the fastest storage anybody will run
+	// this on. A quarter of a second at two gigabytes a second is five hundred
+	// and twelve megabytes, so that is the floor, and the default is twice it.
+	//
+	// Shrinking the sizes toward this floor is not a way to pass: it makes the
+	// FALSE side stricter, because an honest copier then has less to copy and
+	// has to clear the same allowance. The floor is the only direction that
+	// needed defending.
+	MinCopyOnWriteLargeBytes int64 = 512 << 20
+)
+
+// The allowance, which is the single boundary both sides of the assertion are
+// measured against.
+//
+// It answers one question: how much extra branch time is attributable to noise
+// rather than to the extra gibibyte. Two terms, and the larger wins.
+//
+// The absolute floor covers a provider whose branching is quick, where the
+// proportional term would be a few milliseconds and any hiccup would clear it.
+// A quarter of a second is longer than any scheduling hiccup that survives
+// taking the minimum of several alternating samples, and it is a small
+// fraction of what moving a gibibyte costs on any storage that exists.
+//
+// The proportional term covers a provider whose branching is slow, where the
+// jitter itself is measured in seconds: a container start under load varies by
+// much more than a quarter of a second, and holding it to an absolute floor
+// would fail honest providers on a busy machine. Half is deliberately generous.
+// The cost of that generosity is bounded and is stated rather than hidden: a
+// provider whose branch takes eight seconds could copy up to four seconds
+// worth of data and still be called copy on write by this behaviour. The
+// declared latency assertion below is what stops that from being unbounded,
+// and a provider wanting a tighter answer sets a larger large size.
+const (
+	copyOnWriteNoiseFloor      = 250 * time.Millisecond
+	copyOnWriteJitterFraction  = 0.5
+	copyOnWriteBallastRowBytes = 1024
+)
+
+// ballastTable is the table the suite fills to make a golden large.
+//
+// Nothing else in the suite reads it. It exists to occupy storage, so its
+// shape is chosen for exactly one property: the bytes must survive to disk
+// uncompressed. Postgres compresses a value only once the whole tuple crosses
+// the TOAST threshold of about two kilobytes, so rows a little under a
+// kilobyte stay inline and stay literal, and the payload is hex from md5 of a
+// random value rather than a repeated character, because a run of one
+// character would compress to nothing the moment a future Postgres lowered
+// that threshold and the behaviour would then be measuring an empty table.
+const ballastTable = "conformance_ballast"
+
+// copyOnWriteMatchesTheDeclaration is the behaviour.
+func (h *harness) copyOnWriteMatchesTheDeclaration(ctx context.Context) {
+	caps := h.p.Capabilities()
+	small, large, samples := h.copyOnWriteSettings()
+
+	smallV, smallBytes := h.refreshWithBallast(ctx, small)
+	largeV, largeBytes := h.refreshWithBallast(ctx, large)
+
+	if largeBytes <= smallBytes {
+		h.t.Fatalf("the ballast did not grow the golden: the small one carries %s and the "+
+			"large one %s. Nothing about copy on write can be read from two goldens of the "+
+			"same size, and a verdict from them would be a coin toss printed as a check.",
+			bytesText(smallBytes), bytesText(largeBytes))
+	}
+
+	smallTimes := make([]time.Duration, 0, samples)
+	largeTimes := make([]time.Duration, 0, samples)
+	for i := 0; i < samples; i++ {
+		// Alternating, because load drifts and a drift that lands on one arm
+		// reads exactly like the effect being measured.
+		smallTimes = append(smallTimes, h.timeOneBranch(ctx, smallV.ID, fmt.Sprintf("env_cow_small_%d", i)))
+		largeTimes = append(largeTimes, h.timeOneBranch(ctx, largeV.ID, fmt.Sprintf("env_cow_large_%d", i)))
+	}
+
+	ts, tl := minDuration(smallTimes), minDuration(largeTimes)
+	grown := tl - ts
+	allowance := copyOnWriteAllowance(ts)
+	deltaGiB := float64(largeBytes-smallBytes) / float64(1<<30)
+	marginal := grown.Seconds() / deltaGiB
+
+	// The measurement is logged whatever the verdict, because the number is
+	// the deliverable as much as the pass is, and because a failure nobody can
+	// see the readings behind is a failure nobody can act on.
+	h.t.Logf("\ncopy on write, measured\n"+
+		"  provider                 %s, declares CopyOnWrite=%v\n"+
+		"  small golden ballast     %s, branch times %s, min %s\n"+
+		"  large golden ballast     %s, branch times %s, min %s\n"+
+		"  extra data               %s\n"+
+		"  extra branch time        %s, allowance %s\n"+
+		"  marginal cost            %.2f seconds per GiB\n",
+		h.p.Name(), caps.CopyOnWrite,
+		bytesText(smallBytes), durationsText(smallTimes), ts.Round(time.Millisecond),
+		bytesText(largeBytes), durationsText(largeTimes), tl.Round(time.Millisecond),
+		bytesText(largeBytes-smallBytes),
+		grown.Round(time.Millisecond), allowance.Round(time.Millisecond),
+		marginal)
+
+	if caps.CopyOnWrite {
+		if grown > allowance {
+			h.t.Fatalf("this provider declares CopyOnWrite, and branching the golden with %s "+
+				"more data in it took %s longer, which is past the %s this machine's noise "+
+				"can account for. Copy on write means a branch shares storage with its golden, "+
+				"so branch time does not grow with the data; %.2f seconds per GiB is a copy "+
+				"being made and charged to whoever waits for the environment. Either the "+
+				"provider copies and the declaration is wrong, or it shares storage and "+
+				"something else in Branch scales with size.",
+				bytesText(largeBytes-smallBytes), grown.Round(time.Millisecond),
+				allowance.Round(time.Millisecond), marginal)
+		}
+		// The declared latency, checked at the LARGE size, which is where the
+		// claim is actually worth something. A provider whose branch time does
+		// not grow with the data has no reason to exceed at a gibibyte what it
+		// declared at a handful of rows, and without this the flat side of the
+		// assertion could be satisfied by a provider that is uniformly, and
+		// increasingly, slow.
+		if caps.ExpectedBranchLatency > 0 && tl > caps.ExpectedBranchLatency {
+			h.t.Fatalf("this provider declares CopyOnWrite and an expected branch latency of %s, "+
+				"and its fastest branch of the %s golden took %s. The point of the capability "+
+				"is that the larger database costs no more than the smaller one, so a declared "+
+				"latency that holds on the conformance dataset and not on a gibibyte is a "+
+				"number that stops being true exactly where a customer starts caring about it.",
+				caps.ExpectedBranchLatency, bytesText(largeBytes), tl.Round(time.Millisecond))
+		}
+		return
+	}
+
+	if grown <= allowance {
+		h.t.Fatalf("this provider declares CopyOnWrite FALSE, and branching the golden with %s "+
+			"more data in it took only %s longer, inside the %s this machine's noise can "+
+			"account for. Branch time that does not grow with the data is what copy on write "+
+			"IS, so either the capability is understated or the branch is not carrying the "+
+			"golden's data. Understating it is not the safe direction: the wave publishes one "+
+			"table of branch time per provider, a buyer chooses from that table, and a "+
+			"provider that hides a flat branch time is as wrong in that table as one that "+
+			"invents it.",
+			bytesText(largeBytes-smallBytes), grown.Round(time.Millisecond),
+			allowance.Round(time.Millisecond))
+	}
+}
+
+// branchIsWithinTheDeclaredLatency is the assertion Caps.ExpectedBranchLatency
+// has always documented and nothing has ever made.
+//
+// The field's own comment says "The suite asserts against it, so a provider
+// that gets slower fails rather than quietly degrading", and Wave 2 of the
+// plan repeats that promise to five providers that have not been written yet.
+// What the suite actually did was require the number to be greater than zero.
+// So a provider could declare eight seconds, take three minutes, and stay
+// green, and the sentence in the interface was describing protection that was
+// not there. internal/db/pgurl carried a local copy of this assertion for its
+// own provider with a comment saying generalising it belonged to the lane that
+// owns the suite. This is that lane.
+//
+// The minimum of a few timings, not one, and not the mean. One reading on a
+// machine at load twenty six is a reading of the machine.
+func (h *harness) branchIsWithinTheDeclaredLatency(ctx context.Context) {
+	caps := h.p.Capabilities()
+	gv := h.refresh(ctx)
+
+	const attempts = 3
+	times := make([]time.Duration, 0, attempts)
+	for i := 0; i < attempts; i++ {
+		times = append(times, h.timeOneBranch(ctx, gv.ID, fmt.Sprintf("env_latency_%d", i)))
+	}
+	best := minDuration(times)
+	h.t.Logf("branch of the conformance dataset: %s, best of %s, declared %s",
+		best.Round(time.Millisecond), durationsText(times), caps.ExpectedBranchLatency)
+
+	if best > caps.ExpectedBranchLatency {
+		h.t.Fatalf("this provider declares an expected branch latency of %s and its FASTEST of "+
+			"%d branches took %s. The declaration is what the engine plans an environment "+
+			"around and what the wave's comparison table publishes, so a provider that has "+
+			"got slower has to fail here rather than degrade quietly. Either the service "+
+			"regressed or the number was never true.",
+			caps.ExpectedBranchLatency, attempts, best.Round(time.Millisecond))
+	}
+}
+
+// copyOnWriteSettings resolves the sizes and sample count, refusing a
+// configuration that would make the behaviour unable to answer.
+func (h *harness) copyOnWriteSettings() (small, large int64, samples int) {
+	h.t.Helper()
+	small, large = h.opts.CopyOnWriteSmallBytes, h.opts.CopyOnWriteLargeBytes
+	if small <= 0 {
+		small = DefaultCopyOnWriteSmallBytes
+	}
+	if large <= 0 {
+		large = DefaultCopyOnWriteLargeBytes
+	}
+	samples = h.opts.CopyOnWriteSamples
+	if samples <= 0 {
+		samples = DefaultCopyOnWriteSamples
+	}
+	// Refused rather than corrected. A run configured so that the two goldens
+	// cannot be told apart would still print a verdict, and a verdict from a
+	// measurement that could not have gone the other way is the whole defect
+	// this behaviour exists to remove.
+	if large < MinCopyOnWriteLargeBytes {
+		h.t.Fatalf("the large copy on write golden is configured at %s and the floor is %s. "+
+			"Below it, copying the extra data costs less than the allowance the measurement "+
+			"gives to noise, so a provider declaring copy on write would pass without the "+
+			"claim ever having been at risk.",
+			bytesText(large), bytesText(MinCopyOnWriteLargeBytes))
+	}
+	if large < small*MinCopyOnWriteRatio {
+		h.t.Fatalf("the copy on write sizes are %s and %s, a ratio of %.1f, and this behaviour "+
+			"needs at least %d. Below that the extra data costs less to copy than the machine's "+
+			"own noise, so the measurement cannot refuse either declaration and the pass it "+
+			"prints means nothing.",
+			bytesText(small), bytesText(large), float64(large)/float64(small), MinCopyOnWriteRatio)
+	}
+	if samples < MinCopyOnWriteSamples {
+		h.t.Fatalf("copy on write is configured for %d timing per size and needs at least %d; "+
+			"one reading on a loaded machine is a reading of the machine", samples, MinCopyOnWriteSamples)
+	}
+	return small, large, samples
+}
+
+// refreshWithBallast publishes a golden carrying roughly the requested number
+// of bytes, and returns what it actually carries.
+//
+// The ballast is written from inside the Mask callback, which is the one hook
+// every conformant provider must call with a writable connection to the
+// candidate, and it is therefore the one place the suite can change the size
+// of a golden without adding a method to the interface that five real services
+// would have to implement for a test's benefit.
+//
+// The size that comes back is MEASURED with pg_total_relation_size rather than
+// assumed from the row count, because the number the behaviour divides by has
+// to be the number of bytes that exist, not the number that were asked for.
+func (h *harness) refreshWithBallast(ctx context.Context, want int64) (provider.GoldenVersion, int64) {
+	h.t.Helper()
+
+	var got int64
+	spec := h.spec()
+	inner := spec.Mask
+	spec.Mask = func(mctx context.Context, candidate secrets.Value) error {
+		if inner != nil {
+			if err := inner(mctx, candidate); err != nil {
+				return err
+			}
+		}
+		n, err := fillBallast(mctx, candidate, want)
+		if err != nil {
+			return err
+		}
+		got = n
+		return nil
+	}
+
+	gv, err := h.p.RefreshGolden(ctx, spec)
+	h.trackGolden(gv.ID)
+	if err != nil {
+		h.t.Fatalf("RefreshGolden with %s of ballast: %v", bytesText(want), err)
+	}
+	if !gv.Verified || gv.ID == "" {
+		h.t.Fatalf("RefreshGolden with %s of ballast published %q, verified=%v",
+			bytesText(want), gv.ID, gv.Verified)
+	}
+	if got == 0 {
+		h.t.Fatalf("the golden was published and the suite could not put any ballast in it. " +
+			"Copy on write cannot be measured against two goldens of the same size, and " +
+			"reporting that as a pass is what this behaviour exists to stop.")
+	}
+	return gv, got
+}
+
+// fillBallast writes rows into the candidate until the table holds about want
+// bytes, and returns what it holds.
+func fillBallast(ctx context.Context, candidate secrets.Value, want int64) (int64, error) {
+	db, err := sql.Open("pgx", candidate.Reveal())
+	if err != nil {
+		return 0, fmt.Errorf("open the golden candidate to size it: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+	db.SetMaxOpenConns(1)
+	if err := db.PingContext(ctx); err != nil {
+		// Loud, and named as the thing that could not be done. A provider that
+		// hands Mask a connection string nothing can connect to has broken the
+		// contract every other behaviour depends on, and a suite that treated
+		// it as a reason to skip would be reporting a coverage it does not
+		// have.
+		return 0, fmt.Errorf("the connection string this provider passed to Mask does not "+
+			"connect, so the golden cannot be sized and copy on write cannot be measured: %w", err)
+	}
+
+	if _, err := db.ExecContext(ctx,
+		"CREATE TABLE IF NOT EXISTS "+ballastTable+" (pad text NOT NULL)"); err != nil {
+		return 0, fmt.Errorf("create the ballast table: %w", err)
+	}
+	rows := want / copyOnWriteBallastRowBytes
+	if rows < 1 {
+		rows = 1
+	}
+	// Thirty md5 hex digests is nine hundred and sixty characters, which keeps
+	// the tuple under the TOAST threshold so the bytes stay inline and stay
+	// literal. One md5 per row rather than per digest, because the point is
+	// occupying storage and a million calls to random() is the slow part.
+	if _, err := db.ExecContext(ctx,
+		"INSERT INTO "+ballastTable+" (pad) SELECT repeat(md5(random()::text), 30) "+
+			"FROM generate_series(1, $1::bigint)", rows); err != nil {
+		return 0, fmt.Errorf("write %d ballast rows: %w", rows, err)
+	}
+
+	var size int64
+	if err := db.QueryRowContext(ctx,
+		"SELECT pg_total_relation_size($1)", ballastTable).Scan(&size); err != nil {
+		return 0, fmt.Errorf("measure the ballast: %w", err)
+	}
+	return size, nil
+}
+
+// timeOneBranch creates a branch, times it, and destroys it before the next
+// sample starts.
+//
+// Destroyed inline rather than at cleanup for two reasons. A provider with a
+// declared branch limit would refuse the later samples if they accumulated,
+// and a provider whose branches share a machine gets slower as they pile up,
+// which would show up as growth attributable to the ballast when it is
+// attributable to the previous sample.
+func (h *harness) timeOneBranch(ctx context.Context, version, env string) time.Duration {
+	h.t.Helper()
+	start := time.Now()
+	b, err := h.p.Branch(ctx, version, env)
+	took := time.Since(start)
+	if err != nil {
+		h.t.Fatalf("Branch(%s, %s): %v", version, env, err)
+	}
+	h.created.add(b.ProviderRef)
+	h.created.add(b.EnvID)
+	// Registered as well as destroyed below, so that a Fatalf between here and
+	// the destroy still gets swept.
+	h.t.Cleanup(func() { _ = h.p.Destroy(context.Background(), b) })
+	if err := h.p.Destroy(ctx, b); err != nil {
+		h.t.Fatalf("Destroy the timing branch %s: %v", b.ProviderRef, err)
+	}
+	return took
+}
+
+func copyOnWriteAllowance(small time.Duration) time.Duration {
+	proportional := time.Duration(float64(small) * copyOnWriteJitterFraction)
+	if proportional > copyOnWriteNoiseFloor {
+		return proportional
+	}
+	return copyOnWriteNoiseFloor
+}
+
+func minDuration(ds []time.Duration) time.Duration {
+	best := ds[0]
+	for _, d := range ds[1:] {
+		if d < best {
+			best = d
+		}
+	}
+	return best
+}
+
+func durationsText(ds []time.Duration) string {
+	parts := make([]string, 0, len(ds))
+	for _, d := range ds {
+		parts = append(parts, d.Round(time.Millisecond).String())
+	}
+	return "[" + strings.Join(parts, " ") + "]"
+}
+
+func bytesText(n int64) string {
+	switch {
+	case n >= 1<<30:
+		return fmt.Sprintf("%.2f GiB", float64(n)/float64(1<<30))
+	case n >= 1<<20:
+		return fmt.Sprintf("%.1f MiB", float64(n)/float64(1<<20))
+	default:
+		return fmt.Sprintf("%d bytes", n)
+	}
+}

--- a/engine/conformance/cow.go
+++ b/engine/conformance/cow.go
@@ -515,12 +515,23 @@ func (h *harness) copyOnWriteSettings() (small, large int64, samples int) {
 		h.t.Fatalf("copy on write is configured for %d timing per size and needs at least %d; "+
 			"one reading on a loaded machine is a reading of the machine", samples, MinCopyOnWriteSamples)
 	}
-	if small != h.opts.CopyOnWriteSmallBytes || large != h.opts.CopyOnWriteLargeBytes ||
-		samples != h.opts.CopyOnWriteSamples {
-		// Said out loud, always. A measurement taken at other than the sizes
-		// the suite ships is a different measurement, and a reader comparing
-		// two runs has to be able to see that without going to look for an
-		// environment variable somebody set once.
+	// Compared against the DEFAULTS rather than against the options that were
+	// passed in, which is a one word difference and was wrong.
+	//
+	// A zero option means "use the default", so comparing the resolved value
+	// against the option said "this run was tuned" on every run that tuned
+	// nothing, including the self test's, which prints it beside the shipped
+	// numbers it is running at. A notice that announces a departure that did
+	// not happen is worse than no notice: it is the reader's only signal that
+	// a measurement is not comparable, and one that fires always carries no
+	// information at all. The question is whether the run departed from what
+	// the suite SHIPS, so that is what it asks.
+	if small != DefaultCopyOnWriteSmallBytes || large != DefaultCopyOnWriteLargeBytes ||
+		samples != DefaultCopyOnWriteSamples {
+		// Said out loud whenever it is true. A measurement taken at other than
+		// the sizes the suite ships is a different measurement, and a reader
+		// comparing two runs has to be able to see that without going to look
+		// for an environment variable somebody set once.
 		h.t.Logf("copy on write is running at %s against %s with %d samples per size, "+
 			"where the suite's own defaults are %s against %s with %d. The refusable rate "+
 			"printed with the verdict is what this configuration was actually able to see.",

--- a/engine/conformance/cow.go
+++ b/engine/conformance/cow.go
@@ -58,6 +58,7 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -191,36 +192,53 @@ const (
 // measured against: how much extra branch time is attributable to noise rather
 // than to the extra data.
 //
-// It is the OBSERVED SPREAD of the small arm, doubled, with an absolute floor.
-// The spread is this machine, during this run, saying how far its own readings
-// travel while the data is held constant, which is the exact quantity the
-// allowance is meant to be. Taken from the small arm rather than the large one
-// because the minimum already absorbs a slow large sample, and what inflates
-// the growth is an anomalously FAST small one. Doubled because three readings
-// underestimate a range, and heavily so on a machine whose load is drifting.
+// It is twice the gap between the small arm's BEST and SECOND BEST readings,
+// with an absolute floor. That is a narrower quantity than the range of all
+// the samples, and the difference between the two is the whole of this
+// function's reasoning.
+//
+// The verdict compares MINIMA, so the allowance has to describe how far a
+// minimum can move, and the direct evidence for that is the second best
+// reading. The full range describes how far the WORST reading can move, which
+// the minimum has already thrown away.
+//
+// It matters because branching warms up, and warm up is not noise. Measured on
+// a native Postgres 17 at load thirty: three copies of an eight mebibyte
+// golden took 1.199s, 0.292s and 0.174s, and three copies of a golden five
+// hundred and twelve mebibytes larger took 7.440s, 5.296s and 3.608s. Both
+// arms fall monotonically, because the first copy pays for a cold cache and
+// for the checkpoint that building the golden just dirtied. The range of the
+// small arm is 1.025s and it is almost entirely that warm up; the gap between
+// its two best readings is 0.118s and that is the noise. Feeding the range in
+// made the allowance 2.05s against a growth of 3.43s, a margin of 1.7 which is
+// close enough to flake. The gap makes it the 250ms floor, and the margin 13.7.
+//
+// Both arms warm up together, so taking the minimum of each already cancels
+// it, and charging the allowance for it as well would be paying for the same
+// effect twice out of the instrument's ability to see a copy.
 //
 // The ABSOLUTE FLOOR covers a provider whose branching is quick enough that
-// the spread is a few milliseconds and any hiccup would clear it. A quarter of
-// a second survives taking the minimum of several alternating samples, and it
-// is a small fraction of what moving half a gibibyte costs on any storage that
+// the gap is a few milliseconds and any hiccup would clear it. A quarter of a
+// second survives taking the minimum of several alternating samples, and it is
+// a small fraction of what moving half a gibibyte costs on any storage that
 // exists.
 //
-// It USED to carry a third term, half the small arm's own minimum, as a proxy
-// for the noise on a provider whose timings move by seconds. Measuring the
-// thing it was a proxy for is what removed it. On the shared cluster at load
-// twenty six, the small arm read 30.4s and 26.8s: a spread of 3.6s, where half
-// the minimum was 13.4s. The proxy was four times the noise it stood in for,
-// and every second of that came out of the instrument's ability to see a copy.
-// When the quantity can be measured, a proxy for it is a threshold nobody has
-// checked, which is the same defect as the capability this file exists to
-// falsify.
+// This function has now been wrong twice in the same direction, and both times
+// the correction came from a measurement rather than an argument. It was half
+// the small arm's own minimum, a proxy for noise that measured four times the
+// noise it stood in for. Then it was the range, which measured warm up. A
+// threshold nobody has pointed at real readings is exactly the sort of
+// unchecked declaration this file exists to falsify, and this one is in the
+// falsifier.
 //
 // A real limit remains and the failure messages state it: sensitivity is
 // bounded by how still the provider's own timings are, so the instrument is
 // sharp on a steady provider and blunt on an erratic one, and the remedy is a
 // larger large size rather than a smaller allowance.
 func copyOnWriteAllowance(smallTimes []time.Duration) time.Duration {
-	allowance := (maxDuration(smallTimes) - minDuration(smallTimes)) * copyOnWriteSpreadFactor
+	sorted := append([]time.Duration(nil), smallTimes...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	allowance := (sorted[1] - sorted[0]) * copyOnWriteSpreadFactor
 	if allowance < copyOnWriteNoiseFloor {
 		allowance = copyOnWriteNoiseFloor
 	}
@@ -724,16 +742,6 @@ func minDuration(ds []time.Duration) time.Duration {
 		}
 	}
 	return best
-}
-
-func maxDuration(ds []time.Duration) time.Duration {
-	worst := ds[0]
-	for _, d := range ds[1:] {
-		if d > worst {
-			worst = d
-		}
-	}
-	return worst
 }
 
 func durationsText(ds []time.Duration) string {

--- a/engine/conformance/cow.go
+++ b/engine/conformance/cow.go
@@ -74,19 +74,24 @@ import (
 // fast copy "shared storage".
 //
 // A local NVMe file copy runs at roughly two gigabytes a second at the very
-// best. One gibibyte of ballast therefore costs an honest copier at least half
-// a second even on the best hardware this suite will ever meet, and on the
-// machine this was written on, at load twenty six with a hundred foreign
-// containers, Postgres CREATE DATABASE moved it far slower than that. Against
-// an allowance whose absolute floor is a quarter of a second, that is the
-// margin: the fastest plausible honest copy is still twice the allowance, and
-// the realistic one is an order of magnitude past it.
+// best. Half a gibibyte of ballast therefore costs an honest copier a quarter
+// of a second even on the best hardware this suite will ever meet, and a
+// quarter of a second is the allowance's absolute floor. So the default is the
+// smallest size at which a copy running at the speed of the fastest storage
+// that exists is still refused. Larger buys margin nobody needs and costs
+// every run that ever happens; smaller lets a real copy pass as shared storage
+// on a fast disk.
+//
+// None of that asks to be believed. Every run PRINTS the copy rate it was able
+// to refuse, computed from the allowance and the delta it actually measured,
+// so the power of the check is published beside its verdict rather than argued
+// for in a comment somebody would have to find.
 //
 // The small size is not zero. A golden with no ballast at all measures the
 // provider's fixed cost plus whatever a bare Postgres cluster costs to
 // duplicate, and the difference between the two arms would then include the
 // base cluster as well as the ballast. Eight mebibytes is small enough to
-// vanish against a gibibyte and large enough that the small arm is a real
+// vanish against half a gibibyte and large enough that the small arm is a real
 // branch of a real golden rather than a special case.
 //
 // Both are overridable, because a provider that bills per gibibyte or per
@@ -98,16 +103,16 @@ const (
 	// DefaultCopyOnWriteSmallBytes is the ballast in the small golden.
 	DefaultCopyOnWriteSmallBytes int64 = 8 << 20
 	// DefaultCopyOnWriteLargeBytes is the ballast in the large golden.
-	DefaultCopyOnWriteLargeBytes int64 = 1 << 30
+	DefaultCopyOnWriteLargeBytes int64 = 512 << 20
 	// DefaultCopyOnWriteSamples is how many branches are timed per size.
 	DefaultCopyOnWriteSamples = 3
 	// DefaultCopyOnWriteTimeout bounds this behaviour alone.
 	//
 	// Half an hour, which is long by the standards of every other behaviour in
 	// the suite and is what the work actually is on the slowest provider that
-	// runs it. The docker provider's golden is a committed IMAGE, so a
-	// gibibyte of ballast is a gibibyte written into a container and then
-	// tarred into a layer, twice, before any branch is timed at all. A
+	// runs it. The docker provider's golden is a committed IMAGE, so the
+	// ballast is written into a container and then tarred into a layer, twice,
+	// before any branch is timed at all. A
 	// behaviour bounded at the suite's usual few minutes would report that
 	// provider as hung rather than as slow, and the difference matters: one is
 	// a defect and the other is the cost of the measurement.
@@ -128,21 +133,28 @@ const (
 	// MinCopyOnWriteLargeBytes is the least ballast the large golden may
 	// carry, and it is a derived number rather than a taste.
 	//
-	// The ratio floor above stops a run making the two goldens the same size,
-	// but it does not stop a run making them BOTH small, and small is the
-	// direction that grants a free pass to the declaration this behaviour
-	// exists to refuse. A provider claiming copy on write passes trivially
-	// when the extra data costs less to copy than the allowance, so the large
-	// size has to be big enough that copying it costs more than the
-	// allowance's absolute floor even on the fastest storage anybody will run
-	// this on. A quarter of a second at two gigabytes a second is five hundred
-	// and twelve megabytes, so that is the floor, and the default is twice it.
+	// The ratio floor above stops a run making the two goldens the same size.
+	// This one stops a run making them BOTH so small that the arms differ only
+	// in name: below about sixty four mebibytes the ballast is comparable to
+	// what a bare Postgres cluster occupies before anything is put in it, and
+	// two goldens are then two goldens of one size wearing different labels.
 	//
-	// Shrinking the sizes toward this floor is not a way to pass: it makes the
-	// FALSE side stricter, because an honest copier then has less to copy and
-	// has to clear the same allowance. The floor is the only direction that
-	// needed defending.
-	MinCopyOnWriteLargeBytes int64 = 512 << 20
+	// It sits far below the default rather than at it, and that is a decision
+	// with a cost rather than a rounding. Small is the direction that grants a
+	// free pass, because a provider claiming copy on write passes trivially
+	// once the extra data costs less to copy than the allowance. What stops a
+	// run buying a cheap pass that way is not this number, which cannot be
+	// both affordable on every provider and strong on every provider. It is
+	// that the run PUBLISHES the copy rate it was able to refuse, on every run,
+	// pass or fail. A configuration too weak to refuse anything says so in its
+	// own output, where a floor set high enough to make that impossible would
+	// instead have made the behaviour too expensive to run, and the first
+	// thing anybody reached for would be the way to turn it off.
+	//
+	// Shrinking the sizes is not a way to pass the FALSE side either: an
+	// honest copier then has less to copy and has to clear the same allowance,
+	// so it fails, and the failure names the size that would have decided it.
+	MinCopyOnWriteLargeBytes int64 = 64 << 20
 )
 
 // The allowance, which is the single boundary both sides of the assertion are
@@ -267,6 +279,16 @@ func (h *harness) copyOnWriteMatchesTheDeclaration(ctx context.Context) {
 	deltaGiB := float64(delta) / float64(1<<30)
 	marginal := grown.Seconds() / deltaGiB
 
+	// The POWER of the check, published on every run beside its verdict.
+	//
+	// It is the sentence a configured threshold cannot say for itself: a copy
+	// slower than this was refused, and a faster one was not distinguishable
+	// from shared storage at the size and on the machine this run used. A
+	// reader should not have to reconstruct the instrument's blind spot from
+	// three constants and a comment, and a green run that cannot state what it
+	// could have refused is the shape of check this whole file exists against.
+	refusable := allowance.Seconds() / deltaGiB
+
 	// The measurement is logged whatever the verdict, because the number is
 	// the deliverable as much as the pass is, and because a failure nobody can
 	// see the readings behind is a failure nobody can act on.
@@ -276,13 +298,14 @@ func (h *harness) copyOnWriteMatchesTheDeclaration(ctx context.Context) {
 		"  large golden ballast     %s, branch times %s, min %s\n"+
 		"  extra data               %s\n"+
 		"  extra branch time        %s, allowance %s\n"+
-		"  marginal cost            %.2f seconds per GiB\n",
+		"  marginal cost            %.2f seconds per GiB\n"+
+		"  this run could refuse    a copy slower than %.2f seconds per GiB, and nothing faster\n",
 		h.p.Name(), caps.CopyOnWrite,
 		bytesText(smallBytes), durationsText(smallTimes), ts.Round(time.Millisecond),
 		bytesText(largeBytes), durationsText(largeTimes), tl.Round(time.Millisecond),
 		bytesText(delta),
 		grown.Round(time.Millisecond), allowance.Round(time.Millisecond),
-		marginal)
+		marginal, refusable)
 
 	if caps.CopyOnWrite {
 		if grown > allowance {
@@ -296,6 +319,14 @@ func (h *harness) copyOnWriteMatchesTheDeclaration(ctx context.Context) {
 				bytesText(delta), grown.Round(time.Millisecond),
 				allowance.Round(time.Millisecond), marginal)
 		}
+		// A pass here is a bounded claim and it says so. The bound is the
+		// number printed above: this run refused every copy slower than
+		// `refusable` seconds per GiB and could not have refused a faster one,
+		// so a green is "not copying at any rate this configuration can see"
+		// rather than "not copying". The remedy for a reader who wants a
+		// stronger statement is a larger Options.CopyOnWriteLargeBytes, and
+		// naming it here is the difference between a limit and a blind spot.
+
 		// The declared latency, checked at the LARGE size, which is where the
 		// claim is actually worth something. A provider whose branch time does
 		// not grow with the data has no reason to exceed at a gibibyte what it

--- a/engine/conformance/cow.go
+++ b/engine/conformance/cow.go
@@ -57,7 +57,10 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"os"
+	"strconv"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/antifailure/antifailure/engine/internal/secrets"
@@ -269,8 +272,31 @@ func (h *harness) copyOnWriteMatchesTheDeclaration(ctx context.Context) {
 	for i := 0; i < samples; i++ {
 		// Alternating, because load drifts and a drift that lands on one arm
 		// reads exactly like the effect being measured.
-		smallTimes = append(smallTimes, h.timeOneBranch(ctx, smallV.ID, fmt.Sprintf("env_cow_small_%d", i)))
-		largeTimes = append(largeTimes, h.timeOneBranch(ctx, largeV.ID, fmt.Sprintf("env_cow_large_%d", i)))
+		smallTimes = append(smallTimes,
+			h.timeOneBranch(ctx, smallV.ID, fmt.Sprintf("env_cow_small_%d", i), nil))
+
+		// The last branch of the large golden is also weighed, and the reason
+		// is the hole a timing test has by construction.
+		//
+		// Everything below reads "this branch was fast" as evidence that the
+		// provider shares storage. A provider that hands back an EMPTY
+		// database is also fast, for a reason that is the opposite of the
+		// claim, and it would pass the flat side of the assertion while giving
+		// an environment nothing. Branch_ReadsAKnownRow catches that with the
+		// seed rows, but it is a different behaviour, and a behaviour whose
+		// central inference depends on another one having run is a behaviour
+		// that is wrong when somebody uses -run.
+		//
+		// So the last sample checks that the branch carries the ballast, and
+		// it costs nothing: pg_total_relation_size is a catalogue lookup, not
+		// a scan, which is why this is affordable at half a gibibyte when
+		// counting the rows would not be.
+		var weigh func(provider.Branch)
+		if i == samples-1 {
+			weigh = func(b provider.Branch) { h.requireBallast(ctx, b, largeBytes) }
+		}
+		largeTimes = append(largeTimes,
+			h.timeOneBranch(ctx, largeV.ID, fmt.Sprintf("env_cow_large_%d", i), weigh))
 	}
 
 	ts, tl := minDuration(smallTimes), minDuration(largeTimes)
@@ -386,7 +412,7 @@ func (h *harness) branchIsWithinTheDeclaredLatency(ctx context.Context) {
 	const attempts = 3
 	times := make([]time.Duration, 0, attempts)
 	for i := 0; i < attempts; i++ {
-		times = append(times, h.timeOneBranch(ctx, gv.ID, fmt.Sprintf("env_latency_%d", i)))
+		times = append(times, h.timeOneBranch(ctx, gv.ID, fmt.Sprintf("env_latency_%d", i), nil))
 	}
 	best := minDuration(times)
 	h.t.Logf("branch of the conformance dataset: %s, best of %s, declared %s",
@@ -402,11 +428,42 @@ func (h *harness) branchIsWithinTheDeclaredLatency(ctx context.Context) {
 	}
 }
 
+// The environment overrides, which exist because the alternative that was
+// actually reached for is worse.
+//
+// This behaviour is the only one in the suite whose cost is set by a size
+// rather than by a round trip, and on a machine whose storage is saturated the
+// default is not a slow test, it is a test that does not finish. The machine
+// this was written on measured CREATE DATABASE TEMPLATE of a fifteen megabyte
+// database at twenty seven seconds, and filling a golden at about a megabyte a
+// second, both of them the disk rather than Postgres. At those rates a default
+// sized run is most of an hour.
+//
+// The obvious response to that is a flag that skips the behaviour, and a flag
+// that skips it is how the one capability carrying the product's commercial
+// claim goes back to being unfalsifiable on exactly the runs where somebody was
+// in a hurry. So the knob shrinks the measurement instead of removing it, the
+// floors still apply so it cannot shrink to nothing, and the run prints both
+// the override and the copy rate it was left able to refuse. A weakened check
+// that says how weak it is can still be read; a skipped one cannot be read at
+// all.
+const (
+	envCopyOnWriteSmall   = "AF_CONFORMANCE_COW_SMALL_BYTES"
+	envCopyOnWriteLarge   = "AF_CONFORMANCE_COW_LARGE_BYTES"
+	envCopyOnWriteSamples = "AF_CONFORMANCE_COW_SAMPLES"
+)
+
 // copyOnWriteSettings resolves the sizes and sample count, refusing a
 // configuration that would make the behaviour unable to answer.
 func (h *harness) copyOnWriteSettings() (small, large int64, samples int) {
 	h.t.Helper()
 	small, large = h.opts.CopyOnWriteSmallBytes, h.opts.CopyOnWriteLargeBytes
+	if v, ok := envBytes(h.t, envCopyOnWriteSmall); ok {
+		small = v
+	}
+	if v, ok := envBytes(h.t, envCopyOnWriteLarge); ok {
+		large = v
+	}
 	if small <= 0 {
 		small = DefaultCopyOnWriteSmallBytes
 	}
@@ -414,6 +471,9 @@ func (h *harness) copyOnWriteSettings() (small, large int64, samples int) {
 		large = DefaultCopyOnWriteLargeBytes
 	}
 	samples = h.opts.CopyOnWriteSamples
+	if v, ok := envBytes(h.t, envCopyOnWriteSamples); ok {
+		samples = int(v)
+	}
 	if samples <= 0 {
 		samples = DefaultCopyOnWriteSamples
 	}
@@ -439,7 +499,42 @@ func (h *harness) copyOnWriteSettings() (small, large int64, samples int) {
 		h.t.Fatalf("copy on write is configured for %d timing per size and needs at least %d; "+
 			"one reading on a loaded machine is a reading of the machine", samples, MinCopyOnWriteSamples)
 	}
+	if small != h.opts.CopyOnWriteSmallBytes || large != h.opts.CopyOnWriteLargeBytes ||
+		samples != h.opts.CopyOnWriteSamples {
+		// Said out loud, always. A measurement taken at other than the sizes
+		// the suite ships is a different measurement, and a reader comparing
+		// two runs has to be able to see that without going to look for an
+		// environment variable somebody set once.
+		h.t.Logf("copy on write is running at %s against %s with %d samples per size, "+
+			"where the suite's own defaults are %s against %s with %d. The refusable rate "+
+			"printed with the verdict is what this configuration was actually able to see.",
+			bytesText(small), bytesText(large), samples,
+			bytesText(DefaultCopyOnWriteSmallBytes), bytesText(DefaultCopyOnWriteLargeBytes),
+			DefaultCopyOnWriteSamples)
+	}
 	return small, large, samples
+}
+
+// envBytes reads one override, and refuses a value it cannot parse rather than
+// falling back to the default.
+//
+// Falling back is what makes a typo invisible: the run would use the shipped
+// size, take an hour on the machine that could not afford it, and report a
+// number nobody asked for. A misspelt value is a person's intent that did not
+// arrive, so it fails.
+func envBytes(t *testing.T, name string) (int64, bool) {
+	t.Helper()
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return 0, false
+	}
+	v, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || v <= 0 {
+		t.Fatalf("%s is %q, which is not a positive number of bytes. It is refused rather "+
+			"than ignored, because a run that quietly used the default would answer a "+
+			"question nobody asked.", name, raw)
+	}
+	return v, true
 }
 
 // refreshWithBallast publishes a golden carrying roughly the requested number
@@ -544,11 +639,19 @@ func fillBallast(ctx context.Context, candidate secrets.Value, want int64) (int6
 // and a provider whose branches share a machine gets slower as they pile up,
 // which would show up as growth attributable to the ballast when it is
 // attributable to the previous sample.
-func (h *harness) timeOneBranch(ctx context.Context, version, env string) time.Duration {
+func (h *harness) timeOneBranch(ctx context.Context, version, env string, weigh func(provider.Branch)) time.Duration {
 	h.t.Helper()
 	start := time.Now()
 	b, err := h.p.Branch(ctx, version, env)
 	took := time.Since(start)
+	// Checked BEFORE the duration is used anywhere, and that ordering is the
+	// point rather than habit. A dependency that has fallen over produces the
+	// FASTEST reading a stopwatch can take: while this was being written the
+	// shared Postgres went into recovery, and the two branch timings taken
+	// after it did were the best numbers in the table, because a refused
+	// connection returns in a third of a second. On a latency measurement a
+	// catastrophe and a triumph are the same shape, and only the error
+	// distinguishes them.
 	if err != nil {
 		h.t.Fatalf("Branch(%s, %s): %v", version, env, err)
 	}
@@ -557,10 +660,43 @@ func (h *harness) timeOneBranch(ctx context.Context, version, env string) time.D
 	// Registered as well as destroyed below, so that a Fatalf between here and
 	// the destroy still gets swept.
 	h.t.Cleanup(func() { _ = h.p.Destroy(context.Background(), b) })
+	if weigh != nil {
+		weigh(b)
+	}
 	if err := h.p.Destroy(ctx, b); err != nil {
 		h.t.Fatalf("Destroy the timing branch %s: %v", b.ProviderRef, err)
 	}
 	return took
+}
+
+// requireBallast fails a branch that did not bring the golden's bulk with it.
+//
+// Half is the bar rather than all of it, because a provider is entitled to
+// arrive at the same data by a different physical route: a restore rebuilds a
+// heap without the source's dead tuples and its free space map, and a branch
+// that is a little smaller than its golden for that reason is correct. A
+// branch holding a small fraction of the golden is not a copy on write branch
+// however fast it was, and telling those two apart is the whole reason this
+// reads a size rather than requiring equality.
+func (h *harness) requireBallast(ctx context.Context, b provider.Branch, golden int64) {
+	h.t.Helper()
+	var got int64
+	err := h.open(ctx, b).QueryRowContext(ctx,
+		"SELECT pg_total_relation_size($1)", ballastTable).Scan(&got)
+	if err != nil {
+		h.t.Fatalf("weigh the ballast in branch %s: %v. Every reading in this behaviour is "+
+			"the time to produce a branch that HOLDS the golden, and a branch that cannot be "+
+			"read is not one.", b.ProviderRef, err)
+	}
+	if got*2 < golden {
+		h.t.Fatalf("the golden carries %s of ballast and its branch carries %s. This "+
+			"behaviour infers copy on write from a branch being no slower on a large golden "+
+			"than a small one, and a branch that did not bring the data is fast for the "+
+			"opposite reason: it is not a cheap copy of everything, it is an expensive "+
+			"nothing. An environment made from this would look like a twin and hold a "+
+			"fraction of production.",
+			bytesText(golden), bytesText(got))
+	}
 }
 
 func copyOnWriteAllowance(small time.Duration) time.Duration {

--- a/engine/conformance/cow.go
+++ b/engine/conformance/cow.go
@@ -183,46 +183,44 @@ const (
 // and a provider wanting a tighter answer sets a larger large size.
 const (
 	copyOnWriteNoiseFloor      = 250 * time.Millisecond
-	copyOnWriteJitterFraction  = 0.5
+	copyOnWriteSpreadFactor    = 2
 	copyOnWriteBallastRowBytes = 1024
 )
 
 // copyOnWriteAllowance is the boundary both sides of the assertion are
 // measured against: how much extra branch time is attributable to noise rather
-// than to the extra data. Three terms, and the largest wins.
+// than to the extra data.
 //
-// The OBSERVED SPREAD of the small arm is the one that matters most and it is
-// the one a fixed number cannot supply. It is this machine, during this run,
-// telling the measurement how much its own timings move when nothing about the
-// data has changed. On a quiet machine it collapses and the instrument gets
-// sharper; under load it widens and stops accusing an honest provider of
-// copying. Taken from the small arm rather than the large one because the
-// minimum already absorbs a slow large sample, and what inflates the growth is
-// an anomalously FAST small one.
+// It is the OBSERVED SPREAD of the small arm, doubled, with an absolute floor.
+// The spread is this machine, during this run, saying how far its own readings
+// travel while the data is held constant, which is the exact quantity the
+// allowance is meant to be. Taken from the small arm rather than the large one
+// because the minimum already absorbs a slow large sample, and what inflates
+// the growth is an anomalously FAST small one. Doubled because three readings
+// underestimate a range, and heavily so on a machine whose load is drifting.
 //
-// The ABSOLUTE FLOOR covers a provider whose branching is quick and whose
-// spread is therefore a few milliseconds, where any hiccup would clear it. A
-// quarter of a second is longer than a scheduling hiccup that survives taking
-// the minimum of several alternating samples, and it is a small fraction of
-// what moving a gibibyte costs on any storage that exists.
+// The ABSOLUTE FLOOR covers a provider whose branching is quick enough that
+// the spread is a few milliseconds and any hiccup would clear it. A quarter of
+// a second survives taking the minimum of several alternating samples, and it
+// is a small fraction of what moving half a gibibyte costs on any storage that
+// exists.
 //
-// The PROPORTIONAL term covers the case three samples are too few to reveal:
-// a spread that came out near zero by luck on a provider whose timings do in
-// fact move by seconds. Half is deliberately generous.
+// It USED to carry a third term, half the small arm's own minimum, as a proxy
+// for the noise on a provider whose timings move by seconds. Measuring the
+// thing it was a proxy for is what removed it. On the shared cluster at load
+// twenty six, the small arm read 30.4s and 26.8s: a spread of 3.6s, where half
+// the minimum was 13.4s. The proxy was four times the noise it stood in for,
+// and every second of that came out of the instrument's ability to see a copy.
+// When the quantity can be measured, a proxy for it is a threshold nobody has
+// checked, which is the same defect as the capability this file exists to
+// falsify.
 //
-// The cost of that generosity is a real limit and is stated rather than
-// hidden. A provider whose branch takes eight seconds could copy up to four
-// seconds worth of data and still be called copy on write here. Sensitivity is
-// bounded by the provider's OWN fixed cost, so the instrument is sharp on a
-// fast provider and blunt on a slow one, and the remedy is a larger large
-// size rather than a smaller allowance. The failure messages say so, with the
-// size that would have been needed, computed from what was measured.
+// A real limit remains and the failure messages state it: sensitivity is
+// bounded by how still the provider's own timings are, so the instrument is
+// sharp on a steady provider and blunt on an erratic one, and the remedy is a
+// larger large size rather than a smaller allowance.
 func copyOnWriteAllowance(smallTimes []time.Duration) time.Duration {
-	best, worst := minDuration(smallTimes), maxDuration(smallTimes)
-	allowance := worst - best
-	if proportional := time.Duration(float64(best) * copyOnWriteJitterFraction); proportional > allowance {
-		allowance = proportional
-	}
+	allowance := (maxDuration(smallTimes) - minDuration(smallTimes)) * copyOnWriteSpreadFactor
 	if allowance < copyOnWriteNoiseFloor {
 		allowance = copyOnWriteNoiseFloor
 	}
@@ -697,14 +695,6 @@ func (h *harness) requireBallast(ctx context.Context, b provider.Branch, golden 
 			"fraction of production.",
 			bytesText(golden), bytesText(got))
 	}
-}
-
-func copyOnWriteAllowance(small time.Duration) time.Duration {
-	proportional := time.Duration(float64(small) * copyOnWriteJitterFraction)
-	if proportional > copyOnWriteNoiseFloor {
-		return proportional
-	}
-	return copyOnWriteNoiseFloor
 }
 
 // neededSizeAdvice turns the reading into the size that would have decided it.

--- a/engine/conformance/datastore.go
+++ b/engine/conformance/datastore.go
@@ -17,7 +17,7 @@ import (
 // The datastore suite, which is the second one and is deliberately not a copy
 // of the first.
 //
-// RunDatabase checks twenty four behaviours of a Postgres provider, and most
+// RunDatabase checks twenty six behaviours of a Postgres provider, and most
 // of them are about SQL: a known row survives a branch, a sequence comes back
 // after a reset, two branches cannot see each other's writes. None of that can
 // be asked of a datastore in general, because the interface covers ClickHouse
@@ -295,6 +295,28 @@ func (h *dsHarness) capabilitiesAreSelfConsistent() {
 		h.t.Error("copy on write is declared and no golden is; a branch shares storage " +
 			"with the golden it came from, and there is none to share with")
 	}
+	// RECORDED HOLE, on purpose, because a hole nobody wrote down is one
+	// somebody later reads as covered.
+	//
+	// Both rules above are self consistency: they ask whether the declaration
+	// contradicts its neighbours. Neither asks whether it is TRUE. A datastore
+	// declaring CopyOnWrite, Branching and Golden together, and copying every
+	// byte on every branch, still passes this suite.
+	//
+	// The database suite next door now falsifies the same field, by building
+	// two goldens of very different sizes and requiring branch time to grow
+	// with the data if and only if the provider says it does not share
+	// storage. That does not port across as written, and the reason is the
+	// reason this suite exists separately at all: making a golden large means
+	// writing ballast into it, the database suite does that in SQL through the
+	// candidate connection every Postgres provider hands to Mask, and the
+	// stores behind this interface are ClickHouse and Redis and Kafka and a
+	// search index, whose only shared query language is none. The ballast
+	// would have to be per engine, which is a per engine conformance addition
+	// rather than a shared one.
+	//
+	// So the claim on this side is checked for self consistency and is not
+	// falsified, and that sentence is the honest state of it.
 }
 
 // refreshSaysErrNoGolden is the behaviour a cache has to pass.

--- a/engine/conformance/db.go
+++ b/engine/conformance/db.go
@@ -83,9 +83,9 @@ type Options struct {
 	//
 	// A separate number rather than the shared one, because that behaviour is
 	// structurally more expensive than every other in the suite by a wide
-	// margin: it builds two goldens, one of them a gibibyte, and branches each
-	// of them several times, where the rest build one small golden and branch
-	// it once or twice. A single timeout tuned for the others is too short for
+	// margin: it builds two goldens, one of them half a gibibyte, and branches
+	// each of them several times, where the rest build one small golden and
+	// branch it once or twice. A single timeout tuned for the others is too short for
 	// this one, and one tuned for this one stops a hung call anywhere else
 	// failing the behaviour rather than the job, which is what the timeout is
 	// for.
@@ -589,11 +589,11 @@ func (h *harness) capabilitiesAreSelfConsistent() {
 	// rules: it refuses copy on write declared without branching, and copy on
 	// write declared without a golden. Neither has a subject on this side. A
 	// database provider that does not declare Branching has already been
-	// refused four lines above, because the interface says a provider without
-	// it is not a database provider; and provider.Caps has no Golden field
-	// because RefreshGolden is a method every database provider implements,
-	// so there is no configuration in which a database provider has no golden
-	// to share storage with. Restating either rule here would be a branch no
+	// refused at the top of this function, because the interface says a
+	// provider without it is not a database provider; and Caps has no Golden
+	// field, because RefreshGolden is a method every database provider
+	// implements, so there is no configuration in which a database provider
+	// has no golden to share storage with. Restating either rule here would be a branch no
 	// input can reach, and an unreachable check is indistinguishable from a
 	// check that works right up until somebody relies on it.
 	//

--- a/engine/conformance/db.go
+++ b/engine/conformance/db.go
@@ -78,6 +78,18 @@ type Options struct {
 	// CopyOnWriteSamples is how many branches are timed per size. Zero uses
 	// the default.
 	CopyOnWriteSamples int
+	// CopyOnWriteTimeout bounds CopyOnWrite_BranchTimeMatchesTheDeclaration
+	// alone. Zero uses DefaultCopyOnWriteTimeout.
+	//
+	// A separate number rather than the shared one, because that behaviour is
+	// structurally more expensive than every other in the suite by a wide
+	// margin: it builds two goldens, one of them a gibibyte, and branches each
+	// of them several times, where the rest build one small golden and branch
+	// it once or twice. A single timeout tuned for the others is too short for
+	// this one, and one tuned for this one stops a hung call anywhere else
+	// failing the behaviour rather than the job, which is what the timeout is
+	// for.
+	CopyOnWriteTimeout time.Duration
 }
 
 // DefaultSeedSQL is the schema every conformance run works against.
@@ -187,7 +199,17 @@ func RunDatabase(t *testing.T, factory Factory, opts Options) {
 				// make.
 				t.Skipf("skipped: %s does not declare %s", nameOf(probe), reason)
 			}
-			ctx, cancel := context.WithTimeout(context.Background(), opts.Timeout)
+			limit := opts.Timeout
+			if b.Name == "CopyOnWrite_BranchTimeMatchesTheDeclaration" {
+				limit = opts.CopyOnWriteTimeout
+				if limit <= 0 {
+					limit = DefaultCopyOnWriteTimeout
+				}
+				if limit < opts.Timeout {
+					limit = opts.Timeout
+				}
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), limit)
 			defer cancel()
 			runBehavior(ctx, t, b.Name, factory, opts, created)
 		})

--- a/engine/conformance/db.go
+++ b/engine/conformance/db.go
@@ -559,6 +559,27 @@ func (h *harness) capabilitiesAreSelfConsistent() {
 	if h.p.Name() == "" {
 		h.t.Fatal("a provider must have a name, which is what a manifest refers to")
 	}
+	// CopyOnWrite is deliberately not checked HERE, and the two suites reading
+	// the same field differently is worth explaining rather than leaving to
+	// look like an oversight.
+	//
+	// The datastore suite's two copy on write rules are self consistency
+	// rules: it refuses copy on write declared without branching, and copy on
+	// write declared without a golden. Neither has a subject on this side. A
+	// database provider that does not declare Branching has already been
+	// refused four lines above, because the interface says a provider without
+	// it is not a database provider; and provider.Caps has no Golden field
+	// because RefreshGolden is a method every database provider implements,
+	// so there is no configuration in which a database provider has no golden
+	// to share storage with. Restating either rule here would be a branch no
+	// input can reach, and an unreachable check is indistinguishable from a
+	// check that works right up until somebody relies on it.
+	//
+	// What the field needed was not another self consistency rule but a way to
+	// be FALSIFIED, which is CopyOnWrite_BranchTimeMatchesTheDeclaration in
+	// cow.go. Self consistency asks whether a declaration contradicts its
+	// neighbours. It cannot ask whether the declaration is true, and copy on
+	// write is a claim about the world rather than about the struct.
 }
 
 func (h *harness) refreshProducesAVerifiedGolden(ctx context.Context) {

--- a/engine/conformance/db.go
+++ b/engine/conformance/db.go
@@ -22,7 +22,7 @@
 // That second rule is met by both suites. The runtime suite is proved by
 // fakeruntime_test.go and runtime_selftest_test.go; the database suite by
 // db_selftest_test.go, against the two fakes in internal/testutil/fakes. Every
-// one of the twenty four behaviours below has a fault that turns it red, and
+// one of the twenty six behaviours below has a fault that turns it red, and
 // the self test fails if one of them stops going red, if a behaviour passes by
 // skipping, or if a recorded gap quietly closes without the record being
 // removed.
@@ -69,6 +69,15 @@ type Options struct {
 	// SkipSlow omits the behaviors that create several branches, for a run
 	// against a provider that bills per branch.
 	SkipSlow bool
+	// CopyOnWriteSmallBytes and CopyOnWriteLargeBytes are how much ballast the
+	// two goldens of CopyOnWrite_BranchTimeMatchesTheDeclaration carry. Zero
+	// uses the defaults in cow.go, which explains how they were chosen and why
+	// the ratio between them has a floor a run cannot go under.
+	CopyOnWriteSmallBytes int64
+	CopyOnWriteLargeBytes int64
+	// CopyOnWriteSamples is how many branches are timed per size. Zero uses
+	// the default.
+	CopyOnWriteSamples int
 }
 
 // DefaultSeedSQL is the schema every conformance run works against.
@@ -142,6 +151,8 @@ var databaseBehaviors = []Behavior{
 	{"Cancellation_LeavesNoUntrackedResource", "A cancelled branch leaves either nothing or something the inventory reports.", ""},
 	{"GoldenGC_RefusesAReferencedVersion", "Destroying a golden that a branch came from is refused.", ""},
 	{"Refresh_DoesNotDisturbExistingBranches", "A new golden version leaves branches of an older one untouched.", ""},
+	{"Branch_IsWithinTheDeclaredLatency", "Branching the conformance dataset finishes inside the latency the provider declares.", ""},
+	{"CopyOnWrite_BranchTimeMatchesTheDeclaration", "Branch time grows with the data if and only if the provider declares CopyOnWrite false.", ""},
 }
 
 // RunDatabase runs the whole suite against a provider.
@@ -379,6 +390,10 @@ func runBehavior(ctx context.Context, t *testing.T, name string, factory Factory
 		h.goldenGCRefusesAReferencedVersion(ctx)
 	case "Refresh_DoesNotDisturbExistingBranches":
 		h.refreshDoesNotDisturbBranches(ctx)
+	case "Branch_IsWithinTheDeclaredLatency":
+		h.branchIsWithinTheDeclaredLatency(ctx)
+	case "CopyOnWrite_BranchTimeMatchesTheDeclaration":
+		h.copyOnWriteMatchesTheDeclaration(ctx)
 	default:
 		t.Fatalf("conformance: no implementation for behavior %q", name)
 	}

--- a/engine/conformance/db_selftest_test.go
+++ b/engine/conformance/db_selftest_test.go
@@ -177,7 +177,11 @@ func runChild(t *testing.T, c child) (bool, string) {
 	if c.behavior != "" {
 		pattern += "/^" + c.behavior + "$"
 	}
-	cmd := exec.Command(os.Args[0], "-test.run", pattern, "-test.v", "-test.timeout", "20m")
+	// Forty minutes rather than twenty, because one behaviour is now allowed
+	// half an hour by itself. A binary timeout below the behaviour's own bound
+	// turns a slow provider into a panic in the child, and the parent reads a
+	// panic as the suite catching a fault it never caught.
+	cmd := exec.Command(os.Args[0], "-test.run", pattern, "-test.v", "-test.timeout", "40m")
 	cmd.Env = append(os.Environ(),
 		childEnv+"=1",
 		faultEnv+"="+string(c.fault),

--- a/engine/conformance/db_selftest_test.go
+++ b/engine/conformance/db_selftest_test.go
@@ -48,6 +48,7 @@ const (
 	prefixEnv     = "AF_DB_SELFTEST_PREFIX"
 	urlEnv        = "AF_DB_SELFTEST_URL"
 	unverifiedEnv = "AF_DB_SELFTEST_PUBLISH_UNVERIFIED"
+	flatEnv       = "AF_DB_SELFTEST_FLAT_BRANCH"
 )
 
 // The two providers, named so a table can say which one proved a row.
@@ -106,6 +107,7 @@ func TestDatabaseSuiteChild(t *testing.T) {
 				Prefix:            os.Getenv(prefixEnv),
 				SeedSQL:           conformance.DefaultSeedSQL,
 				PublishUnverified: publishUnverified,
+				FlatBranch:        os.Getenv(flatEnv) == "1",
 			})
 			if err != nil {
 				t.Fatalf("build the Postgres backed provider: %v", err)
@@ -124,7 +126,31 @@ func TestDatabaseSuiteChild(t *testing.T) {
 		return p
 	}
 
-	conformance.RunDatabase(t, factory, conformance.Options{Timeout: 3 * time.Minute})
+	conformance.RunDatabase(t, factory, conformance.Options{
+		Timeout: 10 * time.Minute,
+		// The copy on write sizes, held at the suite's own floor rather than
+		// its default, and the reason is a cost this file has to pay four
+		// times over.
+		//
+		// Proving that behaviour needs four children: a provider that copies
+		// and admits it, one that copies and denies it, one that is flat and
+		// admits it, one that is flat and denies it. Each builds two goldens
+		// and branches them, and the copying ones copy the large golden once
+		// per sample while the flat ones copy it once per pool slot. The
+		// server they all share is the same scratch cluster every branch of
+		// this repository runs its database suites against, so the difference
+		// between the floor and the default is several gibibytes of transient
+		// databases on a machine other lanes are working on.
+		//
+		// What this does NOT prove is the shipped default of a gibibyte, and
+		// that is a real gap rather than a rounding: it is stated here so
+		// nobody reads a green self test as having exercised the numbers a
+		// provider actually gets. The floor is the configuration with the
+		// LEAST discriminating power the suite will accept, so a fault caught
+		// here is caught at the default as well.
+		CopyOnWriteLargeBytes: conformance.MinCopyOnWriteLargeBytes,
+		CopyOnWriteSamples:    conformance.MinCopyOnWriteSamples,
+	})
 }
 
 // child describes one re-execution.
@@ -136,6 +162,10 @@ type child struct {
 	// publishUnverified turns on the affordance that makes an unverified
 	// version obtainable. It is not a fault; see the control below.
 	publishUnverified bool
+	// flatBranch turns on the affordance that makes branch time constant,
+	// which is what a copy on write provider has and Postgres does not. It is
+	// not a fault either, and it has its own control below.
+	flatBranch bool
 }
 
 // runChild executes one behaviour in a subprocess and reports whether it
@@ -155,6 +185,9 @@ func runChild(t *testing.T, c child) (bool, string) {
 	)
 	if c.publishUnverified {
 		cmd.Env = append(cmd.Env, unverifiedEnv+"=1")
+	}
+	if c.flatBranch {
+		cmd.Env = append(cmd.Env, flatEnv+"=1")
 	}
 	if c.backend == onPG {
 		cmd.Env = append(cmd.Env, urlEnv+"="+postgresURL(), prefixEnv+"="+newPostgresPrefix(t))
@@ -248,7 +281,7 @@ func TestTheSuitePassesAgainstAProviderThatKeepsItsGuarantees(t *testing.T) {
 // The same control for the provider with storage, run as one child over the
 // whole suite rather than one child per behaviour.
 //
-// It is the only place all twenty four run together, which is what proves the
+// It is the only place all twenty six run together, which is what proves the
 // Postgres fake is a correct provider rather than one that happens to satisfy
 // the five behaviours pointed at it.
 func TestThePostgresBackedFakeKeepsEveryGuarantee(t *testing.T) {
@@ -357,6 +390,14 @@ func TestEveryBehaviorIsProvedAbleToFail(t *testing.T) {
 			// the suite green, so a red here is the fault's.
 			if f == fakes.BranchAcceptsUnverified {
 				c.publishUnverified = true
+			}
+			// The mirror of the line above, for the same reason. This fault's
+			// premise is a provider that branches in constant time and denies
+			// it, so it has no subject on a provider that copies; injectFault
+			// REFUSES it there and the child prints THE FAULT WAS NOT
+			// INJECTED rather than a green nobody could interpret.
+			if f == fakes.CopyOnWriteUnderstated {
+				c.flatBranch = true
 			}
 			passed, out := runChild(t, c)
 
@@ -501,6 +542,36 @@ func TestTheUnverifiedAffordanceBreaksNothingOnItsOwn(t *testing.T) {
 			requireRan(t, behavior, passed, out)
 		})
 	}
+}
+
+// The control for the affordance that makes the flat side of copy on write
+// provable at all.
+//
+// CopyOnWrite_BranchTimeMatchesTheDeclaration asserts in two complementary
+// directions, so proving it can say no needs a provider on each side of the
+// boundary, and Postgres only supplies one of them: CREATE DATABASE ...
+// TEMPLATE copies, so every ordinary Postgres backed provider is on the
+// copying side. FlatBranch puts one on the other side, by making the copies at
+// refresh and handing them out with a rename.
+//
+// Without this control the red under CopyOnWriteUnderstated would be
+// attributable to the affordance rather than to the fault: a provider whose
+// branching is a rename might be failing that behaviour because renaming
+// breaks something, not because the declaration disagrees with the stopwatch.
+// So the same provider, with the honest declaration, has to pass. The pair is
+// what makes each red mean one thing.
+//
+// It runs the copy on write behaviour rather than the whole suite, because the
+// whole suite against a flat provider is a separate and much longer claim, and
+// this control is about one behaviour's boundary.
+func TestTheFlatBranchAffordanceIsHonestWhenItDeclaresCopyOnWrite(t *testing.T) {
+	if !postgresReachable(t) {
+		t.Skipf("skipped: copy on write is a claim about moving bytes and needs a Postgres at %s",
+			postgresURL())
+	}
+	const behavior = "CopyOnWrite_BranchTimeMatchesTheDeclaration"
+	passed, out := runChild(t, child{backend: onPG, behavior: behavior, flatBranch: true})
+	requireRan(t, behavior, passed, out)
 }
 
 // Every behaviour that needs rows is named, and every behaviour that does not

--- a/engine/conformance/db_selftest_test.go
+++ b/engine/conformance/db_selftest_test.go
@@ -127,29 +127,27 @@ func TestDatabaseSuiteChild(t *testing.T) {
 	}
 
 	conformance.RunDatabase(t, factory, conformance.Options{
+		// The copy on write sizes are left at the suite's own defaults, and
+		// that is a deliberate choice rather than the absence of one.
+		//
+		// They were briefly pinned to the floor, because proving that
+		// behaviour needs four children, a provider that copies and admits
+		// it, one that copies and denies it, one that is flat and admits it,
+		// one that is flat and denies it, and each of them builds two goldens
+		// and branches them several times. On the shared cluster that was
+		// several gibibytes of transient databases on a machine other lanes
+		// are working on, and it took that cluster down twice.
+		//
+		// It is affordable at the default against a Postgres this run stood up
+		// for itself, and affordable is the whole argument: a self test run at
+		// sizes the suite does not ship proves the faults are catchable at
+		// SOME configuration, which is a weaker sentence than anybody reading
+		// a green would assume it to be. Point AF_TEST_DATABASE_URL at a
+		// server that is not carrying fifteen other worktrees.
+		//
+		// The timeout is the suite's shared one and it does not bound the copy
+		// on write behaviour, which has its own and much longer.
 		Timeout: 10 * time.Minute,
-		// The copy on write sizes, held at the suite's own floor rather than
-		// its default, and the reason is a cost this file has to pay four
-		// times over.
-		//
-		// Proving that behaviour needs four children: a provider that copies
-		// and admits it, one that copies and denies it, one that is flat and
-		// admits it, one that is flat and denies it. Each builds two goldens
-		// and branches them, and the copying ones copy the large golden once
-		// per sample while the flat ones copy it once per pool slot. The
-		// server they all share is the same scratch cluster every branch of
-		// this repository runs its database suites against, so the difference
-		// between the floor and the default is several gibibytes of transient
-		// databases on a machine other lanes are working on.
-		//
-		// What this does NOT prove is the shipped default of a gibibyte, and
-		// that is a real gap rather than a rounding: it is stated here so
-		// nobody reads a green self test as having exercised the numbers a
-		// provider actually gets. The floor is the configuration with the
-		// LEAST discriminating power the suite will accept, so a fault caught
-		// here is caught at the default as well.
-		CopyOnWriteLargeBytes: conformance.MinCopyOnWriteLargeBytes,
-		CopyOnWriteSamples:    conformance.MinCopyOnWriteSamples,
 	})
 }
 

--- a/engine/internal/docs/pages.gen.go
+++ b/engine/internal/docs/pages.gen.go
@@ -3975,6 +3975,68 @@ against reality. A silent skip is how a provider ends up claiming conformance
 it does not have, so the suite is built to make skipping visible rather than
 convenient.
 
+### Copy on write, which is measured rather than believed
+
+` + "`" + `CopyOnWrite` + "`" + ` says a branch shares storage with its golden, so branch time does
+not grow with the database. It is the claim a customer is really buying, so the
+suite does not take your word for it.
+
+` + "`" + `CopyOnWrite_BranchTimeMatchesTheDeclaration` + "`" + ` builds two goldens, one of them
+half a gibibyte larger than the other, branches each of them several times
+alternately, and takes the fastest of each. Then it asks one question in two
+directions:
+
+- Declared ` + "`" + `true` + "`" + `, and the larger golden branched measurably slower: **fail**.
+  You are copying, and whoever waits for an environment is paying for it.
+- Declared ` + "`" + `false` + "`" + `, and the larger golden branched no slower: **fail**. You have
+  a flat branch time and are not saying so, which puts the wrong row in the
+  comparison table a buyer chooses from.
+
+Those two are complementary, so one of the two possible declarations is refused
+on every run. There is no reading of the stopwatch that lets both pass, which is
+the property a check needs before a green one means anything.
+
+The suite makes a golden large by writing ballast into it from inside the ` + "`" + `Mask` + "`" + `
+callback, so a provider needs no extra method: hand ` + "`" + `Mask` + "`" + ` a connection string
+that works, which every other behaviour needs anyway, and the sizing takes care
+of itself. It also weighs the last branch it makes, because a branch that is
+fast because it is EMPTY would otherwise read as one that is fast because it
+shares storage.
+
+### What the check can and cannot see, printed every time
+
+The allowance the growth is measured against is not a constant. It is twice the
+spread the small golden's own branch times showed during this run, floored at a
+quarter of a second: the machine saying how far its readings travel while the
+data is held still. On a quiet machine that collapses and the check sharpens;
+under load it widens rather than accusing an honest provider of copying.
+
+So the power of the check varies, and every run prints it:
+
+` + "`" + "`" + "`" + `
+  this run could refuse    a copy slower than 0.49 seconds per GiB, and nothing faster
+` + "`" + "`" + "`" + `
+
+Read that line before believing a pass. It is the bound on what the run was
+able to see, and a provider whose branch times are erratic gets a weaker bound
+than one whose are steady. Raise ` + "`" + `Options.CopyOnWriteLargeBytes` + "`" + ` if you want a
+stronger statement than the one your run printed.
+
+` + "`" + `CopyOnWriteSmallBytes` + "`" + `, ` + "`" + `CopyOnWriteLargeBytes` + "`" + ` and ` + "`" + `CopyOnWriteSamples` + "`" + ` tune
+the cost for a provider that bills by the gibibyte, and
+` + "`" + `AF_CONFORMANCE_COW_LARGE_BYTES` + "`" + ` and its two siblings do the same from the
+environment for a machine that cannot afford the default. Both have floors, and
+both make the run say it was tuned. There is deliberately no way to skip the
+behaviour: a run that shrank says how far it shrank and what it could still
+refuse, and that can be read, where a run that skipped cannot.
+
+` + "`" + `ExpectedBranchLatency` + "`" + ` is checked the same way.
+` + "`" + `Branch_IsWithinTheDeclaredLatency` + "`" + ` times the fastest of three branches of the
+conformance dataset against the number you declared. Declare what your service
+does, not what you hope it does: the number is what the engine plans an
+environment around, and a provider that has got slower has to fail here rather
+than degrade quietly.
+
 ## Proving the suite can fail
 
 A green conformance run is worth exactly as much as your confidence that the

--- a/engine/internal/masking/dialect_conformance_test.go
+++ b/engine/internal/masking/dialect_conformance_test.go
@@ -11,7 +11,8 @@ import (
 //
 // The rule this follows is the one L0.1 exists to enforce: every new interface
 // ships with a broken fake and a self test in the same commit. The database
-// conformance suite in this repository declared twenty four behaviours and had
+// conformance suite in this repository declared twenty four behaviours at the
+// time this was written and had
 // never been shown to fail a single one, and a behaviour that has never gone
 // red is a function call, not a check.
 //

--- a/engine/internal/testutil/fakes/database.go
+++ b/engine/internal/testutil/fakes/database.go
@@ -16,8 +16,8 @@
 // and you have learned something the green run could never tell you.
 //
 // There are two providers to break, and the second exists because the first
-// could not reach five of the twenty four behaviours. [InMemoryDatabase] needs
-// nothing and answers nineteen. [NewPostgresDatabase] keeps real rows in real
+// could not reach six of the twenty six behaviours. [InMemoryDatabase] needs
+// nothing and answers twenty. [NewPostgresDatabase] keeps real rows in real
 // databases on a real server, and answers the five about isolation, reset and
 // what a branch actually holds, which are the ones a fake without storage can
 // only pretend to have checked.
@@ -184,6 +184,45 @@ const (
 	// different sets of data answering to one name is how a cleanup destroys
 	// the golden something else is about to branch.
 	RefreshReusesTheVersionIdentifier Fault = "refresh-reuses-the-version-identifier"
+
+	// CopyOnWriteThatCopies declares that branches share storage with their
+	// golden, and copies every byte of it on every branch.
+	//
+	// This is the fault the capability existed without for as long as the
+	// capability existed. Copy on write is the distinguishing commercial claim
+	// of every cloud database in this category, the sentence the wave is sold
+	// on is a sentence about seconds, and until this fault had a behaviour to
+	// go red in, a provider could declare it, copy a terabyte per environment,
+	// and pass the suite.
+	//
+	// It is hosted by the Postgres backed provider, which copies genuinely,
+	// with CREATE DATABASE ... TEMPLATE. Nothing here simulates the copy.
+	CopyOnWriteThatCopies Fault = "copy-on-write-that-copies"
+
+	// CopyOnWriteUnderstated branches in constant time and declares that it
+	// does not, which is the same lie pointing the other way.
+	//
+	// It is a fault rather than modesty, and the reason is the wave's own
+	// deliverable. Every database provider publishes its branch time into one
+	// comparison table, a buyer picks a provider from that table, and a
+	// provider that hides a flat branch time makes that table as wrong as one
+	// that invents it. A check that only fires when a claim is too generous
+	// is half an instrument: it cannot tell a correct declaration from an
+	// unexamined one, because both look like the absence of a complaint.
+	CopyOnWriteUnderstated Fault = "copy-on-write-understated"
+
+	// IgnoresTheDeclaredBranchLatency takes longer to branch than the
+	// provider says branching takes.
+	//
+	// Caps.ExpectedBranchLatency has documented since it was written that "the
+	// suite asserts against it, so a provider that gets slower fails rather
+	// than quietly degrading", and the suite required only that the number be
+	// greater than zero. So a provider could declare eight seconds, take three
+	// minutes, and stay green, and the sentence in the interface described
+	// protection that was not there. internal/db/pgurl kept a private copy of
+	// the assertion for its own provider with a note saying generalising it
+	// belonged to whoever owned the suite.
+	IgnoresTheDeclaredBranchLatency Fault = "ignores-the-declared-branch-latency"
 )
 
 // Faults returns every fault, sorted, so a test can table drive over all of
@@ -229,6 +268,9 @@ var catches = map[Fault]string{
 	GoldenGCDropsAReferencedVersion:           "GoldenGC_RefusesAReferencedVersion",
 	RefreshRebuildsExistingBranches:           "Refresh_DoesNotDisturbExistingBranches",
 	RefreshReusesTheVersionIdentifier:         "Refresh_DoesNotDisturbExistingBranches",
+	CopyOnWriteThatCopies:                     "CopyOnWrite_BranchTimeMatchesTheDeclaration",
+	CopyOnWriteUnderstated:                    "CopyOnWrite_BranchTimeMatchesTheDeclaration",
+	IgnoresTheDeclaredBranchLatency:           "Branch_IsWithinTheDeclaredLatency",
 }
 
 // Catches maps each fault to the conformance behaviour that must fail when it
@@ -262,6 +304,12 @@ func NeedsRows() map[string]bool {
 		"Branch_IsIsolatedFromOtherBranches":     true,
 		"Reset_ReturnsToGoldenState":             true,
 		"Refresh_DoesNotDisturbExistingBranches": true,
+		// Copy on write is a claim about how long it takes to move bytes, so
+		// it is the behaviour with the strongest claim on a real server of
+		// them all: an in-memory provider branches in microseconds whatever it
+		// holds, which is indistinguishable from the property being asserted
+		// and therefore proves nothing about the assertion.
+		"CopyOnWrite_BranchTimeMatchesTheDeclaration": true,
 	}
 }
 
@@ -315,6 +363,13 @@ var providerFaults = map[Fault]bool{
 	BranchSharesTheGoldensStorage:    true,
 	BranchesShareOneDatabase:         true,
 	RefreshRebuildsExistingBranches:  true,
+	// The two copy on write faults are capability flips, and Capabilities
+	// returns no error and takes no context, so a decorator that wanted to
+	// contradict it would have to reimplement the interface rather than
+	// decorate it. They also have to be flipped on a provider whose BRANCHING
+	// matches the lie, which only the provider knows about itself.
+	CopyOnWriteThatCopies:  true,
+	CopyOnWriteUnderstated: true,
 }
 
 // ProviderFaults returns the faults a provider must host itself, sorted.
@@ -474,6 +529,17 @@ func (b *broken) Branch(ctx context.Context, version, envID string) (provider.Br
 		// The failure is reported with no identifier, and the resource is
 		// there. Nothing the caller holds names it.
 		return provider.Branch{}, ctx.Err()
+	}
+	if b.is(IgnoresTheDeclaredBranchLatency) {
+		// Past the number the provider publishes about itself, by a margin no
+		// scheduler produces. A provider that has quietly got slower looks
+		// exactly like this from outside, which is the point: the fault is not
+		// a contrived one, it is what degradation is.
+		select {
+		case <-ctx.Done():
+			return provider.Branch{}, ctx.Err()
+		case <-time.After(b.Database.Capabilities().ExpectedBranchLatency + 50*time.Millisecond):
+		}
 	}
 	if b.is(BranchIsNotIdempotent) {
 		if n := b.count("branch:" + envID); n > 1 {

--- a/engine/internal/testutil/fakes/inmemory.go
+++ b/engine/internal/testutil/fakes/inmemory.go
@@ -101,7 +101,16 @@ func (d *InMemoryDatabase) Capabilities() provider.Caps {
 		Branching:             true,
 		PooledEndpoints:       true,
 		MaxConcurrentBranches: inMemoryBranchLimit,
-		ExpectedBranchLatency: time.Millisecond,
+		// A second, for a provider whose branch is a map insert.
+		//
+		// It was a millisecond, which was true and is no longer wise. Nothing
+		// checked the field then; Branch_IsWithinTheDeclaredLatency checks it
+		// now, and this fake runs in a subprocess on a machine with fifteen
+		// other lanes on it, where a map insert that is descheduled crosses a
+		// millisecond without anything being wrong. A declaration is a promise
+		// the provider has to keep on a bad day, not a boast about a good one,
+		// and the first thing the new assertion did was make this one honest.
+		ExpectedBranchLatency: time.Second,
 		SupportedVersions:     []int{17},
 	}
 }

--- a/engine/internal/testutil/fakes/postgres.go
+++ b/engine/internal/testutil/fakes/postgres.go
@@ -58,6 +58,31 @@ type PostgresOptions struct {
 	// affordance rather than a fault, and it is what makes the branch side of
 	// Branch_RefusesAnUnverifiedGolden reachable at all.
 	PublishUnverified bool
+	// FlatBranch makes branching cost the same whatever the golden holds,
+	// which is what a copy on write provider does and what Postgres cannot.
+	//
+	// It is an affordance rather than a fault, and it is the only way
+	// CopyOnWrite_BranchTimeMatchesTheDeclaration can be proved from both
+	// ends. That behaviour needs four providers: one that copies and admits
+	// it, one that copies and denies it, one that is flat and admits it, and
+	// one that is flat and denies it. Postgres gives the first two for
+	// nothing, because CREATE DATABASE ... TEMPLATE is a file copy. It gives
+	// the other two only if something makes a branch constant time, and no
+	// amount of SQL will share storage between two databases.
+	//
+	// So the copy is made at REFRESH, several times, and Branch hands one out
+	// with ALTER DATABASE ... RENAME, which is a catalogue update and costs
+	// the same for a megabyte and a gibibyte. That is not a simulation of copy
+	// on write, it is the same observable contract: the expensive work happens
+	// once when the golden is built, a branch carries ALL of the golden's data
+	// including whatever ballast the suite put in it, and branch time does not
+	// grow with the data. A provider whose branches are ZFS clones or Aurora
+	// fast clones is doing the same trick with better storage.
+	//
+	// The pool is finite. When it runs out a branch falls back to copying,
+	// which is correct rather than flat, and is why the pool is sized from
+	// what the timing behaviour asks for rather than left at one.
+	FlatBranch bool
 }
 
 // PostgresDatabase is the provider. Use [NewPostgresDatabase].
@@ -80,6 +105,14 @@ type pgState struct {
 	goldens  map[string]provider.GoldenVersion
 	branches map[string]provider.Branch // env id -> branch
 	firstOf  map[string]string          // golden id -> first branch database
+	// pool holds the copies FlatBranch made at refresh, per golden, waiting to
+	// be renamed into a branch.
+	pool map[string][]string
+	// pooled counts every pool database ever made, so two of them never share
+	// a name. A counter rather than the golden's identifier plus an index,
+	// because a golden destroyed and remade would then collide with its own
+	// leftovers.
+	pooled int
 }
 
 var pgStates sync.Map // prefix -> *pgState
@@ -107,6 +140,7 @@ func NewPostgresDatabase(ctx context.Context, opts PostgresOptions) (*PostgresDa
 		goldens:  map[string]provider.GoldenVersion{},
 		branches: map[string]provider.Branch{},
 		firstOf:  map[string]string{},
+		pool:     map[string][]string{},
 	})
 	return &PostgresDatabase{opts: opts, state: st.(*pgState)}, nil
 }
@@ -143,10 +177,26 @@ func validIdentifier(s string) bool {
 
 func (d *PostgresDatabase) Name() string { return "postgres-template" }
 
+// Capabilities declares what this provider does, and its copy on write answer
+// is derived from how it actually branches rather than written down beside it.
+//
+// That is the point of the two faults below. Honest is the default in both
+// modes: a copying provider declares false, a FlatBranch one declares true.
+// Each fault flips exactly that one bit and changes nothing else, so a red in
+// CopyOnWrite_BranchTimeMatchesTheDeclaration is attributable to the
+// declaration disagreeing with the stopwatch and to nothing else.
 func (d *PostgresDatabase) Capabilities() provider.Caps {
+	cow := d.opts.FlatBranch
+	switch {
+	case d.is(CopyOnWriteThatCopies):
+		cow = true // and every branch is still a full CREATE DATABASE ... TEMPLATE
+	case d.is(CopyOnWriteUnderstated):
+		cow = false // and every branch is still a constant time rename
+	}
 	return provider.Caps{
 		Branching:             true,
 		Reset:                 true,
+		CopyOnWrite:           cow,
 		PooledEndpoints:       true,
 		MaxConcurrentBranches: PostgresBranchLimit,
 		ExpectedBranchLatency: 30 * time.Second,
@@ -158,6 +208,25 @@ func (d *PostgresDatabase) injectFault(f Fault) bool {
 	switch f {
 	case BranchLosesTheGoldensRows, BranchSharesTheGoldensStorage,
 		BranchesShareOneDatabase, RefreshRebuildsExistingBranches:
+		d.fault = f
+		return true
+	case CopyOnWriteThatCopies:
+		// Refused on a flat provider, and the refusal is the point. This fault
+		// is "declares copy on write and copies anyway", so injecting it into
+		// a provider that does not copy would produce a green run whose
+		// greenness proved nothing, which is the exact confusion Uninjectable
+		// exists to make impossible.
+		if d.opts.FlatBranch {
+			return false
+		}
+		d.fault = f
+		return true
+	case CopyOnWriteUnderstated:
+		// The mirror image: "branches in constant time and denies it" needs a
+		// provider that branches in constant time.
+		if !d.opts.FlatBranch {
+			return false
+		}
 		d.fault = f
 		return true
 	}
@@ -249,6 +318,74 @@ func (d *PostgresDatabase) dropDatabase(ctx context.Context, name string) error 
 	return exec(ctx, d.opts.AdminURL, "DROP DATABASE IF EXISTS "+quoted(name)+" WITH (FORCE)")
 }
 
+// renameDatabase is the constant time half of FlatBranch.
+//
+// A rename is a catalogue update: it moves no bytes, so it costs the same for
+// a golden of eight mebibytes and one of a gibibyte, which is the whole
+// property CopyOnWrite_BranchTimeMatchesTheDeclaration measures.
+func (d *PostgresDatabase) renameDatabase(ctx context.Context, from, to string) error {
+	return exec(ctx, d.opts.AdminURL,
+		"ALTER DATABASE "+quoted(from)+" RENAME TO "+quoted(to))
+}
+
+// FlatBranchPoolSize is how many constant time branches one golden can serve.
+//
+// Three, because CopyOnWrite_BranchTimeMatchesTheDeclaration times three
+// branches per golden by default and a fourth would be copies of a gibibyte
+// nothing asks for. A run configured with more samples than this exhausts the
+// pool, the extra branches fall back to copying, and the behaviour's minimum
+// is taken over the fast ones, so the failure mode is a weaker measurement
+// rather than a wrong one.
+const FlatBranchPoolSize = 3
+
+// fillPool makes the copies a flat branch hands out. Called once per refresh,
+// where the time it costs is not what anything measures.
+func (d *PostgresDatabase) fillPool(ctx context.Context, goldenID, goldenDB string) error {
+	names := make([]string, 0, FlatBranchPoolSize)
+	for i := 0; i < FlatBranchPoolSize; i++ {
+		d.state.mu.Lock()
+		d.state.pooled++
+		name := fmt.Sprintf("%s_p%d", d.opts.Prefix, d.state.pooled)
+		d.state.mu.Unlock()
+		if err := d.copyDatabase(ctx, goldenDB, name); err != nil {
+			return fmt.Errorf("fill the flat branch pool: %w", err)
+		}
+		names = append(names, name)
+	}
+	d.state.mu.Lock()
+	d.state.pool[goldenID] = append(d.state.pool[goldenID], names...)
+	d.state.mu.Unlock()
+	return nil
+}
+
+// takeFromPool pops a prepared copy, or reports that there is none left.
+func (d *PostgresDatabase) takeFromPool(goldenID string) (string, bool) {
+	d.state.mu.Lock()
+	defer d.state.mu.Unlock()
+	free := d.state.pool[goldenID]
+	if len(free) == 0 {
+		return "", false
+	}
+	name := free[len(free)-1]
+	d.state.pool[goldenID] = free[:len(free)-1]
+	return name, true
+}
+
+// drainPool drops whatever the pool still holds for a golden.
+//
+// Without it a flat provider leaves three copies of every golden behind for
+// ever, and a fake that leaks is a fake that teaches the suite to ignore its
+// own leak check.
+func (d *PostgresDatabase) drainPool(ctx context.Context, goldenID string) {
+	d.state.mu.Lock()
+	free := d.state.pool[goldenID]
+	delete(d.state.pool, goldenID)
+	d.state.mu.Unlock()
+	for _, name := range free {
+		_ = d.dropDatabase(ctx, name)
+	}
+}
+
 // emptyEveryTable is what BranchLosesTheGoldensRows does. It leaves the schema
 // exactly as the golden had it, which is what makes the bug survive a look at
 // the environment: the tables are all there.
@@ -326,6 +463,12 @@ func (d *PostgresDatabase) RefreshGolden(ctx context.Context, spec provider.Gold
 	}
 	d.state.mu.Unlock()
 
+	if d.opts.FlatBranch {
+		if err := d.fillPool(ctx, v.ID, db); err != nil {
+			return v, err
+		}
+	}
+
 	if d.is(RefreshRebuildsExistingBranches) {
 		// Every environment that branched an hour ago is quietly remade from
 		// the new version, losing everything it has done since.
@@ -363,6 +506,7 @@ func (d *PostgresDatabase) DestroyGolden(ctx context.Context, version string) er
 	}
 	delete(d.state.goldens, version)
 	d.state.mu.Unlock()
+	d.drainPool(ctx, version)
 	return d.dropDatabase(ctx, d.goldenDB(version))
 }
 
@@ -417,7 +561,19 @@ func (d *PostgresDatabase) Branch(ctx context.Context, version, envID string) (p
 		}
 	}
 	if copyFrom != "" {
-		if err := d.copyDatabase(ctx, copyFrom, target); err != nil {
+		// The flat path, which moves no bytes. Falling back to a copy when the
+		// pool is empty rather than failing, because a provider that refused
+		// its fourth branch would fail behaviours that have nothing to do with
+		// timing and the red would point at the wrong thing.
+		pooled, ok := "", false
+		if d.opts.FlatBranch {
+			pooled, ok = d.takeFromPool(version)
+		}
+		if ok {
+			if err := d.renameDatabase(ctx, pooled, target); err != nil {
+				return provider.Branch{}, fmt.Errorf("hand out a prepared branch: %w", err)
+			}
+		} else if err := d.copyDatabase(ctx, copyFrom, target); err != nil {
 			return provider.Branch{}, fmt.Errorf("branch the golden: %w", err)
 		}
 	}

--- a/engine/internal/testutil/fakes/postgres.go
+++ b/engine/internal/testutil/fakes/postgres.go
@@ -3,7 +3,7 @@ package fakes
 // A provider.Database with real storage behind it, so the five conformance
 // behaviours that read rows back can be proved able to fail.
 //
-// [InMemoryDatabase] answers nineteen of the twenty four and cannot answer
+// [InMemoryDatabase] answers twenty of the twenty six and cannot answer
 // these, and the reason is not laziness: isolation, reset, and what a branch
 // actually holds are claims about bytes. A fake with no bytes can only agree
 // with whatever it was told, which is the same thing as not checking. So this

--- a/engine/internal/testutil/fakes/postgres.go
+++ b/engine/internal/testutil/fakes/postgres.go
@@ -669,8 +669,17 @@ func (d *PostgresDatabase) Inventory(ctx context.Context) ([]provider.Resource, 
 	out := make([]provider.Resource, 0, len(names))
 	for _, n := range names {
 		kind := "branch"
-		if strings.HasPrefix(n, d.opts.Prefix+"_g_") {
+		switch {
+		case strings.HasPrefix(n, d.opts.Prefix+"_g_"):
 			kind = "golden"
+		case strings.HasPrefix(n, d.opts.Prefix+"_p"):
+			// A prepared copy FlatBranch has not handed out yet. Named rather
+			// than left to fall through to "branch", because a branch with no
+			// environment against its name is exactly what a leak looks like
+			// to whoever reads this inventory, and a resource that is
+			// deliberately waiting should not have to be recognised by the
+			// absence of a field.
+			kind = "pool"
 		}
 		out = append(out, provider.Resource{Kind: kind, ID: n, EnvID: envOf[n]})
 	}


### PR DESCRIPTION
Draft opened centrally so CI runs. `ci.yml` fires on pull_request and on push to main only, so a pushed branch with no pull request gets no verdict at all, and seventeen lane branches were sitting on the remote unverified.

The lane owns this branch and will replace this description with the failure it fixes, its acceptance evidence and its mutation table before it is marked ready.

Opened by the merge coordinator, not by the lane.