### PR TITLE
ee: four entitlement rows named real code and never asked who it served

### DIFF
--- a/.changes/two-answers-to-one-entitlement-question.md
+++ b/.changes/two-answers-to-one-entitlement-question.md
@@ -1,0 +1,45 @@
+# fixed
+
+There were two entitlement systems and they did not know about each other.
+
+The engine has `license.Feature`, twelve names a signed license may carry. The
+control plane has `organizations.plan` and `entitlements.ts`, which is real,
+tested, and about quotas. Nothing reconciled them, so "what does this customer
+get" had no single answer, and a self hosted license and a hosted plan could
+disagree in silence.
+
+Worse than the disagreement was what the twelve names did. Three of them are
+checked by something. The other nine are named in a license, printed by
+`af license status`, listed on the licensing page and sold, and change nothing
+whatever when they are absent, because no code anywhere asks whether they are
+on. A customer who bought nine features and one who bought none were running the
+identical product, and the page written to answer that question said "each is
+named in the license, so a license permits exactly what was bought".
+
+`ee/engine/feature/catalogue.go` is now the one answer. Every feature carries
+what it is, where it is enforced as `path:symbol`, and, when it is not enforced,
+which of three reasons applies: the hosted control plane covers it under the
+plan as a whole rather than under this name, it is implemented and deliberately
+free, or the capability is not built.
+
+Nine tests hold it up, across two build systems and three trees. A feature in
+the license and not the catalogue fails. A `feature.Declare` with no catalogue
+entry fails. A row claiming enforcement at a file that contains no
+`feature.Enabled` call for that exact feature fails, which is how
+`compliance_packs` was found to have spent its whole life declared at
+`compliance.Pack.Evaluate`, a function that takes no context and therefore
+cannot ask about a license at all. And for each feature the catalogue calls
+enforced, the real entry point is called twice, once with a license granting
+everything else and once with everything, and the behaviour has to differ.
+
+The licensing page's feature table is generated from the catalogue and says the
+number out loud. `runtimes.md` opened with "Requires an enterprise license with
+the `multi_runtime` feature" and nothing requires it: the scheduler that would
+place an environment has no caller outside its own tests, it lives under
+`engine/internal` where the enterprise module cannot reach it, and no manifest
+can express a placement requirement to begin with. A test now refuses any page
+making that claim for a feature the catalogue does not call enforced.
+
+The control plane's half is checked from the control plane, in
+`licensed-features.test.ts`, because a developer renaming `orgProcedure` does
+not run a Go module that is deliberately outside the workspace.

--- a/.changes/two-answers-to-one-entitlement-question.md
+++ b/.changes/two-answers-to-one-entitlement-question.md
@@ -14,9 +14,20 @@ which reason applies: it is refused by the control plane rather than the engine,
 it is implemented and deliberately free, it is built and loaded by no binary, or
 the capability does not exist.
 
-Of the twelve, five are refused when a license does not name them, three by the
-engine and two by the control plane. Seven change nothing whatever when they
-are absent, and the page says so.
+Of the twelve, seven are refused when a license does not name them, five by the
+engine and two by the control plane. Five change nothing whatever when they are
+absent, and the page says so.
+
+THAT NUMBER MOVED WHILE THIS WAS BEING WRITTEN, from five to seven, and it moved
+because the product changed rather than because the measurement was wrong. Two
+features were filed as not built on a measurement that was true when it was
+taken and that named its own expiry in its own text: `audit_stream` had a socket
+in the community engine with nothing plugged into it, and `multi_runtime` had a
+scheduler with no caller, no way for a manifest to ask for a placement, and no
+importable home for a check. Both shipped afterwards. The catalogue is
+regenerated from the code rather than restated from the last time somebody
+counted, so the page now reads seven, and the two rows that moved say what they
+used to claim and why that stopped being true.
 
 THE FIRST VERSION OF THIS CATALOGUE PUT FOUR OF THE TWELVE IN THE WRONG PLACE,
 and the four are worth recording because they failed in two opposite directions
@@ -58,8 +69,8 @@ anything a license sells.
 
 The rest of the scaffolding stands. A feature in the license and not the
 catalogue fails. A `feature.Declare` with no catalogue entry fails. A row
-claiming enforcement at a file with no `feature.Enabled` call for that exact
-feature fails, which is how `compliance_packs` was found to have spent its whole
+claiming enforcement at a file with no call refusing that exact feature fails,
+which is how `compliance_packs` was found to have spent its whole
 life declared at `compliance.Pack.Evaluate`, a function that takes no context
 and therefore cannot ask about a license at all. For each feature the catalogue
 calls enforced in the engine, the real entry point is called twice, once with a

--- a/.changes/two-answers-to-one-entitlement-question.md
+++ b/.changes/two-answers-to-one-entitlement-question.md
@@ -8,38 +8,66 @@ tested, and about quotas. Nothing reconciled them, so "what does this customer
 get" had no single answer, and a self hosted license and a hosted plan could
 disagree in silence.
 
-Worse than the disagreement was what the twelve names did. Three of them are
-checked by something. The other nine are named in a license, printed by
-`af license status`, listed on the licensing page and sold, and change nothing
-whatever when they are absent, because no code anywhere asks whether they are
-on. A customer who bought nine features and one who bought none were running the
-identical product, and the page written to answer that question said "each is
-named in the license, so a license permits exactly what was bought".
-
 `ee/engine/feature/catalogue.go` is now the one answer. Every feature carries
-what it is, where it is enforced as `path:symbol`, and, when it is not enforced,
-which of three reasons applies: the hosted control plane covers it under the
-plan as a whole rather than under this name, it is implemented and deliberately
-free, or the capability is not built.
+what it is, where it is enforced as `path:symbol`, and, when it is not refused,
+which reason applies: it is refused by the control plane rather than the engine,
+it is implemented and deliberately free, it is built and loaded by no binary, or
+the capability does not exist.
 
-Nine tests hold it up, across two build systems and three trees. A feature in
-the license and not the catalogue fails. A `feature.Declare` with no catalogue
-entry fails. A row claiming enforcement at a file that contains no
-`feature.Enabled` call for that exact feature fails, which is how
-`compliance_packs` was found to have spent its whole life declared at
-`compliance.Pack.Evaluate`, a function that takes no context and therefore
-cannot ask about a license at all. And for each feature the catalogue calls
-enforced, the real entry point is called twice, once with a license granting
-everything else and once with everything, and the behaviour has to differ.
+Of the twelve, five are refused when a license does not name them, three by the
+engine and two by the control plane. Seven change nothing whatever when they
+are absent, and the page says so.
 
-The licensing page's feature table is generated from the catalogue and says the
-number out loud. `runtimes.md` opened with "Requires an enterprise license with
-the `multi_runtime` feature" and nothing requires it: the scheduler that would
-place an environment has no caller outside its own tests, it lives under
-`engine/internal` where the enterprise module cannot reach it, and no manifest
-can express a placement requirement to begin with. A test now refuses any page
-making that claim for a feature the catalogue does not call enforced.
+THE FIRST VERSION OF THIS CATALOGUE PUT FOUR OF THE TWELVE IN THE WRONG PLACE,
+and the four are worth recording because they failed in two opposite directions
+with one cause. Every one of them found real code and never asked who that code
+served.
 
-The control plane's half is checked from the control plane, in
-`licensed-features.test.ts`, because a developer renaming `orgProcedure` does
-not run a Go module that is deliberately outside the workspace.
+Two were UNDER claimed, because the measurement read one language. Enforcement
+lives in Go and in TypeScript; the count was of `feature.Enabled` call sites,
+which only the engine has. `sso` and `scim` came back zero and were published as
+features nobody has, paid or not, while the enterprise control plane refuses
+both by name with a 402. A zero in that count means not enforced by the ENGINE,
+which is a different fact from not enforced.
+
+Two were OVER claimed, because the code served a different subject. `billing`
+read as free because `billingRouter` is real, mounted and ungated, and that code
+bills the customer FOR Antifailure, while the licensed feature would meter on
+the customer's own behalf and does not exist. `enterprise_dashboard` read as
+covered by the plan because the console really is refused below the enterprise
+tier, which is our own funnel enforcing our own pricing rather than anything a
+license grants. Both are named in `notShipped` and cannot be sold at all.
+
+Two checks now hold those two failures, and NEITHER COVERS THE OTHER'S CASE,
+which is stated here so nobody assumes one gate closes the class. A cross
+language check compares the catalogue's state claims against the TypeScript
+registry's declarations in both directions, and compares the named site byte for
+byte against what that registry actually declared; it catches `sso` and `scim`
+and cannot catch `billing`, because that row was true about the code it named. A
+second check holds the catalogue to `notShipped`, whose own comment says it is
+the only place that has to change when one of these is built; it catches
+`billing` and `enterprise_dashboard` and cannot catch `sso` and `scim`, because
+those are sellable and were merely described wrongly. Nothing automated found
+`billing`. A person read the catalogue's own prose and asked who the code was
+for.
+
+A state meaning "refused on the plan as a whole" has been REMOVED rather than
+left unoccupied. It was the affordance that made the wrong classification
+available, and a refusal keyed on our own pricing tiers does not describe
+anything a license sells.
+
+The rest of the scaffolding stands. A feature in the license and not the
+catalogue fails. A `feature.Declare` with no catalogue entry fails. A row
+claiming enforcement at a file with no `feature.Enabled` call for that exact
+feature fails, which is how `compliance_packs` was found to have spent its whole
+life declared at `compliance.Pack.Evaluate`, a function that takes no context
+and therefore cannot ask about a license at all. For each feature the catalogue
+calls enforced in the engine, the real entry point is called twice, once with a
+license granting everything else and once with everything, and the behaviour has
+to differ. The control plane's half is checked from the control plane, because a
+developer renaming `orgProcedure` does not run a Go module that is deliberately
+outside the workspace.
+
+The licensing page's feature table and its count are generated from the
+catalogue and say the number out loud, including when the number is
+unflattering.

--- a/.changes/two-answers-to-one-entitlement-question.md
+++ b/.changes/two-answers-to-one-entitlement-question.md
@@ -14,23 +14,33 @@ which reason applies: it is refused by the control plane rather than the engine,
 it is implemented and deliberately free, it is built and loaded by no binary, or
 the capability does not exist.
 
-Of the fourteen, nine are refused when a license does not name them, seven by
-the engine and two by the control plane. Five change nothing whatever when they
+Of the fourteen, ten are refused when a license does not name them, eight by
+the engine and two by the control plane. Four change nothing whatever when they
 are absent, and the page says so.
 
-THAT NUMBER MOVED THREE TIMES WHILE THIS WAS BEING WRITTEN, from five to seven
-to nine, and every move was the product changing rather than the measurement
-being wrong. Two features were filed as not built on a measurement that was true
-when it was taken and that named its own expiry in its own text: `audit_stream`
-had a socket in the community engine with nothing plugged into it, and
-`multi_runtime` had a scheduler with no caller, no way for a manifest to ask for
-a placement, and no importable home for a check. Both shipped afterwards. Then
-`cloud_database` and `cloud_runtime` arrived as two new names in the license
-with `ee/engine/cloudgate` already refusing them per call, so they were gated
-before this catalogue had a row for either. The catalogue is regenerated from
-the code rather than restated from the last time somebody counted, so the page
-now reads nine, and every row that moved says what it used to claim and why that
-stopped being true.
+THAT NUMBER MOVED FOUR TIMES WHILE THIS WAS BEING WRITTEN, from five to seven
+to nine to ten, and every move was the product changing rather than the
+measurement being wrong. Three features were filed as not built on a measurement
+that was true when it was taken and that named its own expiry in its own text.
+`audit_stream` had a socket in the community engine with nothing plugged into
+it. `multi_runtime` had a scheduler with no caller, no way for a manifest to ask
+for a placement, and no importable home for a check. `air_gapped` had no
+reference in any Go code outside the constant and the generator's copy of the
+name list, and its reason said in so many words that the lane which would build
+it had not landed. All three shipped afterwards. Then `cloud_database` and
+`cloud_runtime` arrived as two new names in the license with `ee/engine/cloudgate`
+already refusing them per call, so they were gated before this catalogue had a
+row for either.
+
+That last move is the one worth reading, because the rule it broke is written in
+this same change. A reason may describe the tree and may name a commit it is
+true of, and it must NOT describe a future: a forward reference is unverifiable
+when it is written and silently false afterwards. The `air_gapped` row named a
+lane that had not landed, the lane landed, and nothing in the repository could
+tell. The count itself cannot drift, because the sentence on the page is
+generated from the catalogue rather than restated from the last time somebody
+counted, so the page now reads ten. The prose beside it is what needed a rule,
+and now has one.
 
 THE FIRST VERSION OF THIS CATALOGUE PUT FOUR OF THE TWELVE THEN SELLABLE IN THE
 WRONG PLACE, and the four are worth recording because they failed in two

--- a/.changes/two-answers-to-one-entitlement-question.md
+++ b/.changes/two-answers-to-one-entitlement-question.md
@@ -2,7 +2,7 @@
 
 There were two entitlement systems and they did not know about each other.
 
-The engine has `license.Feature`, twelve names a signed license may carry. The
+The engine has `license.Feature`, fourteen names a signed license may carry. The
 control plane has `organizations.plan` and `entitlements.ts`, which is real,
 tested, and about quotas. Nothing reconciled them, so "what does this customer
 get" had no single answer, and a self hosted license and a hosted plan could
@@ -14,25 +14,28 @@ which reason applies: it is refused by the control plane rather than the engine,
 it is implemented and deliberately free, it is built and loaded by no binary, or
 the capability does not exist.
 
-Of the twelve, seven are refused when a license does not name them, five by the
-engine and two by the control plane. Five change nothing whatever when they are
-absent, and the page says so.
+Of the fourteen, nine are refused when a license does not name them, seven by
+the engine and two by the control plane. Five change nothing whatever when they
+are absent, and the page says so.
 
-THAT NUMBER MOVED WHILE THIS WAS BEING WRITTEN, from five to seven, and it moved
-because the product changed rather than because the measurement was wrong. Two
-features were filed as not built on a measurement that was true when it was
-taken and that named its own expiry in its own text: `audit_stream` had a socket
-in the community engine with nothing plugged into it, and `multi_runtime` had a
-scheduler with no caller, no way for a manifest to ask for a placement, and no
-importable home for a check. Both shipped afterwards. The catalogue is
-regenerated from the code rather than restated from the last time somebody
-counted, so the page now reads seven, and the two rows that moved say what they
-used to claim and why that stopped being true.
+THAT NUMBER MOVED THREE TIMES WHILE THIS WAS BEING WRITTEN, from five to seven
+to nine, and every move was the product changing rather than the measurement
+being wrong. Two features were filed as not built on a measurement that was true
+when it was taken and that named its own expiry in its own text: `audit_stream`
+had a socket in the community engine with nothing plugged into it, and
+`multi_runtime` had a scheduler with no caller, no way for a manifest to ask for
+a placement, and no importable home for a check. Both shipped afterwards. Then
+`cloud_database` and `cloud_runtime` arrived as two new names in the license
+with `ee/engine/cloudgate` already refusing them per call, so they were gated
+before this catalogue had a row for either. The catalogue is regenerated from
+the code rather than restated from the last time somebody counted, so the page
+now reads nine, and every row that moved says what it used to claim and why that
+stopped being true.
 
-THE FIRST VERSION OF THIS CATALOGUE PUT FOUR OF THE TWELVE IN THE WRONG PLACE,
-and the four are worth recording because they failed in two opposite directions
-with one cause. Every one of them found real code and never asked who that code
-served.
+THE FIRST VERSION OF THIS CATALOGUE PUT FOUR OF THE TWELVE THEN SELLABLE IN THE
+WRONG PLACE, and the four are worth recording because they failed in two
+opposite directions with one cause. Every one of them found real code and never
+asked who that code served.
 
 Two were UNDER claimed, because the measurement read one language. Enforcement
 lives in Go and in TypeScript; the count was of `feature.Enabled` call sites,

--- a/docs/src/content/docs/enterprise/licensing.md
+++ b/docs/src/content/docs/enterprise/licensing.md
@@ -111,11 +111,11 @@ license leaves you with it rather than with nothing.
 ## What is in `ee/`
 
 <!-- entitlement-names:start -->
-The features a license can name are `air_gapped`, `audit_stream`, `billing`, `compliance_packs`, `enterprise_dashboard`, `enterprise_secrets`, `multi_runtime`, `policy_enforcement`, `rbac`, `scim`, `sso` and `support_access`.
+The features a license can name are `air_gapped`, `audit_stream`, `billing`, `cloud_database`, `cloud_runtime`, `compliance_packs`, `enterprise_dashboard`, `enterprise_secrets`, `multi_runtime`, `policy_enforcement`, `rbac`, `scim`, `sso` and `support_access`.
 <!-- entitlement-names:end -->
 
 <!-- entitlement-count:start -->
-Of the 12 features a license can carry, **7 are refused when the license does not name them**, 5 by the engine and 2 by the control plane. The rest are listed here anyway, with what actually happens without each one, because a feature that is sold and never checked is worth knowing about and the number is only useful if it can come back unflattering.
+Of the 14 features a license can carry, **9 are refused when the license does not name them**, 7 by the engine and 2 by the control plane. The rest are listed here anyway, with what actually happens without each one, because a feature that is sold and never checked is worth knowing about and the number is only useful if it can come back unflattering.
 <!-- entitlement-count:end -->
 
 The table is generated from `ee/engine/feature/catalogue.go`, which is the one
@@ -138,6 +138,8 @@ is where it gets published.
 | `air_gapped` | An installation that reaches nothing outside the operator's own network. | Nothing changes, because the capability is not built yet. |
 | `audit_stream` | Privileged actions forwarded to the organization's own SIEM. | Withheld. `auditsink/auditsink.go:auditsink.permitted` asks the license, and the feature is off when the answer is no. |
 | `billing` | Subscriptions, invoices and the plan an organization is on. | Nothing changes, because the capability is not built yet. |
+| `cloud_database` | Managed cloud database providers, the ones that need an organization behind them rather than a developer's own card. | Withheld. `cloudgate/cloudgate.go:gatedDatabase.Branch` asks the license, and the feature is off when the answer is no. |
+| `cloud_runtime` | Managed cloud runtime providers, on the same rule as the databases. | Withheld. `cloudgate/cloudgate.go:gatedRuntime.Up` asks the license, and the feature is off when the answer is no. |
 | `compliance_packs` | SOC 2 and ISO 27001 evidence gathered from the control plane's own records. | Withheld. `compliance/command.go:Command` asks the license, and the feature is off when the answer is no. |
 | `enterprise_dashboard` | The console: environments, masking, egress, audit and workloads. | Nothing changes, because the capability is not built yet. |
 | `enterprise_secrets` | Declared variables resolved from Vault or a cloud secret manager. | Withheld. `secrets/source.go:Source.Available` asks the license, and the feature is off when the answer is no. |

--- a/docs/src/content/docs/enterprise/licensing.md
+++ b/docs/src/content/docs/enterprise/licensing.md
@@ -115,14 +115,18 @@ The features a license can name are `air_gapped`, `audit_stream`, `billing`, `co
 <!-- entitlement-names:end -->
 
 <!-- entitlement-count:start -->
-Of the 12 features a license can carry, **5 are refused when the license does not name them**, 3 by the engine and 2 by the control plane. The rest are listed here anyway, with what actually happens without each one, because a feature that is sold and never checked is worth knowing about and the number is only useful if it can come back unflattering.
+Of the 12 features a license can carry, **7 are refused when the license does not name them**, 5 by the engine and 2 by the control plane. The rest are listed here anyway, with what actually happens without each one, because a feature that is sold and never checked is worth knowing about and the number is only useful if it can come back unflattering.
 <!-- entitlement-count:end -->
 
 The table is generated from `ee/engine/feature/catalogue.go`, which is the one
 place this product records what a license permits. Every row saying a feature is
 refused names the file that refuses it, and a test opens that file and requires
-a `feature.Enabled` call for that exact feature in it, so a row cannot claim an
-enforcement it does not have. Rows that say nothing changes are the honest
+the call that actually refuses: `feature.Enabled` for a row the enterprise
+engine gates, `edition.Permits` for one the community engine gates by name. So a
+row cannot claim an enforcement it does not have. Which of the two is required
+is decided by the row's own state and never by the shape of the path, because a
+check that guessed from the path would accept an enterprise file for a community
+gate and never notice that the mechanism claimed is not the mechanism there. Rows that say nothing changes are the honest
 answer rather than an omission: a feature that is sold and never checked is a
 gap worth publishing, and this page is where it gets published.
 
@@ -130,12 +134,12 @@ gap worth publishing, and this page is where it gets published.
 | Feature | What it is | Without it |
 | --- | --- | --- |
 | `air_gapped` | An installation that reaches nothing outside the operator's own network. | Nothing changes, because the capability is not built yet. |
-| `audit_stream` | Privileged actions forwarded to the organization's own SIEM. | Nothing changes, because the capability is not built yet. |
+| `audit_stream` | Privileged actions forwarded to the organization's own SIEM. | Withheld. `auditsink/auditsink.go:auditsink.permitted` asks the license, and the feature is off when the answer is no. |
 | `billing` | Subscriptions, invoices and the plan an organization is on. | Nothing changes, because the capability is not built yet. |
 | `compliance_packs` | SOC 2 and ISO 27001 evidence gathered from the control plane's own records. | Withheld. `compliance/command.go:Command` asks the license, and the feature is off when the answer is no. |
 | `enterprise_dashboard` | The console: environments, masking, egress, audit and workloads. | Nothing changes, because the capability is not built yet. |
 | `enterprise_secrets` | Declared variables resolved from Vault or a cloud secret manager. | Withheld. `secrets/source.go:Source.Available` asks the license, and the feature is off when the answer is no. |
-| `multi_runtime` | Placing an environment across several runtimes at once, by requirement and by tag. | Nothing changes, because the capability is not built yet. |
+| `multi_runtime` | Placing an environment across several runtimes at once, by requirement and by tag. | Withheld. `engine/internal/env/env.go:Orchestrator.placement` asks the license, and the feature is off when the answer is no. |
 | `policy_enforcement` | Organization policy that refuses an environment the manifest would have allowed. | Withheld. `policyenforce/policyenforce.go:Hook.Check` asks the license, and the feature is off when the answer is no. |
 | `rbac` | Roles, and a permission on every route. | Nothing changes. It is implemented and deliberately available to everyone. |
 | `scim` | Directory provisioning, so joiners and leavers arrive from the identity provider. | Withheld by the control plane. `ee/web/scim/src/routes.ts:guard` asks the license, and an unlicensed installation is answered 402 naming the feature rather than 404. |

--- a/docs/src/content/docs/enterprise/licensing.md
+++ b/docs/src/content/docs/enterprise/licensing.md
@@ -110,6 +110,10 @@ license leaves you with it rather than with nothing.
 
 ## What is in `ee/`
 
+<!-- entitlement-names:start -->
+The features a license can name are `air_gapped`, `audit_stream`, `billing`, `compliance_packs`, `enterprise_dashboard`, `enterprise_secrets`, `multi_runtime`, `policy_enforcement`, `rbac`, `scim`, `sso` and `support_access`.
+<!-- entitlement-names:end -->
+
 <!-- entitlement-count:start -->
 Of the 12 features a license can carry, **3 are refused when the license does not name them**. The rest are listed here anyway, with what actually happens without each one, because a feature that is sold and never checked is worth knowing about and the number is only useful if it can come back unflattering.
 <!-- entitlement-count:end -->

--- a/docs/src/content/docs/enterprise/licensing.md
+++ b/docs/src/content/docs/enterprise/licensing.md
@@ -126,9 +126,11 @@ engine gates, `edition.Permits` for one the community engine gates by name. So a
 row cannot claim an enforcement it does not have. Which of the two is required
 is decided by the row's own state and never by the shape of the path, because a
 check that guessed from the path would accept an enterprise file for a community
-gate and never notice that the mechanism claimed is not the mechanism there. Rows that say nothing changes are the honest
-answer rather than an omission: a feature that is sold and never checked is a
-gap worth publishing, and this page is where it gets published.
+gate and never notice that the mechanism claimed is not the mechanism there.
+
+Rows that say nothing changes are the honest answer rather than an omission: a
+feature that is sold and never checked is a gap worth publishing, and this page
+is where it gets published.
 
 <!-- entitlements:start -->
 | Feature | What it is | Without it |

--- a/docs/src/content/docs/enterprise/licensing.md
+++ b/docs/src/content/docs/enterprise/licensing.md
@@ -134,9 +134,9 @@ gap worth publishing, and this page is where it gets published.
 | `multi_runtime` | Placing an environment across several runtimes at once, by requirement and by tag. | Nothing changes, because the capability is not built yet. |
 | `policy_enforcement` | Organization policy that refuses an environment the manifest would have allowed. | Withheld. `policyenforce/policyenforce.go:Hook.Check` asks the license, and the feature is off when the answer is no. |
 | `rbac` | Roles, and a permission on every route. | Nothing changes. It is implemented and deliberately available to everyone. |
-| `scim` | Directory provisioning, so joiners and leavers arrive from the identity provider. | Nothing changes, because the capability is not built yet. |
-| `sso` | Single sign on against the organization's own identity provider. | Nothing changes, because the capability is not built yet. |
-| `support_access` | A supported way for the vendor to see what a customer sees. | Nothing changes, because the capability is not built yet. |
+| `scim` | Directory provisioning, so joiners and leavers arrive from the identity provider. | Nothing changes, and not because it is unbuilt. It is implemented and no binary loads it, so nobody has it, paid or not. |
+| `sso` | Single sign on against the organization's own identity provider. | Nothing changes, and not because it is unbuilt. It is implemented and no binary loads it, so nobody has it, paid or not. |
+| `support_access` | A supported way for the vendor to see what a customer sees. | Nothing changes. It is implemented and deliberately available to everyone. |
 <!-- entitlements:end -->
 
 The distinction in the third column between a feature that is refused and one

--- a/docs/src/content/docs/enterprise/licensing.md
+++ b/docs/src/content/docs/enterprise/licensing.md
@@ -115,7 +115,7 @@ The features a license can name are `air_gapped`, `audit_stream`, `billing`, `cl
 <!-- entitlement-names:end -->
 
 <!-- entitlement-count:start -->
-Of the 14 features a license can carry, **9 are refused when the license does not name them**, 7 by the engine and 2 by the control plane. The rest are listed here anyway, with what actually happens without each one, because a feature that is sold and never checked is worth knowing about and the number is only useful if it can come back unflattering.
+Of the 14 features a license can carry, **10 are refused when the license does not name them**, 8 by the engine and 2 by the control plane. The rest are listed here anyway, with what actually happens without each one, because a feature that is sold and never checked is worth knowing about and the number is only useful if it can come back unflattering.
 <!-- entitlement-count:end -->
 
 The table is generated from `ee/engine/feature/catalogue.go`, which is the one
@@ -135,7 +135,7 @@ is where it gets published.
 <!-- entitlements:start -->
 | Feature | What it is | Without it |
 | --- | --- | --- |
-| `air_gapped` | An installation that reaches nothing outside the operator's own network. | Nothing changes, because the capability is not built yet. |
+| `air_gapped` | An installation that reaches nothing outside the operator's own network. | Withheld. `airgapped/airgapped.go:RegisterFromEnvironment` asks the license, and the feature is off when the answer is no. |
 | `audit_stream` | Privileged actions forwarded to the organization's own SIEM. | Withheld. `auditsink/auditsink.go:auditsink.permitted` asks the license, and the feature is off when the answer is no. |
 | `billing` | Subscriptions, invoices and the plan an organization is on. | Nothing changes, because the capability is not built yet. |
 | `cloud_database` | Managed cloud database providers, the ones that need an organization behind them rather than a developer's own card. | Withheld. `cloudgate/cloudgate.go:gatedDatabase.Branch` asks the license, and the feature is off when the answer is no. |
@@ -153,8 +153,8 @@ is where it gets published.
 
 The distinction in the third column between a feature that is refused and one
 the hosted control plane covers under its plan is the one worth reading twice. A
-license carries twelve names and the hosted plan gate carries one boolean, so a
-license naming a feature and a plan that does not are not reconcilable by
+license carries fourteen names and the hosted plan gate carries one boolean, so
+a license naming a feature and a plan that does not are not reconcilable by
 anything. Both are real refusals and only the first is keyed on what was bought.
 
 ### Two of those cannot be sold
@@ -172,31 +172,32 @@ working feature from every direction and is harder to find than the gap it
 covers. A feature nobody can buy and nobody can be granted cannot be mistaken
 for one that ships.
 
-### Two more are not enforced
+### One more is not enforced
 
-A third case, and a different one from the two above: `rbac` and `air_gapped`.
-Both name something real, and in neither case is the license what provides it.
+A third case, and a different one from the two above: `rbac`. It names something
+real, and the license is not what provides it.
 
 The custom roles library is complete and tested, and nothing stores a role
-model, so an organization has no way to have one. Air gapped operation is a
-property every installation already has, licensed or not: verification is a
-signature check against keys stamped into the binary, so it needs no network
-whichever features a license names.
+model, so an organization has no way to have one.
 
-They are reported and not enforced, and that is written down rather than gated,
-for the reason the paragraph above gives: a check on a path nothing reaches is
-worse than no check. Unlike `billing` and `enterprise_dashboard` they are not
-refused at issue, because refusing them would refuse a customer a capability
-they can have. `tools/licensegen` prints a warning naming them beside the key it
-signs instead, so that whoever issues it reads what the license does and does
-not grant before a customer asks.
+It is reported and not enforced, and that is written down rather than gated, for
+the reason the paragraph above gives: a check on a path nothing reaches is worse
+than no check. Unlike `billing` and `enterprise_dashboard` it is not refused at
+issue, because refusing it would refuse a customer a capability they can have.
+`tools/licensegen` prints a warning naming it beside the key it signs instead,
+so that whoever issues it reads what the license does and does not grant before
+a customer asks.
 
 `air_gapped` was in this state and said so nowhere until 2026-09-08. Every
 occurrence of the name in the repository was a copy of the catalogue, the
 license vectors, a line of documentation, or a test, so a license naming it
 verified, reported itself active, printed in `af license status`, and granted
-nothing. That is the same failure the two refused names above exist to prevent,
-reached through the case they do not cover.
+nothing. It is no longer in this state and this page said it was for a day
+longer than it was true: the paragraph naming it stayed here while the gate that
+made it false landed in another pull request, which is the same stale sentence
+this catalogue exists to refuse and is why the row above is generated from the
+code rather than written beside it. The table now reads Withheld for
+`air_gapped`, and the site it names is the one that asks.
 
 All three lists are held to the code by a test rather than by a habit.
 `notShipped` and `unenforced` in `ee/engine/license/license.go` are the single

--- a/docs/src/content/docs/enterprise/licensing.md
+++ b/docs/src/content/docs/enterprise/licensing.md
@@ -110,11 +110,40 @@ license leaves you with it rather than with nothing.
 
 ## What is in `ee/`
 
-`sso`, `scim`, `rbac`, `audit_stream`, `policy_enforcement`, `multi_runtime`,
-`enterprise_secrets`, `billing`, `enterprise_dashboard`, `support_access`,
-`compliance_packs`, `air_gapped`, `cloud_database`, `cloud_runtime`.
+<!-- entitlement-count:start -->
+Of the 12 features a license can carry, **3 are refused when the license does not name them**. The rest are listed here anyway, with what actually happens without each one, because a feature that is sold and never checked is worth knowing about and the number is only useful if it can come back unflattering.
+<!-- entitlement-count:end -->
 
-Each is named in the license, so a license permits exactly what was bought.
+The table is generated from `ee/engine/feature/catalogue.go`, which is the one
+place this product records what a license permits. Every row saying a feature is
+refused names the file that refuses it, and a test opens that file and requires
+a `feature.Enabled` call for that exact feature in it, so a row cannot claim an
+enforcement it does not have. Rows that say nothing changes are the honest
+answer rather than an omission: a feature that is sold and never checked is a
+gap worth publishing, and this page is where it gets published.
+
+<!-- entitlements:start -->
+| Feature | What it is | Without it |
+| --- | --- | --- |
+| `air_gapped` | An installation that reaches nothing outside the operator's own network. | Nothing changes, because the capability is not built yet. |
+| `audit_stream` | Privileged actions forwarded to the organization's own SIEM. | Nothing changes, because the capability is not built yet. |
+| `billing` | Subscriptions, invoices and the plan an organization is on. | Nothing changes. It is implemented and deliberately available to everyone. |
+| `compliance_packs` | SOC 2 and ISO 27001 evidence gathered from the control plane's own records. | Withheld. `compliance/command.go:Command` asks the license, and the feature is off when the answer is no. |
+| `enterprise_dashboard` | The console: environments, masking, egress, audit and workloads. | Not refused by this name. The hosted control plane refuses the capability on the plan as a whole; a self hosted installation with no license keeps it. |
+| `enterprise_secrets` | Declared variables resolved from Vault or a cloud secret manager. | Withheld. `secrets/source.go:Source.Available` asks the license, and the feature is off when the answer is no. |
+| `multi_runtime` | Placing an environment across several runtimes at once, by requirement and by tag. | Nothing changes, because the capability is not built yet. |
+| `policy_enforcement` | Organization policy that refuses an environment the manifest would have allowed. | Withheld. `policyenforce/policyenforce.go:Hook.Check` asks the license, and the feature is off when the answer is no. |
+| `rbac` | Roles, and a permission on every route. | Nothing changes. It is implemented and deliberately available to everyone. |
+| `scim` | Directory provisioning, so joiners and leavers arrive from the identity provider. | Nothing changes, because the capability is not built yet. |
+| `sso` | Single sign on against the organization's own identity provider. | Nothing changes, because the capability is not built yet. |
+| `support_access` | A supported way for the vendor to see what a customer sees. | Nothing changes, because the capability is not built yet. |
+<!-- entitlements:end -->
+
+The distinction in the third column between a feature that is refused and one
+the hosted control plane covers under its plan is the one worth reading twice. A
+license carries twelve names and the hosted plan gate carries one boolean, so a
+license naming a feature and a plan that does not are not reconcilable by
+anything. Both are real refusals and only the first is keyed on what was bought.
 
 ### Two of those cannot be sold
 

--- a/docs/src/content/docs/enterprise/licensing.md
+++ b/docs/src/content/docs/enterprise/licensing.md
@@ -115,7 +115,7 @@ The features a license can name are `air_gapped`, `audit_stream`, `billing`, `co
 <!-- entitlement-names:end -->
 
 <!-- entitlement-count:start -->
-Of the 12 features a license can carry, **3 are refused when the license does not name them**. The rest are listed here anyway, with what actually happens without each one, because a feature that is sold and never checked is worth knowing about and the number is only useful if it can come back unflattering.
+Of the 12 features a license can carry, **5 are refused when the license does not name them**, 3 by the engine and 2 by the control plane. The rest are listed here anyway, with what actually happens without each one, because a feature that is sold and never checked is worth knowing about and the number is only useful if it can come back unflattering.
 <!-- entitlement-count:end -->
 
 The table is generated from `ee/engine/feature/catalogue.go`, which is the one
@@ -131,15 +131,15 @@ gap worth publishing, and this page is where it gets published.
 | --- | --- | --- |
 | `air_gapped` | An installation that reaches nothing outside the operator's own network. | Nothing changes, because the capability is not built yet. |
 | `audit_stream` | Privileged actions forwarded to the organization's own SIEM. | Nothing changes, because the capability is not built yet. |
-| `billing` | Subscriptions, invoices and the plan an organization is on. | Nothing changes. It is implemented and deliberately available to everyone. |
+| `billing` | Subscriptions, invoices and the plan an organization is on. | Nothing changes, because the capability is not built yet. |
 | `compliance_packs` | SOC 2 and ISO 27001 evidence gathered from the control plane's own records. | Withheld. `compliance/command.go:Command` asks the license, and the feature is off when the answer is no. |
-| `enterprise_dashboard` | The console: environments, masking, egress, audit and workloads. | Not refused by this name. The hosted control plane refuses the capability on the plan as a whole; a self hosted installation with no license keeps it. |
+| `enterprise_dashboard` | The console: environments, masking, egress, audit and workloads. | Nothing changes, because the capability is not built yet. |
 | `enterprise_secrets` | Declared variables resolved from Vault or a cloud secret manager. | Withheld. `secrets/source.go:Source.Available` asks the license, and the feature is off when the answer is no. |
 | `multi_runtime` | Placing an environment across several runtimes at once, by requirement and by tag. | Nothing changes, because the capability is not built yet. |
 | `policy_enforcement` | Organization policy that refuses an environment the manifest would have allowed. | Withheld. `policyenforce/policyenforce.go:Hook.Check` asks the license, and the feature is off when the answer is no. |
 | `rbac` | Roles, and a permission on every route. | Nothing changes. It is implemented and deliberately available to everyone. |
-| `scim` | Directory provisioning, so joiners and leavers arrive from the identity provider. | Nothing changes, and not because it is unbuilt. It is implemented and no binary loads it, so nobody has it, paid or not. |
-| `sso` | Single sign on against the organization's own identity provider. | Nothing changes, and not because it is unbuilt. It is implemented and no binary loads it, so nobody has it, paid or not. |
+| `scim` | Directory provisioning, so joiners and leavers arrive from the identity provider. | Withheld by the control plane. `ee/web/scim/src/routes.ts:guard` asks the license, and an unlicensed installation is answered 402 naming the feature rather than 404. |
+| `sso` | Single sign on against the organization's own identity provider. | Withheld by the control plane. `ee/web/sso/src/store.ts:connectionByHandle` asks the license, and an unlicensed installation is answered 402 naming the feature rather than 404. |
 | `support_access` | A supported way for the vendor to see what a customer sees. | Nothing changes. It is implemented and deliberately available to everyone. |
 <!-- entitlements:end -->
 

--- a/ee/engine/airgapped/airgapped.go
+++ b/ee/engine/airgapped/airgapped.go
@@ -56,8 +56,15 @@ func init() {
 	// Recorded so that a feature which is sold and never checked shows up as
 	// such. This registry held three of twelve features and air_gapped was one
 	// of the nine that were sold and enforced nowhere.
-	feature.Declare(license.FeatureAirGapped, "ee/engine/airgapped.RegisterFromEnvironment")
-	feature.Declare(license.FeatureAirGapped, "ee/engine/airgapped.Hook")
+	//
+	// SPELLED path:symbol, relative to ee/engine, because that is the one
+	// format feature.SplitSite parses and the entitlement checks in
+	// ee/engine/cmd/af open the named file and require the licence question to
+	// be in it. A dotted package qualifier reads the same to a person and is
+	// unverifiable to an instrument, which is the whole defect the catalogue
+	// exists to refuse: a site nothing can open is a claim nothing can check.
+	feature.Declare(license.FeatureAirGapped, "airgapped/airgapped.go:RegisterFromEnvironment")
+	feature.Declare(license.FeatureAirGapped, "airgapped/airgapped.go:Hook.Check")
 }
 
 const (

--- a/ee/engine/airgapped/airgapped_test.go
+++ b/ee/engine/airgapped/airgapped_test.go
@@ -241,7 +241,12 @@ func TestTheFeatureNowHasADeclaredEnforcementSite(t *testing.T) {
 	sites := feature.Sites(license.FeatureAirGapped)
 	require.NotEmpty(t, sites,
 		"air_gapped was one of nine features the licence sold and nothing enforced")
-	require.Contains(t, sites, "ee/engine/airgapped.Hook")
+	// path:symbol, relative to ee/engine, which is what feature.SplitSite
+	// parses and what the entitlement checks in ee/engine/cmd/af open. The
+	// earlier spelling was a dotted package qualifier: it reads the same to a
+	// person and names no file, so nothing could confirm it.
+	require.Contains(t, sites, "airgapped/airgapped.go:RegisterFromEnvironment")
+	require.Contains(t, sites, "airgapped/airgapped.go:Hook.Check")
 }
 
 func TestTheHookIsRegisteredSoTheEngineActuallyConsultsIt(t *testing.T) {

--- a/ee/engine/cmd/af/entitlements_test.go
+++ b/ee/engine/cmd/af/entitlements_test.go
@@ -1,0 +1,317 @@
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+
+package main_test
+
+// What the licence actually turns on, measured rather than described.
+//
+// This file is here for the same reason main_test.go is: this is the only place
+// where the enterprise edition exists as a whole. main.go imports compliance,
+// secrets and policyenforce, so their init functions have run and
+// feature.Sites is populated. In any one of those packages the registry holds
+// one entry, and in ee/engine/feature it holds none at all, so the two
+// reconciliations below can only be made from here. A version of them written
+// next to the catalogue would pass on an empty map and prove nothing, which is
+// the shape of failure this repository keeps finding in its own instruments.
+//
+// Two things are checked, and they are different questions.
+//
+// The first is agreement: the catalogue and the registry name the same sites,
+// in both directions, so neither a feature declared and left out of the
+// catalogue nor a catalogue entry claiming a declaration that was deleted can
+// pass.
+//
+// The second is BEHAVIOUR, and it is the one the lane's number comes from. For
+// every gated feature, the real entry point is called twice: once with a licence
+// that grants everything except that feature, and once with a licence that
+// grants it. The first must do less. "It compiles", "the constant is declared"
+// and "Sites is non empty" are not verification; the refusal is.
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/ee/engine/compliance"
+	"github.com/antifailure/antifailure/ee/engine/feature"
+	"github.com/antifailure/antifailure/ee/engine/license"
+	"github.com/antifailure/antifailure/ee/engine/policyenforce"
+	"github.com/antifailure/antifailure/ee/engine/secrets"
+	"github.com/antifailure/antifailure/engine/pkg/extension"
+)
+
+// withEverythingExcept grants every feature the licence sells but one.
+//
+// Deliberately not an empty licence. An empty one proves that the code path
+// needs A licence and not that it needs THIS entitlement, and the difference is
+// the whole of what a per feature gate is for: a customer who bought four
+// features and not the fifth has a valid, active, honoured licence.
+func withEverythingExcept(missing license.Feature) context.Context {
+	granted := []license.Feature{}
+	for _, f := range license.AllFeatures() {
+		if f != missing {
+			granted = append(granted, f)
+		}
+	}
+	return withFeatures(granted...)
+}
+
+func withFeatures(features ...license.Feature) context.Context {
+	v := license.NewVerifier(nil)
+	status := v.Evaluate(license.Claims{
+		ID: "l", Org: "acme", Plan: "enterprise", Features: features,
+		IssuedAt: time.Now().Add(-time.Hour), ExpiresAt: time.Now().AddDate(1, 0, 0),
+	}, license.Evaluation{Org: "acme", Now: time.Now()})
+	return feature.With(context.Background(), status)
+}
+
+func TestEveryGatedFeatureIsDeclaredWhereTheCatalogueSaysItIs(t *testing.T) {
+	for _, e := range feature.Catalogue() {
+		if e.State != feature.StateGated {
+			continue
+		}
+		sites := feature.Sites(e.Feature)
+		require.Containsf(t, sites, e.EnforcedAt,
+			"the catalogue says %s is enforced at %s and the registry holds %v. Either the "+
+				"Declare call is missing from the enterprise binary's imports, or the two "+
+				"strings have drifted.",
+			e.Feature, e.EnforcedAt, sites)
+	}
+}
+
+func TestEveryDeclaredSiteBelongsToAGatedCatalogueEntry(t *testing.T) {
+	// The reverse, and the one that catches the next lane rather than the last.
+	// A feature gated in code and absent from the catalogue is a feature the
+	// licensing page does not know is enforced, so a customer reading the page
+	// is told they get something a licence withholds. This fails until the
+	// catalogue is updated, which is the intended cost of adding a gate.
+	for _, f := range license.AllFeatures() {
+		sites := feature.Sites(f)
+		if len(sites) == 0 {
+			continue
+		}
+		entry, ok := feature.Of(f)
+		require.Truef(t, ok,
+			"%s is declared at %v and has no catalogue entry", f, sites)
+		require.Equalf(t, feature.StateGated, entry.State,
+			"%s is declared at %v and the catalogue calls it %q. A site that refuses IS a "+
+				"gate, so either the state is stale or the Declare is.",
+			f, sites, entry.State)
+		require.Containsf(t, sites, entry.EnforcedAt,
+			"%s is declared at %v and the catalogue names %s", f, sites, entry.EnforcedAt)
+	}
+}
+
+func TestNothingIsDeclaredForAFeatureNoLicenceCanCarry(t *testing.T) {
+	// A call site for a feature no licence grants is dead code that looks like
+	// enforcement, which is the mirror image of a feature nobody checks. The
+	// registry's own doc comment names both and this is the second one.
+	sellable := map[license.Feature]bool{}
+	for _, f := range license.AllFeatures() {
+		sellable[f] = true
+	}
+	for _, f := range feature.Declared() {
+		require.Truef(t, sellable[f],
+			"%s is declared as an enforcement site and no licence can grant it, so that "+
+				"check can never pass", f)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The measurement
+// ---------------------------------------------------------------------------
+
+// proof is one feature's entry point and what to look for when it runs.
+type proof struct {
+	feature license.Feature
+	// run exercises the real entry point under the given context and reports
+	// whether THE LICENSED BEHAVIOUR HAPPENED, plus one line saying what it saw.
+	//
+	// "The licensed behaviour happened" rather than "it refused", and the
+	// difference is not cosmetic: it is the bug this harness was written with.
+	// For a secret source the licensed behaviour is a store that answers, and
+	// for the compliance command it is a report. For the policy hook it is the
+	// REFUSAL: an unlicensed hook permits, because a policy nobody paid for
+	// must not start refusing environments. Written as "did it refuse", the
+	// policy row failed against correct code and the other two passed, which is
+	// a harness reporting the wrong answer twice over.
+	run func(t *testing.T, ctx context.Context) (licensed bool, what string)
+}
+
+// entryPoints is the real call for each feature that has one.
+//
+// One per gated feature and no more. A feature missing from this list is not
+// silently skipped: TestTheEntitlementIsWhatDecides requires the list and the
+// catalogue's gated set to be the same set, so adding a gate without adding a
+// proof of it fails.
+func entryPoints() []proof {
+	return []proof{
+		{
+			feature: license.FeaturePolicy,
+			run: func(t *testing.T, ctx context.Context) (bool, string) {
+				t.Helper()
+				// A policy that refuses this request outright, so the only
+				// variable between the two calls is the entitlement.
+				hook := policyenforce.NewHook(policyenforce.Policy{
+					DeniedHosts: []string{"api.stripe.com"},
+				}, nil)
+				err := hook.Check(ctx, extension.EnvironmentRequest{
+					Org: "acme", Repository: "acme/app", Branch: "main", EnvID: "af-1",
+					EgressHosts: []string{"api.stripe.com"},
+					EgressModes: map[string]string{"api.stripe.com": "sandbox"},
+				})
+				// The licensed behaviour is the refusal. A hook whose licence
+				// has lapsed permits, which is what the gate inside Check is
+				// for: an expired customer must not keep a feature they cannot
+				// turn off without a restart, and must not have their
+				// environments refused by one either.
+				if err == nil {
+					return false, "Hook.Check permitted the environment"
+				}
+				return true, "Hook.Check refused: " + firstLine(err.Error())
+			},
+		},
+		{
+			feature: license.FeatureSecrets,
+			run: func(t *testing.T, ctx context.Context) (bool, string) {
+				t.Helper()
+				source := secrets.New(reachableBackend{})
+				ok, why := source.Available(ctx)
+				if ok {
+					return true, "Source.Available reported the store usable"
+				}
+				return false, "Source.Available refused: " + firstLine(why)
+			},
+		},
+		{
+			feature: license.FeatureCompliance,
+			run: func(t *testing.T, ctx context.Context) (bool, string) {
+				t.Helper()
+				var out, errs strings.Builder
+				code := compliance.Command(ctx, []string{"soc2", "--org", "acme"},
+					compliance.Options{
+						Stdout: &out, Stderr: &errs,
+						Gather: func(context.Context, string, time.Time, time.Time) (
+							compliance.Evidence, error) {
+							return compliance.Evidence{
+								Org: "acme", From: time.Now().AddDate(-1, 0, 0), To: time.Now(),
+							}, nil
+						},
+					})
+				if code == 0 {
+					require.NotEmpty(t, out.String(),
+						"af compliance exited 0 and wrote no report")
+					return true, "af compliance produced a report"
+				}
+				require.Empty(t, out.String(),
+					"a refusal wrote a partial document to standard output")
+				return false, "af compliance exited " + itoa(code) + ": " + firstLine(errs.String())
+			},
+		},
+	}
+}
+
+func TestTheEntitlementIsWhatDecides(t *testing.T) {
+	// The number, measured. For each gated feature: with everything else
+	// granted and this one missing, the entry point must do less; with it
+	// granted, it must do the thing.
+	//
+	// Both halves matter and the second is the one an over eager gate breaks. A
+	// check written the wrong way round refuses under a valid licence, and a
+	// test that only looked at the refusal would call that a pass.
+	proofs := entryPoints()
+
+	haveProof := map[license.Feature]bool{}
+	for _, p := range proofs {
+		haveProof[p.feature] = true
+	}
+	for _, f := range feature.GatedFeatures() {
+		require.Truef(t, haveProof[f],
+			"%s is marked gated in the catalogue and this file exercises no entry point for "+
+				"it, so the claim rests on a string rather than on a refusal", f)
+	}
+	for _, p := range proofs {
+		entry, ok := feature.Of(p.feature)
+		require.Truef(t, ok, "%s is exercised here and is not in the catalogue", p.feature)
+		require.Equalf(t, feature.StateGated, entry.State,
+			"%s is exercised as a gate and the catalogue does not call it gated", p.feature)
+	}
+
+	decided := 0
+	for _, p := range proofs {
+		p := p
+		passed := t.Run(string(p.feature), func(t *testing.T) {
+			without, sawWithout := p.run(t, withEverythingExcept(p.feature))
+			require.Falsef(t, without,
+				"with a valid licence granting every feature except %s, the licensed behaviour "+
+					"still happened: %s. The entitlement is not what decides.",
+				p.feature, sawWithout)
+
+			with, sawWith := p.run(t, withFeatures(license.AllFeatures()...))
+			require.Truef(t, with,
+				"with %s granted the licensed behaviour did not happen: %s. A gate that "+
+					"refuses a customer who paid is worse than no gate, and a test that only "+
+					"looked at the refusal would call that a pass.",
+				p.feature, sawWith)
+
+			t.Logf("%s: without it, %s. With it, %s.", p.feature, sawWithout, sawWith)
+		})
+		if passed {
+			decided++
+		}
+	}
+
+	t.Logf("licensed features whose entitlement decides the behaviour: %d of %d",
+		decided, len(license.AllFeatures()))
+}
+
+func TestTheFeaturesThatRefuseNothingAreTheOnesTheCatalogueNames(t *testing.T) {
+	// The unflattering half, asserted rather than left to a reader.
+	//
+	// Nine of twelve features change nothing when they are absent. That is the
+	// finding, and pinning it here means the day one of them gains a real gate,
+	// this fails until somebody moves it in the catalogue, and the day a tenth
+	// quietly loses one, this fails too.
+	for _, e := range feature.Catalogue() {
+		if e.State == feature.StateGated {
+			continue
+		}
+		require.Emptyf(t, feature.Sites(e.Feature),
+			"the catalogue calls %s %q and something declared an enforcement site for it: %v",
+			e.Feature, e.State, feature.Sites(e.Feature))
+	}
+}
+
+// reachableBackend is a secret store that works, so the only thing that can
+// refuse a lookup is the licence.
+type reachableBackend struct{}
+
+func (reachableBackend) Describe() string { return "a test store at memory://entitlements" }
+
+func (reachableBackend) Reach(context.Context) error { return nil }
+
+func (reachableBackend) Fetch(context.Context, string) (string, bool, error) {
+	return "value", true, nil
+}
+
+func firstLine(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return strings.TrimSpace(s[:i])
+	}
+	return s
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	digits := ""
+	for n > 0 {
+		digits = string(rune('0'+n%10)) + digits
+		n /= 10
+	}
+	return digits
+}

--- a/ee/engine/cmd/af/entitlements_test.go
+++ b/ee/engine/cmd/af/entitlements_test.go
@@ -172,15 +172,24 @@ func TestEveryDeclaredSiteBelongsToAGatedCatalogueEntry(t *testing.T) {
 // string, is the wrong one, because a feature may one day have two genuinely
 // independent gates in two files and forbidding that is a guess about the
 // future. This is the third option and it forbids nothing real: two independent
-// gates both pass, because each file really does contain its own Enabled call.
-// The only thing rejected is a site naming a file that does not check this
-// feature, which is precisely the unverifiable string, rejected by the same
-// rule as everything else rather than by a count.
+// gates both pass, because each file really does contain its own check. The
+// only thing rejected is a site naming a file that does not check this feature,
+// which is precisely the unverifiable string, rejected by the same rule as
+// everything else rather than by a count.
 //
-// It rejects nothing today. All three current Declares name a file holding
-// their own literal, including compliance, whose Declare sits in pack.go and
-// names command.go. A site does not have to name the file it is declared in;
-// what is verified is the file it NAMES.
+// WHICH check is required is read from the catalogue's state and never from the
+// path, and the two are not interchangeable: a gated site must hold a
+// feature.Enabled call for this feature and resolves under ee/engine, while an
+// edition gated site must hold an edition.Permits call for the constant whose
+// VALUE is this feature's wire name and resolves under the repository root.
+// Sniffing the path instead would accept an ee/engine file for an edition gated
+// row and prove only that some licence check is in it.
+//
+// It rejects nothing today. All five current Declares name a file holding their
+// own check, including compliance, whose Declare sits in pack.go and names
+// command.go, and multi_runtime, whose Declare sits in this module and names a
+// file in the community engine. A site does not have to name the file it is
+// declared in; what is verified is the file it NAMES.
 //
 // It lives here rather than beside the catalogue for the reason everything else
 // in this file does: in ee/engine/feature the registry is empty, so the loop

--- a/ee/engine/cmd/af/entitlements_test.go
+++ b/ee/engine/cmd/af/entitlements_test.go
@@ -41,6 +41,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/antifailure/antifailure/ee/engine/airgapped"
 	"github.com/antifailure/antifailure/ee/engine/auditsink"
 	"github.com/antifailure/antifailure/ee/engine/cloudgate"
 	"github.com/antifailure/antifailure/ee/engine/compliance"
@@ -48,6 +49,7 @@ import (
 	"github.com/antifailure/antifailure/ee/engine/license"
 	"github.com/antifailure/antifailure/ee/engine/policyenforce"
 	"github.com/antifailure/antifailure/ee/engine/secrets"
+	"github.com/antifailure/antifailure/engine/pkg/airgap"
 	"github.com/antifailure/antifailure/engine/pkg/extension"
 	"github.com/antifailure/antifailure/engine/pkg/provider"
 	"github.com/antifailure/antifailure/engine/pkg/secret"
@@ -356,6 +358,63 @@ type proof struct {
 func entryPoints() []proof {
 	return []proof{
 		{
+			feature: license.FeatureAirGapped,
+			run: func(t *testing.T, ctx context.Context) (bool, string) {
+				t.Helper()
+				// THE ONE PROOF WITH A PROCESS WIDE SIDE EFFECT, and it is
+				// bracketed rather than tidied away. A licensed run SEALS this
+				// process, which is what the feature is, and airgapped's own
+				// documentation says nothing unseals it: airgap.Reset exists
+				// for tests and is the only way back. Reset runs before the
+				// call as well as after it, because a proof that inherited a
+				// seal from something earlier would report the licensed answer
+				// without the licence having decided anything.
+				//
+				// Safe in this binary because this test is sequential and
+				// every parallel test in the package is paused until the
+				// sequential ones finish, so nothing else can dial inside the
+				// window. That is a property of the package rather than of
+				// this function, so it is written down here where somebody
+				// adding t.Parallel above will meet it.
+				airgap.Reset()
+				t.Cleanup(airgap.Reset)
+
+				reg := extension.NewRegistry()
+				on, notes, err := airgapped.RegisterFromEnvironment(ctx, reg,
+					func(k string) string {
+						if k == airgapped.ModeEnv {
+							return "1"
+						}
+						return ""
+					})
+				if err != nil {
+					require.False(t, on,
+						"RegisterFromEnvironment refused and reported the installation sealed")
+					require.False(t, airgap.Sealed(),
+						"the refusal sealed the process anyway, so the failure mode is the "+
+							"one this feature exists to prevent with the licence reversed")
+					return false, "RegisterFromEnvironment refused: " + firstLine(err.Error())
+				}
+				// Not merely "no error". The observable a customer buys is the
+				// sealed process and a policy hook the engine will consult, so
+				// both are required here: a licensed run that returned cleanly
+				// and sealed nothing would pass a check written as "did it
+				// error" and would leave the installation open.
+				require.True(t, on, "RegisterFromEnvironment returned no error and reported off")
+				require.True(t, airgap.Sealed(),
+					"RegisterFromEnvironment reported the installation air gapped and the "+
+						"process is not sealed")
+				require.NotEmpty(t, notes, "the installation sealed and said nothing about it")
+				require.Error(t,
+					reg.CheckPolicy(context.Background(), extension.EnvironmentRequest{
+						Provider:    "docker",
+						EgressModes: map[string]string{"api.stripe.com": "allow"},
+					}),
+					"the hook was not added to the registry, so the engine would never consult it")
+				return true, "the process sealed and the registry refuses an outward environment"
+			},
+		},
+		{
 			feature: license.FeaturePolicy,
 			run: func(t *testing.T, ctx context.Context) (bool, string) {
 				t.Helper()
@@ -568,10 +627,10 @@ func TestTheEntitlementIsWhatDecides(t *testing.T) {
 func TestTheFeaturesThatRefuseNothingAreTheOnesTheCatalogueNames(t *testing.T) {
 	// The unflattering half, asserted rather than left to a reader.
 	//
-	// Nine of twelve features change nothing when they are absent. That is the
-	// finding, and pinning it here means the day one of them gains a real gate,
-	// this fails until somebody moves it in the catalogue, and the day a tenth
-	// quietly loses one, this fails too.
+	// Four of fourteen features change nothing when they are absent. That is
+	// the finding, and pinning it here means the day one of them gains a real
+	// gate, this fails until somebody moves it in the catalogue, and the day one
+	// of the ten quietly loses one, this fails too.
 	for _, e := range feature.Catalogue() {
 		if e.State == feature.StateGated || e.State == feature.StateEditionGated {
 			continue

--- a/ee/engine/cmd/af/entitlements_test.go
+++ b/ee/engine/cmd/af/entitlements_test.go
@@ -42,12 +42,15 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/antifailure/antifailure/ee/engine/auditsink"
+	"github.com/antifailure/antifailure/ee/engine/cloudgate"
 	"github.com/antifailure/antifailure/ee/engine/compliance"
 	"github.com/antifailure/antifailure/ee/engine/feature"
 	"github.com/antifailure/antifailure/ee/engine/license"
 	"github.com/antifailure/antifailure/ee/engine/policyenforce"
 	"github.com/antifailure/antifailure/ee/engine/secrets"
 	"github.com/antifailure/antifailure/engine/pkg/extension"
+	"github.com/antifailure/antifailure/engine/pkg/provider"
+	"github.com/antifailure/antifailure/engine/pkg/secret"
 )
 
 // withEverythingExcept grants every feature the licence sells but one.
@@ -437,6 +440,50 @@ func entryPoints() []proof {
 			},
 		},
 		{
+			feature: license.FeatureCloudDatabase,
+			run: func(t *testing.T, ctx context.Context) (bool, string) {
+				t.Helper()
+				// The wrapper is what enforces, so the proof goes through it
+				// rather than around it. cloudgate.Wrap REPLACES a registration,
+				// and a provider registered after the wrap is not covered, which
+				// that package says about itself; registering first and wrapping
+				// after is therefore the arrangement the binary uses and the one
+				// worth exercising.
+				db := openedCloudDatabase(t, ctx)
+				_, err := db.Branch(ctx, "gv_1", "env-1")
+				if err == nil {
+					return true, "the provider branched the database"
+				}
+				var refusal *cloudgate.Refusal
+				require.ErrorAsf(t, err, &refusal,
+					"Branch failed with something that is not a licensing refusal: %v. A "+
+						"provider that is merely down would look like this and must not be "+
+						"counted as a gate.", err)
+				require.Equal(t, license.FeatureCloudDatabase, refusal.Feature,
+					"the refusal names the wrong feature, so one entitlement is answering "+
+						"for another")
+				return false, "the gate refused Branch: " + refusal.Error()
+			},
+		},
+		{
+			feature: license.FeatureCloudRuntime,
+			run: func(t *testing.T, ctx context.Context) (bool, string) {
+				t.Helper()
+				rt := openedCloudRuntime(t, ctx)
+				_, err := rt.Up(ctx, provider.EnvSpec{EnvID: "env-1"})
+				if err == nil {
+					return true, "the provider brought the environment up"
+				}
+				var refusal *cloudgate.Refusal
+				require.ErrorAsf(t, err, &refusal,
+					"Up failed with something that is not a licensing refusal: %v", err)
+				require.Equal(t, license.FeatureCloudRuntime, refusal.Feature,
+					"the refusal names the wrong feature, so one entitlement is answering "+
+						"for another")
+				return false, "the gate refused Up: " + refusal.Error()
+			},
+		},
+		{
 			feature: license.FeatureCompliance,
 			run: func(t *testing.T, ctx context.Context) (bool, string) {
 				t.Helper()
@@ -565,4 +612,134 @@ func itoa(n int) string {
 		n /= 10
 	}
 	return digits
+}
+
+// ---------------------------------------------------------------------------
+// The cloud provider proofs need a provider to gate, and a real one would need
+// a cloud account. These are the smallest thing cloudgate can wrap.
+//
+// Deliberately NOT shared with ee/engine/cloudgate's own fakes, which are
+// unexported and belong to that package's tests. A test that reached into
+// another package's fixtures would couple the proof to the shape of the code it
+// is meant to be independent evidence about.
+
+type gateFakeDatabase struct{}
+
+func (gateFakeDatabase) Name() string                { return "aurora" }
+func (gateFakeDatabase) Capabilities() provider.Caps { return provider.Caps{Branching: true} }
+
+func (gateFakeDatabase) RefreshGolden(
+	context.Context, provider.GoldenSpec,
+) (provider.GoldenVersion, error) {
+	return provider.GoldenVersion{ID: "gv_1", Verified: true}, nil
+}
+
+func (gateFakeDatabase) ListGoldens(context.Context) ([]provider.GoldenVersion, error) {
+	return []provider.GoldenVersion{{ID: "gv_1", Verified: true}}, nil
+}
+
+func (gateFakeDatabase) DestroyGolden(context.Context, string) error { return nil }
+
+func (gateFakeDatabase) Branch(_ context.Context, version, envID string) (provider.Branch, error) {
+	return provider.Branch{EnvID: envID, From: version}, nil
+}
+
+func (gateFakeDatabase) Reset(context.Context, provider.Branch) error   { return nil }
+func (gateFakeDatabase) Destroy(context.Context, provider.Branch) error { return nil }
+
+func (gateFakeDatabase) ConnString(
+	context.Context, provider.Branch, provider.ConnMode,
+) (secret.Value, error) {
+	return secret.New("postgres://example"), nil
+}
+
+func (gateFakeDatabase) Inventory(context.Context) ([]provider.Resource, error) {
+	return []provider.Resource{{ID: "cluster-1"}}, nil
+}
+
+func (gateFakeDatabase) Health(context.Context, provider.Branch) (provider.Health, error) {
+	return provider.Health{}, nil
+}
+
+func (gateFakeDatabase) Close() error { return nil }
+
+type gateFakeDatabaseProvider struct{}
+
+func (gateFakeDatabaseProvider) Name() string { return "aurora" }
+
+func (gateFakeDatabaseProvider) Open(
+	context.Context, extension.DatabaseConfig,
+) (provider.Database, error) {
+	return gateFakeDatabase{}, nil
+}
+
+type gateFakeRuntime struct{}
+
+func (gateFakeRuntime) Name() string { return "ecs" }
+
+func (gateFakeRuntime) Capabilities() provider.RuntimeCaps {
+	return provider.RuntimeCaps{Logs: true}
+}
+
+func (gateFakeRuntime) Up(context.Context, provider.EnvSpec) (provider.Env, error) {
+	return provider.Env{EnvID: "env-1"}, nil
+}
+
+func (gateFakeRuntime) Down(context.Context, string) (provider.Teardown, error) {
+	return provider.Teardown{}, nil
+}
+
+func (gateFakeRuntime) Status(context.Context, string) (provider.Env, error) {
+	return provider.Env{EnvID: "env-1"}, nil
+}
+
+func (gateFakeRuntime) Inventory(context.Context) ([]provider.Resource, error) {
+	return []provider.Resource{{ID: "service-1"}}, nil
+}
+
+func (gateFakeRuntime) Close() error { return nil }
+
+type gateFakeRuntimeProvider struct{}
+
+func (gateFakeRuntimeProvider) Name() string { return "ecs" }
+
+func (gateFakeRuntimeProvider) Open(
+	context.Context, extension.RuntimeConfig,
+) (provider.Runtime, error) {
+	return gateFakeRuntime{}, nil
+}
+
+// openedCloudDatabase is a gated database, opened through the wrapper.
+//
+// Wrap is asserted to have wrapped exactly one, because a Wrap that found
+// nothing returns zero and every assertion afterwards would then be made about
+// an UNGATED provider, which permits everything and would read as "the licence
+// decided" in the granted direction and as a broken gate in the other.
+func openedCloudDatabase(t *testing.T, ctx context.Context) provider.Database {
+	t.Helper()
+	reg := extension.NewRegistry()
+	reg.AddDatabaseProvider(gateFakeDatabaseProvider{})
+	require.Equal(t, 1, cloudgate.Wrap(reg),
+		"cloudgate wrapped no provider, so what follows would be testing an ungated one")
+	p, ok := reg.DatabaseProviderNamed("aurora")
+	require.True(t, ok, "wrapping removed the provider instead of replacing it")
+	db, err := p.Open(ctx, extension.DatabaseConfig{})
+	require.NoError(t, err)
+	require.NotNil(t, db)
+	return db
+}
+
+// openedCloudRuntime is openedCloudDatabase for the runtime half.
+func openedCloudRuntime(t *testing.T, ctx context.Context) provider.Runtime {
+	t.Helper()
+	reg := extension.NewRegistry()
+	reg.AddRuntimeProvider(gateFakeRuntimeProvider{})
+	require.Equal(t, 1, cloudgate.Wrap(reg),
+		"cloudgate wrapped no provider, so what follows would be testing an ungated one")
+	p, ok := reg.RuntimeProviderNamed("ecs")
+	require.True(t, ok, "wrapping removed the provider instead of replacing it")
+	rt, err := p.Open(ctx, extension.RuntimeConfig{})
+	require.NoError(t, err)
+	require.NotNil(t, rt)
+	return rt
 }

--- a/ee/engine/cmd/af/entitlements_test.go
+++ b/ee/engine/cmd/af/entitlements_test.go
@@ -28,16 +28,20 @@ package main_test
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/antifailure/antifailure/ee/engine/auditsink"
 	"github.com/antifailure/antifailure/ee/engine/compliance"
 	"github.com/antifailure/antifailure/ee/engine/feature"
 	"github.com/antifailure/antifailure/ee/engine/license"
@@ -110,6 +114,24 @@ func TestEveryGatedFeatureIsDeclaredWhereTheCatalogueSaysItIs(t *testing.T) {
 	}
 }
 
+func TestTheAuditSiteIsTheOneAuditsinkDeclares(t *testing.T) {
+	// The import that would have made this impossible to get wrong is a cycle:
+	// auditsink asks feature for the licence, so feature cannot import
+	// auditsink to reuse its constant. This binary links both, so it is the
+	// only place the two strings can be compared at all.
+	//
+	// Not a duplicate of the site checks below. Those prove the catalogue's
+	// string names a real file and a real symbol that really asks about this
+	// feature; a string can satisfy every one of them and still not be the
+	// string the enforcing package publishes as its own site.
+	entry, ok := feature.Of(license.FeatureAuditStream)
+	require.True(t, ok, "audit_stream has no catalogue entry")
+	require.Equal(t, auditsink.AuditStreamSite, entry.EnforcedAt,
+		"the catalogue names a different audit site from the one auditsink declares. The "+
+			"constant exists so these cannot drift and the import that would enforce it is a "+
+			"cycle, so this assertion is what stands in for it.")
+}
+
 func TestEveryDeclaredSiteBelongsToAGatedCatalogueEntry(t *testing.T) {
 	// The reverse, and the one that catches the next lane rather than the last.
 	// A feature gated in code and absent from the catalogue is a feature the
@@ -124,9 +146,13 @@ func TestEveryDeclaredSiteBelongsToAGatedCatalogueEntry(t *testing.T) {
 		entry, ok := feature.Of(f)
 		require.Truef(t, ok,
 			"%s is declared at %v and has no catalogue entry", f, sites)
-		require.Equalf(t, feature.StateGated, entry.State,
+		require.Containsf(t,
+			[]feature.State{feature.StateGated, feature.StateEditionGated}, entry.State,
 			"%s is declared at %v and the catalogue calls it %q. A site that refuses IS a "+
-				"gate, so either the state is stale or the Declare is.",
+				"gate, so either the state is stale or the Declare is. The two accepted "+
+				"states are the two kinds of ENGINE side refusal: this module asking "+
+				"feature.Enabled, and the community engine asking edition.Permits with the "+
+				"licence crossing the boundary as strings.",
 			f, sites, entry.State)
 		require.Containsf(t, sites, entry.EnforcedAt,
 			"%s is declared at %v and the catalogue names %s", f, sites, entry.EnforcedAt)
@@ -170,7 +196,19 @@ func TestEveryRegisteredSiteNamesAFileThatChecksThatFeature(t *testing.T) {
 			require.Truef(t, ok,
 				"%s is declared at %q, which is not path:symbol", f, site)
 
-			source, err := os.ReadFile(filepath.Join(root, file))
+			// Which root the site resolves against, and which call has to be in
+			// it, are decided by the catalogue's STATE rather than by the shape
+			// of the path. A check that sniffed the path would accept an
+			// ee/engine file for an edition gated entry and never notice that
+			// the mechanism it claims is not the mechanism it has.
+			entry, ok := feature.Of(f)
+			require.Truef(t, ok, "%s is declared at %s and has no catalogue entry", f, site)
+			base := root
+			if entry.State == feature.StateEditionGated {
+				base = repoRoot(t)
+			}
+
+			source, err := os.ReadFile(filepath.Join(base, file))
 			require.NoErrorf(t, err,
 				"%s is declared at %s and that file cannot be read", f, site)
 
@@ -178,6 +216,19 @@ func TestEveryRegisteredSiteNamesAFileThatChecksThatFeature(t *testing.T) {
 				regexp.MustCompile(`func (\([^)]*\) )?`+regexp.QuoteMeta(symbol)+`\(`),
 				string(source),
 				"%s is declared at %s and %s does not DEFINE %s", f, site, file, symbol)
+
+			if entry.State == feature.StateEditionGated {
+				ec := editionConstants(t, repoRoot(t))[f]
+				require.NotEmptyf(t, ec, "no constant in edition.go has the value %q", f)
+				require.Containsf(t, string(source),
+					"edition.Permits(ctx, edition."+ec+")",
+					"%s is edition gated at %s and %s contains no "+
+						"edition.Permits(ctx, edition.%s) call, so that site is a string "+
+						"nothing can verify",
+					f, site, file, ec)
+				checked++
+				continue
+			}
 
 			constant := constants[f]
 			require.NotEmptyf(t, constant, "no constant in license.go has the value %q", f)
@@ -219,6 +270,32 @@ func featureConstants(t *testing.T, root string) map[license.Feature]string {
 		out[license.Feature(m[2])] = m[1]
 	}
 	require.NotEmpty(t, out, "license.go declares no feature constants, so the parse is wrong")
+	return out
+}
+
+// repoRoot is the tree above ee/, for the sites that are not in this module.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	return filepath.Dir(filepath.Dir(eeEngineRoot(t)))
+}
+
+// editionConstants is featureConstants for the COMMUNITY engine's own list.
+//
+// A second reader of a second source of truth, and the two lists are separate
+// on purpose: engine/pkg/edition cannot import ee/engine/license, which is the
+// whole reason the licence crosses the boundary as strings. So the wire name is
+// the only thing they share, and this is what checks that the string an
+// edition gated site tests is the one this feature actually is.
+func editionConstants(t *testing.T, root string) map[license.Feature]string {
+	t.Helper()
+	source, err := os.ReadFile(filepath.Join(root, "engine", "pkg", "edition", "edition.go"))
+	require.NoError(t, err)
+	out := map[license.Feature]string{}
+	for _, m := range regexp.MustCompile(`(Feature\w+)\s+=\s+"([a-z_]+)"`).
+		FindAllStringSubmatch(string(source), -1) {
+		out[license.Feature(m[2])] = m[1]
+	}
+	require.NotEmpty(t, out, "edition.go declares no feature constants, so the parse is wrong")
 	return out
 }
 
@@ -301,6 +378,53 @@ func entryPoints() []proof {
 					return true, "Source.Available reported the store usable"
 				}
 				return false, "Source.Available refused: " + firstLine(why)
+			},
+		},
+		{
+			feature: license.FeatureAuditStream,
+			run: func(t *testing.T, ctx context.Context) (bool, string) {
+				t.Helper()
+				// DELIVERY, not an opinion about delivery. auditsink exports
+				// Unlicensed(), which would have been one line here and would
+				// have proved only that the package agrees with itself. What a
+				// customer buys is that the entry ARRIVES, so the proof is a
+				// real sink posting to a real listener and the observable is
+				// whether anything showed up.
+				var got int32
+				// TLS, because the sink refuses a plaintext URL outright:
+				// the body IS the audit record, and posting it over http is
+				// the thing the record exists to prove is not happening. The
+				// test server's own client trusts its certificate.
+				srv := httptest.NewTLSServer(http.HandlerFunc(
+					func(w http.ResponseWriter, r *http.Request) {
+						atomic.AddInt32(&got, 1)
+						w.WriteHeader(http.StatusOK)
+					}))
+				defer srv.Close()
+
+				sink, err := auditsink.NewWebhook(auditsink.WebhookConfig{
+					URL: srv.URL,
+					// Required, and required for a reason worth keeping: an
+					// entry that cannot be delivered and leaves nothing behind
+					// is an audit stream with an invisible hole in it.
+					DeadLetterFile: filepath.Join(t.TempDir(), "dead.jsonl"),
+					Client:         srv.Client(),
+				})
+				require.NoError(t, err, "the webhook sink could not be built")
+
+				err = sink.Write(ctx, extension.AuditEntry{
+					Action:     "environment.created",
+					OccurredAt: time.Now(),
+				})
+				// Not an error either way: an unlicensed sink accepts the entry
+				// and forwards nothing, which auditsink argues for deliberately
+				// so an expired licence does not read as a broken deployment.
+				require.NoError(t, err, "the sink returned an error rather than declining")
+
+				if atomic.LoadInt32(&got) > 0 {
+					return true, "the webhook sink delivered the entry"
+				}
+				return false, "the webhook sink accepted the entry and forwarded nothing"
 			},
 		},
 		{
@@ -393,7 +517,7 @@ func TestTheFeaturesThatRefuseNothingAreTheOnesTheCatalogueNames(t *testing.T) {
 	// this fails until somebody moves it in the catalogue, and the day a tenth
 	// quietly loses one, this fails too.
 	for _, e := range feature.Catalogue() {
-		if e.State == feature.StateGated {
+		if e.State == feature.StateGated || e.State == feature.StateEditionGated {
 			continue
 		}
 		require.Emptyf(t, feature.Sites(e.Feature),

--- a/ee/engine/cmd/af/entitlements_test.go
+++ b/ee/engine/cmd/af/entitlements_test.go
@@ -28,6 +28,10 @@ package main_test
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -68,6 +72,31 @@ func withFeatures(features ...license.Feature) context.Context {
 }
 
 func TestEveryGatedFeatureIsDeclaredWhereTheCatalogueSaysItIs(t *testing.T) {
+	// WHAT THIS DOES NOT CHECK, said out loud because I advised somebody
+	// wrongly about it and L7.1 corrected me from the source.
+	//
+	// Contains, not Equals, so a feature may register more sites than the
+	// catalogue names. Only the catalogue's own EnforcedAt is ever opened and
+	// verified; a second or third registered site is recorded and unchecked,
+	// whatever it is spelled like. I had suggested that respelling extra sites
+	// in path:symbol form would bring them under the instrument. It does not:
+	// the file check iterates feature.Catalogue() and never reads Sites().
+	//
+	// Nor can it be fixed by simply extending the check to every registered
+	// site, which is the interesting part. Where several surfaces share ONE
+	// gate function, only the file holding that function contains the Enabled
+	// literal, so validating the others the same way would reject correct code
+	// and the only way to keep them would be to weaken the literal check to a
+	// bare name match. That is the compliance_packs defect this format exists
+	// to kill, so the resolution is one canonical site per feature rather than
+	// a looser instrument. A fact like "there are three sinks" belongs
+	// somewhere that answers "what can this forward to", not in a registry
+	// whose question is "where is this gated".
+	//
+	// The residue is a real and accepted hole: an extra registered site is a
+	// string nothing verifies. Contains stays because a feature may one day
+	// have two genuinely independent gates in two files, and forbidding that
+	// outright would be a guess about the future rather than a check.
 	for _, e := range feature.Catalogue() {
 		if e.State != feature.StateGated {
 			continue
@@ -102,6 +131,95 @@ func TestEveryDeclaredSiteBelongsToAGatedCatalogueEntry(t *testing.T) {
 		require.Containsf(t, sites, entry.EnforcedAt,
 			"%s is declared at %v and the catalogue names %s", f, sites, entry.EnforcedAt)
 	}
+}
+
+// TestEveryRegisteredSiteNamesAFileThatChecksThatFeature verifies EVERY site in
+// the registry, not only the one the catalogue names.
+//
+// Contributed by L7.1, and it is a better answer than the two I was choosing
+// between. The catalogue check opens e.EnforcedAt alone, so a second or third
+// registered site was a string nothing verified, and I had wrongly suggested
+// that respelling such a site in path:symbol form would bring it under the
+// instrument. It would not: nothing read it.
+//
+// The obvious fix, requiring the registry to hold EXACTLY the catalogue's
+// string, is the wrong one, because a feature may one day have two genuinely
+// independent gates in two files and forbidding that is a guess about the
+// future. This is the third option and it forbids nothing real: two independent
+// gates both pass, because each file really does contain its own Enabled call.
+// The only thing rejected is a site naming a file that does not check this
+// feature, which is precisely the unverifiable string, rejected by the same
+// rule as everything else rather than by a count.
+//
+// It rejects nothing today. All three current Declares name a file holding
+// their own literal, including compliance, whose Declare sits in pack.go and
+// names command.go. A site does not have to name the file it is declared in;
+// what is verified is the file it NAMES.
+//
+// It lives here rather than beside the catalogue for the reason everything else
+// in this file does: in ee/engine/feature the registry is empty, so the loop
+// would run zero times and report success about a check it never made.
+func TestEveryRegisteredSiteNamesAFileThatChecksThatFeature(t *testing.T) {
+	root := eeEngineRoot(t)
+	constants := featureConstants(t, root)
+
+	checked := 0
+	for _, f := range license.AllFeatures() {
+		for _, site := range feature.Sites(f) {
+			file, symbol, ok := feature.SplitSite(site)
+			require.Truef(t, ok,
+				"%s is declared at %q, which is not path:symbol", f, site)
+
+			source, err := os.ReadFile(filepath.Join(root, file))
+			require.NoErrorf(t, err,
+				"%s is declared at %s and that file cannot be read", f, site)
+
+			require.Regexpf(t,
+				regexp.MustCompile(`func (\([^)]*\) )?`+regexp.QuoteMeta(symbol)+`\(`),
+				string(source),
+				"%s is declared at %s and %s does not DEFINE %s", f, site, file, symbol)
+
+			constant := constants[f]
+			require.NotEmptyf(t, constant, "no constant in license.go has the value %q", f)
+			require.Containsf(t, string(source),
+				"feature.Enabled(ctx, license."+constant+")",
+				"%s is declared at %s and %s contains no feature.Enabled(ctx, license.%s) "+
+					"call, so that site is a string nothing can verify",
+				f, site, file, constant)
+			checked++
+		}
+	}
+
+	require.NotZerof(t, checked,
+		"no enforcement site is registered at all, so this checked nothing. Either every "+
+			"Declare has been removed or this binary no longer imports the packages holding them")
+	t.Logf("registered enforcement sites verified: %d", checked)
+}
+
+// eeEngineRoot is the ee/engine directory, from this test's own source path.
+func eeEngineRoot(t *testing.T) string {
+	t.Helper()
+	_, self, _, ok := runtime.Caller(0)
+	require.True(t, ok, "the test cannot locate its own source")
+	return filepath.Dir(filepath.Dir(filepath.Dir(self)))
+}
+
+// featureConstants maps each wire name to its Go constant, read from license.go.
+//
+// A second READER of one source of truth rather than a second list. The
+// catalogue's own check parses the same file for the same mapping; two readers
+// of one file cannot disagree about it, and a hardcoded table here could.
+func featureConstants(t *testing.T, root string) map[license.Feature]string {
+	t.Helper()
+	source, err := os.ReadFile(filepath.Join(root, "license", "license.go"))
+	require.NoError(t, err)
+	out := map[license.Feature]string{}
+	for _, m := range regexp.MustCompile(`(Feature\w+)\s+Feature\s+=\s+"([a-z_]+)"`).
+		FindAllStringSubmatch(string(source), -1) {
+		out[license.Feature(m[2])] = m[1]
+	}
+	require.NotEmpty(t, out, "license.go declares no feature constants, so the parse is wrong")
+	return out
 }
 
 func TestNothingIsDeclaredForAFeatureNoLicenceCanCarry(t *testing.T) {

--- a/ee/engine/cmd/af/placement.go
+++ b/ee/engine/cmd/af/placement.go
@@ -30,6 +30,12 @@ import (
 )
 
 func init() {
+	// path:symbol, the same form every other declaration uses, because the
+	// registry checks and the licence catalogue both parse this field and a
+	// sentence with a comma in it is readable by neither. That the gate is
+	// edition.Permits rather than feature.Enabled is explained in the
+	// catalogue's entry for this feature, which is where an explanation belongs
+	// and where a reader looking for one will be.
 	feature.Declare(license.FeatureMultiRuntime,
-		"engine/internal/env.(*Orchestrator).placement, gated through edition.Permits")
+		"engine/internal/env/env.go:Orchestrator.placement")
 }

--- a/ee/engine/compliance/pack.go
+++ b/ee/engine/compliance/pack.go
@@ -47,7 +47,17 @@ import (
 func init() {
 	// Recorded so that a feature which is sold and never checked shows up as
 	// such. See ee/engine/feature.
-	feature.Declare(license.FeatureCompliance, "ee/engine/compliance.Pack.Evaluate")
+	//
+	// It names command.go rather than anything in this file, and that is the
+	// correction rather than a quirk. This site used to read
+	// "ee/engine/compliance.Pack.Evaluate", which is not where the licence is
+	// checked and could not be: Evaluate takes an Evidence and no context, so
+	// it has nothing to ask. The declaration was true about the package and
+	// wrong about the call, and nothing could tell, because the string was only
+	// ever compared against itself. The catalogue's form is path:symbol and the
+	// test opens that file and requires a feature.Enabled naming this feature
+	// in it, which is what turned a comfortable name into a checkable claim.
+	feature.Declare(license.FeatureCompliance, "compliance/command.go:Command")
 }
 
 // State is what the evidence showed about one control.

--- a/ee/engine/feature/catalogue.go
+++ b/ee/engine/feature/catalogue.go
@@ -4,6 +4,7 @@ package feature
 
 import (
 	"sort"
+	"strings"
 
 	"github.com/antifailure/antifailure/ee/engine/license"
 )
@@ -80,6 +81,27 @@ const (
 	// refuse. Because says what is actually there, which is usually a schema,
 	// a socket or a pure function with no caller.
 	StateAbsent State = "absent"
+
+	// StateUnmounted is built, complete, tested, and loaded by no binary. So
+	// nobody gets it, whether they paid for it or not.
+	//
+	// ADDED AFTER THIS CATALOGUE WAS WRONG, and the mistake is worth keeping
+	// rather than tidying away, because it is the same mistake in a new place.
+	// sso, scim and rbac sat in the absent column on the evidence that nothing
+	// under web/apps/api/src reads the SSO tables, which is TRUE and is a
+	// statement about one directory. ee/web holds four complete TypeScript
+	// packages, sso with SAML and OIDC, scim, rbac and audit, and I never
+	// looked there. The registry could not have seen them either, correctly:
+	// they do not run in the engine process and no licence key is present in
+	// one. So the measurement was right and its SCOPE was wrong, which is the
+	// failure this file exists to catch, committed by this file.
+	//
+	// It is a separate state from absent because the two say different things
+	// to a buyer and to whoever fixes it. Absent is a feature to build.
+	// Unmounted is a feature already paid for that needs one import, and it is
+	// the worse of the two: absent looks unfinished from every direction, while
+	// unmounted looks finished from every direction except the running process.
+	StateUnmounted State = "unmounted"
 )
 
 // Entitlement is one licensed feature and what this product does about it.
@@ -146,12 +168,16 @@ var catalogue = []Entitlement{
 		Summary:        "Privileged actions forwarded to the organization's own SIEM.",
 		ControlPlaneAt: "",
 		State:          StateAbsent,
-		Because: "extension.AuditSink and Registry.Audit exist in the community engine and NOTHING " +
-			"registers a sink or calls Audit outside extension_test.go. The socket was built and " +
-			"nothing was ever plugged into it, which is the gap ee/engine/cmd/af/main.go warns " +
-			"about in its own header. L0.2 measured the same thing from the other side: nine " +
-			"sockets implementable from outside, six consulted by the engine, and AuditSink is " +
-			"one of the three that are not. Wave 7's L7.1 builds the sinks.",
+		Because: "Absent in the engine and unmounted in the control plane, which is why it is " +
+			"filed under the worse of the two. extension.AuditSink and Registry.Audit exist in " +
+			"the community engine and NOTHING registers a sink or calls Audit outside " +
+			"extension_test.go, verified by grep on this tree: two hits, both in that test. " +
+			"The socket was built and nothing was plugged into it, which is the gap " +
+			"ee/engine/cmd/af/main.go warns about in its own header, and L0.2 measured it from " +
+			"the other side as one of three sockets not consulted. ee/web/audit holds sink " +
+			"implementations for the control plane and no file under web/apps/api/src imports " +
+			"those either. L7.1 builds the engine sinks and L7.6 the entry point that would " +
+			"load the others.",
 	},
 	{
 		Feature:        license.FeatureBilling,
@@ -211,32 +237,42 @@ var catalogue = []Entitlement{
 		Summary:        "Roles, and a permission on every route.",
 		ControlPlaneAt: "permissions.ts:PERMISSIONS",
 		State:          StateFree,
-		Because: "Roles and permissions are real, are enforced on every request by orgProcedure, " +
-			"and are enforced for every organization on every plan including free. Nothing " +
-			"consults the licence, so rbac is sold and given away. Making it gated is a " +
-			"COMMERCIAL decision and not a defect to be fixed quietly: switching it on would " +
-			"refuse permission checks for organizations that have them today, which is a change " +
-			"to what people already paid for rather than a missing check.",
+		Because: "Free rather than unmounted, and it is the only feature where BOTH are true " +
+			"of different code. The roles and permissions in web/apps/api/src/permissions.ts " +
+			"are real, are enforced on every request by orgProcedure, and are enforced for " +
+			"every organization on every plan including free, so nothing consults the licence " +
+			"and rbac is sold and given away. Making that gated is a COMMERCIAL decision and " +
+			"not a defect to fix quietly: switching it on would refuse permission checks for " +
+			"organizations that have them today. Separately, ee/web/rbac adds approvals and a " +
+			"policy file on top, and nothing under web/apps/api/src imports it, so that half " +
+			"is unmounted in the sense the state above describes. The entry is free because " +
+			"what a customer gets today is the working ungated one.",
 	},
 	{
-		Feature: license.FeatureSCIM,
-		Summary: "Directory provisioning, so joiners and leavers arrive from the identity provider.",
-		State:   StateAbsent,
-		Because: "scim_tokens has existed since migration 0014 and nothing under " +
-			"web/apps/api/src reads it, so a SCIM token authenticates nothing. admin/platform.ts " +
-			"records the same finding and deliberately leaves those tokens off the credential " +
-			"list rather than showing a row that cannot be revoked from. There is no " +
-			"provisioning behaviour to refuse.",
+		Feature:        license.FeatureSCIM,
+		Summary:        "Directory provisioning, so joiners and leavers arrive from the identity provider.",
+		ControlPlaneAt: "",
+		State:          StateUnmounted,
+		Because: "ee/web/scim implements the protocol, including the filter grammar and PATCH, " +
+			"and nothing under web/apps/api/src imports it, so not one of its routes is " +
+			"served. admin/platform.ts independently records the other half: scim_tokens has " +
+			"existed since migration 0014 and nothing reads it, so a SCIM token authenticates " +
+			"nothing, which is why the operator portal deliberately leaves those tokens off " +
+			"the credential list rather than showing a row that cannot be revoked from.",
 	},
 	{
-		Feature: license.FeatureSSO,
-		Summary: "Single sign on against the organization's own identity provider.",
-		State:   StateAbsent,
-		Because: "Migration 0014 built the whole schema, and no route configures a connection and " +
-			"no sign in path consults one. writers.test.ts records it under UNWIRED as a table " +
-			"every screen reads and nothing writes: every account still signs in through GitHub " +
-			"or an email link, sso_assertions_seen and sso_break_glass_codes are equally " +
-			"untouched, and no customer can turn single sign on on. There is nothing to refuse.",
+		Feature:        license.FeatureSSO,
+		Summary:        "Single sign on against the organization's own identity provider.",
+		ControlPlaneAt: "",
+		State:          StateUnmounted,
+		Because: "ee/web/sso is a complete implementation, SAML and OIDC, domain binding, " +
+			"assertion replay protection and break glass codes, and NOTHING LOADS IT. No file " +
+			"under web/apps/api/src imports it, so its install() has no caller outside tests " +
+			"and none of its routes is ever registered. Separately, migration 0014's tables " +
+			"have no writer: writers.test.ts records sso_connections under UNWIRED, and the " +
+			"only reads anywhere are two count queries in the operator portal. So a customer " +
+			"who buys sso gets the same product as one who does not, and the reason is one " +
+			"missing import rather than any missing work. L7.6 builds the entry point.",
 	},
 	{
 		Feature:    license.FeatureSecrets,
@@ -245,15 +281,25 @@ var catalogue = []Entitlement{
 		State:      StateGated,
 	},
 	{
-		Feature: license.FeatureSupportAccess,
-		Summary: "A supported way for the vendor to see what a customer sees.",
-		State:   StateAbsent,
-		Because: "support_access has no reference outside the constant and tools/licensegen's " +
-			"copy of the name list. The nearest implemented thing is operator impersonation, " +
-			"which is an OPERATOR capability guarded by admin permissions and by an audit entry " +
-			"that has to exist before the session does, and it is not something a customer's " +
-			"licence turns on. Nothing consults this feature, so nothing changes when it is " +
-			"absent.",
+		Feature:        license.FeatureSupportAccess,
+		Summary:        "A supported way for the vendor to see what a customer sees.",
+		ControlPlaneAt: "admin/customers.ts:registerImpersonationRoutes",
+		State:          StateFree,
+		Because: "Free rather than absent, and the correction is worth recording because the " +
+			"two say different things to a buyer: absent says we did not build it, free says " +
+			"we built it and do not charge for it. This entry read absent on the reasoning " +
+			"that support_access has no reference outside the constant, which is true about " +
+			"the NAME and false about the capability. Operator impersonation is built and is " +
+			"the thing this feature names: POST /v1/admin/impersonation/start and /end, a " +
+			"reason required at the edge and by a CHECK constraint, an audit entry written " +
+			"before the session exists and structurally unable to be skipped because " +
+			"sessions.impersonation_audit_seq is NOT NULL with a foreign key into the chain, a " +
+			"copy of that entry in the CUSTOMER's own log, and a minutes long expiry enforced " +
+			"on every request. What is missing is only that nothing asks the licence first. " +
+			"Adding that ask would be the wrong direction anyway: it is guarded by an operator " +
+			"admin permission rather than by the customer's plan, and refusing support access " +
+			"to a customer whose licence has lapsed withholds help from exactly the person " +
+			"most likely to need it.",
 	},
 }
 
@@ -281,6 +327,35 @@ func Of(f license.Feature) (Entitlement, bool) {
 		}
 	}
 	return Entitlement{}, false
+}
+
+// SplitSite splits a site reference into the file it names and the symbol.
+//
+// The one definition of the format, exported so that the checks in
+// ee/engine/feature and in ee/engine/cmd/af cannot come to disagree about what
+// a site string IS while both believe they are validating it. They read
+// different things, the catalogue and the registry, and they have to read them
+// the same way.
+//
+// The symbol half may be `Command`, `Hook.Check` or `auditsink.permitted`. The
+// receiver or package qualifier is there for a human reader, who needs to know
+// WHICH Check is meant; what a scanner looks for in the file is the last
+// component, because that is what appears after `func`.
+func SplitSite(site string) (file, symbol string, ok bool) {
+	i := strings.IndexByte(site, ':')
+	if i <= 0 || i == len(site)-1 {
+		return "", "", false
+	}
+	file, qualified := site[:i], site[i+1:]
+	if j := strings.LastIndexByte(qualified, '.'); j >= 0 {
+		symbol = qualified[j+1:]
+	} else {
+		symbol = qualified
+	}
+	if symbol == "" {
+		return "", "", false
+	}
+	return file, symbol, true
 }
 
 // GatedFeatures is every feature a missing entitlement actually refuses.

--- a/ee/engine/feature/catalogue.go
+++ b/ee/engine/feature/catalogue.go
@@ -271,6 +271,32 @@ var catalogue = []Entitlement{
 			"refuses THIS, and billingRouter does neither.",
 	},
 	{
+		Feature: license.FeatureCloudDatabase,
+		Summary: "Managed cloud database providers, the ones that need an organization behind " +
+			"them rather than a developer's own card.",
+		EnforcedAt: "cloudgate/cloudgate.go:gatedDatabase.Branch",
+		State:      StateGated,
+		Because: "One site named where there are two gated methods, and the choice is the same " +
+			"one auditsink's entry makes: RefreshGolden and Branch are refused by the same " +
+			"question, so naming both would read as two independent controls. Branch is named " +
+			"because it is the one an environment cannot be created without. The gate is on " +
+			"the methods that CREATE and never on teardown or inventory, which cloudgate " +
+			"argues for and which this row repeats because it is the part a customer feels: " +
+			"a lapsed licence that stopped somebody removing an Aurora cluster would leave " +
+			"them paying for it.",
+	},
+	{
+		Feature: license.FeatureCloudRuntime,
+		Summary: "Managed cloud runtime providers, on the same rule as the databases.",
+		EnforcedAt: "cloudgate/cloudgate.go:gatedRuntime.Up",
+		State:      StateGated,
+		Because: "Up and not Down, for the reason the database row gives about teardown. The " +
+			"two cloud features are separate entries rather than one, because they are " +
+			"separate names in the licence and cloudgate proves in its own suite that one " +
+			"does not grant the other; merging them here would publish a single answer for " +
+			"two things a customer can buy independently.",
+	},
+	{
 		Feature:    license.FeatureCompliance,
 		Summary:    "SOC 2 and ISO 27001 evidence gathered from the control plane's own records.",
 		EnforcedAt: "compliance/command.go:Command",

--- a/ee/engine/feature/catalogue.go
+++ b/ee/engine/feature/catalogue.go
@@ -1,0 +1,300 @@
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+
+package feature
+
+import (
+	"sort"
+
+	"github.com/antifailure/antifailure/ee/engine/license"
+)
+
+// The one answer to what a customer is entitled to.
+//
+// There were two entitlement systems and they did not know about each other.
+// The engine has license.Feature, twelve names a signed licence may carry. The
+// control plane has organizations.plan and web/apps/api/src/entitlements.ts,
+// which is real, tested and about quotas rather than features. Nothing
+// reconciled them, so "what does this customer get" had no single answer and a
+// self hosted licence and a hosted plan could disagree in silence.
+//
+// This is that answer, and the shape is taken from two places in this
+// repository that already solved the same problem for something smaller.
+// entitlements.ts carries enforcedAt on every quota, naming the call that reads
+// it or saying null out loud, and a test walks the catalogue and refuses an
+// entry whose enforcedAt names nothing. admin/controls.ts carries enforcedBy on
+// every operator switch, in the same path:symbol form, for the same reason: a
+// bare function name proves only that SOME file declares one.
+//
+// The rule both of those state, and the one this file exists to apply to the
+// licence:
+//
+//	AN ENTITLEMENT THAT IS REPORTED AND NOT ENFORCED IS ALLOWED HERE. AN
+//	ENTITLEMENT THAT CLAIMS TO BE ENFORCED AND IS NOT IS A LIE THE TEST
+//	REFUSES TO LET SHIP.
+//
+// That is why State exists and why it has four values rather than a boolean.
+// Nine of the twelve features are not enforced, and they are not unenforced for
+// the same reason: some are not built at all, one is built and deliberately
+// free, and some are refused by the hosted control plane on the plan as a whole
+// rather than on the feature. A boolean would flatten those into one word and
+// the word would be wrong for most of them.
+//
+// WHAT A NEW FEATURE COSTS. An entry here, and the two tests are the gate. A
+// license.Feature with no entry fails TestEveryLicensedFeatureIsInTheCatalogue.
+// A Declare with no entry marked StateGated fails the reverse direction in
+// ee/engine/cmd/af. So a feature cannot be sold without somebody writing down
+// what happens when it is absent.
+
+// State is what this installation actually does about one licensed feature.
+//
+// The question each value answers is the same one: a customer whose licence
+// does NOT name this feature, what do they get.
+type State string
+
+const (
+	// StateGated is a refusal keyed on this exact feature. Something calls
+	// Enabled with this constant and does less when the answer is false.
+	// EnforcedAt names where, and a test proves the file holds that call.
+	//
+	// This is the only value that counts toward the number this file is
+	// measured by.
+	StateGated State = "gated"
+
+	// StatePlanWide is a capability the control plane does refuse, but on the
+	// plan as a whole rather than on this feature.
+	//
+	// The distinction is the whole finding. On a hosted plane, trpc.ts refuses
+	// every permission outside HOSTED_GATE_EXEMPT unless the organization is on
+	// the enterprise plan. That is a real refusal and it is one boolean, while
+	// the licence carries twelve, so a licence naming a feature and a plan that
+	// does not are not reconcilable by anything. Counting these as enforced
+	// would flatter the product: the same refusal covers a customer who bought
+	// the feature and one who did not.
+	StatePlanWide State = "plan wide"
+
+	// StateFree is implemented, available to everyone, and deliberately so.
+	// The licence sells it and nothing withholds it.
+	StateFree State = "free"
+
+	// StateAbsent is a capability that is not built, so there is nothing to
+	// refuse. Because says what is actually there, which is usually a schema,
+	// a socket or a pure function with no caller.
+	StateAbsent State = "absent"
+)
+
+// Entitlement is one licensed feature and what this product does about it.
+type Entitlement struct {
+	// Feature is the name a licence carries.
+	Feature license.Feature
+
+	// Summary is one line, in the words that go on the licensing page.
+	Summary string
+
+	// EnforcedAt is where the engine refuses, as `path/from/ee/engine:symbol`,
+	// or empty when the engine does not refuse.
+	//
+	// It is ALSO the string passed to Declare, so the registry and this
+	// catalogue cannot drift into naming two different places. The test opens
+	// this exact file and requires two things of it: the symbol, and a call to
+	// Enabled naming this exact feature. The second is what a bare name grep
+	// cannot do, and it is the one that catches a site copied from a
+	// neighbouring feature.
+	EnforcedAt string
+
+	// ControlPlaneAt is where the control plane implements or refuses this, as
+	// `path/from/web/apps/api/src:symbol`, or empty.
+	//
+	// Present for StatePlanWide and StateFree as well as StateGated, because
+	// the useful answer to "where does this live" is the same either way and
+	// State is what says whether the licence is consulted. A test in each build
+	// system opens the file and looks for the symbol, so a TypeScript rename
+	// fails the TypeScript suite rather than only the Go one that a control
+	// plane developer never runs.
+	ControlPlaneAt string
+
+	// State is what a customer without this feature gets.
+	State State
+
+	// Because is why it is not gated, required for every state but StateGated.
+	//
+	// Required, because "reported but not enforced" is a legitimate state and
+	// an undocumented one is indistinguishable from a bug. The same sentence
+	// entitlements.ts writes above notEnforcedBecause, for the same reason.
+	Because string
+}
+
+// catalogue is every licensed feature, in the order AllFeatures returns them.
+//
+// Every Because below names evidence that can be checked rather than an
+// impression. Where the evidence is a test or a file in this repository that
+// already recorded the same finding, it is cited by name, because two
+// independent statements of one gap drift and the older one is the one people
+// quote.
+var catalogue = []Entitlement{
+	{
+		Feature: license.FeatureAirGapped,
+		Summary: "An installation that reaches nothing outside the operator's own network.",
+		State:   StateAbsent,
+		Because: "air_gapped has no reference in any Go code outside the constant itself and " +
+			"tools/licensegen's copy of the name list. There is no " +
+			"offline verification path, no refusal at any call site, and nothing that would " +
+			"change if a licence named it. Wave 7's L7.2 defines it and builds the lifecycle " +
+			"test that fails on any attempted connection.",
+	},
+	{
+		Feature:        license.FeatureAuditStream,
+		Summary:        "Privileged actions forwarded to the organization's own SIEM.",
+		ControlPlaneAt: "",
+		State:          StateAbsent,
+		Because: "extension.AuditSink and Registry.Audit exist in the community engine and NOTHING " +
+			"registers a sink or calls Audit outside extension_test.go. The socket was built and " +
+			"nothing was ever plugged into it, which is the gap ee/engine/cmd/af/main.go warns " +
+			"about in its own header. L0.2 measured the same thing from the other side: nine " +
+			"sockets implementable from outside, six consulted by the engine, and AuditSink is " +
+			"one of the three that are not. Wave 7's L7.1 builds the sinks.",
+	},
+	{
+		Feature:        license.FeatureBilling,
+		Summary:        "Subscriptions, invoices and the plan an organization is on.",
+		ControlPlaneAt: "routers/billing.ts:billingRouter",
+		State:          StateFree,
+		Because: "Every organization on every installation reaches billing, and that is deliberate " +
+			"rather than an oversight. billing.manage is in HOSTED_GATE_EXEMPT, so even the " +
+			"hosted plan gate refuses it under no condition: gating the path that RESOLVES a " +
+			"refusal would leave a lapsed customer with no exit, which hosted.ts calls a legal " +
+			"exposure and not a courtesy. Nothing here consults a licence and nothing should.",
+	},
+	{
+		Feature:    license.FeatureCompliance,
+		Summary:    "SOC 2 and ISO 27001 evidence gathered from the control plane's own records.",
+		EnforcedAt: "compliance/command.go:Command",
+		State:      StateGated,
+	},
+	{
+		Feature:        license.FeatureDashboard,
+		Summary:        "The console: environments, masking, egress, audit and workloads.",
+		ControlPlaneAt: "trpc.ts:orgProcedure",
+		State:          StatePlanWide,
+		Because: "The console is the only interface this product has and a self hosted install " +
+			"with no licence at all keeps every page of it. On a hosted plane orgProcedure " +
+			"refuses environments.view, and every other permission outside HOSTED_GATE_EXEMPT, " +
+			"unless the organization is on the enterprise plan. That refusal is real and it is " +
+			"keyed on the plan, not on this feature, so a licence naming enterprise_dashboard " +
+			"changes nothing about whether the console loads.",
+	},
+	{
+		Feature:        license.FeatureMultiRuntime,
+		Summary:        "Placing an environment across several runtimes at once, by requirement and by tag.",
+		ControlPlaneAt: "routers/runtimes.ts:runtimesRouter",
+		State:          StateAbsent,
+		Because: "Three separate things have to be true before this can be gated and none of them " +
+			"is. engine/internal/scheduler implements placement completely, including " +
+			"requirements, tags, the unsatisfiable versus queued distinction and health aware " +
+			"placement, and Plan has ZERO callers outside scheduler_test.go; " +
+			"controlplane/sink.go already records that nothing emits environment.queued. It " +
+			"lives under engine/internal, which is unimportable from this module, so a licence " +
+			"check cannot be put there from here at all. And schema.Runtime carries no " +
+			"placement requirement, so no manifest can ask for one. The control plane's runtime " +
+			"registry is real and is refused on the plan when the plane is hosted, but " +
+			"routers/runtimes.ts says in its own header that it deliberately never sends a " +
+			"runtime name to the engine. Gating a pure function nobody calls would be a check " +
+			"that cannot fire.",
+	},
+	{
+		Feature:    license.FeaturePolicy,
+		Summary:    "Organization policy that refuses an environment the manifest would have allowed.",
+		EnforcedAt: "policyenforce/policyenforce.go:Hook.Check",
+		State:      StateGated,
+	},
+	{
+		Feature:        license.FeatureRBAC,
+		Summary:        "Roles, and a permission on every route.",
+		ControlPlaneAt: "permissions.ts:PERMISSIONS",
+		State:          StateFree,
+		Because: "Roles and permissions are real, are enforced on every request by orgProcedure, " +
+			"and are enforced for every organization on every plan including free. Nothing " +
+			"consults the licence, so rbac is sold and given away. Making it gated is a " +
+			"COMMERCIAL decision and not a defect to be fixed quietly: switching it on would " +
+			"refuse permission checks for organizations that have them today, which is a change " +
+			"to what people already paid for rather than a missing check.",
+	},
+	{
+		Feature: license.FeatureSCIM,
+		Summary: "Directory provisioning, so joiners and leavers arrive from the identity provider.",
+		State:   StateAbsent,
+		Because: "scim_tokens has existed since migration 0014 and nothing under " +
+			"web/apps/api/src reads it, so a SCIM token authenticates nothing. admin/platform.ts " +
+			"records the same finding and deliberately leaves those tokens off the credential " +
+			"list rather than showing a row that cannot be revoked from. There is no " +
+			"provisioning behaviour to refuse.",
+	},
+	{
+		Feature: license.FeatureSSO,
+		Summary: "Single sign on against the organization's own identity provider.",
+		State:   StateAbsent,
+		Because: "Migration 0014 built the whole schema, and no route configures a connection and " +
+			"no sign in path consults one. writers.test.ts records it under UNWIRED as a table " +
+			"every screen reads and nothing writes: every account still signs in through GitHub " +
+			"or an email link, sso_assertions_seen and sso_break_glass_codes are equally " +
+			"untouched, and no customer can turn single sign on on. There is nothing to refuse.",
+	},
+	{
+		Feature:    license.FeatureSecrets,
+		Summary:    "Declared variables resolved from Vault or a cloud secret manager.",
+		EnforcedAt: "secrets/source.go:Source.Available",
+		State:      StateGated,
+	},
+	{
+		Feature: license.FeatureSupportAccess,
+		Summary: "A supported way for the vendor to see what a customer sees.",
+		State:   StateAbsent,
+		Because: "support_access has no reference outside the constant and tools/licensegen's " +
+			"copy of the name list. The nearest implemented thing is operator impersonation, " +
+			"which is an OPERATOR capability guarded by admin permissions and by an audit entry " +
+			"that has to exist before the session does, and it is not something a customer's " +
+			"licence turns on. Nothing consults this feature, so nothing changes when it is " +
+			"absent.",
+	},
+}
+
+func init() {
+	sort.Slice(catalogue, func(i, j int) bool {
+		return catalogue[i].Feature < catalogue[j].Feature
+	})
+}
+
+// Catalogue returns every licensed feature and what this product does about it.
+//
+// A copy, because a caller that could edit this could change what an
+// installation claims about itself after the tests had passed on it.
+func Catalogue() []Entitlement {
+	out := make([]Entitlement, len(catalogue))
+	copy(out, catalogue)
+	return out
+}
+
+// Of returns the catalogue entry for one feature.
+func Of(f license.Feature) (Entitlement, bool) {
+	for _, e := range catalogue {
+		if e.Feature == f {
+			return e, true
+		}
+	}
+	return Entitlement{}, false
+}
+
+// GatedFeatures is every feature a missing entitlement actually refuses.
+//
+// The number this lane is measured by is len(GatedFeatures()) over
+// len(license.AllFeatures()), and it is deliberately the smaller of the two
+// numbers that could be reported. See StatePlanWide for the other one and why
+// it does not count.
+func GatedFeatures() []license.Feature {
+	out := []license.Feature{}
+	for _, e := range catalogue {
+		if e.State == StateGated {
+			out = append(out, e.Feature)
+		}
+	}
+	return out
+}

--- a/ee/engine/feature/catalogue.go
+++ b/ee/engine/feature/catalogue.go
@@ -12,7 +12,7 @@ import (
 // The one answer to what a customer is entitled to.
 //
 // There were two entitlement systems and they did not know about each other.
-// The engine has license.Feature, twelve names a signed licence may carry. The
+// The engine has license.Feature, fourteen names a signed licence may carry. The
 // control plane has organizations.plan and web/apps/api/src/entitlements.ts,
 // which is real, tested and about quotas rather than features. Nothing
 // reconciled them, so "what does this customer get" had no single answer and a
@@ -33,12 +33,23 @@ import (
 //	ENTITLEMENT THAT CLAIMS TO BE ENFORCED AND IS NOT IS A LIE THE TEST
 //	REFUSES TO LET SHIP.
 //
-// That is why State exists and why it has four values rather than a boolean.
-// Nine of the twelve features are not enforced, and they are not unenforced for
-// the same reason: some are not built at all, one is built and deliberately
-// free, and some are refused by the hosted control plane on the plan as a whole
-// rather than on the feature. A boolean would flatten those into one word and
-// the word would be wrong for most of them.
+// That is why State exists and why it has six values rather than a boolean.
+// Four of the fourteen features are not enforced, and they are not unenforced
+// for the same reason: two are not built at all and two are built and
+// deliberately free. The ten that ARE enforced are not enforced by one
+// mechanism either: the enterprise engine asks feature.Enabled, the community
+// engine asks edition.Permits with the licence crossing the module boundary as
+// strings, and the control plane asks in TypeScript this package cannot see. A
+// boolean would flatten all of that into one word and the word would be wrong
+// for most of them.
+
+// THE NUMBER IN THE PARAGRAPH ABOVE IS THE ONE THING HERE NOT HELD BY A CHECK,
+// which is said out loud because this file's whole subject is a sentence going
+// false with nothing able to notice. The count a customer reads is generated
+// from this catalogue by ee/engine/feature's reference test and cannot drift;
+// this one is prose, and it is a summary of the same catalogue rather than an
+// independent claim, so a reader who wants the current number should take it
+// from the generated sentence on the licensing page.
 //
 // WHAT A NEW FEATURE COSTS. An entry here, and the two tests are the gate. A
 // license.Feature with no entry fails TestEveryLicensedFeatureIsInTheCatalogue.
@@ -227,19 +238,23 @@ type Entitlement struct {
 // quote.
 var catalogue = []Entitlement{
 	{
-		Feature: license.FeatureAirGapped,
-		Summary: "An installation that reaches nothing outside the operator's own network.",
-		State:   StateAbsent,
-		Because: "The only row where the question the others turn on does not arise, and it is " +
-			"worth saying so rather than leaving the silence to be read as an oversight. " +
-			"There is no code serving ANY subject here: air_gapped has no reference in any Go " +
-			"code outside the constant itself and tools/licensegen's copy of the name list, " +
-			"no offline verification path, and no refusal at any call site. billing and " +
-			"enterprise_dashboard were classified wrongly because real code existed and " +
-			"nobody asked who it served; here there is nothing to attribute to anybody, so " +
-			"absent is the whole answer. Wave 7's L7.2 would define it and build the " +
-			"lifecycle test that fails on any attempted connection, and that is a statement " +
-			"about a lane which has NOT landed as of 88627d7f rather than about this tree.",
+		Feature:    license.FeatureAirGapped,
+		Summary:    "An installation that reaches nothing outside the operator's own network.",
+		EnforcedAt: "airgapped/airgapped.go:RegisterFromEnvironment",
+		State:      StateGated,
+		Because: "This row read absent, on a measurement that was true when it was taken and " +
+			"that named its own expiry in its own text, which is the one thing this " +
+			"catalogue had already forbidden itself: it said the lane that would build this " +
+			"had NOT landed. A reason may describe the tree and may name a sha it is true " +
+			"of, and it must not describe a future, because a forward reference is " +
+			"unverifiable when written and silently false afterwards. #312 landed " +
+			"ee/engine/airgapped, and the sentence went false with nothing able to notice, " +
+			"exactly as predicted by the rule this branch wrote down and then broke. " +
+			"RegisterFromEnvironment is the site named rather than Hook.Check, because it is " +
+			"the one that ASKS: the licence decides once, at startup, whether the process " +
+			"may seal, and an installation that asked to be air gapped without a licence for " +
+			"it does not start. The hook that refuses an environment exists only because " +
+			"that answer was yes, so it is a second declared site and not a second gate.",
 	},
 	{
 		Feature: license.FeatureAuditStream,
@@ -286,8 +301,8 @@ var catalogue = []Entitlement{
 			"them paying for it.",
 	},
 	{
-		Feature: license.FeatureCloudRuntime,
-		Summary: "Managed cloud runtime providers, on the same rule as the databases.",
+		Feature:    license.FeatureCloudRuntime,
+		Summary:    "Managed cloud runtime providers, on the same rule as the databases.",
 		EnforcedAt: "cloudgate/cloudgate.go:gatedRuntime.Up",
 		State:      StateGated,
 		Because: "Up and not Down, for the reason the database row gives about teardown. The " +
@@ -360,7 +375,10 @@ var catalogue = []Entitlement{
 			"organizations that have them today. Separately, ee/web/rbac adds approvals and a " +
 			"policy file on top, and nothing under web/apps/api/src imports it, so that half " +
 			"is unmounted in the sense the state above describes. The entry is free because " +
-			"what a customer gets today is the working ungated one.",
+			"what a customer gets today is the working ungated one. license.go's unenforced " +
+			"map records the same feature for that second half, and this row is held to it: " +
+			"a row calling rbac refused while license.go says it is gated nowhere is two " +
+			"answers to one question, which is the whole reason this file exists.",
 	},
 	{
 		Feature:        license.FeatureSCIM,

--- a/ee/engine/feature/catalogue.go
+++ b/ee/engine/feature/catalogue.go
@@ -61,17 +61,19 @@ const (
 	// measured by.
 	StateGated State = "gated"
 
-	// StatePlanWide is a capability the control plane does refuse, but on the
-	// plan as a whole rather than on this feature.
-	//
-	// The distinction is the whole finding. On a hosted plane, trpc.ts refuses
-	// every permission outside HOSTED_GATE_EXEMPT unless the organization is on
-	// the enterprise plan. That is a real refusal and it is one boolean, while
-	// the licence carries twelve, so a licence naming a feature and a plan that
-	// does not are not reconcilable by anything. Counting these as enforced
-	// would flatter the product: the same refusal covers a customer who bought
-	// the feature and one who did not.
-	StatePlanWide State = "plan wide"
+	// THERE WAS A StatePlanWide HERE AND ITS REMOVAL IS THE POINT, so the
+	// reasoning is kept rather than deleted with it. It meant "the control
+	// plane refuses this, but on the plan as a whole rather than on this
+	// feature", and enterprise_dashboard was its only member for exactly the
+	// wrong reason: somebody reached for a state meaning "refused on the plan"
+	// and put OUR OWN funnel in it. A plan wide refusal is us enforcing our own
+	// pricing tiers, not a licence granting a capability, so it does not
+	// describe anything sellable and has no business being one of the states a
+	// catalogue of sellable things can take. Leaving the slot in place would
+	// leave the same invitation for the next author, on the page that says what
+	// customers buy. The distinction it recorded is real and now lives in
+	// enterprise_dashboard's own Because, which is where a reader meets it in
+	// context instead of as an available category.
 
 	// StateFree is implemented, available to everyone, and deliberately so.
 	// The licence sells it and nothing withholds it.
@@ -102,6 +104,31 @@ const (
 	// the worse of the two: absent looks unfinished from every direction, while
 	// unmounted looks finished from every direction except the running process.
 	StateUnmounted State = "unmounted"
+
+	// StateControlPlaneGated is refused, by name, by the control plane, on a
+	// licence check written in TypeScript that this package cannot see.
+	//
+	// ADDED BECAUSE THIS CATALOGUE DESCRIBED A TWO LANGUAGE PRODUCT BY LOOKING
+	// IN ONE LANGUAGE, and that is a worse error than either of the two rows it
+	// got wrong. Enforcement here lives in Go and in TypeScript. This file
+	// measured `feature.Enabled` call sites, which only the engine has, and
+	// read a zero as "nothing refuses this". A zero in that count means NOT
+	// ENFORCED BY THE ENGINE, which is a different fact from not enforced, and
+	// collapsing the two is how sso and scim came to be published as features
+	// nobody has, paid or not, while the enterprise control plane was refusing
+	// them by name with a 402.
+	//
+	// It is separate from StateGated because the two are checked by different
+	// instruments and neither can see the other's evidence. A gated entry names
+	// an engine file and a Go test opens it and requires an Enabled call for
+	// that exact feature. A control plane gated entry names a site the
+	// TypeScript registry declared, and only the TypeScript suite can confirm
+	// it, because the declaration is made at module scope by the package that
+	// enforces it and a package nothing imports declares nothing.
+	//
+	// So the honest count is two numbers rather than one. See GatedFeatures for
+	// the engine's and ControlPlaneGatedFeatures for this one.
+	StateControlPlaneGated State = "control_plane_gated"
 )
 
 // Entitlement is one licensed feature and what this product does about it.
@@ -126,12 +153,32 @@ type Entitlement struct {
 	// ControlPlaneAt is where the control plane implements or refuses this, as
 	// `path/from/web/apps/api/src:symbol`, or empty.
 	//
-	// Present for StatePlanWide and StateFree as well as StateGated, because
+	// Present for StateFree as well as StateGated and StateControlPlaneGated,
+	// because
 	// the useful answer to "where does this live" is the same either way and
 	// State is what says whether the licence is consulted. A test in each build
 	// system opens the file and looks for the symbol, so a TypeScript rename
 	// fails the TypeScript suite rather than only the Go one that a control
 	// plane developer never runs.
+	//
+	// ONE PATH CONVENTION: from the REPOSITORY ROOT, always.
+	//
+	// It was briefly two, and the bug that produced is the reason this comment
+	// is emphatic. These paths used to be relative to web/apps/api/src, which
+	// is fine while every entry lives there, and the enterprise packages do
+	// not: a control plane gated entry has to name the site the TypeScript
+	// registry declared, byte for byte, and those are repository relative. So a
+	// second convention was introduced and DOCUMENTED HERE AND TAUGHT TO
+	// NOTHING, and both readers promptly tried to open
+	// web/apps/api/src/ee/web/scim/src/routes.ts. A comment describing a rule
+	// that no code implements is the same defect as a licensed feature nothing
+	// enforces, which is the subject of this entire file.
+	//
+	// One convention costs three longer strings and removes the branch from
+	// both readers, and there are two: the Go test in this package and
+	// web/apps/api/test/licensed-features.test.ts, which is deliberately in the
+	// other build system so a control plane developer who renames a symbol and
+	// never runs the Go suite still sees it fail.
 	ControlPlaneAt string
 
 	// State is what a customer without this feature gets.
@@ -157,11 +204,16 @@ var catalogue = []Entitlement{
 		Feature: license.FeatureAirGapped,
 		Summary: "An installation that reaches nothing outside the operator's own network.",
 		State:   StateAbsent,
-		Because: "air_gapped has no reference in any Go code outside the constant itself and " +
-			"tools/licensegen's copy of the name list. There is no " +
-			"offline verification path, no refusal at any call site, and nothing that would " +
-			"change if a licence named it. Wave 7's L7.2 defines it and builds the lifecycle " +
-			"test that fails on any attempted connection.",
+		Because: "The only row where the question the others turn on does not arise, and it is " +
+			"worth saying so rather than leaving the silence to be read as an oversight. " +
+			"There is no code serving ANY subject here: air_gapped has no reference in any Go " +
+			"code outside the constant itself and tools/licensegen's copy of the name list, " +
+			"no offline verification path, and no refusal at any call site. billing and " +
+			"enterprise_dashboard were classified wrongly because real code existed and " +
+			"nobody asked who it served; here there is nothing to attribute to anybody, so " +
+			"absent is the whole answer. Wave 7's L7.2 would define it and build the " +
+			"lifecycle test that fails on any attempted connection, and that is a statement " +
+			"about a lane which has NOT landed as of 88627d7f rather than about this tree.",
 	},
 	{
 		Feature:        license.FeatureAuditStream,
@@ -176,19 +228,27 @@ var catalogue = []Entitlement{
 			"ee/engine/cmd/af/main.go warns about in its own header, and L0.2 measured it from " +
 			"the other side as one of three sockets not consulted. ee/web/audit holds sink " +
 			"implementations for the control plane and no file under web/apps/api/src imports " +
-			"those either. L7.1 builds the engine sinks and L7.6 the entry point that would " +
-			"load the others.",
+			"those either. L7.6's entry point has since landed and mounts sso and scim only, " +
+			"which is checked above rather than assumed. L7.1 would build the engine sinks " +
+			"and has NOT landed as of 88627d7f, so this row is true of that sha and is the " +
+			"one entry in this catalogue with a known expiry: see #309.",
 	},
 	{
-		Feature:        license.FeatureBilling,
-		Summary:        "Subscriptions, invoices and the plan an organization is on.",
-		ControlPlaneAt: "routers/billing.ts:billingRouter",
-		State:          StateFree,
-		Because: "Every organization on every installation reaches billing, and that is deliberate " +
-			"rather than an oversight. billing.manage is in HOSTED_GATE_EXEMPT, so even the " +
-			"hosted plan gate refuses it under no condition: gating the path that RESOLVES a " +
-			"refusal would leave a lapsed customer with no exit, which hosted.ts calls a legal " +
-			"exposure and not a courtesy. Nothing here consults a licence and nothing should.",
+		Feature: license.FeatureBilling,
+		Summary: "Subscriptions, invoices and the plan an organization is on.",
+		State:   StateAbsent,
+		Because: "REAL CODE FOR THE WRONG SUBJECT, and this entry read free on the strength of " +
+			"it. billingRouter exists at routers/billing.ts:132 and is mounted at " +
+			"index.ts:1390, so a reader who greps for billing finds a working, ungated " +
+			"feature and concludes we built it and do not charge for it. That code bills the " +
+			"customer FOR ANTIFAILURE. The licensed feature of this name would meter, rate " +
+			"and charge on the CUSTOMER'S OWN behalf, and nothing in the engine or the " +
+			"control plane does that; there is no billing hook in engine/pkg/extension for an " +
+			"enterprise implementation to plug into either. license.go's notShipped map is " +
+			"the authority and says exactly this, which is why billing cannot be sold at all. " +
+			"ControlPlaneAt is deliberately EMPTY: naming billingRouter here is what caused " +
+			"the mistake, because that field means where the control plane implements or " +
+			"refuses THIS, and billingRouter does neither.",
 	},
 	{
 		Feature:    license.FeatureCompliance,
@@ -197,21 +257,26 @@ var catalogue = []Entitlement{
 		State:      StateGated,
 	},
 	{
-		Feature:        license.FeatureDashboard,
-		Summary:        "The console: environments, masking, egress, audit and workloads.",
-		ControlPlaneAt: "trpc.ts:orgProcedure",
-		State:          StatePlanWide,
-		Because: "The console is the only interface this product has and a self hosted install " +
-			"with no licence at all keeps every page of it. On a hosted plane orgProcedure " +
-			"refuses environments.view, and every other permission outside HOSTED_GATE_EXEMPT, " +
-			"unless the organization is on the enterprise plan. That refusal is real and it is " +
-			"keyed on the plan, not on this feature, so a licence naming enterprise_dashboard " +
-			"changes nothing about whether the console loads.",
+		Feature: license.FeatureDashboard,
+		Summary: "The console: environments, masking, egress, audit and workloads.",
+		State:   StateAbsent,
+		Because: "THE SAME MISTAKE AS billing, and it is worth having both written down " +
+			"because seeing the pair is what teaches the question. This entry read plan wide " +
+			"on the strength of orgProcedure refusing environments.view to an organization " +
+			"that is not on the enterprise plan. That refusal is real, and it is OUR OWN " +
+			"funnel enforcing OUR OWN plans, keyed on organizations.plan and not on this " +
+			"licence name, which the previous wording of this entry already admitted without " +
+			"drawing the conclusion. There is no enterprise dashboard to sell: the name " +
+			"appears in this catalogue, in licensegen's copy, in the feature name lists and " +
+			"in the documentation, and in no implementation anywhere, which is what " +
+			"notShipped records and why it cannot be sold. The Summary maps the name onto " +
+			"the console, and the console is the whole product rather than a licensed part " +
+			"of it. ControlPlaneAt is EMPTY for the reason billing's is.",
 	},
 	{
 		Feature:        license.FeatureMultiRuntime,
 		Summary:        "Placing an environment across several runtimes at once, by requirement and by tag.",
-		ControlPlaneAt: "routers/runtimes.ts:runtimesRouter",
+		ControlPlaneAt: "web/apps/api/src/routers/runtimes.ts:runtimesRouter",
 		State:          StateAbsent,
 		Because: "Three separate things have to be true before this can be gated and none of them " +
 			"is. engine/internal/scheduler implements placement completely, including " +
@@ -235,7 +300,7 @@ var catalogue = []Entitlement{
 	{
 		Feature:        license.FeatureRBAC,
 		Summary:        "Roles, and a permission on every route.",
-		ControlPlaneAt: "permissions.ts:PERMISSIONS",
+		ControlPlaneAt: "web/apps/api/src/permissions.ts:PERMISSIONS",
 		State:          StateFree,
 		Because: "Free rather than unmounted, and it is the only feature where BOTH are true " +
 			"of different code. The roles and permissions in web/apps/api/src/permissions.ts " +
@@ -251,28 +316,37 @@ var catalogue = []Entitlement{
 	{
 		Feature:        license.FeatureSCIM,
 		Summary:        "Directory provisioning, so joiners and leavers arrive from the identity provider.",
-		ControlPlaneAt: "",
-		State:          StateUnmounted,
-		Because: "ee/web/scim implements the protocol, including the filter grammar and PATCH, " +
-			"and nothing under web/apps/api/src imports it, so not one of its routes is " +
-			"served. admin/platform.ts independently records the other half: scim_tokens has " +
-			"existed since migration 0014 and nothing reads it, so a SCIM token authenticates " +
-			"nothing, which is why the operator portal deliberately leaves those tokens off " +
-			"the credential list rather than showing a row that cannot be revoked from.",
+		ControlPlaneAt: "ee/web/scim/src/routes.ts:guard",
+		State:          StateControlPlaneGated,
+		Because: "Refused by the control plane rather than by the engine, which is why the " +
+			"engine's own count of Enabled call sites reports zero for it. ee/web/scim " +
+			"implements the protocol, including the filter grammar and PATCH, its guard asks " +
+			"the licence at routes.ts:198, and ee/web/server/src/register.ts mounts it, so an " +
+			"unlicensed installation is answered 402 naming scim rather than 404. " +
+			"THIS ENTRY READ absent AND THEN unmounted, and both were measured by asking " +
+			"whether anything under web/apps/api/src reads scim_tokens. That is true and it " +
+			"is a statement about the hosted tree, not about the product: the enterprise " +
+			"control plane is a different entry point. The token half of the finding still " +
+			"stands, and admin/platform.ts records it, so the operator portal leaves those " +
+			"tokens off the credential list rather than showing a row nothing can revoke.",
 	},
 	{
 		Feature:        license.FeatureSSO,
 		Summary:        "Single sign on against the organization's own identity provider.",
-		ControlPlaneAt: "",
-		State:          StateUnmounted,
-		Because: "ee/web/sso is a complete implementation, SAML and OIDC, domain binding, " +
-			"assertion replay protection and break glass codes, and NOTHING LOADS IT. No file " +
-			"under web/apps/api/src imports it, so its install() has no caller outside tests " +
-			"and none of its routes is ever registered. Separately, migration 0014's tables " +
-			"have no writer: writers.test.ts records sso_connections under UNWIRED, and the " +
-			"only reads anywhere are two count queries in the operator portal. So a customer " +
-			"who buys sso gets the same product as one who does not, and the reason is one " +
-			"missing import rather than any missing work. L7.6 builds the entry point.",
+		ControlPlaneAt: "ee/web/sso/src/store.ts:connectionByHandle",
+		State:          StateControlPlaneGated,
+		Because: "Refused by the control plane rather than by the engine, which is why the " +
+			"engine's own count of Enabled call sites reports zero for it. ee/web/sso is a " +
+			"complete implementation, SAML and OIDC, domain binding, assertion replay " +
+			"protection and break glass codes; it asks the licence in three places, " +
+			"enforce.ts:167 and store.ts:133 and :202; and ee/web/server/src/register.ts " +
+			"mounts it, so an unlicensed installation is answered 402 naming sso. " +
+			"THIS ENTRY READ absent AND THEN unmounted, and the second was written the day " +
+			"before the entry point it said did not exist was already on main. Both readings " +
+			"came from asking what web/apps/api/src imports, which is the hosted tree and not " +
+			"the only one: the enterprise image runs ee/web/server. The schema half of the " +
+			"older finding still stands, since writers.test.ts records sso_connections under " +
+			"UNWIRED, and that is a gap in the HOSTED plane rather than in this feature.",
 	},
 	{
 		Feature:    license.FeatureSecrets,
@@ -283,7 +357,7 @@ var catalogue = []Entitlement{
 	{
 		Feature:        license.FeatureSupportAccess,
 		Summary:        "A supported way for the vendor to see what a customer sees.",
-		ControlPlaneAt: "admin/customers.ts:registerImpersonationRoutes",
+		ControlPlaneAt: "web/apps/api/src/admin/customers.ts:registerImpersonationRoutes",
 		State:          StateFree,
 		Because: "Free rather than absent, and the correction is worth recording because the " +
 			"two say different things to a buyer: absent says we did not build it, free says " +
@@ -358,12 +432,31 @@ func SplitSite(site string) (file, symbol string, ok bool) {
 	return file, symbol, true
 }
 
+// ControlPlaneGatedFeatures is every feature the CONTROL PLANE refuses by name.
+//
+// A second list rather than more entries in the first, because the two are
+// confirmed by different suites and a caller that merges them silently loses
+// which instrument is standing behind each name. GatedFeatures is what the
+// engine's own entry point test exercises twice, once with the entitlement and
+// once without; these cannot be exercised from Go at all, and the TypeScript
+// catalogue test is what holds them to the registry.
+func ControlPlaneGatedFeatures() []license.Feature {
+	out := []license.Feature{}
+	for _, e := range catalogue {
+		if e.State == StateControlPlaneGated {
+			out = append(out, e.Feature)
+		}
+	}
+	return out
+}
+
 // GatedFeatures is every feature a missing entitlement actually refuses.
 //
 // The number this lane is measured by is len(GatedFeatures()) over
 // len(license.AllFeatures()), and it is deliberately the smaller of the two
-// numbers that could be reported. See StatePlanWide for the other one and why
-// it does not count.
+// numbers that could be reported. The larger one would count a refusal made on
+// the hosted plan as a whole, which covers a customer who bought the feature
+// and one who did not identically and therefore says nothing about the licence.
 func GatedFeatures() []license.Feature {
 	out := []license.Feature{}
 	for _, e := range catalogue {

--- a/ee/engine/feature/catalogue.go
+++ b/ee/engine/feature/catalogue.go
@@ -129,6 +129,32 @@ const (
 	// So the honest count is two numbers rather than one. See GatedFeatures for
 	// the engine's and ControlPlaneGatedFeatures for this one.
 	StateControlPlaneGated State = "control_plane_gated"
+
+	// StateEditionGated is refused by the COMMUNITY engine, through
+	// edition.Permits, with the licence crossing the module boundary as
+	// strings rather than the code crossing it as packages.
+	//
+	// The sixth state exists because "not enforced by the engine" is a
+	// different fact from "not enforced". This is that sentence a third time
+	// with a different subject: not enforced by feature.Enabled IN ee/engine is
+	// a different fact from not enforced, and reading the first as the second
+	// is what would file multi_runtime as absent while
+	// engine/internal/env/env.go refuses a second placement target.
+	//
+	// It is not StateGated, and widening StateGated to swallow it would erase
+	// the distinction the sixth state was created to draw. A gated entry is
+	// confirmed by opening an ee/engine file and requiring a feature.Enabled
+	// call for that exact feature; this one is confirmed by opening an engine/
+	// file and requiring an edition.Permits call. A test that accepted either
+	// mechanism to stay green would have stopped testing both.
+	//
+	// Why the enforcement is there rather than here is ee/engine/cmd/af/
+	// placement.go's argument and it is a good one: the manifest's targets, the
+	// scheduler, the runtime constructors and every command that agrees on
+	// where an environment went would all have to move, and a second copy of
+	// that in the enterprise module would be a second answer to where an
+	// environment is.
+	StateEditionGated State = "edition_gated"
 )
 
 // Entitlement is one licensed feature and what this product does about it.
@@ -216,22 +242,16 @@ var catalogue = []Entitlement{
 			"about a lane which has NOT landed as of 88627d7f rather than about this tree.",
 	},
 	{
-		Feature:        license.FeatureAuditStream,
-		Summary:        "Privileged actions forwarded to the organization's own SIEM.",
-		ControlPlaneAt: "",
-		State:          StateAbsent,
-		Because: "Absent in the engine and unmounted in the control plane, which is why it is " +
-			"filed under the worse of the two. extension.AuditSink and Registry.Audit exist in " +
-			"the community engine and NOTHING registers a sink or calls Audit outside " +
-			"extension_test.go, verified by grep on this tree: two hits, both in that test. " +
-			"The socket was built and nothing was plugged into it, which is the gap " +
-			"ee/engine/cmd/af/main.go warns about in its own header, and L0.2 measured it from " +
-			"the other side as one of three sockets not consulted. ee/web/audit holds sink " +
-			"implementations for the control plane and no file under web/apps/api/src imports " +
-			"those either. L7.6's entry point has since landed and mounts sso and scim only, " +
-			"which is checked above rather than assumed. L7.1 would build the engine sinks " +
-			"and has NOT landed as of 88627d7f, so this row is true of that sha and is the " +
-			"one entry in this catalogue with a known expiry: see #309.",
+		Feature: license.FeatureAuditStream,
+		Summary: "Privileged actions forwarded to the organization's own SIEM.",
+		// The literal rather than auditsink.AuditStreamSite, because auditsink
+		// imports THIS package to ask the licence, so importing it back is a
+		// cycle. The constant exists precisely so the two cannot drift, and the
+		// import that would have enforced that is the one the dependency
+		// forbids, so a test in ee/engine/cmd/af asserts they are equal from a
+		// binary that links both. See TestTheAuditSiteIsTheOneAuditsinkDeclares.
+		EnforcedAt: "auditsink/auditsink.go:auditsink.permitted",
+		State:      StateGated,
 	},
 	{
 		Feature: license.FeatureBilling,
@@ -274,22 +294,25 @@ var catalogue = []Entitlement{
 			"of it. ControlPlaneAt is EMPTY for the reason billing's is.",
 	},
 	{
-		Feature:        license.FeatureMultiRuntime,
-		Summary:        "Placing an environment across several runtimes at once, by requirement and by tag.",
-		ControlPlaneAt: "web/apps/api/src/routers/runtimes.ts:runtimesRouter",
-		State:          StateAbsent,
-		Because: "Three separate things have to be true before this can be gated and none of them " +
-			"is. engine/internal/scheduler implements placement completely, including " +
-			"requirements, tags, the unsatisfiable versus queued distinction and health aware " +
-			"placement, and Plan has ZERO callers outside scheduler_test.go; " +
-			"controlplane/sink.go already records that nothing emits environment.queued. It " +
-			"lives under engine/internal, which is unimportable from this module, so a licence " +
-			"check cannot be put there from here at all. And schema.Runtime carries no " +
-			"placement requirement, so no manifest can ask for one. The control plane's runtime " +
-			"registry is real and is refused on the plan when the plane is hosted, but " +
-			"routers/runtimes.ts says in its own header that it deliberately never sends a " +
-			"runtime name to the engine. Gating a pure function nobody calls would be a check " +
-			"that cannot fire.",
+		Feature:    license.FeatureMultiRuntime,
+		Summary:    "Placing an environment across several runtimes at once, by requirement and by tag.",
+		EnforcedAt: "engine/internal/env/env.go:Orchestrator.placement",
+		State:      StateEditionGated,
+		Because: "Refused by the COMMUNITY engine rather than by this module, which is why a " +
+			"count of feature.Enabled call sites in ee/engine reports zero for it. " +
+			"engine/internal/env/env.go:898 refuses a second placement target unless " +
+			"edition.Permits says otherwise, and scheduler.Plan is called from env.go:924. " +
+			"THIS ENTRY READ absent, on a measurement that was true when it was taken and " +
+			"named its own expiry: the scheduler had no caller, no manifest could express a " +
+			"placement requirement, and gating a pure function nobody calls would have been a " +
+			"check that cannot fire. All three of those changed under it. The licence crosses " +
+			"the module boundary as strings and the engine reads them, rather than the code " +
+			"crossing as packages, and ee/engine/cmd/af/placement.go argues for that " +
+			"arrangement: moving the manifest's targets, the scheduler and the runtime " +
+			"constructors into this module would be a second answer to where an environment " +
+			"is. The control plane's runtime registry is a different subject again, real and " +
+			"refused on the hosted plan, and routers/runtimes.ts deliberately never sends a " +
+			"runtime name to the engine.",
 	},
 	{
 		Feature:    license.FeaturePolicy,
@@ -444,6 +467,21 @@ func ControlPlaneGatedFeatures() []license.Feature {
 	out := []license.Feature{}
 	for _, e := range catalogue {
 		if e.State == StateControlPlaneGated {
+			out = append(out, e.Feature)
+		}
+	}
+	return out
+}
+
+// EditionGatedFeatures is every feature the COMMUNITY engine refuses by name.
+//
+// A third list for the reason there is a second: the three are confirmed by
+// three different instruments, and a caller that merged them would lose which
+// one is standing behind each name.
+func EditionGatedFeatures() []license.Feature {
+	out := []license.Feature{}
+	for _, e := range catalogue {
+		if e.State == StateEditionGated {
 			out = append(out, e.Feature)
 		}
 	}

--- a/ee/engine/feature/catalogue_test.go
+++ b/ee/engine/feature/catalogue_test.go
@@ -1,0 +1,268 @@
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+
+package feature_test
+
+// The instrument for the catalogue, and the only reason the catalogue is worth
+// having.
+//
+// A list of features with a note beside each saying where it is enforced is a
+// comment. What makes it a control is that something opens the file the note
+// names and refuses to pass when the claim is not true there. entitlements.ts
+// says the same thing about its own catalogue and its test does the same thing,
+// and admin/controls.ts says it a third time about operator switches. This is
+// that pattern applied to the twelve names a licence can carry.
+//
+// Three claims are checked here and a fourth in ee/engine/cmd/af, which is the
+// only place where every enterprise package's init has run and the registry is
+// therefore populated. That split is not tidiness. A test in this package
+// cannot import compliance, secrets or policyenforce without an import cycle,
+// so the registry is empty here by construction and a check written here would
+// silently pass on nothing.
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/ee/engine/feature"
+	"github.com/antifailure/antifailure/ee/engine/license"
+)
+
+// eeEngine is the ee/engine directory, and repoRoot the repository root.
+//
+// From the test's own path rather than from the working directory, which for a
+// Go test is the package directory and would break the moment this file moved.
+func eeEngine(t *testing.T) string {
+	t.Helper()
+	_, self, _, ok := runtime.Caller(0)
+	require.True(t, ok, "the test cannot locate its own source")
+	return filepath.Dir(filepath.Dir(self))
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	return filepath.Dir(filepath.Dir(eeEngine(t)))
+}
+
+// symbolName is the last component of a path:symbol reference's symbol half.
+//
+// Hook.Check is written whole because a reader needs the receiver to know which
+// Check is meant, and the grep needs the method name on its own because that is
+// what appears in the source.
+func symbolName(reference string) (file, symbol string, ok bool) {
+	parts := strings.SplitN(reference, ":", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	dotted := strings.Split(parts[1], ".")
+	return parts[0], dotted[len(dotted)-1], true
+}
+
+func TestEveryLicensedFeatureIsInTheCatalogue(t *testing.T) {
+	t.Parallel()
+	// The direction that catches a feature added to the licence and to nothing
+	// else, which is how air_gapped came to be a word with no meaning: it was
+	// added to the const block, to two documentation pages and to licensegen,
+	// and nothing anywhere asks whether it is on.
+	inCatalogue := map[license.Feature]bool{}
+	for _, e := range feature.Catalogue() {
+		require.False(t, inCatalogue[e.Feature],
+			"%s appears twice in the catalogue", e.Feature)
+		inCatalogue[e.Feature] = true
+	}
+
+	for _, f := range license.AllFeatures() {
+		require.Truef(t, inCatalogue[f],
+			"the licence sells %s and the entitlement catalogue does not mention it, so "+
+				"nobody has written down what a customer without it gets. Add an entry to "+
+				"ee/engine/feature/catalogue.go.", f)
+	}
+}
+
+func TestTheCatalogueSellsNothingTheLicenceCannotCarry(t *testing.T) {
+	t.Parallel()
+	// The other direction. A catalogue entry for a feature no licence can grant
+	// describes a product nobody can buy, and it is exactly as invisible as the
+	// first case: both sides look complete from their own end.
+	sellable := map[license.Feature]bool{}
+	for _, f := range license.AllFeatures() {
+		sellable[f] = true
+	}
+	for _, e := range feature.Catalogue() {
+		require.Truef(t, sellable[e.Feature],
+			"the catalogue has an entry for %s and no licence can carry that name, so it "+
+				"describes something nobody can be sold", e.Feature)
+	}
+}
+
+func TestAnEntryThatIsNotGatedSaysWhyOutLoud(t *testing.T) {
+	t.Parallel()
+	// Reported and not enforced is a legitimate state. An UNDOCUMENTED reported
+	// and not enforced is indistinguishable from somebody forgetting the check,
+	// and this is the assertion that keeps the two apart.
+	for _, e := range feature.Catalogue() {
+		require.NotEmptyf(t, e.Summary, "%s has no summary", e.Feature)
+		switch e.State {
+		case feature.StateGated:
+			require.NotEmptyf(t, e.EnforcedAt,
+				"%s is marked gated and names no enforcement site", e.Feature)
+		case feature.StatePlanWide, feature.StateFree, feature.StateAbsent:
+			require.Emptyf(t, e.EnforcedAt,
+				"%s names an engine enforcement site and is not marked gated, which is the "+
+					"one combination that cannot be true: a site that refuses IS a gate",
+				e.Feature)
+			require.NotEmptyf(t, e.Because,
+				"%s is not gated and does not say why, so a reader cannot tell a deliberate "+
+					"decision from a missing check", e.Feature)
+		default:
+			t.Fatalf("%s has state %q, which is not one of the four", e.Feature, e.State)
+		}
+	}
+}
+
+func TestAGatedEntryNamesAFileThatChecksThatExactFeature(t *testing.T) {
+	t.Parallel()
+	// The claim that matters, and the reason the reference is path:symbol
+	// rather than a name.
+	//
+	// A bare name proves only that SOME file declares one, which is the
+	// sentence admin/controls.ts writes above enforcedBy. This goes one further
+	// and requires the named file to contain a call to Enabled naming THIS
+	// feature, because a site copied from a neighbouring feature declares the
+	// right symbol in the right file and gates on the wrong entitlement. That
+	// is not hypothetical here: compliance_packs was declared at
+	// "ee/engine/compliance.Pack.Evaluate" for its whole life, and Pack.Evaluate
+	// takes no context and therefore cannot ask about a licence at all. The
+	// string agreed with itself and with nothing else.
+	root := eeEngine(t)
+	for _, e := range feature.Catalogue() {
+		if e.State != feature.StateGated {
+			continue
+		}
+		file, symbol, ok := symbolName(e.EnforcedAt)
+		require.Truef(t, ok, "%s has EnforcedAt %q, which is not path:symbol",
+			e.Feature, e.EnforcedAt)
+
+		source, err := os.ReadFile(filepath.Join(root, file))
+		require.NoErrorf(t, err,
+			"%s says it is enforced in %s and that file cannot be read", e.Feature, file)
+
+		require.Regexpf(t, regexp.MustCompile(`\b`+regexp.QuoteMeta(symbol)+`\b`), string(source),
+			"%s says it is enforced at %s and %s declares no %s",
+			e.Feature, e.EnforcedAt, file, symbol)
+
+		// The literal call, spelled with `ctx`, which is a real limit and a
+		// deliberate one. A site that named its context something else would
+		// fail this while being perfectly correct. That is the direction to
+		// fail in: a false refusal is noisy and safe, is fixed by following the
+		// convention every other call in this module already follows, and the
+		// alternative is a looser match that would accept a file gating on a
+		// neighbouring feature. tools/figurecheck reaches the same conclusion
+		// about its own denylist in the same words.
+		constant := featureConstant(t, e.Feature)
+		require.Containsf(t, string(source),
+			"feature.Enabled(ctx, license."+constant+")",
+			"%s says it is enforced at %s and %s contains no "+
+				"feature.Enabled(ctx, license.%s) call, so whatever that file does it does "+
+				"not consult this entitlement",
+			e.Feature, e.EnforcedAt, file, constant)
+	}
+}
+
+func TestEveryControlPlaneSiteNamesSomethingThatIsStillThere(t *testing.T) {
+	t.Parallel()
+	// The second of the three places an entitlement answer lives. The engine is
+	// the first and the documentation is the third, and the three drift because
+	// nothing has ever compared them.
+	//
+	// This is the Go half. The TypeScript half is in
+	// web/apps/api/test/licensed-features.test.ts and reads this same catalogue,
+	// so a control plane developer who renames a symbol and never runs the Go
+	// suite still sees it fail.
+	src := filepath.Join(repoRoot(t), "web", "apps", "api", "src")
+	for _, e := range feature.Catalogue() {
+		if e.ControlPlaneAt == "" {
+			continue
+		}
+		file, symbol, ok := symbolName(e.ControlPlaneAt)
+		require.Truef(t, ok, "%s has ControlPlaneAt %q, which is not path:symbol",
+			e.Feature, e.ControlPlaneAt)
+
+		source, err := os.ReadFile(filepath.Join(src, file))
+		require.NoErrorf(t, err,
+			"%s names %s in the control plane and that file cannot be read",
+			e.Feature, e.ControlPlaneAt)
+
+		require.Regexpf(t, regexp.MustCompile(`\b`+regexp.QuoteMeta(symbol)+`\b`), string(source),
+			"%s names %s in the control plane and %s declares no %s",
+			e.Feature, e.ControlPlaneAt, file, symbol)
+	}
+}
+
+func TestTheMeasuredNumberIsPublishedRatherThanAsserted(t *testing.T) {
+	t.Parallel()
+	// The lane's number, printed rather than hidden behind a threshold. A test
+	// that asserted "at least three" would go on passing while the product
+	// stood still, and a number nobody can see is a number nobody checks.
+	//
+	// It reads len(license.AllFeatures()) rather than a literal so that a lane
+	// adding a feature moves the denominator and not this file.
+	total := len(license.AllFeatures())
+	gated := feature.GatedFeatures()
+
+	byState := map[feature.State]int{}
+	for _, e := range feature.Catalogue() {
+		byState[e.State]++
+	}
+
+	t.Logf("licensed features with an enforcement site that refuses: %d of %d", len(gated), total)
+	for _, f := range gated {
+		entry, _ := feature.Of(f)
+		t.Logf("  gated     %-22s %s", f, entry.EnforcedAt)
+	}
+	for _, e := range feature.Catalogue() {
+		if e.State != feature.StateGated {
+			t.Logf("  %-9s %-22s %s", e.State, e.Feature, firstSentence(e.Because))
+		}
+	}
+	t.Logf("gated %d, plan wide %d, free %d, absent %d",
+		byState[feature.StateGated], byState[feature.StatePlanWide],
+		byState[feature.StateFree], byState[feature.StateAbsent])
+
+	require.Equal(t, total, byState[feature.StateGated]+byState[feature.StatePlanWide]+
+		byState[feature.StateFree]+byState[feature.StateAbsent],
+		"the four states do not account for every licensed feature")
+}
+
+func firstSentence(s string) string {
+	if i := strings.Index(s, ". "); i > 0 {
+		return s[:i+1]
+	}
+	return s
+}
+
+// featureConstant is the Go identifier for a feature's wire name.
+//
+// Derived from license.go rather than from a second table, because a second
+// table is the thing this whole file exists to prevent. The source is parsed
+// for `FeatureX Feature = "x"` and the mapping comes back from that.
+func featureConstant(t *testing.T, f license.Feature) string {
+	t.Helper()
+	source, err := os.ReadFile(filepath.Join(eeEngine(t), "license", "license.go"))
+	require.NoError(t, err)
+	matches := regexp.MustCompile(`(Feature\w+)\s+Feature\s+=\s+"([a-z_]+)"`).
+		FindAllStringSubmatch(string(source), -1)
+	require.NotEmpty(t, matches, "license.go declares no feature constants, so the parse is wrong")
+	for _, m := range matches {
+		if m[2] == string(f) {
+			return m[1]
+		}
+	}
+	t.Fatalf("license.go declares no constant whose value is %q", f)
+	return ""
+}

--- a/ee/engine/feature/catalogue_test.go
+++ b/ee/engine/feature/catalogue_test.go
@@ -10,7 +10,7 @@ package feature_test
 // names and refuses to pass when the claim is not true there. entitlements.ts
 // says the same thing about its own catalogue and its test does the same thing,
 // and admin/controls.ts says it a third time about operator switches. This is
-// that pattern applied to the twelve names a licence can carry.
+// that pattern applied to the fourteen names a licence can carry.
 //
 // Three claims are checked here and a fourth in ee/engine/cmd/af, which is the
 // only place where every enterprise package's init has run and the registry is
@@ -196,6 +196,50 @@ func TestAFeatureThatCannotBeSoldIsNotDescribedAsSomethingCustomersHave(t *testi
 			f, entry.ControlPlaneAt)
 	}
 	t.Logf("features that cannot be sold, all absent: %v", notShipped)
+}
+
+func TestAFeatureGatedNowhereIsNotDescribedAsRefused(t *testing.T) {
+	t.Parallel()
+	// THE SECOND AUTHORITY IN license.go, and it arrived after this catalogue
+	// did, which is how it came to be unheld for a while.
+	//
+	// notShipped answers "was it built". unenforced answers a different
+	// question, "is it gated anywhere", and its own comment says a feature can
+	// be shipped and unenforced, which is the ungated case. #360 added it and
+	// the check above could not be widened to cover it: notShipped forces the
+	// single state absent, and a feature that IS built and is gated nowhere may
+	// honestly be free or unmounted, so the assertion has to be a refusal of
+	// three states rather than a demand for one.
+	//
+	// Held in this direction rather than both. A catalogue entry may be free or
+	// unmounted with nothing in license.go recording it, and that is correct
+	// today: support_access is gated nowhere by the licence and is enforced in
+	// the community control plane by an operator permission, so demanding a
+	// record for every ungated row would demand a false one. What cannot stand
+	// is the opposite, a row claiming a refusal for a feature license.go says
+	// is refused nowhere, because those are two answers to one question and the
+	// catalogue is the copy a customer reads.
+	unenforced := license.UnenforcedFeatures()
+	require.NotEmpty(t, unenforced,
+		"nothing is recorded as gated nowhere, so this test is asserting nothing")
+
+	for _, f := range unenforced {
+		entry, ok := feature.Of(f)
+		require.Truef(t, ok, "%s is recorded as gated nowhere and has no catalogue entry", f)
+		require.NotContainsf(t,
+			[]feature.State{
+				feature.StateGated,
+				feature.StateControlPlaneGated,
+				feature.StateEditionGated,
+			},
+			entry.State,
+			"license.go records %s as gated nowhere and the catalogue calls it %q, which "+
+				"claims somebody is refused it for not paying. One of the two is false. If "+
+				"the gate was built, delete the entry in license.go's unenforced map; that "+
+				"entry says what building it would mean. Reason recorded there: %s",
+			f, entry.State, license.UnenforcedBecause(f))
+	}
+	t.Logf("features gated nowhere, none described as refused: %v", unenforced)
 }
 
 func TestAGatedEntryNamesAFileThatChecksThatExactFeature(t *testing.T) {

--- a/ee/engine/feature/catalogue_test.go
+++ b/ee/engine/feature/catalogue_test.go
@@ -106,6 +106,19 @@ func TestAnEntryThatIsNotGatedSaysWhyOutLoud(t *testing.T) {
 		case feature.StateGated:
 			require.NotEmptyf(t, e.EnforcedAt,
 				"%s is marked gated and names no enforcement site", e.Feature)
+		case feature.StateEditionGated:
+			// EnforcedAt is REQUIRED and points outside this module, which is
+			// the one combination the other states forbid. It names a file in
+			// the community engine, and the check that it really refuses lives
+			// in ee/engine/cmd/af, because only that binary has both the
+			// registry and a path to the engine tree.
+			require.NotEmptyf(t, e.EnforcedAt,
+				"%s is refused by the community engine and names no site there", e.Feature)
+			require.NotEmptyf(t, e.Because,
+				"%s is refused through a mechanism this module does not contain and does "+
+					"not say why, so a reader who greps ee/engine for it finds nothing and "+
+					"has no sentence explaining the absence",
+				e.Feature)
 		case feature.StateControlPlaneGated:
 			// Refused, and not by anything this suite can open. The engine has
 			// no site for it by definition, so requiring one here would refuse
@@ -133,7 +146,7 @@ func TestAnEntryThatIsNotGatedSaysWhyOutLoud(t *testing.T) {
 				"%s is not gated and does not say why, so a reader cannot tell a deliberate "+
 					"decision from a missing check", e.Feature)
 		default:
-			t.Fatalf("%s has state %q, which is not one of the five", e.Feature, e.State)
+			t.Fatalf("%s has state %q, which is not one of the six", e.Feature, e.State)
 		}
 	}
 }
@@ -303,12 +316,13 @@ func TestTheMeasuredNumberIsPublishedRatherThanAsserted(t *testing.T) {
 			t.Logf("  %-9s %-22s %s", e.State, e.Feature, firstSentence(e.Because))
 		}
 	}
-	t.Logf("engine gated %d, control plane gated %d, free %d, unmounted %d, absent %d",
-		byState[feature.StateGated], byState[feature.StateControlPlaneGated],
-		byState[feature.StateFree], byState[feature.StateUnmounted],
-		byState[feature.StateAbsent])
+	t.Logf("engine gated %d, edition gated %d, control plane gated %d, free %d, "+
+		"unmounted %d, absent %d",
+		byState[feature.StateGated], byState[feature.StateEditionGated],
+		byState[feature.StateControlPlaneGated], byState[feature.StateFree],
+		byState[feature.StateUnmounted], byState[feature.StateAbsent])
 
-	require.Equal(t, total, byState[feature.StateGated]+
+	require.Equal(t, total, byState[feature.StateGated]+byState[feature.StateEditionGated]+
 		byState[feature.StateControlPlaneGated]+byState[feature.StateFree]+
 		byState[feature.StateUnmounted]+byState[feature.StateAbsent],
 		"the states do not account for every licensed feature")

--- a/ee/engine/feature/catalogue_test.go
+++ b/ee/engine/feature/catalogue_test.go
@@ -106,8 +106,25 @@ func TestAnEntryThatIsNotGatedSaysWhyOutLoud(t *testing.T) {
 		case feature.StateGated:
 			require.NotEmptyf(t, e.EnforcedAt,
 				"%s is marked gated and names no enforcement site", e.Feature)
-		case feature.StatePlanWide, feature.StateFree, feature.StateAbsent,
-			feature.StateUnmounted:
+		case feature.StateControlPlaneGated:
+			// Refused, and not by anything this suite can open. The engine has
+			// no site for it by definition, so requiring one here would refuse
+			// the state; what is required instead is the name of a site the
+			// TypeScript registry declared, which the catalogue test in
+			// ee/web/features compares against that registry in both
+			// directions. This assertion is the half that can be made from Go.
+			require.Emptyf(t, e.EnforcedAt,
+				"%s is refused by the control plane and names an ENGINE enforcement site, "+
+					"which would mean the engine refuses it too and it should be gated",
+				e.Feature)
+			require.NotEmptyf(t, e.ControlPlaneAt,
+				"%s is marked refused by the control plane and names no site there, so the "+
+					"claim cannot be checked against the registry from either language",
+				e.Feature)
+			require.NotEmptyf(t, e.Because,
+				"%s is refused in a language this suite cannot read and does not say why",
+				e.Feature)
+		case feature.StateFree, feature.StateAbsent, feature.StateUnmounted:
 			require.Emptyf(t, e.EnforcedAt,
 				"%s names an engine enforcement site and is not marked gated, which is the "+
 					"one combination that cannot be true: a site that refuses IS a gate",
@@ -116,9 +133,56 @@ func TestAnEntryThatIsNotGatedSaysWhyOutLoud(t *testing.T) {
 				"%s is not gated and does not say why, so a reader cannot tell a deliberate "+
 					"decision from a missing check", e.Feature)
 		default:
-			t.Fatalf("%s has state %q, which is not one of the four", e.Feature, e.State)
+			t.Fatalf("%s has state %q, which is not one of the five", e.Feature, e.State)
 		}
 	}
+}
+
+func TestAFeatureThatCannotBeSoldIsNotDescribedAsSomethingCustomersHave(t *testing.T) {
+	t.Parallel()
+	// THE CHECK THAT WOULD HAVE CAUGHT TWO ROWS AT ONCE, and neither of them was
+	// found by any instrument. A person read the catalogue's own notShipped map
+	// and asked, of code this file had already located correctly, "real code for
+	// WHOM".
+	//
+	// billing read free because billingRouter is real, mounted and ungated. It
+	// bills the customer FOR Antifailure; the licensed feature would meter on
+	// the CUSTOMER'S behalf and does not exist. enterprise_dashboard read plan
+	// wide because orgProcedure really does refuse the console below the
+	// enterprise plan. That is our own funnel enforcing our own plans, keyed on
+	// organizations.plan rather than on this licence name. Both entries were
+	// TRUE about the code they named and false about the feature they described.
+	//
+	// license.go's notShipped is the one place that records what cannot be sold,
+	// and its own comment says it is the only thing that has to change when one
+	// of these is built. So it is the right authority to hold the catalogue to:
+	// a feature nobody can buy cannot be free, which claims we give it away;
+	// cannot be gated or control plane gated, which claim we refuse it to
+	// somebody who did not pay; and cannot be unmounted, which claims it is
+	// built. Absent is the only state that is not a sentence about a product
+	// that exists.
+	notShipped := license.NotShippedFeatures()
+	require.NotEmpty(t, notShipped,
+		"nothing is marked unsellable, so this test is asserting nothing")
+
+	for _, f := range notShipped {
+		entry, ok := feature.Of(f)
+		require.Truef(t, ok, "%s cannot be sold and has no catalogue entry", f)
+		require.Equalf(t, feature.StateAbsent, entry.State,
+			"%s cannot be sold, and the catalogue calls it %q. Every state but absent is a "+
+				"claim about a capability customers can have: free says we give it away, "+
+				"gated and control plane gated say we refuse it to somebody who did not pay, "+
+				"and unmounted says it is built. license.go says this one does not exist. "+
+				"Reason recorded there: %s",
+			f, entry.State, license.NotShippedBecause(f))
+		require.Emptyf(t, entry.ControlPlaneAt,
+			"%s cannot be sold and the catalogue names %s as where the control plane does it. "+
+				"That field means where this feature is implemented or refused, and a "+
+				"capability that does not exist has no such place. Naming a real file that "+
+				"serves a DIFFERENT subject is exactly how this row came to be wrong.",
+			f, entry.ControlPlaneAt)
+	}
+	t.Logf("features that cannot be sold, all absent: %v", notShipped)
 }
 
 func TestAGatedEntryNamesAFileThatChecksThatExactFeature(t *testing.T) {
@@ -193,7 +257,7 @@ func TestEveryControlPlaneSiteNamesSomethingThatIsStillThere(t *testing.T) {
 	// web/apps/api/test/licensed-features.test.ts and reads this same catalogue,
 	// so a control plane developer who renames a symbol and never runs the Go
 	// suite still sees it fail.
-	src := filepath.Join(repoRoot(t), "web", "apps", "api", "src")
+	src := repoRoot(t)
 	for _, e := range feature.Catalogue() {
 		if e.ControlPlaneAt == "" {
 			continue
@@ -239,14 +303,14 @@ func TestTheMeasuredNumberIsPublishedRatherThanAsserted(t *testing.T) {
 			t.Logf("  %-9s %-22s %s", e.State, e.Feature, firstSentence(e.Because))
 		}
 	}
-	t.Logf("gated %d, plan wide %d, free %d, unmounted %d, absent %d",
-		byState[feature.StateGated], byState[feature.StatePlanWide],
+	t.Logf("engine gated %d, control plane gated %d, free %d, unmounted %d, absent %d",
+		byState[feature.StateGated], byState[feature.StateControlPlaneGated],
 		byState[feature.StateFree], byState[feature.StateUnmounted],
 		byState[feature.StateAbsent])
 
-	require.Equal(t, total, byState[feature.StateGated]+byState[feature.StatePlanWide]+
-		byState[feature.StateFree]+byState[feature.StateUnmounted]+
-		byState[feature.StateAbsent],
+	require.Equal(t, total, byState[feature.StateGated]+
+		byState[feature.StateControlPlaneGated]+byState[feature.StateFree]+
+		byState[feature.StateUnmounted]+byState[feature.StateAbsent],
 		"the states do not account for every licensed feature")
 }
 

--- a/ee/engine/feature/catalogue_test.go
+++ b/ee/engine/feature/catalogue_test.go
@@ -49,18 +49,13 @@ func repoRoot(t *testing.T) string {
 	return filepath.Dir(filepath.Dir(eeEngine(t)))
 }
 
-// symbolName is the last component of a path:symbol reference's symbol half.
+// symbolName is feature.SplitSite, which is the one definition of the format.
 //
-// Hook.Check is written whole because a reader needs the receiver to know which
-// Check is meant, and the grep needs the method name on its own because that is
-// what appears in the source.
+// A local alias rather than a second implementation. This test and the registry
+// check in ee/engine/cmd/af read different things and have to read them the
+// same way, and two parsers agreeing today is how they come to disagree later.
 func symbolName(reference string) (file, symbol string, ok bool) {
-	parts := strings.SplitN(reference, ":", 2)
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return "", "", false
-	}
-	dotted := strings.Split(parts[1], ".")
-	return parts[0], dotted[len(dotted)-1], true
+	return feature.SplitSite(reference)
 }
 
 func TestEveryLicensedFeatureIsInTheCatalogue(t *testing.T) {
@@ -111,7 +106,8 @@ func TestAnEntryThatIsNotGatedSaysWhyOutLoud(t *testing.T) {
 		case feature.StateGated:
 			require.NotEmptyf(t, e.EnforcedAt,
 				"%s is marked gated and names no enforcement site", e.Feature)
-		case feature.StatePlanWide, feature.StateFree, feature.StateAbsent:
+		case feature.StatePlanWide, feature.StateFree, feature.StateAbsent,
+			feature.StateUnmounted:
 			require.Emptyf(t, e.EnforcedAt,
 				"%s names an engine enforcement site and is not marked gated, which is the "+
 					"one combination that cannot be true: a site that refuses IS a gate",
@@ -152,8 +148,21 @@ func TestAGatedEntryNamesAFileThatChecksThatExactFeature(t *testing.T) {
 		require.NoErrorf(t, err,
 			"%s says it is enforced in %s and that file cannot be read", e.Feature, file)
 
-		require.Regexpf(t, regexp.MustCompile(`\b`+regexp.QuoteMeta(symbol)+`\b`), string(source),
-			"%s says it is enforced at %s and %s declares no %s",
+		// DEFINED in that file, not merely mentioned in it. Contributed by
+		// L7.1, which hit the gap while adopting this format: a site can name a
+		// file that contains the Enabled literal for its own reasons and
+		// defines the named symbol somewhere else entirely, and a word grep
+		// accepts it. compliance/command.go is the live example, because it
+		// calls Packs() three times and Packs is declared in frameworks.go.
+		//
+		// The optional receiver group is the general case this had to grow.
+		// Two of the three sites are methods, so the pattern accepts both
+		// `func Command(` and `func (s *Source) Available(`.
+		require.Regexpf(t,
+			regexp.MustCompile(`func (\([^)]*\) )?`+regexp.QuoteMeta(symbol)+`\(`),
+			string(source),
+			"%s says it is enforced at %s and %s does not DEFINE %s. A file that merely "+
+				"mentions the symbol can be a file whose gate lives somewhere else.",
 			e.Feature, e.EnforcedAt, file, symbol)
 
 		// The literal call, spelled with `ctx`, which is a real limit and a
@@ -230,13 +239,15 @@ func TestTheMeasuredNumberIsPublishedRatherThanAsserted(t *testing.T) {
 			t.Logf("  %-9s %-22s %s", e.State, e.Feature, firstSentence(e.Because))
 		}
 	}
-	t.Logf("gated %d, plan wide %d, free %d, absent %d",
+	t.Logf("gated %d, plan wide %d, free %d, unmounted %d, absent %d",
 		byState[feature.StateGated], byState[feature.StatePlanWide],
-		byState[feature.StateFree], byState[feature.StateAbsent])
+		byState[feature.StateFree], byState[feature.StateUnmounted],
+		byState[feature.StateAbsent])
 
 	require.Equal(t, total, byState[feature.StateGated]+byState[feature.StatePlanWide]+
-		byState[feature.StateFree]+byState[feature.StateAbsent],
-		"the four states do not account for every licensed feature")
+		byState[feature.StateFree]+byState[feature.StateUnmounted]+
+		byState[feature.StateAbsent],
+		"the states do not account for every licensed feature")
 }
 
 func firstSentence(s string) string {

--- a/ee/engine/feature/feature.go
+++ b/ee/engine/feature/feature.go
@@ -40,9 +40,38 @@ func StatusFrom(ctx context.Context) license.Status {
 // Enabled reports whether a feature may be used.
 //
 // The whole public surface for the rest of the enterprise code. Every enterprise
-// entry point begins with this, and there is a test that every feature has at
+// entry point that gates on a licence begins with this.
+//
+// THE SENTENCE THAT USED TO BE HERE WAS FALSE, and it is worth saying so rather
+// than quietly deleting it, because it is the same defect as the one this
+// package exists to catch. It read "there is a test that every feature has at
 // least one call site, because a feature nobody checks is a feature that is
-// either free or missing and both are wrong.
+// either free or missing and both are wrong". There was no such test. What
+// existed was TestDeclaredSitesAreRecordedForTheDeadCodeCheck, which declared a
+// site naming ee/web/auth.Handler, a package that has never existed, from a
+// test binary that links none of the packages doing the enforcing, and then
+// asserted that Sites(FeatureCompliance) was EMPTY. It was empty because
+// nothing in that binary could have filled it, so the assertion could not fail
+// for any reason to do with the product. A comment claiming a check, sitting
+// above a check that cannot say no, is exactly what a licensed feature that
+// enforces nothing looks like from the inside.
+//
+// The claim was also wrong on its own terms. Nine of the twelve features have
+// no call site and that is the measured, published state of this product rather
+// than a bug to be asserted away; see catalogue.go. What is actually true, and
+// what is actually tested:
+//
+//   - Every feature a licence can carry has a catalogue entry saying what
+//     happens without it. TestEveryLicensedFeatureIsInTheCatalogue.
+//   - A catalogue entry that CLAIMS enforcement names a file that contains a
+//     literal Enabled call for that exact feature.
+//     TestAGatedEntryNamesAFileThatChecksThatExactFeature.
+//   - Every Declare corresponds to a catalogue entry marked gated, and every
+//     gated entry to a Declare, checked from ee/engine/cmd/af, which is the
+//     only package where every enterprise init has run and this registry is
+//     therefore populated at all.
+//   - Each gated feature's real entry point behaves differently with the
+//     entitlement and without it. TestTheEntitlementIsWhatDecides.
 func Enabled(ctx context.Context, f license.Feature) bool {
 	return StatusFrom(ctx).Enabled(f)
 }

--- a/ee/engine/feature/feature.go
+++ b/ee/engine/feature/feature.go
@@ -56,7 +56,7 @@ func StatusFrom(ctx context.Context) license.Status {
 // above a check that cannot say no, is exactly what a licensed feature that
 // enforces nothing looks like from the inside.
 //
-// The claim was also wrong on its own terms. Nine of the twelve features have
+// The claim was also wrong on its own terms. Four of the fourteen features have
 // no call site and that is the measured, published state of this product rather
 // than a bug to be asserted away; see catalogue.go. What is actually true, and
 // what is actually tested:

--- a/ee/engine/feature/feature_test.go
+++ b/ee/engine/feature/feature_test.go
@@ -50,15 +50,44 @@ func TestAValueOfTheWrongTypeInTheContextGrantsNothing(t *testing.T) {
 	require.False(t, feature.Enabled(ctx, license.FeatureSSO))
 }
 
-func TestDeclaredSitesAreRecordedForTheDeadCodeCheck(t *testing.T) {
+func TestTheRegistryRecordsWhatWasDeclaredAndNothingElse(t *testing.T) {
 	t.Parallel()
-	// A feature a license can grant and nothing checks is a feature that is
-	// silently free. The registry is what makes that visible, so it has to
-	// actually record.
-	feature.Declare(license.FeatureSSO, "ee/web/auth.Handler")
-	require.Contains(t, feature.Sites(license.FeatureSSO), "ee/web/auth.Handler")
-	require.Contains(t, feature.Declared(), license.FeatureSSO)
-	require.Empty(t, feature.Sites(license.FeatureCompliance))
+	// A UNIT TEST OF THE REGISTRY, and the rename says so because the old name
+	// did not. This was TestDeclaredSitesAreRecordedForTheDeadCodeCheck, and it
+	// was not the dead code check and could not have been. It declared a site
+	// naming ee/web/auth.Handler, a package that has never existed, and then
+	// asserted Sites(FeatureCompliance) was empty. That assertion passed because
+	// this binary links neither the compliance package nor any other enforcing
+	// one, so nothing could have filled the registry, so it could not fail for
+	// any reason to do with the product. It is the shape of check this whole
+	// lane exists to find, and it was inside the package doing the finding.
+	//
+	// The dead code check is real and it is in ee/engine/cmd/af, because that
+	// is the only package where main.go's imports have run every init and the
+	// registry is populated at all. It cannot be written here: this package is
+	// imported BY compliance, secrets and policyenforce, so importing them back
+	// is a cycle.
+	//
+	// A name no licence carries, deliberately. Declaring a real feature here
+	// would put a site in the global registry for a feature this build does not
+	// enforce, which is the false signal the registry exists to make visible.
+	const fabricated = license.Feature("a_name_no_licence_carries")
+
+	require.Empty(t, feature.Sites(fabricated),
+		"the registry answered for a feature nothing has declared")
+
+	feature.Declare(fabricated, "feature/feature_test.go:TestTheRegistryRecords")
+	require.Contains(t, feature.Sites(fabricated),
+		"feature/feature_test.go:TestTheRegistryRecords")
+	require.Contains(t, feature.Declared(), fabricated)
+
+	// Sites answers about the feature it was asked about. Without this, a Sites
+	// that returned every recorded site regardless of key would satisfy every
+	// assertion above, and every reconciliation built on it would be comparing
+	// one list against itself.
+	require.NotContains(t, feature.Sites(license.FeatureBilling),
+		"feature/feature_test.go:TestTheRegistryRecords",
+		"a site declared for one feature was returned for another")
 }
 
 func TestAnExpiredLicenseInAContextGrantsNothing(t *testing.T) {

--- a/ee/engine/feature/reference_test.go
+++ b/ee/engine/feature/reference_test.go
@@ -113,11 +113,11 @@ func entitlementTable() string {
 // page against the licence by reading a bounded window under this heading,
 // because reading the whole page would pick up every name mentioned in prose
 // anywhere on it and would pass a page that had stopped listing the catalogue
-// at all. The table does not fit in that window and cannot be made to: twelve
-// rows are two thousand characters. So the window needs a list, and a list
-// typed by hand under a generated table is a fourth copy of the twelve names,
-// sitting inside the one document whose subject is what happens when the copies
-// disagree.
+// at all. The table does not fit in that window and cannot be made to:
+// fourteen rows are just under three thousand characters. So the window needs a
+// list, and a list typed by hand under a generated table is a fourth copy of
+// the fourteen names, sitting inside the one document whose subject is what
+// happens when the copies disagree.
 
 func namesSentence() string {
 	all := license.AllFeatures()

--- a/ee/engine/feature/reference_test.go
+++ b/ee/engine/feature/reference_test.go
@@ -48,6 +48,8 @@ const (
 	entitlementsEnd   = "<!-- entitlements:end -->"
 	countStart        = "<!-- entitlement-count:start -->"
 	countEnd          = "<!-- entitlement-count:end -->"
+	namesStart        = "<!-- entitlement-names:start -->"
+	namesEnd          = "<!-- entitlement-names:end -->"
 )
 
 // effect is the column that decides whether the page is worth reading: what a
@@ -89,6 +91,36 @@ func entitlementTable() string {
 	return b.String()
 }
 
+// namesSentence is the list of names itself, in the sentence a reader meets
+// before the table.
+//
+// Generated for the reason countSentence gives, and for one more that is
+// particular to this sentence. The control plane's catalogue test compares the
+// page against the licence by reading a bounded window under this heading,
+// because reading the whole page would pick up every name mentioned in prose
+// anywhere on it and would pass a page that had stopped listing the catalogue
+// at all. The table does not fit in that window and cannot be made to: twelve
+// rows are two thousand characters. So the window needs a list, and a list
+// typed by hand under a generated table is a fourth copy of the twelve names,
+// sitting inside the one document whose subject is what happens when the copies
+// disagree.
+
+func namesSentence() string {
+	all := license.AllFeatures()
+	if len(all) == 0 {
+		return "A license carries no features.\n"
+	}
+	names := make([]string, 0, len(all))
+	for _, f := range all {
+		names = append(names, "`"+string(f)+"`")
+	}
+	list := names[0]
+	if len(names) > 1 {
+		list = strings.Join(names[:len(names)-1], ", ") + " and " + names[len(names)-1]
+	}
+	return "The features a license can name are " + list + ".\n"
+}
+
 // countSentence is the number, on the page, in the words a customer would use.
 //
 // Generated rather than typed, for the reason the masking reference gives about
@@ -121,7 +153,9 @@ func TestTheLicensingPageIsCurrentWithTheCatalogue(t *testing.T) {
 	raw, err := os.ReadFile(licensingPath)
 	require.NoError(t, err)
 
-	want, err := splice(string(raw), countStart, countEnd, countSentence())
+	want, err := splice(string(raw), namesStart, namesEnd, namesSentence())
+	require.NoError(t, err)
+	want, err = splice(want, countStart, countEnd, countSentence())
 	require.NoError(t, err)
 	want, err = splice(want, entitlementsStart, entitlementsEnd, entitlementTable())
 	require.NoError(t, err)

--- a/ee/engine/feature/reference_test.go
+++ b/ee/engine/feature/reference_test.go
@@ -71,6 +71,13 @@ func effect(e feature.Entitlement) string {
 		return "Nothing changes. It is implemented and deliberately available to everyone."
 	case feature.StateAbsent:
 		return "Nothing changes, because the capability is not built yet."
+	case feature.StateEditionGated:
+		// Named as a refusal like the other two, because to a customer all
+		// three are the same event: they asked for something and were told no
+		// on the strength of what they bought. Which process said no, and
+		// through which mechanism, is our detail and not theirs.
+		return "Withheld. `" + e.EnforcedAt + "` asks the license, and the feature is off " +
+			"when the answer is no."
 	case feature.StateControlPlaneGated:
 		// Named as a refusal, like StateGated, because to a customer the two
 		// are the same event: they asked for something and were told no on the
@@ -135,7 +142,7 @@ func namesSentence() string {
 // holds is not prose, whatever it looks like, and left by hand beside a
 // generated table it is how a page comes to contradict itself.
 func countSentence() string {
-	engine := len(feature.GatedFeatures())
+	engine := len(feature.GatedFeatures()) + len(feature.EditionGatedFeatures())
 	plane := len(feature.ControlPlaneGatedFeatures())
 	total := len(license.AllFeatures())
 	// Split, because one number hid the error this page was corrected for.

--- a/ee/engine/feature/reference_test.go
+++ b/ee/engine/feature/reference_test.go
@@ -67,13 +67,20 @@ func effect(e feature.Entitlement) string {
 		// which is the opposite of what happens.
 		return "Withheld. `" + e.EnforcedAt + "` asks the license, and the feature is off " +
 			"when the answer is no."
-	case feature.StatePlanWide:
-		return "Not refused by this name. The hosted control plane refuses the capability on " +
-			"the plan as a whole; a self hosted installation with no license keeps it."
 	case feature.StateFree:
 		return "Nothing changes. It is implemented and deliberately available to everyone."
 	case feature.StateAbsent:
 		return "Nothing changes, because the capability is not built yet."
+	case feature.StateControlPlaneGated:
+		// Named as a refusal, like StateGated, because to a customer the two
+		// are the same event: they asked for something and were told no on the
+		// strength of what they bought. Which process said no is our detail,
+		// not theirs. The code is named because 402 rather than 404 is the
+		// whole point of gate.ts, and a reader who greps the engine for this
+		// feature and finds nothing needs the sentence that explains why.
+		return "Withheld by the control plane. `" + e.ControlPlaneAt + "` asks the license, " +
+			"and an unlicensed installation is answered 402 naming the feature rather " +
+			"than 404."
 	case feature.StateUnmounted:
 		return "Nothing changes, and not because it is unbuilt. It is implemented and no " +
 			"binary loads it, so nobody has it, paid or not."
@@ -128,14 +135,21 @@ func namesSentence() string {
 // holds is not prose, whatever it looks like, and left by hand beside a
 // generated table it is how a page comes to contradict itself.
 func countSentence() string {
-	gated := len(feature.GatedFeatures())
+	engine := len(feature.GatedFeatures())
+	plane := len(feature.ControlPlaneGatedFeatures())
 	total := len(license.AllFeatures())
+	// Split, because one number hid the error this page was corrected for.
+	// Counting only the engine's gates reported three of twelve and read as
+	// "nine of these do nothing", when two of the nine were being refused by
+	// name in another language. The total is the honest headline and the split
+	// is what stops the next reader drawing the old conclusion from it.
 	return fmt.Sprintf(
 		"Of the %d features a license can carry, **%d are refused when the license does not "+
-			"name them**. The rest are listed here anyway, with what actually happens without "+
-			"each one, because a feature that is sold and never checked is worth knowing about "+
-			"and the number is only useful if it can come back unflattering.\n",
-		total, gated)
+			"name them**, %d by the engine and %d by the control plane. The rest are listed "+
+			"here anyway, with what actually happens without each one, because a feature that "+
+			"is sold and never checked is worth knowing about and the number is only useful "+
+			"if it can come back unflattering.\n",
+		total, engine+plane, engine, plane)
 }
 
 // splice replaces the block between one pair of markers.

--- a/ee/engine/feature/reference_test.go
+++ b/ee/engine/feature/reference_test.go
@@ -1,0 +1,199 @@
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+
+package feature_test
+
+// The third place an entitlement answer lives.
+//
+// The engine is the first, the control plane is the second, and this is the
+// documentation. All three drifted because nothing had ever compared them, and
+// the documentation is the one that drifts worst: it is the copy a customer
+// reads, a security review quotes and a salesperson repeats, and it is the only
+// one of the three that nothing compiles.
+//
+// What the page said before this existed was twelve names and one sentence:
+// "Each is named in the license, so a license permits exactly what was bought."
+// The names were right and the sentence was not. Nine of the twelve are named
+// in a licence and permit nothing either way, because nothing anywhere asks
+// whether they are on, so a customer who bought nine features and one who
+// bought none were running the identical product. That is not a wording
+// problem. It is the product's own claim about itself being untrue, in the one
+// document written to answer exactly that question.
+//
+// So the table is generated from the catalogue and this test refuses a page
+// that has fallen behind it, the same way the transform reference is generated
+// from the masking registry. The prose around the markers is left alone,
+// because a generator has nothing to say about why any of it is the case.
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/ee/engine/feature"
+	"github.com/antifailure/antifailure/ee/engine/license"
+)
+
+var updateEntitlements = flag.Bool("update-entitlements", false,
+	"rewrite the entitlement table in the licensing page")
+
+const (
+	licensingPath     = "../../../docs/src/content/docs/enterprise/licensing.md"
+	entitlementsStart = "<!-- entitlements:start -->"
+	entitlementsEnd   = "<!-- entitlements:end -->"
+	countStart        = "<!-- entitlement-count:start -->"
+	countEnd          = "<!-- entitlement-count:end -->"
+)
+
+// effect is the column that decides whether the page is worth reading: what a
+// customer who does NOT have this feature gets.
+//
+// One sentence per state rather than per feature, because the state is the
+// answer and a per feature sentence would be a second place to say the same
+// thing. The detail lives in the catalogue's Because and in the source.
+func effect(e feature.Entitlement) string {
+	switch e.State {
+	case feature.StateGated:
+		// "Withheld" rather than "refused", because for one of the three the
+		// licensed behaviour IS a refusal: an unlicensed policy hook permits.
+		// "Refused" in that row would read as the environment being refused,
+		// which is the opposite of what happens.
+		return "Withheld. `" + e.EnforcedAt + "` asks the license, and the feature is off " +
+			"when the answer is no."
+	case feature.StatePlanWide:
+		return "Not refused by this name. The hosted control plane refuses the capability on " +
+			"the plan as a whole; a self hosted installation with no license keeps it."
+	case feature.StateFree:
+		return "Nothing changes. It is implemented and deliberately available to everyone."
+	case feature.StateAbsent:
+		return "Nothing changes, because the capability is not built yet."
+	}
+	return ""
+}
+
+func entitlementTable() string {
+	var b strings.Builder
+	b.WriteString("| Feature | What it is | Without it |\n")
+	b.WriteString("| --- | --- | --- |\n")
+	for _, e := range feature.Catalogue() {
+		fmt.Fprintf(&b, "| `%s` | %s | %s |\n", e.Feature, e.Summary, effect(e))
+	}
+	return b.String()
+}
+
+// countSentence is the number, on the page, in the words a customer would use.
+//
+// Generated rather than typed, for the reason the masking reference gives about
+// its uniqueness sentence: a sentence that restates a fact the registry already
+// holds is not prose, whatever it looks like, and left by hand beside a
+// generated table it is how a page comes to contradict itself.
+func countSentence() string {
+	gated := len(feature.GatedFeatures())
+	total := len(license.AllFeatures())
+	return fmt.Sprintf(
+		"Of the %d features a license can carry, **%d are refused when the license does not "+
+			"name them**. The rest are listed here anyway, with what actually happens without "+
+			"each one, because a feature that is sold and never checked is worth knowing about "+
+			"and the number is only useful if it can come back unflattering.\n",
+		total, gated)
+}
+
+// splice replaces the block between one pair of markers.
+func splice(page, start, end, body string) (string, error) {
+	i := strings.Index(page, start)
+	j := strings.Index(page, end)
+	if i < 0 || j < 0 || j < i {
+		return "", fmt.Errorf(
+			"the page has no %s and %s pair, so there is nowhere to put the block", start, end)
+	}
+	return page[:i] + start + "\n" + body + page[j:], nil
+}
+
+func TestTheLicensingPageIsCurrentWithTheCatalogue(t *testing.T) {
+	raw, err := os.ReadFile(licensingPath)
+	require.NoError(t, err)
+
+	want, err := splice(string(raw), countStart, countEnd, countSentence())
+	require.NoError(t, err)
+	want, err = splice(want, entitlementsStart, entitlementsEnd, entitlementTable())
+	require.NoError(t, err)
+
+	if *updateEntitlements {
+		require.NoError(t, os.WriteFile(licensingPath, []byte(want), 0o644))
+		return
+	}
+	require.Equal(t, want, string(raw),
+		"the licensing page is out of date with the entitlement catalogue. Regenerate from "+
+			"ee/engine with: GOWORK=off go test ./feature -update-entitlements")
+}
+
+func TestEveryLicensedFeatureAppearsOnThePage(t *testing.T) {
+	// The page's own claim, checked directly rather than through the diff. The
+	// diff above catches both directions and says only that the file differs;
+	// this says which feature went missing, which is the sentence somebody
+	// reading a failed CI run needs.
+	raw, err := os.ReadFile(licensingPath)
+	require.NoError(t, err)
+	page := string(raw)
+
+	for _, f := range license.AllFeatures() {
+		require.Containsf(t, page, "| `"+string(f)+"` |",
+			"%s is a feature a licence can carry and the licensing page does not list it", f)
+	}
+}
+
+// requirementLine is the sentence an enterprise page opens with when it claims
+// a licence is needed to use what it describes.
+var requirementLine = regexp.MustCompile(
+	"\\*Requires an enterprise license with the `([a-z_]+)` feature")
+
+func TestNoPageClaimsALicenceRequirementTheProductDoesNotHave(t *testing.T) {
+	// The claim this catches is the one that costs the most, because it is made
+	// to the reader who is deciding whether to buy.
+	//
+	// runtimes.md opened with "Requires an enterprise license with the
+	// multi_runtime feature" and nothing anywhere requires it: the scheduler
+	// that would enforce placement has no caller outside its own tests, it
+	// lives under engine/internal where the enterprise module cannot reach it,
+	// and no manifest can express a placement requirement in the first place.
+	// The page was selling a licence for a behaviour identical to the one you
+	// get without it. Three other pages make the same sentence and all three
+	// are true, which is exactly why nobody looked.
+	pages, err := filepath.Glob("../../../docs/src/content/docs/enterprise/*.md")
+	require.NoError(t, err)
+	require.NotEmpty(t, pages, "no enterprise documentation pages were found, so this "+
+		"test is scanning nothing")
+
+	gated := map[license.Feature]bool{}
+	for _, f := range feature.GatedFeatures() {
+		gated[f] = true
+	}
+
+	checked := 0
+	for _, page := range pages {
+		raw, err := os.ReadFile(page)
+		require.NoError(t, err)
+		for _, m := range requirementLine.FindAllStringSubmatch(string(raw), -1) {
+			checked++
+			named := license.Feature(m[1])
+			entry, ok := feature.Of(named)
+			require.Truef(t, ok,
+				"%s requires the %s feature and no licence can carry that name",
+				filepath.Base(page), named)
+			require.Truef(t, gated[named],
+				"%s says it requires the %s feature and the catalogue calls that %q, so the "+
+					"page promises a licence check the product does not make. Either gate it "+
+					"or say what actually happens without it.",
+				filepath.Base(page), named, entry.State)
+		}
+	}
+	require.NotZerof(t, checked,
+		"no page makes a licence requirement claim, which is either a documentation change "+
+			"nobody told this test about or a broken pattern")
+	t.Logf("enterprise pages claiming a licence requirement: %d, all gated", checked)
+}

--- a/ee/engine/feature/reference_test.go
+++ b/ee/engine/feature/reference_test.go
@@ -72,6 +72,9 @@ func effect(e feature.Entitlement) string {
 		return "Nothing changes. It is implemented and deliberately available to everyone."
 	case feature.StateAbsent:
 		return "Nothing changes, because the capability is not built yet."
+	case feature.StateUnmounted:
+		return "Nothing changes, and not because it is unbuilt. It is implemented and no " +
+			"binary loads it, so nobody has it, paid or not."
 	}
 	return ""
 }

--- a/ee/engine/policyenforce/policyenforce.go
+++ b/ee/engine/policyenforce/policyenforce.go
@@ -36,7 +36,7 @@ import (
 func init() {
 	// Recorded so that a feature which is sold and never checked shows up as
 	// such. See ee/engine/feature.
-	feature.Declare(license.FeaturePolicy, "ee/engine/policyenforce.Hook")
+	feature.Declare(license.FeaturePolicy, "policyenforce/policyenforce.go:Hook.Check")
 }
 
 // Policy is what an organization requires of every repository.

--- a/ee/engine/policyenforce/policyenforce_test.go
+++ b/ee/engine/policyenforce/policyenforce_test.go
@@ -547,6 +547,13 @@ func TestTheRefusalCarriesTheDocumentedErrorCode(t *testing.T) {
 
 func TestFeatureIsDeclaredSoItCannotBeSoldAndNeverChecked(t *testing.T) {
 	t.Parallel()
-	require.Contains(t, feature.Sites(license.FeaturePolicy),
-		"ee/engine/policyenforce.Hook")
+	// Against the catalogue rather than against a literal, so that the site
+	// this package registers and the site the licensing page publishes cannot
+	// be two different strings. A literal here agreed with itself and with
+	// nothing else, which is how the compliance declaration spent its whole
+	// life naming a function that does not check a licence.
+	entry, ok := feature.Of(license.FeaturePolicy)
+	require.True(t, ok, "policy_enforcement is not in the entitlement catalogue")
+	require.Equal(t, feature.StateGated, entry.State)
+	require.Contains(t, feature.Sites(license.FeaturePolicy), entry.EnforcedAt)
 }

--- a/ee/engine/secrets/source.go
+++ b/ee/engine/secrets/source.go
@@ -55,7 +55,7 @@ import (
 func init() {
 	// Recorded so that a feature which is sold and never checked shows up as
 	// such. See ee/engine/feature.
-	feature.Declare(license.FeatureSecrets, "ee/engine/secrets.Source")
+	feature.Declare(license.FeatureSecrets, "secrets/source.go:Source.Available")
 }
 
 // Backend is one store, reduced to the two things a lookup needs.

--- a/ee/web/features/test/catalogue.test.ts
+++ b/ee/web/features/test/catalogue.test.ts
@@ -55,6 +55,8 @@ const repo = path.resolve(here, '..', '..', '..', '..')
 
 const licenseGo = await readFile(path.join(repo, 'ee/engine/license/license.go'), 'utf8')
 const licensegenGo = await readFile(path.join(repo, 'tools/licensegen/main.go'), 'utf8')
+const catalogueGo = await readFile(
+  path.join(repo, 'ee/engine/feature/catalogue.go'), 'utf8')
 const licensingDoc = await readFile(
   path.join(repo, 'docs/src/content/docs/enterprise/licensing.md'), 'utf8')
 const issuingDoc = await readFile(
@@ -409,5 +411,145 @@ describe('every feature a licence can grant is accounted for somewhere', () => {
         `licensing.md lists ${feature} and never says the licence does not enforce it`,
       )
     }
+  })
+})
+
+
+/**
+ * The Go catalogue's own claim about each feature, as feature name to state.
+ *
+ * Parsed rather than duplicated, for the reason every other reader in this file
+ * is: the catalogue is a fifth copy of the answer and a copy with no gate is a
+ * copy that drifts. Read through the Feature constants so that renaming a
+ * constant cannot silently drop a row, and taken from the literal `State:` on
+ * each entry rather than from a hand kept list.
+ */
+function goCatalogueStates(catalogueSource: string, licenseSource: string): Map<string, string> {
+  const featureNames = new Map<string, string>()
+  for (const line of licenseSource.split('\n')) {
+    const m = /^\s*(Feature[A-Za-z]+)\s+Feature\s*=\s*"([a-z_]+)"\s*$/.exec(line)
+    if (m?.[1] && m[2]) featureNames.set(m[1], m[2])
+  }
+  const stateValues = new Map<string, string>()
+  for (const m of catalogueSource.matchAll(
+    /^\s*(State[A-Za-z]+)\s+State\s*=\s*"([a-z_]+)"\s*$/gm)) {
+    stateValues.set(m[1]!, m[2]!)
+  }
+  const body = /var catalogue = \[\]Entitlement\{([\s\S]*)\n\}/.exec(catalogueSource)
+  assert.ok(body?.[1], 'no catalogue literal was found in catalogue.go')
+
+  const out = new Map<string, string>()
+  const starts = [...body[1].matchAll(/Feature:\s*license\.(Feature[A-Za-z]+)/g)]
+  for (let i = 0; i < starts.length; i += 1) {
+    const at = starts[i]!.index!
+    const until = i + 1 < starts.length ? starts[i + 1]!.index! : body[1].length
+    const entry = body[1].slice(at, until)
+    const name = featureNames.get(starts[i]![1]!)
+    assert.ok(name, `the catalogue names ${starts[i]![1]}, which is not a Feature constant`)
+    const state = /State:\s*(State[A-Za-z]+)/.exec(entry)
+    assert.ok(state?.[1], `the catalogue entry for ${name} names no State`)
+    const value = stateValues.get(state[1]!)
+    assert.ok(value, `${name} has state ${state[1]}, which is not a State constant`)
+    out.set(name, value)
+  }
+  return out
+}
+
+/** The `ControlPlaneAt` string on one catalogue entry, or null. */
+function goControlPlaneAt(catalogueSource: string, licenseSource: string, feature: string): string | null {
+  const featureConstant = [...licenseSource.matchAll(
+    /^\s*(Feature[A-Za-z]+)\s+Feature\s*=\s*"([a-z_]+)"\s*$/gm)]
+    .find((m) => m[2] === feature)?.[1]
+  assert.ok(featureConstant, `${feature} has no Feature constant`)
+  const body = /var catalogue = \[\]Entitlement\{([\s\S]*)\n\}/.exec(catalogueSource)
+  assert.ok(body?.[1], 'no catalogue literal was found in catalogue.go')
+  const starts = [...body[1].matchAll(/Feature:\s*license\.(Feature[A-Za-z]+)/g)]
+  for (let i = 0; i < starts.length; i += 1) {
+    if (starts[i]![1] !== featureConstant) continue
+    const at = starts[i]!.index!
+    const until = i + 1 < starts.length ? starts[i + 1]!.index! : body[1].length
+    const m = /ControlPlaneAt:\s*"([^"]*)"/.exec(body[1].slice(at, until))
+    return m?.[1] ?? null
+  }
+  return null
+}
+
+const CONTROL_PLANE_GATED = 'control_plane_gated'
+
+describe('the two languages agree about who refuses what', () => {
+  // THE GAP THIS CLOSES, and it had already shipped a false sentence onto the
+  // pricing page by the time it was written.
+  //
+  // Enforcement in this product lives in two languages. The engine gates three
+  // features in Go. The enterprise control plane gates two in TypeScript, in
+  // packages the Go catalogue cannot import and the Go registry cannot see. The
+  // catalogue measured `feature.Enabled` call sites, found none for sso and
+  // scim, and published "it is implemented and no binary loads it, so nobody
+  // has it, paid or not" about two features that ee/web/server mounts and that
+  // answer 402 by name to an unlicensed caller.
+  //
+  // Nothing caught it. The Go side asserts that a non gated entry has no
+  // declared site, and it reads the GO registry, which a TypeScript declare()
+  // never reaches. The checks above compare NAMES across the four copies and
+  // never compare the Go catalogue's STATE claims to this registry. So both
+  // halves were internally consistent and the product's own description of what
+  // a customer gets for their money was wrong, with every gate green.
+  //
+  // This is the comparison neither language could make alone, and it is made
+  // here because this is the only suite that has both: the Go source as text,
+  // and the registry as a live object populated by importing the packages that
+  // do the enforcing.
+  it('every feature declared here is called control plane gated by the Go catalogue', () => {
+    const states = goCatalogueStates(catalogueGo, licenseGo)
+    assert.ok(states.size > 0, 'no catalogue entries were parsed, so this test proves nothing')
+    for (const feature of declared()) {
+      assert.equal(
+        states.get(feature), CONTROL_PLANE_GATED,
+        `${feature} declares an enforcement site in this process and the Go catalogue calls ` +
+          `it ${states.get(feature)}. A feature this control plane refuses by name is being ` +
+          'published as one nobody is refused, which is what the catalogue exists to prevent.',
+      )
+    }
+  })
+
+  it('every feature the Go catalogue calls control plane gated is declared here', () => {
+    // The other direction, and the one a missing import breaks. If a package
+    // stops being imported at the top of this file its declare() never runs,
+    // the registry goes quiet, and a catalogue entry claiming a refusal would
+    // otherwise stand with nothing behind it.
+    const states = goCatalogueStates(catalogueGo, licenseGo)
+    const claimed = [...states.entries()]
+      .filter(([, state]) => state === CONTROL_PLANE_GATED)
+      .map(([feature]) => feature)
+      .sort()
+    assert.ok(
+      claimed.length > 0,
+      'the Go catalogue calls nothing control plane gated, so this direction proves nothing',
+    )
+    assert.deepEqual(
+      claimed, declared(),
+      'the Go catalogue and this registry disagree about which features the control plane ' +
+        'refuses. Either an entry claims a refusal no package declares, or a package ' +
+        'declares one the catalogue has not been told about.',
+    )
+  })
+
+  it('the site the Go catalogue names is one this registry actually declared', () => {
+    // Byte for byte against the registry rather than merely resolvable on
+    // disk. A path that exists and is not the declared site is the same defect
+    // one level down as a state that is right about the feature and wrong about
+    // the file, which is the failure the engine already shipped once.
+    let checked = 0
+    for (const feature of declared()) {
+      const named = goControlPlaneAt(catalogueGo, licenseGo, feature)
+      assert.ok(named, `${feature} is refused here and the Go catalogue names no site for it`)
+      assert.ok(
+        sites(feature).includes(named),
+        `the Go catalogue says ${feature} is refused at ${named} and this registry declared ` +
+          `${JSON.stringify(sites(feature))}. The catalogue is naming a place nothing declared.`,
+      )
+      checked += 1
+    }
+    assert.ok(checked >= 2, `only ${checked} sites were compared, and there are at least two`)
   })
 })

--- a/engine/internal/docs/pages.gen.go
+++ b/engine/internal/docs/pages.gen.go
@@ -5322,15 +5322,13 @@ license leaves you with it rather than with nothing.
 
 ## What is in ` + "`" + `ee/` + "`" + `
 
-<<<<<<< HEAD
-` + "`" + `sso` + "`" + `, ` + "`" + `scim` + "`" + `, ` + "`" + `rbac` + "`" + `, ` + "`" + `audit_stream` + "`" + `, ` + "`" + `policy_enforcement` + "`" + `, ` + "`" + `multi_runtime` + "`" + `,
-` + "`" + `enterprise_secrets` + "`" + `, ` + "`" + `billing` + "`" + `, ` + "`" + `enterprise_dashboard` + "`" + `, ` + "`" + `support_access` + "`" + `,
-` + "`" + `compliance_packs` + "`" + `, ` + "`" + `air_gapped` + "`" + `, ` + "`" + `cloud_database` + "`" + `, ` + "`" + `cloud_runtime` + "`" + `.
-=======
+<!-- entitlement-names:start -->
+The features a license can name are ` + "`" + `air_gapped` + "`" + `, ` + "`" + `audit_stream` + "`" + `, ` + "`" + `billing` + "`" + `, ` + "`" + `compliance_packs` + "`" + `, ` + "`" + `enterprise_dashboard` + "`" + `, ` + "`" + `enterprise_secrets` + "`" + `, ` + "`" + `multi_runtime` + "`" + `, ` + "`" + `policy_enforcement` + "`" + `, ` + "`" + `rbac` + "`" + `, ` + "`" + `scim` + "`" + `, ` + "`" + `sso` + "`" + ` and ` + "`" + `support_access` + "`" + `.
+<!-- entitlement-names:end -->
+
 <!-- entitlement-count:start -->
-Of the 12 features a license can carry, **3 are refused when the license does not name them**. The rest are listed here anyway, with what actually happens without each one, because a feature that is sold and never checked is worth knowing about and the number is only useful if it can come back unflattering.
+Of the 12 features a license can carry, **5 are refused when the license does not name them**, 3 by the engine and 2 by the control plane. The rest are listed here anyway, with what actually happens without each one, because a feature that is sold and never checked is worth knowing about and the number is only useful if it can come back unflattering.
 <!-- entitlement-count:end -->
->>>>>>> 9ccf7d74 (ee: nine of twelve licensed features permitted nothing and refused nothing)
 
 The table is generated from ` + "`" + `ee/engine/feature/catalogue.go` + "`" + `, which is the one
 place this product records what a license permits. Every row saying a feature is
@@ -5345,16 +5343,16 @@ gap worth publishing, and this page is where it gets published.
 | --- | --- | --- |
 | ` + "`" + `air_gapped` + "`" + ` | An installation that reaches nothing outside the operator's own network. | Nothing changes, because the capability is not built yet. |
 | ` + "`" + `audit_stream` + "`" + ` | Privileged actions forwarded to the organization's own SIEM. | Nothing changes, because the capability is not built yet. |
-| ` + "`" + `billing` + "`" + ` | Subscriptions, invoices and the plan an organization is on. | Nothing changes. It is implemented and deliberately available to everyone. |
+| ` + "`" + `billing` + "`" + ` | Subscriptions, invoices and the plan an organization is on. | Nothing changes, because the capability is not built yet. |
 | ` + "`" + `compliance_packs` + "`" + ` | SOC 2 and ISO 27001 evidence gathered from the control plane's own records. | Withheld. ` + "`" + `compliance/command.go:Command` + "`" + ` asks the license, and the feature is off when the answer is no. |
-| ` + "`" + `enterprise_dashboard` + "`" + ` | The console: environments, masking, egress, audit and workloads. | Not refused by this name. The hosted control plane refuses the capability on the plan as a whole; a self hosted installation with no license keeps it. |
+| ` + "`" + `enterprise_dashboard` + "`" + ` | The console: environments, masking, egress, audit and workloads. | Nothing changes, because the capability is not built yet. |
 | ` + "`" + `enterprise_secrets` + "`" + ` | Declared variables resolved from Vault or a cloud secret manager. | Withheld. ` + "`" + `secrets/source.go:Source.Available` + "`" + ` asks the license, and the feature is off when the answer is no. |
 | ` + "`" + `multi_runtime` + "`" + ` | Placing an environment across several runtimes at once, by requirement and by tag. | Nothing changes, because the capability is not built yet. |
 | ` + "`" + `policy_enforcement` + "`" + ` | Organization policy that refuses an environment the manifest would have allowed. | Withheld. ` + "`" + `policyenforce/policyenforce.go:Hook.Check` + "`" + ` asks the license, and the feature is off when the answer is no. |
 | ` + "`" + `rbac` + "`" + ` | Roles, and a permission on every route. | Nothing changes. It is implemented and deliberately available to everyone. |
-| ` + "`" + `scim` + "`" + ` | Directory provisioning, so joiners and leavers arrive from the identity provider. | Nothing changes, because the capability is not built yet. |
-| ` + "`" + `sso` + "`" + ` | Single sign on against the organization's own identity provider. | Nothing changes, because the capability is not built yet. |
-| ` + "`" + `support_access` + "`" + ` | A supported way for the vendor to see what a customer sees. | Nothing changes, because the capability is not built yet. |
+| ` + "`" + `scim` + "`" + ` | Directory provisioning, so joiners and leavers arrive from the identity provider. | Withheld by the control plane. ` + "`" + `ee/web/scim/src/routes.ts:guard` + "`" + ` asks the license, and an unlicensed installation is answered 402 naming the feature rather than 404. |
+| ` + "`" + `sso` + "`" + ` | Single sign on against the organization's own identity provider. | Withheld by the control plane. ` + "`" + `ee/web/sso/src/store.ts:connectionByHandle` + "`" + ` asks the license, and an unlicensed installation is answered 402 naming the feature rather than 404. |
+| ` + "`" + `support_access` + "`" + ` | A supported way for the vendor to see what a customer sees. | Nothing changes. It is implemented and deliberately available to everyone. |
 <!-- entitlements:end -->
 
 The distinction in the third column between a feature that is refused and one

--- a/engine/internal/docs/pages.gen.go
+++ b/engine/internal/docs/pages.gen.go
@@ -5322,11 +5322,46 @@ license leaves you with it rather than with nothing.
 
 ## What is in ` + "`" + `ee/` + "`" + `
 
+<<<<<<< HEAD
 ` + "`" + `sso` + "`" + `, ` + "`" + `scim` + "`" + `, ` + "`" + `rbac` + "`" + `, ` + "`" + `audit_stream` + "`" + `, ` + "`" + `policy_enforcement` + "`" + `, ` + "`" + `multi_runtime` + "`" + `,
 ` + "`" + `enterprise_secrets` + "`" + `, ` + "`" + `billing` + "`" + `, ` + "`" + `enterprise_dashboard` + "`" + `, ` + "`" + `support_access` + "`" + `,
 ` + "`" + `compliance_packs` + "`" + `, ` + "`" + `air_gapped` + "`" + `, ` + "`" + `cloud_database` + "`" + `, ` + "`" + `cloud_runtime` + "`" + `.
+=======
+<!-- entitlement-count:start -->
+Of the 12 features a license can carry, **3 are refused when the license does not name them**. The rest are listed here anyway, with what actually happens without each one, because a feature that is sold and never checked is worth knowing about and the number is only useful if it can come back unflattering.
+<!-- entitlement-count:end -->
+>>>>>>> 9ccf7d74 (ee: nine of twelve licensed features permitted nothing and refused nothing)
 
-Each is named in the license, so a license permits exactly what was bought.
+The table is generated from ` + "`" + `ee/engine/feature/catalogue.go` + "`" + `, which is the one
+place this product records what a license permits. Every row saying a feature is
+refused names the file that refuses it, and a test opens that file and requires
+a ` + "`" + `feature.Enabled` + "`" + ` call for that exact feature in it, so a row cannot claim an
+enforcement it does not have. Rows that say nothing changes are the honest
+answer rather than an omission: a feature that is sold and never checked is a
+gap worth publishing, and this page is where it gets published.
+
+<!-- entitlements:start -->
+| Feature | What it is | Without it |
+| --- | --- | --- |
+| ` + "`" + `air_gapped` + "`" + ` | An installation that reaches nothing outside the operator's own network. | Nothing changes, because the capability is not built yet. |
+| ` + "`" + `audit_stream` + "`" + ` | Privileged actions forwarded to the organization's own SIEM. | Nothing changes, because the capability is not built yet. |
+| ` + "`" + `billing` + "`" + ` | Subscriptions, invoices and the plan an organization is on. | Nothing changes. It is implemented and deliberately available to everyone. |
+| ` + "`" + `compliance_packs` + "`" + ` | SOC 2 and ISO 27001 evidence gathered from the control plane's own records. | Withheld. ` + "`" + `compliance/command.go:Command` + "`" + ` asks the license, and the feature is off when the answer is no. |
+| ` + "`" + `enterprise_dashboard` + "`" + ` | The console: environments, masking, egress, audit and workloads. | Not refused by this name. The hosted control plane refuses the capability on the plan as a whole; a self hosted installation with no license keeps it. |
+| ` + "`" + `enterprise_secrets` + "`" + ` | Declared variables resolved from Vault or a cloud secret manager. | Withheld. ` + "`" + `secrets/source.go:Source.Available` + "`" + ` asks the license, and the feature is off when the answer is no. |
+| ` + "`" + `multi_runtime` + "`" + ` | Placing an environment across several runtimes at once, by requirement and by tag. | Nothing changes, because the capability is not built yet. |
+| ` + "`" + `policy_enforcement` + "`" + ` | Organization policy that refuses an environment the manifest would have allowed. | Withheld. ` + "`" + `policyenforce/policyenforce.go:Hook.Check` + "`" + ` asks the license, and the feature is off when the answer is no. |
+| ` + "`" + `rbac` + "`" + ` | Roles, and a permission on every route. | Nothing changes. It is implemented and deliberately available to everyone. |
+| ` + "`" + `scim` + "`" + ` | Directory provisioning, so joiners and leavers arrive from the identity provider. | Nothing changes, because the capability is not built yet. |
+| ` + "`" + `sso` + "`" + ` | Single sign on against the organization's own identity provider. | Nothing changes, because the capability is not built yet. |
+| ` + "`" + `support_access` + "`" + ` | A supported way for the vendor to see what a customer sees. | Nothing changes, because the capability is not built yet. |
+<!-- entitlements:end -->
+
+The distinction in the third column between a feature that is refused and one
+the hosted control plane covers under its plan is the one worth reading twice. A
+license carries twelve names and the hosted plan gate carries one boolean, so a
+license naming a feature and a plan that does not are not reconcilable by
+anything. Both are real refusals and only the first is keyed on what was bought.
 
 ### Two of those cannot be sold
 

--- a/engine/internal/docs/pages.gen.go
+++ b/engine/internal/docs/pages.gen.go
@@ -5323,11 +5323,11 @@ license leaves you with it rather than with nothing.
 ## What is in ` + "`" + `ee/` + "`" + `
 
 <!-- entitlement-names:start -->
-The features a license can name are ` + "`" + `air_gapped` + "`" + `, ` + "`" + `audit_stream` + "`" + `, ` + "`" + `billing` + "`" + `, ` + "`" + `compliance_packs` + "`" + `, ` + "`" + `enterprise_dashboard` + "`" + `, ` + "`" + `enterprise_secrets` + "`" + `, ` + "`" + `multi_runtime` + "`" + `, ` + "`" + `policy_enforcement` + "`" + `, ` + "`" + `rbac` + "`" + `, ` + "`" + `scim` + "`" + `, ` + "`" + `sso` + "`" + ` and ` + "`" + `support_access` + "`" + `.
+The features a license can name are ` + "`" + `air_gapped` + "`" + `, ` + "`" + `audit_stream` + "`" + `, ` + "`" + `billing` + "`" + `, ` + "`" + `cloud_database` + "`" + `, ` + "`" + `cloud_runtime` + "`" + `, ` + "`" + `compliance_packs` + "`" + `, ` + "`" + `enterprise_dashboard` + "`" + `, ` + "`" + `enterprise_secrets` + "`" + `, ` + "`" + `multi_runtime` + "`" + `, ` + "`" + `policy_enforcement` + "`" + `, ` + "`" + `rbac` + "`" + `, ` + "`" + `scim` + "`" + `, ` + "`" + `sso` + "`" + ` and ` + "`" + `support_access` + "`" + `.
 <!-- entitlement-names:end -->
 
 <!-- entitlement-count:start -->
-Of the 12 features a license can carry, **7 are refused when the license does not name them**, 5 by the engine and 2 by the control plane. The rest are listed here anyway, with what actually happens without each one, because a feature that is sold and never checked is worth knowing about and the number is only useful if it can come back unflattering.
+Of the 14 features a license can carry, **9 are refused when the license does not name them**, 7 by the engine and 2 by the control plane. The rest are listed here anyway, with what actually happens without each one, because a feature that is sold and never checked is worth knowing about and the number is only useful if it can come back unflattering.
 <!-- entitlement-count:end -->
 
 The table is generated from ` + "`" + `ee/engine/feature/catalogue.go` + "`" + `, which is the one
@@ -5338,9 +5338,11 @@ engine gates, ` + "`" + `edition.Permits` + "`" + ` for one the community engine
 row cannot claim an enforcement it does not have. Which of the two is required
 is decided by the row's own state and never by the shape of the path, because a
 check that guessed from the path would accept an enterprise file for a community
-gate and never notice that the mechanism claimed is not the mechanism there. Rows that say nothing changes are the honest
-answer rather than an omission: a feature that is sold and never checked is a
-gap worth publishing, and this page is where it gets published.
+gate and never notice that the mechanism claimed is not the mechanism there.
+
+Rows that say nothing changes are the honest answer rather than an omission: a
+feature that is sold and never checked is a gap worth publishing, and this page
+is where it gets published.
 
 <!-- entitlements:start -->
 | Feature | What it is | Without it |
@@ -5348,6 +5350,8 @@ gap worth publishing, and this page is where it gets published.
 | ` + "`" + `air_gapped` + "`" + ` | An installation that reaches nothing outside the operator's own network. | Nothing changes, because the capability is not built yet. |
 | ` + "`" + `audit_stream` + "`" + ` | Privileged actions forwarded to the organization's own SIEM. | Withheld. ` + "`" + `auditsink/auditsink.go:auditsink.permitted` + "`" + ` asks the license, and the feature is off when the answer is no. |
 | ` + "`" + `billing` + "`" + ` | Subscriptions, invoices and the plan an organization is on. | Nothing changes, because the capability is not built yet. |
+| ` + "`" + `cloud_database` + "`" + ` | Managed cloud database providers, the ones that need an organization behind them rather than a developer's own card. | Withheld. ` + "`" + `cloudgate/cloudgate.go:gatedDatabase.Branch` + "`" + ` asks the license, and the feature is off when the answer is no. |
+| ` + "`" + `cloud_runtime` + "`" + ` | Managed cloud runtime providers, on the same rule as the databases. | Withheld. ` + "`" + `cloudgate/cloudgate.go:gatedRuntime.Up` + "`" + ` asks the license, and the feature is off when the answer is no. |
 | ` + "`" + `compliance_packs` + "`" + ` | SOC 2 and ISO 27001 evidence gathered from the control plane's own records. | Withheld. ` + "`" + `compliance/command.go:Command` + "`" + ` asks the license, and the feature is off when the answer is no. |
 | ` + "`" + `enterprise_dashboard` + "`" + ` | The console: environments, masking, egress, audit and workloads. | Nothing changes, because the capability is not built yet. |
 | ` + "`" + `enterprise_secrets` + "`" + ` | Declared variables resolved from Vault or a cloud secret manager. | Withheld. ` + "`" + `secrets/source.go:Source.Available` + "`" + ` asks the license, and the feature is off when the answer is no. |

--- a/engine/internal/docs/pages.gen.go
+++ b/engine/internal/docs/pages.gen.go
@@ -5327,7 +5327,7 @@ The features a license can name are ` + "`" + `air_gapped` + "`" + `, ` + "`" + 
 <!-- entitlement-names:end -->
 
 <!-- entitlement-count:start -->
-Of the 14 features a license can carry, **9 are refused when the license does not name them**, 7 by the engine and 2 by the control plane. The rest are listed here anyway, with what actually happens without each one, because a feature that is sold and never checked is worth knowing about and the number is only useful if it can come back unflattering.
+Of the 14 features a license can carry, **10 are refused when the license does not name them**, 8 by the engine and 2 by the control plane. The rest are listed here anyway, with what actually happens without each one, because a feature that is sold and never checked is worth knowing about and the number is only useful if it can come back unflattering.
 <!-- entitlement-count:end -->
 
 The table is generated from ` + "`" + `ee/engine/feature/catalogue.go` + "`" + `, which is the one
@@ -5347,7 +5347,7 @@ is where it gets published.
 <!-- entitlements:start -->
 | Feature | What it is | Without it |
 | --- | --- | --- |
-| ` + "`" + `air_gapped` + "`" + ` | An installation that reaches nothing outside the operator's own network. | Nothing changes, because the capability is not built yet. |
+| ` + "`" + `air_gapped` + "`" + ` | An installation that reaches nothing outside the operator's own network. | Withheld. ` + "`" + `airgapped/airgapped.go:RegisterFromEnvironment` + "`" + ` asks the license, and the feature is off when the answer is no. |
 | ` + "`" + `audit_stream` + "`" + ` | Privileged actions forwarded to the organization's own SIEM. | Withheld. ` + "`" + `auditsink/auditsink.go:auditsink.permitted` + "`" + ` asks the license, and the feature is off when the answer is no. |
 | ` + "`" + `billing` + "`" + ` | Subscriptions, invoices and the plan an organization is on. | Nothing changes, because the capability is not built yet. |
 | ` + "`" + `cloud_database` + "`" + ` | Managed cloud database providers, the ones that need an organization behind them rather than a developer's own card. | Withheld. ` + "`" + `cloudgate/cloudgate.go:gatedDatabase.Branch` + "`" + ` asks the license, and the feature is off when the answer is no. |
@@ -5365,8 +5365,8 @@ is where it gets published.
 
 The distinction in the third column between a feature that is refused and one
 the hosted control plane covers under its plan is the one worth reading twice. A
-license carries twelve names and the hosted plan gate carries one boolean, so a
-license naming a feature and a plan that does not are not reconcilable by
+license carries fourteen names and the hosted plan gate carries one boolean, so
+a license naming a feature and a plan that does not are not reconcilable by
 anything. Both are real refusals and only the first is keyed on what was bought.
 
 ### Two of those cannot be sold
@@ -5384,31 +5384,32 @@ working feature from every direction and is harder to find than the gap it
 covers. A feature nobody can buy and nobody can be granted cannot be mistaken
 for one that ships.
 
-### Two more are not enforced
+### One more is not enforced
 
-A third case, and a different one from the two above: ` + "`" + `rbac` + "`" + ` and ` + "`" + `air_gapped` + "`" + `.
-Both name something real, and in neither case is the license what provides it.
+A third case, and a different one from the two above: ` + "`" + `rbac` + "`" + `. It names something
+real, and the license is not what provides it.
 
 The custom roles library is complete and tested, and nothing stores a role
-model, so an organization has no way to have one. Air gapped operation is a
-property every installation already has, licensed or not: verification is a
-signature check against keys stamped into the binary, so it needs no network
-whichever features a license names.
+model, so an organization has no way to have one.
 
-They are reported and not enforced, and that is written down rather than gated,
-for the reason the paragraph above gives: a check on a path nothing reaches is
-worse than no check. Unlike ` + "`" + `billing` + "`" + ` and ` + "`" + `enterprise_dashboard` + "`" + ` they are not
-refused at issue, because refusing them would refuse a customer a capability
-they can have. ` + "`" + `tools/licensegen` + "`" + ` prints a warning naming them beside the key it
-signs instead, so that whoever issues it reads what the license does and does
-not grant before a customer asks.
+It is reported and not enforced, and that is written down rather than gated, for
+the reason the paragraph above gives: a check on a path nothing reaches is worse
+than no check. Unlike ` + "`" + `billing` + "`" + ` and ` + "`" + `enterprise_dashboard` + "`" + ` it is not refused at
+issue, because refusing it would refuse a customer a capability they can have.
+` + "`" + `tools/licensegen` + "`" + ` prints a warning naming it beside the key it signs instead,
+so that whoever issues it reads what the license does and does not grant before
+a customer asks.
 
 ` + "`" + `air_gapped` + "`" + ` was in this state and said so nowhere until 2026-09-08. Every
 occurrence of the name in the repository was a copy of the catalogue, the
 license vectors, a line of documentation, or a test, so a license naming it
 verified, reported itself active, printed in ` + "`" + `af license status` + "`" + `, and granted
-nothing. That is the same failure the two refused names above exist to prevent,
-reached through the case they do not cover.
+nothing. It is no longer in this state and this page said it was for a day
+longer than it was true: the paragraph naming it stayed here while the gate that
+made it false landed in another pull request, which is the same stale sentence
+this catalogue exists to refuse and is why the row above is generated from the
+code rather than written beside it. The table now reads Withheld for
+` + "`" + `air_gapped` + "`" + `, and the site it names is the one that asks.
 
 All three lists are held to the code by a test rather than by a habit.
 ` + "`" + `notShipped` + "`" + ` and ` + "`" + `unenforced` + "`" + ` in ` + "`" + `ee/engine/license/license.go` + "`" + ` are the single

--- a/engine/internal/docs/pages.gen.go
+++ b/engine/internal/docs/pages.gen.go
@@ -5327,14 +5327,18 @@ The features a license can name are ` + "`" + `air_gapped` + "`" + `, ` + "`" + 
 <!-- entitlement-names:end -->
 
 <!-- entitlement-count:start -->
-Of the 12 features a license can carry, **5 are refused when the license does not name them**, 3 by the engine and 2 by the control plane. The rest are listed here anyway, with what actually happens without each one, because a feature that is sold and never checked is worth knowing about and the number is only useful if it can come back unflattering.
+Of the 12 features a license can carry, **7 are refused when the license does not name them**, 5 by the engine and 2 by the control plane. The rest are listed here anyway, with what actually happens without each one, because a feature that is sold and never checked is worth knowing about and the number is only useful if it can come back unflattering.
 <!-- entitlement-count:end -->
 
 The table is generated from ` + "`" + `ee/engine/feature/catalogue.go` + "`" + `, which is the one
 place this product records what a license permits. Every row saying a feature is
 refused names the file that refuses it, and a test opens that file and requires
-a ` + "`" + `feature.Enabled` + "`" + ` call for that exact feature in it, so a row cannot claim an
-enforcement it does not have. Rows that say nothing changes are the honest
+the call that actually refuses: ` + "`" + `feature.Enabled` + "`" + ` for a row the enterprise
+engine gates, ` + "`" + `edition.Permits` + "`" + ` for one the community engine gates by name. So a
+row cannot claim an enforcement it does not have. Which of the two is required
+is decided by the row's own state and never by the shape of the path, because a
+check that guessed from the path would accept an enterprise file for a community
+gate and never notice that the mechanism claimed is not the mechanism there. Rows that say nothing changes are the honest
 answer rather than an omission: a feature that is sold and never checked is a
 gap worth publishing, and this page is where it gets published.
 
@@ -5342,12 +5346,12 @@ gap worth publishing, and this page is where it gets published.
 | Feature | What it is | Without it |
 | --- | --- | --- |
 | ` + "`" + `air_gapped` + "`" + ` | An installation that reaches nothing outside the operator's own network. | Nothing changes, because the capability is not built yet. |
-| ` + "`" + `audit_stream` + "`" + ` | Privileged actions forwarded to the organization's own SIEM. | Nothing changes, because the capability is not built yet. |
+| ` + "`" + `audit_stream` + "`" + ` | Privileged actions forwarded to the organization's own SIEM. | Withheld. ` + "`" + `auditsink/auditsink.go:auditsink.permitted` + "`" + ` asks the license, and the feature is off when the answer is no. |
 | ` + "`" + `billing` + "`" + ` | Subscriptions, invoices and the plan an organization is on. | Nothing changes, because the capability is not built yet. |
 | ` + "`" + `compliance_packs` + "`" + ` | SOC 2 and ISO 27001 evidence gathered from the control plane's own records. | Withheld. ` + "`" + `compliance/command.go:Command` + "`" + ` asks the license, and the feature is off when the answer is no. |
 | ` + "`" + `enterprise_dashboard` + "`" + ` | The console: environments, masking, egress, audit and workloads. | Nothing changes, because the capability is not built yet. |
 | ` + "`" + `enterprise_secrets` + "`" + ` | Declared variables resolved from Vault or a cloud secret manager. | Withheld. ` + "`" + `secrets/source.go:Source.Available` + "`" + ` asks the license, and the feature is off when the answer is no. |
-| ` + "`" + `multi_runtime` + "`" + ` | Placing an environment across several runtimes at once, by requirement and by tag. | Nothing changes, because the capability is not built yet. |
+| ` + "`" + `multi_runtime` + "`" + ` | Placing an environment across several runtimes at once, by requirement and by tag. | Withheld. ` + "`" + `engine/internal/env/env.go:Orchestrator.placement` + "`" + ` asks the license, and the feature is off when the answer is no. |
 | ` + "`" + `policy_enforcement` + "`" + ` | Organization policy that refuses an environment the manifest would have allowed. | Withheld. ` + "`" + `policyenforce/policyenforce.go:Hook.Check` + "`" + ` asks the license, and the feature is off when the answer is no. |
 | ` + "`" + `rbac` + "`" + ` | Roles, and a permission on every route. | Nothing changes. It is implemented and deliberately available to everyone. |
 | ` + "`" + `scim` + "`" + ` | Directory provisioning, so joiners and leavers arrive from the identity provider. | Withheld by the control plane. ` + "`" + `ee/web/scim/src/routes.ts:guard` + "`" + ` asks the license, and an unlicensed installation is answered 402 naming the feature rather than 404. |

--- a/web/apps/api/test/licensed-features.test.ts
+++ b/web/apps/api/test/licensed-features.test.ts
@@ -1,0 +1,228 @@
+// The other end of the entitlement catalogue, read from the side that cannot
+// import it.
+//
+// There are two entitlement systems in this product. The engine has
+// `license.Feature`, a set of names a signed licence may carry, and the control
+// plane has `organizations.plan` and `entitlements.ts`, which is about quotas.
+// Nothing reconciled them, so "what does this customer get" had two answers and
+// a self hosted licence and a hosted plan could disagree in silence.
+//
+// The single answer now lives in `ee/engine/feature/catalogue.go`, and every
+// entry that says the control plane does something names the file and the
+// symbol. The Go suite checks those claims. This file checks them again from
+// here, and the duplication is the point rather than an oversight: a control
+// plane developer renaming `orgProcedure` runs this suite and does not run a
+// Go module that is deliberately outside the workspace, so a check that lived
+// only over there would go unread until CI, or until a customer found it.
+//
+// `admin-platform.test.ts` is the precedent and the shape is copied from it: it
+// compares the TypeScript tool list against `serve.go` in BOTH directions and
+// caught three registered but unlisted tools the day it was written.
+//
+// THE PARSES ARE GUARDED. Every regex below is checked for having matched
+// something before its result is used. A parse that quietly matches nothing
+// passes every assertion made from it and reports success about a check it
+// never made, which is the exact defect this repository keeps finding in its
+// own instruments.
+
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+/** The repository root: test, api, apps, web. */
+const root = path.resolve(here, '..', '..', '..', '..')
+const apiSrc = path.join(root, 'web', 'apps', 'api', 'src')
+const licenseGo = path.join(root, 'ee', 'engine', 'license', 'license.go')
+const catalogueGo = path.join(root, 'ee', 'engine', 'feature', 'catalogue.go')
+
+/** `FeatureSSO Feature = "sso"` from the engine's own constant block. */
+async function licensedFeatures(): Promise<Map<string, string>> {
+  const source = await readFile(licenseGo, 'utf8')
+  const found = new Map<string, string>()
+  for (const m of source.matchAll(/(Feature\w+)\s+Feature\s+=\s+"([a-z_]+)"/g)) {
+    found.set(m[1] ?? '', m[2] ?? '')
+  }
+  assert.ok(
+    found.size >= 10,
+    `parsed ${found.size} feature constants out of ${licenseGo}, which means the const block ` +
+      `moved and every assertion below is being made about nothing`,
+  )
+  return found
+}
+
+interface Entry {
+  constant: string
+  state: string
+  controlPlaneAt: string | null
+}
+
+/**
+ * The catalogue, read out of the Go literal.
+ *
+ * Split on `Feature: license.` because that field opens every entry, so an
+ * entry that gained a field or lost one still parses. The count is checked
+ * against the constant block, which is what makes a parse that drifts fail
+ * loudly rather than silently returning a shorter list.
+ */
+async function catalogue(): Promise<Entry[]> {
+  const source = await readFile(catalogueGo, 'utf8')
+  const body = source.slice(source.indexOf('var catalogue = []Entitlement{'))
+  assert.ok(body.length > 0, `${catalogueGo} declares no catalogue variable`)
+
+  const entries: Entry[] = []
+  const chunks = body.split(/\n\t\tFeature:\s+license\./).slice(1)
+  for (const chunk of chunks) {
+    // `?? ''` rather than a non-null assertion after assert.ok, because the
+    // compiler is the second reader here and narrowing through an assertion
+    // function is a rule with edges. An empty string fails the check below and
+    // says which entry, which is what a reader needs either way.
+    const constant = chunk.match(/^(Feature\w+)/)?.[1] ?? ''
+    assert.notEqual(constant, '', 'a catalogue entry does not open with a license.Feature constant')
+    const state = chunk.match(/State:\s+State(\w+)/)?.[1] ?? ''
+    assert.notEqual(state, '', `${constant} has no State`)
+    entries.push({
+      constant,
+      state: state.toLowerCase(),
+      controlPlaneAt: chunk.match(/ControlPlaneAt:\s+"([^"]+)"/)?.[1] ?? null,
+    })
+  }
+  return entries
+}
+
+describe('the entitlement catalogue and this control plane still agree', () => {
+  test('every feature a licence can carry has an entry, so nothing is unaccounted for', async () => {
+    // The direction that catches a lane adding a feature to the engine and
+    // nowhere else, which is how `air_gapped` became a word that means nothing:
+    // it reached the const block, two documentation pages and licensegen, and
+    // no code anywhere asks whether it is on. This suite fails on the next one
+    // even though it is a Go change, because the control plane is the other
+    // half of the answer and has to be told.
+    const features = await licensedFeatures()
+    const entries = await catalogue()
+    const covered = new Set(entries.map((e) => e.constant))
+
+    for (const [constant, wire] of features) {
+      assert.ok(
+        covered.has(constant),
+        `the licence sells ${wire} and ee/engine/feature/catalogue.go has no entry for it, ` +
+          `so nobody has written down what a customer without it gets`,
+      )
+    }
+    assert.equal(
+      entries.length,
+      features.size,
+      'the catalogue and the constant block are different lengths',
+    )
+  })
+
+  test('every control plane site the catalogue names is still in this source tree', async () => {
+    // The file as well as the symbol, for the reason admin/controls.ts gives
+    // about enforcedBy: a bare name proves only that SOME file declares one,
+    // and enforcement moving into a module nothing calls would still satisfy
+    // that.
+    const entries = await catalogue()
+    const named = entries.filter((e) => e.controlPlaneAt !== null)
+    assert.ok(
+      named.length > 0,
+      'no catalogue entry names a control plane site, so this test is checking nothing',
+    )
+
+    for (const entry of named) {
+      const [file = '', symbol = ''] = (entry.controlPlaneAt ?? '').split(':')
+      assert.ok(file !== '' && symbol !== '',
+        `${entry.constant} has ControlPlaneAt ${entry.controlPlaneAt}, which is not file:symbol`)
+      const source = await readFile(path.join(apiSrc, file), 'utf8')
+      assert.match(
+        source,
+        new RegExp(`\\b${symbol}\\b`),
+        `${entry.constant} says ${entry.controlPlaneAt} is where this lives in the control ` +
+          `plane, and ${file} declares no ${symbol}`,
+      )
+    }
+  })
+})
+
+describe('the two facts the catalogue asserts about the plan gate', () => {
+  // These are prose in the catalogue and behaviour here, and prose that
+  // describes behaviour is worth nothing until something checks it. Three
+  // people in this repository once agreed a thing was cross site when
+  // SameSite=Strict had already made it same site only. A claim needs its
+  // mitigation checked, not just described.
+
+  test('billing is free because the plan gate exempts it, and it still does', async () => {
+    // `billing` is marked free rather than plan wide, and the whole reason is
+    // that `billing.manage` is exempt from the hosted gate: gating the path
+    // that RESOLVES a refusal would leave a lapsed customer with no exit, which
+    // hosted.ts calls a legal exposure rather than a courtesy. Remove it from
+    // the exempt set and the catalogue's answer for `billing` becomes wrong.
+    const source = await readFile(path.join(apiSrc, 'hosted.ts'), 'utf8')
+    const set = source.match(/HOSTED_GATE_EXEMPT[^=]*=\s*new Set\(\[([^\]]+)\]\)/)?.[1] ?? ''
+    assert.notEqual(set, '', 'hosted.ts no longer declares HOSTED_GATE_EXEMPT as a Set literal')
+    assert.match(
+      set,
+      /'billing\.manage'/,
+      "the catalogue says billing is free because billing.manage is exempt from the hosted " +
+        'plan gate, and it is no longer in HOSTED_GATE_EXEMPT',
+    )
+  })
+
+  test('the dashboard is plan wide because orgProcedure asks the plan, and it still does', async () => {
+    // `enterprise_dashboard` is marked plan wide rather than gated because the
+    // refusal that exists is keyed on the plan as a whole and knows nothing
+    // about the twelve names a licence carries. That is the finding, and it
+    // stops being true the day this call changes.
+    const source = await readFile(path.join(apiSrc, 'trpc.ts'), 'utf8')
+    assert.match(
+      source,
+      /hasHostedAccess\(/,
+      'the catalogue says orgProcedure refuses on the plan and trpc.ts no longer calls ' +
+        'hasHostedAccess, so what the dashboard is gated on has changed',
+    )
+    assert.match(
+      source,
+      /HOSTED_GATE_EXEMPT\.has\(/,
+      'trpc.ts no longer consults HOSTED_GATE_EXEMPT, so the exemption the catalogue relies ' +
+        'on for billing is not applied on the request path',
+    )
+  })
+
+  test('no licence feature name has become a string this control plane branches on', async () => {
+    // The drift the lane is named for, in the direction nothing else watches: a
+    // second entitlement catalogue growing over here.
+    //
+    // Deliberately narrow. `'sso'` is a sign in method label in server.ts and
+    // `'billing'` is an admin role in admin/permissions.ts, and both are
+    // ordinary English words that happen to collide with a feature name. So the
+    // assertion is not that the strings are absent, it is that no single file
+    // holds THREE or more of them, which is what a copy of the licence's list
+    // looks like and what an incidental collision never does.
+    const features = await licensedFeatures()
+    const wire = [...features.values()]
+    const { readdir } = await import('node:fs/promises')
+
+    async function* walk(dir: string): AsyncGenerator<string> {
+      for (const item of await readdir(dir, { withFileTypes: true })) {
+        const full = path.join(dir, item.name)
+        if (item.isDirectory()) yield* walk(full)
+        else if (item.name.endsWith('.ts')) yield full
+      }
+    }
+
+    let scanned = 0
+    for await (const file of walk(apiSrc)) {
+      scanned += 1
+      const source = await readFile(file, 'utf8')
+      const present = wire.filter((n) => new RegExp(`(['"])${n}\\1`).test(source))
+      assert.ok(
+        present.length < 3,
+        `${path.relative(root, file)} names ${present.join(', ')} as string literals, which ` +
+          `is a copy of the licence's feature list. There is one catalogue and it is ` +
+          `ee/engine/feature/catalogue.go; a second one here is what this test exists to stop.`,
+      )
+    }
+    assert.ok(scanned > 50, `walked ${scanned} TypeScript files under src, which is too few`)
+  })
+})

--- a/web/apps/api/test/licensed-features.test.ts
+++ b/web/apps/api/test/licensed-features.test.ts
@@ -145,47 +145,72 @@ describe('the entitlement catalogue and this control plane still agree', () => {
   })
 })
 
-describe('the two facts the catalogue asserts about the plan gate', () => {
+describe('the claims the catalogue makes about billing, the dashboard and the plan gate', () => {
   // These are prose in the catalogue and behaviour here, and prose that
   // describes behaviour is worth nothing until something checks it. Three
   // people in this repository once agreed a thing was cross site when
   // SameSite=Strict had already made it same site only. A claim needs its
   // mitigation checked, not just described.
+  //
+  // THE FIRST VERSION OF THIS BLOCK CHECKED THE PREVIOUS ANSWER AND STAYED
+  // GREEN, which is worth leaving written down because it is the same defect
+  // the whole lane is about. It held two tests named "billing is free because
+  // the plan gate exempts it" and "the dashboard is plan wide", against rows
+  // that now read absent, through a state called plan_wide that has since been
+  // deleted. Both passed, because both asserted true things about hosted.ts and
+  // trpc.ts. What had gone false was the REASON, and a green test whose failure
+  // message would teach the next person a deleted classification is worse than
+  // no test at all.
 
-  test('billing is free because the plan gate exempts it, and it still does', async () => {
-    // `billing` is marked free rather than plan wide, and the whole reason is
-    // that `billing.manage` is exempt from the hosted gate: gating the path
-    // that RESOLVES a refusal would leave a lapsed customer with no exit, which
-    // hosted.ts calls a legal exposure rather than a courtesy. Remove it from
-    // the exempt set and the catalogue's answer for `billing` becomes wrong.
-    const source = await readFile(path.join(apiSrc, 'hosted.ts'), 'utf8')
-    const set = source.match(/HOSTED_GATE_EXEMPT[^=]*=\s*new Set\(\[([^\]]+)\]\)/)?.[1] ?? ''
-    assert.notEqual(set, '', 'hosted.ts no longer declares HOSTED_GATE_EXEMPT as a Set literal')
-    assert.match(
-      set,
-      /'billing\.manage'/,
-      "the catalogue says billing is free because billing.manage is exempt from the hosted " +
-        'plan gate, and it is no longer in HOSTED_GATE_EXEMPT',
-    )
+  test('neither names a control plane site, because the code that looked like theirs serves us', async () => {
+    // The fact both rows assert in their own words, and the exact regression
+    // that produced the original error. billing read free because billingRouter
+    // is real, mounted and ungated, and that code bills the customer FOR
+    // Antifailure rather than metering on the customer's own behalf.
+    // enterprise_dashboard read as covered by the plan because orgProcedure
+    // really does refuse the console below the enterprise tier, which is our
+    // own funnel enforcing our own pricing. Putting either path back into
+    // ControlPlaneAt is how the mistake gets made again, so it fails here.
+    const entries = await catalogue()
+    for (const constant of ['FeatureBilling', 'FeatureDashboard']) {
+      const entry = entries.find((e) => e.constant === constant)
+      assert.ok(entry, `the catalogue has no entry for ${constant}, so this test proves nothing`)
+      assert.equal(
+        entry.state, 'absent',
+        `the catalogue calls ${constant} ${entry.state}. It is named in license.go's ` +
+          'notShipped map, which is the authority on what cannot be sold at all, and a ' +
+          'catalogue that calls it anything else is describing a capability that does not exist.',
+      )
+      assert.equal(
+        entry.controlPlaneAt, null,
+        `the catalogue says ${constant} is implemented at ${entry.controlPlaneAt} in the ` +
+          'control plane. That field means where the control plane implements or refuses ' +
+          'THIS feature, and naming code that serves us rather than the customer is the ' +
+          'precise mistake both of these rows were corrected for.',
+      )
+    }
   })
 
-  test('the dashboard is plan wide because orgProcedure asks the plan, and it still does', async () => {
-    // `enterprise_dashboard` is marked plan wide rather than gated because the
-    // refusal that exists is keyed on the plan as a whole and knows nothing
-    // about the twelve names a licence carries. That is the finding, and it
-    // stops being true the day this call changes.
+  test('the console refusal that misled the catalogue is still real and still keyed on the plan', async () => {
+    // The other half of the enterprise_dashboard row, and it is a claim about
+    // this tree rather than about the catalogue. The row says the refusal that
+    // exists here is our own funnel, keyed on organizations.plan and knowing
+    // nothing about the twelve names a licence carries. If trpc.ts stopped
+    // asking the plan, that sentence would be describing something that is gone
+    // and the row would need rewriting for the opposite reason it was rewritten
+    // last time.
     const source = await readFile(path.join(apiSrc, 'trpc.ts'), 'utf8')
     assert.match(
       source,
       /hasHostedAccess\(/,
-      'the catalogue says orgProcedure refuses on the plan and trpc.ts no longer calls ' +
-        'hasHostedAccess, so what the dashboard is gated on has changed',
+      'the catalogue says the console refusal is keyed on the plan and trpc.ts no longer ' +
+        'calls hasHostedAccess, so what the console is gated on has changed',
     )
     assert.match(
       source,
       /HOSTED_GATE_EXEMPT\.has\(/,
-      'trpc.ts no longer consults HOSTED_GATE_EXEMPT, so the exemption the catalogue relies ' +
-        'on for billing is not applied on the request path',
+      'trpc.ts no longer consults HOSTED_GATE_EXEMPT, so the plan gate the catalogue ' +
+        'describes is not the gate applied on the request path',
     )
   })
 

--- a/web/apps/api/test/licensed-features.test.ts
+++ b/web/apps/api/test/licensed-features.test.ts
@@ -134,7 +134,7 @@ describe('the entitlement catalogue and this control plane still agree', () => {
       const [file = '', symbol = ''] = (entry.controlPlaneAt ?? '').split(':')
       assert.ok(file !== '' && symbol !== '',
         `${entry.constant} has ControlPlaneAt ${entry.controlPlaneAt}, which is not file:symbol`)
-      const source = await readFile(path.join(apiSrc, file), 'utf8')
+      const source = await readFile(path.join(root, file), 'utf8')
       assert.match(
         source,
         new RegExp(`\\b${symbol}\\b`),

--- a/web/apps/api/test/licensed-features.test.ts
+++ b/web/apps/api/test/licensed-features.test.ts
@@ -195,7 +195,7 @@ describe('the claims the catalogue makes about billing, the dashboard and the pl
     // The other half of the enterprise_dashboard row, and it is a claim about
     // this tree rather than about the catalogue. The row says the refusal that
     // exists here is our own funnel, keyed on organizations.plan and knowing
-    // nothing about the twelve names a licence carries. If trpc.ts stopped
+    // nothing about the fourteen names a licence carries. If trpc.ts stopped
     // asking the plan, that sentence would be describing something that is gone
     // and the row would need rewriting for the opposite reason it was rewritten
     // last time.


### PR DESCRIPTION
## What changed

The licensing page named features without distinguishing what the product actually withholds. Engine declarations also named packages or methods that did not perform the stated licence check. This change makes the catalogue describe each feature's actual state, normalizes enforcement references to path:symbol, compares those references to the linked registries, and generates the licensing table and count from that catalogue.

The current catalogue has fourteen features: seven gated in the enterprise engine, one gated through the community engine's edition interface, two gated in the enterprise control plane, two deliberately free, and two absent. The tests exercise all seven enterprise engine features both with the entitlement and with every other entitlement except that one. The control plane checks reconcile the Go catalogue with the TypeScript registry in both directions.

The distinction matters for billing and enterprise_dashboard: our own billing and console exist, but that does not implement the separate licensed capabilities. RBAC and support access remain free as recorded by the catalogue. SSO and SCIM are withheld by the control plane, so counting only Go checks would describe them incorrectly.

## Failure paths covered

| Failure path | Test |
| --- | --- |
| A feature recorded as unenforced is described as gated | TestAFeatureGatedNowhereIsNotDescribedAsRefused |
| An empty exemption map makes that comparison vacuous | TestAFeatureGatedNowhereIsNotDescribedAsRefused |
| Air gap startup ignores its licence | TestTheEntitlementIsWhatDecides |
| Licensed air gap startup leaves the process unsealed | TestTheEntitlementIsWhatDecides |
| Air gap startup omits the policy hook | TestTheEntitlementIsWhatDecides |
| A cloud database branches without its entitlement | TestTheEntitlementIsWhatDecides |
| An enforcement reference cannot be parsed | TestTheFeatureNowHasADeclaredEnforcementSite |
| A declared feature is marked absent | TestEveryDeclaredSiteBelongsToAGatedCatalogueEntry |
| A registered site names a file without its licence check | TestEveryRegisteredSiteNamesAFileThatChecksThatFeature |
| The generated licensing page disagrees with a state change | TestTheLicensingPageIsCurrentWithTheCatalogue |

## Security considerations

This change verifies entitlement enforcement and corrects the registry descriptions; it adds no new permission, outbound connection, stored data class, or dependency. The source checks establish that the named file and function exist and that the file contains the expected licence question. They do not prove that the question is inside that exact function. Behavioural tests separately exercise refusal and delivery. Audit delivery evidence here covers the engine webhook sink. It does not claim that the separate, unfinished control plane audit forwarder works.

## Exit criteria evidence

Verification targets ea6d03f799524e326cefb0194686376ffd112aff in an isolated checkout. Each of the ten mutation cells ran its named test before the change, failed that same test with its subject broken, and passed after restoring the original bytes. Every run required the named test to execute and rejected skips. Raw logs and the complete table accompany the local handover.

The existing CI run for that exact head is successful:
https://github.com/antifailure/antifailure/actions/runs/34362875980

All nine required contexts report SUCCESS. CodeQL, Security, Cross platform lint, control-plane-image, and Dogfood also report success at workflow level. There are no unresolved review threads.

The earlier database evidence was inspected, not rerun during this verification: the enterprise server logs record 35 passed and zero skipped; admincustomers records 26 passed and zero skipped. Those logs correct the former PR description's claim that admincustomers was never executed. No local full just gate, visual review, production deployment, or cloud provider live proof is claimed by this continuation.

Fresh local output after restoring every mutation:

```text
{"stage": "restored", "kind": "go", "exit": 0, "tests": 61, "skips": 0, "failures": []}
{"stage": "restored", "kind": "ts", "exit": 0, "tests": 12, "skips": 0, "failures": []}
Full suites restored and vet passed. Source matches ea6d03f7.
```

The RBAC removal control left five other Go tests failing after the new check was removed. This demonstrates overlapping detection, not unique detection. The TypeScript suite stayed green in both mutated states.
