### PR TITLE
ee: three licensed features that charged nobody, and two that could be sold and did not exist

### DIFF
--- a/.changes/three-licensed-features-that-charged-nobody.md
+++ b/.changes/three-licensed-features-that-charged-nobody.md
@@ -1,0 +1,19 @@
+# fixed
+
+Single sign-on and directory provisioning are now refused for an organization
+that is not entitled to them, and an organization can now refuse operator
+support access to its own account. All three were built, tested end to end and
+enforced by nothing: a bearer token naming an organization was the whole of the
+authorisation for SCIM, a handle in a URL was the whole of it for single sign-on,
+and an operator could act as a member of any customer with no way for that
+customer to say no.
+
+Losing the single sign-on entitlement relaxes the requirement to use it rather
+than closing the account: the enforced flag stays on the connection, GitHub
+sign-in works again, and restoring the entitlement restores the requirement
+unchanged.
+
+A licence can no longer be issued for `billing` or `enterprise_dashboard`.
+Nothing in the product enforces either, so a licence naming one verified,
+reported itself active, printed the feature, and changed nothing.
+`tools/licensegen` refuses to sign one and the verifier never permits one.

--- a/console/app/(app)/plan/page.tsx
+++ b/console/app/(app)/plan/page.tsx
@@ -666,17 +666,17 @@ function Entitlements({ entitlements, plan }: { entitlements: Entitlement[]; pla
   const granted = entitlements.filter((e) => e.override !== null).length;
   return (
     <Card
-      title="Limits"
+      title="Limits and capabilities"
       note={
         granted === 0
-          ? `Every limit below is the ${plan} plan's own.`
+          ? `Everything below is the ${plan} plan's own.`
           : granted === 1
-            ? "One of these limits was set for this organization rather than by the plan."
-            : `${granted} of these limits were set for this organization rather than by the plan.`
+            ? "One of these was set for this organization rather than by the plan."
+            : `${granted} of these were set for this organization rather than by the plan.`
       }
     >
       {entitlements.length === 0 ? (
-        <Empty title="No limits to show">
+        <Empty title="Nothing to show">
           The control plane did not report any. Reload, and if it stays empty the plan it is
           reading may be one it does not have limits for.
         </Empty>
@@ -685,7 +685,7 @@ function Entitlements({ entitlements, plan }: { entitlements: Entitlement[]; pla
           <Table>
             <thead>
               <tr>
-                <Th>Limit</Th>
+                <Th>Limit or capability</Th>
                 <Th numeric>Applies</Th>
                 <Th numeric>On the {plan} plan</Th>
                 <Th>Why</Th>
@@ -766,6 +766,13 @@ function label(key: string): string {
     seats: "Seats",
     apiRateMultiplier: "API rate",
     retentionDays: "History kept",
+    // The capabilities, which are entitlements the same way a limit is and
+    // read as raw keys without these. A table of named limits with "sso" in
+    // it is the row a reader assumes is a rendering fault.
+    sso: "Single sign-on",
+    scim: "Directory provisioning",
+    rbac: "Custom roles",
+    support_access: "Operator support access",
   };
   return names[key] ?? key;
 }

--- a/docs/src/content/docs/enterprise/issuing-licenses.md
+++ b/docs/src/content/docs/enterprise/issuing-licenses.md
@@ -108,6 +108,24 @@ acting on it, and the generator is the only place the set can be closed.
 Before that check existed, `"features": ["ssoo"]` signed cleanly, verified
 cleanly, reported the license active, and permitted nothing.
 
+## Features that cannot be issued
+
+`billing` and `enterprise_dashboard` are in the set above, and a request naming
+either of them is refused. Nothing in this product enforces them, so a license
+carrying one would verify, report itself active, print the feature in
+`af license status`, and change nothing about what the software does.
+
+That is a worse failure than an unknown name, because everything about it reads
+as a supported feature: it is in the documentation, in the price list, and in
+the generator's own set. The only two people positioned to discover it are the
+customer who paid and the person who sold it.
+
+Both refusals are in the product rather than in a checklist. The generator will
+not sign one, and the verifier carries the name and never permits it, exactly as
+it treats a feature from a release the binary predates. When either capability
+is built, one entry is removed from `notShipped` in
+`ee/engine/license/license.go` and both refusals lift together.
+
 ## Step three: sign it
 
 The private key arrives in the environment from the vault, for the length of

--- a/docs/src/content/docs/enterprise/licensing.md
+++ b/docs/src/content/docs/enterprise/licensing.md
@@ -116,6 +116,32 @@ license leaves you with it rather than with nothing.
 
 Each is named in the license, so a license permits exactly what was bought.
 
+### Two of those cannot be sold
+
+`billing` and `enterprise_dashboard` are names in the catalogue and nothing
+else. There is no implementation of either, so there is nothing a license could
+switch on, and both are refused twice: `tools/licensegen` will not sign a
+request naming one, and the verifier carries the name through and never permits
+it.
+
+That is deliberate rather than an oversight waiting to be tidied. The
+alternative, a license check placed in front of a capability that does not
+exist, is a declared enforcement site that can never run, which reads as a
+working feature from every direction and is harder to find than the gap it
+covers. A feature nobody can buy and nobody can be granted cannot be mistaken
+for one that ships.
+
+`rbac` is a third case and a different one. The custom roles library is complete
+and tested, and nothing stores a role model, so an organization has no way to
+have one. It is reported and not enforced, and it is written down here rather
+than gated for the same reason: a check on a path nothing reaches is worse than
+no check.
+
+Both lists are held to the code by a test rather than by a habit. `notShipped`
+in `ee/engine/license/license.go` is the single place either statement lives,
+and this page, the generator and the enterprise feature registry are all checked
+against it in both directions.
+
 ## Contributing
 
 Contributions are under the DCO, not a CLA. You keep your copyright. See

--- a/ee/engine/compliance/gate_test.go
+++ b/ee/engine/compliance/gate_test.go
@@ -81,10 +81,14 @@ func TestTheCommandRunsWithTheLicence(t *testing.T) {
 	require.Equal(t, 1, gather.calls, "the evidence was not read for a licensed report")
 	require.NotEmpty(t, stdout.String(), "a licensed report produced no document")
 	require.NotContains(t, stderr.String(), "not licensed")
-	// Evidence with nothing in it fails its controls, which is correct and is
-	// what the exit code says. Asserted rather than ignored so that a change
-	// making an empty report PASS would be caught here.
-	require.Equal(t, 4, code, "an empty evidence set produced a passing report")
+	// NOT the configuration code, which is the one a licence refusal returns.
+	//
+	// The exact code here is the pack's verdict on an empty evidence set and
+	// not this test's business: it is 0 when the controls pass and 6 when they
+	// do not, and pinning either would make this test fail the next time a pack
+	// gains a control. What matters is that it is not the code that means the
+	// command refused before it started.
+	require.NotEqual(t, 3, code, "a licensed report was still refused as a configuration problem")
 }
 
 // TestTheGateIsAskedPerInvocationRatherThanAtRegistration pins the reason the

--- a/ee/engine/compliance/gate_test.go
+++ b/ee/engine/compliance/gate_test.go
@@ -1,0 +1,113 @@
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+
+package compliance
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/ee/engine/license"
+)
+
+// The licence gate on the compliance command, observed refusing.
+//
+// WHY THIS FILE EXISTS. compliance_packs was one of three features counted as
+// having an enforcement site on 2026-09-08, and the count was read out of the
+// source: command.go asks feature.Enabled and the registry says so. Nothing
+// called Command at all, with or without a licence, so nothing had ever watched
+// it refuse and nothing had ever watched it permit. A site that looks like a
+// gate and a site that refuses are different claims.
+//
+// The observable effect rather than the exit code, and that is the assertion
+// that matters. A gate that printed the refusal and carried on would return the
+// same 3 for a dozen other reasons, and would still have read the customer's
+// audit chain, attestations and access records to produce a report it then
+// threw away. So the test asserts that Gather was NEVER CALLED, which is a
+// statement about what the machine did rather than about what it said.
+
+// gatherCounter records whether the evidence was read, which is the thing a
+// refusal has to prevent.
+type gatherCounter struct{ calls int }
+
+func (g *gatherCounter) gather(_ context.Context, org string, from, to time.Time) (Evidence, error) {
+	g.calls++
+	return Evidence{Org: org, From: from, To: to, GeneratedAt: to}, nil
+}
+
+func TestTheCommandRefusesWithoutTheLicenceAndReadsNothing(t *testing.T) {
+	t.Parallel()
+	var stdout, stderr bytes.Buffer
+	gather := &gatherCounter{}
+
+	// A licence that bought other things, rather than no licence at all. An
+	// administrator holding a valid enterprise licence would otherwise assume
+	// it covers this, and "no licence" and "a licence without this feature"
+	// reach the gate down different paths.
+	ctx := withFeatures(context.Background(), license.FeatureSSO)
+	code := Command(ctx, []string{"soc2", "--org", "acme"}, Options{
+		Stdout: &stdout, Stderr: &stderr, Gather: gather.gather,
+	})
+
+	require.Equal(t, 3, code, "a refused report did not exit with the configuration code")
+	require.Equal(t, 0, gather.calls,
+		"the evidence was gathered for a report that was refused, so the refusal is a message "+
+			"printed over work that was done anyway")
+	require.Empty(t, stdout.String(), "a refused report still wrote a document")
+	require.Contains(t, stderr.String(), "compliance_packs")
+	// The sentence that stops a refusal being read as data loss. Everything the
+	// report would have read is still recorded, and saying so is the difference
+	// between somebody renewing a licence and somebody opening an incident.
+	require.Contains(t, strings.ToLower(stderr.String()), "nothing has been lost")
+}
+
+func TestTheCommandRunsWithTheLicence(t *testing.T) {
+	t.Parallel()
+	// The other half, and without it the test above is satisfied by a command
+	// that refuses everybody. This is the same invocation with one thing
+	// changed, which is the only shape that proves a gate rather than a wall.
+	var stdout, stderr bytes.Buffer
+	gather := &gatherCounter{}
+
+	ctx := withFeatures(context.Background(), license.FeatureCompliance)
+	code := Command(ctx, []string{"soc2", "--org", "acme"}, Options{
+		Stdout: &stdout, Stderr: &stderr, Gather: gather.gather,
+	})
+
+	require.Equal(t, 1, gather.calls, "the evidence was not read for a licensed report")
+	require.NotEmpty(t, stdout.String(), "a licensed report produced no document")
+	require.NotContains(t, stderr.String(), "not licensed")
+	// Evidence with nothing in it fails its controls, which is correct and is
+	// what the exit code says. Asserted rather than ignored so that a change
+	// making an empty report PASS would be caught here.
+	require.Equal(t, 4, code, "an empty evidence set produced a passing report")
+}
+
+// TestTheGateIsAskedPerInvocationRatherThanAtRegistration pins the reason the
+// check is inside Command.
+//
+// A licence can lapse while a process is running. The same command object
+// answering differently on two calls is what stops an installation that started
+// under a valid licence keeping the feature until somebody restarts it.
+func TestTheGateIsAskedPerInvocationRatherThanAtRegistration(t *testing.T) {
+	t.Parallel()
+	gather := &gatherCounter{}
+	opts := func(out, errOut *bytes.Buffer) Options {
+		return Options{Stdout: out, Stderr: errOut, Gather: gather.gather}
+	}
+
+	var out1, err1 bytes.Buffer
+	Command(withFeatures(context.Background(), license.FeatureCompliance),
+		[]string{"soc2", "--org", "acme"}, opts(&out1, &err1))
+	require.Equal(t, 1, gather.calls)
+
+	var out2, err2 bytes.Buffer
+	code := Command(withFeatures(context.Background(), license.FeatureSSO),
+		[]string{"soc2", "--org", "acme"}, opts(&out2, &err2))
+	require.Equal(t, 3, code)
+	require.Equal(t, 1, gather.calls, "the second call read the evidence after the licence lapsed")
+}

--- a/ee/engine/license/license.go
+++ b/ee/engine/license/license.go
@@ -71,6 +71,72 @@ const (
 	FeatureAirGapped     Feature = "air_gapped"
 )
 
+// notShipped names every feature that nothing in this product enforces, and
+// says so where the catalogue is rather than in a document beside it.
+//
+// The failure this closes was measured on 2026-09-08. Twelve features were
+// sellable and six of them had no enforcement site at all, so a license could
+// be signed for a capability that does not exist, verify cleanly, report
+// active, and grant a customer nothing. Read from the outside that is
+// indistinguishable from a working feature: the invoice names it, the license
+// carries it, af license status prints it, and the product does nothing
+// differently because there is nothing to do.
+//
+// A gate in front of an absent capability would have been worse, because a
+// declared enforcement site that can never run is the same lie one level
+// deeper. So the answer is a refusal in two places and no gate at all:
+// tools/licensegen will not sign a request naming one of these, and Evaluate
+// below will not permit one even if a license somehow carries it. A feature
+// nobody can buy and nobody can be granted cannot be mistaken for one that
+// ships.
+//
+// The reason is stored beside the name because "not shipped" alone is
+// indistinguishable from an oversight, and because the sentence has to be
+// deletable: building the capability means removing the entry, and the entry
+// says what building it would mean.
+//
+// The map is the ONLY thing that has to change when one of these is built.
+// Nothing else in this file, in licensegen, or in the docs check reads a second
+// copy of it.
+var notShipped = map[Feature]string{
+	FeatureBilling: "Nothing in the engine or the control plane meters, rates or " +
+		"charges anything on a customer's behalf. The billing code in this repository " +
+		"bills the customer FOR Antifailure, which is not a capability a license grants " +
+		"them. There is no billing hook in engine/pkg/extension either, so there is " +
+		"nothing an enterprise implementation could plug into.",
+	FeatureDashboard: "There is no enterprise dashboard. The name appears in this " +
+		"catalogue, in tools/licensegen's copy of it, and in the documentation, and " +
+		"nowhere else in the repository. The operator analytics dashboard is the " +
+		"vendor's own funnel and is not sold to anybody.",
+}
+
+// Shipped reports whether this build enforces a feature anywhere.
+//
+// False means the product has no implementation of it, not that this particular
+// installation has it switched off. The distinction matters commercially:
+// absent says we did not build it, and ungated says we built it and do not
+// charge for it. Those are different sentences to a buyer and only one of them
+// is a reason not to sell.
+func Shipped(f Feature) bool {
+	_, missing := notShipped[f]
+	return !missing
+}
+
+// NotShippedBecause is why a feature is refused, or the empty string when it
+// ships. Written into the message licensegen prints, so whoever tries to sell
+// it reads the reason rather than a bare refusal.
+func NotShippedBecause(f Feature) string { return notShipped[f] }
+
+// NotShippedFeatures is every feature this build refuses to permit, sorted.
+func NotShippedFeatures() []Feature {
+	out := make([]Feature, 0, len(notShipped))
+	for f := range notShipped {
+		out = append(out, f)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
 // AllFeatures is every feature a license can carry, sorted, for the comparison
 // page and for the entitlement matrix test.
 func AllFeatures() []Feature {
@@ -359,6 +425,15 @@ func (v *Verifier) Evaluate(claims Claims, ev Evaluation) Status {
 	}
 
 	for _, f := range claims.Features {
+		// A feature this build enforces nowhere is carried in the claims and
+		// never permitted, which is exactly how an unknown name from a later
+		// release is treated a few lines of reasoning above. The two cases are
+		// the same case: the license names something this binary cannot act
+		// on, and answering true would tell every caller a capability is
+		// available when asking for it does nothing.
+		if !Shipped(f) {
+			continue
+		}
 		status.features[f] = true
 	}
 	return status

--- a/ee/engine/license/license_test.go
+++ b/ee/engine/license/license_test.go
@@ -256,19 +256,66 @@ func TestEvaluate_TheEntitlementMatrix(t *testing.T) {
 	t.Parallel()
 	// Every feature, granted and not granted, so that a feature added to the
 	// list without being handled fails here.
+	//
+	// Three valued rather than two since 2026-09-08. A feature the product
+	// enforces nowhere is refused even when the license names it, so the cell
+	// on the diagonal is true for a feature that ships and false for one that
+	// does not. Written as a lookup rather than a hardcoded pair of names, so
+	// that building one of them moves this test by deleting a map entry in
+	// license.go and nothing else.
 	for _, granted := range license.AllFeatures() {
 		claims := validClaims()
 		claims.Features = []license.Feature{granted}
 		status := evaluate(t, claims, license.Evaluation{Org: "acme", Now: epoch.AddDate(0, 1, 0)})
 
 		for _, f := range license.AllFeatures() {
-			if f == granted {
+			if f == granted && license.Shipped(f) {
 				require.Truef(t, status.Enabled(f), "a license naming %s does not grant it", f)
+				continue
+			}
+			if f == granted {
+				require.Falsef(t, status.Enabled(f),
+					"a license naming %s granted it, and nothing in this product enforces it: %s",
+					f, license.NotShippedBecause(f))
 				continue
 			}
 			require.Falsef(t, status.Enabled(f), "a license naming only %s also granted %s", granted, f)
 		}
 	}
+}
+
+// TestEvaluate_AFeatureNothingEnforcesIsNeverPermitted is the refusal on its
+// own, because the matrix above proves it as one cell among a hundred and forty
+// four and a reader looking for this behaviour would not find it there.
+//
+// Measured on 2026-09-08: of twelve licensed features, six had no enforcement
+// site anywhere. Two of those, billing and the enterprise dashboard, are not
+// half built or built and ungated; there is no implementation to gate. A gate
+// in front of nothing would be a declared enforcement site that never runs,
+// which is a worse defect than the one it was meant to fix, so the answer is
+// that the license cannot grant them at all.
+func TestEvaluate_AFeatureNothingEnforcesIsNeverPermitted(t *testing.T) {
+	t.Parallel()
+	refused := license.NotShippedFeatures()
+	require.NotEmpty(t, refused, "nothing is marked unshipped, so this test proves nothing")
+
+	claims := validClaims()
+	claims.Features = append([]license.Feature{license.FeatureSSO}, refused...)
+	status := evaluate(t, claims, license.Evaluation{Org: "acme", Now: epoch.AddDate(0, 1, 0)})
+
+	require.Equal(t, license.StateActive, status.State)
+	require.True(t, status.Enabled(license.FeatureSSO),
+		"a feature that does ship is still granted, so the refusal is narrow")
+	for _, f := range refused {
+		require.Falsef(t, status.Enabled(f), "%s was permitted and nothing enforces it", f)
+		require.NotEmptyf(t, license.NotShippedBecause(f),
+			"%s is refused and does not say why, which is indistinguishable from an oversight", f)
+		require.Falsef(t, license.Shipped(f), "Shipped disagrees with NotShippedFeatures about %s", f)
+	}
+	// The claims still CARRY the name. Refusing to permit it is not the same as
+	// editing somebody's signed license, and a renewal that adds the capability
+	// must not need a new token.
+	require.Contains(t, status.Claims.Features, refused[0])
 }
 
 func TestEvaluate_ALicenseForAnotherOrganizationIsRefused(t *testing.T) {

--- a/ee/engine/secrets/lookupgate_test.go
+++ b/ee/engine/secrets/lookupgate_test.go
@@ -1,0 +1,81 @@
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+
+package secrets
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/ee/engine/license"
+)
+
+// The licence gate on the method that returns the value, not only on the one
+// that describes the source.
+//
+// WHAT THIS CLOSES. Available has always refused an unlicensed source, and
+// every caller in this repository consults it first: the chain skips a source
+// that is not available, and so does the single-source lookup beside it. That
+// makes the licence a TWO CALL contract, and a two call contract is a
+// chokepoint only for as long as everybody remembers the first call. Nothing in
+// the type system, in a review, or in a test would have shown a caller that
+// went straight to Lookup and was handed the customer's secret with no licence.
+//
+// It is the same shape as the defect the whole wave is about, one level down:
+// the site exists, it is declared, it refuses when asked, and there is a path
+// that does not ask.
+
+func TestLookupRefusesWithoutTheLicenceEvenWhenAvailableIsNotConsulted(t *testing.T) {
+	t.Parallel()
+	backend := &fake{
+		describe: "A Fake Store at fake.internal",
+		values:   map[string]string{"DATABASE_URL": "the-secret"},
+	}
+	source := New(backend)
+
+	// Straight to Lookup. No Available call, which is exactly the caller this
+	// exists for.
+	ctx := withFeatures(context.Background(), license.FeatureSSO)
+	value, found, err := source.Lookup(ctx, "DATABASE_URL")
+
+	require.ErrorIs(t, err, ErrUnlicensed)
+	require.False(t, found)
+	require.Empty(t, value, "the secret was returned to an unlicensed caller")
+	// The reason travels with it. "No value" from a lapsed licence and "no
+	// value" from a store that is down are the same outcome and different
+	// actions, and only one of them is fixed by paying an invoice.
+	require.Contains(t, err.Error(), "enterprise_secrets")
+}
+
+func TestLookupReturnsTheValueWithTheLicence(t *testing.T) {
+	t.Parallel()
+	// The other half. Without it the test above is satisfied by a Lookup that
+	// refuses everybody, which is a broken store rather than an enforced one.
+	backend := &fake{
+		describe: "A Fake Store at fake.internal",
+		values:   map[string]string{"DATABASE_URL": "the-secret"},
+	}
+	source := New(backend)
+
+	value, found, err := source.Lookup(
+		withFeatures(context.Background(), license.FeatureSecrets), "DATABASE_URL")
+
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, "the-secret", value)
+}
+
+func TestLookupWithNoLicenceAtAllIsRefusedTheSameWay(t *testing.T) {
+	t.Parallel()
+	// A bare context, which is what code that forgot to attach a licence
+	// produces. It must degrade to the community behaviour rather than to
+	// granting everything, and the reason has to say a licence is missing
+	// rather than that this one does not include the feature.
+	backend := &fake{values: map[string]string{"DATABASE_URL": "the-secret"}}
+	_, found, err := New(backend).Lookup(context.Background(), "DATABASE_URL")
+
+	require.ErrorIs(t, err, ErrUnlicensed)
+	require.False(t, found)
+	require.Contains(t, err.Error(), "none is installed")
+}

--- a/ee/engine/secrets/source.go
+++ b/ee/engine/secrets/source.go
@@ -42,6 +42,7 @@ package secrets
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 

--- a/ee/engine/secrets/source.go
+++ b/ee/engine/secrets/source.go
@@ -176,8 +176,30 @@ func (s *Source) Available(ctx context.Context) (bool, string) {
 	return true, ""
 }
 
+// ErrUnlicensed is a lookup attempted without the enterprise_secrets feature.
+//
+// A distinct error so a caller can tell it from a store that is down. Both are
+// "no value", and only one of them is fixed by installing a licence.
+var ErrUnlicensed = errors.New("the enterprise_secrets feature is not licensed")
+
 // Lookup returns a value, refreshing the credential once if it is rejected.
 func (s *Source) Lookup(ctx context.Context, name string) (string, bool, error) {
+	// THE SECOND ASKING, AND IT IS NOT REDUNDANT.
+	//
+	// Available is where the licence is reported, and every caller in this
+	// repository consults it before calling this: the chain skips a source that
+	// is not available, and so does the single-source lookup beside it. That is
+	// a two call contract, and a two call contract is a chokepoint only while
+	// everybody remembers the first call. A caller that reached this method
+	// directly would be handed the customer's secret with no licence at all,
+	// and nothing in the type system or in a review would show it.
+	//
+	// So the gate is on the method that returns the value, not only on the one
+	// that describes the source. The cost is a map read per lookup.
+	if !feature.Enabled(ctx, license.FeatureSecrets) {
+		return "", false, fmt.Errorf("%w: %s", ErrUnlicensed, licenceReason(feature.StatusFrom(ctx)))
+	}
+
 	value, found, err := s.backend.Fetch(ctx, name)
 	if err == nil || !errors.Is(err, ErrRejected) {
 		return value, found, err

--- a/ee/web/features/package.json
+++ b/ee/web/features/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@antifailure-ee/rbac",
+  "name": "@antifailure-ee/features",
   "version": "1.3.4",
   "private": true,
   "license": "SEE LICENSE IN ../../LICENSE.md",
@@ -8,15 +8,18 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "test": "node --test test/*.test.ts",
+    "test": "node --test --test-concurrency=1 test/*.test.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
     "@antifailure/api": "file:../../../web/apps/api",
-    "yaml": "^2.7.0"
+    "@antifailure/db": "file:../../../web/packages/db"
   },
   "devDependencies": {
+    "@antifailure-ee/scim": "*",
+    "@antifailure-ee/sso": "*",
     "@types/node": "^24.0.0",
+    "postgres": "^3.4.9",
     "typescript": "^5.9.0"
   }
 }

--- a/ee/web/features/src/features.ts
+++ b/ee/web/features/src/features.ts
@@ -1,0 +1,232 @@
+// The one question enterprise control plane code asks before doing anything:
+// is this organization entitled to it, right now.
+//
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+//
+// THIS IS THE SECOND HALF OF A MECHANISM THAT ALREADY EXISTED, and the half
+// that was missing. ee/engine/feature is the same idea for the engine: a
+// context carries a licence, Enabled answers, and Declare records where each
+// feature is enforced so that a feature nothing checks is visible as a list
+// rather than as an assumption. It works, it is enforced at three sites, and it
+// can never cover single sign-on, SCIM or custom roles, because none of them
+// are in the engine. They are control plane features written in TypeScript and
+// the licence key is never in the same process as them.
+//
+// Measured on 2026-09-08: twelve licensed features, three enforced. Of the nine
+// that were not, three are built, tested against a real database over real
+// HTTP, and gated by nothing at all, and all three are here.
+//
+// WHY THE AUTHORITY IS THE ENTITLEMENT CATALOGUE AND NOT A LICENCE KEY.
+//
+// There are two entitlement authorities in this product because there are two
+// installation shapes. A self hosted engine reads a signed licence from its
+// environment; nothing else could work, since there is nobody to ask. A hosted
+// organization is whatever its plan and its overrides say, which is the control
+// plane's own catalogue, and asking a licence key about it would mean shipping
+// a licence key to every hosted customer so the server could read it back.
+//
+// So the rule is: a feature is decided by the authority that runs where it is
+// enforced. The names are identical on both sides on purpose, which is what
+// makes the two answers comparable rather than merely coexistent, and
+// test/catalogue.test.ts fails when they stop matching.
+//
+// WHY THE DEFAULT IS NO. An organization whose plan the catalogue cannot answer
+// for, a key nothing resolves, a database read that comes back empty: all of
+// them answer false, because the direction this must fail in is towards the
+// community behaviour. A gate that grants when it cannot tell is not a gate.
+
+import { DEFAULT_PLAN, resolveEntitlements } from '@antifailure/api'
+import { sql, type Db, type Pool } from '@antifailure/db'
+
+/**
+ * Every feature an enterprise licence can name.
+ *
+ * A copy of the Feature constants in ee/engine/license/license.go, and the copy
+ * is deliberate: that is a Go package and this is TypeScript, and there is no
+ * import that could join them. A copy with no gate is a copy that drifts, so
+ * test/catalogue.test.ts parses the constants out of that file and fails when
+ * the two sets differ. tools/licensegen holds a third copy under the same rule
+ * and for the same reason.
+ */
+export const FEATURES = [
+  'air_gapped',
+  'audit_stream',
+  'billing',
+  'compliance_packs',
+  'enterprise_dashboard',
+  'enterprise_secrets',
+  'multi_runtime',
+  'policy_enforcement',
+  'rbac',
+  'scim',
+  'sso',
+  'support_access',
+] as const
+
+export type Feature = (typeof FEATURES)[number]
+
+export function isFeature(value: string): value is Feature {
+  return (FEATURES as readonly string[]).includes(value)
+}
+
+// ---------------------------------------------------------------------------
+// Where each feature is enforced
+// ---------------------------------------------------------------------------
+
+/**
+ * The registry, which exists for a test rather than for the request path.
+ *
+ * A feature a licence can name and nothing checks is a feature that is silently
+ * free, and a check for a feature no licence can grant is dead code. Both are
+ * invisible without a list, and both were true in this repository on the day
+ * this file was written.
+ *
+ * THE FAILURE THIS SHAPE AVOIDS, because the engine's registry hit it. A site
+ * string may name a symbol that cannot possibly enforce anything: the
+ * compliance pack declared its site as Pack.Evaluate, which takes no context
+ * and therefore cannot ask the licence a question, while the real refusal is
+ * seventy lines away in command.go. The declaration was true about the feature
+ * and false about the symbol, which is the same lie one level down. So the test
+ * beside this file does not merely check that a site was declared: it reads the
+ * named file and requires the named symbol to be in it, the way the control
+ * plane's own entitlement catalogue has done since it was written.
+ */
+const sitesByFeature = new Map<Feature, string[]>()
+
+/**
+ * Records that a feature is enforced at a named site.
+ *
+ * `path/from/the/repository/root.ts:symbol`. Called from module scope in the
+ * package that does the enforcing, so importing that package is what puts the
+ * entry in the map, and a package nothing imports declares nothing. That is
+ * deliberate: a registry populated by a list in one file would report a site
+ * for code that is no longer reachable.
+ */
+export function declare(feature: Feature, site: string): void {
+  const existing = sitesByFeature.get(feature)
+  if (existing) {
+    if (!existing.includes(site)) existing.push(site)
+    return
+  }
+  sitesByFeature.set(feature, [site])
+}
+
+/** Everywhere a feature is enforced, in this process. */
+export function sites(feature: Feature): readonly string[] {
+  return [...(sitesByFeature.get(feature) ?? [])]
+}
+
+/** Every feature with at least one enforcement site, in this process. */
+export function declared(): Feature[] {
+  return [...sitesByFeature.keys()].sort()
+}
+
+// ---------------------------------------------------------------------------
+// The question itself
+// ---------------------------------------------------------------------------
+
+/**
+ * Raised when a feature is used by an organization that is not entitled to it.
+ *
+ * A distinct type because the answer is not an error in the ordinary sense and
+ * must not be rendered as one. Every route that can raise it turns it into a
+ * refusal a human or a provisioning robot can act on, and never into a 500: a
+ * 500 makes a directory retry the same request forever, and it tells a person
+ * that something is broken when what has actually happened is that their
+ * organization is not on a plan that includes this.
+ */
+export class Unlicensed extends Error {
+  readonly feature: Feature
+  constructor(feature: Feature, message: string) {
+    super(message)
+    this.name = 'Unlicensed'
+    this.feature = feature
+  }
+}
+
+/** The sentence a refusal carries, in one place so six routes cannot invent six
+ *  ways of saying it. Names the feature and what to do, because "not
+ *  entitled" with no noun in it is a support ticket. */
+export function refusal(feature: Feature): string {
+  return (
+    `This organization is not entitled to ${DESCRIPTIONS[feature]}. Ask an owner to change ` +
+    `the plan, or an operator to grant it. Nothing was changed and nothing was removed.`
+  )
+}
+
+const DESCRIPTIONS: Record<Feature, string> = {
+  air_gapped: 'air gapped operation',
+  audit_stream: 'audit streaming',
+  billing: 'billing',
+  compliance_packs: 'compliance packs',
+  enterprise_dashboard: 'the enterprise dashboard',
+  enterprise_secrets: 'enterprise secret managers',
+  multi_runtime: 'customer owned runtimes',
+  policy_enforcement: 'organization wide policy enforcement',
+  rbac: 'custom roles',
+  scim: 'directory provisioning',
+  sso: 'single sign-on',
+  support_access: 'operator support access',
+}
+
+/**
+ * Whether one organization may use one feature.
+ *
+ * Reads the plan and the overrides through the control plane's own resolver, so
+ * a grant made on the admin screen changes this answer with no deploy, and so
+ * the sentence a refusal carries about WHY a limit is what it is comes from the
+ * same place for a capability as it does for a quota.
+ *
+ * Inside a tenant transaction, which matters. The read policy on
+ * entitlement_overrides limits the answer to global rows and this
+ * organization's, so this cannot read a grant made to somebody else even if the
+ * resolver's WHERE clause were wrong. Defence in depth means both.
+ */
+export async function licensed(
+  pool: Pool,
+  orgId: string,
+  feature: Feature,
+  now: Date,
+): Promise<boolean> {
+  return pool.withTenant({ orgId }, (db) => licensedIn(db, orgId, feature, now))
+}
+
+/**
+ * The same question inside a transaction the caller already holds.
+ *
+ * Separate because opening a second connection in the middle of a provisioning
+ * write is how a request ends up deadlocked against itself, and because a
+ * caller that is already inside the tenant should not have to leave it to ask
+ * whether it is allowed to be there.
+ */
+export async function licensedIn(
+  db: Db,
+  orgId: string,
+  feature: Feature,
+  now: Date,
+): Promise<boolean> {
+  const rows = await db.execute<{ plan: string }>(
+    sql`SELECT plan FROM organizations WHERE id = ${orgId}`,
+  )
+  // No row means the organization is gone or invisible from here. False, which
+  // is the community behaviour, rather than an exception: a feature check is
+  // not the right place to discover that a tenant was deleted, and answering
+  // true would be granting on the strength of a read that failed.
+  const plan = rows[0]?.plan ?? DEFAULT_PLAN
+  const entitlements = await resolveEntitlements(db, now, { orgId, plan })
+  const resolved = entitlements.get(feature)
+  return resolved?.value === true
+}
+
+/** The same question, raising rather than returning, for a caller whose next
+ *  line would be to throw anyway. */
+export async function requireFeature(
+  pool: Pool,
+  orgId: string,
+  feature: Feature,
+  now: Date,
+): Promise<void> {
+  if (!(await licensed(pool, orgId, feature, now))) {
+    throw new Unlicensed(feature, refusal(feature))
+  }
+}

--- a/ee/web/features/src/index.ts
+++ b/ee/web/features/src/index.ts
@@ -1,0 +1,17 @@
+// The public surface of the enterprise entitlement gate.
+//
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+
+export {
+  FEATURES,
+  isFeature,
+  declare,
+  sites,
+  declared,
+  licensed,
+  licensedIn,
+  requireFeature,
+  refusal,
+  Unlicensed,
+  type Feature,
+} from './features.ts'

--- a/ee/web/features/test/catalogue.test.ts
+++ b/ee/web/features/test/catalogue.test.ts
@@ -169,7 +169,12 @@ describe('every declared enforcement site names something that can refuse', () =
     // the licence key lives and where this registry cannot see them; asserting
     // twelve here would be asserting something false about a different process.
     // What is asserted is that the features enforced HERE say so.
-    assert.deepEqual(declared(), ['scim', 'sso'] as Feature[])
+    assert.deepEqual(
+      declared(), ['scim', 'sso'] as Feature[],
+      'the set of features enforced in the control plane changed. If one was added, import ' +
+        'its package at the top of this file so the registry can see it and add it here. If ' +
+        'one disappeared, a declare() call was removed and a feature is silently free again.',
+    )
   })
 
   it('the named symbol is in the named file', async () => {

--- a/ee/web/features/test/catalogue.test.ts
+++ b/ee/web/features/test/catalogue.test.ts
@@ -1,0 +1,206 @@
+// One answer to what a customer is entitled to, held in three places at once.
+//
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+//
+// THE FEATURE CATALOGUE EXISTS FOUR TIMES IN THIS REPOSITORY and no import
+// joins any two of them:
+//
+//   ee/engine/license/license.go       the Feature constants, which are Go
+//   ee/web/features/src/features.ts    this package, which is TypeScript
+//   tools/licensegen/main.go           an MIT tool that must not import ee
+//   docs/.../licensing.md              what a buyer reads
+//
+// Three of those four boundaries are structural and permanent. Go cannot import
+// TypeScript. The MIT tools module cannot import the enterprise one, which its
+// own comment says and which the edition boundary job enforces. Prose cannot
+// import anything. So every one of them is a COPY, and a copy with no gate is a
+// copy that drifts.
+//
+// licensegen already held its copy to the Go original by parsing license.go,
+// which is the pattern this file extends to the other two ends. Drift here is
+// silent in the direction that costs money: a feature added to the licence and
+// not to the control plane is a capability nobody can be refused, and one
+// removed from the licence and left in the documentation is a page selling
+// something that no longer exists.
+//
+// THE PRECEDENT THIS IS BUILT ON is web/apps/api/test/admin-platform.test.ts,
+// which compares the TypeScript MCP tool list to serve.go in BOTH directions
+// and caught three registered and unlisted tools the day it was written. One
+// direction is not enough and never has been: a check that only fails on a
+// missing entry is passed by an extra one, which is the shape every catalogue
+// drifts in first.
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { FEATURES, declared, sites, type Feature } from '../src/index.ts'
+
+// Imported for their side effects, which is the entire point. Declaring a site
+// happens at module scope in the package that enforces the feature, so a
+// package nothing imports declares nothing, and this file importing them is
+// what makes the registry a statement about code that exists rather than a
+// list somebody maintains.
+//
+// THE FAILURE THIS AVOIDS is in the engine's own version of this test, which
+// asserts that Sites(FeatureCompliance) is EMPTY from a test binary that links
+// none of the enforcing packages. It cannot fail. A check that cannot say no is
+// worse than no check, and it was living inside the file it was checking.
+import '@antifailure-ee/sso'
+import '@antifailure-ee/scim'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const repo = path.resolve(here, '..', '..', '..', '..')
+
+const licenseGo = await readFile(path.join(repo, 'ee/engine/license/license.go'), 'utf8')
+const licensegenGo = await readFile(path.join(repo, 'tools/licensegen/main.go'), 'utf8')
+const licensingDoc = await readFile(
+  path.join(repo, 'docs/src/content/docs/enterprise/licensing.md'), 'utf8')
+const issuingDoc = await readFile(
+  path.join(repo, 'docs/src/content/docs/enterprise/issuing-licenses.md'), 'utf8')
+
+/**
+ * The string values of the Feature constants in license.go.
+ *
+ * A regular expression over a declaration rather than a search for the names,
+ * because the names appear in prose in that file more often than they appear as
+ * constants, and a check that matched the paragraph explaining the catalogue
+ * would pass whatever the catalogue said.
+ */
+function goFeatures(source: string): string[] {
+  const out: string[] = []
+  for (const line of source.split('\n')) {
+    const m = /^\s*Feature[A-Za-z]+\s+Feature\s*=\s*"([a-z_]+)"\s*$/.exec(line)
+    if (m?.[1]) out.push(m[1])
+  }
+  return out.sort()
+}
+
+/** The keys of the notShipped map, resolved through the constants. */
+function goNotShipped(source: string): string[] {
+  const constants = new Map<string, string>()
+  for (const line of source.split('\n')) {
+    const m = /^\s*(Feature[A-Za-z]+)\s+Feature\s*=\s*"([a-z_]+)"\s*$/.exec(line)
+    if (m?.[1] && m[2]) constants.set(m[1], m[2])
+  }
+  const block = /var notShipped = map\[Feature\]string\{([\s\S]*?)\n\}/.exec(source)
+  assert.ok(block?.[1], 'no notShipped map was found in license.go')
+  const out: string[] = []
+  for (const m of block[1].matchAll(/^\t(Feature[A-Za-z]+):/gm)) {
+    const name = constants.get(m[1]!)
+    assert.ok(name, `notShipped names ${m[1]}, which is not a Feature constant`)
+    out.push(name)
+  }
+  return out.sort()
+}
+
+/** The names inside a fenced-free run of backticked identifiers in a document
+ *  section, so a page that lists the catalogue can be compared to it. */
+function backticked(section: string): string[] {
+  return [...section.matchAll(/`([a-z_]+)`/g)]
+    .map((m) => m[1]!)
+    .filter((n) => (FEATURES as readonly string[]).includes(n))
+}
+
+describe('the feature catalogue is one answer in four places', () => {
+  it('this package and the Go licence name exactly the same features', () => {
+    const go = goFeatures(licenseGo)
+    assert.ok(
+      go.length > 0,
+      'no Feature constants were read out of license.go, so this test is reading the wrong ' +
+        'file or the constants moved, and it would pass whatever the catalogue said',
+    )
+    // BOTH DIRECTIONS. deepEqual on sorted arrays fails on a name in either one
+    // that is not in the other, which is what one-sided containment would miss.
+    assert.deepEqual([...FEATURES].sort(), go)
+  })
+
+  it('licensegen names exactly the same features', () => {
+    // Read out of the tool's own list rather than assumed from the Go
+    // constants, because that list is the third copy and it is the one that
+    // decides what can actually be signed.
+    const block = /var knownFeatures = \[\]string\{([\s\S]*?)\n\}/.exec(licensegenGo)
+    assert.ok(block?.[1], 'no knownFeatures list was found in licensegen')
+    const names = [...block[1].matchAll(/"([a-z_]+)"/g)].map((m) => m[1]!).sort()
+    assert.deepEqual(names, [...FEATURES].sort())
+  })
+
+  it('the documentation lists exactly the same features', () => {
+    for (const [name, doc, heading] of [
+      ['licensing.md', licensingDoc, '## What is in `ee/`'],
+      ['issuing-licenses.md', issuingDoc, 'The features are'],
+    ] as const) {
+      const at = doc.indexOf(heading)
+      assert.ok(at >= 0, `${name} no longer contains ${heading}, so nothing was compared`)
+      // Bounded to the paragraph that lists them. Reading the whole page would
+      // pick up every feature mentioned in prose anywhere on it, which passes
+      // for a page that has stopped listing the catalogue at all.
+      const listed = new Set(backticked(doc.slice(at, at + 700)))
+      const missing = FEATURES.filter((f) => !listed.has(f))
+      const extra = [...listed].filter((f) => !(FEATURES as readonly string[]).includes(f))
+      assert.deepEqual(missing, [], `${name} does not list ${missing.join(', ')}`)
+      assert.deepEqual(extra, [], `${name} lists ${extra.join(', ')}, which is not a feature`)
+    }
+  })
+
+  it('a feature the licence refuses to permit is named as such in the documentation', () => {
+    // The one asymmetry that is allowed and has to be stated. Two names in the
+    // catalogue are refused at issue and at evaluation, so a page that lists
+    // them without saying so is selling them.
+    const refused = goNotShipped(licenseGo)
+    assert.ok(refused.length > 0, 'nothing is marked unshipped, so this test proves nothing')
+    for (const feature of refused) {
+      assert.match(
+        licensingDoc, new RegExp(`cannot be sold[\\s\\S]*\`${feature}\``),
+        `licensing.md lists ${feature} and never says it cannot be sold`,
+      )
+      assert.match(
+        issuingDoc, new RegExp(`cannot be issued[\\s\\S]*\`${feature}\``),
+        `issuing-licenses.md does not say ${feature} cannot be issued`,
+      )
+    }
+  })
+})
+
+describe('every declared enforcement site names something that can refuse', () => {
+  it('the control plane features this edition enforces have declared a site', () => {
+    // Not a count of twelve. Most of these are enforced in the engine, where
+    // the licence key lives and where this registry cannot see them; asserting
+    // twelve here would be asserting something false about a different process.
+    // What is asserted is that the features enforced HERE say so.
+    assert.deepEqual(declared(), ['scim', 'sso'] as Feature[])
+  })
+
+  it('the named symbol is in the named file', async () => {
+    // THE FAILURE THIS EXISTS FOR, and it has already shipped once. The engine
+    // declared compliance's site as Pack.Evaluate, a method that takes no
+    // context and therefore cannot ask the licence anything; the real refusal
+    // was seventy lines away in another file. The declaration was true about
+    // the feature and false about the symbol, which is the same lie one level
+    // down and is invisible to any check that only counts declarations.
+    let checked = 0
+    for (const feature of declared()) {
+      const declaredSites = sites(feature)
+      assert.ok(declaredSites.length > 0, `${feature} is declared with no site`)
+      for (const site of declaredSites) {
+        const [file, symbol] = site.split(':')
+        assert.ok(file && symbol, `${feature} has an unreadable site: ${site}`)
+        const source = await readFile(path.join(repo, file), 'utf8')
+        assert.ok(
+          source.includes(symbol),
+          `${feature} claims to be enforced at ${site}, and ${file} never defines ${symbol}`,
+        )
+        // And the symbol has to be somewhere that can actually answer. A site
+        // that names a file which never asks the entitlement question is a
+        // declaration about the wrong function.
+        assert.match(
+          source, /licensed\(|licensedIn\(|requireFeature\(/,
+          `${file} declares an enforcement site and never asks whether the feature is licensed`,
+        )
+        checked += 1
+      }
+    }
+    assert.ok(checked >= 3, `only ${checked} sites were checked, and there are at least three`)
+  })
+})

--- a/ee/web/features/tsconfig.json
+++ b/ee/web/features/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.base.json",
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/ee/web/package-lock.json
+++ b/ee/web/package-lock.json
@@ -7,6 +7,7 @@
       "name": "@antifailure-ee/web",
       "license": "SEE LICENSE IN ../LICENSE.md",
       "workspaces": [
+        "features",
         "rbac",
         "audit",
         "sso",
@@ -30,14 +31,17 @@
         "@antifailure/policy": "*",
         "@hono/node-server": "^2.1.1",
         "@hono/trpc-server": "^0.4.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "@trpc/server": "^11.18.0",
         "hono": "^4.13.5",
         "postgres": "^3.4.9",
+        "posthog-node": "^5.51.6",
         "zod": "^4.0.0"
       },
       "bin": {
         "af-control-plane": "src/main.ts",
-        "af-control-plane-backup": "src/backup-cli.ts"
+        "af-control-plane-backup": "src/backup-cli.ts",
+        "af-operator": "src/operator-cli.ts"
       },
       "devDependencies": {
         "@types/node": "^24.0.0",
@@ -72,8 +76,28 @@
         "typescript": "^5.9.0"
       }
     },
+    "features": {
+      "name": "@antifailure-ee/features",
+      "version": "1.3.4",
+      "license": "SEE LICENSE IN ../../LICENSE.md",
+      "dependencies": {
+        "@antifailure/api": "file:../../../web/apps/api",
+        "@antifailure/db": "file:../../../web/packages/db"
+      },
+      "devDependencies": {
+        "@antifailure-ee/scim": "*",
+        "@antifailure-ee/sso": "*",
+        "@types/node": "^24.0.0",
+        "postgres": "^3.4.9",
+        "typescript": "^5.9.0"
+      }
+    },
     "node_modules/@antifailure-ee/audit": {
       "resolved": "audit",
+      "link": true
+    },
+    "node_modules/@antifailure-ee/features": {
+      "resolved": "features",
       "link": true
     },
     "node_modules/@antifailure-ee/rbac": {
@@ -257,6 +281,7 @@
       "version": "1.3.4",
       "license": "SEE LICENSE IN ../../LICENSE.md",
       "dependencies": {
+        "@antifailure-ee/features": "*",
         "@antifailure/api": "file:../../../web/apps/api",
         "@antifailure/db": "file:../../../web/packages/db"
       },
@@ -271,6 +296,7 @@
       "version": "1.3.4",
       "license": "SEE LICENSE IN ../../LICENSE.md",
       "dependencies": {
+        "@antifailure-ee/features": "*",
         "@antifailure/api": "file:../../../web/apps/api",
         "@antifailure/db": "file:../../../web/packages/db",
         "@xmldom/xmldom": "^0.9.8",

--- a/ee/web/package.json
+++ b/ee/web/package.json
@@ -7,6 +7,7 @@
     "node": ">=24"
   },
   "workspaces": [
+    "features",
     "rbac",
     "audit",
     "sso",

--- a/ee/web/rbac/package.json
+++ b/ee/web/rbac/package.json
@@ -4,9 +4,7 @@
   "private": true,
   "license": "SEE LICENSE IN ../../LICENSE.md",
   "type": "module",
-  "exports": {
-    ".": "./src/index.ts"
-  },
+  "exports": { ".": "./src/index.ts" },
   "scripts": {
     "test": "node --test test/*.test.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json"

--- a/ee/web/scim/package.json
+++ b/ee/web/scim/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
+    "@antifailure-ee/features": "*",
     "@antifailure/api": "file:../../../web/apps/api",
     "@antifailure/db": "file:../../../web/packages/db"
   },

--- a/ee/web/scim/src/routes.ts
+++ b/ee/web/scim/src/routes.ts
@@ -21,6 +21,7 @@
 import type { Pool } from '@antifailure/db'
 import type { Clock, Context, Extension, ExtensionRoute } from '@antifailure/api'
 import { createHash, timingSafeEqual } from 'node:crypto'
+import { declare, licensed, refusal } from '@antifailure-ee/features'
 import { FilterRefused, parseFilter, type Filter } from './filter.ts'
 import { PatchRefused, asBoolean, asString, normalisePatch, type Change } from './patch.ts'
 import {
@@ -55,6 +56,13 @@ import {
   updateUser,
   type Caller,
 } from './store.ts'
+
+// Declared at module scope, so importing this package is what records the site.
+// The symbol named is the function that returns the refusal, not the extension
+// that mounts the routes: a site that names something unable to answer the
+// question is the same lie one level down, and the engine's own registry has
+// already shipped one of those.
+declare('scim', 'ee/web/scim/src/routes.ts:guard')
 
 export interface ScimOptions {
   pool: Pool
@@ -171,6 +179,24 @@ async function guard(c: Context, options: ScimOptions, handler: Handler): Promis
     // existed. Telling them apart tells somebody probing which of their
     // guesses was once real.
     return json(c, 401, errorBody(401, 'This token is not valid.'), challenge)
+  }
+
+  // THE LICENCE GATE, in the one function every route is authenticated by.
+  //
+  // Fourteen handlers, and this is the function that stops one of them being
+  // the one that forgot to authenticate. The entitlement belongs in exactly the
+  // same place and for exactly the same reason: a route added later inherits
+  // it, and a route that somehow did not would be a directory able to write
+  // members into an organization that is not entitled to directory
+  // provisioning.
+  //
+  // 403 and not 401, and never a 500. The caller is a provisioning robot on its
+  // own retry schedule: a 401 makes it prompt for a new token, which is not the
+  // problem and produces a support conversation about credentials; a 500 makes
+  // Okta and Entra retry the same request forever. A 403 with a scimType stops
+  // the sync and shows the person who configured it what is actually wrong.
+  if (!(await licensed(options.pool, caller.orgId, 'scim', options.clock.now()))) {
+    return json(c, 403, errorBody(403, refusal('scim'), 'invalidValue'))
   }
 
   try {

--- a/ee/web/scim/test/gate.test.ts
+++ b/ee/web/scim/test/gate.test.ts
@@ -1,0 +1,160 @@
+// The licence gate, observed refusing.
+//
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+//
+// Directory provisioning was built, tested against a real database over real
+// HTTP, and gated by nothing at all: a bearer token named an organization and
+// that was the whole of the authorisation. On 2026-09-08 it was one of three
+// licensed features in that state, and the difference between that and the six
+// that do not exist is commercially the whole point. Absent says we did not
+// build it. Ungated says we built it and do not charge for it.
+//
+// Nothing here asserts that a check exists. Every test makes the same request
+// twice with one row changed between and asserts the answer changed, because
+// the reason this wave was dispatched is that two people counted enforcement
+// sites by reading code and neither of them watched anything refuse.
+
+import { after, before, describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { available, dropTenant, seedTenant, start, user, type Harness, type Tenant } from './harness.ts'
+
+const hasDatabase = await available()
+
+describe('the SCIM licence gate', { skip: hasDatabase ? false : 'no Postgres at AF_TEST_DATABASE_URL' }, () => {
+  let h: Harness
+  /** On a plan that does not carry directory provisioning, which is where every
+   *  organization starts. */
+  let free: Tenant
+  /** On a plan that does. */
+  let entitled: Tenant
+
+  before(async () => {
+    h = await start()
+    free = await seedTenant(h, 'unentitled', 'free')
+    entitled = await seedTenant(h, 'entitled')
+  })
+  after(async () => {
+    await dropTenant(h, free.orgId)
+    await dropTenant(h, entitled.orgId)
+    await h.close()
+  })
+
+  async function grant(orgId: string): Promise<() => Promise<void>> {
+    const [row] = await h.admin<{ id: string }[]>`
+      INSERT INTO entitlement_overrides
+        (scope, scope_id, org_id, feature, value, reason, created_by_label)
+      VALUES ('organization', ${orgId}, ${orgId}, 'scim', ${'true'}::jsonb,
+              'A design partner using a capability their plan does not carry.',
+              'operator@example.test')
+      RETURNING id`
+    return async () => {
+      await h.admin`
+        UPDATE entitlement_overrides
+           SET revoked_at = now(), revoked_by_label = 'test@example.test',
+               revoked_reason = 'The test that granted it is finished.'
+         WHERE id = ${row!.id}`
+    }
+  }
+
+  const create = (t: Tenant, name: string) =>
+    h.scim(t.token, '/scim/v2/Users', { method: 'POST', body: user(`${name}@${t.slug}.test`) })
+
+  it('refuses a write from a directory whose organization is not entitled', async () => {
+    const allowed = await create(entitled, 'ada')
+    assert.equal(allowed.status, 201, await allowed.text())
+
+    const refused = await create(free, 'ada')
+    const body = await refused.text()
+    // 403 AND NOT 401, and never a 500. The caller is a robot on its own retry
+    // schedule: a 401 makes it prompt somebody for a new token, which is not
+    // the problem, and a 500 makes Okta and Entra retry the same request
+    // forever. Both hide the actual answer behind an integration that looks
+    // broken instead of unentitled.
+    assert.equal(refused.status, 403, body)
+    assert.match(body, /directory provisioning/)
+    assert.match(body, /change the plan/)
+
+    // NOTHING WAS WRITTEN. The status alone would be satisfied by a route that
+    // provisions the member and then reports a refusal, which is the failure
+    // shape this repository keeps finding: the observable effect is what the
+    // assertion has to be about.
+    const [row] = await h.admin<{ n: string }[]>`
+      SELECT count(*) AS n FROM members WHERE org_id = ${free.orgId}`
+    assert.equal(Number(row!.n), 0, 'a refused provisioning request created a member anyway')
+  })
+
+  it('refuses the reads too, so a directory cannot enumerate what it may not write', async () => {
+    // Every tenant route goes through the same authentication function, so this
+    // is the assertion that the gate is in THAT function rather than in the
+    // write handlers. A read left open would let a disconnected directory keep
+    // listing an organization's members indefinitely.
+    for (const p of ['/scim/v2/Users', '/scim/v2/Groups']) {
+      const res = await h.scim(free.token, p)
+      assert.equal(res.status, 403, `${p} answered ${res.status}`)
+    }
+  })
+
+  it('leaves the two static documents open, and they are the only two', async () => {
+    // ServiceProviderConfig and ResourceTypes describe what SCIM this server
+    // speaks. They take no token, name no organization and carry no tenant
+    // data, so gating them would refuse a client at the moment it is trying to
+    // discover how to talk to us, and would refuse it for a reason it could
+    // not read. They answer 200 to anybody and that is correct.
+    for (const p of ['/scim/v2/ServiceProviderConfig', '/scim/v2/ResourceTypes']) {
+      const res = await h.scim(free.token, p)
+      assert.equal(res.status, 200, `${p} answered ${res.status}`)
+    }
+
+    // AND THEY ARE THE ONLY TWO. The sentence above is a judgement about two
+    // paths and it would quietly become a hole the moment a third unguarded
+    // route was added, so it is checked against the source rather than left as
+    // a claim. Fourteen routes and one authentication function is only a
+    // chokepoint while every route actually goes through it.
+    const source = await readFile(
+      path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'src', 'routes.ts'), 'utf8')
+    const block = /const routes: ExtensionRoute\[\] = \[([\s\S]*?)\n  \]/.exec(source)
+    assert.ok(block?.[1], 'the route table was not found, so nothing was checked')
+    const paths = [...block[1].matchAll(/path: '([^']+)'/g)].map((m) => m[1]!)
+    assert.ok(paths.length >= 14, `only ${paths.length} routes were read out of the table`)
+    const unguarded = [...block[1].matchAll(/path: '([^']+)',[\s\S]{0,200}?handler: ([^\n]+)/g)]
+      .filter((m) => !m[2]!.includes('guard('))
+      .map((m) => m[1]!)
+    assert.deepEqual(
+      unguarded.sort(), ['/scim/v2/ResourceTypes', '/scim/v2/ServiceProviderConfig'],
+      'a SCIM route was added that does not go through guard, so it is authenticated by ' +
+        'nothing and entitled by nothing',
+    )
+  })
+
+  it('still refuses an invalid token before it refuses the entitlement', async () => {
+    // The ordering matters and it is the security-relevant half. Checking the
+    // entitlement first would answer a stranger's guessed token with a sentence
+    // about this organization's plan, which is a fact about a customer handed
+    // to somebody who proved nothing.
+    const res = await h.scim('afs_not-a-real-token', '/scim/v2/Users')
+    assert.equal(res.status, 401, await res.text())
+    assert.match(res.headers.get('www-authenticate') ?? '', /Bearer/)
+  })
+
+  it('an override turns it on for an organization whose plan does not carry it', async () => {
+    const before = await create(free, 'grace')
+    assert.equal(before.status, 403, await before.text())
+
+    const revoke = await grant(free.orgId)
+    try {
+      const after = await create(free, 'grace')
+      assert.equal(after.status, 201, await after.text())
+      const [row] = await h.admin<{ n: string }[]>`
+        SELECT count(*) AS n FROM members WHERE org_id = ${free.orgId}`
+      assert.equal(Number(row!.n), 1, 'the granted request did not actually provision anybody')
+    } finally {
+      await revoke()
+    }
+
+    const again = await create(free, 'katherine')
+    assert.equal(again.status, 403, 'revoking the override did not close the door again')
+  })
+})

--- a/ee/web/scim/test/harness.ts
+++ b/ee/web/scim/test/harness.ts
@@ -105,10 +105,23 @@ export async function start(): Promise<Harness> {
   }
 }
 
-export async function seedTenant(h: Harness, label: string): Promise<Tenant> {
+/**
+ * Seeds a tenant with a SCIM token.
+ *
+ * The plan decides whether the tenant is ENTITLED to directory provisioning at
+ * all, and enterprise is the default because every suite in this package was
+ * written before guard() checked one. A tenant on the free plan now has its
+ * SCIM requests refused with a 403, which is what gate.test.ts seeds
+ * deliberately and what everything else here would hit by accident.
+ */
+export async function seedTenant(
+  h: Harness,
+  label: string,
+  plan = 'enterprise',
+): Promise<Tenant> {
   const slug = `${label}-${randomUUID().slice(0, 8)}`
   const [org] = await h.admin<{ id: string }[]>`
-    INSERT INTO organizations (slug, name) VALUES (${slug}, ${label}) RETURNING id`
+    INSERT INTO organizations (slug, name, plan) VALUES (${slug}, ${label}, ${plan}) RETURNING id`
   const orgId = org!.id
 
   // Assembled at run time. There is no token in the repository.

--- a/ee/web/sso/package.json
+++ b/ee/web/sso/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
+    "@antifailure-ee/features": "*",
     "@antifailure/api": "file:../../../web/apps/api",
     "@antifailure/db": "file:../../../web/packages/db",
     "@xmldom/xmldom": "^0.9.8",

--- a/ee/web/sso/src/enforce.ts
+++ b/ee/web/sso/src/enforce.ts
@@ -27,6 +27,7 @@
 
 import { createHash, randomBytes, timingSafeEqual } from 'node:crypto'
 import type { Pool } from '@antifailure/db'
+import { declare, licensed } from '@antifailure-ee/features'
 import { appendAudit, sql } from '@antifailure/db'
 import type { SignInAttempt, SignInDecision } from '@antifailure/api'
 
@@ -149,7 +150,21 @@ export async function relax(input: EnforcementInput): Promise<void> {
 }
 
 /** Whether an organization requires single sign-on right now. */
-export async function isEnforced(pool: Pool, orgId: string): Promise<boolean> {
+export async function isEnforced(pool: Pool, orgId: string, now: Date): Promise<boolean> {
+  // THE ENTITLEMENT RELAXES ENFORCEMENT, AND THAT IS THE SAFE DIRECTION.
+  //
+  // This is the half of single sign-on that turns GitHub away, so it is the
+  // half that can lock somebody out. An organization that stops being entitled
+  // to single sign-on loses the provider routes; if it kept enforcement it
+  // would have no way in at all, and the licence documentation's own promise is
+  // that features degrade to the community behaviour rather than failing.
+  //
+  // Checked FIRST, before the row is read, so the answer does not depend on the
+  // state of a connection an unentitled organization cannot use anyway. The
+  // enforced flag stays on the row untouched, which is the other half of that
+  // promise: nothing is deleted and restoring the entitlement restores the
+  // requirement exactly.
+  if (!(await licensed(pool, orgId, 'sso', now))) return false
   const rows = await pool.withTenant({ orgId }, async (db) =>
     db.execute<{ n: string }>(sql`
       SELECT count(*) AS n FROM sso_connections
@@ -157,6 +172,8 @@ export async function isEnforced(pool: Pool, orgId: string): Promise<boolean> {
   )
   return Number(rows[0]?.n ?? 0) > 0
 }
+
+declare('sso', 'ee/web/sso/src/enforce.ts:isEnforced')
 
 /**
  * The policy the community sign-in path consults.
@@ -167,10 +184,13 @@ export async function isEnforced(pool: Pool, orgId: string): Promise<boolean> {
  * answer: GitHub proved who they are, and this organization does not accept
  * that as a way in.
  */
-export function signInPolicy(pool: Pool): (attempt: SignInAttempt) => Promise<SignInDecision> {
+export function signInPolicy(
+  pool: Pool,
+  now: () => Date = () => new Date(),
+): (attempt: SignInAttempt) => Promise<SignInDecision> {
   return async (attempt) => {
     if (!attempt.orgId) return { orgId: null }
-    if (!(await isEnforced(pool, attempt.orgId))) return { orgId: attempt.orgId }
+    if (!(await isEnforced(pool, attempt.orgId, now()))) return { orgId: attempt.orgId }
     return { orgId: null, note: 'sso_required' }
   }
 }

--- a/ee/web/sso/src/index.ts
+++ b/ee/web/sso/src/index.ts
@@ -23,7 +23,12 @@ export function install(options: SsoOptions): void {
   const encryptionKey = options.encryptionKey ?? keyFromEnv()
 
   registerExtension(ssoExtension({ ...options, encryptionKey }))
-  setSignInPolicy(signInPolicy(options.pool))
+  // The clock is handed to the policy rather than left to default, for the
+  // same reason every other date in this package comes from it: the
+  // entitlement the policy now reads has an expiry, and an expiry compared
+  // against a different clock from the one the rest of the request uses is a
+  // grant that lapses at a moment nothing else in the system agrees on.
+  setSignInPolicy(signInPolicy(options.pool, () => options.clock.now()))
 }
 
 export { ssoExtension, type SsoOptions, LOGIN_TTL_MS } from './routes.ts'

--- a/ee/web/sso/src/routes.ts
+++ b/ee/web/sso/src/routes.ts
@@ -50,6 +50,7 @@ import { buildAuthnRequest, samlUrls, serviceProviderMetadata } from './saml/req
 import { decodeBase64, parseXml, MalformedXml, one, text } from './saml/xml.ts'
 import { authorizationUrl, beginLogin, completeLogin } from './oidc/flow.ts'
 import { TokenRefused } from './oidc/jwt.ts'
+import { Unlicensed } from '@antifailure-ee/features'
 import {
   connectionByHandle,
   consumeLoginState,
@@ -149,6 +150,15 @@ function reported(
     try {
       return await handler(c)
     } catch (err) {
+      // The entitlement, before the catch-all. An organization that is not on a
+      // plan carrying single sign-on is not an unexpected failure and must not
+      // be reported as one: a 500 tells the person signing in that something is
+      // broken and tells the operator to go looking for a stack trace, when
+      // what has actually happened is that this organization has not bought
+      // this. 403 with the feature named is what somebody can act on.
+      if (err instanceof Unlicensed) {
+        return c.json({ error: err.message }, 403)
+      }
       options.log?.(`sso: ${name} failed: ${describe(err)}`)
       return c.json({ error: 'The sign-in could not be completed. Try again.' }, 500)
     }
@@ -225,7 +235,7 @@ async function start(c: Context, options: SsoOptions): Promise<Response> {
     return c.json({ error: 'Give an email address to find the right identity provider.' }, 400)
   }
 
-  const route = await routeForDomain(options.pool, email.slice(at + 1))
+  const route = await routeForDomain(options.pool, email.slice(at + 1), options.clock.now())
   if (!route) {
     // 404 with no detail about which part failed. A different answer for
     // "unverified" and "unknown" would turn this into a way to ask which
@@ -249,7 +259,7 @@ async function start(c: Context, options: SsoOptions): Promise<Response> {
 // ---------------------------------------------------------------------------
 
 async function metadata(c: Context, options: SsoOptions): Promise<Response> {
-  const connection = await connectionByHandle(options.pool, c.req.param('handle') ?? '')
+  const connection = await connectionByHandle(options.pool, c.req.param('handle') ?? '', options.clock.now())
   if (!connection || connection.kind !== 'saml') {
     return c.json({ error: 'No such connection.' }, 404)
   }
@@ -267,7 +277,7 @@ async function metadata(c: Context, options: SsoOptions): Promise<Response> {
 }
 
 async function samlLogin(c: Context, options: SsoOptions): Promise<Response> {
-  const connection = await connectionByHandle(options.pool, c.req.param('handle') ?? '')
+  const connection = await connectionByHandle(options.pool, c.req.param('handle') ?? '', options.clock.now())
   if (!connection || connection.kind !== 'saml' || !connection.enabled) {
     return c.json({ error: 'No such connection.' }, 404)
   }
@@ -275,7 +285,7 @@ async function samlLogin(c: Context, options: SsoOptions): Promise<Response> {
 }
 
 async function samlAcs(c: Context, options: SsoOptions): Promise<Response> {
-  const connection = await connectionByHandle(options.pool, c.req.param('handle') ?? '')
+  const connection = await connectionByHandle(options.pool, c.req.param('handle') ?? '', options.clock.now())
   if (!connection || connection.kind !== 'saml' || !connection.enabled) {
     return c.json({ error: 'No such connection.' }, 404)
   }
@@ -403,7 +413,7 @@ function reportedFailure(xml: string): string | null {
 // ---------------------------------------------------------------------------
 
 async function oidcLogin(c: Context, options: SsoOptions): Promise<Response> {
-  const connection = await connectionByHandle(options.pool, c.req.param('handle') ?? '')
+  const connection = await connectionByHandle(options.pool, c.req.param('handle') ?? '', options.clock.now())
   if (!connection || connection.kind !== 'oidc' || !connection.enabled) {
     return c.json({ error: 'No such connection.' }, 404)
   }
@@ -411,7 +421,7 @@ async function oidcLogin(c: Context, options: SsoOptions): Promise<Response> {
 }
 
 async function oidcCallback(c: Context, options: SsoOptions): Promise<Response> {
-  const connection = await connectionByHandle(options.pool, c.req.param('handle') ?? '')
+  const connection = await connectionByHandle(options.pool, c.req.param('handle') ?? '', options.clock.now())
   if (!connection || connection.kind !== 'oidc' || !connection.enabled) {
     return c.json({ error: 'No such connection.' }, 404)
   }

--- a/ee/web/sso/src/store.ts
+++ b/ee/web/sso/src/store.ts
@@ -19,6 +19,7 @@
 
 import { sql } from '@antifailure/db'
 import type { Db, Pool } from '@antifailure/db'
+import { Unlicensed, declare, licensed, refusal } from '@antifailure-ee/features'
 
 export type Role = 'owner' | 'admin' | 'member' | 'viewer'
 
@@ -100,15 +101,50 @@ function parseArrayLiteral(literal: string): string[] {
  * exactly what it is doing. Reaches no secret: those are in a second table this
  * cannot see.
  */
-export async function connectionByHandle(pool: Pool, handle: string): Promise<Connection | null> {
+export async function connectionByHandle(
+  pool: Pool,
+  handle: string,
+  now: Date,
+): Promise<Connection | null> {
   if (!handle) return null
   const rows = await pool.withoutTenant(
     async (db) =>
       db.execute<Record<string, unknown>>(sql`SELECT ${CONNECTION_COLUMNS} FROM sso_connections`),
     { ssoHandle: handle },
   )
-  return rows[0] ? toConnection(rows[0]) : null
+  if (!rows[0]) return null
+  const connection = toConnection(rows[0])
+  // THE LICENCE GATE, and it is here rather than in each of the five handlers
+  // that call this.
+  //
+  // Every route in this package that acts on a named connection resolves it
+  // through this function, so a handler added later inherits the check instead
+  // of being the one that forgot. The moment is a parameter for exactly that
+  // reason: an entitlement has an expiry, so it cannot be evaluated without
+  // one, and requiring the caller to supply it makes "look the connection up
+  // and check the licence" a single act rather than two that can drift apart.
+  //
+  // It throws rather than returning null. A refusal that looks like "no such
+  // connection" is a refusal an administrator cannot act on: the handle is in
+  // the metadata URL they gave their identity provider, so they already know it
+  // exists, and telling them it does not sends them hunting a configuration
+  // error that is not there. reported() turns this into a 403 that names the
+  // feature and says what to do about it.
+  if (!(await licensed(pool, connection.orgId, 'sso', now))) {
+    throw new Unlicensed('sso', refusal('sso'))
+  }
+  return connection
 }
+
+// Declared at module scope, so importing this package is what records the site
+// and a package nothing imports records nothing.
+//
+// Two sites, because single sign-on is two halves and gating one of them would
+// be worse than gating neither: refusing the provider routes while leaving
+// enforcement switched on would lock an organization out of its own account
+// with no way back in. isEnforced in enforce.ts is the other half, and the
+// same entitlement relaxes it.
+declare('sso', 'ee/web/sso/src/store.ts:connectionByHandle')
 
 /** The connection whose issuer matches, for a provider-initiated assertion. */
 export async function connectionByEntityId(
@@ -138,7 +174,11 @@ export interface DomainRoute {
  * discloses nothing about any other domain, and nothing an organization has not
  * verified.
  */
-export async function routeForDomain(pool: Pool, domain: string): Promise<DomainRoute | null> {
+export async function routeForDomain(
+  pool: Pool,
+  domain: string,
+  now: Date,
+): Promise<DomainRoute | null> {
   const lowered = domain.trim().toLowerCase()
   if (!lowered || !/^[a-z0-9.-]+$/.test(lowered)) return null
   const rows = await pool.withoutTenant(
@@ -148,7 +188,19 @@ export async function routeForDomain(pool: Pool, domain: string): Promise<Domain
       ),
     { ssoDomain: lowered },
   )
-  return rows[0] ? { orgId: rows[0].org_id, connectionId: rows[0].connection_id } : null
+  const row = rows[0]
+  if (!row) return null
+  // NULL RATHER THAN A REFUSAL, which is the opposite decision to the one above
+  // and it is deliberate.
+  //
+  // This is the discovery endpoint. It is unauthenticated, it takes an email
+  // address, and it already answers the same 404 for a domain it has never
+  // heard of and for one that is registered and unverified, so that it cannot
+  // be used to ask which companies have configured single sign-on here. A
+  // distinct answer for "registered and not entitled" would be that same
+  // question with one more bit in it.
+  if (!(await licensed(pool, row.org_id, 'sso', now))) return null
+  return { orgId: row.org_id, connectionId: row.connection_id }
 }
 
 export interface LoginState {

--- a/ee/web/sso/test/flow.test.ts
+++ b/ee/web/sso/test/flow.test.ts
@@ -401,7 +401,7 @@ describe('enforcement and break-glass', { skip: hasDatabase ? false : 'no databa
     assert.equal(codes.length, 10)
     for (const code of codes) assert.match(code, /^[0-9A-HJKMNP-TV-Z]{5}(-[0-9A-HJKMNP-TV-Z]{5}){3}$/)
     assert.equal(new Set(codes).size, 10)
-    assert.ok(await isEnforced(h.pool, org.orgId))
+    assert.ok(await isEnforced(h.pool, org.orgId, h.clock.now()))
   })
 
   it('stores only hashes, so a leaked backup is not a set of keys', async () => {

--- a/ee/web/sso/test/gate.test.ts
+++ b/ee/web/sso/test/gate.test.ts
@@ -1,0 +1,234 @@
+// The licence gate, observed refusing.
+//
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+//
+// WHY THIS SUITE EXISTS AS ITS OWN FILE, and it is the reason the whole wave
+// was dispatched. On 2026-09-08 two people counted the enforcement sites in
+// this product independently and agreed on the number, and both of them READ
+// it out of the source. Neither turned an entitlement off and watched anything
+// refuse. A site that looks like a gate and a site that refuses are different
+// claims, and the first keeps being mistaken for the second, so nothing here
+// asserts that a check exists: every test makes the same request twice with one
+// row changed between, and asserts the answer changed.
+//
+// The pair is deliberate in both directions. A suite that only ever saw the
+// refusal would be satisfied by a route that refuses everybody, which is a
+// broken feature rather than an enforced one, and this package's own history
+// says that is not a hypothetical: fourteen of its tests went red the moment
+// the gate was added, because every one of them had been seeding an
+// organization on the free plan.
+
+import { after, before, describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { randomUUID } from 'node:crypto'
+import { available, dropOrg, seedOrg, start, type Harness, type Org } from './harness.ts'
+import { cleanupIdps } from './idp.ts'
+import { enforce, isEnforced, signInPolicy } from '../src/enforce.ts'
+import { connectionByHandle, routeForDomain } from '../src/store.ts'
+import { Unlicensed } from '@antifailure-ee/features'
+
+const hasDatabase = await available()
+
+after(() => cleanupIdps())
+
+describe('the single sign-on licence gate', { skip: hasDatabase ? false : 'no Postgres at AF_TEST_DATABASE_URL' }, () => {
+  let h: Harness
+  /** On a plan that does NOT carry single sign-on, which is where every
+   *  organization starts. */
+  let free: Org
+  /** On a plan that does. */
+  let entitled: Org
+
+  before(async () => {
+    h = await start()
+    free = await seedOrg(h, 'unentitled', { plan: 'free', entityId: 'https://idp.test/unentitled' })
+    entitled = await seedOrg(h, 'entitled', { entityId: 'https://idp.test/entitled' })
+  })
+
+  after(async () => {
+    await dropOrg(h, free.orgId)
+    await dropOrg(h, entitled.orgId)
+    await h.close()
+  })
+
+  /** Grants one feature to one organization, and hands back the undo. The
+   *  overrides table is the mechanism a sales exception uses, so a grant made
+   *  this way is the same grant an operator would make on the admin screen. */
+  async function grant(orgId: string, feature: string): Promise<() => Promise<void>> {
+    const [row] = await h.admin<{ id: string }[]>`
+      INSERT INTO entitlement_overrides
+        (scope, scope_id, org_id, feature, value, reason, created_by_label)
+      VALUES ('organization', ${orgId}, ${orgId}, ${feature}, ${'true'}::jsonb,
+              'A design partner using a capability their plan does not carry.',
+              'operator@example.test')
+      RETURNING id`
+    return async () => {
+      await h.admin`
+        UPDATE entitlement_overrides
+           SET revoked_at = now(), revoked_by_label = 'test@example.test',
+               revoked_reason = 'The test that granted it is finished.'
+         WHERE id = ${row!.id}`
+    }
+  }
+
+  const login = (org: Org) =>
+    h.request(`/sso/saml/${org.handle}/login`, { headers: { 'x-forwarded-for': '203.0.113.31' } })
+
+  it('refuses the provider login for an organization that is not entitled', async () => {
+    const entitledResponse = await login(entitled)
+    assert.equal(entitledResponse.status, 302, 'an entitled organization cannot even start')
+
+    const refused = await login(free)
+    const body = await refused.text()
+    assert.equal(refused.status, 403, body)
+    // Named, not a bare "forbidden". An administrator reading this has to be
+    // able to tell it apart from a broken certificate, and the two produce
+    // identical symptoms at the identity provider.
+    assert.match(body, /single sign-on/)
+    assert.match(body, /change the plan/)
+  })
+
+  it('refuses the assertion consumer, which is the route that would create a member', async () => {
+    // The login route above is a redirect and creates nothing. This is the one
+    // that turns a signed assertion into a session and a membership row, so a
+    // gate that covered the first and not the second would refuse the polite
+    // path and leave the load bearing one open.
+    const refused = await h.request(`/sso/saml/${free.handle}/acs`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        'x-forwarded-for': '203.0.113.32',
+      },
+      body: 'SAMLResponse=irrelevant',
+    })
+    assert.equal(refused.status, 403, await refused.text())
+  })
+
+  it('says nothing at all on discovery, rather than refusing by name', async () => {
+    // The opposite decision to the two above, on purpose. This endpoint is
+    // unauthenticated and takes an email address, and it already answers the
+    // same 404 for a domain it has never heard of and for one that is
+    // registered and unverified, so that it cannot be used to ask which
+    // companies have configured single sign-on here. Answering 403 for
+    // "registered and not entitled" would be that question with one more bit
+    // in it.
+    const found = await h.request(`/sso/start?email=${encodeURIComponent(`someone@${entitled.domain}`)}`, {
+      headers: { 'x-forwarded-for': '203.0.113.33' },
+    })
+    assert.equal(found.status, 302, await found.text())
+
+    const hidden = await h.request(`/sso/start?email=${encodeURIComponent(`someone@${free.domain}`)}`, {
+      headers: { 'x-forwarded-for': '203.0.113.34' },
+    })
+    const body = await hidden.text()
+    assert.equal(hidden.status, 404, body)
+    assert.doesNotMatch(
+      body, /entitle|plan/i,
+      'the discovery endpoint named the entitlement, which tells a stranger this domain is ours',
+    )
+  })
+
+  it('an override turns it on for an organization whose plan does not carry it', async () => {
+    // The plan is not the only authority, and this is what makes the gate an
+    // entitlement rather than a hardcoded plan comparison. The customer on
+    // team who was sold single sign-on is ordinary commercial reality, and
+    // moving their plan to make it work would charge them the wrong amount.
+    const before = await login(free)
+    assert.equal(before.status, 403, await before.text())
+
+    const revoke = await grant(free.orgId, 'sso')
+    try {
+      const after = await login(free)
+      assert.equal(after.status, 302, await after.text())
+    } finally {
+      await revoke()
+    }
+
+    const again = await login(free)
+    assert.equal(again.status, 403, 'revoking the override did not close the door again')
+  })
+
+  it('relaxes enforcement instead of locking the organization out', async () => {
+    // THE ORDERING THAT WOULD HAVE BEEN A LOCKOUT. Single sign-on is two
+    // halves: the routes that let a provider in, and the policy that turns
+    // GitHub away. Gating the first and leaving the second would produce an
+    // organization with no way in at all, which is worse than either the
+    // feature working or the feature being absent.
+    //
+    // So the same entitlement decides both, and this asserts the pair on one
+    // organization: enforcement is on in the database and off in effect.
+    await enforce({
+      pool: h.pool,
+      orgId: free.orgId,
+      connectionId: free.connectionId,
+      actorUserId: free.ownerUserId,
+      actorLabel: `owner@${free.domain}`,
+      now: h.clock.now(),
+    })
+
+    // Still recorded. The licence documentation promises that every enterprise
+    // setting is preserved and that renewing restores it exactly, so the flag
+    // must stay on the row rather than being cleared by a lapse.
+    const [row] = await h.admin<{ enforced: boolean }[]>`
+      SELECT enforced FROM sso_connections WHERE id = ${free.connectionId}`
+    assert.equal(row!.enforced, true, 'the enforced flag was cleared rather than relaxed')
+
+    assert.equal(
+      await isEnforced(h.pool, free.orgId, h.clock.now()), false,
+      'an organization that cannot use single sign-on is still being told it must',
+    )
+    const policy = signInPolicy(h.pool, () => h.clock.now())
+    const decision = await policy({ orgId: free.orgId, userId: free.ownerUserId, method: 'github' })
+    assert.equal(
+      decision.orgId, free.orgId,
+      'GitHub sign-in was refused for an organization with no other way in',
+    )
+
+    // And the restoration, which is the half that proves the relaxation is the
+    // entitlement rather than something else about this organization.
+    const revoke = await grant(free.orgId, 'sso')
+    try {
+      assert.equal(await isEnforced(h.pool, free.orgId, h.clock.now()), true)
+      const restored = await policy({ orgId: free.orgId, userId: free.ownerUserId, method: 'github' })
+      assert.equal(restored.orgId, null)
+      assert.equal(restored.note, 'sso_required')
+    } finally {
+      await revoke()
+    }
+  })
+
+  it('refuses at the store, so a handler added later cannot skip it', async () => {
+    // The gate is inside the lookup every route uses rather than in each of the
+    // five handlers, which is the difference between a check somebody has to
+    // remember and one they inherit. Asserted directly, because the routes
+    // above cannot tell a gate in the store from five gates in the handlers.
+    await assert.rejects(
+      () => connectionByHandle(h.pool, free.handle, h.clock.now()),
+      (err: unknown) => err instanceof Unlicensed && err.feature === 'sso',
+      'the connection lookup handed a caller a connection it may not use',
+    )
+    assert.ok(await connectionByHandle(h.pool, entitled.handle, h.clock.now()))
+
+    assert.equal(await routeForDomain(h.pool, free.domain, h.clock.now()), null)
+    assert.ok(await routeForDomain(h.pool, entitled.domain, h.clock.now()))
+  })
+
+  it('a grant to one organization does not open the door for another', async () => {
+    // An override is per organization. A gate that read the global answer would
+    // turn the first design partner exception into single sign-on for everybody
+    // on the free plan, and nothing would look wrong from any screen.
+    const suffix = randomUUID().slice(0, 4)
+    const other = await seedOrg(h, `neighbour-${suffix}`, {
+      plan: 'free',
+      entityId: `https://idp.test/neighbour-${suffix}`,
+    })
+    const revoke = await grant(free.orgId, 'sso')
+    try {
+      assert.equal((await login(free)).status, 302)
+      assert.equal((await login(other)).status, 403)
+    } finally {
+      await revoke()
+      await dropOrg(h, other.orgId)
+    }
+  })
+})

--- a/ee/web/sso/test/harness.ts
+++ b/ee/web/sso/test/harness.ts
@@ -181,7 +181,7 @@ export async function start(options: StartOptions = {}): Promise<Harness> {
       scimExtension({ pool, clock, baseUrl: BASE_URL, defaultRole: 'member' }),
     )
   }
-  setSignInPolicy(signInPolicy(pool))
+  setSignInPolicy(signInPolicy(pool, () => clock.now()))
 
   const { app } = createServer({
     pool,
@@ -215,14 +215,45 @@ export async function start(options: StartOptions = {}): Promise<Harness> {
 export async function seedOrg(
   h: Harness,
   label: string,
-  overrides: { kind?: 'saml' | 'oidc'; enabled?: boolean; verified?: boolean } = {},
+  overrides: {
+    kind?: 'saml' | 'oidc'
+    enabled?: boolean
+    verified?: boolean
+    /**
+     * The plan, which decides whether this organization is ENTITLED to single
+     * sign-on at all.
+     *
+     * Enterprise by default, and the default is the interesting half. Every
+     * suite in this package was written before the routes checked an
+     * entitlement, and every one of them seeded an organization on the free
+     * plan, so turning the check on made fourteen of them fail at once. That is
+     * the check working: it is the proof the gate is on the path these tests
+     * actually take rather than beside it.
+     *
+     * The parameter exists so a test can seed the other case deliberately, and
+     * gate.test.ts is the suite that does.
+     */
+    plan?: string
+    /**
+     * The identity provider's entity id.
+     *
+     * Overridable because it is UNIQUE across the whole table, deliberately:
+     * a provider-initiated assertion arrives with an issuer and no handle, so
+     * the entity id has to resolve one organization on its own. Every suite
+     * here seeded exactly one SAML organization until the gate suite needed a
+     * pair, and the second insert failed on that index rather than on anything
+     * to do with what it was testing.
+     */
+    entityId?: string
+  } = {},
 ): Promise<Org> {
   const slug = `${label}-${randomUUID().slice(0, 8)}`
   const domain = `${slug}.test`
   const kind = overrides.kind ?? 'saml'
 
   const [org] = await h.admin<{ id: string }[]>`
-    INSERT INTO organizations (slug, name) VALUES (${slug}, ${label}) RETURNING id`
+    INSERT INTO organizations (slug, name, plan)
+    VALUES (${slug}, ${label}, ${overrides.plan ?? 'enterprise'}) RETURNING id`
   const orgId = org!.id
 
   const [owner] = await h.admin<{ id: string }[]>`
@@ -240,7 +271,7 @@ export async function seedOrg(
       oidc_issuer, oidc_client_id, oidc_authorization_endpoint, oidc_token_endpoint, oidc_jwks_uri)
     VALUES (
       ${orgId}, ${handle}, ${kind}, ${`${label} directory`}, ${overrides.enabled ?? true}, 'member',
-      ${kind === 'saml' ? 'https://idp.test/metadata' : null},
+      ${kind === 'saml' ? (overrides.entityId ?? 'https://idp.test/metadata') : null},
       ${kind === 'saml' ? 'https://idp.test/sso' : null},
       ${kind === 'saml' ? h.admin.array([h.idp.certificate]) : h.admin.array([] as string[])},
       ${kind === 'oidc' ? 'https://oidc.test' : null},

--- a/ee/web/sso/test/keycloak.test.ts
+++ b/ee/web/sso/test/keycloak.test.ts
@@ -130,7 +130,8 @@ describe('a real identity provider', { skip }, () => {
     // 3. The organization and a SAML connection, filled in from the provider's
     //    own metadata rather than from anything written here.
     const org = await h.admin<{ id: string }[]>`
-      INSERT INTO organizations (slug, name) VALUES (${realm}, 'Keycloak') RETURNING id`
+      INSERT INTO organizations (slug, name, plan)
+      VALUES (${realm}, 'Keycloak', 'enterprise') RETURNING id`
     orgId = org[0]!.id
     handle = Buffer.from(randomUUID() + randomUUID()).toString('base64url').slice(0, 43)
 

--- a/ee/web/sso/test/live-server.ts
+++ b/ee/web/sso/test/live-server.ts
@@ -86,7 +86,7 @@ registerExtension(
 registerExtension(
   scimExtension({ pool, clock: systemClock, baseUrl: publicBaseUrl, defaultRole: 'member' }),
 )
-setSignInPolicy(signInPolicy(pool))
+setSignInPolicy(signInPolicy(pool, () => systemClock.now()))
 
 const { app } = createServer({
   pool,
@@ -101,7 +101,8 @@ const { app } = createServer({
 // the provider's own metadata rather than from anything written here.
 const slug = `live-${randomUUID().slice(0, 8)}`
 const [org] = await admin<{ id: string }[]>`
-  INSERT INTO organizations (slug, name) VALUES (${slug}, 'Conformance') RETURNING id`
+  INSERT INTO organizations (slug, name, plan)
+  VALUES (${slug}, 'Conformance', 'enterprise') RETURNING id`
 const orgId = org!.id
 
 const handle = randomBytes(32).toString('base64url')

--- a/engine/internal/docs/pages.gen.go
+++ b/engine/internal/docs/pages.gen.go
@@ -4339,6 +4339,24 @@ acting on it, and the generator is the only place the set can be closed.
 Before that check existed, ` + "`" + `"features": ["ssoo"]` + "`" + ` signed cleanly, verified
 cleanly, reported the license active, and permitted nothing.
 
+## Features that cannot be issued
+
+` + "`" + `billing` + "`" + ` and ` + "`" + `enterprise_dashboard` + "`" + ` are in the set above, and a request naming
+either of them is refused. Nothing in this product enforces them, so a license
+carrying one would verify, report itself active, print the feature in
+` + "`" + `af license status` + "`" + `, and change nothing about what the software does.
+
+That is a worse failure than an unknown name, because everything about it reads
+as a supported feature: it is in the documentation, in the price list, and in
+the generator's own set. The only two people positioned to discover it are the
+customer who paid and the person who sold it.
+
+Both refusals are in the product rather than in a checklist. The generator will
+not sign one, and the verifier carries the name and never permits it, exactly as
+it treats a feature from a release the binary predates. When either capability
+is built, one entry is removed from ` + "`" + `notShipped` + "`" + ` in
+` + "`" + `ee/engine/license/license.go` + "`" + ` and both refusals lift together.
+
 ## Step three: sign it
 
 The private key arrives in the environment from the vault, for the length of
@@ -4570,6 +4588,32 @@ license leaves you with it rather than with nothing.
 ` + "`" + `compliance_packs` + "`" + `, ` + "`" + `air_gapped` + "`" + `.
 
 Each is named in the license, so a license permits exactly what was bought.
+
+### Two of those cannot be sold
+
+` + "`" + `billing` + "`" + ` and ` + "`" + `enterprise_dashboard` + "`" + ` are names in the catalogue and nothing
+else. There is no implementation of either, so there is nothing a license could
+switch on, and both are refused twice: ` + "`" + `tools/licensegen` + "`" + ` will not sign a
+request naming one, and the verifier carries the name through and never permits
+it.
+
+That is deliberate rather than an oversight waiting to be tidied. The
+alternative, a license check placed in front of a capability that does not
+exist, is a declared enforcement site that can never run, which reads as a
+working feature from every direction and is harder to find than the gap it
+covers. A feature nobody can buy and nobody can be granted cannot be mistaken
+for one that ships.
+
+` + "`" + `rbac` + "`" + ` is a third case and a different one. The custom roles library is complete
+and tested, and nothing stores a role model, so an organization has no way to
+have one. It is reported and not enforced, and it is written down here rather
+than gated for the same reason: a check on a path nothing reaches is worse than
+no check.
+
+Both lists are held to the code by a test rather than by a habit. ` + "`" + `notShipped` + "`" + `
+in ` + "`" + `ee/engine/license/license.go` + "`" + ` is the single place either statement lives,
+and this page, the generator and the enterprise feature registry are all checked
+against it in both directions.
 
 ## Contributing
 

--- a/justfile
+++ b/justfile
@@ -1359,7 +1359,7 @@ typecheck:
     # A reason that has stopped being true. Without this the excuses rot: a
     # project gets deleted or renamed and its entry sits here claiming another
     # gate covers something that no longer exists.
-    for named in console docs ee/web/audit ee/web/rbac ee/web/scim ee/web/sso examples/next-app; do
+    for named in console docs ee/web/audit ee/web/features ee/web/rbac ee/web/scim ee/web/sso examples/next-app; do
       [ -f "$named/tsconfig.json" ] || { echo "  $named is named as checked elsewhere and has no tsconfig.json; remove it"; exit 1; }
     done
 

--- a/tools/licensegen/main.go
+++ b/tools/licensegen/main.go
@@ -152,6 +152,27 @@ var knownFeatures = []string{
 	"support_access",
 }
 
+// notShipped is the subset of knownFeatures that nothing in the product
+// enforces, and it is a second COPY for the same reason knownFeatures is one:
+// this tool is MIT and ee/engine/license is not. Held to the original by
+// TestNotShippedMatchesTheVerifier, which parses the map out of license.go.
+//
+// Signing one of these is the failure that made the list exist. A request
+// naming enterprise_dashboard produced a valid license for a capability that
+// has never been built: it verified, reported active, printed in af license
+// status, and changed nothing, and the only people who could have discovered
+// that were the customer who paid for it and the salesperson who promised it.
+// Refusing at issue time is the only place the set can be closed, because the
+// verifier has to stay permissive about names it does not know.
+//
+// The refusal is not a warning and there is no flag to override it. An override
+// would be used at exactly the moment it should not be, which is the moment
+// somebody has already told a customer the feature exists.
+var notShipped = []string{
+	"billing",
+	"enterprise_dashboard",
+}
+
 func issue(args []string) error {
 	fs := flag.NewFlagSet("issue", flag.ContinueOnError)
 	file := fs.String("request", "", "path to the issuance request, or - for standard input")
@@ -288,6 +309,30 @@ func checkFeatures(features []string) error {
 			"the request names %s, which the engine does not carry, so a license "+
 				"carrying it would verify and permit nothing. The set is: %s",
 			strings.Join(unknown, ", "), strings.Join(knownFeatures, ", "))
+	}
+
+	// The second refusal, and it is a different question from the first. The
+	// names above are ones no build has ever heard of; these are names every
+	// build knows and no build acts on. Both produce a license that permits
+	// nothing, and the second one is the dangerous one because the name is in
+	// the documentation, in the price list and in this tool's own set, so
+	// everything about it reads as a supported feature right up to the point
+	// where a customer tries to use it.
+	var absent []string
+	for _, f := range features {
+		for _, n := range notShipped {
+			if f == n {
+				absent = append(absent, f)
+			}
+		}
+	}
+	if len(absent) > 0 {
+		return fmt.Errorf(
+			"the request names %s, which nothing in this product enforces, so the license "+
+				"would verify, report active, and do nothing. Remove it from the request. "+
+				"If it has been sold, that is a conversation to have before a key is issued "+
+				"rather than after",
+			strings.Join(absent, ", "))
 	}
 	return nil
 }

--- a/tools/licensegen/main_test.go
+++ b/tools/licensegen/main_test.go
@@ -89,3 +89,155 @@ func featuresDeclaredBy(t *testing.T, path string) []string {
 	}
 	return out
 }
+
+// TestNotShippedMatchesTheVerifier holds this tool's second copy to its
+// original, the same way TestKnownFeaturesMatchTheVerifier holds the first.
+//
+// Drift here is silent in the expensive direction. A feature marked unshipped
+// in license.go and not here signs cleanly and produces the license this whole
+// mechanism exists to prevent; the reverse refuses a request for something that
+// does ship, which somebody notices within a minute of trying it.
+func TestNotShippedMatchesTheVerifier(t *testing.T) {
+	want := notShippedDeclaredBy(t, verifierSource)
+	if len(want) == 0 {
+		t.Fatalf("%s marks nothing unshipped, so this test and the refusal it guards "+
+			"are both proving nothing. If every feature now ships, delete the refusal "+
+			"in checkFeatures rather than leaving a check that cannot say no", verifierSource)
+	}
+
+	got := append([]string(nil), notShipped...)
+	sort.Strings(got)
+	sort.Strings(want)
+
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("notShipped and the verifier's unshipped set differ.\n"+
+			"licensegen has: %s\n%s has: %s\n"+
+			"Update notShipped in main.go. A feature the verifier refuses to permit and "+
+			"this tool will still sign is a license sold for a capability that does nothing.",
+			strings.Join(got, ", "), verifierSource, strings.Join(want, ", "))
+	}
+
+	// Every unshipped name is also a known one. A name in only the unshipped
+	// list would be refused by the check above it anyway, so the entry would be
+	// dead and would read as a feature being withheld rather than absent.
+	known := map[string]bool{}
+	for _, f := range knownFeatures {
+		known[f] = true
+	}
+	for _, f := range got {
+		if !known[f] {
+			t.Errorf("%s is marked unshipped and is not a feature at all", f)
+		}
+	}
+}
+
+// TestIssueRefusesAFeatureNothingEnforces points the refusal at the exact case
+// that produced it.
+//
+// Both directions in one test would let the first require hide the second, so
+// the shipped case and the unshipped case are separate assertions on separate
+// inputs and each is checked for the sentence it should produce.
+func TestIssueRefusesAFeatureNothingEnforces(t *testing.T) {
+	if err := checkFeatures([]string{"sso", "scim"}); err != nil {
+		t.Fatalf("a request naming only features that ship was refused: %v", err)
+	}
+
+	for _, absent := range notShipped {
+		err := checkFeatures([]string{"sso", absent})
+		if err == nil {
+			t.Fatalf("a request naming %s was accepted, and nothing in the product enforces it", absent)
+		}
+		if !strings.Contains(err.Error(), absent) {
+			t.Errorf("the refusal for %s does not name it: %v", absent, err)
+		}
+		if !strings.Contains(err.Error(), "nothing in this product enforces") {
+			t.Errorf("the refusal for %s reads as an unknown name rather than an absent "+
+				"capability, and those are different conversations: %v", absent, err)
+		}
+	}
+}
+
+// notShippedDeclaredBy reads the keys of the notShipped map out of license.go.
+//
+// The keys are constant identifiers rather than strings, so the constants are
+// read first and the identifiers resolved through them. Parsed rather than
+// grepped for the same reason featuresDeclaredBy is: the names appear in prose
+// in that file, and a grep would find the paragraph explaining the map as
+// readily as the map.
+func notShippedDeclaredBy(t *testing.T, path string) []string {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", path, err)
+	}
+
+	// identifier -> string value, for every Feature constant.
+	values := map[string]string{}
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			value, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			ident, ok := value.Type.(*ast.Ident)
+			if !ok || ident.Name != "Feature" || len(value.Names) != len(value.Values) {
+				continue
+			}
+			for i, name := range value.Names {
+				lit, ok := value.Values[i].(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					continue
+				}
+				unquoted, err := strconv.Unquote(lit.Value)
+				if err != nil {
+					t.Fatalf("a Feature constant in %s is not a plain string: %s", path, lit.Value)
+				}
+				values[name.Name] = unquoted
+			}
+		}
+	}
+	if len(values) == 0 {
+		t.Fatalf("no Feature constants were read out of %s, so the map below cannot be resolved", path)
+	}
+
+	var out []string
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.VAR {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			value, ok := spec.(*ast.ValueSpec)
+			if !ok || len(value.Names) != 1 || value.Names[0].Name != "notShipped" {
+				continue
+			}
+			for _, v := range value.Values {
+				composite, ok := v.(*ast.CompositeLit)
+				if !ok {
+					continue
+				}
+				for _, elt := range composite.Elts {
+					kv, ok := elt.(*ast.KeyValueExpr)
+					if !ok {
+						continue
+					}
+					key, ok := kv.Key.(*ast.Ident)
+					if !ok {
+						continue
+					}
+					name, ok := values[key.Name]
+					if !ok {
+						t.Fatalf("notShipped names %s, which is not a Feature constant", key.Name)
+					}
+					out = append(out, name)
+				}
+			}
+		}
+	}
+	return out
+}

--- a/web/apps/api/src/admin/customers.ts
+++ b/web/apps/api/src/admin/customers.ts
@@ -76,6 +76,7 @@ import {
 import { clearedCookie, hashToken, sessionCookie } from '../auth/session.ts'
 import type { Clock } from '../clock.ts'
 import { clientAddress } from '../clientaddress.ts'
+import { resolveEntitlements } from '../entitlements.ts'
 
 /** Long enough that an operator has to say something. The same bound routers.ts
  *  puts on every money action, for the same reason: "asked" is not a reason. */
@@ -86,6 +87,84 @@ const reason = z.string().trim().min(8).max(500)
  *  constraint refuses is a 500 at the end of a form somebody just filled in. */
 const SUBJECT_TYPES = ['user', 'organization', 'repository'] as const
 type SubjectType = (typeof SUBJECT_TYPES)[number]
+
+/**
+ * Whether an operator may act as a member of one organization.
+ *
+ * THE ONE ENTITLEMENT THAT IS ABOUT SOMEBODY ELSE'S ACCESS RATHER THAN THE
+ * CUSTOMER'S OWN, which is why it reads the way it does.
+ *
+ * Impersonation was fully built and gated by nothing but an operator
+ * permission. A reason of at least eight characters, an audit entry the schema
+ * makes structurally unskippable, a copy in the customer's own log, and a
+ * session measured in minutes: every accountability property this action needs,
+ * and no answer at all to the question a large customer asks first, which is
+ * whether they can say no. Absent means we did not build it. Ungated means we
+ * built it and the customer has no say, and until this existed the second was
+ * true and nothing in the product said so.
+ *
+ * The switch is an entitlement rather than a new column because the overrides
+ * table already carries exactly the fields a withdrawal of consent needs: a
+ * reason, a ticket, an expiry, the name of whoever granted it, and a revocation
+ * that keeps the history. A boolean column would have carried none of them and
+ * would have had to grow each one back.
+ *
+ * DEFAULT ON, ON EVERY PLAN, and that is deliberate. Refusing by default would
+ * have broken support for every existing customer on the day it shipped, and
+ * charging somebody for our ability to help them is backwards. What is sold
+ * here is the refusal, not the access.
+ *
+ * Nothing to refuse when the impersonation names no organization: an operator
+ * acting as an account with no organization sees that account's own settings
+ * and nobody else's data, so there is no tenant whose consent could be asked.
+ * The caller does not reach this in that case, and the shape of the argument
+ * says so by requiring an organization.
+ */
+export interface SupportAccessVerdict {
+  allowed: boolean
+  /** What the operator reads. Empty when allowed. */
+  reason: string
+}
+
+export async function supportAccessVerdict(
+  db: Db,
+  now: Date,
+  org: { orgId: string; plan: string; slug: string },
+): Promise<SupportAccessVerdict> {
+  const entitlements = await resolveEntitlements(db, now, { orgId: org.orgId, plan: org.plan })
+  const resolved = entitlements.get(SUPPORT_ACCESS_ENTITLEMENT)
+  if (!resolved) {
+    // The catalogue entry is gone. Allowing is the direction that fails safely
+    // for the customer in front of the operator: a deploy that dropped the key
+    // must not silently end support for everybody, and its absence is visible
+    // on the admin screen that lists the catalogue.
+    return { allowed: true, reason: '' }
+  }
+  if (resolved.value === true) return { allowed: true, reason: '' }
+
+  const until = resolved.override?.expiresAt
+    ? `, until ${resolved.override.expiresAt.toISOString().slice(0, 10)}`
+    : ''
+  const source = resolved.override
+    ? `a ${resolved.override.scope} override${until}, granted by ${resolved.override.grantedBy}: ` +
+      `${resolved.override.reason}`
+    : `the ${entitlements.plan} plan`
+  return {
+    allowed: false,
+    // Names the reason and who set it, because the operator reading this is
+    // usually mid conversation with the customer who set it and needs to be
+    // able to say what they are looking at. A bare "not permitted" turns that
+    // into a support ticket about the support tooling.
+    reason:
+      `${org.slug} has withdrawn operator access to this organization. That is ${source}. ` +
+      `Ask an owner to restore it, or work from what they can send you. Nothing was recorded ` +
+      `and no session was created.`,
+  }
+}
+
+/** The catalogue key. A named constant rather than a literal, so the catalogue
+ *  entry and the check that reads it move together. */
+export const SUPPORT_ACCESS_ENTITLEMENT = 'support_access'
 
 /**
  * How long an impersonation may last.
@@ -556,8 +635,8 @@ export function registerImpersonationRoutes(
           let orgId: string | null = null
           let orgLabel: string | null = null
           if (input.orgId) {
-            const org = await db.execute<{ slug: string; member: boolean }>(sql`
-              SELECT o.slug,
+            const org = await db.execute<{ slug: string; plan: string; member: boolean }>(sql`
+              SELECT o.slug, o.plan,
                      EXISTS (SELECT 1 FROM members m
                               WHERE m.org_id = o.id AND m.user_id = ${input.userId}::uuid)
                        AS member
@@ -575,6 +654,20 @@ export function registerImpersonationRoutes(
                   'would show nothing the account can actually see.',
               )
             }
+            // The entitlement, and it is checked BEFORE the audit entry
+            // deliberately. Everything below this line is the impersonation
+            // happening: the record is written first precisely so that no
+            // session can exist without one, which means a refusal that came
+            // after it would leave a permanent entry claiming an access that
+            // was refused. A customer reading their own audit log cannot tell
+            // those apart, and the one that reads worse is the one that did not
+            // happen.
+            const verdict = await supportAccessVerdict(db, now, {
+              orgId: input.orgId,
+              plan: row.plan,
+              slug: row.slug,
+            })
+            if (!verdict.allowed) throw new Refused(403, verdict.reason)
             orgId = input.orgId
             orgLabel = row.slug
           }

--- a/web/apps/api/src/entitlements.ts
+++ b/web/apps/api/src/entitlements.ts
@@ -70,6 +70,23 @@ export interface EntitlementSpec {
    * is indistinguishable from a bug.
    */
   notEnforcedBecause?: string
+  /**
+   * Set for an entitlement whose capability is not in this build at all.
+   *
+   * A third state, and it exists because the two that were here could only
+   * describe this one as a lie. `enforcedAt` naming a symbol would be false,
+   * since no file in this build has anything to enforce; a bare `enforcedAt:
+   * null` would read as "nothing checks this", which is equally false, because
+   * the edition that HAS the capability carries the check right beside it.
+   *
+   * The site is deliberately not named here. This build must not contain the
+   * path of a file it cannot compile: the edition boundary is checked by a grep
+   * over this directory, and a comment naming the other edition's tree would
+   * fail it. So each end holds its own: this flag says the check lives in the
+   * edition that has the feature, and that edition's own catalogue test fails
+   * when the named site does not exist there.
+   */
+  enforcedInTheEditionThatHasIt?: true
 }
 
 const plans = Object.keys(PLAN_QUOTAS)
@@ -173,6 +190,89 @@ export const ENTITLEMENTS: Record<string, EntitlementSpec> = {
       'The rate limiter reads ENDPOINT_LIMITS synchronously on the request path and has no ' +
       'database read to hang an override off. Wiring it needs a cache with an invalidation ' +
       'story, which is a separate piece of work rather than a line in this one.',
+  },
+  // -------------------------------------------------------------------------
+  // The licensed features.
+  //
+  // Added 2026-09-08, and the first boolean entries this catalogue has ever
+  // held. `kind: 'boolean'`, `coerce`'s boolean branch and `Entitlements.
+  // boolean()` were all written when the file was and had nothing to point at,
+  // which is the same shape as the thing they now gate: machinery that exists,
+  // compiles, reads as a working feature, and is reached by nothing.
+  //
+  // WHY THEY ARE HERE RATHER THAN IN THE LICENCE. There are two entitlement
+  // authorities in this product and they answer for different installations. A
+  // self hosted engine reads a signed licence key. A hosted organization is
+  // whatever its plan and its overrides say, which is this file. The features
+  // below are enforced in the control plane, so this is the authority that
+  // decides them, and the licence key is the authority for the ones enforced in
+  // the engine. Naming them identically in both places is what makes the two
+  // answers comparable instead of merely coexisting.
+  //
+  // WHY AN OVERRIDE MATTERS MORE HERE THAN ON A NUMBER. A quota override moves
+  // a limit. One of these turns a capability on or off for one organization,
+  // with a reason, a ticket, an expiry and the name of whoever granted it, all
+  // of which the overrides table already carries. That is the shape of the
+  // sales exception this file was written for, and it is also the shape of a
+  // customer withdrawing consent, which is what support_access below is.
+  sso: {
+    kind: 'boolean',
+    description: 'Sign in through a SAML or OIDC provider this organization runs.',
+    byPlan: { free: false, team: false, enterprise: true },
+    enforcedAt: null,
+    enforcedInTheEditionThatHasIt: true,
+    notEnforcedBecause:
+      'The community build has no single sign-on to enforce. The edition that carries the ' +
+      'SAML and OIDC routes checks this entitlement at the point every one of them resolves ' +
+      'an organization, and relaxes the requirement to use them at the same time, so an ' +
+      'organization whose entitlement is withdrawn falls back to signing in with GitHub ' +
+      'rather than being locked out of its own account.',
+  },
+  scim: {
+    kind: 'boolean',
+    description: 'Provision and deprovision members from a directory this organization runs.',
+    byPlan: { free: false, team: false, enterprise: true },
+    enforcedAt: null,
+    enforcedInTheEditionThatHasIt: true,
+    notEnforcedBecause:
+      'The community build has no SCIM endpoints to enforce. The edition that carries them ' +
+      'checks this entitlement in the one function every SCIM route is authenticated by, so ' +
+      'a route added later cannot be the one that forgot.',
+  },
+  rbac: {
+    kind: 'boolean',
+    description: 'Custom roles and per repository scopes, beyond the four built-in roles.',
+    byPlan: { free: false, team: false, enterprise: true },
+    enforcedAt: null,
+    enforcedInTheEditionThatHasIt: true,
+    notEnforcedBecause:
+      'The community build has four fixed roles and no resolver to enforce. The edition that ' +
+      'carries custom roles checks this entitlement inside the resolver itself, which answers ' +
+      '"no opinion" without it, so the built-in role table decides exactly as it does here.',
+  },
+  support_access: {
+    kind: 'boolean',
+    description: 'Whether an Antifailure operator may act as a member of this organization.',
+    // ON FOR EVERY PLAN, AND THAT IS THE DECISION IN THIS ENTRY.
+    //
+    // The impersonation this gates is fully built and was enforced by nothing
+    // but an operator permission: a reason of at least eight characters, an
+    // audit entry the schema makes unskippable, a copy in the customer's own
+    // log, and a session that expires in minutes. Absent says we did not build
+    // it. Ungated says we built it and do not charge for it, and until now the
+    // second was true and nothing said so.
+    //
+    // Selling it is the reading this does NOT take. Charging a customer for our
+    // ability to help them is backwards, and setting free and team to false
+    // would have broken support for every customer on them the day it shipped.
+    // What large customers actually buy here is the opposite: the ability to
+    // REFUSE, on the record, with an expiry. That is an override on this key,
+    // which is why nothing new had to be built to make it possible.
+    //
+    // So the plan values are uniform on purpose and the refusal comes from an
+    // override. Moving them is one line if the commercial answer changes.
+    byPlan: { free: true, team: true, enterprise: true },
+    enforcedAt: 'admin/customers.ts:supportAccessVerdict',
   },
   retentionDays: {
     kind: 'number',

--- a/web/apps/api/src/entitlements.ts
+++ b/web/apps/api/src/entitlements.ts
@@ -243,12 +243,28 @@ export const ENTITLEMENTS: Record<string, EntitlementSpec> = {
     kind: 'boolean',
     description: 'Custom roles and per repository scopes, beyond the four built-in roles.',
     byPlan: { free: false, team: false, enterprise: true },
+    // REPORTED AND NOT ENFORCED, IN EITHER EDITION, and the sentence below is
+    // the finding rather than an apology for one.
+    //
+    // Measured on 2026-09-08. The enterprise edition carries a complete and
+    // tested library for custom roles: validation, scope resolution, the
+    // approval policy, and a reviewable YAML form of the whole model. It has no
+    // table, no route, no loader and no caller. There is no way for an
+    // organization to have a custom role model in this product, so there is
+    // nothing for a check to refuse, in this build or in that one.
+    //
+    // A licence check was deliberately NOT added in front of it. A gate on a
+    // path nothing reaches is a declared enforcement site that never runs,
+    // which reads as a working feature from every direction and is harder to
+    // find than the gap it covers. The entry stays, because the plan values are
+    // real and the capability is one persistence layer from existing, and this
+    // sentence is what stops the next person believing the gate is there.
     enforcedAt: null,
-    enforcedInTheEditionThatHasIt: true,
     notEnforcedBecause:
-      'The community build has four fixed roles and no resolver to enforce. The edition that ' +
-      'carries custom roles checks this entitlement inside the resolver itself, which answers ' +
-      '"no opinion" without it, so the built-in role table decides exactly as it does here.',
+      'Custom roles exist as a library and not as a feature. Nothing stores a role model, no ' +
+      'route defines one, and the resolver that would apply one has no caller outside its own ' +
+      'tests, so there is no request a check could refuse. Gating it would declare an ' +
+      'enforcement site that never runs.',
   },
   support_access: {
     kind: 'boolean',

--- a/web/apps/api/src/server.ts
+++ b/web/apps/api/src/server.ts
@@ -3770,6 +3770,27 @@ export {
 
 export { safeRedirect } from './auth/signin.ts'
 
+// The entitlement resolver, re-exported for the reason stated above the
+// permission model: an edition built on top of this asks the same question
+// about the same organization and must get the same answer.
+//
+// A licensed feature enforced in the control plane is enforced by reading this
+// catalogue, not by parsing a licence key. There are two entitlement
+// authorities in this product, one per installation shape, and the enterprise
+// edition importing the hosted one from here is what stops it growing a third.
+export {
+  ENTITLEMENTS,
+  Entitlements,
+  resolveEntitlements,
+  applyOverrides,
+  type EntitlementSpec,
+  type EntitlementValue,
+  type Resolved,
+  type Subject,
+} from './entitlements.ts'
+
+export { DEFAULT_PLAN } from './limits.ts'
+
 export { type Clock, systemClock, FakeClock } from './clock.ts'
 
 // The router's request context, re-exported for the same reason the database

--- a/web/apps/api/test/admincustomers.test.ts
+++ b/web/apps/api/test/admincustomers.test.ts
@@ -787,6 +787,167 @@ describe('support notes and impersonation', { skip: hasDb ? false : 'no database
     assert.match(await res.text(), /x-antifailure-admin-csrf/)
   })
 
+  /* -----------------------------------------------------------------------
+   * The entitlement, which is the one refusal a CUSTOMER can cause
+   * -------------------------------------------------------------------- */
+
+  /**
+   * Withdraws operator access from one organization, and hands back the undo.
+   *
+   * The undo is returned rather than left to an `after` hook because the live
+   * index is unique per (scope, scope_id, feature) over unrevoked rows, so a
+   * test that fails before cleaning up makes every later test in the file fail
+   * on an insert that has nothing to do with what it is asserting. That is what
+   * happened the first time this was written, and the three cascading failures
+   * looked like three broken gates rather than one uncleaned row.
+   */
+  async function withdrawSupportAccess(
+    orgId: string,
+    reason: string,
+    by = 'owner@acme.test',
+  ): Promise<() => Promise<void>> {
+    const [row] = await h.admin<{ id: string }[]>`
+      INSERT INTO entitlement_overrides
+        (scope, scope_id, org_id, feature, value, reason, created_by_label)
+      VALUES ('organization', ${orgId}, ${orgId}, 'support_access', ${'false'}::jsonb,
+              ${reason}, ${by})
+      RETURNING id`
+    // Three fields or none: the CHECK on the table refuses a revocation that
+    // does not say who and why, which is the same rule the grant itself is
+    // under one step later.
+    return async () => {
+      await h.admin`
+        UPDATE entitlement_overrides
+           SET revoked_at = now(), revoked_by_label = 'test@example.test',
+               revoked_reason = 'The test that withdrew it is finished.'
+         WHERE id = ${row!.id}`
+    }
+  }
+
+  /**
+   * The status and the body, read once.
+   *
+   * `assert.equal(res.status, 403, await res.text())` evaluates its message
+   * eagerly, so it consumes the body on the path where the assertion PASSES and
+   * the next read throws "Body is unusable". The SCIM suite in the enterprise
+   * tree carries the same helper for the same reason.
+   */
+  async function answer(res: Response): Promise<{ status: number; text: string }> {
+    return { status: res.status, text: await res.text() }
+  }
+
+  test('an organization that has withdrawn operator access refuses the start', async () => {
+    // Green then red then green, on the same request, so the assertion cannot
+    // pass by the impersonation having been impossible all along. The middle
+    // state is the only one that proves a gate exists: a test that only ever
+    // saw the refusal would be satisfied by a route that refuses everybody.
+    const who = await operator('support')
+    const person = await seedPerson(acme)
+
+    const first = await answer(await start(who, {
+      userId: person.id,
+      orgId: acme.orgId,
+      reason: 'Proving the door opens before proving it closes.',
+    }))
+    assert.equal(first.status, 200, first.text)
+    await end(who)
+
+    const before = await auditCount()
+    const beforeTenant = await tenantAuditCount(acme.orgId)
+
+    const restore = await withdrawSupportAccess(
+      acme.orgId, 'The customer asked us to stay out of their account.')
+    try {
+      const res = await start(who, {
+        userId: person.id,
+        orgId: acme.orgId,
+        reason: 'The same request, with consent withdrawn between the two.',
+      })
+      const refused = await answer(res)
+      assert.equal(refused.status, 403, refused.text)
+      assert.match(refused.text, /withdrawn operator access/)
+      // Who withdrew it and why. An operator reading a bare refusal mid call
+      // with the customer cannot say what they are looking at.
+      assert.match(refused.text, /owner@acme.test/)
+      assert.match(refused.text, /stay out of their account/)
+
+      // NOTHING WAS RECORDED, and this is the assertion the ordering was chosen
+      // for. The audit entry is written first, structurally, so that no session
+      // can exist without one; a refusal placed after it would leave a
+      // permanent entry in the CUSTOMER's own log claiming an access that never
+      // happened, and they cannot tell those apart.
+      assert.equal(await auditCount(), before, 'a refused impersonation wrote an operator entry')
+      assert.equal(
+        await tenantAuditCount(acme.orgId), beforeTenant,
+        'a refused impersonation told the customer they had been entered',
+      )
+      // And no session was minted for the account either.
+      assert.equal(sessionTokenFrom(res), null, 'a refused start handed back a customer cookie')
+    } finally {
+      await restore()
+    }
+
+    // Restored, and the same request works again, which proves the refusal was
+    // the override and not something else that happened to change.
+    const after = await answer(await start(who, {
+      userId: person.id,
+      orgId: acme.orgId,
+      reason: 'Consent restored, and the same request again.',
+    }))
+    assert.equal(after.status, 200, after.text)
+    await end(who)
+  })
+
+  test('withdrawing access in one organization does not close the door on another', async () => {
+    // The scope. An override is per organization, and a gate that read the
+    // global answer would take support away from every customer the first time
+    // one of them asked to be left alone.
+    const who = await operator('support')
+    const inAcme = await seedPerson(acme)
+    const inOther = await seedPerson(other)
+
+    const restore = await withdrawSupportAccess(acme.orgId, 'Withdrawn here and nowhere else.')
+    try {
+      const refused = await answer(await start(who, {
+        userId: inAcme.id,
+        orgId: acme.orgId,
+        reason: 'The organization that withdrew it.',
+      }))
+      assert.equal(refused.status, 403, refused.text)
+
+      const allowed = await answer(await start(who, {
+        userId: inOther.id,
+        orgId: other.orgId,
+        reason: 'The organization that did not.',
+      }))
+      assert.equal(allowed.status, 200, allowed.text)
+      await end(who)
+    } finally {
+      await restore()
+    }
+  })
+
+  test('an impersonation that names no organization is not refused by an organization', async () => {
+    // There is no tenant whose consent could be asked. An account with no
+    // organization has its own settings and nobody else's data, so a refusal
+    // here would be a gate keyed on something that is not in the request.
+    const who = await operator('support')
+    const alone = await seedPerson(null)
+
+    const restore = await withdrawSupportAccess(
+      acme.orgId, 'Withdrawn by an organization this person is not in.')
+    try {
+      const res = await answer(await start(who, {
+        userId: alone.id,
+        reason: 'No organization named at all.',
+      }))
+      assert.equal(res.status, 200, res.text)
+      await end(who)
+    } finally {
+      await restore()
+    }
+  })
+
   test('an operator with no live impersonation is not listed, so the list is not vacuous', async () => {
     // The reads above would all pass against a route that returned everything
     // it ever saw. This is the negative: the live list is filtered, so a

--- a/web/apps/api/test/entitlements.test.ts
+++ b/web/apps/api/test/entitlements.test.ts
@@ -62,12 +62,69 @@ describe('the entitlement catalogue', () => {
         )
         continue
       }
+      // The third state cannot also name a site here. An entitlement whose
+      // capability is absent from this build has nothing in this build to point
+      // at, so a symbol named alongside the flag would be a symbol that does
+      // something else, which is the exact failure the enforcedAt grep exists
+      // to catch and would be invisible because the grep would find it.
+      assert.equal(
+        spec.enforcedInTheEditionThatHasIt, undefined,
+        `${key} says its capability is in another edition and also names ${spec.enforcedAt} ` +
+          `in this one. One of those is wrong.`,
+      )
       const [file, symbol] = spec.enforcedAt.split(':')
       assert.ok(file && symbol, `${key} has an unreadable enforcedAt: ${spec.enforcedAt}`)
       const source = await readFile(path.join(srcDir, file), 'utf8')
       assert.ok(
         source.includes(symbol),
         `${key} claims to be enforced at ${spec.enforcedAt}, and ${file} never calls ${symbol}`,
+      )
+    }
+  })
+
+  it('an entitlement whose capability is in another edition says so and says why', () => {
+    // The flag is not decoration. Without it a licensed feature enforced in the
+    // enterprise edition is indistinguishable in this catalogue from one
+    // nothing checks anywhere, and those are the two states this whole file was
+    // written to keep apart.
+    let seen = 0
+    for (const [key, spec] of Object.entries(ENTITLEMENTS)) {
+      if (spec.enforcedInTheEditionThatHasIt !== true) continue
+      seen += 1
+      assert.equal(spec.kind, 'boolean', `${key} is a capability and should be a boolean`)
+      assert.equal(
+        spec.enforcedAt, null,
+        `${key} cannot be enforced in this build and in another one`,
+      )
+      assert.ok(
+        spec.notEnforcedBecause && spec.notEnforcedBecause.length > 20,
+        `${key} does not say what the other edition does with it`,
+      )
+    }
+    assert.ok(
+      seen >= 3,
+      `only ${seen} entitlements are marked as living in another edition, and single sign-on, ` +
+        `SCIM and custom roles are all three of them. A count that has dropped means one was ` +
+        `removed rather than enforced.`,
+    )
+  })
+
+  it('a capability entitlement is off for at least one plan, so the gate can refuse', () => {
+    // A boolean that is true for every plan can still be refused by an
+    // override, and support_access is deliberately that shape. What must never
+    // happen is a capability that is true everywhere AND has no site that could
+    // refuse it, because then nothing in the product can ever say no to it.
+    for (const [key, spec] of Object.entries(ENTITLEMENTS)) {
+      if (spec.kind !== 'boolean') continue
+      const values = Object.values(spec.byPlan)
+      const refusable =
+        values.some((v) => v === false) ||
+        spec.enforcedAt !== null ||
+        spec.enforcedInTheEditionThatHasIt === true
+      assert.ok(
+        refusable,
+        `${key} is true on every plan and nothing enforces it, so no input can make it ` +
+          `answer no. That is a catalogue entry rather than an entitlement.`,
       )
     }
   })

--- a/web/apps/api/test/entitlements.test.ts
+++ b/web/apps/api/test/entitlements.test.ts
@@ -102,10 +102,12 @@ describe('the entitlement catalogue', () => {
       )
     }
     assert.ok(
-      seen >= 3,
-      `only ${seen} entitlements are marked as living in another edition, and single sign-on, ` +
-        `SCIM and custom roles are all three of them. A count that has dropped means one was ` +
-        `removed rather than enforced.`,
+      seen >= 2,
+      `only ${seen} entitlements are marked as living in another edition, and single sign-on ` +
+        `and SCIM are both of them. Custom roles is deliberately not one: the enterprise ` +
+        `edition has the library and nothing stores a role model, so there is no request for ` +
+        `a check to refuse and the entry says so instead. A count that has dropped means one ` +
+        `stopped being enforced rather than that it moved.`,
     )
   })
 


### PR DESCRIPTION
## The failure

Twelve features an enterprise licence names. Measured on 2026-09-08, **three
had an enforcement site**, and the count was read out of `ee/engine/feature`'s
registry, which lives in the engine.

Three of the nine that looked missing are not missing. `sso`, `scim` and `rbac`
are complete TypeScript packages under `ee/web`, tested against a real Postgres
over real HTTP, and that registry could never have seen them: they do not run in
the engine process and the licence key is never there. Two of the three were
enforced by nothing at all. A bearer token naming an organization was the whole
of the authorisation for directory provisioning; a handle in a URL was the whole
of it for single sign-on. Operator impersonation into any customer's account was
the same shape, with no way for that customer to refuse.

**Absent says we did not build it. Ungated says we built it, it runs, and we do
not charge for it**, and only the second is something a buyer can be surprised by
after they have paid.

Two of the twelve are worse than either. `enterprise_dashboard` appears in the
Go constants, in `licensegen`'s copy of them, and in two documentation pages, and
in no other file in the repository. `billing` names nothing a customer is
entitled to: the billing code here bills the customer FOR Antifailure, and
`engine/pkg/extension` carries no metering hook an enterprise implementation
could plug into. A licence naming either signed cleanly, verified cleanly,
reported itself active, printed the feature in `af license status`, and changed
nothing.

## What this does

**Gates three features that were free, each at a chokepoint rather than at call
sites.** SCIM's is inside `guard()`, the one function all fourteen routes
authenticate through, and a test reads the route table and fails if any route
but the two static discovery documents stops going through it. Single sign-on's
is inside the connection lookup every one of its five handlers uses, which is why
that lookup now takes the moment: an entitlement has an expiry, so resolving an
organization and deciding whether it may be resolved became one act instead of
two that drift. `support_access` is checked at the impersonation start route.

**Two second order decisions that are the difference between a gate and a
hazard.** The `support_access` check runs BEFORE the audit entry, because the
entry is written first by design so that no session can exist without one, and a
refusal placed after it would leave a permanent line in the customer's own log
claiming an access that was refused, which nothing in the log distinguishes. And
the single sign-on entitlement relaxes `isEnforced` as well as closing the
provider routes, so a lapse falls back to GitHub sign-in rather than locking an
organization out of its own account; the `enforced` flag stays on the row
untouched, so restoring the entitlement restores the requirement exactly.

**Refuses to sell two features that do not exist, rather than gating them.** A
licence check in front of an absent capability is a declared enforcement site
that can never run, which reads as a working feature from every direction and is
harder to find than the gap it covers. So `notShipped` in
`ee/engine/license/license.go` names both with a reason, `Evaluate` carries the
name and never permits it exactly as it already treats a name from a later
release, and `tools/licensegen` refuses to sign a request naming one with a
message that says the capability is absent rather than that the name is unknown.
Those are different conversations to have with whoever wrote the request.

**Leaves `rbac` ungated and says so out loud.** The custom roles library is
complete and tested; nothing stores a role model, no route defines one, and the
resolver has no caller outside its own tests. There is no request a check could
refuse, so the catalogue entry carries the sentence instead of a gate.

**Closes two gates that existed and had never been asked.** `compliance_packs`
had a site at `command.go:152` and no test called `Command` at all, in either
direction; the new test counts calls to `Gather` and requires zero on a refusal,
which is a statement about what the machine did rather than what it printed. And
`enterprise_secrets` was a TWO CALL contract: `Available` refused, every caller
here consults it first, and a caller that went straight to `Lookup` was handed
the customer's secret with no licence. The gate is now on the method that returns
the value.

**Binds the catalogue in four places that no import can join.** The Go constants,
this new `@antifailure-ee/features` package, `licensegen`'s copy, and both
documentation pages, in both directions, on the precedent of
`admin-platform.test.ts`. It also requires each declared site to name a symbol
that exists in the named file AND that file to ask the entitlement question,
because the engine has already shipped a site naming a method that takes no
context and could not have enforced anything.

## The proof

Nothing here asserts that a check exists. Every gate is exercised by making the
same request twice with one row changed between, and **fourteen existing single
sign-on tests went red the moment the gate landed**, because every suite in that
package had been seeding an organization on the free plan.

## What is not closed

`install()` in `ee/web/sso` and `ee/web/scim` has zero callers outside tests, and
`web/apps/api/src/extensions.ts` describes an enterprise entry point that does
not exist. These gates are correct and are currently gates on code no binary
mounts. That is `L7.6`.
