### PR TITLE
ee: a manifest naming the ecs runtime was answered by a list of two names

### DIFF
--- a/.changes/ecs-runtime-containment-report.md
+++ b/.changes/ecs-runtime-containment-report.md
@@ -1,0 +1,20 @@
+# added
+
+`runtime.provider: ecs` is now answered by a containment report instead of by a
+list of the two runtimes that exist. It still refuses to start an environment,
+and the refusal is the feature: it enumerates thirteen distinct ways out of an
+ECS task on Fargate, names the eight the generated configuration closes and the
+five it does not, and says which verdicts are computed from a configuration
+nobody has applied to an AWS account.
+
+Two things the enumeration found are worth knowing even if you never run on ECS.
+A security group cannot deny egress on Fargate, because the image pull runs over
+the task's own interface under that same security group, so denying egress
+produces a task that never starts. And on AWS a security group cannot filter a
+DNS query at all: the Amazon provided resolver answers recursive lookups for
+public names from anywhere in the VPC and the VPC user guide states plainly that
+neither security groups nor network ACLs can filter traffic to it, so closing
+that path takes a Route 53 Resolver DNS Firewall rule that blocks every domain.
+
+The honest summary is unchanged and is now written down: Antifailure runs on EKS
+and not on raw ECS.

--- a/docs/src/content/docs/enterprise/runtimes.md
+++ b/docs/src/content/docs/enterprise/runtimes.md
@@ -50,4 +50,81 @@ What the enterprise edition adds here is not a third runtime. It is placement
 across several of them at once: the requirements, the tags and the scheduling
 described above.
 
+## Why there is no ECS runtime
+
+`runtime.provider: ecs` is registered in the enterprise binary and it refuses,
+every time, with a report rather than an error. The reason is worth reading
+before assuming it is a gap somebody will close next release.
+
+A runtime is allowed to exist here only if it can prove an environment has no
+way out, and the Kubernetes runtime proves it the only way a proof works: it
+creates the `NetworkPolicy` objects itself, then runs one pod under exactly the
+rules a service runs under and has it try to escape before any application image
+starts. If any attempt gets out the environment does not start and you get
+**AF-RUN-043**. That is not caution. Several container network plugins accept a
+`NetworkPolicy` object and enforce nothing, every status reads green, and the
+only thing that can tell the two apart is a packet.
+
+ECS on Fargate cannot be given the same treatment, for two reasons that are
+properties of the platform rather than of this implementation.
+
+**The image pull runs inside the boundary.** A kubelet pulls on the node, so a
+pod can be denied every egress rule and still start. On Fargate platform version
+1.4.0 the ECR login, the image pull and the log push all flow over the task's own
+network interface, under the task's own security group, and AWS states that a
+Fargate task must have a route to the registry to pull an image. So a security
+group that denies egress does not produce a contained environment. It produces a
+task that never starts, and the endpoints that let it start are themselves
+reachable addresses.
+
+**The enforcement cannot be observed without an account.** Whether a cluster
+enforces a `NetworkPolicy` is answerable on a laptop in ninety seconds. Whether
+AWS enforces a route table is a fact about an account, and no test in this
+repository is permitted to need one.
+
+So what ships is the enumeration and the predicate over it, and the refusal
+carries both. Thirteen distinct egress paths out of a Fargate task, of which
+**eight are closed by the configuration this runtime would generate, three are
+open, and two are not decided by either the configuration or AWS's own
+documentation**. Every closed verdict is a statement about a JSON document and
+not about an observed packet, and the report says so in those words.
+
+The three that are open are open because closing them would stop the environment
+existing, or because AWS provides no way to close them: the ECR and CloudWatch
+Logs interface endpoints and the S3 gateway endpoint that the image pull needs,
+and the task metadata endpoint, which is on by default for every Fargate task on
+platform version 1.4.0 or later with no documented way to turn it off.
+
+The two that are unproven are named rather than rounded up. The instance
+metadata service at `169.254.169.254` is the sharper of them: the Fargate launch
+type removes the documented credential source, because EC2 instance profiles are
+not available to containers in Fargate tasks, but AWS does not state that the
+address stops answering, and those are different claims. Settling it needs one
+request from one running task.
+
+One finding is worth carrying away even if you never run on ECS. **On AWS the
+security group is irrelevant to a DNS query.** The VPC user guide states that
+traffic to and from the Amazon DNS server cannot be filtered with network ACLs
+or security groups, and that resolver answers recursive queries for public names
+from anywhere in the VPC. A DNS question is chosen by whoever asks it, so that
+is a data channel out that no security group audit will ever show you. Closing
+it takes a Route 53 Resolver DNS Firewall rule group whose last rule blocks every
+domain and which does not fail open. A containment argument carried over from
+Kubernetes gets this one wrong, because there the same attempt is closed by the
+policy that closes everything else.
+
+**The honest summary is that Antifailure runs on EKS and not on raw ECS.** Use
+`runtime.provider: kubernetes` against an EKS cluster, where the probe runs.
+
+The report is generated for a real network rather than for a made up one, so
+that the security group rules and route table entries it judges are the ones
+your account would get. Six variables describe that network, and they are
+variables rather than manifest fields because a VPC identifier is a property of
+one company's account and does not belong in a file that gets forked:
+`AF_ECS_REGION`, `AF_ECS_CLUSTER`, `AF_ECS_VPC_ID`, `AF_ECS_VPC_CIDR`,
+`AF_ECS_SUBNET_IDS` and `AF_ECS_SUBNET_CIDRS`, the last two comma separated and
+in matching order. Setting them changes the report and does not change the
+answer, and the refusal you get without them says so before you go and build a
+VPC to find out.
+
 Related: [scheduling](/docs/concepts/scheduling), [licensing](/docs/enterprise/licensing).

--- a/ee/engine/cmd/af/main.go
+++ b/ee/engine/cmd/af/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/antifailure/antifailure/ee/engine/feature"
 	"github.com/antifailure/antifailure/ee/engine/license"
 	"github.com/antifailure/antifailure/ee/engine/policyenforce"
+	"github.com/antifailure/antifailure/ee/engine/runtime/ecs"
 	"github.com/antifailure/antifailure/ee/engine/secrets"
 	"github.com/antifailure/antifailure/engine/pkg/afcli"
 	"github.com/antifailure/antifailure/engine/pkg/edition"
@@ -117,6 +118,18 @@ func main() {
 	for _, rule := range policyenforce.Rules(policy) {
 		fmt.Fprintf(os.Stderr, "af: organization policy: %s\n", rule)
 	}
+	// The ECS runtime, registered so that a manifest naming it is answered by
+	// the package that knows why it cannot have one, rather than by the
+	// engine's generic "this build has local and kubernetes" message.
+	//
+	// Registered even though it refuses every Open, and the refusal is the
+	// point. A person who writes runtime.provider: ecs has a question, and the
+	// two possible answers are a list of the runtimes that exist, which tells
+	// them nothing, or thirteen enumerated egress paths with the five that are
+	// not closed named individually. The second is the deliverable. See
+	// ee/engine/runtime/ecs/runtime.go for why there is no runtime behind it.
+	extension.Default.AddRuntimeProvider(ecs.NewProvider())
+
 	if warning := status.Warning; warning != "" {
 		fmt.Fprintf(os.Stderr, "af: %s\n", warning)
 	}

--- a/ee/engine/runtime/ecs/egress.go
+++ b/ee/engine/runtime/ecs/egress.go
@@ -1,3 +1,6 @@
+// Not MIT. This directory is covered by the Antifailure Enterprise License; see
+// ee/LICENSE.md.
+
 package ecs
 
 import (
@@ -85,7 +88,7 @@ func Paths() []Path {
 				"outbound IPv6.",
 			ClosedBy: "no IPv6 range on the VPC or its subnets, no egress only gateway route, " +
 				"and no IPv6 egress rule",
-			Check:    checkPublicIPv6,
+			Check: checkPublicIPv6,
 		},
 		{
 			ID:   "public-resolver-over-udp",

--- a/ee/engine/runtime/ecs/egress.go
+++ b/ee/engine/runtime/ecs/egress.go
@@ -299,7 +299,7 @@ func (r Report) String() string {
 	fmt.Fprintf(&b, "%d of %d egress paths out of an ECS task on Fargate are closed by the "+
 		"generated configuration (%d open, %d unproven).\n", r.Closed, r.Total, r.Open, r.Unproven)
 	for _, v := range r.Verdicts {
-		fmt.Fprintf(&b, "  %-8s %s\n           %s\n", v.Verdict, v.Path.ID, v.Detail)
+		fmt.Fprintf(&b, "  %-9s %s\n             %s\n", v.Verdict, v.Path.ID, v.Detail)
 	}
 	b.WriteString("\n" + Caveat + "\n")
 	return b.String()

--- a/ee/engine/runtime/ecs/egress.go
+++ b/ee/engine/runtime/ecs/egress.go
@@ -1,0 +1,768 @@
+package ecs
+
+import (
+	"fmt"
+	"net/netip"
+	"sort"
+	"strings"
+)
+
+// Verdict is what the predicate can say about one egress path.
+//
+// Three values rather than two, and the third is the point of the file. A
+// containment claim written with a boolean has nowhere to put "I looked and the
+// configuration does not decide this", so it rounds that case to whichever
+// answer the author was hoping for. Every instrument in this repository that
+// turned out to be lying had exactly that shape: a check that could not say "I
+// could not look" reported a pass instead.
+type Verdict string
+
+const (
+	// Closed means the generated configuration removes this path. It does NOT
+	// mean a packet was observed failing to get out. See Report.Caveat.
+	Closed Verdict = "closed"
+	// Open means the path exists in the generated configuration, either
+	// because AWS provides no way to remove it or because removing it would
+	// stop the environment from starting.
+	Open Verdict = "open"
+	// Unproven means the configuration does not decide it and neither does the
+	// documentation. It is not a weaker Closed and it must never be counted as
+	// one.
+	Unproven Verdict = "unproven"
+)
+
+// Path is one distinct way out of an ECS task on Fargate.
+//
+// Distinct means a different route, not a different phrasing of one route. Two
+// entries that the same single change would close are one path, because a
+// count of paths is only worth publishing if closing one of them is real work.
+type Path struct {
+	// ID is stable and appears in the refusal message and in the report.
+	ID string
+	// Name is one line a person can read.
+	Name string
+	// Why records that this is a route somebody has actually used, which is
+	// the bar for being in this list at all. A theoretical path inflates the
+	// denominator and makes the ratio look worse than the product is, which is
+	// its own kind of dishonesty.
+	Why string
+	// ClosedBy names the mechanism, or says plainly that nothing closes it.
+	ClosedBy string
+	// Check evaluates the path against a plan and returns the verdict with the
+	// detail that justifies it. The detail is never empty, because a verdict
+	// with no reason is a verdict nobody can check.
+	Check func(Plan) (Verdict, string)
+}
+
+// Paths is every egress path out of an ECS task on Fargate that this lane
+// could enumerate, in a stable order.
+//
+// The order is the order a person should read them: the three that look like
+// the internet, then the resolver, then the two link local endpoints, then the
+// routes the design itself has to open, then the ones somebody turns on.
+//
+// Every AWS behaviour asserted below was read from AWS documentation on
+// 2026-09-07 and the page is named in the text. None of it is from memory,
+// because the whole lane is a containment claim and a containment claim built
+// on a recollection of a cloud provider's defaults is worth nothing.
+func Paths() []Path {
+	return []Path{
+		{
+			ID:   "public-ipv4-through-a-gateway",
+			Name: "a TCP connection to a public IPv4 address, with no name lookup at all",
+			Why: "It is the obvious answer to interception by DNS, and it is what every " +
+				"exfiltration tool does first. It needs no resolver and it leaves no query.",
+			ClosedBy: "no route to an internet gateway or a NAT gateway, no public address " +
+				"on the task ENI, and no security group egress rule naming a public range",
+			Check: checkPublicIPv4,
+		},
+		{
+			ID:   "public-ipv6-through-an-egress-only-gateway",
+			Name: "the same connection over IPv6, which IPv4 security group rules do not cover",
+			Why: "A security group carries IPv4 and IPv6 rules separately, so a group audited " +
+				"in IPv4 and read as contained can be wide open over IPv6 through an egress " +
+				"only internet gateway, which exists precisely to give private subnets " +
+				"outbound IPv6.",
+			ClosedBy: "no IPv6 range on the VPC or its subnets, no egress only gateway route, " +
+				"and no IPv6 egress rule",
+			Check:    checkPublicIPv6,
+		},
+		{
+			ID:   "public-resolver-over-udp",
+			Name: "a DNS query straight to a public resolver, whose payload is whatever the client puts in it",
+			Why: "A name lookup is a data channel. The question in a DNS query is chosen by " +
+				"the sender, so a resolver that answers recursively is an unlogged upload " +
+				"with a 1024 packet per second budget, and a firewall that allows port 53 " +
+				"because it is only DNS is allowing exactly that.",
+			ClosedBy: "no route out and no egress rule reaching port 53 on a public range",
+			Check:    checkPublicResolver,
+		},
+		{
+			ID:   "the-amazon-provided-resolver",
+			Name: "the same query to the Route 53 Resolver at 169.254.169.253 or the VPC range plus two",
+			Why: "This is the sharpest one on AWS and it is the one a Kubernetes intuition " +
+				"gets wrong. The Amazon DNS server resolves public names recursively for " +
+				"anything in the VPC, and the VPC user guide states that you cannot filter " +
+				"traffic to or from it using network ACLs or security groups. So the whole " +
+				"security group is irrelevant to this path.",
+			ClosedBy: "a Route 53 Resolver DNS Firewall rule group associated with this VPC " +
+				"whose last rule blocks every domain and which does not fail open, or " +
+				"enableDnsSupport turned off on the VPC",
+			Check: checkAmazonResolver,
+		},
+		{
+			ID:   "the-ec2-instance-metadata-service",
+			Name: "169.254.169.254, which on an EC2 container instance hands out the instance role's credentials",
+			Why: "It is not on the internet and it is the highest value target in the list, " +
+				"because it turns any request forgery in the application into cloud " +
+				"credentials. The ECS documentation says containers on EC2 container " +
+				"instances can reach instance metadata and IAM role credentials, and names " +
+				"the defence as ECS_AWSVPC_BLOCK_IMDS, which is an ECS container agent " +
+				"variable set on the instance.",
+			ClosedBy: "nothing a task definition can say. The Fargate launch type removes the " +
+				"documented credential source, because EC2 instance profiles are not " +
+				"available to containers in Fargate tasks, but AWS does not document " +
+				"whether the address answers, so the configuration does not settle it",
+			Check: checkInstanceMetadata,
+		},
+		{
+			ID:   "the-task-role-credentials-endpoint",
+			Name: "169.254.170.2, which vends the task role's credentials to anything in the container",
+			Why: "It is the Fargate equivalent of the instance metadata service and it is " +
+				"always there. Any code in the container reads AWS_CONTAINER_CREDENTIALS_" +
+				"RELATIVE_URI and gets a signing key for whatever the task role permits.",
+			ClosedBy: "no taskRoleArn in the task definition, so the endpoint has nothing to " +
+				"vend. The endpoint itself cannot be turned off",
+			Check: checkTaskRoleCredentials,
+		},
+		{
+			ID:   "the-task-metadata-endpoint",
+			Name: "169.254.170.2/v4, on by default and with no documented way to turn it off",
+			Why: "It discloses the task ARN, the cluster name, the ENI address and container " +
+				"statistics to anything in the container. It is not a route to the internet " +
+				"and it vends no credentials once the task role is gone, but it is an " +
+				"endpoint the environment did not ask for and cannot remove.",
+			ClosedBy: "nothing. The ECS documentation states the task metadata endpoint is on " +
+				"by default for every Fargate task on platform version 1.4.0 or later",
+			Check: checkTaskMetadata,
+		},
+		{
+			ID:   "the-interface-endpoints-the-image-pull-needs",
+			Name: "the ECR and CloudWatch Logs interface endpoints, which the task must reach in order to start",
+			Why: "On Fargate platform version 1.4.0 the ECR login, the image pull and the log " +
+				"push all flow over the TASK ENI, under this security group, and the " +
+				"documentation says plainly that a Fargate task must have a route to the " +
+				"registry to pull an image. There is no equivalent of a kubelet pulling the " +
+				"image outside the pod's policy, so a task whose security group denies " +
+				"everything never starts.",
+			ClosedBy: "nothing, without giving up the ability to run an environment at all. " +
+				"It is narrowed by an endpoint policy per endpoint and by egress rules " +
+				"naming the endpoints' own security group rather than an address range",
+			Check: checkInterfaceEndpoints,
+		},
+		{
+			ID:   "the-s3-gateway-endpoint-the-layers-come-from",
+			Name: "the S3 gateway endpoint, reached through a route table prefix list rather than an ENI",
+			Why: "ECR stores image layers in S3, so the pull needs S3 as well as ECR. A " +
+				"gateway endpoint is a route, and an unrestricted one is a path to every " +
+				"bucket in the region, including the ones that accept anonymous writes.",
+			ClosedBy: "nothing, for the same reason as the interface endpoints. It is narrowed " +
+				"by an endpoint policy",
+			Check: checkS3Gateway,
+		},
+		{
+			ID:   "the-ecs-exec-channel",
+			Name: "ECS Exec, which is an interactive shell inbound and an unmetered channel outbound",
+			Why: "It is the one path on this list that a person opens deliberately, while " +
+				"debugging, and then leaves open. It runs over AWS Systems Manager rather " +
+				"than over anything the egress policy describes.",
+			ClosedBy: "enableExecuteCommand false and no ssmmessages endpoint in the plan",
+			Check:    checkExecuteCommand,
+		},
+		{
+			ID:   "a-peering-transit-or-private-gateway-route",
+			Name: "a route to the corporate network, which never touches the internet and is not covered by an internet check",
+			Why: "A containment check written as no internet gateway and no NAT gateway passes " +
+				"a VPC that is peered with the production VPC. That is worse than reaching " +
+				"the internet, because the thing on the other side is the database this " +
+				"environment is a twin of.",
+			ClosedBy: "a route table holding only the local route and the gateway endpoint " +
+				"prefix lists",
+			Check: checkPrivateGatewayRoutes,
+		},
+		{
+			ID:   "a-neighbouring-environment",
+			Name: "another environment's tasks in the same VPC",
+			Why: "Every environment in this design shares a VPC, and a security group written " +
+				"once and reused is how an environment reaches a peer environment's " +
+				"datastore while every rule in it still reads as correct. The Kubernetes " +
+				"suite has a behaviour for exactly this and it is the slowest and most " +
+				"important one it has.",
+			ClosedBy: "one security group per environment, egress rules naming only that group " +
+				"or an endpoint's group, and no rule naming a range wider than this " +
+				"environment's own subnets",
+			Check: checkNeighbouringEnvironment,
+		},
+		{
+			ID:   "the-local-amazon-time-sync-service",
+			Name: "the link local NTP service, which shares the link local packet budget with the resolver and metadata",
+			Why: "The VPC DNS quota page counts Route 53 Resolver queries, instance metadata " +
+				"requests and Amazon Time Service NTP requests against one 1024 packet per " +
+				"second link local budget, which is documentary evidence that a link local " +
+				"NTP service is reachable from inside the network.",
+			ClosedBy: "not established. The EC2 page for the local Amazon Time Sync Service " +
+				"does not state the link local address and does not say whether security " +
+				"groups filter it, so this lane could not settle the path and does not " +
+				"assert either answer",
+			Check: checkTimeSync,
+		},
+	}
+}
+
+// PathVerdict is one path with what the predicate decided about one plan.
+type PathVerdict struct {
+	Path    Path
+	Verdict Verdict
+	Detail  string
+}
+
+// Report is the whole predicate applied to one plan.
+type Report struct {
+	// Verdicts are in Paths order.
+	Verdicts []PathVerdict
+	// Closed, Open and Unproven count the verdicts. They are separate fields
+	// rather than one ratio because the ratio that matters is closed over
+	// total, and burying an unproven inside a numerator is the exact arithmetic
+	// this repository already caught its own fidelity instrument doing.
+	Closed   int
+	Open     int
+	Unproven int
+	// Total is len(Verdicts).
+	Total int
+}
+
+// Caveat is the sentence that has to travel with every number this package
+// produces, and it is a constant so that it cannot be paraphrased away.
+//
+// It is here because the difference between what this package proves and what
+// it would need an AWS account to prove is the whole honesty of the runtime. A
+// Closed verdict is a statement about a JSON document. Whether AWS enforces
+// that document is a statement about an account, and nothing in this repository
+// has ever observed it.
+const Caveat = "Every verdict here is computed from the configuration this runtime would " +
+	"generate. None of it has been applied to an AWS account and no packet has been " +
+	"observed failing to leave a task. A closed verdict means the generated " +
+	"configuration removes the path, not that AWS was seen enforcing it."
+
+// Evaluate applies every path's check to a plan.
+func Evaluate(plan Plan) Report {
+	paths := Paths()
+	report := Report{Verdicts: make([]PathVerdict, 0, len(paths)), Total: len(paths)}
+	for _, path := range paths {
+		verdict, detail := path.Check(plan)
+		report.Verdicts = append(report.Verdicts, PathVerdict{Path: path, Verdict: verdict, Detail: detail})
+		switch verdict {
+		case Closed:
+			report.Closed++
+		case Open:
+			report.Open++
+		default:
+			report.Unproven++
+		}
+	}
+	return report
+}
+
+// Contained reports whether every enumerated path is closed.
+//
+// It is false for the plans this package generates, and that is not a bug to be
+// fixed later. Three of the paths cannot be closed on ECS at all and two cannot
+// be decided without an account, so a true here would mean the enumeration had
+// been shortened rather than that the containment had improved.
+func (r Report) Contained() bool { return r.Closed == r.Total }
+
+// NotClosed lists the paths that are not closed, in Paths order, for the
+// refusal message.
+func (r Report) NotClosed() []PathVerdict {
+	var out []PathVerdict
+	for _, v := range r.Verdicts {
+		if v.Verdict != Closed {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// String renders the report the way the refusal prints it.
+func (r Report) String() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d of %d egress paths out of an ECS task on Fargate are closed by the "+
+		"generated configuration (%d open, %d unproven).\n", r.Closed, r.Total, r.Open, r.Unproven)
+	for _, v := range r.Verdicts {
+		fmt.Fprintf(&b, "  %-8s %s\n           %s\n", v.Verdict, v.Path.ID, v.Detail)
+	}
+	b.WriteString("\n" + Caveat + "\n")
+	return b.String()
+}
+
+// checkPublicIPv4 requires that all three of the mechanisms the plan relies on
+// are present.
+//
+// All three rather than any one of them, and that choice needs defending
+// because a single one of them is sufficient on its own. The predicate is a
+// statement about the configuration this runtime generates, not about the
+// minimum configuration that would happen to work: a plan that has lost one of
+// its three closures is no longer the plan the proof covers, and reporting it
+// closed would mean the check cannot fail when the generator regresses. A check
+// that cannot say no is worse than no check.
+func checkPublicIPv4(p Plan) (Verdict, string) {
+	var missing []string
+	for _, r := range p.Network.RouteTable.Routes {
+		if kind := gatewayKind(r.Target); kind == "an internet gateway" || kind == "a NAT gateway" {
+			missing = append(missing, fmt.Sprintf("the route table sends %s to %s (%s)",
+				r.Destination, r.Target, kind))
+		}
+	}
+	if p.Network.RouteTable.AssignPublicIP != AssignPublicIPDisabled {
+		missing = append(missing, fmt.Sprintf("assignPublicIp is %q and must be %q",
+			p.Network.RouteTable.AssignPublicIP, AssignPublicIPDisabled))
+	}
+	for _, rule := range p.Network.SecurityGroup.Egress {
+		if rule.CIDRv4 != "" && reachesPublicIPv4(rule.CIDRv4) {
+			missing = append(missing, fmt.Sprintf("a security group egress rule permits %s to %s",
+				describePorts(rule), rule.CIDRv4))
+		}
+	}
+	if len(missing) > 0 {
+		return Open, strings.Join(missing, "; ")
+	}
+	return Closed, "no internet gateway or NAT gateway route, assignPublicIp DISABLED, and no " +
+		"egress rule naming a range outside RFC 1918, RFC 6598 and the link local block"
+}
+
+// checkPublicIPv6 is separate from checkPublicIPv4 because a security group
+// holds the two rule sets separately and an audit written in one does not see
+// the other.
+func checkPublicIPv6(p Plan) (Verdict, string) {
+	var missing []string
+	if p.Network.VPC.IPv6CIDR != "" {
+		missing = append(missing, fmt.Sprintf("the VPC carries the IPv6 range %s", p.Network.VPC.IPv6CIDR))
+	}
+	for _, s := range p.Network.Subnets {
+		if s.IPv6CIDR != "" {
+			missing = append(missing, fmt.Sprintf("subnet %s carries the IPv6 range %s", s.ID, s.IPv6CIDR))
+		}
+	}
+	for _, r := range p.Network.RouteTable.Routes {
+		if gatewayKind(r.Target) == "an egress only internet gateway" || strings.Contains(r.Destination, "::/0") {
+			missing = append(missing, fmt.Sprintf("the route table sends %s to %s", r.Destination, r.Target))
+		}
+	}
+	for _, rule := range p.Network.SecurityGroup.Egress {
+		if rule.CIDRv6 != "" {
+			missing = append(missing, fmt.Sprintf("a security group egress rule permits %s to %s",
+				describePorts(rule), rule.CIDRv6))
+		}
+	}
+	if len(missing) > 0 {
+		return Open, strings.Join(missing, "; ")
+	}
+	return Closed, "no IPv6 range on the VPC or its subnets, no egress only internet gateway " +
+		"route, and no IPv6 egress rule"
+}
+
+// checkPublicResolver looks for port 53 reaching a public range specifically,
+// as well as for the route, because allowing DNS out is the exception people
+// grant without thinking of it as egress.
+func checkPublicResolver(p Plan) (Verdict, string) {
+	var missing []string
+	for _, r := range p.Network.RouteTable.Routes {
+		if kind := gatewayKind(r.Target); kind == "an internet gateway" || kind == "a NAT gateway" {
+			missing = append(missing, fmt.Sprintf("the route table sends %s to %s, which a "+
+				"query to a public resolver would take", r.Destination, r.Target))
+		}
+	}
+	for _, rule := range p.Network.SecurityGroup.Egress {
+		if !ruleCoversPort(rule, 53) {
+			continue
+		}
+		if rule.CIDRv4 != "" && reachesPublicIPv4(rule.CIDRv4) {
+			missing = append(missing, fmt.Sprintf("a security group egress rule permits %s to %s, "+
+				"which reaches a public resolver", describePorts(rule), rule.CIDRv4))
+		}
+		if rule.CIDRv6 != "" {
+			missing = append(missing, fmt.Sprintf("a security group egress rule permits %s to %s",
+				describePorts(rule), rule.CIDRv6))
+		}
+	}
+	if len(missing) > 0 {
+		return Open, strings.Join(missing, "; ")
+	}
+	return Closed, "no route out and no egress rule that reaches port 53 on a range outside the VPC"
+}
+
+// checkAmazonResolver is the one check where the security group is irrelevant,
+// and saying so is the useful part.
+func checkAmazonResolver(p Plan) (Verdict, string) {
+	const irrelevant = "security groups and network ACLs cannot filter this path, so nothing in " +
+		"the security group above is evidence about it: "
+
+	if !p.Network.VPC.EnableDNSSupport {
+		return Closed, irrelevant + "enableDnsSupport is off on the VPC, so queries to the " +
+			"Amazon provided DNS server do not succeed"
+	}
+	fw := p.Network.DNSFirewall
+	if fw == nil {
+		return Open, irrelevant + "enableDnsSupport is on and no Route 53 Resolver DNS Firewall " +
+			"rule group is associated with this VPC, so the resolver answers recursive queries " +
+			"for any public name"
+	}
+	var missing []string
+	if fw.AssociatedVPCID != p.Network.VPC.ID {
+		missing = append(missing, fmt.Sprintf("the rule group is associated with %q and this "+
+			"plan's VPC is %q", fw.AssociatedVPCID, p.Network.VPC.ID))
+	}
+	if fw.FailOpen {
+		missing = append(missing, "the association fails open, so a rule the firewall cannot "+
+			"reach permits the query")
+	}
+	if last, ok := lastRule(fw.Rules); !ok {
+		missing = append(missing, "the rule group has no rules")
+	} else if !isBlockEverything(last) {
+		missing = append(missing, fmt.Sprintf("the last rule by priority is %s on %s and must "+
+			"be BLOCK on *", last.Action, strings.Join(last.Domains, ", ")))
+	}
+	if len(missing) > 0 {
+		return Open, irrelevant + strings.Join(missing, "; ")
+	}
+	return Closed, irrelevant + "a DNS Firewall rule group associated with this VPC blocks every " +
+		"domain in its last rule and does not fail open"
+}
+
+// checkInstanceMetadata is the path the lane was warned about by name, and the
+// answer it produces is deliberately not Closed.
+//
+// The Fargate launch type removes the documented credential source: the ECS
+// task IAM role page states that EC2 instance profiles are not available to
+// containers in Fargate tasks. What it does not state, anywhere this lane could
+// find, is that 169.254.169.254 does not answer inside a Fargate task. Those
+// are different claims. The first is about what credentials exist and the
+// second is about what the address does, and rounding the second up to the
+// first is precisely how a containment claim softens into a plausible sentence.
+//
+// So Fargate is Unproven and EC2 is Open, and neither is Closed, because no
+// field of a task definition or a security group closes a link local address.
+func checkInstanceMetadata(p Plan) (Verdict, string) {
+	if !strings.EqualFold(p.LaunchType, "FARGATE") {
+		return Open, fmt.Sprintf("the launch type is %q. On a container instance the "+
+			"documented defence is the ECS_AWSVPC_BLOCK_IMDS agent variable, which is set on "+
+			"the instance and which no task definition can set, so this plan cannot close it",
+			p.LaunchType)
+	}
+	return Unproven, "the launch type is FARGATE, so no EC2 instance profile exists for the " +
+		"endpoint to vend, but AWS does not document whether 169.254.169.254 answers inside a " +
+		"Fargate task and a link local address is not filtered by the security group. Settling " +
+		"this needs one request from one running task, which needs an account"
+}
+
+// checkTaskRoleCredentials is closed by an absence, which is the cheapest and
+// most durable kind of closure in this file.
+func checkTaskRoleCredentials(p Plan) (Verdict, string) {
+	if arn := strings.TrimSpace(p.TaskDefinition.TaskRoleARN); arn != "" {
+		return Open, fmt.Sprintf("the task definition sets taskRoleArn to %q, and 169.254.170.2 "+
+			"vends that role's credentials to anything in the container that reads "+
+			"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", arn)
+	}
+	return Closed, "the task definition sets no taskRoleArn, so the credentials endpoint has " +
+		"nothing to vend. The execution role is not reachable from the container: ECS documents " +
+		"that execution role permissions are not accessed by the application"
+}
+
+// checkTaskMetadata can only ever return Open, and a check with one possible
+// answer is usually a bug. This one is a finding.
+//
+// It is written as a check rather than as a comment so that it appears in the
+// report, is counted in the denominator, and is printed in the refusal. A path
+// nothing can close is exactly the path a summary leaves out.
+func checkTaskMetadata(p Plan) (Verdict, string) {
+	return Open, fmt.Sprintf("platform version %q. The task metadata endpoint is on by default "+
+		"for every Fargate task on platform version 1.4.0 or later and AWS documents no way to "+
+		"turn it off. It discloses the task ARN, the cluster, the ENI address and container "+
+		"statistics. With no task role it vends no credentials", p.PlatformVersion)
+}
+
+// checkInterfaceEndpoints reports the endpoints the design is obliged to open,
+// and reports how narrow they are, which is the only thing that can change.
+func checkInterfaceEndpoints(p Plan) (Verdict, string) {
+	var reachable, unrestricted []string
+	for _, e := range p.Network.Endpoints {
+		if !strings.EqualFold(e.Type, "Interface") {
+			continue
+		}
+		reachable = append(reachable, e.Service)
+		if strings.TrimSpace(e.PolicyDocument) == "" {
+			unrestricted = append(unrestricted, e.Service)
+		}
+	}
+	if len(reachable) == 0 {
+		return Closed, "the plan holds no interface endpoints. Note that a Fargate task in a " +
+			"subnet with no route out and no ECR endpoint cannot pull an image, so a plan that " +
+			"closes this path cannot start an environment"
+	}
+	sort.Strings(reachable)
+	detail := fmt.Sprintf("the task can reach %s, because on Fargate 1.4.0 the image pull runs "+
+		"over the task ENI under this security group", strings.Join(reachable, ", "))
+	if len(unrestricted) > 0 {
+		sort.Strings(unrestricted)
+		return Open, detail + fmt.Sprintf("; and %s carry no endpoint policy, so the "+
+			"narrowing is absent as well", strings.Join(unrestricted, ", "))
+	}
+	return Open, detail + "; each carries an endpoint policy and is reached through an egress " +
+		"rule naming the endpoints' security group rather than an address range"
+}
+
+// checkS3Gateway is separate from the interface endpoints because a gateway
+// endpoint is a route table entry rather than an ENI, so it is not governed by
+// the same rules and is not found by the same audit.
+func checkS3Gateway(p Plan) (Verdict, string) {
+	for _, e := range p.Network.Endpoints {
+		if !strings.EqualFold(e.Type, "Gateway") {
+			continue
+		}
+		if strings.TrimSpace(e.PolicyDocument) == "" {
+			return Open, fmt.Sprintf("%s is a gateway endpoint with no endpoint policy, which "+
+				"is a route to every bucket in the region", e.Service)
+		}
+		return Open, fmt.Sprintf("%s is reachable, because ECR stores image layers in S3 and "+
+			"the pull needs both. It carries an endpoint policy, which is the only narrowing "+
+			"available to a gateway endpoint", e.Service)
+	}
+	return Closed, "the plan holds no gateway endpoint. An ECR pull needs one, so a plan that " +
+		"closes this path cannot start an environment"
+}
+
+// checkExecuteCommand looks at the task definition and at the endpoints,
+// because the flag alone is not the path: an ssmmessages endpoint left in the
+// VPC is the route the flag would use, and it outlives the flag.
+func checkExecuteCommand(p Plan) (Verdict, string) {
+	var missing []string
+	if p.TaskDefinition.EnableExecuteCommand {
+		missing = append(missing, "enableExecuteCommand is true")
+	}
+	for _, e := range p.Network.Endpoints {
+		if strings.Contains(e.Service, "ssmmessages") || strings.Contains(e.Service, ".ssm") {
+			missing = append(missing, fmt.Sprintf("%s is reachable, which is the channel ECS "+
+				"Exec runs over", e.Service))
+		}
+	}
+	if len(missing) > 0 {
+		return Open, strings.Join(missing, "; ")
+	}
+	return Closed, "enableExecuteCommand is false and no Systems Manager endpoint is reachable"
+}
+
+// checkPrivateGatewayRoutes is the path a naive internet check misses entirely.
+func checkPrivateGatewayRoutes(p Plan) (Verdict, string) {
+	var found []string
+	for _, r := range p.Network.RouteTable.Routes {
+		switch gatewayKind(r.Target) {
+		case "a VPC peering connection", "a transit gateway", "a virtual private gateway",
+			"a local gateway", "a carrier gateway":
+			found = append(found, fmt.Sprintf("%s to %s (%s)", r.Destination, r.Target,
+				gatewayKind(r.Target)))
+		}
+	}
+	if len(found) > 0 {
+		return Open, "the route table reaches a network that is not the internet and not this " +
+			"VPC: " + strings.Join(found, "; ")
+	}
+	return Closed, "the route table holds only the local route and gateway endpoint prefix lists"
+}
+
+// checkNeighbouringEnvironment is the isolation promise, and it is written
+// against the security group rather than against the subnet because every
+// environment in this design shares a VPC and therefore shares a range.
+func checkNeighbouringEnvironment(p Plan) (Verdict, string) {
+	own := map[string]bool{p.Network.SecurityGroup.ID: true}
+	for _, e := range p.Network.Endpoints {
+		if e.SecurityGroupID != "" {
+			own[e.SecurityGroupID] = true
+		}
+	}
+	var missing []string
+	for _, rule := range p.Network.SecurityGroup.Egress {
+		if rule.PeerSecurityGroupID != "" && !own[rule.PeerSecurityGroupID] {
+			missing = append(missing, fmt.Sprintf("an egress rule names security group %s, "+
+				"which is neither this environment's group nor an endpoint's",
+				rule.PeerSecurityGroupID))
+		}
+		if rule.CIDRv4 == "" {
+			continue
+		}
+		if !withinSubnets(rule.CIDRv4, p.Network.Subnets) {
+			missing = append(missing, fmt.Sprintf("an egress rule permits %s to %s, which is "+
+				"wider than this environment's own subnets", describePorts(rule), rule.CIDRv4))
+		}
+	}
+	for _, rule := range p.Network.SecurityGroup.Ingress {
+		if rule.PeerSecurityGroupID != "" && !own[rule.PeerSecurityGroupID] {
+			missing = append(missing, fmt.Sprintf("an ingress rule admits security group %s, "+
+				"which is neither this environment's group nor an endpoint's",
+				rule.PeerSecurityGroupID))
+		}
+	}
+	if len(missing) > 0 {
+		return Open, strings.Join(missing, "; ")
+	}
+	return Closed, "every rule names this environment's own security group or an endpoint's, " +
+		"and no rule names a range wider than this environment's subnets"
+}
+
+// checkTimeSync returns Unproven whatever the plan says, and that is the
+// honest answer rather than a placeholder.
+//
+// The VPC DNS quota page counts NTP requests against the same link local packet
+// budget as the resolver and instance metadata, which is documentary evidence
+// that a link local NTP service exists inside the network. The EC2 page for the
+// local Amazon Time Sync Service does not give the address and says nothing
+// about filtering. One page implies the path and no page decides it, so the
+// verdict says so and the path stays in the denominator.
+func checkTimeSync(Plan) (Verdict, string) {
+	return Unproven, "the VPC DNS quota page counts Amazon Time Service NTP requests against " +
+		"the same 1024 packet per second link local budget as the resolver and instance " +
+		"metadata, so a link local NTP service is reachable from inside the VPC. No AWS page " +
+		"this lane read states whether a security group filters it, and this lane does not " +
+		"assert an answer it could not source"
+}
+
+// gatewayKind names an AWS target by its id prefix, because in AWS the prefix
+// is the type and reading it is not a heuristic.
+func gatewayKind(target string) string {
+	switch {
+	case strings.HasPrefix(target, "igw-"):
+		return "an internet gateway"
+	case strings.HasPrefix(target, "nat-"):
+		return "a NAT gateway"
+	case strings.HasPrefix(target, "eigw-"):
+		return "an egress only internet gateway"
+	case strings.HasPrefix(target, "pcx-"):
+		return "a VPC peering connection"
+	case strings.HasPrefix(target, "tgw-"):
+		return "a transit gateway"
+	case strings.HasPrefix(target, "vgw-"):
+		return "a virtual private gateway"
+	case strings.HasPrefix(target, "lgw-"):
+		return "a local gateway"
+	case strings.HasPrefix(target, "cagw-"):
+		return "a carrier gateway"
+	case strings.HasPrefix(target, "vpce-"):
+		return "a VPC endpoint"
+	case target == "local":
+		return "the VPC itself"
+	default:
+		return "an unrecognised target"
+	}
+}
+
+// privateRanges are the ranges a rule may name without reaching the internet.
+//
+// Link local is in the list because a rule naming it does not reach a public
+// address, NOT because link local is safe. The two link local endpoints have
+// their own paths above, and they are not filtered by security groups at all,
+// so a security group check has nothing to say about them either way.
+var privateRanges = []netip.Prefix{
+	netip.MustParsePrefix("10.0.0.0/8"),
+	netip.MustParsePrefix("172.16.0.0/12"),
+	netip.MustParsePrefix("192.168.0.0/16"),
+	netip.MustParsePrefix("100.64.0.0/10"),
+	netip.MustParsePrefix("169.254.0.0/16"),
+	netip.MustParsePrefix("127.0.0.0/8"),
+}
+
+// reachesPublicIPv4 reports whether a CIDR contains any address outside the
+// private ranges.
+//
+// It fails towards public on purpose. A CIDR this function cannot parse is
+// reported as reaching the internet, because the alternative is that a
+// malformed rule silently counts as containment, and the whole file exists to
+// stop a containment claim resting on something nobody looked at.
+func reachesPublicIPv4(cidr string) bool {
+	prefix, err := netip.ParsePrefix(strings.TrimSpace(cidr))
+	if err != nil || !prefix.Addr().Is4() {
+		return true
+	}
+	for _, private := range privateRanges {
+		if private.Overlaps(prefix) && private.Bits() <= prefix.Bits() &&
+			private.Contains(prefix.Addr()) {
+			return false
+		}
+	}
+	return true
+}
+
+// withinSubnets reports whether a CIDR is inside one of the plan's own subnets.
+func withinSubnets(cidr string, subnets []Subnet) bool {
+	prefix, err := netip.ParsePrefix(strings.TrimSpace(cidr))
+	if err != nil {
+		return false
+	}
+	for _, s := range subnets {
+		sub, err := netip.ParsePrefix(strings.TrimSpace(s.IPv4CIDR))
+		if err != nil {
+			continue
+		}
+		if sub.Contains(prefix.Addr()) && sub.Bits() <= prefix.Bits() {
+			return true
+		}
+	}
+	return false
+}
+
+// ruleCoversPort reports whether a rule permits a port. Protocol "-1" is every
+// protocol and every port, which AWS represents with a port range of zero.
+func ruleCoversPort(rule Rule, port int) bool {
+	if rule.Protocol == "-1" {
+		return true
+	}
+	return rule.FromPort <= port && port <= rule.ToPort
+}
+
+// describePorts renders a rule's protocol and ports for a message.
+func describePorts(rule Rule) string {
+	if rule.Protocol == "-1" {
+		return "every protocol and port"
+	}
+	if rule.FromPort == rule.ToPort {
+		return fmt.Sprintf("%s/%d", rule.Protocol, rule.FromPort)
+	}
+	return fmt.Sprintf("%s/%d to %d", rule.Protocol, rule.FromPort, rule.ToPort)
+}
+
+// lastRule returns the rule with the highest priority number, which is the one
+// DNS Firewall evaluates last and therefore the one that decides a query no
+// earlier rule matched.
+func lastRule(rules []DNSFirewallRule) (DNSFirewallRule, bool) {
+	if len(rules) == 0 {
+		return DNSFirewallRule{}, false
+	}
+	last := rules[0]
+	for _, r := range rules[1:] {
+		if r.Priority > last.Priority {
+			last = r
+		}
+	}
+	return last, true
+}
+
+// isBlockEverything reports whether a rule blocks every domain.
+func isBlockEverything(rule DNSFirewallRule) bool {
+	if !strings.EqualFold(rule.Action, "BLOCK") {
+		return false
+	}
+	for _, d := range rule.Domains {
+		if strings.TrimSpace(d) == "*" {
+			return true
+		}
+	}
+	return false
+}

--- a/ee/engine/runtime/ecs/egress_test.go
+++ b/ee/engine/runtime/ecs/egress_test.go
@@ -1,0 +1,437 @@
+package ecs_test
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/ee/engine/runtime/ecs"
+	"github.com/antifailure/antifailure/engine/pkg/extension"
+)
+
+// reference is the account description the generated plan is built from
+// throughout these tests. One value, so that a test that changes the plan is
+// visibly changing it rather than quietly using a different account.
+func reference() ecs.Inputs {
+	return ecs.Inputs{
+		Region:      "us-east-1",
+		Cluster:     "antifailure",
+		VPCID:       "vpc-0af1",
+		VPCCIDR:     "10.20.0.0/16",
+		SubnetIDs:   []string{"subnet-0a", "subnet-0b"},
+		SubnetCIDRs: []string{"10.20.1.0/24", "10.20.2.0/24"},
+	}
+}
+
+func referencePlan() ecs.Plan { return ecs.Generate(reference(), "af-example") }
+
+// expected is the verdict every path gets on the generated plan.
+//
+// It is written out in full rather than computed, because the point of the
+// table is to be a thing a person disagrees with. A test that asserted "the
+// report matches Evaluate" would pass for any predicate at all.
+var expected = map[string]ecs.Verdict{
+	"public-ipv4-through-a-gateway":              ecs.Closed,
+	"public-ipv6-through-an-egress-only-gateway": ecs.Closed,
+	"public-resolver-over-udp":                   ecs.Closed,
+	"the-amazon-provided-resolver":               ecs.Closed,
+	"the-ec2-instance-metadata-service":          ecs.Unproven,
+	"the-task-role-credentials-endpoint":         ecs.Closed,
+	"the-task-metadata-endpoint":                 ecs.Open,
+	"the-interface-endpoints-the-image-pull-needs": ecs.Open,
+	"the-s3-gateway-endpoint-the-layers-come-from": ecs.Open,
+	"the-ecs-exec-channel":                         ecs.Closed,
+	"a-peering-transit-or-private-gateway-route":   ecs.Closed,
+	"a-neighbouring-environment":                   ecs.Closed,
+	"the-local-amazon-time-sync-service":           ecs.Unproven,
+}
+
+// TestTheGeneratedPlanGetsTheVerdictItShould is the baseline every mutation
+// below is measured against.
+func TestTheGeneratedPlanGetsTheVerdictItShould(t *testing.T) {
+	report := ecs.Evaluate(referencePlan())
+	require.Equal(t, len(expected), report.Total,
+		"the enumeration and this table have drifted apart")
+	for _, v := range report.Verdicts {
+		want, ok := expected[v.Path.ID]
+		require.True(t, ok, "path %q is not in the table", v.Path.ID)
+		require.Equal(t, want, v.Verdict, "path %q said %q because: %s",
+			v.Path.ID, v.Verdict, v.Detail)
+		require.NotEmpty(t, v.Detail, "path %q gave a verdict with no reason", v.Path.ID)
+	}
+}
+
+// TestTheNumber is the figure this lane owes, asserted rather than described.
+//
+// It is deliberately not 13 of 13. Three of the paths cannot be closed on ECS
+// at all and two cannot be decided without an AWS account, so a green here at
+// 13 would mean somebody had shortened the enumeration.
+func TestTheNumber(t *testing.T) {
+	report := ecs.Evaluate(referencePlan())
+	require.Equal(t, 13, report.Total, "egress paths enumerated")
+	require.Equal(t, 8, report.Closed, "closed by the generated configuration")
+	require.Equal(t, 3, report.Open, "open, and named")
+	require.Equal(t, 2, report.Unproven, "not decided by the configuration or the documentation")
+	require.False(t, report.Contained(), "this plan must not report itself contained")
+	require.Len(t, report.NotClosed(), 5)
+}
+
+// mutation is one break in the generated plan and the paths it should move.
+type mutation struct {
+	// path is the path whose check the break is aimed at.
+	path string
+	// what describes the break, for the failure message.
+	what string
+	// apply breaks the plan.
+	apply func(*ecs.Plan)
+	// alsoOpens are paths that legitimately move as well, named so that a
+	// break which moves everything cannot pass by moving its target too.
+	alsoOpens []string
+}
+
+// mutations is the mutation test, run rather than reported.
+//
+// Every path this package calls Closed has one entry, because a verdict that
+// cannot become Open is not a check. The repository's rule is one break per
+// assertion, and that is what the alsoOpens field enforces: a break has to move
+// its own path and the named ones and nothing else, so a predicate that
+// returned Open for everything fails on the first row.
+func mutations() []mutation {
+	return []mutation{
+		{
+			path: "public-ipv4-through-a-gateway",
+			what: "a default route to an internet gateway",
+			apply: func(p *ecs.Plan) {
+				p.Network.RouteTable.Routes = append(p.Network.RouteTable.Routes,
+					ecs.Route{Destination: "0.0.0.0/0", Target: "igw-0bad"})
+			},
+			alsoOpens: []string{"public-resolver-over-udp"},
+		},
+		{
+			path: "public-ipv4-through-a-gateway",
+			what: "a public address on the task ENI",
+			apply: func(p *ecs.Plan) {
+				p.Network.RouteTable.AssignPublicIP = ecs.AssignPublicIPEnabled
+			},
+		},
+		{
+			path: "public-ipv4-through-a-gateway",
+			what: "an egress rule naming a public range",
+			apply: func(p *ecs.Plan) {
+				p.Network.SecurityGroup.Egress = append(p.Network.SecurityGroup.Egress,
+					ecs.Rule{Protocol: "tcp", FromPort: 443, ToPort: 443, CIDRv4: "0.0.0.0/0"})
+			},
+			// It also opens the resolver path, because a rule covering every
+			// address on port 443 covers port 53 only if the range does; this
+			// one does not, so the resolver path is untouched. It opens the
+			// neighbour path, because 0.0.0.0/0 is wider than the subnets.
+			alsoOpens: []string{"a-neighbouring-environment"},
+		},
+		{
+			path: "public-ipv6-through-an-egress-only-gateway",
+			what: "an IPv6 range on the VPC",
+			apply: func(p *ecs.Plan) { p.Network.VPC.IPv6CIDR = "2600:1f18::/56" },
+		},
+		{
+			path: "public-ipv6-through-an-egress-only-gateway",
+			what: "an egress only internet gateway route",
+			apply: func(p *ecs.Plan) {
+				p.Network.RouteTable.Routes = append(p.Network.RouteTable.Routes,
+					ecs.Route{Destination: "::/0", Target: "eigw-0bad"})
+			},
+		},
+		{
+			path: "public-resolver-over-udp",
+			what: "an egress rule reaching port 53 on a public resolver",
+			apply: func(p *ecs.Plan) {
+				p.Network.SecurityGroup.Egress = append(p.Network.SecurityGroup.Egress,
+					ecs.Rule{Protocol: "udp", FromPort: 53, ToPort: 53, CIDRv4: "1.1.1.1/32"})
+			},
+			// A public range in an egress rule is also exactly what the first
+			// path checks for, and it should be found by both.
+			alsoOpens: []string{"public-ipv4-through-a-gateway", "a-neighbouring-environment"},
+		},
+		{
+			path:  "the-amazon-provided-resolver",
+			what:  "a DNS firewall association that fails open",
+			apply: func(p *ecs.Plan) { p.Network.DNSFirewall.FailOpen = true },
+		},
+		{
+			path: "the-amazon-provided-resolver",
+			what: "a last rule that alerts instead of blocking",
+			apply: func(p *ecs.Plan) {
+				rules := p.Network.DNSFirewall.Rules
+				rules[len(rules)-1].Action = "ALERT"
+			},
+		},
+		{
+			path: "the-amazon-provided-resolver",
+			what: "a rule group associated with a different VPC",
+			apply: func(p *ecs.Plan) {
+				p.Network.DNSFirewall.AssociatedVPCID = "vpc-somebody-else"
+			},
+		},
+		{
+			path:  "the-amazon-provided-resolver",
+			what:  "no DNS firewall at all",
+			apply: func(p *ecs.Plan) { p.Network.DNSFirewall = nil },
+		},
+		{
+			path: "the-task-role-credentials-endpoint",
+			what: "a task role, which 169.254.170.2 then vends",
+			apply: func(p *ecs.Plan) {
+				p.TaskDefinition.TaskRoleARN = "arn:aws:iam::111122223333:role/app"
+			},
+		},
+		{
+			path:  "the-ecs-exec-channel",
+			what:  "ECS Exec turned on",
+			apply: func(p *ecs.Plan) { p.TaskDefinition.EnableExecuteCommand = true },
+		},
+		{
+			path: "the-ecs-exec-channel",
+			what: "a Systems Manager endpoint left in the VPC",
+			apply: func(p *ecs.Plan) {
+				p.Network.Endpoints = append(p.Network.Endpoints, ecs.VPCEndpoint{
+					Service: "com.amazonaws.us-east-1.ssmmessages", Type: "Interface",
+					SecurityGroupID: "sg-af-example-endpoints", PolicyDocument: "{}",
+				})
+			},
+		},
+		{
+			path: "a-peering-transit-or-private-gateway-route",
+			what: "a route to a peered VPC, which reaches production without touching the internet",
+			apply: func(p *ecs.Plan) {
+				p.Network.RouteTable.Routes = append(p.Network.RouteTable.Routes,
+					ecs.Route{Destination: "10.90.0.0/16", Target: "pcx-0prod"})
+			},
+		},
+		{
+			path: "a-peering-transit-or-private-gateway-route",
+			what: "a transit gateway route",
+			apply: func(p *ecs.Plan) {
+				p.Network.RouteTable.Routes = append(p.Network.RouteTable.Routes,
+					ecs.Route{Destination: "10.0.0.0/8", Target: "tgw-0corp"})
+			},
+		},
+		{
+			path: "a-neighbouring-environment",
+			what: "an egress rule naming another environment's security group",
+			apply: func(p *ecs.Plan) {
+				p.Network.SecurityGroup.Egress = append(p.Network.SecurityGroup.Egress,
+					ecs.Rule{Protocol: "tcp", FromPort: 5432, ToPort: 5432,
+						PeerSecurityGroupID: "sg-af-other-environment"})
+			},
+		},
+		{
+			path: "a-neighbouring-environment",
+			what: "an egress rule covering the whole VPC rather than this environment's subnets",
+			apply: func(p *ecs.Plan) {
+				p.Network.SecurityGroup.Egress = append(p.Network.SecurityGroup.Egress,
+					ecs.Rule{Protocol: "-1", CIDRv4: "10.20.0.0/16"})
+			},
+		},
+	}
+}
+
+// TestEveryClosureCanSayNo breaks the thing each closed path depends on and
+// requires the verdict to change.
+//
+// This is the mutation test, run in continuous integration rather than
+// performed once by hand and written up. A predicate whose Closed verdicts
+// survive their own mutation is a check that cannot say no, which this
+// repository has repeatedly found to be worse than no check at all.
+func TestEveryClosureCanSayNo(t *testing.T) {
+	for _, m := range mutations() {
+		t.Run(m.path+"/"+m.what, func(t *testing.T) {
+			require.Equal(t, ecs.Closed, expected[m.path],
+				"a mutation is only meaningful against a path the plan closes")
+
+			broken := referencePlan()
+			m.apply(&broken)
+			after := verdictsByID(ecs.Evaluate(broken))
+
+			require.Equal(t, ecs.Open, after[m.path],
+				"breaking %s left %s reporting %q, so that check cannot fail",
+				m.what, m.path, after[m.path])
+
+			moved := map[string]bool{m.path: true}
+			for _, id := range m.alsoOpens {
+				moved[id] = true
+				require.Equal(t, ecs.Open, after[id],
+					"%s was declared to move as well and did not", id)
+			}
+			for id, want := range expected {
+				if moved[id] {
+					continue
+				}
+				require.Equal(t, want, after[id],
+					"breaking %s also moved %s, which it was not declared to", m.what, id)
+			}
+		})
+	}
+}
+
+// TestEveryClosedPathHasAMutation stops a path from being added with a check
+// nothing ever breaks.
+//
+// Without it, the suite above measures whatever it happens to cover, and the
+// way a check that cannot say no gets into a repository is by arriving after
+// the test that would have caught it.
+func TestEveryClosedPathHasAMutation(t *testing.T) {
+	covered := map[string]bool{}
+	for _, m := range mutations() {
+		covered[m.path] = true
+	}
+	for id, want := range expected {
+		if want != ecs.Closed {
+			continue
+		}
+		require.True(t, covered[id],
+			"%s is reported closed and no mutation proves that check can fail", id)
+	}
+}
+
+// TestEveryPathIsDescribed requires the prose, because the enumeration is the
+// deliverable and an id with no reason attached is not evidence of anything.
+func TestEveryPathIsDescribed(t *testing.T) {
+	seen := map[string]bool{}
+	for _, p := range ecs.Paths() {
+		require.NotEmpty(t, p.ID)
+		require.False(t, seen[p.ID], "duplicate path id %q", p.ID)
+		seen[p.ID] = true
+		require.NotEmpty(t, p.Name, "%s has no name", p.ID)
+		require.NotEmpty(t, p.Why, "%s does not say why it is a real route", p.ID)
+		require.NotEmpty(t, p.ClosedBy, "%s does not say what closes it", p.ID)
+		require.NotNil(t, p.Check, "%s has no check", p.ID)
+	}
+}
+
+// TestTheReportCarriesItsCaveat is the one assertion that guards the honesty of
+// every number this package produces.
+func TestTheReportCarriesItsCaveat(t *testing.T) {
+	out := ecs.Evaluate(referencePlan()).String()
+	require.Contains(t, out, "8 of 13 egress paths")
+	require.Contains(t, out, ecs.Caveat)
+	require.Contains(t, out, "not that AWS was seen enforcing it")
+}
+
+// TestNoEmDashInTheProse holds the repository's writing rule on the strings
+// themselves rather than on the source, the way the engine's own four
+// assertions do, because this package is prose as much as it is code and a file
+// scanner does not read a composed report.
+func TestNoEmDashInTheProse(t *testing.T) {
+	report := ecs.Evaluate(referencePlan())
+	require.NotContains(t, report.String(), "—")
+	for _, p := range ecs.Paths() {
+		for _, s := range []string{p.Name, p.Why, p.ClosedBy} {
+			require.NotContains(t, s, "—", "%s", p.ID)
+			require.NotContains(t, s, "--", "%s", p.ID)
+		}
+	}
+}
+
+// TestTheProviderRefusesAndSaysWhy is the end to end assertion: a manifest
+// naming this runtime reaches Open and gets a refusal carrying the report.
+func TestTheProviderRefusesAndSaysWhy(t *testing.T) {
+	env := map[string]string{
+		ecs.EnvRegion: "us-east-1", ecs.EnvCluster: "antifailure",
+		ecs.EnvVPC: "vpc-0af1", ecs.EnvVPCCIDR: "10.20.0.0/16",
+		ecs.EnvSubnets: "subnet-0a,subnet-0b", ecs.EnvSubnetCIDR: "10.20.1.0/24,10.20.2.0/24",
+	}
+	p := &ecs.Provider{Getenv: func(k string) string { return env[k] }}
+	require.Equal(t, "ecs", p.Name())
+
+	rt, err := p.Open(context.Background(), extension.RuntimeConfig{})
+	require.Nil(t, rt, "a refusing provider must return no runtime at all")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "refuses to start an environment, on purpose")
+	require.Contains(t, err.Error(), "8 of 13 egress paths")
+	require.Contains(t, err.Error(), "the-ec2-instance-metadata-service")
+	require.Contains(t, err.Error(), "runtime.provider kubernetes")
+}
+
+// TestTheProviderSaysWhichVariablesAreMissing keeps the two refusals apart. An
+// installation that has described no network should be told that, not handed a
+// containment report about an empty plan.
+func TestTheProviderSaysWhichVariablesAreMissing(t *testing.T) {
+	p := &ecs.Provider{Getenv: func(string) string { return "" }}
+	rt, err := p.Open(context.Background(), extension.RuntimeConfig{})
+	require.Nil(t, rt)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), ecs.EnvVPC)
+	require.Contains(t, err.Error(), "Even fully described it would refuse")
+}
+
+// TestTheGeneratedPlanStartsSomething guards the direction the score could be
+// gamed in.
+//
+// Two of the three open paths close instantly if the plan simply stops emitting
+// the endpoints, and the resulting environment would pull no image and run
+// nothing. So the score going up must not be achievable by deleting the reason
+// it is down.
+func TestTheGeneratedPlanStartsSomething(t *testing.T) {
+	plan := referencePlan()
+	var services []string
+	for _, e := range plan.Network.Endpoints {
+		services = append(services, e.Service)
+	}
+	sort.Strings(services)
+	require.Contains(t, services, "com.amazonaws.us-east-1.ecr.api")
+	require.Contains(t, services, "com.amazonaws.us-east-1.ecr.dkr")
+	require.Contains(t, services, "com.amazonaws.us-east-1.s3",
+		"ECR serves image layers from S3 and a pull needs both")
+	require.NotEmpty(t, plan.TaskDefinition.ExecutionRoleARN,
+		"without an execution role nothing can pull an image")
+	require.Empty(t, plan.TaskDefinition.TaskRoleARN,
+		"the execution role is required and the task role must not be")
+}
+
+// TestThePlatformVersionIsPinned guards the one field whose default would make
+// the security group a claim about traffic it cannot see.
+func TestThePlatformVersionIsPinned(t *testing.T) {
+	plan := referencePlan()
+	require.Equal(t, "1.4.0", plan.PlatformVersion,
+		"below 1.4.0 a task carries a second Fargate owned ENI for image pulls that no rule "+
+			"in this plan describes and that VPC flow logs do not show")
+	require.Equal(t, "FARGATE", plan.LaunchType)
+	require.Equal(t, "awsvpc", plan.TaskDefinition.NetworkMode)
+}
+
+// TestTheInstanceMetadataVerdictIsNotRoundedUp is its own test because it is
+// the path the lane was warned about by name and the failure mode is a
+// plausible sentence rather than a wrong boolean.
+func TestTheInstanceMetadataVerdictIsNotRoundedUp(t *testing.T) {
+	plan := referencePlan()
+	byID := verdictsByID(ecs.Evaluate(plan))
+	require.Equal(t, ecs.Unproven, byID["the-ec2-instance-metadata-service"],
+		"Fargate removes the documented credential source and does not document that the "+
+			"address stops answering. Those are different claims")
+
+	plan.LaunchType = "EC2"
+	byID = verdictsByID(ecs.Evaluate(plan))
+	require.Equal(t, ecs.Open, byID["the-ec2-instance-metadata-service"],
+		"on a container instance the defence is an agent variable no task definition can set")
+
+	detail := detailByID(ecs.Evaluate(referencePlan()))["the-ec2-instance-metadata-service"]
+	require.Contains(t, strings.ToLower(detail), "needs an account")
+}
+
+func verdictsByID(r ecs.Report) map[string]ecs.Verdict {
+	out := map[string]ecs.Verdict{}
+	for _, v := range r.Verdicts {
+		out[v.Path.ID] = v.Verdict
+	}
+	return out
+}
+
+func detailByID(r ecs.Report) map[string]string {
+	out := map[string]string{}
+	for _, v := range r.Verdicts {
+		out[v.Path.ID] = v.Detail
+	}
+	return out
+}

--- a/ee/engine/runtime/ecs/egress_test.go
+++ b/ee/engine/runtime/ecs/egress_test.go
@@ -124,10 +124,11 @@ func mutations() []mutation {
 				p.Network.SecurityGroup.Egress = append(p.Network.SecurityGroup.Egress,
 					ecs.Rule{Protocol: "tcp", FromPort: 443, ToPort: 443, CIDRv4: "0.0.0.0/0"})
 			},
-			// It also opens the resolver path, because a rule covering every
-			// address on port 443 covers port 53 only if the range does; this
-			// one does not, so the resolver path is untouched. It opens the
-			// neighbour path, because 0.0.0.0/0 is wider than the subnets.
+			// It opens the neighbour path as well, because 0.0.0.0/0 is wider
+			// than this environment's subnets. It does NOT open the resolver
+			// path, because this rule is port 443 and that check looks for a
+			// rule reaching port 53, which is the distinction that keeps the
+			// two paths separate rather than one path counted twice.
 			alsoOpens: []string{"a-neighbouring-environment"},
 		},
 		{

--- a/ee/engine/runtime/ecs/egress_test.go
+++ b/ee/engine/runtime/ecs/egress_test.go
@@ -1,3 +1,6 @@
+// Not MIT. This directory is covered by the Antifailure Enterprise License; see
+// ee/LICENSE.md.
+
 package ecs_test
 
 import (
@@ -34,13 +37,13 @@ func referencePlan() ecs.Plan { return ecs.Generate(reference(), "af-example") }
 // table is to be a thing a person disagrees with. A test that asserted "the
 // report matches Evaluate" would pass for any predicate at all.
 var expected = map[string]ecs.Verdict{
-	"public-ipv4-through-a-gateway":              ecs.Closed,
-	"public-ipv6-through-an-egress-only-gateway": ecs.Closed,
-	"public-resolver-over-udp":                   ecs.Closed,
-	"the-amazon-provided-resolver":               ecs.Closed,
-	"the-ec2-instance-metadata-service":          ecs.Unproven,
-	"the-task-role-credentials-endpoint":         ecs.Closed,
-	"the-task-metadata-endpoint":                 ecs.Open,
+	"public-ipv4-through-a-gateway":                ecs.Closed,
+	"public-ipv6-through-an-egress-only-gateway":   ecs.Closed,
+	"public-resolver-over-udp":                     ecs.Closed,
+	"the-amazon-provided-resolver":                 ecs.Closed,
+	"the-ec2-instance-metadata-service":            ecs.Unproven,
+	"the-task-role-credentials-endpoint":           ecs.Closed,
+	"the-task-metadata-endpoint":                   ecs.Open,
 	"the-interface-endpoints-the-image-pull-needs": ecs.Open,
 	"the-s3-gateway-endpoint-the-layers-come-from": ecs.Open,
 	"the-ecs-exec-channel":                         ecs.Closed,
@@ -132,8 +135,8 @@ func mutations() []mutation {
 			alsoOpens: []string{"a-neighbouring-environment"},
 		},
 		{
-			path: "public-ipv6-through-an-egress-only-gateway",
-			what: "an IPv6 range on the VPC",
+			path:  "public-ipv6-through-an-egress-only-gateway",
+			what:  "an IPv6 range on the VPC",
 			apply: func(p *ecs.Plan) { p.Network.VPC.IPv6CIDR = "2600:1f18::/56" },
 		},
 		{
@@ -313,9 +316,21 @@ func TestEveryPathIsDescribed(t *testing.T) {
 
 // TestTheReportCarriesItsCaveat is the one assertion that guards the honesty of
 // every number this package produces.
+//
+// The second assertion is the load bearing one. A reader must not be able to
+// see "8 closed" without also seeing "2 unproven" in the same breath, because
+// the unproven pair is what stops the eight from reading as a containment
+// guarantee, and a summary that quotes the numerator alone is how a figure
+// stops being true while every word in it stays accurate.
 func TestTheReportCarriesItsCaveat(t *testing.T) {
 	out := ecs.Evaluate(referencePlan()).String()
-	require.Contains(t, out, "8 of 13 egress paths")
+	first, _, _ := strings.Cut(strings.TrimSpace(out), "\n")
+	require.Contains(t, first, "8 of 13 egress paths",
+		"the headline must carry the ratio")
+	require.Contains(t, first, "2 unproven",
+		"the headline must carry the unproven count beside the closed count, so that "+
+			"neither can be quoted without the other")
+	require.Contains(t, first, "3 open")
 	require.Contains(t, out, ecs.Caveat)
 	require.Contains(t, out, "not that AWS was seen enforcing it")
 }

--- a/ee/engine/runtime/ecs/plan.go
+++ b/ee/engine/runtime/ecs/plan.go
@@ -1,0 +1,277 @@
+// Package ecs is the AWS ECS on Fargate runtime, and it is mostly a proof
+// about containment rather than a placer of containers.
+//
+// The Kubernetes runtime earns its existence by creating NetworkPolicy objects
+// and then running a pod that tries to escape four ways before any application
+// image starts, refusing the environment with AF-RUN-043 when any attempt
+// succeeds. That order matters: the policy is a request to whatever CNI the
+// cluster runs, several CNIs accept the object and enforce nothing, and the
+// only thing that can tell those apart is a packet.
+//
+// ECS has the same gap in a worse place. A task definition, a security group
+// and a route table are all objects AWS accepts, and whether they contain
+// anything is a fact about the account they were applied to. So this package is
+// built around a predicate over the configuration an environment would be given
+// rather than around an API client, because the predicate is the part that can
+// be proved in continuous integration on a machine with no AWS account, and the
+// enforcement is the part that cannot.
+//
+// What this package deliberately does NOT do is start an environment. See
+// runtime.go for why, and read egress.go first: the enumeration there is the
+// deliverable, and the runtime's refusal is a consequence of it.
+package ecs
+
+// Plan is the whole AWS configuration one environment would be given.
+//
+// It is one flat value rather than a client talking to AWS, and that is the
+// design decision the rest of the package rests on. A predicate over a value
+// can be evaluated by a test, printed in an error message, checked into a
+// golden file and mutated one field at a time. A predicate over an account can
+// be evaluated in exactly one place, which is an account somebody is paying
+// for, and a repository whose containment proof lives there has no containment
+// proof at all on the day the credentials expire.
+//
+// Every field here is a field of a real AWS request or resource. Nothing is a
+// summary or a boolean standing in for a shape, because a summary is where the
+// thing being asserted stops being the thing being applied.
+type Plan struct {
+	// Region is the AWS region, which appears in the endpoint service names
+	// the plan has to match against.
+	Region string
+	// Cluster is the ECS cluster the tasks are placed in.
+	Cluster string
+	// LaunchType must be FARGATE. It is checked rather than assumed because
+	// the EC2 launch type puts the task on a container instance whose instance
+	// profile credentials are reachable from inside the container, and the
+	// only documented defence there is an agent variable on the instance
+	// (ECS_AWSVPC_BLOCK_IMDS) that no task definition can set.
+	LaunchType string
+	// PlatformVersion is the Fargate platform version. Below 1.4.0 a task gets
+	// a second, Fargate owned ENI carrying image pulls and secret retrieval
+	// which does not appear in VPC flow logs and which no security group in
+	// this plan describes, so a plan that does not pin 1.4.0 or later is
+	// making a claim about traffic it cannot see.
+	PlatformVersion string
+	// TaskDefinition is what runs.
+	TaskDefinition TaskDefinition
+	// Network is everything the packets can and cannot do.
+	Network NetworkPlan
+}
+
+// TaskDefinition is the ECS task definition, cut down to the fields that decide
+// whether anything can get out.
+type TaskDefinition struct {
+	// Family names the definition.
+	Family string
+	// NetworkMode must be awsvpc, which is the only mode Fargate supports and
+	// the only one that gives the task its own ENI and therefore its own
+	// security group.
+	NetworkMode string
+	// TaskRoleARN is the role whose credentials 169.254.170.2 vends to
+	// anything inside the container that asks.
+	//
+	// It must be EMPTY. That endpoint cannot be turned off on Fargate, so the
+	// only way to make it vend nothing is to give it nothing, and an
+	// environment that is a twin of production has no business holding
+	// production's IAM permissions in the first place.
+	TaskRoleARN string
+	// ExecutionRoleARN is the role Fargate itself uses to pull the image and
+	// push logs. It is NOT vended to the container: the credentials endpoint
+	// serves the task role, and the ECS documentation states plainly that
+	// execution role permissions "aren't accessed by" the application. It is
+	// therefore allowed to be set, and it has to be, because without it no
+	// image can be pulled at all.
+	ExecutionRoleARN string
+	// EnableExecuteCommand is ECS Exec. It must be false. It opens a channel to
+	// AWS Systems Manager that is an interactive shell inbound and an
+	// unmetered data channel outbound, and it is the one egress path in this
+	// list that a person turns on deliberately while debugging and forgets.
+	EnableExecuteCommand bool
+	// Containers are the images and their environments, in the order they
+	// appear in the definition.
+	Containers []Container
+}
+
+// Container is one container in the task definition.
+type Container struct {
+	// Name is the container name.
+	Name string
+	// Image is the image reference.
+	Image string
+	// Essential marks a container whose exit stops the task.
+	Essential bool
+}
+
+// NetworkPlan is the VPC, the subnets, the security group, the route table,
+// the endpoints and the DNS firewall, which together are the containment.
+type NetworkPlan struct {
+	// VPC is the network the task's ENI lives in.
+	VPC VPC
+	// Subnets are the subnets awsVpcConfiguration names.
+	Subnets []Subnet
+	// SecurityGroup is the single security group on the task ENI. One per
+	// environment, because a security group shared between environments is
+	// how one environment reaches another's database while every rule in it
+	// still reads as correct.
+	SecurityGroup SecurityGroup
+	// RouteTable is the table associated with every subnet above.
+	RouteTable RouteTable
+	// Endpoints are the VPC endpoints the task can reach. They exist because
+	// on Fargate 1.4.0 the image pull runs over the task ENI, so a task in a
+	// subnet with no route out cannot start without them.
+	Endpoints []VPCEndpoint
+	// DNSFirewall is the Route 53 Resolver DNS Firewall association, which is
+	// the ONLY thing in this struct that can close the resolver path. AWS
+	// states that traffic to the Amazon DNS server cannot be filtered with
+	// security groups or network ACLs, so without this the resolver at
+	// 169.254.169.253 answers recursive queries for any public name and the
+	// query itself carries whatever the client put in it.
+	DNSFirewall *DNSFirewall
+}
+
+// VPC is the network's own attributes.
+type VPC struct {
+	// ID is the VPC id.
+	ID string
+	// IPv4CIDR is the primary IPv4 range. The Route 53 Resolver also answers
+	// at this range's base address plus two, which is why the predicate reads
+	// it rather than only checking 169.254.169.253.
+	IPv4CIDR string
+	// IPv6CIDR is the IPv6 range, and it must be empty. Every security group
+	// rule in this plan is written in IPv4, and an IPv6 range with an egress
+	// only internet gateway is a full route to the internet that an IPv4
+	// reading of the same security group calls contained.
+	IPv6CIDR string
+	// EnableDNSSupport is whether the Amazon provided resolver answers at all.
+	EnableDNSSupport bool
+}
+
+// Subnet is one subnet the task may be placed in.
+type Subnet struct {
+	// ID is the subnet id.
+	ID string
+	// IPv4CIDR is its range.
+	IPv4CIDR string
+	// IPv6CIDR must be empty, for the reason on VPC.IPv6CIDR.
+	IPv6CIDR string
+	// MapPublicIPOnLaunch must be false.
+	MapPublicIPOnLaunch bool
+}
+
+// AssignPublicIP is the awsVpcConfiguration field of the same name. A task with
+// a public address in a subnet routed to an internet gateway is on the internet
+// whatever else the plan says, so it is a field of its own rather than a
+// property of the subnet.
+type AssignPublicIP string
+
+// The two values ECS accepts.
+const (
+	AssignPublicIPEnabled  AssignPublicIP = "ENABLED"
+	AssignPublicIPDisabled AssignPublicIP = "DISABLED"
+)
+
+// RouteTable is the route table associated with every subnet in the plan.
+type RouteTable struct {
+	// ID is the table id.
+	ID string
+	// Routes are its entries.
+	Routes []Route
+	// AssignPublicIP is what awsVpcConfiguration asks for. It sits here rather
+	// than on Subnet because it is a property of the task placement and not of
+	// the subnet, and because putting it beside the routes is where a reader
+	// checking "can this reach the internet" will look.
+	AssignPublicIP AssignPublicIP
+}
+
+// Route is one route table entry.
+type Route struct {
+	// Destination is a CIDR or a prefix list id.
+	Destination string
+	// Target is what the traffic is handed to: "local", a VPC endpoint, a
+	// gateway. The predicate reads its prefix, because AWS resource id
+	// prefixes are the type: igw for an internet gateway, nat for a NAT
+	// gateway, eigw for an egress only internet gateway, pcx for a peering
+	// connection, tgw for a transit gateway, vgw for a virtual private
+	// gateway, vpce for a VPC endpoint.
+	Target string
+}
+
+// SecurityGroup is the group on the task ENI.
+type SecurityGroup struct {
+	// ID is the group id.
+	ID string
+	// Egress are the outbound rules. A security group permits only what its
+	// rules name, so an empty list permits nothing outbound. It cannot be
+	// empty here, because the image pull runs over this ENI.
+	Egress []Rule
+	// Ingress are the inbound rules.
+	Ingress []Rule
+}
+
+// Rule is one security group rule.
+type Rule struct {
+	// Protocol is tcp, udp, icmp, or "-1" for every protocol.
+	Protocol string
+	// FromPort and ToPort bound the port range.
+	FromPort int
+	ToPort   int
+	// CIDRv4 is an IPv4 destination, empty when the rule names something else.
+	CIDRv4 string
+	// CIDRv6 is an IPv6 destination.
+	CIDRv6 string
+	// PrefixListID is an AWS managed prefix list, which is how a gateway
+	// endpoint's address ranges are named in a rule.
+	PrefixListID string
+	// PeerSecurityGroupID is another security group as the destination, which
+	// is how the task is allowed to reach the interface endpoints without
+	// naming an address range that will change.
+	PeerSecurityGroupID string
+}
+
+// VPCEndpoint is one endpoint the environment can reach.
+type VPCEndpoint struct {
+	// Service is the full service name, such as
+	// com.amazonaws.us-east-1.ecr.dkr.
+	Service string
+	// Type is Interface or Gateway.
+	Type string
+	// SecurityGroupID is the group on an interface endpoint's own ENIs.
+	SecurityGroupID string
+	// PolicyDocument is the endpoint policy. An endpoint with no policy allows
+	// every action on every resource in that service that the caller has
+	// credentials for, which for an anonymous caller is not much and for a
+	// caller who found any credentials at all is the whole service.
+	PolicyDocument string
+	// PrivateDNSEnabled is whether the service's public name resolves to the
+	// endpoint inside this VPC.
+	PrivateDNSEnabled bool
+}
+
+// DNSFirewall is a Route 53 Resolver DNS Firewall rule group associated with
+// the VPC.
+type DNSFirewall struct {
+	// RuleGroupID is the rule group.
+	RuleGroupID string
+	// AssociatedVPCID must be the plan's VPC. A rule group that exists and is
+	// associated with a different VPC filters nothing here, and it is exactly
+	// the sort of thing that reads as configured in a console screenshot.
+	AssociatedVPCID string
+	// FailOpen is the association's failure mode. True means that when DNS
+	// Firewall cannot reach a rule, the query is allowed through, which turns
+	// the containment into a best effort.
+	FailOpen bool
+	// Rules are the rule group's rules, and the predicate requires that the
+	// last one by priority blocks every domain.
+	Rules []DNSFirewallRule
+}
+
+// DNSFirewallRule is one rule in the group.
+type DNSFirewallRule struct {
+	// Priority orders the rules. Lower is evaluated first.
+	Priority int
+	// Domains are the domain patterns the rule matches. "*" is every domain.
+	Domains []string
+	// Action is ALLOW, BLOCK, or ALERT. ALERT logs and permits, which is worth
+	// naming because it is the value somebody sets while tuning and leaves.
+	Action string
+}

--- a/ee/engine/runtime/ecs/plan.go
+++ b/ee/engine/runtime/ecs/plan.go
@@ -1,6 +1,9 @@
 // Package ecs is the AWS ECS on Fargate runtime, and it is mostly a proof
 // about containment rather than a placer of containers.
 //
+// Not MIT. This directory is covered by the Antifailure Enterprise License; see
+// ee/LICENSE.md.
+//
 // The Kubernetes runtime earns its existence by creating NetworkPolicy objects
 // and then running a pod that tries to escape four ways before any application
 // image starts, refusing the environment with AF-RUN-043 when any attempt

--- a/ee/engine/runtime/ecs/runtime.go
+++ b/ee/engine/runtime/ecs/runtime.go
@@ -1,3 +1,6 @@
+// Not MIT. This directory is covered by the Antifailure Enterprise License; see
+// ee/LICENSE.md.
+
 package ecs
 
 import (

--- a/ee/engine/runtime/ecs/runtime.go
+++ b/ee/engine/runtime/ecs/runtime.go
@@ -1,0 +1,340 @@
+package ecs
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/antifailure/antifailure/engine/pkg/extension"
+	"github.com/antifailure/antifailure/engine/pkg/provider"
+)
+
+// Name is the value runtime.provider takes in a manifest to reach this
+// package.
+const Name = "ecs"
+
+// Provider is the registered runtime provider for AWS ECS on Fargate.
+//
+// It never returns a runtime, and that is the deliverable rather than a stage
+// on the way to one. Read Open.
+type Provider struct {
+	// Getenv reads the network the environment would be placed in. It is a
+	// field rather than a call to os.Getenv so that a test can drive the
+	// generator without setting process wide state, which is the mistake that
+	// makes one test's environment leak into another's.
+	Getenv func(string) string
+}
+
+// The environment variables that describe the account's network.
+//
+// They are environment variables rather than manifest fields deliberately. A
+// VPC id, a subnet id and a security group id are properties of an
+// organisation's AWS account, they differ per installation, and putting them in
+// antifailure.yaml would mean a repository's manifest carried one company's
+// network layout into every fork of it.
+const (
+	EnvRegion     = "AF_ECS_REGION"
+	EnvCluster    = "AF_ECS_CLUSTER"
+	EnvVPC        = "AF_ECS_VPC_ID"
+	EnvVPCCIDR    = "AF_ECS_VPC_CIDR"
+	EnvSubnets    = "AF_ECS_SUBNET_IDS"
+	EnvSubnetCIDR = "AF_ECS_SUBNET_CIDRS"
+)
+
+// NewProvider builds the provider with the process environment.
+func NewProvider() *Provider { return &Provider{Getenv: os.Getenv} }
+
+// Name is the manifest value.
+func (p *Provider) Name() string { return Name }
+
+// Open refuses, every time, and returns the containment report as the reason.
+//
+// This is the whole lane and it needs the argument written where somebody
+// deleting it will read it.
+//
+// The plan this repository works from carries a standing risk in section 10:
+// the containment claim must not soften to make a cloud runtime possible, and
+// if ECS cannot be proved contained then the honest answer is that Antifailure
+// runs on EKS and not on raw ECS. The Kubernetes runtime is allowed to exist
+// because it creates the NetworkPolicy objects itself and then runs a pod under
+// them that tries to escape four ways before any application image starts. Two
+// properties make that possible and ECS on Fargate has neither.
+//
+// The first is that the image pull happens outside the policy. A kubelet pulls
+// on the node, so a pod can be denied every egress rule and still start. On
+// Fargate platform version 1.4.0 the ECR login, the image pull and the log push
+// all run over the task ENI under the task's own security group, and AWS states
+// that a Fargate task must have a route to the registry to pull an image. So a
+// security group that denies egress is not a configuration that runs an
+// environment, it is a configuration that runs nothing, and the row of the plan
+// that describes this lane as "a security group that denies egress" describes
+// something that cannot exist.
+//
+// The second is that the enforcement can be observed cheaply. A kind cluster on
+// this machine will tell you in ninety seconds whether its CNI enforces a
+// NetworkPolicy. Whether AWS enforces a route table is a fact about an account,
+// and the plan's own standing risk says no test may need a cloud account. So
+// the escape probe that earns a runtime its existence has never run here.
+//
+// What this package therefore does is publish the enumeration, generate the
+// configuration, prove the predicate over that configuration in continuous
+// integration, and refuse. A runtime that came up and could not prove it had no
+// egress would be worse than no runtime at all, because from the outside it
+// looks exactly like one that can.
+func (p *Provider) Open(_ context.Context, cfg extension.RuntimeConfig) (provider.Runtime, error) {
+	in, missing := p.inputs()
+	if len(missing) > 0 {
+		return nil, fmt.Errorf("the ecs runtime is not available, and this installation has not "+
+			"described a network for it either: %s are unset. Even fully described it would "+
+			"refuse, for the reason af prints when they are set. Use runtime.provider "+
+			"kubernetes against EKS, which is proved contained by a probe that runs before "+
+			"any application image", strings.Join(missing, ", "))
+	}
+	report := Evaluate(Generate(in, environmentID(cfg)))
+
+	var b strings.Builder
+	b.WriteString("the ecs runtime refuses to start an environment, on purpose.\n\n")
+	b.WriteString(report.String())
+	b.WriteString("\nThe Kubernetes runtime is allowed to exist because it creates its own " +
+		"NetworkPolicy objects and then runs a pod under them that tries to escape before any " +
+		"application image starts. On Fargate the image pull runs over the task ENI under the " +
+		"task's own security group, so a security group that denies egress starts nothing, and " +
+		"whether AWS enforces the rest is a fact about an account that no test in this " +
+		"repository is allowed to need. Use runtime.provider kubernetes against EKS.\n")
+	return nil, fmt.Errorf("%s", b.String())
+}
+
+// inputs reads the network description and reports what is missing.
+func (p *Provider) inputs() (Inputs, []string) {
+	get := p.Getenv
+	if get == nil {
+		get = os.Getenv
+	}
+	in := Inputs{
+		Region:      strings.TrimSpace(get(EnvRegion)),
+		Cluster:     strings.TrimSpace(get(EnvCluster)),
+		VPCID:       strings.TrimSpace(get(EnvVPC)),
+		VPCCIDR:     strings.TrimSpace(get(EnvVPCCIDR)),
+		SubnetIDs:   splitList(get(EnvSubnets)),
+		SubnetCIDRs: splitList(get(EnvSubnetCIDR)),
+	}
+	var missing []string
+	for _, pair := range []struct {
+		name  string
+		empty bool
+	}{
+		{EnvRegion, in.Region == ""},
+		{EnvCluster, in.Cluster == ""},
+		{EnvVPC, in.VPCID == ""},
+		{EnvVPCCIDR, in.VPCCIDR == ""},
+		{EnvSubnets, len(in.SubnetIDs) == 0},
+		{EnvSubnetCIDR, len(in.SubnetCIDRs) == 0},
+	} {
+		if pair.empty {
+			missing = append(missing, pair.name)
+		}
+	}
+	return in, missing
+}
+
+// environmentID is a stable name for the environment the plan is generated for.
+//
+// The runtime config carries no environment id, because a runtime is opened
+// once and creates many environments. The generated plan is therefore for a
+// named example rather than for a specific environment, and calling it that in
+// the identifier is better than picking one and implying the plan is about it.
+func environmentID(cfg extension.RuntimeConfig) string {
+	if ns := strings.TrimSpace(cfg.Runtime.NamespacePrefix); ns != "" {
+		return ns + "example"
+	}
+	return "af-example"
+}
+
+// splitList parses a comma separated environment variable.
+func splitList(v string) []string {
+	var out []string
+	for _, part := range strings.Split(v, ",") {
+		if part = strings.TrimSpace(part); part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+// Inputs are the account facts a plan is generated from.
+type Inputs struct {
+	Region      string
+	Cluster     string
+	VPCID       string
+	VPCCIDR     string
+	SubnetIDs   []string
+	SubnetCIDRs []string
+}
+
+// Generate builds the configuration one environment would be given.
+//
+// This is the function the predicate is a predicate about. It is deterministic
+// and it takes no clock and no randomness, so the plan for a given account and
+// environment is the same every time and a golden file over it is a real
+// regression test rather than a snapshot of one run.
+//
+// Everything it emits is the tightest shape the paths in egress.go allow. Where
+// a path cannot be closed, this function does not pretend: it still emits the
+// endpoints the image pull needs, because a plan that omitted them would score
+// better and start nothing.
+func Generate(in Inputs, envID string) Plan {
+	sg := "sg-" + envID
+	endpointSG := "sg-" + envID + "-endpoints"
+
+	subnets := make([]Subnet, 0, len(in.SubnetIDs))
+	for i, id := range in.SubnetIDs {
+		cidr := ""
+		if i < len(in.SubnetCIDRs) {
+			cidr = in.SubnetCIDRs[i]
+		}
+		subnets = append(subnets, Subnet{ID: id, IPv4CIDR: cidr})
+	}
+
+	endpoints := []VPCEndpoint{
+		interfaceEndpoint(in.Region, "ecr.api", endpointSG, envID),
+		interfaceEndpoint(in.Region, "ecr.dkr", endpointSG, envID),
+		interfaceEndpoint(in.Region, "logs", endpointSG, envID),
+		{
+			Service:         fmt.Sprintf("com.amazonaws.%s.s3", in.Region),
+			Type:            "Gateway",
+			PolicyDocument:  s3EndpointPolicy(in.Region),
+			SecurityGroupID: "",
+		},
+	}
+
+	// Egress names the endpoints' security group rather than an address range,
+	// because an interface endpoint's ENI addresses are assigned by AWS and a
+	// rule written against them is wrong the first time one is replaced.
+	egress := []Rule{
+		{Protocol: "tcp", FromPort: 443, ToPort: 443, PeerSecurityGroupID: endpointSG},
+		{Protocol: "tcp", FromPort: 443, ToPort: 443, PrefixListID: "pl-" + in.Region + "-s3"},
+	}
+	// And one rule per subnet for traffic inside the environment, which is not
+	// egress: a service reaching another service, the sidecar or the database
+	// alias never leaves this environment and is not decided against the
+	// egress policy.
+	for _, s := range subnets {
+		if s.IPv4CIDR != "" {
+			egress = append(egress, Rule{Protocol: "-1", CIDRv4: s.IPv4CIDR})
+		}
+	}
+
+	return Plan{
+		Region:  in.Region,
+		Cluster: in.Cluster,
+		// Pinned rather than left to LATEST. Below 1.4.0 a task carries a
+		// second Fargate owned ENI for image pulls and secret retrieval that
+		// no security group in this plan describes and that does not appear in
+		// VPC flow logs, so a plan on an older platform version is making a
+		// claim about traffic it cannot see.
+		LaunchType:      "FARGATE",
+		PlatformVersion: "1.4.0",
+		TaskDefinition: TaskDefinition{
+			Family:      envID,
+			NetworkMode: "awsvpc",
+			// Empty, and it is the single most important field in the file.
+			// 169.254.170.2 cannot be turned off, so the only way it vends
+			// nothing is for there to be nothing to vend.
+			TaskRoleARN:          "",
+			ExecutionRoleARN:     fmt.Sprintf("arn:aws:iam::*:role/%s-execution", envID),
+			EnableExecuteCommand: false,
+		},
+		Network: NetworkPlan{
+			VPC: VPC{
+				ID:       in.VPCID,
+				IPv4CIDR: in.VPCCIDR,
+				IPv6CIDR: "",
+				// Left ON, and the DNS firewall closes the resolver path
+				// instead. Turning it off would also close it, and it would
+				// break the private DNS names of the very interface endpoints
+				// the image pull needs, so the environment would stop starting.
+				EnableDNSSupport: true,
+			},
+			Subnets:       subnets,
+			SecurityGroup: SecurityGroup{ID: sg, Egress: egress},
+			RouteTable: RouteTable{
+				ID:             "rtb-" + envID,
+				AssignPublicIP: AssignPublicIPDisabled,
+				Routes: []Route{
+					{Destination: in.VPCCIDR, Target: "local"},
+					{Destination: "pl-" + in.Region + "-s3", Target: "vpce-" + envID + "-s3"},
+				},
+			},
+			Endpoints: endpoints,
+			DNSFirewall: &DNSFirewall{
+				RuleGroupID:     "rslvr-frg-" + envID,
+				AssociatedVPCID: in.VPCID,
+				FailOpen:        false,
+				Rules: []DNSFirewallRule{
+					// The allow rules come first by priority and name only what
+					// the environment is obliged to resolve. The block rule is
+					// last, so a name that matched nothing above is refused
+					// rather than resolved.
+					{Priority: 10, Action: "ALLOW", Domains: allowedDomains(in.Region)},
+					{Priority: 1000, Action: "BLOCK", Domains: []string{"*"}},
+				},
+			},
+		},
+	}
+}
+
+// interfaceEndpoint builds one interface endpoint with a policy.
+func interfaceEndpoint(region, service, sg, envID string) VPCEndpoint {
+	return VPCEndpoint{
+		Service:           fmt.Sprintf("com.amazonaws.%s.%s", region, service),
+		Type:              "Interface",
+		SecurityGroupID:   sg,
+		PrivateDNSEnabled: true,
+		PolicyDocument:    endpointPolicy(service, envID),
+	}
+}
+
+// endpointPolicy narrows an interface endpoint to the environment's own
+// repository or log group.
+//
+// An endpoint with no policy permits every action in that service that the
+// caller has credentials for. The container has no credentials while the task
+// role is absent, so today this narrows very little, and it is written anyway
+// because the day somebody adds a task role is the day it is the only thing
+// standing between this environment and the whole service.
+func endpointPolicy(service, envID string) string {
+	switch service {
+	case "ecr.api", "ecr.dkr":
+		return fmt.Sprintf(`{"Statement":[{"Effect":"Allow","Principal":"*","Action":`+
+			`["ecr:GetAuthorizationToken","ecr:BatchGetImage","ecr:GetDownloadUrlForLayer"],`+
+			`"Resource":"arn:aws:ecr:*:*:repository/%s*"}]}`, envID)
+	case "logs":
+		return fmt.Sprintf(`{"Statement":[{"Effect":"Allow","Principal":"*","Action":`+
+			`["logs:CreateLogStream","logs:PutLogEvents"],`+
+			`"Resource":"arn:aws:logs:*:*:log-group:/antifailure/%s:*"}]}`, envID)
+	default:
+		return `{"Statement":[{"Effect":"Deny","Principal":"*","Action":"*","Resource":"*"}]}`
+	}
+}
+
+// s3EndpointPolicy narrows the gateway endpoint to the buckets ECR serves
+// layers from in this region.
+func s3EndpointPolicy(region string) string {
+	return fmt.Sprintf(`{"Statement":[{"Effect":"Allow","Principal":"*","Action":`+
+		`["s3:GetObject"],"Resource":"arn:aws:s3:::prod-%s-starport-layer-bucket/*"}]}`, region)
+}
+
+// allowedDomains is what the DNS firewall lets through, which is only what the
+// image pull and the log push have to resolve.
+func allowedDomains(region string) []string {
+	out := []string{
+		fmt.Sprintf("api.ecr.%s.amazonaws.com", region),
+		fmt.Sprintf("dkr.ecr.%s.amazonaws.com", region),
+		fmt.Sprintf("logs.%s.amazonaws.com", region),
+		fmt.Sprintf("prod-%s-starport-layer-bucket.s3.%s.amazonaws.com", region, region),
+	}
+	sort.Strings(out)
+	return out
+}

--- a/engine/api/packages.txt
+++ b/engine/api/packages.txt
@@ -39,4 +39,5 @@ unstable github.com/antifailure/antifailure/ee/engine/compliance     Enterprise.
 unstable github.com/antifailure/antifailure/ee/engine/feature        Enterprise. Feature gating for the licensed build, which moves with the licence terms rather than with semantic versioning.
 unstable github.com/antifailure/antifailure/ee/engine/license        Enterprise. Licence parsing and verification, which changes whenever the licence format does.
 unstable github.com/antifailure/antifailure/ee/engine/policyenforce  Enterprise. Policy enforcement for the licensed build, tied to rules that are added and sharpened in minor releases.
+unstable github.com/antifailure/antifailure/ee/engine/runtime/ecs    Enterprise. The ECS containment enumeration and the predicate over the configuration a Fargate runtime would generate. Unstable because the enumeration is meant to grow: a path nobody had thought of is a finding rather than a breaking change, and freezing the shape would make adding one cost a major version.
 unstable github.com/antifailure/antifailure/ee/engine/secrets        Enterprise. The licensed secret backends, which follow whatever each vendor's API does.

--- a/engine/internal/docs/pages.gen.go
+++ b/engine/internal/docs/pages.gen.go
@@ -4741,6 +4741,83 @@ What the enterprise edition adds here is not a third runtime. It is placement
 across several of them at once: the requirements, the tags and the scheduling
 described above.
 
+## Why there is no ECS runtime
+
+` + "`" + `runtime.provider: ecs` + "`" + ` is registered in the enterprise binary and it refuses,
+every time, with a report rather than an error. The reason is worth reading
+before assuming it is a gap somebody will close next release.
+
+A runtime is allowed to exist here only if it can prove an environment has no
+way out, and the Kubernetes runtime proves it the only way a proof works: it
+creates the ` + "`" + `NetworkPolicy` + "`" + ` objects itself, then runs one pod under exactly the
+rules a service runs under and has it try to escape before any application image
+starts. If any attempt gets out the environment does not start and you get
+**AF-RUN-043**. That is not caution. Several container network plugins accept a
+` + "`" + `NetworkPolicy` + "`" + ` object and enforce nothing, every status reads green, and the
+only thing that can tell the two apart is a packet.
+
+ECS on Fargate cannot be given the same treatment, for two reasons that are
+properties of the platform rather than of this implementation.
+
+**The image pull runs inside the boundary.** A kubelet pulls on the node, so a
+pod can be denied every egress rule and still start. On Fargate platform version
+1.4.0 the ECR login, the image pull and the log push all flow over the task's own
+network interface, under the task's own security group, and AWS states that a
+Fargate task must have a route to the registry to pull an image. So a security
+group that denies egress does not produce a contained environment. It produces a
+task that never starts, and the endpoints that let it start are themselves
+reachable addresses.
+
+**The enforcement cannot be observed without an account.** Whether a cluster
+enforces a ` + "`" + `NetworkPolicy` + "`" + ` is answerable on a laptop in ninety seconds. Whether
+AWS enforces a route table is a fact about an account, and no test in this
+repository is permitted to need one.
+
+So what ships is the enumeration and the predicate over it, and the refusal
+carries both. Thirteen distinct egress paths out of a Fargate task, of which
+**eight are closed by the configuration this runtime would generate, three are
+open, and two are not decided by either the configuration or AWS's own
+documentation**. Every closed verdict is a statement about a JSON document and
+not about an observed packet, and the report says so in those words.
+
+The three that are open are open because closing them would stop the environment
+existing, or because AWS provides no way to close them: the ECR and CloudWatch
+Logs interface endpoints and the S3 gateway endpoint that the image pull needs,
+and the task metadata endpoint, which is on by default for every Fargate task on
+platform version 1.4.0 or later with no documented way to turn it off.
+
+The two that are unproven are named rather than rounded up. The instance
+metadata service at ` + "`" + `169.254.169.254` + "`" + ` is the sharper of them: the Fargate launch
+type removes the documented credential source, because EC2 instance profiles are
+not available to containers in Fargate tasks, but AWS does not state that the
+address stops answering, and those are different claims. Settling it needs one
+request from one running task.
+
+One finding is worth carrying away even if you never run on ECS. **On AWS the
+security group is irrelevant to a DNS query.** The VPC user guide states that
+traffic to and from the Amazon DNS server cannot be filtered with network ACLs
+or security groups, and that resolver answers recursive queries for public names
+from anywhere in the VPC. A DNS question is chosen by whoever asks it, so that
+is a data channel out that no security group audit will ever show you. Closing
+it takes a Route 53 Resolver DNS Firewall rule group whose last rule blocks every
+domain and which does not fail open. A containment argument carried over from
+Kubernetes gets this one wrong, because there the same attempt is closed by the
+policy that closes everything else.
+
+**The honest summary is that Antifailure runs on EKS and not on raw ECS.** Use
+` + "`" + `runtime.provider: kubernetes` + "`" + ` against an EKS cluster, where the probe runs.
+
+The report is generated for a real network rather than for a made up one, so
+that the security group rules and route table entries it judges are the ones
+your account would get. Six variables describe that network, and they are
+variables rather than manifest fields because a VPC identifier is a property of
+one company's account and does not belong in a file that gets forked:
+` + "`" + `AF_ECS_REGION` + "`" + `, ` + "`" + `AF_ECS_CLUSTER` + "`" + `, ` + "`" + `AF_ECS_VPC_ID` + "`" + `, ` + "`" + `AF_ECS_VPC_CIDR` + "`" + `,
+` + "`" + `AF_ECS_SUBNET_IDS` + "`" + ` and ` + "`" + `AF_ECS_SUBNET_CIDRS` + "`" + `, the last two comma separated and
+in matching order. Setting them changes the report and does not change the
+answer, and the refusal you get without them says so before you go and build a
+VPC to find out.
+
 Related: [scheduling](/docs/concepts/scheduling), [licensing](/docs/enterprise/licensing).
 `,
 	"enterprise/scim.md": `---

--- a/tools/docs/dictionary.txt
+++ b/tools/docs/dictionary.txt
@@ -32,6 +32,7 @@ goleak
 gosec
 govulncheck
 kubeconfig
+kubelet
 llms
 lockfile
 lockfiles


### PR DESCRIPTION
## What this is

Lane L5.1, AWS ECS on Fargate. It does not add a runtime. It adds the
enumeration of every way out of an ECS task, a predicate over the configuration
such a runtime would generate, and a refusal that prints both.

Section 10 of the plan carries a standing risk: the containment claim must not
soften to make a cloud runtime possible, and if ECS cannot be proved contained
then the honest answer is that Antifailure runs on EKS and not on raw ECS. This
is that answer, with the work behind it rather than as an opinion.

## The number

**13 distinct egress paths out of a Fargate task. 8 closed by the generated
configuration, 3 open, 2 unproven.**

Produced by `TestTheNumber` in `ee/engine/runtime/ecs`, and printed by the
binary itself when a manifest names the runtime.

The three open paths are open because closing them removes the environment: the
ECR and CloudWatch Logs interface endpoints and the S3 gateway endpoint the
image pull needs, plus the task metadata endpoint, which AWS documents as on by
default with no way to turn it off. The two unproven ones are named rather than
rounded up.

## Two lines of the lane row are wrong

**"a security group that denies egress" cannot exist on Fargate.** On platform
version 1.4.0 the ECR login, the image pull and the log push all flow over the
task ENI under the task's own security group, and AWS states that a Fargate task
must have a route to the registry to pull an image. There is no kubelet here
pulling outside the pod's policy. Denying egress produces a task that never
starts, not a task that cannot escape.

**"IMDS disabled for the task" is not a field.** The documented defence is
`ECS_AWSVPC_BLOCK_IMDS`, an ECS container agent variable set on an EC2 container
instance, and no task definition can set it. On Fargate no EC2 instance profile
exists for the endpoint to vend, but AWS nowhere states that 169.254.169.254
stops answering, and those are different claims. The verdict is therefore
`unproven`, not `closed`.

## The finding worth carrying to L5.2 and L5.3

On AWS the security group is irrelevant to a DNS query. The VPC user guide states
that traffic to and from the Amazon DNS server cannot be filtered with network
ACLs or security groups. The Route 53 Resolver answers recursive queries for
public names from anywhere in the VPC, and a DNS question's payload is chosen by
whoever asks it. Only a Route 53 Resolver DNS Firewall rule group whose last rule
blocks every domain, and which does not fail open, closes it.

A containment argument carried over from Kubernetes gets this wrong, because
there the same attempt is closed by the NetworkPolicy that closes everything
else. Cloud Run and Container Apps each have their own version of this and each
lane owes its own primary source.

## What is proved and what is only asserted

Proved: the predicate. Every path reported closed carries a mutation that breaks
the mechanism it depends on and requires the verdict to change, and a separate
test refuses any closed path with no mutation aimed at it.

Asserted, not proved: the eight closed verdicts themselves. They are statements
about a JSON document that has never been applied to an AWS account. No packet
has been observed failing to leave a task. `Report.Caveat` is a constant so this
sentence travels with every number the package produces and cannot be
paraphrased away.

`conformance.RunRuntime` is NOT green here. It cannot be, because there is no
runtime for it to run against. Nothing in this branch claims otherwise.

## The conformance run this proposes and does not perform

One run, in a dedicated AWS account used for nothing else, to settle the two
unproven paths and to check that AWS enforces what the plan says. One Fargate
task in one throwaway VPC, running the escape script and exiting. Ceiling: 25 US
dollars. Teardown proved by a `resourcegroupstaggingapi` inventory of the run's
tag returning empty, recorded in the run report. Not performed tonight, and it
needs Vir's explicit approval because it spends money under his account.

## Section 2.4 item 6: three lines of the plan found wrong

Two are in the lane row and are stated above. The third is the row's edition.

**The row places ECS in `/ee`, and nothing in this repository justifies that
today.** Section 2.5 says a runtime is MIT unless it carries licensed
governance, and `local` and `kubernetes` are both MIT. The only candidate
feature that exists is `multi_runtime`, and it does not fit twice over: it has
**zero enforcement sites** anywhere in the tree, appearing only in its own
declaration, in `tools/licensegen`, in a test asserting it is off, and in the
docs; and `docs/enterprise/runtimes.md` defines it as placement across several
runtimes rather than as the right to have another one, so gating a runtime on it
would make that page wrong. The `cloud_runtime` feature that would fit is
L6.2's row and does not exist yet.

There is a stronger argument than the letter of 2.5 for moving it, and it is
about what this package actually does. **This is not a runtime, it is the
product telling the truth about where it cannot run.** Behind the enterprise
licence, a community user who points a manifest at ECS gets no refusal at all
and is left believing it works. The refusal is worth more to the person who has
not paid than to the person who has.

The package stays under `ee/` in this branch on the team lead's instruction, who
is sequencing that move across this lane and L5.3 at merge time rather than
having each lane do it independently.

## A shared gate finding for the next `/ee` package

`tools/licensecheck` is a required context and it requires the literal string
`Antifailure Enterprise License` in the **first 400 bytes** of every `.go`,
`.ts` and `.tsx` file under `ee/`. A new package under `ee/` fails it on every
file it adds. This lane hit it on 4 of 4 new files and L5.3 hit it on 4 of 4 of
its own, independently, which makes it a property of adding a directory rather
than anybody's oversight.
