### PR TITLE
engine: the AWS surface an emulator answers for, declared where the notices generator can read it

### DIFF
--- a/.changes/an-azure-storage-account-in-an-environment-was-still-production.md
+++ b/.changes/an-azure-storage-account-in-an-environment-was-still-production.md
@@ -1,0 +1,22 @@
+# added
+
+An Azure storage account named in an environment was still the production one.
+
+An application reaching Azure Blob, Queue or Table Storage from an environment
+had two options and both were bad. Leave the host alone and the request went to
+the real storage account, where an object written from a preview environment is
+indistinguishable from production data afterwards. Point it at an emulator and
+the application had to carry a `BlobEndpoint=` that only exists outside
+production, so the code under test stopped being the code that ships.
+
+Azurite now answers for `*.blob.core.windows.net`, `*.queue.core.windows.net`
+and `*.table.core.windows.net` inside the environment, with nothing in the
+application naming it. The account travels in the first label of the hostname,
+so the sidecar preserving the Host header is what lets Azurite serve the
+account the application already asks for.
+
+Service Bus and Cosmos DB are named as outside that surface rather than left
+for somebody to discover in a failure. The Service Bus emulator needs a SQL
+Server container beside it, which an emulator declaration cannot yet express,
+and it refuses to start until a person accepts a EULA, which is not an
+acceptance a build makes on somebody's behalf.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -119,6 +119,32 @@ output against this file.
 - `sigs.k8s.io/structured-merge-diff/v6` v6.4.2
 - `sigs.k8s.io/yaml` v1.6.0
 
+## Container images
+
+An environment starts an emulator when a manifest asks for one, and an
+emulator is somebody else's software running beside the application.
+It is not linked into the binary, so the module list above cannot see
+it, and an image whose licence is recorded by hand goes stale the
+first time a digest is bumped. These come from the declarations the
+engine starts the containers from.
+
+- LocalStack, Apache License 2.0. Copyright (c) 2017+ LocalStack contributors, Copyright (c) 2016 Atlassian Pty Ltd
+  - Answers for AWS as `aws`
+  - `localstack/localstack@sha256:4aef81c531684570d7b3cfd2805afa02194c929d52bbeedabb7d4874798b1572`
+  - https://github.com/localstack/localstack/blob/main/LICENSE.txt
+- Azurite, MIT License. Copyright (c) Microsoft Corporation
+  - Answers for Azure as `azure-blob`
+  - `mcr.microsoft.com/azure-storage/azurite@sha256:830430c1da1a2d537e08f3e6764dd1f5ae00cf0346bcaf625b968ec3f0971fd5`
+  - https://github.com/Azure/Azurite/blob/main/LICENSE
+- Azurite, MIT License. Copyright (c) Microsoft Corporation
+  - Answers for Azure as `azure-queue`
+  - `mcr.microsoft.com/azure-storage/azurite@sha256:830430c1da1a2d537e08f3e6764dd1f5ae00cf0346bcaf625b968ec3f0971fd5`
+  - https://github.com/Azure/Azurite/blob/main/LICENSE
+- Azurite, MIT License. Copyright (c) Microsoft Corporation
+  - Answers for Azure as `azure-table`
+  - `mcr.microsoft.com/azure-storage/azurite@sha256:830430c1da1a2d537e08f3e6764dd1f5ae00cf0346bcaf625b968ec3f0971fd5`
+  - https://github.com/Azure/Azurite/blob/main/LICENSE
+
 ## Node packages
 
 The agent runner depends on Playwright, which is Apache 2.0 licensed,

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -128,21 +128,30 @@ it, and an image whose licence is recorded by hand goes stale the
 first time a digest is bumped. These come from the declarations the
 engine starts the containers from.
 
-- LocalStack, Apache License 2.0. Copyright (c) 2017+ LocalStack contributors, Copyright (c) 2016 Atlassian Pty Ltd
+- LocalStack, Apache License 2.0
+  Copyright (c) 2017+ LocalStack contributors, Copyright (c) 2016
+  Atlassian Pty Ltd
   - Answers for AWS as `aws`
-  - `localstack/localstack@sha256:4aef81c531684570d7b3cfd2805afa02194c929d52bbeedabb7d4874798b1572`
+  - `localstack/localstack` pinned at
+  sha256:4aef81c531684570d7b3cfd2805afa02194c929d52bbeedabb7d4874798b1572
   - https://github.com/localstack/localstack/blob/main/LICENSE.txt
-- Azurite, MIT License. Copyright (c) Microsoft Corporation
+- Azurite, MIT License
+  Copyright (c) Microsoft Corporation
   - Answers for Azure as `azure-blob`
-  - `mcr.microsoft.com/azure-storage/azurite@sha256:830430c1da1a2d537e08f3e6764dd1f5ae00cf0346bcaf625b968ec3f0971fd5`
+  - `mcr.microsoft.com/azure-storage/azurite` pinned at
+  sha256:830430c1da1a2d537e08f3e6764dd1f5ae00cf0346bcaf625b968ec3f0971fd5
   - https://github.com/Azure/Azurite/blob/main/LICENSE
-- Azurite, MIT License. Copyright (c) Microsoft Corporation
+- Azurite, MIT License
+  Copyright (c) Microsoft Corporation
   - Answers for Azure as `azure-queue`
-  - `mcr.microsoft.com/azure-storage/azurite@sha256:830430c1da1a2d537e08f3e6764dd1f5ae00cf0346bcaf625b968ec3f0971fd5`
+  - `mcr.microsoft.com/azure-storage/azurite` pinned at
+  sha256:830430c1da1a2d537e08f3e6764dd1f5ae00cf0346bcaf625b968ec3f0971fd5
   - https://github.com/Azure/Azurite/blob/main/LICENSE
-- Azurite, MIT License. Copyright (c) Microsoft Corporation
+- Azurite, MIT License
+  Copyright (c) Microsoft Corporation
   - Answers for Azure as `azure-table`
-  - `mcr.microsoft.com/azure-storage/azurite@sha256:830430c1da1a2d537e08f3e6764dd1f5ae00cf0346bcaf625b968ec3f0971fd5`
+  - `mcr.microsoft.com/azure-storage/azurite` pinned at
+  sha256:830430c1da1a2d537e08f3e6764dd1f5ae00cf0346bcaf625b968ec3f0971fd5
   - https://github.com/Azure/Azurite/blob/main/LICENSE
 
 ## Node packages

--- a/docs/src/content/docs/guides/azure.md
+++ b/docs/src/content/docs/guides/azure.md
@@ -64,6 +64,64 @@ emulator has no route out in any case: it attaches to the environment's inner
 network, which is created `internal`, so having nowhere to send a credential is
 a property of the network rather than a promise.
 
+## What it costs per environment
+
+Measured on 2026-09-08 on an Apple Silicon machine, 8 core, with Docker
+Desktop holding 7.654 GiB, **at load averages between 24 and 28**, because the
+machine was running other work at the same time. The load is published with the
+numbers rather than left out: the memory figures are stable under it and the
+start times are not, and saying which is which is worth more than a best case.
+
+Image sizes are compressed download bytes for the `linux/arm64` member, read
+from the registry.
+
+| Container | Image | Resident | Started |
+| --- | --- | --- | --- |
+| `azure-blob` | 108.9 MiB | 69.9 MiB | bound all three ports |
+| `azure-queue` | the same image, nothing more on disk | 66.7 MiB | bound all three ports |
+| `azure-table` | the same image, nothing more on disk | 67.1 MiB | bound all three ports |
+| **all three** | **108.9 MiB once** | **203.8 MiB** | |
+
+One Azurite measured alone was 83.5 MiB, so the marginal cost of the second and
+third is about 67 MiB each. An environment that names only blob pays 69.9 MiB
+and one image.
+
+That is the whole cost of Azure Blob, Queue and Table in an environment: **one
+image and about 200 MiB of memory**, or a third of that for one service.
+
+### What Service Bus would have cost, which is why it is not here
+
+| Container | Image | Result |
+| --- | --- | --- |
+| `servicebus-emulator` | 81.7 MiB | halted: `SQL Health Check failed` |
+| `mssql/server` companion | 595.9 MiB, AMD64 only | **killed after 707 seconds, never ready** |
+
+**677.6 MiB of image before either process answers anything**, against 108.9 MiB
+for all of Azurite. The SQL Server companion was given a 3 GB allocation of its
+own and was killed by the memory limit after 707 seconds, having reached TLS
+initialisation and no further; it never printed `SQL Server is now ready for
+client connections`, and the Service Bus emulator beside it then failed its SQL
+health check and halted. Under emulated AMD64 on ARM64 this is what the pair
+does on a developer laptop.
+
+The load average was 25 to 26 throughout, on a shared machine, so this does not
+prove SQL Server cannot start here. It does mean the pair is in a different
+class of weight from Azurite by roughly an order of magnitude in image bytes and
+more than that in memory, and that a developer with an Apple Silicon machine
+who names Service Bus in a manifest would be waiting on an emulated SQL Server
+rather than testing their application. Opt in is the right answer even before
+the EULA below.
+
+### Cosmos DB
+
+`cosmosdb/linux/azure-cosmos-emulator:vnext-preview` has a real ARM64 build and
+needs no companion. It is **645.6 MiB of image**, six times Azurite, and held
+**89.9 MiB resident**. Its readiness was NOT measured: the predicate used to
+watch for it matched the word `ready` inside its own retry line
+`readiness check still waiting for Postgres startup`, so the 97 seconds it
+reported is not a start time and is not published as one. Its own health line
+still read `PostgreSQL=FAIL, Gateway=FAIL, Explorer=FAIL` at that point.
+
 ## Not answered, and why
 
 Naming a service and not building it is worse than leaving it out, so these
@@ -87,14 +145,16 @@ better reason for it to be opt in than any number on this page.
 **Its companion has no ARM64 build.** `mcr.microsoft.com/mssql/server:2022-latest`
 is a single AMD64 manifest with no ARM64 member, so on an Apple Silicon machine
 Service Bus drags an emulated AMD64 SQL Server into every environment that
-names it. The measured cost is below.
+names it. Measured above: 677.6 MiB of image, and the SQL Server never became
+ready in 707 seconds with 3 GB of its own.
 
 ### Azure Cosmos DB
 
 The Linux emulator is a single image with a real ARM64 build and no EULA gate,
-and its cost is below. It is not registered here yet because nothing in the
-conformance suite proves it, and a service in the surface that nothing proves
-is a claim rather than a capability.
+and its cost is above. It is not registered here because nothing in the
+conformance suite proves it, and a service in the surface that nothing proves is
+a claim rather than a capability. At 645.6 MiB it is also six times Azurite, so
+if it lands it lands opt in.
 
 ### Everything else Azure runs
 

--- a/docs/src/content/docs/guides/azure.md
+++ b/docs/src/content/docs/guides/azure.md
@@ -1,0 +1,111 @@
+---
+title: Azure
+description: The Azure services an environment answers for, the ones it refuses, and what each costs.
+sidebar:
+  order: 23
+---
+
+An application in an environment reaches Azure Blob Storage, Queue Storage and
+Table Storage without knowing it. It builds
+`https://youraccount.blob.core.windows.net` the way it does in production, that
+name resolves to the environment's sidecar, the sidecar terminates TLS with a
+certificate authority the environment already trusts, and Azurite answers.
+
+There is no endpoint override, no `BlobEndpoint=` in a connection string that
+only exists in tests, and no client construction that differs from the one that
+ships. That is the whole point of this page. The emulator is a commodity;
+reaching it without changing the application is not.
+
+## The surface
+
+This table is **the** surface. A host outside it is not routed to an emulator:
+it falls through to the environment's egress policy, whose default is block, so
+it is refused rather than answered. A silent wrong answer from an emulator is
+worse than a refusal, because it will be believed.
+
+| Service | Host | Emulator | Answered by |
+| --- | --- | --- | --- |
+| Azure Blob Storage | `*.blob.core.windows.net` | `azure-blob` | Azurite |
+| Azure Queue Storage | `*.queue.core.windows.net` | `azure-queue` | Azurite |
+| Azure Table Storage | `*.table.core.windows.net` | `azure-table` | Azurite |
+
+Azurite is published by Microsoft and is MIT licensed. It is the only one of
+the three Microsoft Azure emulators that is open source, and that difference
+decides more of this page than weight does.
+
+## Why three emulators for one image
+
+Azurite is a single container that listens on **three ports**: blob on 10000,
+queue on 10001 and table on 10002. An emulator declaration carries one port, so
+blob, queue and table are registered separately against the same image.
+
+The shape turned out better than the constraint that produced it. An
+environment starts the emulators its egress rules name, so a manifest that
+touches blob only starts one container and pays for one, and a refusal is
+written per service: a request to Azure Files is refused with Files named,
+rather than with "Azure" named.
+
+## The account name travels in the host
+
+Azure puts the storage account in the first label of the hostname, so
+`youraccount.blob.core.windows.net` carries the account the way a virtual
+hosted S3 URL carries the bucket. The sidecar rewrites the destination and
+**preserves the Host header**, and Azurite reads the account out of that header
+when the host is a name rather than an address.
+
+So nothing needs to tell Azurite which account it is serving through a flag.
+`AZURITE_ACCOUNTS` is deliberately not set, because the account an environment
+needs is whichever one its substituted credential names, and that is a property
+of the manifest rather than of this build.
+
+The credential is substituted, not passed through. A request signed with a key
+the environment recognises as live is refused before it leaves, and the
+emulator has no route out in any case: it attaches to the environment's inner
+network, which is created `internal`, so having nowhere to send a credential is
+a property of the network rather than a promise.
+
+## Not answered, and why
+
+Naming a service and not building it is worse than leaving it out, so these
+are named here rather than discovered in a failure.
+
+### Azure Service Bus
+
+Microsoft publishes an emulator for it and this build does not start one, for
+two measured reasons and one that is not about cost at all.
+
+**It cannot be declared yet.** `mcr.microsoft.com/azure-messaging/servicebus-emulator`
+requires a SQL Server container beside it, which it dials on startup, and an
+emulator declaration carries one image. Nothing here can express a companion.
+
+**It refuses to start until somebody accepts a EULA.** Started bare, with no
+environment set, it exits with code 133 in 47 seconds and says so: the
+Service Bus emulator EULA has to be accepted through `ACCEPT_EULA=Y`. That is
+an acceptance a user makes, not one a build makes on their behalf, which is a
+better reason for it to be opt in than any number on this page.
+
+**Its companion has no ARM64 build.** `mcr.microsoft.com/mssql/server:2022-latest`
+is a single AMD64 manifest with no ARM64 member, so on an Apple Silicon machine
+Service Bus drags an emulated AMD64 SQL Server into every environment that
+names it. The measured cost is below.
+
+### Azure Cosmos DB
+
+The Linux emulator is a single image with a real ARM64 build and no EULA gate,
+and its cost is below. It is not registered here yet because nothing in the
+conformance suite proves it, and a service in the surface that nothing proves
+is a claim rather than a capability.
+
+### Everything else Azure runs
+
+Azure Files (`*.file.core.windows.net`), Data Lake Storage Gen2
+(`*.dfs.core.windows.net`), Key Vault (`*.vault.azure.net`), Event Hubs and the
+management plane are outside the surface. So are the sovereign cloud suffixes
+`core.chinacloudapi.cn` and `core.usgovcloudapi.net`, which are different hosts
+and are refused rather than answered.
+
+Two of these are worth calling out because a reader is likely to expect them to
+be covered by something that is. A **Service Bus queue is not a Queue Storage
+queue**, and the **Cosmos DB Table API** is not Table Storage: it speaks the
+same protocol on `table.cosmos.azure.com` but its partitioning and throughput
+behaviour is what a Cosmos user is testing, and Azurite is not that.

--- a/docs/src/content/docs/guides/azure.md
+++ b/docs/src/content/docs/guides/azure.md
@@ -132,6 +132,20 @@ are named here rather than discovered in a failure.
 Microsoft publishes an emulator for it and this build does not start one, for
 two measured reasons and one that is not about cost at all.
 
+**Its wire protocol may not reach an emulator at all.** Every Azure Service Bus
+SDK defaults to AMQP 1.0 on port 5672, which is not HTTP. A rule in emulate
+mode makes the sidecar terminate the connection and read an HTTP request out of
+it, so an AMQP connection would be dropped rather than forwarded. Service Bus
+also speaks HTTP on 5300, and that path would work.
+
+This is the reason that would matter most, and it is **NOT CONFIRMED BY
+EXPERIMENT**. It was reasoned from `policy.inspectMode` and the sidecar's
+`http.ReadRequest` by the lane that owns the routing, and neither that lane nor
+this one has driven an AMQP client at an emulate rule. It is recorded here
+because a reader deciding whether to wait for Service Bus deserves to know the
+strongest argument against it exists, and recorded as unconfirmed because it
+has not been run.
+
 **It cannot be declared yet.** `mcr.microsoft.com/azure-messaging/servicebus-emulator`
 requires a SQL Server container beside it, which it dials on startup, and an
 emulator declaration carries one image. Nothing here can express a companion.

--- a/engine/api/packages.txt
+++ b/engine/api/packages.txt
@@ -30,6 +30,7 @@ stable   github.com/antifailure/antifailure/engine/conformance     The suite tha
 
 unstable github.com/antifailure/antifailure/engine/pkg/afcli       The socket the enterprise binary plugs its command tree into. Deliberately narrow rather than a general embedding API for the CLI.
 unstable github.com/antifailure/antifailure/engine/pkg/edition     How a binary reports which edition it is. Enterprise wiring, and the set of editions is ours to change.
+unstable github.com/antifailure/antifailure/engine/pkg/emulator    The emulator images this build can start, declared as data. Public only so the notices generator, which lives in another module and cannot import engine/internal, reads the same declaration the engine starts the container from. The set of emulators and the digests move whenever an upstream image does.
 unstable github.com/antifailure/antifailure/engine/pkg/extension   The registration point for an edition's extra behaviour. The same socket as afcli, one layer down.
 unstable github.com/antifailure/antifailure/engine/pkg/livekey     Reads the live key material a hosted deployment is configured with. Internal plumbing that happens to sit outside internal so the enterprise module can reach it.
 unstable github.com/antifailure/antifailure/engine/chaos           The suite that proves the failure paths the documentation claims. Tests of this repository, run against this repository, and not an interface anybody integrates against.

--- a/engine/internal/docs/pages.gen.go
+++ b/engine/internal/docs/pages.gen.go
@@ -6177,6 +6177,178 @@ piece, and the page opens by saying what still works without it, which is all
 of it. Read that one when you want environments that outlive a workflow run, a
 shared address for them, or a record across repositories.
 `,
+	"guides/azure.md": `---
+title: Azure
+description: The Azure services an environment answers for, the ones it refuses, and what each costs.
+sidebar:
+  order: 23
+---
+
+An application in an environment reaches Azure Blob Storage, Queue Storage and
+Table Storage without knowing it. It builds
+` + "`" + `https://youraccount.blob.core.windows.net` + "`" + ` the way it does in production, that
+name resolves to the environment's sidecar, the sidecar terminates TLS with a
+certificate authority the environment already trusts, and Azurite answers.
+
+There is no endpoint override, no ` + "`" + `BlobEndpoint=` + "`" + ` in a connection string that
+only exists in tests, and no client construction that differs from the one that
+ships. That is the whole point of this page. The emulator is a commodity;
+reaching it without changing the application is not.
+
+## The surface
+
+This table is **the** surface. A host outside it is not routed to an emulator:
+it falls through to the environment's egress policy, whose default is block, so
+it is refused rather than answered. A silent wrong answer from an emulator is
+worse than a refusal, because it will be believed.
+
+| Service | Host | Emulator | Answered by |
+| --- | --- | --- | --- |
+| Azure Blob Storage | ` + "`" + `*.blob.core.windows.net` + "`" + ` | ` + "`" + `azure-blob` + "`" + ` | Azurite |
+| Azure Queue Storage | ` + "`" + `*.queue.core.windows.net` + "`" + ` | ` + "`" + `azure-queue` + "`" + ` | Azurite |
+| Azure Table Storage | ` + "`" + `*.table.core.windows.net` + "`" + ` | ` + "`" + `azure-table` + "`" + ` | Azurite |
+
+Azurite is published by Microsoft and is MIT licensed. It is the only one of
+the three Microsoft Azure emulators that is open source, and that difference
+decides more of this page than weight does.
+
+## Why three emulators for one image
+
+Azurite is a single container that listens on **three ports**: blob on 10000,
+queue on 10001 and table on 10002. An emulator declaration carries one port, so
+blob, queue and table are registered separately against the same image.
+
+The shape turned out better than the constraint that produced it. An
+environment starts the emulators its egress rules name, so a manifest that
+touches blob only starts one container and pays for one, and a refusal is
+written per service: a request to Azure Files is refused with Files named,
+rather than with "Azure" named.
+
+## The account name travels in the host
+
+Azure puts the storage account in the first label of the hostname, so
+` + "`" + `youraccount.blob.core.windows.net` + "`" + ` carries the account the way a virtual
+hosted S3 URL carries the bucket. The sidecar rewrites the destination and
+**preserves the Host header**, and Azurite reads the account out of that header
+when the host is a name rather than an address.
+
+So nothing needs to tell Azurite which account it is serving through a flag.
+` + "`" + `AZURITE_ACCOUNTS` + "`" + ` is deliberately not set, because the account an environment
+needs is whichever one its substituted credential names, and that is a property
+of the manifest rather than of this build.
+
+The credential is substituted, not passed through. A request signed with a key
+the environment recognises as live is refused before it leaves, and the
+emulator has no route out in any case: it attaches to the environment's inner
+network, which is created ` + "`" + `internal` + "`" + `, so having nowhere to send a credential is
+a property of the network rather than a promise.
+
+## What it costs per environment
+
+Measured on 2026-09-08 on an Apple Silicon machine, 8 core, with Docker
+Desktop holding 7.654 GiB, **at load averages between 24 and 28**, because the
+machine was running other work at the same time. The load is published with the
+numbers rather than left out: the memory figures are stable under it and the
+start times are not, and saying which is which is worth more than a best case.
+
+Image sizes are compressed download bytes for the ` + "`" + `linux/arm64` + "`" + ` member, read
+from the registry.
+
+| Container | Image | Resident | Started |
+| --- | --- | --- | --- |
+| ` + "`" + `azure-blob` + "`" + ` | 108.9 MiB | 69.9 MiB | bound all three ports |
+| ` + "`" + `azure-queue` + "`" + ` | the same image, nothing more on disk | 66.7 MiB | bound all three ports |
+| ` + "`" + `azure-table` + "`" + ` | the same image, nothing more on disk | 67.1 MiB | bound all three ports |
+| **all three** | **108.9 MiB once** | **203.8 MiB** | |
+
+One Azurite measured alone was 83.5 MiB, so the marginal cost of the second and
+third is about 67 MiB each. An environment that names only blob pays 69.9 MiB
+and one image.
+
+That is the whole cost of Azure Blob, Queue and Table in an environment: **one
+image and about 200 MiB of memory**, or a third of that for one service.
+
+### What Service Bus would have cost, which is why it is not here
+
+| Container | Image | Result |
+| --- | --- | --- |
+| ` + "`" + `servicebus-emulator` + "`" + ` | 81.7 MiB | halted: ` + "`" + `SQL Health Check failed` + "`" + ` |
+| ` + "`" + `mssql/server` + "`" + ` companion | 595.9 MiB, AMD64 only | **killed after 707 seconds, never ready** |
+
+**677.6 MiB of image before either process answers anything**, against 108.9 MiB
+for all of Azurite. The SQL Server companion was given a 3 GB allocation of its
+own and was killed by the memory limit after 707 seconds, having reached TLS
+initialisation and no further; it never printed ` + "`" + `SQL Server is now ready for
+client connections` + "`" + `, and the Service Bus emulator beside it then failed its SQL
+health check and halted. Under emulated AMD64 on ARM64 this is what the pair
+does on a developer laptop.
+
+The load average was 25 to 26 throughout, on a shared machine, so this does not
+prove SQL Server cannot start here. It does mean the pair is in a different
+class of weight from Azurite by roughly an order of magnitude in image bytes and
+more than that in memory, and that a developer with an Apple Silicon machine
+who names Service Bus in a manifest would be waiting on an emulated SQL Server
+rather than testing their application. Opt in is the right answer even before
+the EULA below.
+
+### Cosmos DB
+
+` + "`" + `cosmosdb/linux/azure-cosmos-emulator:vnext-preview` + "`" + ` has a real ARM64 build and
+needs no companion. It is **645.6 MiB of image**, six times Azurite, and held
+**89.9 MiB resident**. Its readiness was NOT measured: the predicate used to
+watch for it matched the word ` + "`" + `ready` + "`" + ` inside its own retry line
+` + "`" + `readiness check still waiting for Postgres startup` + "`" + `, so the 97 seconds it
+reported is not a start time and is not published as one. Its own health line
+still read ` + "`" + `PostgreSQL=FAIL, Gateway=FAIL, Explorer=FAIL` + "`" + ` at that point.
+
+## Not answered, and why
+
+Naming a service and not building it is worse than leaving it out, so these
+are named here rather than discovered in a failure.
+
+### Azure Service Bus
+
+Microsoft publishes an emulator for it and this build does not start one, for
+two measured reasons and one that is not about cost at all.
+
+**It cannot be declared yet.** ` + "`" + `mcr.microsoft.com/azure-messaging/servicebus-emulator` + "`" + `
+requires a SQL Server container beside it, which it dials on startup, and an
+emulator declaration carries one image. Nothing here can express a companion.
+
+**It refuses to start until somebody accepts a EULA.** Started bare, with no
+environment set, it exits with code 133 in 47 seconds and says so: the
+Service Bus emulator EULA has to be accepted through ` + "`" + `ACCEPT_EULA=Y` + "`" + `. That is
+an acceptance a user makes, not one a build makes on their behalf, which is a
+better reason for it to be opt in than any number on this page.
+
+**Its companion has no ARM64 build.** ` + "`" + `mcr.microsoft.com/mssql/server:2022-latest` + "`" + `
+is a single AMD64 manifest with no ARM64 member, so on an Apple Silicon machine
+Service Bus drags an emulated AMD64 SQL Server into every environment that
+names it. Measured above: 677.6 MiB of image, and the SQL Server never became
+ready in 707 seconds with 3 GB of its own.
+
+### Azure Cosmos DB
+
+The Linux emulator is a single image with a real ARM64 build and no EULA gate,
+and its cost is above. It is not registered here because nothing in the
+conformance suite proves it, and a service in the surface that nothing proves is
+a claim rather than a capability. At 645.6 MiB it is also six times Azurite, so
+if it lands it lands opt in.
+
+### Everything else Azure runs
+
+Azure Files (` + "`" + `*.file.core.windows.net` + "`" + `), Data Lake Storage Gen2
+(` + "`" + `*.dfs.core.windows.net` + "`" + `), Key Vault (` + "`" + `*.vault.azure.net` + "`" + `), Event Hubs and the
+management plane are outside the surface. So are the sovereign cloud suffixes
+` + "`" + `core.chinacloudapi.cn` + "`" + ` and ` + "`" + `core.usgovcloudapi.net` + "`" + `, which are different hosts
+and are refused rather than answered.
+
+Two of these are worth calling out because a reader is likely to expect them to
+be covered by something that is. A **Service Bus queue is not a Queue Storage
+queue**, and the **Cosmos DB Table API** is not Table Storage: it speaks the
+same protocol on ` + "`" + `table.cosmos.azure.com` + "`" + ` but its partitioning and throughput
+behaviour is what a Cosmos user is testing, and Azurite is not that.
+`,
 	"guides/build.md": `---
 title: Building services
 description: How an image is produced for each service, and what to do when it will not build.

--- a/engine/internal/docs/pages.gen.go
+++ b/engine/internal/docs/pages.gen.go
@@ -6311,6 +6311,20 @@ are named here rather than discovered in a failure.
 Microsoft publishes an emulator for it and this build does not start one, for
 two measured reasons and one that is not about cost at all.
 
+**Its wire protocol may not reach an emulator at all.** Every Azure Service Bus
+SDK defaults to AMQP 1.0 on port 5672, which is not HTTP. A rule in emulate
+mode makes the sidecar terminate the connection and read an HTTP request out of
+it, so an AMQP connection would be dropped rather than forwarded. Service Bus
+also speaks HTTP on 5300, and that path would work.
+
+This is the reason that would matter most, and it is **NOT CONFIRMED BY
+EXPERIMENT**. It was reasoned from ` + "`" + `policy.inspectMode` + "`" + ` and the sidecar's
+` + "`" + `http.ReadRequest` + "`" + ` by the lane that owns the routing, and neither that lane nor
+this one has driven an AMQP client at an emulate rule. It is recorded here
+because a reader deciding whether to wait for Service Bus deserves to know the
+strongest argument against it exists, and recorded as unconfirmed because it
+has not been run.
+
 **It cannot be declared yet.** ` + "`" + `mcr.microsoft.com/azure-messaging/servicebus-emulator` + "`" + `
 requires a SQL Server container beside it, which it dials on startup, and an
 emulator declaration carries one image. Nothing here can express a companion.

--- a/engine/pkg/emulator/aws.go
+++ b/engine/pkg/emulator/aws.go
@@ -1,0 +1,173 @@
+package emulator
+
+// AWSName is the value an egress rule names the AWS emulator by.
+const AWSName = "aws"
+
+// awsImage is LocalStack, pinned by digest.
+//
+// The digest is the multi architecture index for the 2026.08.1 release, which
+// is also tagged stable and latest, so an arm64 machine and an amd64 runner
+// resolve the same declaration to their own image and neither is pinned to the
+// other's architecture. A tag is refused by the registry's validation and that
+// refusal is the point: an emulator answering for production's API behind a
+// tag that moves changes what an environment was tested against without
+// anything in this repository changing.
+const awsImage = "localstack/localstack@sha256:" +
+	"4aef81c531684570d7b3cfd2805afa02194c929d52bbeedabb7d4874798b1572"
+
+// AWSPort is LocalStack's single gateway port. Every service is answered on
+// it, which is why one container answers for nine services and the sidecar
+// needs one address rather than nine.
+const AWSPort = 4566
+
+func init() { register(aws) }
+
+// aws is the AWS surface, answered by LocalStack.
+//
+// NINE SERVICES, AND THE LIST IS THE SURFACE. An AWS host outside it is not
+// routed here: it falls through to the environment's egress policy, whose
+// default is block, so it is refused rather than answered. That is deliberate
+// and it is the expensive half of this lane. LocalStack answers for more of
+// AWS than this, and a service left in the surface that nothing in the
+// conformance suite proves is a claim rather than a capability. Every entry
+// below names the call that proves it.
+var aws = &Emulator{
+	EmulatorName: AWSName,
+	Vendor:       "AWS",
+	Project:      "LocalStack",
+	ProjectURL:   "https://github.com/localstack/localstack",
+	Image:        awsImage,
+	Port:         AWSPort,
+	Env: map[string]string{
+		// The allowlist, and the reason it is one. SERVICES alone only
+		// decides what is loaded eagerly; STRICT_SERVICE_LOADING makes it the
+		// set of services that may be loaded at all, so a call to a service
+		// outside the surface is refused by LocalStack itself rather than
+		// quietly answered by an implementation nothing in this repository
+		// has ever tested.
+		"SERVICES": "s3,sqs,sns,dynamodb,kinesis,events,secretsmanager,ssm,sts",
+
+		"STRICT_SERVICE_LOADING": "1",
+
+		// The emulator sits on the environment's inner network, which Docker
+		// creates internal, so it has no route out whatever it tries. These
+		// two mean it does not try: LocalStack otherwise reports usage events
+		// and fetches a CA bundle on first use, and a container spending its
+		// startup on connections that cannot complete is a container that
+		// takes longer to answer and fills the log with failures that are not
+		// the user's problem.
+		"DISABLE_EVENTS":         "1",
+		"SKIP_SSL_CERT_DOWNLOAD": "1",
+
+		// Nothing an environment does to the emulator survives the
+		// environment. A twin that inherited the last twin's buckets would be
+		// reproducible only by accident.
+		"PERSISTENCE": "0",
+
+		// Listen on every interface inside the container, because the address
+		// the sidecar forwards to is the container's address on the inner
+		// network and not localhost.
+		"GATEWAY_LISTEN": "0.0.0.0:4566",
+
+		// The log is read by a person diagnosing a failed twin, so it carries
+		// warnings and errors and not a line per request.
+		"DEBUG":  "0",
+		"LS_LOG": "warning",
+	},
+	Services: []Service{
+		{
+			Name: "Amazon S3",
+			// Four spellings, which is path style and virtual hosted style,
+			// each global and regional. Virtual hosted addressing is the case
+			// this whole lane is loudest about: the bucket travels in the Host
+			// header, LocalStack reads it from there, and that is why the
+			// sidecar preserves the Host header and rewrites only the
+			// destination. Rewriting Host would destroy the bucket name.
+			Hosts: []string{
+				"s3.amazonaws.com", "s3.*.amazonaws.com",
+				"*.s3.amazonaws.com", "*.s3.*.amazonaws.com",
+			},
+			Proves: "CreateBucket, PutObject and GetObject, in both addressing styles",
+			Note: "The dualstack and transfer acceleration endpoints are outside this, " +
+				"and so is S3 Express One Zone, which resolves under a different suffix.",
+		},
+		{
+			Name:   "Amazon SQS",
+			Hosts:  []string{"sqs.*.amazonaws.com"},
+			Proves: "CreateQueue, SendMessage and ReceiveMessage",
+		},
+		{
+			Name:   "Amazon SNS",
+			Hosts:  []string{"sns.*.amazonaws.com"},
+			Proves: "CreateTopic and Publish",
+			Note: "A subscription to a real email address or phone number cannot be " +
+				"delivered from here, which is the point of it being here.",
+		},
+		{
+			Name:   "Amazon DynamoDB",
+			Hosts:  []string{"dynamodb.*.amazonaws.com", "streams.dynamodb.*.amazonaws.com"},
+			Proves: "CreateTable, PutItem and GetItem",
+		},
+		{
+			Name:   "Amazon Kinesis",
+			Hosts:  []string{"kinesis.*.amazonaws.com"},
+			Proves: "CreateStream and PutRecord",
+		},
+		{
+			Name:   "Amazon EventBridge",
+			Hosts:  []string{"events.*.amazonaws.com"},
+			Proves: "PutRule and PutEvents",
+		},
+		{
+			Name:   "AWS Secrets Manager",
+			Hosts:  []string{"secretsmanager.*.amazonaws.com"},
+			Proves: "CreateSecret and GetSecretValue",
+		},
+		{
+			Name:   "AWS Systems Manager Parameter Store",
+			Hosts:  []string{"ssm.*.amazonaws.com"},
+			Proves: "PutParameter and GetParameter",
+		},
+		{
+			Name:  "AWS STS",
+			Hosts: []string{"sts.amazonaws.com", "sts.*.amazonaws.com"},
+			// STS is not here because anybody asked for it. Most AWS SDKs
+			// resolve credentials before the first real call, and several
+			// credential chains call GetCallerIdentity or AssumeRole to do it.
+			// An emulated surface without STS fails at startup with an error
+			// naming the wrong service, and the person reading it goes looking
+			// at S3.
+			Proves: "GetCallerIdentity and AssumeRole",
+		},
+	},
+	Outside: []Service{
+		{
+			Name: "AWS Lambda, ECS, EKS, Batch and Step Functions",
+			Note: "LocalStack runs these by starting further containers through the " +
+				"Docker socket. The environment does not hand a container the Docker " +
+				"socket, so this is refused rather than half answered.",
+		},
+		{
+			Name: "Amazon RDS, Aurora, ElastiCache and OpenSearch",
+			Note: "A datastore is not emulated here. Postgres is branched from a golden " +
+				"and a second store is declared in the manifest with a stance, which is a " +
+				"better answer than an emulator with an empty schema in it.",
+		},
+		{
+			Name: "Amazon SES and SESv2",
+			Note: "Mail is captured into the environment's inbox, where an agent can read " +
+				"it and no real address receives anything. An emulator would swallow it.",
+		},
+		{
+			Name: "Amazon API Gateway, CloudFormation, IAM, CloudWatch and everything else AWS runs",
+			Note: "Outside the surface. The request is refused by the egress policy rather " +
+				"than answered, because a wrong answer from an emulator is worse than a " +
+				"refusal: it will be trusted.",
+		},
+	},
+	Licence: Licence{
+		Name:   "Apache License 2.0",
+		Holder: "Copyright (c) 2017+ LocalStack contributors, Copyright (c) 2016 Atlassian Pty Ltd",
+		URL:    "https://github.com/localstack/localstack/blob/main/LICENSE.txt",
+	},
+}

--- a/engine/pkg/emulator/azure.go
+++ b/engine/pkg/emulator/azure.go
@@ -1,0 +1,187 @@
+package emulator
+
+// The Azure surface, and why it is five registrations rather than one.
+//
+// Azurite is ONE IMAGE THAT LISTENS ON THREE PORTS, blob 10000, queue 10001
+// and table 10002, and extension.EmulatorContainer carries one port. So blob,
+// queue and table are registered separately, same image and same environment,
+// one port each. That is not a workaround dressed up as a design. An
+// environment starts the emulators its egress rules name, so a manifest that
+// touches blob only starts one container and pays for one, and the refusal
+// outside the surface is written per service rather than per cloud: a request
+// to Azure Files is refused with Files named, not with "Azure" named.
+//
+// Service Bus and Cosmos DB are NOT registered, and the reasons are measured
+// rather than tasteful. They are named in Outside below and the numbers are in
+// docs/guides/azure.md. A service named in the surface and not answered would
+// be worse than one absent, so neither appears in Services until it can be
+// started, and Service Bus cannot be declared at all yet: it needs a second
+// container beside it and EmulatorContainer carries one image.
+
+// The names an egress rule names these by.
+//
+// Hyphens rather than underscores, because the alias the sidecar reaches an
+// emulator by is af-emu-<name> and that has to be a legal DNS label. An
+// underscore is legal in a Docker network alias and illegal in a hostname, so
+// a name carrying one resolves through some resolvers and not others, which is
+// worse than either resolving or failing everywhere.
+const (
+	AzureBlobName  = "azure-blob"
+	AzureQueueName = "azure-queue"
+	AzureTableName = "azure-table"
+)
+
+// azuriteImage is Azurite, pinned by the digest of its multi architecture
+// index, so an arm64 laptop and an amd64 runner each resolve the one
+// declaration to their own image and neither is pinned to the other's
+// architecture.
+const azuriteImage = "mcr.microsoft.com/azure-storage/azurite@sha256:" +
+	"830430c1da1a2d537e08f3e6764dd1f5ae00cf0346bcaf625b968ec3f0971fd5"
+
+// The ports Azurite's own default command binds, which is why there are three
+// registrations rather than one.
+const (
+	AzureBlobPort  = 10000
+	AzureQueuePort = 10001
+	AzureTablePort = 10002
+)
+
+func init() {
+	register(azureBlob)
+	register(azureQueue)
+	register(azureTable)
+}
+
+// azuriteLicence is Azurite's, and it is the only one of the three Azure
+// emulators that is open source. That difference is the reason Service Bus and
+// Cosmos are opt in as much as their weight is.
+var azuriteLicence = Licence{
+	Name:   "MIT License",
+	Holder: "Copyright (c) Microsoft Corporation",
+	URL:    "https://github.com/Azure/Azurite/blob/main/LICENSE",
+}
+
+// azuriteEnv is what every Azurite container is started with.
+//
+// It is deliberately almost empty. Azurite serves the account devstoreaccount1
+// with the well known development key, and it reads the account name out of
+// the HOST HEADER when the host is a name rather than an address, which is
+// what production style addressing means and is why the sidecar preserving
+// Host is load bearing here as much as it is for a virtual hosted S3 bucket.
+// So an application handed a substituted connection string naming
+// devstoreaccount1 builds the URL https://devstoreaccount1.blob.core.windows.net
+// itself, the name resolves to the sidecar, and nothing in the application
+// knows an emulator exists.
+//
+// AZURITE_ACCOUNTS is not set here on purpose. It would name accounts, and the
+// account an environment needs is the one the manifest's substituted
+// credential carries, which this build cannot know. An application that reads
+// its account name from configuration needs nothing; one that hard codes a
+// production account name is the documented limit.
+func azuriteEnv() map[string]string {
+	return map[string]string{
+		// The log is read by a person diagnosing a failed twin, so it carries
+		// the request line and not a debug trace.
+		"AZURITE_LOOSE": "false",
+	}
+}
+
+var azureBlob = &Emulator{
+	EmulatorName: AzureBlobName,
+	Vendor:       "Azure",
+	Project:      "Azurite",
+	ProjectURL:   "https://github.com/Azure/Azurite",
+	Image:        azuriteImage,
+	Port:         AzureBlobPort,
+	Env:          azuriteEnv(),
+	Services: []Service{
+		{
+			Name: "Azure Blob Storage",
+			// One spelling, because Azure puts the account in the first label
+			// and there is no path style alternative to cover. The secondary
+			// read endpoint account-secondary.blob.core.windows.net is one
+			// label too and is matched by the same pattern, which is correct:
+			// an emulator has one copy and answers a secondary read from it.
+			Hosts:  []string{"*.blob.core.windows.net"},
+			Proves: "CreateContainer, UploadBlob, DownloadBlob and ListBlobs",
+			Note: "Shared Key and SAS are the credential shapes. Entra ID tokens are not, " +
+				"because Azurite's OAuth mode requires it to terminate TLS itself and in an " +
+				"environment the sidecar terminates it.",
+		},
+	},
+	Outside: []Service{
+		{
+			Name: "Azure Data Lake Storage Gen2",
+			Note: "The hierarchical namespace answers on dfs.core.windows.net, which is a " +
+				"different host and is not routed here. Azurite implements the blob " +
+				"endpoint of a storage account and not the DFS one, so a request that " +
+				"reached it would get a plausible answer to the wrong question.",
+		},
+		{
+			Name: "Azure Files",
+			Note: "file.core.windows.net is a different service on a different host and " +
+				"Azurite does not implement it.",
+		},
+		{
+			Name: "The sovereign cloud suffixes, core.chinacloudapi.cn and core.usgovcloudapi.net",
+			Note: "A different suffix is a different host and is not routed here. It falls " +
+				"through to the egress policy, whose default is block, so it is refused " +
+				"rather than answered.",
+		},
+	},
+	Licence: azuriteLicence,
+}
+
+var azureQueue = &Emulator{
+	EmulatorName: AzureQueueName,
+	Vendor:       "Azure",
+	Project:      "Azurite",
+	ProjectURL:   "https://github.com/Azure/Azurite",
+	Image:        azuriteImage,
+	Port:         AzureQueuePort,
+	Env:          azuriteEnv(),
+	Services: []Service{
+		{
+			Name:   "Azure Queue Storage",
+			Hosts:  []string{"*.queue.core.windows.net"},
+			Proves: "CreateQueue, SendMessage, ReceiveMessages and DeleteMessage",
+		},
+	},
+	Outside: []Service{
+		{
+			Name: "Azure Service Bus",
+			Note: "A Service Bus queue is not a Queue Storage queue and is not answered " +
+				"here. It answers on servicebus.windows.net, Microsoft's emulator for it " +
+				"needs a SQL Server container beside it, and this build cannot declare a " +
+				"second container yet. The measured cost is in the Azure guide.",
+		},
+	},
+	Licence: azuriteLicence,
+}
+
+var azureTable = &Emulator{
+	EmulatorName: AzureTableName,
+	Vendor:       "Azure",
+	Project:      "Azurite",
+	ProjectURL:   "https://github.com/Azure/Azurite",
+	Image:        azuriteImage,
+	Port:         AzureTablePort,
+	Env:          azuriteEnv(),
+	Services: []Service{
+		{
+			Name:   "Azure Table Storage",
+			Hosts:  []string{"*.table.core.windows.net"},
+			Proves: "CreateTable, CreateEntity, GetEntity and ListEntities",
+		},
+	},
+	Outside: []Service{
+		{
+			Name: "The Cosmos DB Table API",
+			Note: "It speaks the Table protocol and answers on table.cosmos.azure.com, " +
+				"which is a different host and is not routed here. Azurite is Table " +
+				"Storage, so a Cosmos account's throughput and partitioning behaviour is " +
+				"not what would be exercised.",
+		},
+	},
+	Licence: azuriteLicence,
+}

--- a/engine/pkg/emulator/azure_test.go
+++ b/engine/pkg/emulator/azure_test.go
@@ -1,0 +1,182 @@
+package emulator_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/internal/policy"
+	"github.com/antifailure/antifailure/engine/pkg/emulator"
+	"github.com/antifailure/antifailure/engine/pkg/extension"
+	"github.com/antifailure/antifailure/engine/pkg/schema"
+)
+
+// Azure is three registrations of one image, and every property below is one
+// somebody downstream depends on.
+
+func mustAzure(t *testing.T, name string) *emulator.Emulator {
+	t.Helper()
+	e, ok := emulator.Named(name)
+	require.True(t, ok, "an egress rule naming %s must find an emulator", name)
+	return e
+}
+
+// The three names, the three ports, and the one image. A second registration
+// that reused the first one's port would answer blob for a queue call, which
+// Azurite would answer plausibly rather than refuse, and nothing else in this
+// package would notice.
+func TestAzure_ThreeRegistrationsOfOneImageOnThreeDistinctPorts(t *testing.T) {
+	t.Parallel()
+
+	want := map[string]int{
+		emulator.AzureBlobName:  emulator.AzureBlobPort,
+		emulator.AzureQueueName: emulator.AzureQueuePort,
+		emulator.AzureTableName: emulator.AzureTablePort,
+	}
+
+	images := make(map[string]bool)
+	ports := make(map[int]string)
+	for name, port := range want {
+		e := mustAzure(t, name)
+		require.Equal(t, name, e.Name())
+		require.Contains(t, emulator.Names(), name)
+
+		c := e.Container()
+		require.Equal(t, port, c.Port,
+			"%s must forward to the port Azurite binds that service on", name)
+
+		prior, taken := ports[c.Port]
+		require.False(t, taken,
+			"%s and %s both forward to port %d, so one of them answers for the other's "+
+				"service and Azurite would answer it plausibly rather than refuse",
+			name, prior, c.Port)
+		ports[c.Port] = name
+
+		images[c.Image] = true
+	}
+	require.Len(t, images, 1,
+		"the three registrations are one Azurite image, so an environment naming all "+
+			"three pays for one image on disk")
+}
+
+func TestAzure_ImagesArePinnedByDigestRatherThanATag(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{
+		emulator.AzureBlobName, emulator.AzureQueueName, emulator.AzureTableName,
+	} {
+		require.Contains(t, mustAzure(t, name).Container().Image, "@sha256:",
+			"%s: a tag that moves changes what an environment was tested against "+
+				"with nothing in this repository changing", name)
+	}
+}
+
+// A built in emulator that could not pass the check outside registrations are
+// held to would be a double standard the first outside emulator discovers.
+func TestAzure_PassesTheRegistryValidationOutsideEmulatorsAreHeldTo(t *testing.T) {
+	t.Parallel()
+	r := extension.NewRegistry()
+	for _, name := range []string{
+		emulator.AzureBlobName, emulator.AzureQueueName, emulator.AzureTableName,
+	} {
+		r.AddEmulator(mustAzure(t, name))
+	}
+	require.NoError(t, r.Validate(nil))
+}
+
+// AZURITE_ACCOUNTS is the one variable that would break the claim this lane
+// makes, because naming accounts here would mean the account an environment can
+// use is decided by this build rather than by the manifest's substituted
+// credential.
+func TestAzure_DoesNotPinTheStorageAccountThisBuildCannotKnow(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{
+		emulator.AzureBlobName, emulator.AzureQueueName, emulator.AzureTableName,
+	} {
+		env := mustAzure(t, name).Container().Env
+		require.NotContains(t, env, "AZURITE_ACCOUNTS",
+			"%s: naming accounts here decides in this build which storage account an "+
+				"environment may serve, and that is the manifest's to decide", name)
+	}
+}
+
+// Host matching lives in more than one place in this repository and what holds
+// those places together is a corpus, not a shared belief. This is that corpus
+// for Azure: every host the surface claims is compiled by the REAL policy
+// engine, and the endpoint an SDK resolves is decided by the rule the emulator
+// would have written.
+func TestAzure_HostPatternsDecideTheEndpointsAnSDKResolves(t *testing.T) {
+	t.Parallel()
+
+	var rules []schema.EgressRule
+	byHost := map[string]*emulator.Emulator{}
+	for _, name := range []string{
+		emulator.AzureBlobName, emulator.AzureQueueName, emulator.AzureTableName,
+	} {
+		e := mustAzure(t, name)
+		for _, h := range e.Hosts() {
+			rules = append(rules, schema.EgressRule{Host: h, Mode: schema.ModeAllow})
+			byHost[h] = e
+		}
+	}
+	engine, err := policy.New(&schema.Egress{Default: schema.ModeBlock, Rules: rules})
+	require.NoError(t, err, "every host in the surface must compile as a policy rule")
+
+	// The account travels in the first label, so these are the shapes an SDK
+	// actually resolves, including the secondary read endpoint, which is one
+	// label and is correctly answered from the one copy an emulator holds.
+	reached := map[string]string{
+		"shopfront.blob.core.windows.net":            emulator.AzureBlobName,
+		"shopfront-secondary.blob.core.windows.net":  emulator.AzureBlobName,
+		"shopfront.queue.core.windows.net":           emulator.AzureQueueName,
+		"shopfront-secondary.queue.core.windows.net": emulator.AzureQueueName,
+		"shopfront.table.core.windows.net":           emulator.AzureTableName,
+	}
+	for host, wantName := range reached {
+		req, parseErr := policy.ParseRequest("POST", "https://"+host+"/")
+		require.NoError(t, parseErr)
+		require.True(t, engine.Evaluate(req).Matched(),
+			"%s matched no rule the surface writes", host)
+
+		var claimed []string
+		for _, e := range byHost {
+			if _, ok := e.ServiceFor(host); ok {
+				claimed = append(claimed, e.Name())
+			}
+		}
+		require.Len(t, claimed, 1,
+			"%s is claimed by %v, and a host claimed by none is decided by a rule the "+
+				"surface table refuses while a host claimed by two answers by rule order",
+			host, claimed)
+		require.Equal(t, wantName, claimed[0],
+			"%s is routed to the wrong emulator, so a queue call would be answered by "+
+				"the blob service, plausibly rather than refused", host)
+	}
+
+	// Outside the surface. Each of these is a host somebody could reasonably
+	// expect to be covered by something that is, which is why they are here
+	// rather than a single obviously foreign name.
+	refused := []string{
+		"shopfront.file.core.windows.net",       // Azure Files
+		"shopfront.dfs.core.windows.net",        // Data Lake Storage Gen2
+		"shopfront.servicebus.windows.net",      // Service Bus, not Queue Storage
+		"shopfront.table.cosmos.azure.com",      // the Cosmos Table API, not Table Storage
+		"shopfront.documents.azure.com",         // Cosmos DB
+		"shopfront.vault.azure.net",             // Key Vault
+		"blob.core.windows.net",                 // the apex, which carries no account
+		"shopfront.blob.core.chinacloudapi.cn",  // a sovereign suffix
+		"shopfront.blob.core.usgovcloudapi.net", // a sovereign suffix
+		"shopfront.blob.core.windows.net.evil.example",
+	}
+	for _, host := range refused {
+		req, parseErr := policy.ParseRequest("POST", "https://"+host+"/")
+		require.NoError(t, parseErr)
+		require.False(t, engine.Evaluate(req).Matched(),
+			"%s is outside the surface and a rule the emulator writes decided it", host)
+
+		for _, e := range byHost {
+			_, covered := e.ServiceFor(host)
+			require.False(t, covered,
+				"%s is outside the surface and %s answered it", host, e.Name())
+		}
+	}
+}

--- a/engine/pkg/emulator/emulator.go
+++ b/engine/pkg/emulator/emulator.go
@@ -238,3 +238,26 @@ func Names() []string {
 	sort.Strings(out)
 	return out
 }
+
+// RegisterBuiltin adds every built in emulator to a registry.
+//
+// It exists because the engine resolves an emulate rule through the registry
+// and through nothing else: a rule names an emulator, the registry supplies
+// the image, the digest, the port and the variables, and a name nothing
+// registered is refused rather than defaulted. So an emulator this repository
+// ships has to arrive the same way one written outside it does, and a
+// declaration nobody registers is a provider named and not built, which is the
+// thing this plan refuses on every other socket.
+//
+// A name already registered is left alone rather than added twice. Two
+// emulators under one name is what Registry.Validate refuses, and an
+// organization that has registered its own licensed image under the name aws
+// has made a deliberate choice that a built in registration must not undo.
+func RegisterBuiltin(r *extension.Registry) {
+	for _, e := range Builtin() {
+		if _, taken := r.EmulatorNamed(e.Name()); taken {
+			continue
+		}
+		r.AddEmulator(e)
+	}
+}

--- a/engine/pkg/emulator/emulator.go
+++ b/engine/pkg/emulator/emulator.go
@@ -1,0 +1,240 @@
+// Package emulator declares the third party emulators this build can start.
+//
+// Antifailure does not write emulators. LocalStack, Azurite and the vendors'
+// own emulators exist and carry years of fidelity work that a hand written
+// replacement would not have, and nobody buys this product because its S3
+// emulator is good. What the engine adds is that the application needs no
+// endpoint override to reach one: every name resolves to the sidecar, the
+// sidecar terminates TLS with a certificate authority the environment already
+// trusts, and it answers for s3.amazonaws.com itself. The unmodified
+// production code path runs against the emulator.
+//
+// This package is the declaration half of that, and it is deliberately data:
+// an image pinned by digest, the hostnames it answers for, the services it
+// covers, and the licence it ships under. It holds no routing, because routing
+// lives in the sidecar, and no container lifecycle, because that lives in the
+// runtime.
+//
+// It is a public package rather than an internal one for a reason that is not
+// about API design. THIRD_PARTY_NOTICES.md is generated, and the generator
+// lives in the tools module, which cannot import engine/internal. An emulator
+// image whose licence is recorded by hand goes stale the first time somebody
+// bumps a digest, so the licence has to be readable from the same declaration
+// the engine starts the container from.
+package emulator
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/antifailure/antifailure/engine/pkg/extension"
+)
+
+// Service is one cloud service an emulator answers for.
+//
+// The hosts are written out per service rather than covered by one wildcard,
+// for the reason the detection catalog gives at the same list: naming the
+// service is the point. A refusal that says "this is Amazon S3 and it is
+// outside the emulated surface" is a sentence somebody can act on, and one
+// that says "no rule matches" is not.
+type Service struct {
+	// Name is what a person calls it, such as "Amazon S3".
+	Name string
+	// Hosts are the hostnames its SDK resolves, in the spellings the policy
+	// engine compiles: a star stands for one whole label, so a regional
+	// endpoint is sqs.*.amazonaws.com and a virtual hosted bucket is
+	// *.s3.*.amazonaws.com.
+	Hosts []string
+	// Proves is the API call the conformance suite makes against this
+	// service. A service listed here with nothing proving it is a claim, and
+	// this field is what stops the surface table being one.
+	Proves string
+	// Note carries anything true about this service's coverage that a reader
+	// would otherwise find out from a failure.
+	Note string
+}
+
+// Licence is the attribution one emulator image owes.
+type Licence struct {
+	// Name is the licence, such as "Apache License 2.0".
+	Name string
+	// Holder is the copyright line, as the project writes it.
+	Holder string
+	// URL is where the licence text lives.
+	URL string
+}
+
+// Emulator is a third party emulator this build can start.
+//
+// It implements extension.Emulator, which is the socket the registry validates
+// and the engine resolves through, so a built in emulator and one registered
+// from outside the engine module are the same kind of thing to everything
+// downstream. There is no second interface.
+type Emulator struct {
+	// EmulatorName is the value an egress rule names this emulator by.
+	EmulatorName string
+	// Vendor is the cloud it answers for, such as "AWS".
+	Vendor string
+	// Project is the emulator's own name, such as "LocalStack".
+	Project string
+	// ProjectURL is where the emulator itself lives.
+	ProjectURL string
+	// Image is the container image, PINNED BY DIGEST. The registry's
+	// validation refuses a tag, because an emulator is the thing answering
+	// for production's API and a tag that moves changes what an environment
+	// was tested against with nothing in this repository changing.
+	Image string
+	// Port is the port inside the container the sidecar forwards to.
+	Port int
+	// Env is what the container is started with.
+	Env map[string]string
+	// Services are the cloud services this emulator answers for. THIS IS THE
+	// SURFACE. A host outside it is refused rather than answered, because a
+	// silent wrong answer from an emulator is worse than a refusal: it will
+	// be trusted.
+	Services []Service
+	// Outside names services of the same cloud that are deliberately NOT
+	// answered, with the reason. A gap a reader finds in a failure is worse
+	// than one they read first, and a provider named and not built is worse
+	// than one absent.
+	Outside []Service
+	// Licence is the attribution this image owes.
+	Licence Licence
+}
+
+// Name is the value an egress rule names this emulator by.
+func (e *Emulator) Name() string { return e.EmulatorName }
+
+// Hosts are the hostnames it answers for, gathered from its covered services.
+//
+// Derived rather than declared separately, so that a service added to the
+// surface table without its hosts, or a host routed to the emulator with no
+// service claiming it, cannot happen: there is one list and it is the table.
+func (e *Emulator) Hosts() []string {
+	seen := make(map[string]bool)
+	out := make([]string, 0, len(e.Services))
+	for _, s := range e.Services {
+		for _, h := range s.Hosts {
+			if seen[h] {
+				continue
+			}
+			seen[h] = true
+			out = append(out, h)
+		}
+	}
+	return out
+}
+
+// Container describes what the engine starts.
+func (e *Emulator) Container() extension.EmulatorContainer {
+	env := make(map[string]string, len(e.Env))
+	for k, v := range e.Env {
+		env[k] = v
+	}
+	return extension.EmulatorContainer{Image: e.Image, Port: e.Port, Env: env}
+}
+
+// ServiceFor returns the covered service a host belongs to.
+//
+// A host that no covered service claims returns false, which is the refusal:
+// the emulator answers for its surface and for nothing else.
+func (e *Emulator) ServiceFor(host string) (Service, bool) {
+	for _, s := range e.Services {
+		for _, pattern := range s.Hosts {
+			if hostMatches(pattern, host) {
+				return s, true
+			}
+		}
+	}
+	return Service{}, false
+}
+
+// hostMatches is the same rule the policy engine compiles, in the small.
+//
+// A star stands for exactly one label anywhere in the pattern, EXCEPT a
+// leading one, which stands for one or more. That asymmetry is not a detail:
+// *.s3.*.amazonaws.com has to answer for my.bucket.s3.us-east-1.amazonaws.com,
+// because a dot is legal in an S3 bucket name and virtual hosted addressing
+// puts the bucket in the hostname. A version of this function that required
+// the label counts to be equal refused that bucket while the policy engine
+// routed it to the emulator, so the sidecar would have forwarded a request the
+// surface table said was outside the surface. The test that compiles every
+// pattern with the real engine is what found it, and it is why this function
+// is checked against that engine rather than trusted to agree with it: host
+// matching already lives in more than one place in this repository, and what
+// holds those places together is a corpus of vectors, never a shared belief.
+func hostMatches(pattern, host string) bool {
+	pattern = strings.ToLower(strings.TrimSuffix(pattern, "."))
+	anyPrefix := strings.HasPrefix(pattern, "*.")
+	if anyPrefix {
+		pattern = pattern[2:]
+	}
+	p := strings.Split(pattern, ".")
+	h := strings.Split(strings.ToLower(strings.TrimSuffix(host, ".")), ".")
+
+	if anyPrefix {
+		// The leading star covers at least one label, so an apex is not
+		// matched by a pattern about its subdomains.
+		if len(h) <= len(p) {
+			return false
+		}
+		h = h[len(h)-len(p):]
+	} else if len(p) != len(h) {
+		return false
+	}
+	for i := range p {
+		if h[i] == "" {
+			return false
+		}
+		if p[i] != "*" && p[i] != h[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// builtin holds the emulators compiled into this build, keyed by name.
+//
+// Registered from each cloud's own file in an init rather than listed in one
+// place, so that three lanes adding three clouds do not all edit one slice
+// literal and meet in a merge. Builtin sorts, so the order does not depend on
+// which file the linker initialised first.
+var builtin = map[string]*Emulator{}
+
+// register adds an emulator to this build. It panics on a duplicate name,
+// because two emulators under one name is a build defect and the registry's
+// own validation would refuse it later, at the first af up, with the same
+// message and much less context.
+func register(e *Emulator) {
+	if _, dup := builtin[e.EmulatorName]; dup {
+		panic(fmt.Sprintf("emulator: two emulators are built in as %q", e.EmulatorName))
+	}
+	builtin[e.EmulatorName] = e
+}
+
+// Builtin returns every emulator this build can start, ordered by name.
+func Builtin() []*Emulator {
+	out := make([]*Emulator, 0, len(builtin))
+	for _, e := range builtin {
+		out = append(out, e)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].EmulatorName < out[j].EmulatorName })
+	return out
+}
+
+// Named returns the built in emulator registered under a name.
+func Named(name string) (*Emulator, bool) {
+	e, ok := builtin[name]
+	return e, ok
+}
+
+// Names lists what is built in, ordered.
+func Names() []string {
+	out := make([]string, 0, len(builtin))
+	for name := range builtin {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/engine/pkg/emulator/emulator_test.go
+++ b/engine/pkg/emulator/emulator_test.go
@@ -1,0 +1,204 @@
+package emulator_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/internal/policy"
+	"github.com/antifailure/antifailure/engine/pkg/emulator"
+	"github.com/antifailure/antifailure/engine/pkg/extension"
+	"github.com/antifailure/antifailure/engine/pkg/schema"
+)
+
+// The AWS emulator is a declaration, and every property below is a property
+// somebody downstream depends on: the registry refuses an unpinned image, the
+// sidecar routes what Hosts returns, and a service in the surface table with
+// nothing proving it is a claim rather than a capability.
+
+func TestAWS_IsBuiltInUnderTheNameAnEgressRuleWouldUse(t *testing.T) {
+	t.Parallel()
+	e, ok := emulator.Named(emulator.AWSName)
+	require.True(t, ok, "an egress rule naming aws must find an emulator")
+	require.Equal(t, "aws", e.Name())
+	require.Contains(t, emulator.Names(), "aws")
+}
+
+func TestAWS_ImageIsPinnedByDigestRatherThanATag(t *testing.T) {
+	t.Parallel()
+	e, _ := emulator.Named(emulator.AWSName)
+	require.Contains(t, e.Container().Image, "@sha256:",
+		"a tag that moves changes what an environment was tested against")
+	require.Equal(t, 4566, e.Container().Port)
+}
+
+// The registry validates registrations before an environment is created, and
+// it already refuses a hostless emulator and an unpinned image. A built in
+// emulator that could not pass the check outside registrations are held to
+// would be a double standard the first outside emulator would discover.
+func TestAWS_PassesTheRegistryValidationOutsideEmulatorsAreHeldTo(t *testing.T) {
+	t.Parallel()
+	r := extension.NewRegistry()
+	r.AddEmulator(mustAWS(t))
+	require.NoError(t, r.Validate(map[string][]string{}))
+
+	named, ok := r.EmulatorNamed("aws")
+	require.True(t, ok)
+	require.NotEmpty(t, named.Hosts())
+}
+
+func TestAWS_CoversEveryServiceTheLaneOwes(t *testing.T) {
+	t.Parallel()
+	e := mustAWS(t)
+	owed := []string{
+		"Amazon S3", "Amazon SQS", "Amazon SNS", "Amazon DynamoDB",
+		"Amazon Kinesis", "Amazon EventBridge", "AWS Secrets Manager",
+		"AWS Systems Manager Parameter Store", "AWS STS",
+	}
+	have := make(map[string]bool)
+	for _, s := range e.Services {
+		have[s.Name] = true
+	}
+	for _, name := range owed {
+		require.True(t, have[name], "%s is missing from the emulated surface", name)
+	}
+	require.Len(t, e.Services, len(owed),
+		"a service in the surface that nothing above owes is a claim nobody checks")
+}
+
+// STS is the one that fails at startup rather than at the call site, so it
+// gets its own test rather than sitting inside the list above. Several
+// credential chains call it before the first real request, and an emulated
+// surface without it fails with an error naming the wrong service.
+func TestAWS_AnswersForSTSBothGloballyAndRegionally(t *testing.T) {
+	t.Parallel()
+	e := mustAWS(t)
+	for _, host := range []string{"sts.amazonaws.com", "sts.us-east-1.amazonaws.com"} {
+		svc, ok := e.ServiceFor(host)
+		require.True(t, ok, "%s is not routed to the emulator", host)
+		require.Equal(t, "AWS STS", svc.Name)
+	}
+}
+
+// Virtual hosted addressing is the case this lane is loudest about: the bucket
+// travels in the Host header, which is why the sidecar preserves it.
+func TestAWS_AnswersForBothS3AddressingStyles(t *testing.T) {
+	t.Parallel()
+	e := mustAWS(t)
+	for _, host := range []string{
+		"s3.amazonaws.com",
+		"s3.us-east-1.amazonaws.com",
+		"mybucket.s3.amazonaws.com",
+		"mybucket.s3.us-east-1.amazonaws.com",
+	} {
+		svc, ok := e.ServiceFor(host)
+		require.True(t, ok, "%s is not routed to the emulator", host)
+		require.Equal(t, "Amazon S3", svc.Name)
+	}
+}
+
+// The expensive half of the lane. A silent wrong answer from an emulator is
+// worse than a refusal because it will be trusted, so a service outside the
+// surface must not be routed here at all.
+func TestAWS_RefusesAWSHostsOutsideTheSurface(t *testing.T) {
+	t.Parallel()
+	e := mustAWS(t)
+	for _, host := range []string{
+		"lambda.us-east-1.amazonaws.com",
+		"email.us-east-1.amazonaws.com",
+		"rds.us-east-1.amazonaws.com",
+		"apigateway.us-east-1.amazonaws.com",
+		"cloudformation.us-east-1.amazonaws.com",
+		"iam.amazonaws.com",
+		"monitoring.us-east-1.amazonaws.com",
+		"ecs.us-east-1.amazonaws.com",
+	} {
+		_, ok := e.ServiceFor(host)
+		require.False(t, ok, "%s is outside the surface and must not be answered", host)
+	}
+}
+
+func TestAWS_EveryCoveredServiceNamesTheCallThatProvesIt(t *testing.T) {
+	t.Parallel()
+	e := mustAWS(t)
+	for _, s := range e.Services {
+		require.NotEmpty(t, s.Hosts, "%s claims no host", s.Name)
+		require.NotEmpty(t, s.Proves,
+			"%s is in the surface with nothing proving it, which is a claim", s.Name)
+	}
+	require.NotEmpty(t, e.Outside, "a gap found in a failure is worse than one read first")
+	for _, s := range e.Outside {
+		require.NotEmpty(t, s.Note, "%s is excluded with no reason given", s.Name)
+	}
+}
+
+func TestAWS_RecordsTheLicenceTheNoticesFileOwes(t *testing.T) {
+	t.Parallel()
+	e := mustAWS(t)
+	require.Equal(t, "Apache License 2.0", e.Licence.Name)
+	require.Contains(t, e.Licence.Holder, "LocalStack")
+	require.True(t, strings.HasPrefix(e.Licence.URL, "https://"))
+	require.Equal(t, "LocalStack", e.Project)
+}
+
+// Host matching lives in more than one place in this repository and the thing
+// that holds those places together is a corpus, not a shared function. This is
+// that corpus for the emulator's own patterns: every host the surface claims
+// is compiled by the REAL policy engine, and the endpoint an SDK resolves is
+// decided by the rule the emulator would have written.
+func TestAWS_HostPatternsDecideTheEndpointsAnSDKResolves(t *testing.T) {
+	t.Parallel()
+	e := mustAWS(t)
+
+	rules := make([]schema.EgressRule, 0, len(e.Hosts()))
+	for _, h := range e.Hosts() {
+		rules = append(rules, schema.EgressRule{Host: h, Mode: schema.ModeAllow})
+	}
+	engine, err := policy.New(&schema.Egress{Default: schema.ModeBlock, Rules: rules})
+	require.NoError(t, err, "every host in the surface must compile as a policy rule")
+
+	reached := []string{
+		"s3.amazonaws.com", "s3.eu-west-1.amazonaws.com",
+		"mybucket.s3.amazonaws.com", "my.bucket.s3.us-east-1.amazonaws.com",
+		"sqs.us-east-1.amazonaws.com", "sns.ap-south-1.amazonaws.com",
+		"dynamodb.us-east-2.amazonaws.com", "streams.dynamodb.us-east-2.amazonaws.com",
+		"kinesis.us-west-2.amazonaws.com", "events.eu-central-1.amazonaws.com",
+		"secretsmanager.us-east-1.amazonaws.com", "ssm.us-east-1.amazonaws.com",
+		"sts.amazonaws.com", "sts.us-east-1.amazonaws.com",
+	}
+	for _, host := range reached {
+		req, parseErr := policy.ParseRequest("POST", "https://"+host+"/")
+		require.NoError(t, parseErr)
+		d := engine.Evaluate(req)
+		require.True(t, d.Matched(), "%s matched no rule the surface writes", host)
+
+		_, covered := e.ServiceFor(host)
+		require.True(t, covered,
+			"%s is decided by a rule the emulator writes and yet ServiceFor refuses it, "+
+				"so the sidecar and the surface table disagree about the same host", host)
+	}
+
+	refused := []string{
+		"lambda.us-east-1.amazonaws.com", "email.us-east-1.amazonaws.com",
+		"iam.amazonaws.com", "rds.us-east-1.amazonaws.com",
+		"s3.amazonaws.com.evil.example", "notamazonaws.com",
+	}
+	for _, host := range refused {
+		req, parseErr := policy.ParseRequest("POST", "https://"+host+"/")
+		require.NoError(t, parseErr)
+		d := engine.Evaluate(req)
+		require.False(t, d.Matched(),
+			"%s is outside the surface and a rule the emulator writes decided it", host)
+
+		_, covered := e.ServiceFor(host)
+		require.False(t, covered, "%s is outside the surface and ServiceFor answered it", host)
+	}
+}
+
+func mustAWS(t *testing.T) *emulator.Emulator {
+	t.Helper()
+	e, ok := emulator.Named(emulator.AWSName)
+	require.True(t, ok)
+	return e
+}

--- a/tools/notices/main.go
+++ b/tools/notices/main.go
@@ -287,9 +287,21 @@ func render(targets []target, mods []module) string {
 	b.WriteString("first time a digest is bumped. These come from the declarations the\n")
 	b.WriteString("engine starts the containers from.\n\n")
 	for _, e := range emulator.Builtin() {
-		fmt.Fprintf(&b, "- %s, %s. %s\n", e.Project, e.Licence.Name, e.Licence.Holder)
+		fmt.Fprintf(&b, "- %s, %s\n", e.Project, e.Licence.Name)
+		// A copyright holder is prose somebody else wrote and its length is
+		// theirs, not ours, so it is wrapped rather than truncated or left to
+		// run past the width every other line here is held to.
+		for _, l := range wrapAt(e.Licence.Holder, 70) {
+			fmt.Fprintf(&b, "  %s\n", l)
+		}
 		fmt.Fprintf(&b, "  - Answers for %s as `%s`\n", e.Vendor, e.Name())
-		fmt.Fprintf(&b, "  - `%s`\n", e.Image)
+		// The repository and the digest on separate lines, because a
+		// sha256 digest is 71 characters of unbreakable token and the
+		// generated prose is held to 74. Splitting at the @ is the only
+		// wrap point a digest reference has.
+		repo, digest, _ := strings.Cut(e.Image, "@")
+		fmt.Fprintf(&b, "  - `%s` pinned at\n", repo)
+		fmt.Fprintf(&b, "  %s\n", digest)
 		fmt.Fprintf(&b, "  - %s\n", e.Licence.URL)
 	}
 
@@ -322,4 +334,24 @@ func wrap(text string, width int) string {
 	}
 	b.WriteString("\n")
 	return b.String()
+}
+
+// wrapAt breaks a line on spaces at a width. A word longer than the width
+// stays on its own line rather than being cut, because a token nobody can
+// break is a value and shortening it would make it wrong.
+func wrapAt(text string, width int) []string {
+	words := strings.Fields(text)
+	if len(words) == 0 {
+		return nil
+	}
+	lines := []string{words[0]}
+	for _, w := range words[1:] {
+		last := len(lines) - 1
+		if len(lines[last])+1+len(w) <= width {
+			lines[last] += " " + w
+			continue
+		}
+		lines = append(lines, w)
+	}
+	return lines
 }

--- a/tools/notices/main.go
+++ b/tools/notices/main.go
@@ -38,6 +38,8 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+
+	"github.com/antifailure/antifailure/engine/pkg/emulator"
 )
 
 type module struct {
@@ -277,6 +279,20 @@ func render(targets []target, mods []module) string {
 	for _, m := range mods {
 		fmt.Fprintf(&b, "- `%s` %s\n", m.Path, m.Version)
 	}
+	b.WriteString("\n## Container images\n\n")
+	b.WriteString("An environment starts an emulator when a manifest asks for one, and an\n")
+	b.WriteString("emulator is somebody else's software running beside the application.\n")
+	b.WriteString("It is not linked into the binary, so the module list above cannot see\n")
+	b.WriteString("it, and an image whose licence is recorded by hand goes stale the\n")
+	b.WriteString("first time a digest is bumped. These come from the declarations the\n")
+	b.WriteString("engine starts the containers from.\n\n")
+	for _, e := range emulator.Builtin() {
+		fmt.Fprintf(&b, "- %s, %s. %s\n", e.Project, e.Licence.Name, e.Licence.Holder)
+		fmt.Fprintf(&b, "  - Answers for %s as `%s`\n", e.Vendor, e.Name())
+		fmt.Fprintf(&b, "  - `%s`\n", e.Image)
+		fmt.Fprintf(&b, "  - %s\n", e.Licence.URL)
+	}
+
 	b.WriteString("\n## Node packages\n\n")
 	b.WriteString("The agent runner depends on Playwright, which is Apache 2.0 licensed,\n")
 	b.WriteString("and on its own transitive dependencies. Run `npm ls --all` inside\n")

--- a/tools/notices/main_test.go
+++ b/tools/notices/main_test.go
@@ -139,6 +139,13 @@ func TestTheGeneratedProseStaysInsideItsWidth(t *testing.T) {
 		}
 	}
 	for _, line := range strings.Split(render(many, nil), "\n") {
+		// A line that is one unbreakable token has no wrap point, and a
+		// sha256 digest is 71 characters of exactly that. The rule is
+		// about prose the reader has to scan, not about a value that
+		// would be wrong if it were shortened.
+		if !strings.Contains(strings.TrimSpace(line), " ") {
+			continue
+		}
 		if len(line) > 74 {
 			t.Errorf("a generated line is %d characters: %q", len(line), line)
 		}

--- a/tools/socketcheck/main.go
+++ b/tools/socketcheck/main.go
@@ -82,10 +82,6 @@ var notConsulted = map[string]string{
 	"AuditSink": "Registry.Audit has no caller anywhere in the engine, so a registered " +
 		"sink receives nothing. Closing it means emitting the entries the audit log " +
 		"already writes through the registry as well.",
-	"Emulator": "an egress rule cannot name an emulator yet and the sidecar has no route " +
-		"to one, so a registration describes a container nothing starts. Closing it means " +
-		"the emulate mode and the sidecar route that makes an unmodified application " +
-		"reach it.",
 }
 
 // inventoryMethods are the registry methods that walk every socket at once.


### PR DESCRIPTION
Draft opened centrally so CI runs. `ci.yml` fires on pull_request and on push to main only, so a pushed branch with no pull request gets no verdict at all.

The lane owns this branch and will replace this description with the failure it fixes, its acceptance evidence and its mutation table before it is marked ready.

Opened by the merge coordinator, not by the lane.