### PR TITLE
engine: a proposal with no reader is the same silence in a new place

### DIFF
--- a/.changes/a-store-and-a-cloud-the-manifest-never-mentioned.md
+++ b/.changes/a-store-and-a-cloud-the-manifest-never-mentioned.md
@@ -1,0 +1,38 @@
+# added
+
+A compose file running ClickHouse and LocalStack produced a manifest that
+mentioned neither.
+
+Both halves were a silence rather than a wrong answer, which is why nothing
+caught them. The image classifier recognised ClickHouse, Redis and
+Elasticsearch, and the merge read postgres, asked about mysql and mongodb and
+dropped every other classification on the floor; Kafka was not classified at
+all. So the twin of an analytics product came up holding a masked Postgres and
+an empty everything else. af init now proposes a stance for every store beside
+the primary, with the reason written per engine, and a store this build has no
+provider for is reported with the stance it would have taken instead of being
+written into a manifest af up would then refuse.
+
+A cloud emulator in that same compose file is the strongest statement a
+repository makes about which cloud it talks to, because somebody configured it
+rather than installed it. LocalStack with SERVICES=s3,sqs,sns is read as the
+roster, and each service on it gets the catalog's rule for the real host.
+
+The catalog itself matched a dependency by its exact name, which works for a
+package called stripe and stops working the moment a vendor ships one client
+per service. Twenty two entries are added, covering Lambda, CloudWatch, KMS,
+Step Functions, Athena, Bedrock, Cognito, API Gateway, Firehose, BigQuery,
+Cloud Logging, Cloud Monitoring, Bigtable, Spanner, Vertex AI, Cloud Run, the
+Google and Microsoft token endpoints, Azure OpenAI, Azure AI Search, Azure
+Monitor and App Configuration. Every host is written out rather than derived
+from the package name, because AWS spells Step Functions as states and
+CloudWatch Logs as logs, and a host guessed wrong matches nothing while looking
+like coverage.
+
+Measured against the probe corpus, which grew from 30 concrete cloud endpoints
+to 62: before, 30 were named by a rule and 32 were refused with "no rule
+matches"; after, 62 are named and none is answered by a wildcard. What the
+catalog still does not cover is named at af init rather than discovered as an
+unreadable refusal in an environment, and the one endpoint that cannot be
+covered without reintroducing a wildcard is stated in the entry and held there
+by a test.

--- a/engine/internal/cli/init.go
+++ b/engine/internal/cli/init.go
@@ -108,6 +108,19 @@ type InitReport struct {
 	Findings         int               `json:"findings"`
 	Partial          bool              `json:"partial"`
 	UnassignedImages []string          `json:"unassigned_images,omitempty"`
+	// Datastores are the stores found beside the primary database. Every one
+	// detection found is here, and Declared says which of them reached the
+	// manifest, because a store this build has no provider for is one af up
+	// would refuse and is therefore reported rather than written.
+	Datastores []InitDatastore `json:"datastores,omitempty"`
+	// Emulators are the cloud emulators the repository runs in its own
+	// compose file, and the rules each one produced.
+	Emulators []detect.DetectedEmulator `json:"emulators,omitempty"`
+	// CloudGaps are the cloud services this application uses that the catalog
+	// has no host for. Each one is a request that will be refused in an
+	// environment with "no rule matches" rather than by name, and naming it
+	// here is the only moment it is cheap to fix.
+	CloudGaps []string `json:"cloud_gaps,omitempty"`
 	// Written is every file the command wrote, the manifest first.
 	Written []string `json:"written"`
 	// Workflow says what happened to .github/workflows/antifailure.yml:
@@ -120,6 +133,54 @@ type InitReport struct {
 	// NoTerminal reports that questions took their defaults because there
 	// was no terminal to ask them on and --non-interactive was not passed.
 	NoTerminal bool `json:"no_terminal,omitempty"`
+}
+
+// InitDatastore is one store detection found beside the primary database.
+type InitDatastore struct {
+	Name   string `json:"name"`
+	Engine string `json:"engine"`
+	Stance string `json:"stance"`
+	// From names the store a derived one is rebuilt from, and is empty for
+	// every other stance.
+	From string `json:"from,omitempty"`
+	// Declared says the store reached the manifest. False means this build
+	// has no provider for its engine, so declaring it would have produced a
+	// manifest af up refuses.
+	Declared bool   `json:"declared"`
+	Evidence string `json:"evidence,omitempty"`
+}
+
+// initDatastores turns the proposals into the report's rows.
+func initDatastores(proposed []detect.ProposedDatastore) []InitDatastore {
+	if len(proposed) == 0 {
+		return nil
+	}
+	out := make([]InitDatastore, 0, len(proposed))
+	for _, p := range proposed {
+		out = append(out, InitDatastore{
+			Name: p.Name, Engine: p.Engine, Stance: string(p.Stance),
+			From: p.From, Declared: p.Provisionable, Evidence: p.Evidence,
+		})
+	}
+	return out
+}
+
+// cloudGaps collects the cloud services a dependency names that no catalog
+// entry claims.
+//
+// The finding exists because a missing egress rule is invisible by
+// construction: the manifest lists what was recognised and says nothing at all
+// about what was not, so the gap only surfaces as a refusal nobody can read,
+// in an environment, at the moment the call is made. This is the one place it
+// can be read before then.
+func cloudGaps(findings []detect.Finding) []string {
+	var out []string
+	for _, f := range detect.OfKind(findings, detect.KindNote) {
+		if strings.HasPrefix(f.Subject, "cloud-service.") {
+			out = append(out, f.Detail)
+		}
+	}
+	return out
 }
 
 func runInit(ctx context.Context, env *Env, opts initOptions) error {
@@ -225,6 +286,9 @@ func runInit(ctx context.Context, env *Env, opts initOptions) error {
 		ManifestPath: manifestPath, Created: true, Services: names,
 		EgressRules: len(res.Draft.Egress.Rules), Questions: res.Questions,
 		UnassignedImages: res.UnassignedImages,
+		Datastores:       initDatastores(res.Datastores),
+		Emulators:        res.Emulators,
+		CloudGaps:        cloudGaps(res.Findings),
 		Assumed:          assumed, Findings: len(res.Findings), Partial: res.Partial,
 		Written: []string{manifestPath}, Workflow: "none", NoTerminal: noTerminal,
 	}
@@ -578,6 +642,53 @@ func renderInitSummary(env *Env, res *detect.Result, assumed map[string]string, 
 		env.Out.Table([]Column{Col("HOST"), Col("MODE"), Flex("WHY")}, ruleRows)
 		env.Out.Note(StyleDim,
 			"Everything not listed is blocked. Nothing reaches the internet by accident.")
+	}
+
+	if len(res.Datastores) > 0 {
+		env.Out.Section("Datastores")
+		dsRows := make([][]string, 0, len(res.Datastores))
+		for _, d := range res.Datastores {
+			stance := string(d.Stance)
+			if d.From != "" {
+				stance += " from " + d.From
+			}
+			where := "manifest"
+			if !d.Provisionable {
+				where = "not declared"
+			}
+			dsRows = append(dsRows, []string{d.Name, d.Engine, stance, where, d.Because})
+		}
+		env.Out.Table([]Column{
+			Col("STORE"), Col("ENGINE"), Col("STANCE"), Col("WHERE"), Flex("WHY"),
+		}, dsRows)
+		// The unprovisionable ones get a sentence each rather than a shared
+		// one. A store this build has no provider for is running in the
+		// developer's compose file and works there, so the missing piece is
+		// this engine's ability to hold a copy of it, and saying that badly
+		// reads as "your store is unsupported".
+		for _, d := range res.Datastores {
+			if !d.Provisionable {
+				env.Out.Note(StyleWarn, d.UnprovisionableNote())
+			}
+		}
+	}
+
+	if len(res.Emulators) > 0 {
+		env.Out.Section("Cloud emulators")
+		for _, e := range res.Emulators {
+			env.Out.Note(StyleDim, e.Note())
+		}
+		env.Out.Note(StyleDim,
+			"Environments reach these clouds through the rules above rather than through an "+
+				"emulator, so no endpoint override is needed and the code under test is the "+
+				"code that ships.")
+	}
+
+	if gaps := cloudGaps(res.Findings); len(gaps) > 0 {
+		env.Out.Section("Cloud services with no rule")
+		for _, gap := range gaps {
+			env.Out.Note(StyleWarn, gap)
+		}
 	}
 
 	if len(assumed) > 0 {

--- a/engine/internal/cli/init_clouds_test.go
+++ b/engine/internal/cli/init_clouds_test.go
@@ -111,14 +111,63 @@ func TestInitClouds_TheReportNamesEveryStoreIncludingTheOnesLeftOut(t *testing.T
 		"a store this build cannot provide must be reported rather than dropped or declared")
 }
 
+// datastoreRow returns the one row of the Datastores table whose STORE column
+// is name, matched on the row's own leading field.
+//
+// It is a leading field rather than a substring because a substring cannot
+// tell the STORE column from the rest of the row, and every word this test
+// wants is in the rest of the row. Each store's reason is rendered in its own
+// row's WHY column, and each of these reasons happens to contain the compose
+// service's name: ClickHouse's reason opens "the events are here", Redis's
+// says "a cache is rebuilt from the primary", Kafka's says "a broker wants its
+// topics". So a row printing the ENGINE in the STORE column still contains
+// every word, on that same row, and only the position separates the two.
+//
+// Exactly one row must match. Two would mean the search found the table and
+// something else, and returning the first would be a check reading whichever
+// one came out on top.
+func datastoreRow(t *testing.T, stdout, name string) string {
+	t.Helper()
+	var found []string
+	for _, line := range strings.Split(stdout, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if field, _, ok := strings.Cut(trimmed, " "); ok && field == name {
+			found = append(found, trimmed)
+		}
+	}
+	require.Len(t, found, 1,
+		"want exactly one summary row whose first column is %q, got %d: %v", name, len(found), found)
+	return found[0]
+}
+
 func TestInitClouds_TheSummaryPrintsTheStoresAndTheirStances(t *testing.T) {
 	dir := cloudsFixture(t)
 	got := runCLI(t, dir, nil, "init", "--non-interactive")
 	require.Equal(t, 0, got.code, got.stderr)
 
-	// The table, by the developer's own names for the stores.
-	for _, want := range []string{"events", "clickhouse", "golden", "cache", "redis", "empty", "broker", "kafka"} {
-		require.Contains(t, got.stdout, want, "the summary does not mention %q", want)
+	// The table, by the developer's own names for the stores, read a row at a
+	// time and anchored on the STORE column.
+	//
+	// This asserted Contains over the whole summary until a mutation proved it
+	// could not fail: printing the ENGINE in the STORE column, which deletes
+	// the developer's own name for every store, left all eight words on the
+	// page and the test green. "clickhouse", "redis" and "kafka" came back
+	// from the ENGINE column, "events" from ClickHouse's reason, and "cache"
+	// and "broker" from the sentences about the two stores left out. The
+	// richer the rendered page, the weaker a Contains against it, and this
+	// page is deliberately rich.
+	for _, want := range []struct{ store, engine, stance, where string }{
+		{"events", "clickhouse", "golden", "manifest"},
+		{"cache", "redis", "empty", "not declared"},
+		{"broker", "kafka", "topics_only", "not declared"},
+	} {
+		row := datastoreRow(t, got.stdout, want.store)
+		require.Contains(t, row, want.engine,
+			"the row for %q does not name the engine it runs", want.store)
+		require.Contains(t, row, want.stance,
+			"the row for %q does not carry the stance, which is the decision", want.store)
+		require.Contains(t, row, want.where,
+			"the row for %q does not say whether it reached the manifest", want.store)
 	}
 	// And the sentence for the two it did not declare, each with the stance it
 	// would have taken, because the stance is the decision.

--- a/engine/internal/cli/init_clouds_test.go
+++ b/engine/internal/cli/init_clouds_test.go
@@ -1,0 +1,191 @@
+package cli_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A finding nothing prints is the same silence in a new place.
+//
+// Detection can propose a stance for every store in a compose file and name
+// every cloud service with no rule, and if af init never renders any of it the
+// developer's experience is unchanged: a manifest that mentions one store, and
+// a refusal in an environment three days later that says no rule matches.
+// These tests run the real command over a real directory and read its real
+// output, so a proposal with no reader fails here rather than shipping.
+
+// cloudsFixture is an analytics product: Postgres for records, ClickHouse for
+// events, Redis for cache, Kafka for the bus, LocalStack standing in for AWS,
+// and one AWS SDK the catalog has no host for.
+func cloudsFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	for name, content := range map[string]string{
+		"package.json": `{"name":"insight","scripts":{"start":"next start"},
+			"dependencies":{"next":"15.0.0","@aws-sdk/client-textract":"3.0.0"}}`,
+		"Dockerfile": "FROM node:20\nCMD [\"node\", \"server.js\"]\n",
+		"docker-compose.yml": `services:
+  web:
+    build: .
+    ports:
+      - "3000:3000"
+  db:
+    image: postgres:16
+  events:
+    image: clickhouse/clickhouse-server:24.3
+  cache:
+    image: redis:7
+  broker:
+    image: confluentinc/cp-kafka:7.6.0
+  localstack:
+    image: localstack/localstack:3.4
+    environment:
+      SERVICES: s3,sqs
+`,
+	} {
+		filename := filepath.Join(dir, name)
+		require.NoError(t, os.MkdirAll(filepath.Dir(filename), 0o700))
+		require.NoError(t, os.WriteFile(filename, []byte(content), 0o600))
+	}
+	return dir
+}
+
+func initCloudsJSON(t *testing.T, dir string) struct {
+	Datastores []struct {
+		Name     string `json:"name"`
+		Engine   string `json:"engine"`
+		Stance   string `json:"stance"`
+		From     string `json:"from"`
+		Declared bool   `json:"declared"`
+		Evidence string `json:"evidence"`
+	} `json:"datastores"`
+	Emulators []struct {
+		Product  string   `json:"Product"`
+		Cloud    string   `json:"Cloud"`
+		Service  string   `json:"Service"`
+		Services []string `json:"Services"`
+		Hosts    []string `json:"Hosts"`
+		Unnamed  []string `json:"Unnamed"`
+	} `json:"emulators"`
+	CloudGaps []string `json:"cloud_gaps"`
+} {
+	t.Helper()
+	var report struct {
+		Datastores []struct {
+			Name     string `json:"name"`
+			Engine   string `json:"engine"`
+			Stance   string `json:"stance"`
+			From     string `json:"from"`
+			Declared bool   `json:"declared"`
+			Evidence string `json:"evidence"`
+		} `json:"datastores"`
+		Emulators []struct {
+			Product  string   `json:"Product"`
+			Cloud    string   `json:"Cloud"`
+			Service  string   `json:"Service"`
+			Services []string `json:"Services"`
+			Hosts    []string `json:"Hosts"`
+			Unnamed  []string `json:"Unnamed"`
+		} `json:"emulators"`
+		CloudGaps []string `json:"cloud_gaps"`
+	}
+	got := runCLI(t, dir, nil, "init", "--non-interactive", "--output", "json")
+	require.Equal(t, 0, got.code, got.stderr)
+	require.NoError(t, json.Unmarshal([]byte(got.stdout), &report))
+	return report
+}
+
+func TestInitClouds_TheReportNamesEveryStoreIncludingTheOnesLeftOut(t *testing.T) {
+	report := initCloudsJSON(t, cloudsFixture(t))
+
+	declared := map[string]bool{}
+	for _, d := range report.Datastores {
+		declared[d.Name] = d.Declared
+	}
+	require.Equal(t, map[string]bool{"events": true, "cache": false, "broker": false}, declared,
+		"a store this build cannot provide must be reported rather than dropped or declared")
+}
+
+func TestInitClouds_TheSummaryPrintsTheStoresAndTheirStances(t *testing.T) {
+	dir := cloudsFixture(t)
+	got := runCLI(t, dir, nil, "init", "--non-interactive")
+	require.Equal(t, 0, got.code, got.stderr)
+
+	// The table, by the developer's own names for the stores.
+	for _, want := range []string{"events", "clickhouse", "golden", "cache", "redis", "empty", "broker", "kafka"} {
+		require.Contains(t, got.stdout, want, "the summary does not mention %q", want)
+	}
+	// And the sentence for the two it did not declare, each with the stance it
+	// would have taken, because the stance is the decision.
+	require.Contains(t, got.stdout, "It is not in the manifest",
+		"a store left out of the manifest must be named in the summary")
+}
+
+func TestInitClouds_OnlyTheProvidableStoreReachesTheManifestOnDisk(t *testing.T) {
+	dir := cloudsFixture(t)
+	got := runCLI(t, dir, nil, "init", "--non-interactive")
+	require.Equal(t, 0, got.code, got.stderr)
+
+	body, err := os.ReadFile(filepath.Join(dir, "antifailure.yaml"))
+	require.NoError(t, err)
+	text := string(body)
+	require.Contains(t, text, "clickhouse")
+	require.NotContains(t, text, "engine: redis",
+		"a datastore this build has no provider for makes a manifest af up refuses")
+	require.NotContains(t, text, "engine: kafka")
+}
+
+func TestInitClouds_TheEmulatorAndItsRulesAreReported(t *testing.T) {
+	report := initCloudsJSON(t, cloudsFixture(t))
+	require.Len(t, report.Emulators, 1)
+	em := report.Emulators[0]
+	require.Equal(t, "LocalStack", em.Product)
+	require.Equal(t, "aws", em.Cloud)
+	require.Equal(t, []string{"s3", "sqs"}, em.Services)
+	require.Contains(t, em.Hosts, "s3.amazonaws.com")
+	require.Contains(t, em.Hosts, "sqs.*.amazonaws.com")
+	require.Empty(t, em.Unnamed)
+}
+
+func TestInitClouds_TheSummaryPrintsTheEmulator(t *testing.T) {
+	dir := cloudsFixture(t)
+	got := runCLI(t, dir, nil, "init", "--non-interactive")
+	require.Equal(t, 0, got.code, got.stderr)
+	require.Contains(t, got.stdout, "Cloud emulators")
+	require.Contains(t, got.stdout, "LocalStack")
+}
+
+func TestInitClouds_TheServiceWithNoRuleIsNamedInTheReportAndTheSummary(t *testing.T) {
+	report := initCloudsJSON(t, cloudsFixture(t))
+	require.Len(t, report.CloudGaps, 1)
+	require.Contains(t, report.CloudGaps[0], "@aws-sdk/client-textract")
+
+	// A second directory, because af init refuses to replace a manifest it
+	// already wrote and the two runs must not share one.
+	got := runCLI(t, cloudsFixture(t), nil, "init", "--non-interactive")
+	require.Equal(t, 0, got.code, got.stderr)
+	require.Contains(t, got.stdout, "Cloud services with no rule")
+	require.Contains(t, got.stdout, "textract",
+		"a service that will be refused with no rule matches must be named while it is cheap to fix")
+}
+
+func TestInitClouds_ARepositoryWithNoneOfThisPrintsNoneOfIt(t *testing.T) {
+	// A section that appears on every run is a section nobody reads. This is
+	// the direction that makes the other six worth having.
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"),
+		[]byte(`{"name":"plain","scripts":{"start":"next start"},"dependencies":{"next":"15.0.0"}}`), 0o600))
+
+	got := runCLI(t, dir, nil, "init", "--non-interactive")
+	require.Equal(t, 0, got.code, got.stderr)
+	for _, section := range []string{"Datastores", "Cloud emulators", "Cloud services with no rule"} {
+		require.NotContains(t, got.stdout, section,
+			"%q appeared for a repository that has none", section)
+	}
+	require.NotContains(t, strings.ToLower(got.stdout), "it is not in the manifest")
+}

--- a/engine/internal/detect/cloud_catalog_test.go
+++ b/engine/internal/detect/cloud_catalog_test.go
@@ -195,6 +195,69 @@ var cloudEndpoints = []string{
 	"shopfront.file.core.windows.net",
 	"shopfront.documents.azure.com",
 	"shopfront.vault.azure.net",
+
+	// The rest of each cloud. Every one of these was a request no rule named
+	// before, so the sidecar refused it with "no rule matches" and the
+	// developer had no way to learn which service they had just been stopped
+	// from reaching. The AWS half is worse than that: it matched the mail
+	// wildcard, so it was answered 200 with an empty body.
+	//
+	// The spellings are the vendor's, deliberately, because that is the point
+	// of the table. AWS calls Step Functions states, CloudWatch Logs logs and
+	// CloudWatch itself monitoring, and a host derived from the package name
+	// would be sfn, cloudwatch-logs and cloudwatch, none of which resolve.
+	"lambda.us-east-1.amazonaws.com",
+	"logs.us-east-1.amazonaws.com",
+	"monitoring.us-east-1.amazonaws.com",
+	"kms.eu-west-1.amazonaws.com",
+	"states.us-east-1.amazonaws.com",
+	"athena.us-east-1.amazonaws.com",
+	"bedrock-runtime.us-east-1.amazonaws.com",
+	"cognito-idp.us-east-1.amazonaws.com",
+	"cognito-identity.us-east-1.amazonaws.com",
+	"apigateway.us-east-1.amazonaws.com",
+	"abcd1234.execute-api.us-east-1.amazonaws.com",
+	"firehose.us-east-1.amazonaws.com",
+	"bigquery.googleapis.com",
+	"bigquerystorage.googleapis.com",
+	"logging.googleapis.com",
+	"monitoring.googleapis.com",
+	"bigtable.googleapis.com",
+	"bigtableadmin.googleapis.com",
+	"spanner.googleapis.com",
+	"aiplatform.googleapis.com",
+	"run.googleapis.com",
+	// The token endpoint every Google client calls before it calls anything
+	// else. An unnamed refusal here is the FIRST thing a Google application
+	// sees, and it says nothing about Google.
+	"oauth2.googleapis.com",
+	"accounts.google.com",
+	"iamcredentials.googleapis.com",
+	// The Azure peer of those three.
+	"login.microsoftonline.com",
+	"login.windows.net",
+	"shopfront.openai.azure.com",
+	"shopfront.search.windows.net",
+	"dc.services.visualstudio.com",
+	"shopfront.in.applicationinsights.azure.com",
+	"shopfront.livediagnostics.monitor.azure.com",
+	"shopfront.azconfig.io",
+}
+
+// statedCloudGaps are cloud endpoints this catalog deliberately does NOT
+// name, with the reason, kept beside the corpus rather than in a comment
+// somebody has to find.
+//
+// A star in an egress pattern stands for one whole label. Vertex AI's regional
+// endpoint is us-central1-aiplatform.googleapis.com, where the region and the
+// service share a label, so no pattern short of *.googleapis.com covers it and
+// that is the wildcard L0.3 removed. The request is therefore still refused,
+// because the default is block, and its refusal says no rule matches rather
+// than naming Vertex. A gap that is stated and measured beats a gap that is
+// closed by a wildcard.
+var statedCloudGaps = []string{
+	"us-central1-aiplatform.googleapis.com",
+	"europe-west4-aiplatform.googleapis.com",
 }
 
 // everyCloudSDK is a repository that reaches all three clouds.
@@ -214,7 +277,21 @@ func everyCloudSDK() map[string]string {
 			"@azure/storage-blob":"12.0.0","@azure/storage-queue":"12.0.0",
 			"@azure/service-bus":"7.0.0","@azure/cosmos":"4.0.0",
 			"@azure/data-tables":"13.0.0","@azure/storage-file-share":"12.0.0",
-			"@azure/keyvault-secrets":"4.0.0"}}`,
+			"@azure/keyvault-secrets":"4.0.0",
+			"@aws-sdk/client-lambda":"3.0.0","@aws-sdk/client-cloudwatch-logs":"3.0.0",
+			"@aws-sdk/client-cloudwatch":"3.0.0","@aws-sdk/client-kms":"3.0.0",
+			"@aws-sdk/client-sfn":"3.0.0","@aws-sdk/client-athena":"3.0.0",
+			"@aws-sdk/client-bedrock-runtime":"3.0.0",
+			"@aws-sdk/client-cognito-identity-provider":"3.0.0",
+			"@aws-sdk/client-cognito-identity":"3.0.0",
+			"@aws-sdk/client-api-gateway":"3.0.0","@aws-sdk/client-firehose":"3.0.0",
+			"@google-cloud/bigquery":"7.0.0","@google-cloud/logging":"11.0.0",
+			"@google-cloud/monitoring":"4.0.0","@google-cloud/bigtable":"5.0.0",
+			"@google-cloud/spanner":"7.0.0","@google-cloud/aiplatform":"3.0.0",
+			"@google-cloud/run":"1.0.0","google-auth-library":"9.0.0",
+			"@azure/identity":"4.0.0","@azure/openai":"2.0.0",
+			"@azure/search-documents":"12.0.0","@azure/monitor-opentelemetry":"1.0.0",
+			"@azure/app-configuration":"1.0.0"}}`,
 		".env.example": "SES_SMTP_USERNAME=\nSES_SMTP_PASSWORD=\n",
 	}
 }
@@ -276,4 +353,31 @@ func TestCatalog_TheNumber(t *testing.T) {
 		"nothing may be answered as a success by a rule that did not name it")
 	require.Positive(t, bInvented,
 		"the before figure has to be non zero or this measures nothing")
+}
+
+// TestCatalog_TheStatedGapsAreStillGaps holds the catalog to its own admission.
+//
+// A gap the code claims is deliberate and a gap nobody noticed look identical
+// from the outside, and the only difference that survives a year is whether
+// something measures it. If a later entry closes one of these, this test goes
+// red and the comment claiming it is unreachable has to be deleted in the same
+// commit. If somebody closes it with *.googleapis.com, TestCatalog_TheNumber
+// goes red instead, because the wildcard would answer for the whole of Google.
+func TestCatalog_TheStatedGapsAreStillGaps(t *testing.T) {
+	t.Parallel()
+	res := run(t, "shopfront", everyCloudSDK())
+	e, err := policy.New(res.Draft.Egress)
+	require.NoError(t, err)
+
+	for _, host := range statedCloudGaps {
+		d := e.Evaluate(policy.Request{Host: host, TLS: true, Path: "/", Method: "POST"})
+		require.False(t, d.Matched(),
+			"%s is named by a rule now, so the comment calling it an unreachable gap is wrong", host)
+	}
+	for _, r := range res.Draft.Egress.Rules {
+		require.NotEqual(t, "*.googleapis.com", r.Host,
+			"one wildcard cannot be allowed to decide BigQuery, Firestore and the token endpoint together")
+		require.NotEqual(t, "*.amazonaws.com", r.Host)
+		require.NotEqual(t, "*.windows.net", r.Host)
+	}
 }

--- a/engine/internal/detect/cloudsdk.go
+++ b/engine/internal/detect/cloudsdk.go
@@ -1,0 +1,306 @@
+package detect
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// The clouds, recognised from the SDK a repository actually depends on.
+//
+// The catalog matches a dependency by its exact name, which works for a
+// package called stripe and stops working the moment a vendor ships one client
+// per service. @aws-sdk/client-lambda, @google-cloud/bigquery and
+// @azure/identity were each a dependency no entry claimed, so the application
+// got no rule for the host it was about to call, and the request was refused
+// with "no rule matches" rather than with the service's name. That is the same
+// defect L0.3 fixed for the nine AWS services it named, one level up: the
+// wildcard is gone and the gap it hid is now a silence.
+//
+// A silence is what this file turns into a sentence. Every cloud SDK package
+// is parsed into the cloud it belongs to and the service token it names, the
+// tokens the catalog claims are subtracted, and what is left is REPORTED by
+// name rather than left to be discovered when something is refused in
+// production shaped code.
+
+// cloudDisplayName is what a person calls the cloud.
+func cloudDisplayName(cloud string) string {
+	switch cloud {
+	case "aws":
+		return "AWS"
+	case "gcp":
+		return "Google Cloud"
+	case "azure":
+		return "Azure"
+	}
+	return cloud
+}
+
+// cloudSDK is one dependency recognised as a cloud client.
+type cloudSDK struct {
+	// Cloud is aws, gcp or azure.
+	Cloud string
+	// Token is the service the package names, in the vendor's own spelling.
+	// Empty for an SDK that covers the whole cloud in one package, which boto3
+	// and the v2 aws-sdk both are.
+	Token string
+	// Package is the dependency as declared.
+	Package string
+}
+
+// cloudSDKOf parses a dependency name into the cloud and service it names.
+//
+// The vendor's own package layout is the parser: the AWS JavaScript SDK v3
+// ships one @aws-sdk/client-<service> per service, Google ships
+// @google-cloud/<service>, and Azure ships @azure/<service>. Python spells the
+// same three as boto3, google-cloud-<service> and azure-<service>.
+//
+// It returns the token and NOT a host, which is the whole point. Turning
+// cloudwatch-logs into logs.<region>.amazonaws.com, sfn into states, or
+// secret-manager into secretmanager is a table, and it lives in the catalog
+// where each entry also carries the reason it is refused. A host derived here
+// mechanically would be wrong for those three and silently wrong, which is
+// worse than not naming the service at all.
+func cloudSDKOf(pkg string) (cloudSDK, bool) {
+	p := strings.ToLower(pkg)
+	switch {
+	case strings.HasPrefix(p, "@aws-sdk/client-"):
+		return cloudSDK{Cloud: "aws", Token: strings.TrimPrefix(p, "@aws-sdk/client-"), Package: pkg}, true
+	case strings.HasPrefix(p, "@aws-sdk/"):
+		// lib-storage, credential-providers, s3-request-presigner and the
+		// rest are helpers around a client rather than services of their own.
+		// The cloud is established; the service is not, and claiming one
+		// would invent a host.
+		return cloudSDK{Cloud: "aws", Package: pkg}, true
+	case strings.HasPrefix(p, "@google-cloud/"):
+		return cloudSDK{Cloud: "gcp", Token: strings.TrimPrefix(p, "@google-cloud/"), Package: pkg}, true
+	case strings.HasPrefix(p, "@azure/"):
+		return cloudSDK{Cloud: "azure", Token: strings.TrimPrefix(p, "@azure/"), Package: pkg}, true
+	case strings.HasPrefix(p, "google-cloud-"):
+		return cloudSDK{Cloud: "gcp", Token: strings.TrimPrefix(p, "google-cloud-"), Package: pkg}, true
+	case strings.HasPrefix(p, "azure-"):
+		return cloudSDK{Cloud: "azure", Token: strings.TrimPrefix(p, "azure-"), Package: pkg}, true
+	case p == "boto3", p == "botocore", p == "aioboto3", p == "aiobotocore",
+		p == "aws-sdk", p == "aws-sdk-go", p == "aws-sdk-go-v2":
+		// One package for the whole of AWS. It says which cloud and nothing
+		// about which service, and guessing from it is what put every AWS
+		// host under a mail rule in the first place.
+		return cloudSDK{Cloud: "aws", Package: pkg}, true
+	}
+	return cloudSDK{}, false
+}
+
+// catalogClaimsToken reports whether an entry covers a service token.
+func (tp ThirdParty) catalogClaimsToken(cloud, token string) bool {
+	if tp.Cloud != cloud || token == "" {
+		return false
+	}
+	for _, t := range tp.Tokens {
+		if t == token {
+			return true
+		}
+	}
+	return false
+}
+
+// thirdPartiesForCloud returns the catalog entries for a cloud.
+//
+// With tokens given, only the entries those tokens name, which is what an
+// emulator's own configuration provides: LocalStack's SERVICES=s3,sqs,sns is
+// the developer stating which three services this application uses, and it is
+// better evidence than a dependency list because it is what they configured
+// rather than what they installed. With no tokens, nothing: a cloud named with
+// no service named is exactly the wildcard shape this catalog was rewritten to
+// remove, and the caller reports the gap instead.
+func thirdPartiesForCloud(cloud string, tokens []string) []ThirdParty {
+	if len(tokens) == 0 {
+		return nil
+	}
+	var out []ThirdParty
+	for _, tp := range thirdParties {
+		for _, tok := range tokens {
+			if tp.catalogClaimsToken(cloud, strings.ToLower(strings.TrimSpace(tok))) {
+				out = append(out, tp)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// unnamedCloudServices reports the cloud SDK packages no catalog entry claims.
+//
+// This is the instrument that can say no. A catalog with a gap in it and a
+// catalog with no gap look identical from the outside, and the difference only
+// shows up as a refusal nobody can read, in an environment, at the moment the
+// application makes the call. Naming the gap at af init is the whole point:
+// the finding says which package, which cloud and which service, so the answer
+// is a pull request against the catalog rather than a bug report about a
+// refusal.
+func unnamedCloudServices(deps map[string]string) []Finding {
+	type gap struct {
+		cloud, token, pkg, evidence string
+	}
+	seen := map[string]bool{}
+	var gaps []gap
+	for pkg, file := range deps {
+		sdk, ok := cloudSDKOf(pkg)
+		if !ok || sdk.Token == "" {
+			// A package naming the cloud and not the service cannot produce a
+			// host, so there is no gap to report: the services it reaches are
+			// whatever the rest of the dependency list says.
+			continue
+		}
+		claimed := false
+		for _, tp := range thirdParties {
+			if tp.catalogClaimsToken(sdk.Cloud, sdk.Token) {
+				claimed = true
+				break
+			}
+		}
+		if claimed || seen[sdk.Cloud+"/"+sdk.Token] {
+			continue
+		}
+		seen[sdk.Cloud+"/"+sdk.Token] = true
+		gaps = append(gaps, gap{cloud: sdk.Cloud, token: sdk.Token, pkg: pkg, evidence: file})
+	}
+	// deps iterates in a random order and these findings reach the manifest's
+	// reader, so sort them or two runs over one tree disagree.
+	sort.Slice(gaps, func(i, j int) bool {
+		if gaps[i].cloud != gaps[j].cloud {
+			return gaps[i].cloud < gaps[j].cloud
+		}
+		return gaps[i].token < gaps[j].token
+	})
+
+	out := make([]Finding, 0, len(gaps))
+	for _, g := range gaps {
+		out = append(out, Finding{
+			Kind: KindNote, Subject: "cloud-service." + g.cloud + "." + g.token,
+			Value: g.pkg, Confidence: High, Evidence: g.evidence,
+			Analyzer: "thirdparty",
+			Detail: fmt.Sprintf(
+				"%s depends on %s, so this application calls the %s service %s, and the catalog "+
+					"has no host for it. Requests to it are refused, because the default is block, "+
+					"and the refusal says no rule matches rather than naming the service. Add an "+
+					"entry for it, or write the rule into egress by hand.",
+				g.evidence, g.pkg, cloudDisplayName(g.cloud), g.token),
+		})
+	}
+	return out
+}
+
+// DetectedEmulator is a cloud emulator the repository already runs in its own
+// compose file, and what detection did about it.
+//
+// Every field on it exists to be printed. An emulator is the strongest
+// statement a repository makes about which cloud it talks to, and it is also
+// the thing this product replaces, so a person reading af init has to be told
+// that it was found, which services it named, which rules that produced, and
+// which services it named that got no rule at all. The last of those is the
+// one that would otherwise be invisible: a service with no rule is refused
+// with "no rule matches", in an environment, at the moment it is called.
+type DetectedEmulator struct {
+	// Product is what the emulator is called: LocalStack, Azurite.
+	Product string
+	// Cloud is aws, gcp or azure.
+	Cloud string
+	// Service is the compose service that runs it.
+	Service string
+	// Image is the image as the compose file declares it.
+	Image string
+	// Evidence is the file the emulator was found in.
+	Evidence string
+	// Services are the service tokens the emulator's own configuration names,
+	// in the developer's own spelling. Empty when it names none.
+	Services []string
+	// Hosts are the egress rules this emulator produced, by host, and empty
+	// for an emulator that named no service the catalog claims.
+	Hosts []string
+	// Unnamed are the tokens the emulator named that no catalog entry claims.
+	// Each one is a service this application uses and has no rule for.
+	Unnamed []string
+}
+
+// emulatorTokens splits an emulator's own service list into tokens.
+//
+// LocalStack spells it SERVICES=s3,sqs,sns, and older compose files put spaces
+// after the commas. Anything else that carries a list carries it the same way.
+func emulatorTokens(list string) []string {
+	var out []string
+	seen := map[string]bool{}
+	for _, tok := range strings.Split(list, ",") {
+		tok = strings.ToLower(strings.TrimSpace(tok))
+		if tok == "" || seen[tok] {
+			continue
+		}
+		seen[tok] = true
+		out = append(out, tok)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// unclaimedTokens returns the tokens no catalog entry claims for a cloud.
+//
+// This is the emulator's half of what unnamedCloudServices does for a
+// dependency list, and it is the better half: SERVICES=s3,sqs,textract is a
+// developer stating that this application calls Textract, where a dependency
+// on boto3 states only that it calls AWS.
+func unclaimedTokens(cloud string, tokens []string) []string {
+	var out []string
+	for _, tok := range tokens {
+		claimed := false
+		for _, tp := range thirdParties {
+			if tp.catalogClaimsToken(cloud, tok) {
+				claimed = true
+				break
+			}
+		}
+		if !claimed {
+			out = append(out, tok)
+		}
+	}
+	return out
+}
+
+// Note is the sentence af init prints about an emulator it found.
+//
+// It says what was found, what it produced, and what it did not produce. The
+// third clause is the one worth the function: an emulator naming a service the
+// catalog has no entry for is a refusal already scheduled, and the only moment
+// it can be cheaply fixed is now, while somebody is reading this.
+func (d DetectedEmulator) Note() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s runs %s (%s), which answers for %s.",
+		d.Evidence, d.Service, d.Image, cloudDisplayName(d.Cloud))
+	switch {
+	case len(d.Services) == 0:
+		fmt.Fprintf(&b, " It names no services, so no rules were written from it. "+
+			"An emulator answering for anything asked of it cannot say which services this "+
+			"application uses, and the rules came from the dependency list instead.")
+	case len(d.Hosts) > 0:
+		fmt.Fprintf(&b, " It names %s, so %s reached the network policy.",
+			strings.Join(d.Services, ", "), plural(len(d.Hosts), "rule", "rules"))
+	}
+	if len(d.Unnamed) > 0 {
+		them := "those services are"
+		if len(d.Unnamed) == 1 {
+			them = "that service is"
+		}
+		fmt.Fprintf(&b, " The catalog has no host for %s, so calls to %s refused with "+
+			"no rule matches rather than by name. Write the rule into egress by hand, or add "+
+			"an entry for it.", strings.Join(d.Unnamed, ", "), them)
+	}
+	return b.String()
+}
+
+// plural picks the word for a count, so a sentence about one rule does not say
+// 1 rules. It is here rather than shared because these are the only two
+// sentences in this package that count anything.
+func plural(n int, one, many string) string {
+	if n == 1 {
+		return "1 " + one
+	}
+	return fmt.Sprintf("%d %s", n, many)
+}

--- a/engine/internal/detect/cloudsdk.go
+++ b/engine/internal/detect/cloudsdk.go
@@ -272,8 +272,8 @@ func unclaimedTokens(cloud string, tokens []string) []string {
 // it can be cheaply fixed is now, while somebody is reading this.
 func (d DetectedEmulator) Note() string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "%s runs %s (%s), which answers for %s.",
-		d.Evidence, d.Service, d.Image, cloudDisplayName(d.Cloud))
+	fmt.Fprintf(&b, "%s runs %s as %s (%s), which answers for %s.",
+		d.Evidence, d.Product, d.Service, d.Image, cloudDisplayName(d.Cloud))
 	switch {
 	case len(d.Services) == 0:
 		fmt.Fprintf(&b, " It names no services, so no rules were written from it. "+

--- a/engine/internal/detect/container.go
+++ b/engine/internal/detect/container.go
@@ -638,11 +638,6 @@ func containerPort(spec string) int {
 	return n
 }
 
-func envNameOf(item string) string {
-	name, _ := envPair(item)
-	return name
-}
-
 // envPair splits a compose environment list entry into its name and value.
 // An entry with no equals sign passes the variable through from the host, so
 // the name is known and the value is not.

--- a/engine/internal/detect/container.go
+++ b/engine/internal/detect/container.go
@@ -394,6 +394,25 @@ func (a *ComposeAnalyzer) Analyze(_ context.Context, r *Repo) ([]Finding, error)
 		for _, svc := range parseCompose(body) {
 			name := sanitizeServiceName(svc.name)
 
+			// A cloud emulator in compose is not a service to build either,
+			// and it is the clearest statement a repository makes about which
+			// cloud it talks to. Checked before infraKind, because
+			// fake-gcs-server and MinIO are both object stores and only one of
+			// them is an emulator standing in for a named cloud service.
+			if cloud, product := emulatorCloud(svc.image); cloud != "" {
+				out = append(out, Finding{
+					Kind: KindEmulator, Subject: cloud, Value: svc.image,
+					Confidence: High, Evidence: p,
+					Detail: fmt.Sprintf("%s runs %s, which answers for %s.", p, product, cloudDisplayName(cloud)),
+					Extra: map[string]string{
+						"product":  product,
+						"service":  svc.name,
+						"services": svc.envValues["SERVICES"],
+					},
+				})
+				continue
+			}
+
 			// A database or queue in compose is infrastructure the environment
 			// provides, not a service to build. Recognising it is how the
 			// database provider gets chosen without asking.
@@ -403,6 +422,21 @@ func (a *ComposeAnalyzer) Analyze(_ context.Context, r *Repo) ([]Finding, error)
 					Confidence: High, Evidence: p,
 					Detail: fmt.Sprintf("%s runs %s as the %s.", p, svc.image, kind),
 				})
+				// A store beside the primary needs a stance, and until this
+				// finding existed every classification other than postgres,
+				// mysql and mongodb was made and then discarded by
+				// mergeDatabase. The compose service's own name travels with
+				// it, because that is what the developer calls the store and
+				// renaming it to the engine would make the manifest describe
+				// a store they do not recognise.
+				if engine := datastoreEngineOf(kind); engine != "" {
+					out = append(out, Finding{
+						Kind: KindDatastore, Subject: engine, Value: svc.image,
+						Confidence: High, Evidence: p,
+						Detail: fmt.Sprintf("%s runs %s as %s.", p, svc.image, svc.name),
+						Extra:  map[string]string{"service": svc.name},
+					})
+				}
 				continue
 			}
 
@@ -455,6 +489,29 @@ type composeService struct {
 	command      string
 	dependsOn    []string
 	envNames     []string
+	// envValues holds the values as well as the names, for the handful of
+	// variables whose value is the finding. LocalStack's SERVICES is the
+	// case this exists for: it names the AWS services the application uses,
+	// declared by the developer, and it is better evidence than a dependency
+	// list because it is what they configured rather than what they installed.
+	envValues map[string]string
+}
+
+// setEnv records one compose environment entry, name and value.
+func (c *composeService) setEnv(name, value string) {
+	if name == "" {
+		return
+	}
+	c.envNames = append(c.envNames, name)
+	if value == "" {
+		return
+	}
+	if c.envValues == nil {
+		c.envValues = map[string]string{}
+	}
+	if _, exists := c.envValues[name]; !exists {
+		c.envValues[name] = value
+	}
 }
 
 // parseCompose reads the fields detection needs with an indentation aware
@@ -538,14 +595,12 @@ func parseCompose(body string) []composeService {
 			case "depends_on":
 				cur.dependsOn = append(cur.dependsOn, strings.TrimSuffix(item, ":"))
 			case "environment":
-				if n := envNameOf(item); n != "" {
-					cur.envNames = append(cur.envNames, n)
-				}
+				cur.setEnv(envPair(item))
 			}
 		case section == "depends_on" && strings.HasSuffix(trimmed, ":"):
 			cur.dependsOn = append(cur.dependsOn, strings.TrimSuffix(trimmed, ":"))
 		case section == "environment" && key != "":
-			cur.envNames = append(cur.envNames, key)
+			cur.setEnv(key, strings.Trim(value, `"'`))
 		default:
 			if key != "" {
 				section = ""
@@ -584,13 +639,21 @@ func containerPort(spec string) int {
 }
 
 func envNameOf(item string) string {
+	name, _ := envPair(item)
+	return name
+}
+
+// envPair splits a compose environment list entry into its name and value.
+// An entry with no equals sign passes the variable through from the host, so
+// the name is known and the value is not.
+func envPair(item string) (name, value string) {
 	if i := strings.IndexByte(item, '='); i > 0 {
-		return item[:i]
+		return item[:i], strings.Trim(item[i+1:], `"'`)
 	}
 	if item != "" && !strings.ContainsAny(item, " \t:") {
-		return item
+		return item, ""
 	}
-	return ""
+	return "", ""
 }
 
 // infraKind recognises an image as infrastructure rather than application code.
@@ -600,12 +663,7 @@ func infraKind(image string) string {
 		return ""
 	}
 	// Strip a registry prefix and a tag so that ghcr.io/x/postgres:16 matches.
-	base := l
-	if i := strings.LastIndexByte(base, '/'); i >= 0 {
-		base = base[i+1:]
-	}
-	base = strings.SplitN(base, ":", 2)[0]
-	base = strings.SplitN(base, "@", 2)[0]
+	base := imageBase(l)
 
 	switch {
 	case strings.Contains(base, "postgres"), strings.Contains(base, "pgvector"),
@@ -620,19 +678,72 @@ func infraKind(image string) string {
 	case strings.Contains(base, "rabbitmq"):
 		return "rabbitmq"
 	case strings.Contains(base, "elasticsearch"), strings.Contains(base, "opensearch"):
-		return "search"
+		return "elasticsearch"
 	case strings.Contains(base, "minio"):
 		return "objectstore"
 	case strings.Contains(base, "clickhouse"):
 		return "clickhouse"
+	// Kafka was not recognised at all, which is why a compose file running one
+	// produced no finding of any kind rather than a classification that was
+	// then dropped. cp-kafka is Confluent's image and redpanda is the
+	// protocol compatible one, so both answer to the same stance.
+	case strings.Contains(base, "kafka"), strings.Contains(base, "redpanda"):
+		return "kafka"
 	}
 	return ""
+}
+
+// emulatorCloud recognises an image as a cloud emulator and names the cloud it
+// answers for.
+//
+// A compose file running LocalStack is the strongest evidence there is that
+// the application talks to AWS, stronger than a dependency name: somebody has
+// already gone to the trouble of standing one up and pointing the application
+// at it. It is also the thing this product exists to remove, because reaching
+// an emulator that way costs an endpoint override, and the override means the
+// code under test is not the code that ships.
+//
+// Recognising the image does two things. The emulator is not a service to
+// build, which it was in danger of becoming as soon as it carried a port or a
+// command; and the cloud it answers for gets its rules named rather than left
+// to a refusal that says no rule matches.
+func emulatorCloud(image string) (cloud, product string) {
+	base := imageBase(image)
+	switch {
+	case strings.Contains(base, "localstack"):
+		return "aws", "LocalStack"
+	case strings.Contains(base, "moto"):
+		return "aws", "moto"
+	case strings.Contains(base, "elasticmq"):
+		return "aws", "ElasticMQ"
+	case strings.Contains(base, "azurite"):
+		return "azure", "Azurite"
+	case strings.Contains(base, "fake-gcs-server"):
+		return "gcp", "fake-gcs-server"
+	case strings.Contains(base, "pubsub-emulator"), strings.Contains(base, "gcloud-pubsub"):
+		return "gcp", "the Pub/Sub emulator"
+	}
+	return "", ""
+}
+
+// imageBase strips a registry prefix, a tag and a digest so that
+// ghcr.io/x/localstack:3.4 and localstack/localstack@sha256:... both match.
+func imageBase(image string) string {
+	base := strings.ToLower(image)
+	if i := strings.LastIndexByte(base, '/'); i >= 0 {
+		base = base[i+1:]
+	}
+	base = strings.SplitN(base, ":", 2)[0]
+	base = strings.SplitN(base, "@", 2)[0]
+	return base
 }
 
 func isInfraName(name string) bool {
 	switch strings.ToLower(name) {
 	case "db", "database", "postgres", "postgresql", "pg", "redis", "cache",
-		"mysql", "mongo", "mongodb", "rabbitmq", "queue", "elasticsearch", "minio":
+		"mysql", "mongo", "mongodb", "rabbitmq", "queue", "elasticsearch", "minio",
+		"clickhouse", "kafka", "redpanda", "opensearch", "valkey",
+		"localstack", "azurite", "elasticmq", "moto", "pubsub", "fake-gcs-server":
 		return true
 	}
 	return false

--- a/engine/internal/detect/datastore.go
+++ b/engine/internal/detect/datastore.go
@@ -1,0 +1,203 @@
+package detect
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/antifailure/antifailure/engine/pkg/provider"
+	"github.com/antifailure/antifailure/engine/pkg/schema"
+)
+
+// The second store, proposed from what the repository already runs.
+//
+// A compose file that runs ClickHouse beside Postgres left no trace at all in
+// the manifest af init wrote. The image classifier recognised it, the finding
+// was made, and mergeDatabase read the ones it understood and dropped the
+// rest on the floor: Kafka was not classified at all, and ClickHouse, Redis
+// and Elasticsearch were classified and then discarded. So the twin of an
+// analytics product came up holding a masked Postgres and an empty everything
+// else, and nothing in the file the developer read said so.
+//
+// What this file does is name them. A stance is DECLARED and never defaulted,
+// which is the rule schema.DatastoreStance exists to enforce, so detection
+// proposes one per store with the reason written out, and the proposal is
+// something a person confirms at af init rather than something they have to
+// discover they needed.
+//
+// The half of this that is easy to get wrong is the other direction. Writing
+// an entry for a store this build cannot bring up would produce a manifest
+// af up refuses, and af init promises the opposite: the draft is normalized
+// and validated before it is written precisely so that the file it leaves
+// behind is one every later command accepts. The validator would not catch it,
+// because Datastore.Engine is an open set on purpose and the refusal happens
+// at run time in the provider lookup. So provisionable is asked per store, the
+// answer comes from the same list the engine's own refusal is written from,
+// and a store this build cannot serve is REPORTED rather than declared.
+
+// ProposedDatastore is one store detection found beside the primary database,
+// and the stance it would take.
+//
+// Provisionable is what decides whether it reaches the manifest. Both kinds
+// are in this list on purpose: the one thing worse than a store nobody
+// declared is a store nobody mentioned.
+type ProposedDatastore struct {
+	// Name is what the store is called in the manifest and in the report.
+	Name string
+	// Engine is what it runs, as the datastores list spells it.
+	Engine string
+	// Stance is what detection proposes doing about its contents.
+	Stance schema.DatastoreStance
+	// Because is the reason for the stance, written for a person.
+	Because string
+	// From names the store a derived one is rebuilt from.
+	From string
+	// Evidence is the file that showed detection this store exists.
+	Evidence string
+	// Image is the container image the store was recognised from.
+	Image string
+	// Provisionable reports whether this build can bring the engine up. A
+	// store that is not is left out of the manifest and named in the summary.
+	Provisionable bool
+}
+
+// stanceProposal is the stance detection proposes per engine, and why.
+//
+// Section 4.3 of the plan is the source of these, and the reasons are written
+// out per engine rather than shared, for the same reason the cloud catalog's
+// refusals are: a sentence that explains five stores explains none of them,
+// and this one is copied verbatim into the fidelity report.
+type stanceProposal struct {
+	stance  schema.DatastoreStance
+	because string
+	from    string
+}
+
+var stanceProposals = map[string]stanceProposal{
+	"clickhouse": {
+		stance: schema.StanceGolden,
+		because: "the events are here rather than in Postgres, so a twin without them tests " +
+			"every chart and every analytics migration against nothing",
+	},
+	"redis": {
+		stance:  schema.StanceEmpty,
+		because: "a cache is rebuilt from the primary and a copy of one would be noise",
+	},
+	"kafka": {
+		stance: schema.StanceTopicsOnly,
+		because: "a broker wants its topics and consumer groups rather than a replay of " +
+			"production traffic, which would be delivered to whatever is consuming",
+	},
+	"elasticsearch": {
+		stance: schema.StanceDerived,
+		from:   schema.PrimaryDatastore,
+		because: "an index rebuilt from the branch cannot be stale against it, and a clone " +
+			"of production's index can",
+	},
+	"mongodb": {
+		stance: schema.StanceGolden,
+		because: "this holds application records rather than a cache, so an empty one is a " +
+			"twin of nothing",
+	},
+}
+
+// datastoreEngineOf maps the image classifier's answer onto the engine name a
+// datastores entry spells, or empty for a classification that is not a second
+// store.
+//
+// postgres is absent deliberately. It is the primary, it arrives through
+// database:, and normalize turns that into the entry named primary. A second
+// entry for it would be two records of one store.
+func datastoreEngineOf(kind string) string {
+	switch kind {
+	case "clickhouse", "redis", "kafka", "elasticsearch", "mongodb":
+		return kind
+	}
+	return ""
+}
+
+// mergeDatastores turns the datastore findings into proposals, and the
+// provisionable proposals into manifest entries.
+//
+// A mongodb with no Postgres beside it is the application's own database
+// rather than a second store, and mergeDatabase already asks about that case
+// by name. Proposing a stance for it too would be the same fact said twice in
+// two different vocabularies, so it is proposed only when a Postgres was found
+// as well.
+func mergeDatastores(findings []Finding, hasPostgres bool) ([]ProposedDatastore, []schema.Datastore) {
+	seen := map[string]bool{}
+	var proposed []ProposedDatastore
+
+	for _, f := range OfKind(findings, KindDatastore) {
+		engine := f.Subject
+		if engine == "mongodb" && !hasPostgres {
+			continue
+		}
+		p, ok := stanceProposals[engine]
+		if !ok {
+			continue
+		}
+		name := sanitizeServiceName(f.Extra["service"])
+		if name == "" {
+			name = engine
+		}
+		if name == schema.PrimaryDatastore {
+			// primary is reserved for the entry database: normalizes into,
+			// and the validator refuses a second store under that name. A
+			// compose service somebody called primary is not a reason to
+			// produce a manifest af init would then refuse to write.
+			name = engine
+		}
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		proposed = append(proposed, ProposedDatastore{
+			Name:          name,
+			Engine:        engine,
+			Stance:        p.stance,
+			Because:       p.because,
+			From:          p.from,
+			Evidence:      f.Evidence,
+			Image:         f.Value,
+			Provisionable: provider.ProvidesDatastoreEngine(engine),
+		})
+	}
+
+	sort.SliceStable(proposed, func(i, j int) bool { return proposed[i].Name < proposed[j].Name })
+
+	var entries []schema.Datastore
+	for _, p := range proposed {
+		if !p.Provisionable {
+			continue
+		}
+		entries = append(entries, schema.Datastore{
+			Name:    p.Name,
+			Engine:  p.Engine,
+			Stance:  p.Stance,
+			Because: p.Because,
+			From:    p.From,
+		})
+	}
+	return proposed, entries
+}
+
+// UnprovisionableNote is the sentence af init prints about a store it found
+// and did not declare.
+//
+// It says the stance it would have taken, because the stance is the decision
+// and a person reading this is the one who has to make it. It does not say
+// "unsupported": the store is running in their compose file and works there,
+// and what is missing is this engine's ability to hold a copy of it.
+func (p ProposedDatastore) UnprovisionableNote() string {
+	engines := strings.Join(provider.BuiltInDatastoreEngines(), ", ")
+	from := ""
+	if p.From != "" {
+		from = fmt.Sprintf(" from %s", p.From)
+	}
+	return fmt.Sprintf(
+		"%s runs %s (%s). The stance for it would be %s%s, because %s. "+
+			"It is not in the manifest, because this build brings up %s and would refuse a "+
+			"datastore it has no provider for.",
+		p.Evidence, p.Name, p.Image, p.Stance, from, p.Because, engines)
+}

--- a/engine/internal/detect/datastore_test.go
+++ b/engine/internal/detect/datastore_test.go
@@ -1,0 +1,258 @@
+package detect_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/internal/detect"
+	"github.com/antifailure/antifailure/engine/pkg/schema"
+)
+
+// A compose file running ClickHouse beside Postgres left no trace at all in
+// the manifest af init wrote. The image classifier recognised it, the finding
+// was made, and mergeDatabase read the ones it understood and dropped the rest
+// on the floor. So the twin of an analytics product came up holding a masked
+// Postgres and an empty everything else, and nothing in the file the developer
+// read said so.
+//
+// These tests are about what detection now proposes. The stance is the
+// decision and it is never defaulted, so the thing being asserted throughout
+// is that a proposal exists, carries a reason, and is either declared or
+// reported by name.
+
+// analyticsStack is a repository whose compose file runs five stores.
+func analyticsStack() map[string]string {
+	return map[string]string{
+		"package.json": `{"name":"insight","scripts":{"start":"next start"},
+			"dependencies":{"next":"15.0.0"}}`,
+		"docker-compose.yml": `services:
+  web:
+    build: .
+    ports:
+      - "3000:3000"
+  db:
+    image: postgres:16
+  events:
+    image: clickhouse/clickhouse-server:24.3
+  cache:
+    image: redis:7
+  broker:
+    image: confluentinc/cp-kafka:7.6.0
+  search:
+    image: elasticsearch:8.13.0
+`,
+		"Dockerfile": "FROM node:20\nCMD [\"node\", \"server.js\"]\n",
+	}
+}
+
+func proposalFor(t *testing.T, got []detect.ProposedDatastore, name string) detect.ProposedDatastore {
+	t.Helper()
+	for _, p := range got {
+		if p.Name == name {
+			return p
+		}
+	}
+	var names []string
+	for _, p := range got {
+		names = append(names, p.Name)
+	}
+	t.Fatalf("no datastore proposal named %q; found %v", name, names)
+	return detect.ProposedDatastore{}
+}
+
+func TestDatastores_EveryStoreBesideThePrimaryIsProposed(t *testing.T) {
+	t.Parallel()
+	// The finding this lane exists for. Four of these five classifications
+	// were made and then discarded, and Kafka was not classified at all.
+	res := run(t, "insight", analyticsStack())
+	got := res.Datastores
+
+	var names []string
+	for _, p := range got {
+		names = append(names, p.Name)
+	}
+	require.ElementsMatch(t, []string{"broker", "cache", "events", "search"}, names,
+		"a store the compose file runs must not vanish between the finding and the manifest")
+}
+
+func TestDatastores_ThePrimaryIsNotProposedTwice(t *testing.T) {
+	t.Parallel()
+	// database: normalizes into the entry called primary, so a second entry
+	// for Postgres would be two records of one store.
+	res := run(t, "insight", analyticsStack())
+	for _, p := range res.Datastores {
+		require.NotEqual(t, "postgres", p.Engine,
+			"the primary arrives through database: and must not also arrive as a datastore")
+	}
+}
+
+func TestDatastores_EveryProposalCarriesAStanceAndAReason(t *testing.T) {
+	t.Parallel()
+	// A stance is DECLARED and never defaulted, which is the rule
+	// schema.DatastoreStance exists to enforce. A proposal with no reason is
+	// a decision nobody can check afterwards.
+	res := run(t, "insight", analyticsStack())
+	reasons := map[string]bool{}
+	for _, p := range res.Datastores {
+		require.NotEmpty(t, p.Stance, "%s was proposed with no stance", p.Name)
+		require.Contains(t, schema.AllDatastoreStances(), p.Stance,
+			"%s proposes a stance the manifest does not accept", p.Name)
+		require.NotEmpty(t, p.Because, "%s has a stance nobody can check", p.Name)
+		reasons[p.Because] = true
+	}
+	require.Len(t, reasons, 4,
+		"a sentence that explains four stores explains none of them")
+}
+
+func TestDatastores_TheCacheIsEmptyAndTheEventsAreGolden(t *testing.T) {
+	t.Parallel()
+	// The two stances that matter most and point opposite ways. An analytics
+	// product with an empty ClickHouse tests every chart against nothing; a
+	// cloned Redis is noise, because it is rebuilt from the primary.
+	got := run(t, "insight", analyticsStack()).Datastores
+	require.Equal(t, schema.StanceGolden, proposalFor(t, got, "events").Stance)
+	require.Equal(t, schema.StanceEmpty, proposalFor(t, got, "cache").Stance)
+	require.Equal(t, schema.StanceTopicsOnly, proposalFor(t, got, "broker").Stance)
+
+	search := proposalFor(t, got, "search")
+	require.Equal(t, schema.StanceDerived, search.Stance)
+	require.Equal(t, schema.PrimaryDatastore, search.From,
+		"a derived store with nothing to derive from is refused by the validator")
+}
+
+func TestDatastores_TheComposeServiceNameIsWhatTheStoreIsCalled(t *testing.T) {
+	t.Parallel()
+	// The developer calls it events. Renaming it to clickhouse would make the
+	// manifest describe a store they do not recognise, in their own
+	// repository, on the first file this product ever writes for them.
+	got := run(t, "insight", analyticsStack()).Datastores
+	require.Equal(t, "clickhouse", proposalFor(t, got, "events").Engine)
+	require.Equal(t, "redis", proposalFor(t, got, "cache").Engine)
+	require.Equal(t, "kafka", proposalFor(t, got, "broker").Engine)
+	require.Equal(t, "elasticsearch", proposalFor(t, got, "search").Engine)
+}
+
+func TestDatastores_OnlyTheOnesThisBuildCanProvideReachTheManifest(t *testing.T) {
+	t.Parallel()
+	// The direction that is easy to get wrong. Declaring an engine no provider
+	// serves produces a manifest af up refuses, and af init promises the
+	// opposite: the draft is normalized and validated before it is written so
+	// that the file it leaves behind is one every later command accepts. The
+	// validator cannot catch this, because Datastore.Engine is an open set on
+	// purpose and the refusal happens at run time in the provider lookup.
+	res := run(t, "insight", analyticsStack())
+	var engines []string
+	for _, d := range res.Draft.Datastores {
+		engines = append(engines, d.Engine)
+	}
+	require.Equal(t, []string{"clickhouse"}, engines,
+		"a datastore this build has no provider for must not be written into the draft")
+}
+
+func TestDatastores_AStoreLeftOutIsStillNamed(t *testing.T) {
+	t.Parallel()
+	// The one thing worse than a store nobody declared is a store nobody
+	// mentioned. The sentence has to say the stance it would have taken,
+	// because the stance is the decision and the reader is the one who has to
+	// make it.
+	got := run(t, "insight", analyticsStack()).Datastores
+	cache := proposalFor(t, got, "cache")
+	require.False(t, cache.Provisionable)
+
+	note := cache.UnprovisionableNote()
+	require.Contains(t, note, "docker-compose.yml", "the note must say where the store was found")
+	require.Contains(t, note, "cache", "the note must call the store what the developer calls it")
+	require.Contains(t, note, string(schema.StanceEmpty),
+		"the note must say the stance it would have taken")
+	require.Contains(t, note, "rebuilt from the primary",
+		"the note must carry the reason, not a generic one")
+	require.Contains(t, note, "clickhouse",
+		"the note must say which engines this build does provide")
+	require.NotContains(t, strings.ToLower(note), "unsupported",
+		"the store works in their compose file; what is missing is this engine's side")
+}
+
+func TestDatastores_TheDraftWithDatastoresStillValidates(t *testing.T) {
+	t.Parallel()
+	// A draft the validator refuses is never written, so a proposal that
+	// produces one is a detection bug rather than a manifest one.
+	files := analyticsStack()
+	requireDraftValidates(t, run(t, "insight", files).Draft, files)
+}
+
+func TestDatastores_AMongoWithNoPostgresIsTheDatabaseAndNotASecondStore(t *testing.T) {
+	t.Parallel()
+	// mergeDatabase already asks about this case by name. Proposing a stance
+	// for it as well would be one fact stated twice in two vocabularies.
+	res := run(t, "notes", map[string]string{
+		"package.json": `{"name":"notes","scripts":{"start":"node server.js"},
+			"dependencies":{"express":"4.0.0","mongoose":"8.0.0"}}`,
+		"docker-compose.yml": `services:
+  web:
+    build: .
+    ports:
+      - "3000:3000"
+  mongo:
+    image: mongo:7
+`,
+		"Dockerfile": "FROM node:20\nCMD [\"node\", \"server.js\"]\n",
+	})
+	require.Empty(t, res.Datastores,
+		"the application's own database must not also be proposed as a store beside itself")
+}
+
+func TestDatastores_AMongoBesideAPostgresIsASecondStore(t *testing.T) {
+	t.Parallel()
+	// The other ordering of the same question, and the one the guard must not
+	// swallow.
+	res := run(t, "hybrid", map[string]string{
+		"package.json": `{"name":"hybrid","scripts":{"start":"node server.js"},
+			"dependencies":{"express":"4.0.0","mongoose":"8.0.0","pg":"8.0.0"}}`,
+		"docker-compose.yml": `services:
+  web:
+    build: .
+    ports:
+      - "3000:3000"
+  db:
+    image: postgres:16
+  docs:
+    image: mongo:7
+`,
+		"Dockerfile": "FROM node:20\nCMD [\"node\", \"server.js\"]\n",
+	})
+	docs := proposalFor(t, res.Datastores, "docs")
+	require.Equal(t, "mongodb", docs.Engine)
+	require.Equal(t, schema.StanceGolden, docs.Stance,
+		"a store holding application records is a twin of nothing when it is empty")
+}
+
+func TestDatastores_AServiceCalledPrimaryDoesNotCollideWithTheDatabase(t *testing.T) {
+	t.Parallel()
+	// primary is reserved for the entry database: normalizes into, and the
+	// validator refuses a second store under that name. A compose service
+	// somebody happened to call primary is not a reason to produce a manifest
+	// af init would then refuse to write.
+	files := map[string]string{
+		"package.json": `{"name":"insight","scripts":{"start":"next start"},
+			"dependencies":{"next":"15.0.0"}}`,
+		"docker-compose.yml": `services:
+  web:
+    build: .
+    ports:
+      - "3000:3000"
+  db:
+    image: postgres:16
+  primary:
+    image: clickhouse/clickhouse-server:24.3
+`,
+		"Dockerfile": "FROM node:20\nCMD [\"node\", \"server.js\"]\n",
+	}
+	res := run(t, "insight", files)
+	for _, d := range res.Draft.Datastores {
+		require.NotEqual(t, schema.PrimaryDatastore, d.Name,
+			"two stores called primary is a manifest the validator refuses")
+	}
+	requireDraftValidates(t, res.Draft, files)
+}

--- a/engine/internal/detect/detect.go
+++ b/engine/internal/detect/detect.go
@@ -70,11 +70,22 @@ func (c Confidence) String() string {
 type Kind string
 
 const (
-	KindService    Kind = "service"
-	KindPort       Kind = "port"
-	KindCommand    Kind = "command"
-	KindBuild      Kind = "build"
-	KindDatabase   Kind = "database"
+	KindService  Kind = "service"
+	KindPort     Kind = "port"
+	KindCommand  Kind = "command"
+	KindBuild    Kind = "build"
+	KindDatabase Kind = "database"
+	// KindDatastore is a store beside the primary database: ClickHouse,
+	// Redis, Kafka, Elasticsearch or Mongo. It is separate from KindDatabase
+	// because the two are merged by different rules and used to be merged by
+	// one: mergeDatabase read postgres, asked about mysql and mongodb, and
+	// silently dropped every other classification the image reader made.
+	KindDatastore Kind = "datastore"
+	// KindEmulator is a cloud emulator the repository already runs, such as
+	// LocalStack or Azurite. It is evidence about the cloud rather than a
+	// service to build, and it is the strongest evidence there is: somebody
+	// stood one up and pointed the application at it.
+	KindEmulator   Kind = "emulator"
 	KindMigration  Kind = "migration"
 	KindEnvVar     Kind = "env"
 	KindThirdParty Kind = "third_party"
@@ -304,6 +315,18 @@ type Result struct {
 	// Questions are the things af init has to ask, because a finding was below
 	// the confidence threshold or two analyzers disagreed.
 	Questions []Question
+	// Datastores are the stores found beside the primary database and the
+	// stance detection proposes for each. Every one detection found is here,
+	// including the ones this build cannot bring up and therefore did not
+	// write into the draft, because a store nobody mentioned is worse than a
+	// store nobody declared.
+	Datastores []ProposedDatastore
+	// Emulators are the cloud emulators the repository runs in its own
+	// compose file, and the egress rules each one produced. An emulator is
+	// the strongest statement a repository makes about which cloud it talks
+	// to, and it is the thing this product replaces, so it is reported rather
+	// than quietly consumed.
+	Emulators []DetectedEmulator
 	// UnassignedImages names Dockerfiles whose runtime was not established by
 	// a command, port, framework or Compose declaration. Their base image may
 	// inherit a process, so omission must be visible rather than called unused.
@@ -431,7 +454,9 @@ func Run(ctx context.Context, fsys fs.FS, root string, opts Options) (*Result, e
 	}
 
 	sortFindings(res.Findings)
-	res.Draft, res.Questions = Merge(res.Findings, root)
+	var proposals Proposals
+	res.Draft, res.Questions, proposals = Merge(res.Findings, root)
+	res.Datastores, res.Emulators = proposals.Datastores, proposals.Emulators
 	assigned := map[string]bool{}
 	for _, svc := range res.Draft.Services {
 		if svc.Build != nil {

--- a/engine/internal/detect/emulator_test.go
+++ b/engine/internal/detect/emulator_test.go
@@ -1,0 +1,253 @@
+package detect_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/internal/detect"
+	"github.com/antifailure/antifailure/engine/pkg/schema"
+)
+
+// A compose file running LocalStack is the strongest evidence there is that
+// an application talks to AWS, stronger than a dependency name: somebody has
+// already gone to the trouble of standing one up and pointing the application
+// at it. It was previously about to be detected as a service to build, and the
+// cloud it answers for produced no rules at all.
+//
+// It is also the thing this product replaces, because reaching an emulator
+// costs an endpoint override, and the override means the code under test is
+// not the code that ships.
+
+// localstackRepo runs LocalStack and names three services, with no AWS SDK in
+// the dependency list at all. That is the case that matters: the roster comes
+// from what the developer configured rather than from what they installed.
+func localstackRepo(services string) map[string]string {
+	env := ""
+	if services != "" {
+		env = "    environment:\n      SERVICES: " + services + "\n"
+	}
+	return map[string]string{
+		"package.json": `{"name":"shopfront","scripts":{"start":"next start"},
+			"dependencies":{"next":"15.0.0"}}`,
+		"docker-compose.yml": `services:
+  web:
+    build: .
+    ports:
+      - "3000:3000"
+  localstack:
+    image: localstack/localstack:3.4
+    ports:
+      - "4566:4566"
+` + env,
+		"Dockerfile": "FROM node:20\nCMD [\"node\", \"server.js\"]\n",
+	}
+}
+
+func emulatorFor(t *testing.T, res *detect.Result, service string) detect.DetectedEmulator {
+	t.Helper()
+	for _, e := range res.Emulators {
+		if e.Service == service {
+			return e
+		}
+	}
+	var names []string
+	for _, e := range res.Emulators {
+		names = append(names, e.Service)
+	}
+	t.Fatalf("no emulator for service %q; found %v", service, names)
+	return detect.DetectedEmulator{}
+}
+
+func TestEmulator_AnEmulatorIsNotAServiceToBuild(t *testing.T) {
+	t.Parallel()
+	// It carries a port and an image, which is everything a service needs to
+	// look like one. Building it would put a copy of LocalStack in the
+	// manifest as though it were part of the application.
+	res := run(t, "shopfront", localstackRepo("s3,sqs,sns"))
+	for _, s := range res.Draft.Services {
+		require.NotEqual(t, "localstack", s.Name,
+			"the emulator is infrastructure the environment replaces, not code to build")
+	}
+}
+
+func TestEmulator_TheCloudItAnswersForIsNamed(t *testing.T) {
+	t.Parallel()
+	res := run(t, "shopfront", localstackRepo("s3,sqs,sns"))
+	em := emulatorFor(t, res, "localstack")
+	require.Equal(t, "aws", em.Cloud)
+	require.Equal(t, "LocalStack", em.Product)
+	require.Equal(t, "docker-compose.yml", em.Evidence)
+	require.Equal(t, []string{"s3", "sns", "sqs"}, em.Services)
+}
+
+func TestEmulator_TheServicesItNamesBecomeRules(t *testing.T) {
+	t.Parallel()
+	// There is no @aws-sdk anything in this repository. Without the emulator
+	// being read, S3, SQS and SNS get no rule, and each call is refused with
+	// "no rule matches" rather than by name.
+	res := run(t, "shopfront", localstackRepo("s3,sqs,sns"))
+	for _, host := range []string{
+		"s3.amazonaws.com", "s3.*.amazonaws.com", "*.s3.amazonaws.com", "*.s3.*.amazonaws.com",
+		"sqs.*.amazonaws.com", "sns.*.amazonaws.com",
+	} {
+		r := ruleFor(t, res.Draft, host)
+		require.Equal(t, schema.ModeBlock, r.Mode, "%s must be refused rather than answered", host)
+		require.NotEmpty(t, r.Note, "%s is blocked and the manifest must say why", host)
+	}
+}
+
+func TestEmulator_AServiceItDoesNotNameGetsNoRule(t *testing.T) {
+	t.Parallel()
+	// The emulator is the roster, and a roster that adds services nobody
+	// listed is a wildcard with extra steps. A repository running LocalStack
+	// for S3 alone does not get a Secrets Manager rule it has no use for.
+	res := run(t, "shopfront", localstackRepo("s3"))
+	var hosts []string
+	for _, r := range res.Draft.Egress.Rules {
+		hosts = append(hosts, r.Host)
+	}
+	require.Contains(t, hosts, "s3.amazonaws.com")
+	require.NotContains(t, hosts, "secretsmanager.*.amazonaws.com",
+		"an emulator naming S3 is not evidence that the application reads secrets")
+	require.NotContains(t, hosts, "*.amazonaws.com",
+		"a cloud named with no service named is the wildcard this catalog removed")
+}
+
+func TestEmulator_AnEmulatorNamingNothingWritesNoRules(t *testing.T) {
+	t.Parallel()
+	// LocalStack with no SERVICES answers for whatever is asked of it. That is
+	// not a list, and inventing one from it would put every AWS host in the
+	// manifest on the strength of a container nobody configured.
+	res := run(t, "shopfront", localstackRepo(""))
+	em := emulatorFor(t, res, "localstack")
+	require.Empty(t, em.Services)
+	require.Empty(t, em.Hosts)
+	for _, r := range res.Draft.Egress.Rules {
+		require.NotContains(t, r.Host, "amazonaws.com",
+			"an emulator that named no service cannot produce an AWS rule")
+	}
+	require.Contains(t, em.Note(), "It names no services",
+		"the reader has to be told why an emulator they can see produced nothing")
+}
+
+func TestEmulator_AServiceTheCatalogDoesNotClaimIsReported(t *testing.T) {
+	t.Parallel()
+	// The instrument that can say no. A service the developer configured and
+	// the catalog has no host for is a refusal already scheduled, and af init
+	// is the last cheap moment to fix it.
+	res := run(t, "shopfront", localstackRepo("s3,textract,rekognition"))
+	em := emulatorFor(t, res, "localstack")
+	require.Equal(t, []string{"rekognition", "textract"}, em.Unnamed)
+
+	note := em.Note()
+	require.Contains(t, note, "textract")
+	require.Contains(t, note, "rekognition")
+	require.Contains(t, note, "no rule matches",
+		"the note must say what the refusal will actually look like")
+}
+
+func TestEmulator_ARuleTheDependencyScanAlreadyWroteIsNotWrittenTwice(t *testing.T) {
+	t.Parallel()
+	// Two rules for one host is a manifest the validator refuses, and the
+	// first one carries the same reason the second would.
+	files := localstackRepo("s3,sqs")
+	files["package.json"] = `{"name":"shopfront","scripts":{"start":"next start"},
+		"dependencies":{"next":"15.0.0","@aws-sdk/client-s3":"3.0.0"}}`
+	res := run(t, "shopfront", files)
+
+	seen := map[string]int{}
+	for _, r := range res.Draft.Egress.Rules {
+		seen[r.Host]++
+	}
+	for host, n := range seen {
+		require.Equal(t, 1, n, "%s has %d rules and the validator accepts one", host, n)
+	}
+	requireDraftValidates(t, res.Draft, files)
+}
+
+func TestEmulator_AzuriteAnswersForAzureAndNotForAWS(t *testing.T) {
+	t.Parallel()
+	// The cloud is read off the image rather than assumed, and the three
+	// emulators do not share a table.
+	res := run(t, "shopfront", map[string]string{
+		"package.json": `{"name":"shopfront","scripts":{"start":"next start"},
+			"dependencies":{"next":"15.0.0"}}`,
+		"docker-compose.yml": `services:
+  web:
+    build: .
+    ports:
+      - "3000:3000"
+  azurite:
+    image: mcr.microsoft.com/azure-storage/azurite:3.29.0
+    environment:
+      SERVICES: blob,queue
+`,
+		"Dockerfile": "FROM node:20\nCMD [\"node\", \"server.js\"]\n",
+	})
+	em := emulatorFor(t, res, "azurite")
+	require.Equal(t, "azure", em.Cloud)
+	require.Equal(t, "Azurite", em.Product)
+	r := ruleFor(t, res.Draft, "*.blob.core.windows.net")
+	require.Equal(t, schema.ModeBlock, r.Mode)
+	for _, rule := range res.Draft.Egress.Rules {
+		require.NotContains(t, rule.Host, "amazonaws.com",
+			"an Azure emulator is not evidence about AWS")
+	}
+}
+
+func TestEmulator_MinIOIsAnObjectStoreAndNotAnEmulator(t *testing.T) {
+	t.Parallel()
+	// The distinction the ordering in ComposeAnalyzer exists for.
+	// fake-gcs-server and MinIO are both object stores, and only one of them
+	// stands in for a named cloud service. Calling MinIO an AWS emulator would
+	// write nine S3 rules for an application that never calls AWS.
+	res := run(t, "shopfront", map[string]string{
+		"package.json": `{"name":"shopfront","scripts":{"start":"next start"},
+			"dependencies":{"next":"15.0.0"}}`,
+		"docker-compose.yml": `services:
+  web:
+    build: .
+    ports:
+      - "3000:3000"
+  minio:
+    image: minio/minio:latest
+`,
+		"Dockerfile": "FROM node:20\nCMD [\"node\", \"server.js\"]\n",
+	})
+	require.Empty(t, res.Emulators, "MinIO is object storage the environment runs, not a stand in for S3")
+}
+
+func TestEmulator_TheCloudSDKGapIsNamedFromTheDependencyList(t *testing.T) {
+	t.Parallel()
+	// The dependency half of the same instrument. Textract is a service this
+	// application calls and the catalog has no host for, so it is reported by
+	// name rather than discovered as a refusal in an environment.
+	res := run(t, "shopfront", map[string]string{
+		"package.json": `{"name":"shopfront","scripts":{"start":"next start"},
+			"dependencies":{"next":"15.0.0","@aws-sdk/client-textract":"3.0.0"}}`,
+	})
+	var details []string
+	for _, f := range detect.OfKind(res.Findings, detect.KindNote) {
+		if f.Subject == "cloud-service.aws.textract" {
+			details = append(details, f.Detail)
+		}
+	}
+	require.Len(t, details, 1, "a cloud SDK the catalog does not claim must be reported exactly once")
+	require.Contains(t, details[0], "@aws-sdk/client-textract")
+	require.Contains(t, details[0], "no rule matches")
+}
+
+func TestEmulator_ASDKForAServiceTheCatalogClaimsIsNotAGap(t *testing.T) {
+	t.Parallel()
+	// The other direction. A gap report for a service that has a rule is
+	// noise, and noise is what makes a report stop being read.
+	res := run(t, "shopfront", map[string]string{
+		"package.json": `{"name":"shopfront","scripts":{"start":"next start"},
+			"dependencies":{"next":"15.0.0","@aws-sdk/client-s3":"3.0.0","boto3":"1.34.0"}}`,
+	})
+	for _, f := range detect.OfKind(res.Findings, detect.KindNote) {
+		require.NotContains(t, f.Subject, "cloud-service.",
+			"%s has a rule, so reporting it as a gap is noise", f.Subject)
+	}
+}

--- a/engine/internal/detect/merge.go
+++ b/engine/internal/detect/merge.go
@@ -21,7 +21,7 @@ import (
 // When two analyzers disagree, the stronger evidence wins and the
 // disagreement becomes a question, because a conflict is exactly the case
 // where a silent choice is most likely to be wrong.
-func Merge(findings []Finding, root string) (*schema.Manifest, []Question) {
+func Merge(findings []Finding, root string) (*schema.Manifest, []Question, Proposals) {
 	m := &schema.Manifest{
 		Version: schema.ManifestVersion,
 		Name:    sanitizeServiceName(path.Base(root)),
@@ -40,7 +40,14 @@ func Merge(findings []Finding, root string) (*schema.Manifest, []Question) {
 	}
 
 	m.Database = mergeDatabase(findings, services, &questions)
-	m.Egress = mergeEgress(findings)
+	// A store beside the primary, with the stance detection proposes for it.
+	// Only the ones this build can bring up reach the draft; the rest are
+	// returned so af init can name them, because a manifest declaring an
+	// engine no provider serves is a manifest af up refuses, and af init
+	// promises the opposite.
+	var proposals Proposals
+	proposals.Datastores, m.Datastores = mergeDatastores(findings, hasPostgresFinding(findings))
+	m.Egress, proposals.Emulators = mergeEgress(findings)
 	m.Personas = defaultPersonas()
 	m.Auth = mergeAuth(findings)
 	m.Workflows = suggestedWorkflows(findings)
@@ -54,7 +61,40 @@ func Merge(findings []Finding, root string) (*schema.Manifest, []Question) {
 		return m.Services[i].Name < m.Services[j].Name
 	})
 	sort.SliceStable(questions, func(i, j int) bool { return questions[i].ID < questions[j].ID })
-	return m, questions
+	return m, questions, proposals
+}
+
+// Proposals are the things detection found and could not simply write into the
+// manifest.
+//
+// They are separate from the draft because each one needs a sentence rather
+// than a line: a datastore this build has no provider for would make a
+// manifest af up refuses, and an emulator is evidence about the manifest
+// rather than a part of it. Before this existed both were dropped on the
+// floor by Merge, which is why a compose file running ClickHouse and
+// LocalStack produced a manifest that mentioned neither.
+type Proposals struct {
+	// Datastores are the stores found beside the primary database, both the
+	// ones written into the draft and the ones this build cannot bring up.
+	Datastores []ProposedDatastore
+	// Emulators are the cloud emulators the repository runs in its own
+	// compose file, and the rules each one produced.
+	Emulators []DetectedEmulator
+}
+
+// hasPostgresFinding reports whether anything in the repository said Postgres.
+//
+// It is what tells a Mongo that IS the application's database apart from a
+// Mongo sitting beside a Postgres as a second store. mergeDatabase already
+// asks about the first case by name, and proposing a stance for it as well
+// would be one fact stated twice in two vocabularies.
+func hasPostgresFinding(findings []Finding) bool {
+	for _, f := range OfKind(findings, KindDatabase) {
+		if f.Subject == "postgres" {
+			return true
+		}
+	}
+	return false
 }
 
 // primaryServiceName picks the name the application should carry: the first
@@ -795,7 +835,7 @@ func isDatabaseURLName(name string) bool {
 	return false
 }
 
-func mergeEgress(findings []Finding) *schema.Egress {
+func mergeEgress(findings []Finding) (*schema.Egress, []DetectedEmulator) {
 	e := &schema.Egress{Default: schema.ModeBlock}
 	seen := map[string]bool{}
 	// A provider's webhook path belongs on the host that serves its API, not
@@ -834,8 +874,73 @@ func mergeEgress(findings []Finding) *schema.Egress {
 		}
 		e.Rules = append(e.Rules, rule)
 	}
+	emulators := mergeEmulators(findings, e, seen)
 	sort.SliceStable(e.Rules, func(i, j int) bool { return e.Rules[i].Host < e.Rules[j].Host })
-	return e
+	return e, emulators
+}
+
+// mergeEmulators turns a cloud emulator running in the repository's own
+// compose file into the egress rules for the cloud it answers for.
+//
+// An emulator's own configuration is better evidence about which services an
+// application uses than its dependency list is, because somebody configured it
+// rather than installed it: LocalStack with SERVICES=s3,sqs,sns is a developer
+// stating that this application calls exactly those three. It is also the
+// thing this product replaces, since reaching an emulator costs an endpoint
+// override and the override means the code under test is not the code that
+// ships. So the emulator is read as the roster, and every service on it gets
+// the catalog's rule for the real host, with the catalog's own reason.
+//
+// A host the dependency scan already claimed is left alone rather than added
+// twice. Two rules for one host is a manifest the validator refuses, and the
+// first one carries the same reason as the second would.
+//
+// The mode is the catalog's, which today is block for every cloud service
+// this can reach. That is the honest answer while nothing answers for the
+// service in the environment: a rule promising something else would be a
+// promise the engine cannot keep.
+func mergeEmulators(findings []Finding, e *schema.Egress, seen map[string]bool) []DetectedEmulator {
+	found := OfKind(findings, KindEmulator)
+	if len(found) == 0 {
+		return nil
+	}
+	out := make([]DetectedEmulator, 0, len(found))
+	for _, f := range found {
+		em := DetectedEmulator{
+			Product:  f.Extra["product"],
+			Cloud:    f.Subject,
+			Service:  f.Extra["service"],
+			Image:    f.Value,
+			Evidence: f.Evidence,
+			Services: emulatorTokens(f.Extra["services"]),
+		}
+		for _, tp := range thirdPartiesForCloud(em.Cloud, em.Services) {
+			for _, host := range tp.Hosts {
+				if seen[host] {
+					continue
+				}
+				seen[host] = true
+				em.Hosts = append(em.Hosts, host)
+				e.Rules = append(e.Rules, schema.EgressRule{
+					Host: host,
+					Mode: schema.Mode(tp.Mode),
+					Note: tp.Why,
+				})
+			}
+		}
+		em.Unnamed = unclaimedTokens(em.Cloud, em.Services)
+		out = append(out, em)
+	}
+	// Findings arrive sorted, but two emulators in one compose file must not
+	// swap places between runs because a map iteration inside the analyzer
+	// changed, and the note is read by a person who runs af init twice.
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Evidence != out[j].Evidence {
+			return out[i].Evidence < out[j].Evidence
+		}
+		return out[i].Service < out[j].Service
+	})
+	return out
 }
 
 // mergeAuth turns the authentication finding into the manifest's auth block.

--- a/engine/internal/detect/thirdparty.go
+++ b/engine/internal/detect/thirdparty.go
@@ -41,6 +41,20 @@ type ThirdParty struct {
 	WebhookPath string
 	// Credential is the variable holding its key, when there is a convention.
 	Credential string
+	// Cloud names the cloud this entry belongs to: aws, gcp or azure, and
+	// empty for everything else. It is what lets an emulator running in the
+	// repository's own compose file select the entries for the cloud it
+	// answers for.
+	Cloud string
+	// Tokens are the names this service goes by inside its cloud: the client
+	// suffix in an SDK package, and the word an emulator's own configuration
+	// uses. @aws-sdk/client-secrets-manager, LocalStack's
+	// SERVICES=secretsmanager and the endpoint prefix secretsmanager are the
+	// same service under three spellings, and a table is the only thing that
+	// knows that. Deriving the endpoint from the package name mechanically
+	// gets sfn, sesv2 and cloudwatch-logs wrong, and a silently wrong host is
+	// worse than a refusal, because the refusal is read.
+	Tokens []string
 }
 
 // thirdParties is the catalog. It is a data table rather than code so that
@@ -86,6 +100,7 @@ var thirdParties = []ThirdParty{
 		Why:      "Mail is captured into the inbox so that agents can read it and no real address receives anything.",
 		Packages: []string{"@aws-sdk/client-ses", "@aws-sdk/client-sesv2"},
 		EnvHints: []string{"AWS_SES_REGION"},
+		Cloud:    "aws", Tokens: []string{"ses", "sesv2", "email"},
 	},
 	{
 		Name: "Amazon SES over SMTP", Hosts: []string{"email-smtp.*.amazonaws.com"}, Mode: "block",
@@ -93,6 +108,7 @@ var thirdParties = []ThirdParty{
 			"Mail sent this way would not reach the inbox, and an environment able to open it could " +
 			"send to a real address.",
 		EnvHints: []string{"SES_SMTP_USERNAME", "SES_SMTP_PASSWORD"},
+		Cloud:    "aws", Tokens: []string{"ses-smtp"},
 	},
 	{
 		Name: "Twilio", Hosts: []string{"api.twilio.com", "verify.twilio.com"}, Mode: "capture",
@@ -242,6 +258,7 @@ var thirdParties = []ThirdParty{
 		Packages: []string{"@aws-sdk/client-s3", "@aws-sdk/lib-storage", "aws-sdk", "boto3",
 			"aws-sdk-go", "aws-sdk-go-v2", "aws-sdk-s3", "fog-aws"},
 		EnvHints: []string{"AWS_S3_BUCKET", "S3_BUCKET", "AWS_BUCKET_NAME"},
+		Cloud:    "aws", Tokens: []string{"s3"},
 	},
 	{
 		Name: "Amazon SQS", Hosts: []string{"sqs.*.amazonaws.com"}, Mode: "block",
@@ -249,6 +266,7 @@ var thirdParties = []ThirdParty{
 			"environment reaching into production through the back door.",
 		Packages: []string{"@aws-sdk/client-sqs", "aws-sdk", "boto3", "aws-sdk-go", "aws-sdk-go-v2"},
 		EnvHints: []string{"SQS_QUEUE_URL", "AWS_SQS_QUEUE_URL"},
+		Cloud:    "aws", Tokens: []string{"sqs"},
 	},
 	{
 		Name: "Amazon SNS", Hosts: []string{"sns.*.amazonaws.com"}, Mode: "block",
@@ -256,6 +274,7 @@ var thirdParties = []ThirdParty{
 			"number and an email address.",
 		Packages: []string{"@aws-sdk/client-sns", "aws-sdk", "boto3", "aws-sdk-go", "aws-sdk-go-v2"},
 		EnvHints: []string{"SNS_TOPIC_ARN", "AWS_SNS_TOPIC_ARN"},
+		Cloud:    "aws", Tokens: []string{"sns"},
 	},
 	{
 		Name:  "Amazon DynamoDB",
@@ -266,6 +285,7 @@ var thirdParties = []ThirdParty{
 		Packages: []string{"@aws-sdk/client-dynamodb", "@aws-sdk/lib-dynamodb", "dynamoose",
 			"aws-sdk", "boto3", "aws-sdk-go", "aws-sdk-go-v2"},
 		EnvHints: []string{"DYNAMODB_TABLE", "AWS_DYNAMODB_TABLE"},
+		Cloud:    "aws", Tokens: []string{"dynamodb", "dynamodbstreams"},
 	},
 	{
 		Name: "Amazon Kinesis", Hosts: []string{"kinesis.*.amazonaws.com"}, Mode: "block",
@@ -273,6 +293,7 @@ var thirdParties = []ThirdParty{
 			"back off it.",
 		Packages: []string{"@aws-sdk/client-kinesis", "aws-sdk", "boto3", "aws-sdk-go", "aws-sdk-go-v2"},
 		EnvHints: []string{"KINESIS_STREAM_NAME"},
+		Cloud:    "aws", Tokens: []string{"kinesis"},
 	},
 	{
 		Name: "Amazon EventBridge", Hosts: []string{"events.*.amazonaws.com"}, Mode: "block",
@@ -280,6 +301,7 @@ var thirdParties = []ThirdParty{
 			"targets are whatever those rules point at.",
 		Packages: []string{"@aws-sdk/client-eventbridge", "aws-sdk", "boto3", "aws-sdk-go", "aws-sdk-go-v2"},
 		EnvHints: []string{"EVENT_BUS_NAME", "EVENTBRIDGE_BUS_NAME"},
+		Cloud:    "aws", Tokens: []string{"eventbridge", "events"},
 	},
 	{
 		Name: "AWS Secrets Manager", Hosts: []string{"secretsmanager.*.amazonaws.com"}, Mode: "block",
@@ -287,6 +309,7 @@ var thirdParties = []ThirdParty{
 			"against a copy of production data, which is the one thing this product exists to stop.",
 		Packages: []string{"@aws-sdk/client-secrets-manager", "aws-sdk", "boto3", "aws-sdk-go", "aws-sdk-go-v2"},
 		EnvHints: []string{"AWS_SECRET_NAME", "SECRETS_MANAGER_SECRET_ID"},
+		Cloud:    "aws", Tokens: []string{"secrets-manager", "secretsmanager"},
 	},
 	{
 		Name: "AWS Systems Manager Parameter Store", Hosts: []string{"ssm.*.amazonaws.com"}, Mode: "block",
@@ -294,6 +317,7 @@ var thirdParties = []ThirdParty{
 			"credentials, so it is refused for the same reason Secrets Manager is.",
 		Packages: []string{"@aws-sdk/client-ssm", "aws-sdk", "boto3", "aws-sdk-go", "aws-sdk-go-v2"},
 		EnvHints: []string{"SSM_PARAMETER_PATH", "AWS_SSM_PATH"},
+		Cloud:    "aws", Tokens: []string{"ssm"},
 	},
 	{
 		Name: "AWS STS", Hosts: []string{"sts.amazonaws.com", "sts.*.amazonaws.com"}, Mode: "block",
@@ -301,6 +325,7 @@ var thirdParties = []ThirdParty{
 			"an hour, and no rule about any other host applies to what it does with one.",
 		Packages: []string{"@aws-sdk/client-sts", "aws-sdk", "boto3", "aws-sdk-go", "aws-sdk-go-v2"},
 		EnvHints: []string{"AWS_ROLE_ARN", "AWS_WEB_IDENTITY_TOKEN_FILE"},
+		Cloud:    "aws", Tokens: []string{"sts"},
 	},
 	{
 		Name: "Google Cloud Storage", Hosts: []string{"storage.googleapis.com"}, Mode: "block",
@@ -308,18 +333,21 @@ var thirdParties = []ThirdParty{
 			"official Cloud Storage emulator, which is why this is a refusal rather than a redirect.",
 		Packages: []string{"@google-cloud/storage", "google-cloud-storage", "gcs-resumable-upload"},
 		EnvHints: []string{"GCS_BUCKET", "GOOGLE_CLOUD_STORAGE_BUCKET"},
+		Cloud:    "gcp", Tokens: []string{"storage"},
 	},
 	{
 		Name: "Google Cloud Pub/Sub", Hosts: []string{"pubsub.googleapis.com"}, Mode: "block",
 		Why:      "A message published to a real topic is delivered to production subscribers.",
 		Packages: []string{"@google-cloud/pubsub", "google-cloud-pubsub"},
 		EnvHints: []string{"PUBSUB_TOPIC", "GOOGLE_PUBSUB_TOPIC"},
+		Cloud:    "gcp", Tokens: []string{"pubsub"},
 	},
 	{
 		Name: "Google Cloud Firestore", Hosts: []string{"firestore.googleapis.com"}, Mode: "block",
 		Why:      "This is a production datastore, and an environment writing to it is writing to production.",
 		Packages: []string{"@google-cloud/firestore", "google-cloud-firestore", "firebase-admin"},
 		EnvHints: []string{"FIRESTORE_PROJECT_ID", "FIRESTORE_EMULATOR_HOST"},
+		Cloud:    "gcp", Tokens: []string{"firestore"},
 	},
 	{
 		Name: "Google Secret Manager", Hosts: []string{"secretmanager.googleapis.com"}, Mode: "block",
@@ -327,6 +355,7 @@ var thirdParties = []ThirdParty{
 			"against a copy of production data.",
 		Packages: []string{"@google-cloud/secret-manager", "google-cloud-secret-manager"},
 		EnvHints: []string{"GOOGLE_SECRET_NAME", "SECRET_MANAGER_PROJECT"},
+		Cloud:    "gcp", Tokens: []string{"secret-manager", "secretmanager"},
 	},
 	{
 		Name: "Google Cloud Tasks", Hosts: []string{"cloudtasks.googleapis.com"}, Mode: "block",
@@ -334,6 +363,7 @@ var thirdParties = []ThirdParty{
 			"is watching for it.",
 		Packages: []string{"@google-cloud/tasks", "google-cloud-tasks"},
 		EnvHints: []string{"CLOUD_TASKS_QUEUE", "GOOGLE_CLOUD_TASKS_QUEUE"},
+		Cloud:    "gcp", Tokens: []string{"tasks", "cloudtasks"},
 	},
 	{
 		Name: "Azure Blob Storage", Hosts: []string{"*.blob.core.windows.net"}, Mode: "block",
@@ -341,12 +371,14 @@ var thirdParties = []ThirdParty{
 			"tells it apart from production data afterwards.",
 		Packages: []string{"@azure/storage-blob", "azure-storage-blob", "azure-storage"},
 		EnvHints: []string{"AZURE_STORAGE_ACCOUNT", "AZURE_STORAGE_CONNECTION_STRING"},
+		Cloud:    "azure", Tokens: []string{"storage-blob", "blob"},
 	},
 	{
 		Name: "Azure Queue Storage", Hosts: []string{"*.queue.core.windows.net"}, Mode: "block",
 		Why:      "A message sent to a real queue is picked up by production workers.",
 		Packages: []string{"@azure/storage-queue", "azure-storage-queue"},
 		EnvHints: []string{"AZURE_QUEUE_NAME"},
+		Cloud:    "azure", Tokens: []string{"storage-queue", "queue"},
 	},
 	{
 		Name: "Azure Service Bus", Hosts: []string{"*.servicebus.windows.net"}, Mode: "block",
@@ -355,12 +387,14 @@ var thirdParties = []ThirdParty{
 			"environment pays for on purpose rather than by default.",
 		Packages: []string{"@azure/service-bus", "azure-servicebus"},
 		EnvHints: []string{"SERVICEBUS_CONNECTION_STRING", "AZURE_SERVICEBUS_NAMESPACE"},
+		Cloud:    "azure", Tokens: []string{"service-bus", "servicebus", "eventhubs", "event-hubs"},
 	},
 	{
 		Name: "Azure Table Storage", Hosts: []string{"*.table.core.windows.net"}, Mode: "block",
 		Why:      "This is a production datastore, and an environment writing to it is writing to production.",
 		Packages: []string{"@azure/data-tables", "azure-data-tables"},
 		EnvHints: []string{"AZURE_TABLE_NAME"},
+		Cloud:    "azure", Tokens: []string{"data-tables", "table"},
 	},
 	{
 		Name: "Azure Files", Hosts: []string{"*.file.core.windows.net"}, Mode: "block",
@@ -368,12 +402,14 @@ var thirdParties = []ThirdParty{
 			"it apart from production data afterwards.",
 		Packages: []string{"@azure/storage-file-share", "azure-storage-file-share"},
 		EnvHints: []string{"AZURE_FILE_SHARE_NAME"},
+		Cloud:    "azure", Tokens: []string{"storage-file-share", "file"},
 	},
 	{
 		Name: "Azure Cosmos DB", Hosts: []string{"*.documents.azure.com"}, Mode: "block",
 		Why:      "This is a production datastore, and an environment writing to it is writing to production.",
 		Packages: []string{"@azure/cosmos", "azure-cosmos"},
 		EnvHints: []string{"COSMOS_ENDPOINT", "AZURE_COSMOS_CONNECTION_STRING"},
+		Cloud:    "azure", Tokens: []string{"cosmos"},
 	},
 	{
 		Name: "Azure Key Vault", Hosts: []string{"*.vault.azure.net"}, Mode: "block",
@@ -381,6 +417,262 @@ var thirdParties = []ThirdParty{
 			"against a copy of production data.",
 		Packages: []string{"@azure/keyvault-secrets", "@azure/keyvault-keys", "azure-keyvault-secrets"},
 		EnvHints: []string{"AZURE_KEY_VAULT_URL", "KEY_VAULT_NAME"},
+		Cloud:    "azure", Tokens: []string{"keyvault-secrets", "keyvault-keys", "keyvault"},
+	},
+
+	// The rest of each cloud, added because the nine, five and seven above
+	// were the services one lane could name in one pass and an application
+	// touches more than that.
+	//
+	// A repository depending on @aws-sdk/client-lambda got no rule at all, so
+	// the invoke was refused with "no rule matches" rather than "this is
+	// Lambda". That refusal is correct and it is unreadable, and the whole
+	// argument for a per service catalog is that the sentence can be acted on.
+	// Every entry here is still block, for the same reason as the ones above:
+	// block is the honest answer until an emulator answers for the service,
+	// and this build has none.
+	//
+	// The endpoint is written out rather than derived from the package name.
+	// AWS spells three of these differently in the two places, sfn against
+	// states and cloudwatch-logs against logs among them, and a host guessed
+	// wrong is worse than a host not named: the wrong pattern matches nothing,
+	// the request falls through, and the catalog looks like it covered a
+	// service it never did.
+	{
+		Name: "AWS Lambda", Hosts: []string{"lambda.*.amazonaws.com"}, Mode: "block",
+		Why: "Invoking a real function runs production code, with production's own permissions, " +
+			"at a time nobody is watching for it.",
+		Packages: []string{"@aws-sdk/client-lambda", "aws-lambda"},
+		EnvHints: []string{"LAMBDA_FUNCTION_NAME", "AWS_LAMBDA_FUNCTION_NAME"},
+		Cloud:    "aws", Tokens: []string{"lambda"},
+	},
+	{
+		Name: "Amazon CloudWatch Logs", Hosts: []string{"logs.*.amazonaws.com"}, Mode: "block",
+		Why: "A preview environment's log lines land in the production log group, where an on " +
+			"call engineer reads them as production and an alarm counts them as production.",
+		Packages: []string{"@aws-sdk/client-cloudwatch-logs", "watchtower"},
+		EnvHints: []string{"CLOUDWATCH_LOG_GROUP", "AWS_LOG_GROUP"},
+		Cloud:    "aws", Tokens: []string{"cloudwatch-logs", "logs"},
+	},
+	{
+		Name: "Amazon CloudWatch", Hosts: []string{"monitoring.*.amazonaws.com"}, Mode: "block",
+		Why: "Metrics from a preview environment distort the production dashboards and the " +
+			"alarms wired to them.",
+		Packages: []string{"@aws-sdk/client-cloudwatch"},
+		EnvHints: []string{"CLOUDWATCH_NAMESPACE"},
+		Cloud:    "aws", Tokens: []string{"cloudwatch", "monitoring"},
+	},
+	{
+		Name: "AWS KMS", Hosts: []string{"kms.*.amazonaws.com"}, Mode: "block",
+		Why: "A decrypt turns production ciphertext into plaintext inside an environment running " +
+			"unreviewed code, which is the same exposure a secret store is refused for.",
+		Packages: []string{"@aws-sdk/client-kms"},
+		EnvHints: []string{"KMS_KEY_ID", "AWS_KMS_KEY_ID"},
+		Cloud:    "aws", Tokens: []string{"kms"},
+	},
+	{
+		Name: "AWS Step Functions", Hosts: []string{"states.*.amazonaws.com"}, Mode: "block",
+		Why: "Starting a real execution runs every step of a production workflow, and the steps " +
+			"are whatever that state machine points at.",
+		Packages: []string{"@aws-sdk/client-sfn"},
+		EnvHints: []string{"STATE_MACHINE_ARN", "SFN_STATE_MACHINE_ARN"},
+		Cloud:    "aws", Tokens: []string{"sfn", "stepfunctions", "states"},
+	},
+	{
+		Name: "Amazon Athena", Hosts: []string{"athena.*.amazonaws.com"}, Mode: "block",
+		Why: "A query reads the production data lake unmasked, and it is billed by the volume it " +
+			"scans, so a loop in a preview environment is a bill as well as a leak.",
+		Packages: []string{"@aws-sdk/client-athena", "pyathena"},
+		EnvHints: []string{"ATHENA_WORKGROUP", "ATHENA_DATABASE"},
+		Cloud:    "aws", Tokens: []string{"athena"},
+	},
+	{
+		Name: "Amazon Bedrock",
+		Hosts: []string{
+			"bedrock.*.amazonaws.com", "bedrock-runtime.*.amazonaws.com",
+		},
+		Mode: "block",
+		Why: "Model calls are billed per token and answer differently every run, so reaching " +
+			"them costs money and makes the run non repeatable.",
+		Packages: []string{"@aws-sdk/client-bedrock", "@aws-sdk/client-bedrock-runtime"},
+		EnvHints: []string{"BEDROCK_MODEL_ID", "AWS_BEDROCK_MODEL_ID"},
+		Cloud:    "aws", Tokens: []string{"bedrock", "bedrock-runtime"},
+	},
+	{
+		Name: "Amazon Cognito",
+		Hosts: []string{
+			"cognito-idp.*.amazonaws.com", "cognito-identity.*.amazonaws.com",
+		},
+		Mode: "block",
+		Why: "A sign up writes a real user into the production pool, and that user can then sign " +
+			"in to production. Personas exist so this does not have to happen.",
+		Packages: []string{"@aws-sdk/client-cognito-identity-provider",
+			"@aws-sdk/client-cognito-identity", "amazon-cognito-identity-js"},
+		EnvHints: []string{"COGNITO_USER_POOL_ID", "AWS_COGNITO_USER_POOL_ID"},
+		Cloud:    "aws", Tokens: []string{"cognito-identity-provider", "cognito-idp", "cognito"},
+	},
+	{
+		Name: "Amazon API Gateway",
+		Hosts: []string{
+			"apigateway.*.amazonaws.com", "*.execute-api.*.amazonaws.com",
+		},
+		Mode: "block",
+		Why: "A call to a deployed API reaches the production service behind it, and the " +
+			"management endpoint can change what that API does for everyone.",
+		Packages: []string{"@aws-sdk/client-api-gateway", "@aws-sdk/client-apigatewayv2"},
+		EnvHints: []string{"API_GATEWAY_ID", "APIGATEWAY_ENDPOINT"},
+		Cloud:    "aws", Tokens: []string{"api-gateway", "apigateway", "apigatewayv2", "execute-api"},
+	},
+	{
+		Name: "Amazon Data Firehose", Hosts: []string{"firehose.*.amazonaws.com"}, Mode: "block",
+		Why: "Records put onto a real delivery stream are written to whatever it delivers to, " +
+			"usually a production bucket or warehouse, and cannot be taken back out.",
+		Packages: []string{"@aws-sdk/client-firehose"},
+		EnvHints: []string{"FIREHOSE_STREAM_NAME"},
+		Cloud:    "aws", Tokens: []string{"firehose"},
+	},
+	{
+		Name: "Google BigQuery",
+		Hosts: []string{
+			"bigquery.googleapis.com", "bigquerystorage.googleapis.com",
+		},
+		Mode: "block",
+		Why: "A query reads production's warehouse unmasked and is billed by the bytes it scans, " +
+			"and an insert lands in a table the business reports from.",
+		Packages: []string{"@google-cloud/bigquery", "google-cloud-bigquery"},
+		EnvHints: []string{"BIGQUERY_DATASET", "GOOGLE_BIGQUERY_DATASET"},
+		Cloud:    "gcp", Tokens: []string{"bigquery", "bigquerystorage"},
+	},
+	{
+		Name: "Google Cloud Logging", Hosts: []string{"logging.googleapis.com"}, Mode: "block",
+		Why: "A preview environment's log lines land in the production project, where they are " +
+			"read and alerted on as production.",
+		Packages: []string{"@google-cloud/logging", "@google-cloud/logging-winston", "google-cloud-logging"},
+		EnvHints: []string{"GOOGLE_CLOUD_LOG_NAME"},
+		Cloud:    "gcp", Tokens: []string{"logging", "logging-winston"},
+	},
+	{
+		Name: "Google Cloud Monitoring", Hosts: []string{"monitoring.googleapis.com"}, Mode: "block",
+		Why:      "Metrics from a preview environment distort the production dashboards and alerting policies.",
+		Packages: []string{"@google-cloud/monitoring", "google-cloud-monitoring"},
+		EnvHints: []string{"GOOGLE_CLOUD_METRIC_PREFIX"},
+		Cloud:    "gcp", Tokens: []string{"monitoring"},
+	},
+	{
+		Name: "Google Cloud Bigtable",
+		Hosts: []string{
+			"bigtable.googleapis.com", "bigtableadmin.googleapis.com",
+		},
+		Mode:     "block",
+		Why:      "This is a production datastore, and an environment writing to it is writing to production.",
+		Packages: []string{"@google-cloud/bigtable", "google-cloud-bigtable"},
+		EnvHints: []string{"BIGTABLE_INSTANCE_ID", "BIGTABLE_EMULATOR_HOST"},
+		Cloud:    "gcp", Tokens: []string{"bigtable", "bigtableadmin"},
+	},
+	{
+		Name: "Google Cloud Spanner", Hosts: []string{"spanner.googleapis.com"}, Mode: "block",
+		Why:      "This is a production datastore, and an environment writing to it is writing to production.",
+		Packages: []string{"@google-cloud/spanner", "google-cloud-spanner"},
+		EnvHints: []string{"SPANNER_INSTANCE_ID", "SPANNER_EMULATOR_HOST"},
+		Cloud:    "gcp", Tokens: []string{"spanner"},
+	},
+	{
+		Name: "Google Vertex AI", Hosts: []string{"aiplatform.googleapis.com"}, Mode: "block",
+		// The regional spelling is us-central1-aiplatform.googleapis.com and
+		// it is NOT here. A star in a rule stands for one whole label, and
+		// us-central1-aiplatform is not one, so the only pattern that would
+		// cover it is *.googleapis.com, which is the wildcard this catalog was
+		// rewritten to remove. A regional endpoint therefore still reaches
+		// nothing, because the default is block, and its refusal says no rule
+		// matches rather than naming Vertex. A stated gap, not an oversight.
+		Why: "Model calls are billed per token and answer differently every run, so reaching " +
+			"them costs money and makes the run non repeatable.",
+		Packages: []string{"@google-cloud/aiplatform", "@google-cloud/vertexai", "google-cloud-aiplatform"},
+		EnvHints: []string{"VERTEX_AI_LOCATION", "GOOGLE_VERTEX_PROJECT"},
+		Cloud:    "gcp", Tokens: []string{"aiplatform", "vertexai"},
+	},
+	{
+		Name: "Google Cloud Run", Hosts: []string{"run.googleapis.com"}, Mode: "block",
+		Why: "The admin API deploys and scales real services, so an environment that can reach " +
+			"it can change what production runs.",
+		Packages: []string{"@google-cloud/run", "google-cloud-run"},
+		EnvHints: []string{"CLOUD_RUN_SERVICE", "K_SERVICE"},
+		Cloud:    "gcp", Tokens: []string{"run"},
+	},
+	{
+		Name: "Google OAuth token endpoint",
+		Hosts: []string{
+			"oauth2.googleapis.com", "accounts.google.com", "iamcredentials.googleapis.com",
+		},
+		Mode: "block",
+		// The one every other Google entry depends on. A client library
+		// exchanges a service account key here before it calls anything at
+		// all, so an unnamed refusal at this host is the FIRST thing a Google
+		// application sees and it says nothing about Google.
+		Why: "This is where a service account key is exchanged for an access token. An " +
+			"environment holding one holds production's identity for an hour, and no rule about " +
+			"any other host applies to what it does with it.",
+		Packages: []string{"google-auth-library", "google-auth", "@google-cloud/local-auth",
+			"googleapis", "google-api-python-client"},
+		EnvHints: []string{"GOOGLE_APPLICATION_CREDENTIALS", "GOOGLE_SERVICE_ACCOUNT_KEY"},
+		Cloud:    "gcp", Tokens: []string{"auth", "local-auth", "iamcredentials"},
+	},
+	{
+		Name: "Microsoft Entra ID",
+		Hosts: []string{
+			"login.microsoftonline.com", "login.windows.net",
+		},
+		Mode: "block",
+		// The Azure peer of the entry above, and the same reasoning: every
+		// @azure/* client asks DefaultAzureCredential for a token first, and
+		// that request goes here.
+		Why: "This is where a client credential is exchanged for a token in the production " +
+			"tenant. An environment that can reach it holds production's identity, and every " +
+			"other Azure rule is downstream of that.",
+		Packages: []string{"@azure/identity", "@azure/msal-node", "azure-identity", "msal"},
+		EnvHints: []string{"AZURE_TENANT_ID", "AZURE_CLIENT_ID", "AZURE_CLIENT_SECRET"},
+		Cloud:    "azure", Tokens: []string{"identity", "msal-node", "msal"},
+	},
+	{
+		Name: "Azure OpenAI", Hosts: []string{"*.openai.azure.com"}, Mode: "mock",
+		// Mock rather than block, matching OpenAI and Anthropic above. What
+		// this one costs is money and a different answer every run, not a
+		// write to production, and a mock keeps the run repeatable where a
+		// refusal only makes it fail.
+		Why:      "Model calls are mocked so that a preview run costs nothing and returns the same answer twice.",
+		Packages: []string{"@azure/openai", "@azure/ai-openai"},
+		EnvHints: []string{"AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_API_KEY"},
+		Cloud:    "azure", Tokens: []string{"openai", "ai-openai"},
+	},
+	{
+		Name: "Azure AI Search", Hosts: []string{"*.search.windows.net"}, Mode: "block",
+		Why: "An index write changes what production search returns, and a query reads " +
+			"production's documents unmasked.",
+		Packages: []string{"@azure/search-documents", "azure-search-documents"},
+		EnvHints: []string{"AZURE_SEARCH_ENDPOINT", "AZURE_SEARCH_INDEX_NAME"},
+		Cloud:    "azure", Tokens: []string{"search-documents", "search"},
+	},
+	{
+		Name: "Azure Monitor and Application Insights",
+		Hosts: []string{
+			"dc.services.visualstudio.com", "*.in.applicationinsights.azure.com",
+			"*.livediagnostics.monitor.azure.com",
+		},
+		Mode: "block",
+		Why: "Telemetry from a preview environment drowns the production error feed and moves " +
+			"the availability numbers somebody is judged on.",
+		Packages: []string{"@azure/monitor-opentelemetry", "applicationinsights",
+			"azure-monitor-opentelemetry"},
+		EnvHints: []string{"APPLICATIONINSIGHTS_CONNECTION_STRING", "APPINSIGHTS_INSTRUMENTATIONKEY"},
+		Cloud:    "azure", Tokens: []string{"monitor-opentelemetry", "monitor"},
+	},
+	{
+		Name: "Azure App Configuration", Hosts: []string{"*.azconfig.io"}, Mode: "block",
+		Why: "It holds production configuration and, through its Key Vault references, " +
+			"production credentials, so it is refused for the same reason Key Vault is.",
+		Packages: []string{"@azure/app-configuration", "azure-appconfiguration"},
+		EnvHints: []string{"AZURE_APPCONFIG_ENDPOINT", "APP_CONFIGURATION_CONNECTION_STRING"},
+		Cloud:    "azure", Tokens: []string{"app-configuration", "appconfiguration", "appconfig"},
 	},
 }
 
@@ -427,6 +719,9 @@ func (a *ThirdPartyAnalyzer) Analyze(_ context.Context, r *Repo) ([]Finding, err
 			})
 		}
 	}
+	// The gap, named. A cloud SDK the catalog does not claim produces no rule
+	// at all, and a missing rule is invisible in the manifest by definition.
+	out = append(out, unnamedCloudServices(deps)...)
 	return out, nil
 }
 

--- a/engine/internal/env/datastore_engines_internal_test.go
+++ b/engine/internal/env/datastore_engines_internal_test.go
@@ -1,0 +1,88 @@
+package env
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/pkg/provider"
+)
+
+// The switch in newDatastoreProvider and provider.BuiltInDatastoreEngines are
+// two records of one fact, and they used to be three: the refusal message
+// carried the sentence "The engines it can provide are: clickhouse" as a
+// string literal, so a second provider would have landed with the refusal
+// still naming one engine and detection still declining to propose the other.
+//
+// This reads the switch's own case labels out of the source and requires them
+// to be the list. It is a structural check on purpose, because the drift it
+// catches is structural: two lists that disagree. The behavioural half is
+// datastore_up_live_test.go, which brings a real ClickHouse up, and the
+// refusal case below, which is what a manifest naming an engine nothing serves
+// actually produces.
+func TestBuiltInDatastoreEnginesAreTheOnesTheSwitchAnswers(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "datastores.go", nil, 0)
+	require.NoError(t, err)
+
+	var cases []string
+	ast.Inspect(file, func(n ast.Node) bool {
+		fn, ok := n.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "newDatastoreProvider" {
+			return true
+		}
+		ast.Inspect(fn.Body, func(inner ast.Node) bool {
+			sw, ok := inner.(*ast.SwitchStmt)
+			if !ok || sw.Tag == nil {
+				return true
+			}
+			sel, ok := sw.Tag.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "Engine" {
+				return true
+			}
+			for _, stmt := range sw.Body.List {
+				clause, ok := stmt.(*ast.CaseClause)
+				if !ok {
+					continue
+				}
+				for _, expr := range clause.List {
+					lit, ok := expr.(*ast.BasicLit)
+					if ok && lit.Kind == token.STRING {
+						cases = append(cases, lit.Value[1:len(lit.Value)-1])
+					}
+				}
+			}
+			return false
+		})
+		return false
+	})
+
+	require.NotEmpty(t, cases,
+		"the switch on ds.Engine was not found, so this test measured nothing")
+
+	want := append([]string(nil), provider.BuiltInDatastoreEngines()...)
+	sort.Strings(want)
+	sort.Strings(cases)
+	require.Equal(t, want, cases,
+		"the engines this build answers to and the engines it says it answers to disagree, "+
+			"so af init either declines to propose a store it could provide or writes one af up refuses")
+}
+
+// An empty list is the failure this cannot be allowed to pass through. It
+// would make the refusal say "The engines it can provide are: " and make
+// detection propose nothing at all, and both would look like a working
+// build with no datastore support rather than a broken list.
+func TestBuiltInDatastoreEnginesIsNotEmpty(t *testing.T) {
+	engines := provider.BuiltInDatastoreEngines()
+	require.NotEmpty(t, engines)
+	for _, e := range engines {
+		require.True(t, provider.ProvidesDatastoreEngine(e),
+			"%s is on the list and the predicate reading that list says no", e)
+	}
+	require.False(t, provider.ProvidesDatastoreEngine("redis"),
+		"an engine nothing here brings up must not be claimed")
+}

--- a/engine/internal/env/datastores.go
+++ b/engine/internal/env/datastores.go
@@ -186,9 +186,10 @@ func (o *Orchestrator) newDatastoreProvider(
 			"path", o.opts.Root+"/antifailure.yaml",
 			"detail", fmt.Sprintf(
 				"the datastore %q declares the engine %q and this build has no provider for "+
-					"it. The engines it can provide are: clickhouse. Remove the datastore, or "+
+					"it. The engines it can provide are: %s. Remove the datastore, or "+
 					"register a provider for %q and name it in the datastore's provider key",
-				ds.Name, ds.Engine, ds.Engine))
+				ds.Name, ds.Engine,
+				strings.Join(provider.BuiltInDatastoreEngines(), ", "), ds.Engine))
 	}
 }
 

--- a/engine/pkg/provider/datastore.go
+++ b/engine/pkg/provider/datastore.go
@@ -115,3 +115,34 @@ type Datastore interface {
 // declared stance rather than a failure. A cache is rebuilt from the primary
 // and a copy of one would be noise.
 var ErrNoGolden = errors.New("provider: this datastore holds no golden")
+
+// BuiltInDatastoreEngines names the datastore engines this build can bring up
+// without a registered provider, in the order they should be listed to a
+// person.
+//
+// It is here rather than beside the switch that consults it because two places
+// need the same answer and they used to disagree by construction. The engine
+// refuses a datastore whose engine it has no provider for, naming the engines
+// it does have; detection proposes datastores from a compose file and must not
+// write one the engine will then refuse, because af init promises the manifest
+// it writes is one af up accepts. A list in each file is two records of one
+// fact, and the second is wrong the moment a provider lands.
+//
+// A registered provider is NOT here and that is deliberate. Registration is
+// per process and detection runs before any of it, so a list including
+// registrations would be a different list in af init than in af up, which is
+// the disagreement this exists to prevent.
+func BuiltInDatastoreEngines() []string {
+	return []string{"clickhouse"}
+}
+
+// ProvidesDatastoreEngine reports whether this build can bring up an engine
+// with no registered provider.
+func ProvidesDatastoreEngine(engine string) bool {
+	for _, e := range BuiltInDatastoreEngines() {
+		if e == engine {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## The silence

A compose file running Postgres, ClickHouse, Redis, Kafka and LocalStack
produced a manifest that mentioned Postgres.

Nothing in that was a wrong answer, which is why nothing caught it. The image
classifier already recognised ClickHouse, Redis and Elasticsearch; `mergeDatabase`
read postgres, asked about mysql and mongodb, and dropped every other
classification on the floor. Kafka was not classified at all. So the twin of an
analytics product came up holding a masked Postgres and an empty everything
else, and the file the developer read said nothing about it. A test asserting
what the manifest says cannot see a store that is not in it.

The cloud half is the same shape one level up. The catalog matched a dependency
by its exact name, which works for a package called `stripe` and stops working
the moment a vendor ships one client per service. `@aws-sdk/client-lambda`,
`@google-cloud/bigquery` and `@azure/identity` were each a dependency no entry
claimed, so the application got no rule for the host it was about to call, and
the request was refused in an environment three days later with "no rule
matches" rather than with the service's name.

## The failure this PR is named after

The first commit on this branch fixed both of those and put the answers on
`detect.Result`. `Result.Datastores`, `Result.Emulators` and the
`cloud-service.` notes then had exactly zero readers. Detection could name
every store in the compose file and every cloud service with no rule, and
`af init` rendered none of it, so the developer's experience was unchanged: the
same manifest mentioning one store, and the same unreadable refusal later. A
proposal nobody prints is the same silence in a new place, and it is the shape
of a feature that passes review and does nothing.

## What it does now

**Every store beside the primary gets a proposed stance, with the reason
written per engine.** `clickhouse` golden, `redis` empty, `kafka` topics only,
`elasticsearch` derived from the primary, `mongodb` golden. The reason is per
engine rather than shared because a sentence that explains five stores explains
none of them, and it is copied verbatim into the report a person reads.

**A store this build has no provider for is reported rather than written.**
Writing a datastore entry for an engine with no provider produces a manifest
`af up` refuses, and `af init` promises the opposite: the draft is normalized
and validated before it is written precisely so the file it leaves behind is one
every later command accepts. The validator cannot catch this, because
`Datastore.Engine` is an open set on purpose and the refusal happens at run time
in the provider lookup. So the store is asked whether this build can serve it,
and the ones that cannot are named in the summary with the stance they would
have taken. The one thing worse than a store nobody declared is a store nobody
mentioned.

**A cloud emulator in the compose file is read as the roster.** LocalStack with
`SERVICES=s3,sqs` is a developer stating that this application calls exactly
those two, and it is better evidence than a dependency list because somebody
configured it rather than installed it. Each service on it gets the catalog's
rule for the real host, hosts the dependency scan already claimed are left
alone rather than written twice, and the emulator stops being detected as a
service to build. The check runs before `infraKind`, because MinIO and
fake-gcs-server are both object stores in a compose file and only one of them
stands in for a named cloud service. Calling MinIO an AWS emulator would write
four S3 rules for an application that never calls AWS.

**Twenty two catalog entries, every host written out rather than derived.** AWS
spells Step Functions `states`, CloudWatch Logs `logs` and CloudWatch itself
`monitoring`. A host derived from the package name would be
`sfn.us-east-1.amazonaws.com`, which resolves to nothing, and a pattern that
matches nothing looks exactly like a service the catalog covered. The Google
and Microsoft token endpoints are in there for their own reason: an unnamed
refusal at `oauth2.googleapis.com` is the first thing a Google application
sees, and it says nothing about Google.

**What the catalog still does not cover is a sentence at `af init`.**
`unnamedCloudServices` parses every cloud SDK package into the cloud and the
service token it names, subtracts what the catalog claims, and reports the rest
by name, where the answer is a pull request against the catalog rather than a
bug report about a refusal nobody could read.

## The reader, traced

The whole point of the branch is that these have readers, so here is the trace
rather than the claim. Counts are non test call sites, on `2859ce4e`.

| Capability | Defined | Wired | Effective |
| --- | --- | --- | --- |
| `Merge` returning `Proposals` | `detect/merge.go:24` | 1 caller, `detect.go:458` | copied onto `Result` at `detect.go:459` |
| `Result.Datastores` | `detect.go:323` | 2 readers, `cli/init.go:289` and `:647` | JSON `datastores` and the summary table |
| `Result.Emulators` | `detect.go:329` | 2 readers, `cli/init.go:290` and `:676` | JSON `emulators` and the "Cloud emulators" section |
| `cloud-service.` notes | `cloudsdk.go:140` | 2 readers via `cloudGaps`, `init.go:291` and `:687` | JSON `cloud_gaps` and the "Cloud services with no rule" section |
| `UnprovisionableNote` | `detect/datastore.go:192` | 1 caller, `init.go:671` | the sentence per undeclared store |
| `DetectedEmulator.Note` | `detect/cloudsdk.go:273` | 1 caller, `init.go:679` | the emulator line |
| `BuiltInDatastoreEngines` | `pkg/provider/datastore.go:135` | 2 callers, `detect/datastore.go:193` and `env/datastores.go:192` | the refusal message and the proposal both read one list |
| `ProvidesDatastoreEngine` | `pkg/provider/datastore.go:141` | 1 caller, `detect/datastore.go:163` | decides `Provisionable` |

`renderInitSummary` itself has one caller, `init.go:331`, on the real command
path. Nothing added here is reachable only from a test.

## The engines list gate

The switch in `newDatastoreProvider` and `provider.BuiltInDatastoreEngines` are
two records of one fact, and they used to be three: the refusal message carried
"The engines it can provide are: clickhouse" as a string literal. A second
provider would have landed with the refusal still naming one engine and
`af init` still declining to propose the other, and nothing would have said so.

`TestBuiltInDatastoreEnginesAreTheOnesTheSwitchAnswers` reads the switch's own
case labels out of the AST and requires them to be the list. It fails rather
than skips when it cannot find the switch, because a check that cannot say no
is worse than no check.

## Acceptance evidence

All nine required contexts on `d4d43307` report `SUCCESS`: engine, control
plane, edition boundary, enterprise, runner, www, known vulnerabilities, no
credentials in the tree, and commits are attributed to their author. All five
workflow runs on that commit report `success`, and `nightly, the whole corpus`
is `SKIPPED` and is not required. Nothing pending, nothing failing.
`mergeStateStatus` is `CLEAN`.

Run locally in a clean worktree, one package at a time. The `cli` figure is
from the fixed test file at `d4d43307`; `detect` and `env` are unchanged by
that commit and are from `2859ce4e`:

```
[baseline-cli exit 0]
  RUN=7 PASS=7 FAIL=0
ok  github.com/antifailure/antifailure/engine/internal/cli    0.336s
[baseline-detect exit 0]
  RUN=30 PASS=30 FAIL=0
ok  github.com/antifailure/antifailure/engine/internal/detect 0.572s
[baseline-env exit 0]
  RUN=2 PASS=2 FAIL=0
ok  github.com/antifailure/antifailure/engine/internal/env    0.129s
```

The seven `TestInitClouds_` tests run the real command over a real directory
and read its real output. Six assert a presence. The seventh asserts an
absence, and it is the one that makes the other six worth having: a repository
with no second store, no emulator and no unclaimed SDK must print none of the
three sections, because a section that appears on every run is a section nobody
reads.

The 30 in `detect` are this branch's 22 datastore and emulator tests, its
`TestCatalog_TheStatedGapsAreStillGaps`, and the catalog tests that were
already there. `TestCatalog_TheNumber` carries the measurement:

```
--- PASS: TestCatalog_TheNumber (0.01s)
--- PASS: TestCatalog_TheStatedGapsAreStillGaps (0.01s)
```

Measured on this tree against the probe corpus, which grew from 30 concrete
cloud endpoints to 62:

```
cloud endpoints probed: 62
main:   30 named by a rule, 32 unnamed, 0 answered 200 by one wildcard
branch: 62 named by a rule, 0 unnamed, 0 answered 200 by one wildcard
```

## Mutation table

Ten cells. Each break was applied to a clean tree, the single test aimed at was
run with `-run` on its exact name, and the tree was restored and confirmed
empty before the next cell. Every cell reports `RUN=1`, so no cell is a pattern
that matched nothing.

| Cell | The break | Test aimed at | Verdict |
| --- | --- | --- | --- |
| M1 | the report's `datastores` is never filled | `TheReportNamesEveryStoreIncludingTheOnesLeftOut` | CAUGHT |
| M2 | the Datastores section prints unconditionally | `ARepositoryWithNoneOfThisPrintsNoneOfIt` | CAUGHT |
| M3 | the summary reads an empty gap list | `TheServiceWithNoRuleIsNamedInTheReportAndTheSummary` | CAUGHT |
| M4 | every store claims to be provisionable | `OnlyTheProvidableStoreReachesTheManifestOnDisk` | CAUGHT |
| M5 | `BuiltInDatastoreEngines` gains an engine the switch does not answer | `BuiltInDatastoreEnginesAreTheOnesTheSwitchAnswers` | CAUGHT |
| M6 | the emulator section header is renamed | `TheSummaryPrintsTheEmulator` | CAUGHT |
| M7 | `mergeEmulators` result is discarded | `TheEmulatorAndItsRulesAreReported` | CAUGHT |
| M8 | the STORE column prints the engine instead of the developer's own name | `TheSummaryPrintsTheStoresAndTheirStances` | SURVIVED, then CAUGHT |
| M9 | the WHERE column always says manifest | `TheSummaryPrintsTheStoresAndTheirStances` | CAUGHT |
| M10 | the STANCE column is always golden | `TheSummaryPrintsTheStoresAndTheirStances` | CAUGHT |

## M8 survived, and the test it survived is now fixed

The production line was right and the test could not say no about it.
`TestInitClouds_TheSummaryPrintsTheStoresAndTheirStances` asserted `Contains`
over the whole rendered summary for eight words. Printing the ENGINE in the
STORE column deletes the developer's own name for every store from the one
table the test is named for, and the test stayed green.

Every word came back from somewhere else on the page. Dumped from the real
summary with the break applied:

```
  kafka       kafka       topics_only  not declared  a broker wants its topic...
  redis       redis       empty        not declared  a cache is rebuilt from ...
  clickhouse  clickhouse  golden       manifest      the events are here rath...
  docker-compose.yml runs broker (confluentinc/cp-kafka:7.6.0). The stance for
  docker-compose.yml runs cache (redis:7). The stance for it would be empty,
```

`clickhouse`, `redis` and `kafka` came back from the ENGINE column, which the
break did not touch. `broker` and `cache` came back from the unprovisionable
sentences, which print the service name independently of the table. `events`
came back from ClickHouse's own reason, "the events are here rather than in
Postgres". Six words of the eight, and not one of them said anything about the
column it was there to prove.

**The shape generalises, and several tests in this repository assert this way.**
A `Contains` against a rendered page cannot say no about a POSITION, and the
richer the page the weaker the assertion. This page is deliberately rich: every
row carries a sentence of prose about its own store, and each of those
sentences happens to contain that store's compose name, so even a `Contains`
against the RIGHT ROW would have passed. Only the leading field separates the
two.

So the row is now found by its leading field, exactly one row must match, and
the engine, the stance and the where are asserted on that row. Two matches is a
failure rather than a first hit, because a search that found the table and
something else and then read whichever came out on top is the same defect one
level down.

M8 rerun against the fixed test, with M9 and M10 added as the controls that
stop it being a check on the first column with three dead assertions behind it:

```
--- FAIL: TestInitClouds_TheSummaryPrintsTheStoresAndTheirStances (0.02s)
    Messages: want exactly one summary row whose first column is "events", got 0: []

--- FAIL: TestInitClouds_TheSummaryPrintsTheStoresAndTheirStances (0.03s)
    Error:    "cache   redis       empty        manifest  a cache is rebuilt fr..."
              does not contain "not declared"

--- FAIL: TestInitClouds_TheSummaryPrintsTheStoresAndTheirStances (0.02s)
    Error:    "cache   redis       golden  not declared  a cache is rebuilt fro..."
              does not contain "empty"
```

The surviving cell is worth more than a clean sweep of eight would have been. A
test named for what the summary prints, that cannot fail when the summary stops
printing it, certifies nothing and reads as though it certifies everything.

## Stated gaps

Vertex AI's regional endpoint is `us-central1-aiplatform.googleapis.com`, where
the region and the service share one label, and a star in an egress pattern
stands for one whole label, so nothing short of `*.googleapis.com` covers it.
That is the wildcard L0.3 removed, so the endpoint stays refused and unnamed on
purpose. `TestCatalog_TheStatedGapsAreStillGaps` holds the code to that
admission from both sides: it goes red if a later entry quietly names one, and
`TestCatalog_TheNumber` goes red instead if somebody closes it with the
wildcard. A gap nobody measures becomes a gap nobody remembers stating.
