### PR TITLE
engine: the sidecar could not speak the protocol gRPC is defined over

### DIFF
--- a/.changes/an-application-that-speaks-grpc-could-not-run-in-an-environment.md
+++ b/.changes/an-application-that-speaks-grpc-could-not-run-in-an-environment.md
@@ -1,0 +1,26 @@
+# fixed
+
+An application that speaks gRPC could not run inside an environment at all.
+
+The sidecar terminated TLS on its inspected path with no ALPN offered and then
+read HTTP/1.1 out of whatever was inside. gRPC is defined over HTTP/2, and
+HTTP/2 over TLS is negotiated with ALPN, so a gRPC client closed the connection
+in the handshake with "missing selected ALPN property" before it wrote a single
+request. Nothing in the decision log explained it, because nothing had been
+decided yet: the refusal came from the application's own client library. Five
+of the six Google Cloud services an SDK reaches by default are gRPC, which is
+how this surfaced, but the reach of it was every gRPC client anywhere.
+
+Cleartext had the same hole by a different route. A client built with insecure
+credentials, which is what every emulator's documented setup uses, opens with
+the HTTP/2 connection preface, and the plain listener's HTTP/1.1 reader turned
+that into a request whose method was PRI and which carried no Host header, then
+refused it for naming no host.
+
+Both connections are now read as the protocol they are, and every decision the
+sidecar makes for an HTTP/1.1 request is made for an HTTP/2 one: the host is
+taken from the authority the client wrote, the live credential tripwire runs
+before the mode is acted on, a blocked host is still blocked, and the sandbox
+substitution still happens. Bodies stream in both directions, because a gRPC
+call is long lived and a bounded read on it would end the stream early and
+leave the client reporting a status the server never sent.

--- a/engine/cmd/af-proxy/adversarial_test.go
+++ b/engine/cmd/af-proxy/adversarial_test.go
@@ -127,8 +127,14 @@ func newSidecar(t *testing.T, egress *schema.Egress) *sidecar {
 		// use an address no rule names.
 		destinations: newDestinations(eng.Rules(), "", eng.AllowsIPv6()),
 		transport:    &http.Transport{MaxIdleConnsPerHost: 4, IdleConnTimeout: time.Second},
+		// Built the same way main does, because a path that only exists in
+		// production is a path no test can fail on.
+		transportH2:  newForwardTransport(h2ALPN()),
+		transportH2C: newForwardTransport(h2cPriorKnowledge()),
 	}
 	s.transport.DialContext = s.dialGuarded
+	s.transportH2.DialContext = s.dialGuarded
+	s.transportH2C.DialContext = s.dialGuarded
 
 	done := make(chan struct{})
 	go func() {
@@ -163,6 +169,8 @@ func newSidecar(t *testing.T, egress *schema.Egress) *sidecar {
 		_ = pw.Close()
 		<-done
 		s.transport.CloseIdleConnections()
+		s.transportH2.CloseIdleConnections()
+		s.transportH2C.CloseIdleConnections()
 	})
 	return s
 }

--- a/engine/cmd/af-proxy/grpc_test.go
+++ b/engine/cmd/af-proxy/grpc_test.go
@@ -1,0 +1,597 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/interop/grpc_testing"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	"github.com/antifailure/antifailure/engine/pkg/schema"
+)
+
+// gRPC through the sidecar.
+//
+// The sidecar terminated TLS with no ALPN and read HTTP/1.1 out of whatever it
+// found, so a gRPC client could not talk to it at all: grpc-go requires h2 to
+// be selected during the handshake and closes the connection when nothing is,
+// with "missing selected ALPN property". Every one of these tests fails on the
+// tree before this change, and the first of them fails in the handshake rather
+// than anywhere a policy could be blamed.
+//
+// The pairs matter as much as the tests. A gRPC call that fails looks the same
+// whether the policy refused it, the fixture never started, or the protocol
+// was never negotiated, so every refusal here is paired with a control that
+// must succeed through the same sidecar against the same fixture, differing
+// only in the thing the policy is supposed to notice.
+
+// grpcName is the host the environment's rules are written about.
+//
+// A name rather than an address, because a rule naming an address takes a
+// different branch in the policy and the address branch is not what an
+// application resolving a vendor endpoint exercises.
+const grpcName = "grpc.example.test"
+
+// echoOrigin is a real gRPC server standing in for the origin.
+//
+// It counts what reached it, which is the assertion in the refusal tests: a
+// refusal that still forwarded the call is the failure that matters and it is
+// invisible from the client's side.
+type echoOrigin struct {
+	grpc_testing.UnimplementedTestServiceServer
+	mu       sync.Mutex
+	calls    int
+	authSeen []string
+}
+
+func (o *echoOrigin) UnaryCall(
+	ctx context.Context, req *grpc_testing.SimpleRequest,
+) (*grpc_testing.SimpleResponse, error) {
+	o.mu.Lock()
+	o.calls++
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		o.authSeen = append(o.authSeen, strings.Join(md.Get("authorization"), ","))
+	}
+	o.mu.Unlock()
+	return &grpc_testing.SimpleResponse{Payload: req.GetPayload()}, nil
+}
+
+// FullDuplexCall echoes each message as it arrives.
+//
+// It answers per message rather than after the client half closes, which is
+// what makes the bidirectional test able to fail: a proxy that read the whole
+// request body before forwarding it would wait for a half close the client is
+// not going to send until it has an answer, and the call would deadlock rather
+// than return the wrong bytes.
+func (o *echoOrigin) FullDuplexCall(
+	stream grpc.BidiStreamingServer[grpc_testing.StreamingOutputCallRequest,
+		grpc_testing.StreamingOutputCallResponse],
+) error {
+	for {
+		in, err := stream.Recv()
+		if err != nil {
+			// io.EOF is the client half closing, which is the end of a
+			// healthy call.
+			return nil
+		}
+		o.mu.Lock()
+		o.calls++
+		o.mu.Unlock()
+		if err := stream.Send(&grpc_testing.StreamingOutputCallResponse{
+			Payload: in.GetPayload(),
+		}); err != nil {
+			return err
+		}
+	}
+}
+
+func (o *echoOrigin) count() int {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.calls
+}
+
+func (o *echoOrigin) lastAuth() string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if len(o.authSeen) == 0 {
+		return ""
+	}
+	return o.authSeen[len(o.authSeen)-1]
+}
+
+// startGRPCOrigin runs a TLS gRPC server for a name and returns its address
+// and the roots that verify it.
+func startGRPCOrigin(t *testing.T, name string) (*echoOrigin, string, *x509.CertPool) {
+	t.Helper()
+	certPEM, keyPEM, err := GenerateAuthority("grpc-origin-fixture", time.Now())
+	require.NoError(t, err)
+	ca, err := newCertAuthority(certPEM, keyPEM)
+	require.NoError(t, err)
+	leaf, err := ca.leaf(name)
+	require.NoError(t, err)
+
+	roots := x509.NewCertPool()
+	require.True(t, roots.AppendCertsFromPEM([]byte(certPEM)))
+
+	o := &echoOrigin{}
+	srv := grpc.NewServer(grpc.Creds(credentials.NewTLS(&tls.Config{
+		Certificates: []tls.Certificate{*leaf},
+		MinVersion:   tls.VersionTLS12,
+	})))
+	grpc_testing.RegisterTestServiceServer(srv, o)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(srv.Stop)
+	return o, ln.Addr().String(), roots
+}
+
+// startPlainGRPCOrigin runs a cleartext gRPC server, which is what every
+// emulator's documented setup speaks.
+func startPlainGRPCOrigin(t *testing.T) (*echoOrigin, string) {
+	t.Helper()
+	o := &echoOrigin{}
+	srv := grpc.NewServer()
+	grpc_testing.RegisterTestServiceServer(srv, o)
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(srv.Stop)
+	return o, ln.Addr().String()
+}
+
+// pointSidecarAt wires a sidecar so that the name a rule is written about
+// reaches a loopback fixture.
+//
+// The port rewrite in the dialer is the one piece of scaffolding here and it
+// is deliberately after the guard rather than around it: dialGuarded resolves
+// the name and refuses the address, and the port it is handed changes nothing
+// about that decision. The fixture cannot bind 443, so something has to move
+// the port, and moving it inside the guard would have removed the guard from
+// the test.
+func pointSidecarAt(t *testing.T, s *sidecar, upstream string, roots *x509.CertPool) {
+	t.Helper()
+	_, fixturePort, err := net.SplitHostPort(upstream)
+	require.NoError(t, err)
+
+	// Loopback is where the fixture is, and the guard refuses loopback unless
+	// it is the environment's own network or a rule names it.
+	s.destinations = newDestinations(nil, "127.0.0.0/8", false)
+	s.resolve = func(context.Context, string) ([]net.IP, error) {
+		return []net.IP{net.IPv4(127, 0, 0, 1)}, nil
+	}
+	dial := func(ctx context.Context, network, address string) (net.Conn, error) {
+		host, port, splitErr := net.SplitHostPort(address)
+		if splitErr != nil {
+			return nil, splitErr
+		}
+		if port == "443" || port == "80" {
+			port = fixturePort
+		}
+		return s.dialGuarded(ctx, network, net.JoinHostPort(host, port))
+	}
+	for _, tr := range []*http.Transport{s.transport, s.transportH2, s.transportH2C} {
+		tr.DialContext = dial
+		if roots != nil {
+			tr.TLSClientConfig = &tls.Config{RootCAs: roots, MinVersion: tls.VersionTLS12}
+		}
+	}
+	t.Cleanup(func() {
+		s.transport.CloseIdleConnections()
+		s.transportH2.CloseIdleConnections()
+		s.transportH2C.CloseIdleConnections()
+	})
+}
+
+// environmentCA gives the sidecar an authority and returns the roots a service
+// inside the environment would trust.
+func environmentCA(t *testing.T, s *sidecar) *x509.CertPool {
+	t.Helper()
+	certPEM, keyPEM, err := GenerateAuthority("grpc-lane", time.Now())
+	require.NoError(t, err)
+	ca, err := newCertAuthority(certPEM, keyPEM)
+	require.NoError(t, err)
+	s.ca = ca
+	roots := x509.NewCertPool()
+	require.True(t, roots.AppendCertsFromPEM([]byte(certPEM)))
+	return roots
+}
+
+// frontDoor runs one of the sidecar's transparent listeners on a real socket
+// and returns its address.
+func frontDoor(t *testing.T, handle func(net.Conn)) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+	go func() {
+		for {
+			conn, acceptErr := ln.Accept()
+			if acceptErr != nil {
+				return
+			}
+			go handle(conn)
+		}
+	}()
+	return ln.Addr().String()
+}
+
+// grpcClient dials the sidecar the way an application's client does: at the
+// vendor's own name, over TLS, with no endpoint override and no knowledge that
+// anything is in the way.
+func grpcClient(t *testing.T, front string, roots *x509.CertPool) grpc_testing.TestServiceClient {
+	t.Helper()
+	cc, err := grpc.NewClient(
+		// passthrough so the name is handed to the dialer rather than looked
+		// up. The name resolving to the sidecar is what the environment's own
+		// resolver does, and a test resolver is not what is under test here.
+		"passthrough:///"+grpcName+":443",
+		grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
+			ServerName: grpcName, RootCAs: roots, MinVersion: tls.VersionTLS12,
+		})),
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "tcp", front)
+		}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cc.Close() })
+	return grpc_testing.NewTestServiceClient(cc)
+}
+
+// inspectedEgress is a policy that puts this host on the inspected path.
+//
+// Paths are what make the sidecar terminate the connection rather than tunnel
+// it, and a rule with no path is decided on the host alone and never reads
+// inside, so a policy without one would test the tunnel and not the protocol.
+func inspectedEgress(mode schema.Mode) *schema.Egress {
+	return &schema.Egress{
+		Default: schema.ModeBlock,
+		Rules:   []schema.EgressRule{{Host: grpcName, Mode: mode, Paths: []string{"/"}}},
+	}
+}
+
+func payload(text string) *grpc_testing.Payload {
+	return &grpc_testing.Payload{Body: []byte(text)}
+}
+
+// The reproduction, and the smallest statement of the finding.
+//
+// An unmodified application calling a gRPC service through the sidecar. Before
+// the ALPN change this failed in the TLS handshake with "missing selected ALPN
+// property", which is grpc-go refusing to speak to a server that selected no
+// protocol, so nothing the policy did or did not do was ever reached.
+func TestGRPC_AUnaryCallReachesTheOriginThroughTheSidecar(t *testing.T) {
+	o, upstream, originRoots := startGRPCOrigin(t, grpcName)
+	s := newSidecar(t, inspectedEgress(schema.ModeAllow))
+	envRoots := environmentCA(t, s)
+	pointSidecarAt(t, s, upstream, originRoots)
+	front := frontDoor(t, s.serveTransparentTLS)
+
+	client := grpcClient(t, front, envRoots)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	resp, err := client.UnaryCall(ctx, &grpc_testing.SimpleRequest{Payload: payload("hello")})
+	require.NoError(t, err, "a gRPC client cannot reach anything through this sidecar")
+	require.Equal(t, "hello", string(resp.GetPayload().GetBody()))
+	require.Equal(t, 1, o.count(), "the call never reached the origin")
+
+	// The policy read inside the connection, which is the other half of the
+	// claim: an HTTP/2 request that reached the network without a decision
+	// would be a hole rather than a feature.
+	rec := s.waitFor(t, func(r record) bool { return r.Host == grpcName && r.Path != "" })
+	require.True(t, rec.Allowed)
+	require.Equal(t, "inspect", rec.Via)
+	require.Equal(t, "POST", rec.Method,
+		"gRPC is POST, and a decision log that cannot say so cannot enforce a method rule")
+	require.Equal(t, "/grpc.testing.TestService/UnaryCall", rec.Path,
+		"the method name is the path, so a path rule is how a gRPC method is named")
+	require.False(t, rec.HostOnly, "an inspected HTTP/2 request is not a host only decision")
+}
+
+// The half that a buffer cannot fake.
+//
+// gRPC streams are long lived and bidirectional. A proxy that read the request
+// body to its end before forwarding it would hang here rather than return the
+// wrong answer, because the server does not reply until it has a message and
+// the client does not half close until it has a reply.
+func TestGRPC_ABidirectionalStreamCarriesMessagesInBothDirections(t *testing.T) {
+	o, upstream, originRoots := startGRPCOrigin(t, grpcName)
+	s := newSidecar(t, inspectedEgress(schema.ModeAllow))
+	envRoots := environmentCA(t, s)
+	pointSidecarAt(t, s, upstream, originRoots)
+	front := frontDoor(t, s.serveTransparentTLS)
+
+	client := grpcClient(t, front, envRoots)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	stream, err := client.FullDuplexCall(ctx)
+	require.NoError(t, err)
+
+	for i := range 3 {
+		sent := fmt.Sprintf("message %d", i)
+		require.NoError(t, stream.Send(&grpc_testing.StreamingOutputCallRequest{
+			Payload: payload(sent),
+		}))
+		// Received before the next is sent. That ordering is the assertion: a
+		// proxy that waits for the whole request before forwarding any of it
+		// never gets past this line.
+		got, recvErr := stream.Recv()
+		require.NoError(t, recvErr, "the stream stalled after %d messages", i)
+		require.Equal(t, sent, string(got.GetPayload().GetBody()))
+	}
+	require.NoError(t, stream.CloseSend())
+	require.Equal(t, 3, o.count())
+}
+
+// A gRPC error is carried in trailers, and a trailers only response is carried
+// in headers.
+//
+// An unimplemented method answers with a single headers frame holding
+// grpc-status and closing the stream. Relayed as headers it would leave the
+// stream with no trailers at all, and grpc-go reports that as an internal
+// protocol failure rather than as the Unimplemented the server sent, so a
+// developer would be sent to debug the network for an ordinary application
+// error.
+func TestGRPC_AStatusFromTheOriginArrivesAsAStatusAndNotAProtocolError(t *testing.T) {
+	_, upstream, originRoots := startGRPCOrigin(t, grpcName)
+	s := newSidecar(t, inspectedEgress(schema.ModeAllow))
+	envRoots := environmentCA(t, s)
+	pointSidecarAt(t, s, upstream, originRoots)
+	front := frontDoor(t, s.serveTransparentTLS)
+
+	client := grpcClient(t, front, envRoots)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	// EmptyCall is on the service and the fixture does not implement it, so
+	// the server answers with a status and nothing else.
+	_, err := client.EmptyCall(ctx, &grpc_testing.Empty{})
+	require.Error(t, err)
+	require.Equal(t, codes.Unimplemented, status.Code(err),
+		"the origin's own status did not survive the sidecar")
+}
+
+// The containment claim, over the protocol that could not reach the policy.
+func TestGRPC_ABlockedHostIsRefusedOverGRPC(t *testing.T) {
+	o, upstream, originRoots := startGRPCOrigin(t, grpcName)
+	s := newSidecar(t, &schema.Egress{
+		Default: schema.ModeBlock,
+		Rules: []schema.EgressRule{
+			// Named with a path so the connection is inspected, and blocked so
+			// that what is being tested is the decision rather than the route.
+			{Host: grpcName, Mode: schema.ModeBlock, Paths: []string{"/"}},
+		},
+	})
+	envRoots := environmentCA(t, s)
+	pointSidecarAt(t, s, upstream, originRoots)
+	front := frontDoor(t, s.serveTransparentTLS)
+
+	client := grpcClient(t, front, envRoots)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	_, err := client.UnaryCall(ctx, &grpc_testing.SimpleRequest{Payload: payload("hello")})
+	require.Error(t, err, "a blocked host answered a gRPC call")
+	require.Zero(t, o.count(), "the call reached the origin through a blocked rule")
+
+	rec := s.waitFor(t, func(r record) bool { return r.Host == grpcName && r.Path != "" })
+	require.False(t, rec.Allowed)
+	require.Equal(t, "inspect", rec.Via)
+	require.Equal(t, string(schema.ModeBlock), rec.Mode)
+}
+
+// The control for the test above.
+//
+// Without it, a sidecar that refused every gRPC call for any reason at all
+// would pass, which is exactly the shape of the defect this lane is closing.
+func TestGRPC_AnAllowedHostAnswersTheSameCall(t *testing.T) {
+	o, upstream, originRoots := startGRPCOrigin(t, grpcName)
+	s := newSidecar(t, inspectedEgress(schema.ModeAllow))
+	envRoots := environmentCA(t, s)
+	pointSidecarAt(t, s, upstream, originRoots)
+	front := frontDoor(t, s.serveTransparentTLS)
+
+	client := grpcClient(t, front, envRoots)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	_, err := client.UnaryCall(ctx, &grpc_testing.SimpleRequest{Payload: payload("hello")})
+	require.NoError(t, err)
+	require.Equal(t, 1, o.count())
+}
+
+// The live credential tripwire, over gRPC.
+//
+// A credential travels in gRPC metadata, which is an HTTP/2 header, so the
+// same scan applies. It has to, because an environment holds a copy of
+// production data and a key that can act on production must not leave it
+// whichever protocol the application chose.
+func TestGRPC_ALiveCredentialIsRefusedOverGRPC(t *testing.T) {
+	o, upstream, originRoots := startGRPCOrigin(t, grpcName)
+	s := newSidecar(t, inspectedEgress(schema.ModeAllow))
+	envRoots := environmentCA(t, s)
+	pointSidecarAt(t, s, upstream, originRoots)
+	front := frontDoor(t, s.serveTransparentTLS)
+
+	client := grpcClient(t, front, envRoots)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	live := metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+liveKey())
+	_, err := client.UnaryCall(live, &grpc_testing.SimpleRequest{Payload: payload("charge")})
+	require.Error(t, err, "a live credential reached the origin over gRPC")
+	require.Zero(t, o.count(), "the call carrying a live credential reached the origin")
+
+	rec := s.waitFor(t, func(r record) bool { return strings.Contains(r.Reason, "live credential") })
+	require.False(t, rec.Allowed)
+	require.Equal(t, "inspect", rec.Via)
+	require.NotContains(t, rec.Reason, "A1b2C3d4", "the refusal never echoes the key")
+
+	// The control. Same client, same rule, same host: only the metadata
+	// differs, so the refusal above is the tripwire and not a broken fixture.
+	ok := metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer whatever-the-app-had")
+	_, err = client.UnaryCall(ok, &grpc_testing.SimpleRequest{Payload: payload("charge")})
+	require.NoError(t, err)
+	require.Equal(t, 1, o.count(), "the control call did not reach the origin")
+}
+
+// Sandbox mode over gRPC.
+//
+// The substitution is the whole difference between sandbox mode and asking
+// somebody to configure a sandbox key correctly, and it has to happen on every
+// protocol or it happens on whichever one the application did not use.
+func TestGRPC_ASandboxCredentialIsSubstitutedOverGRPC(t *testing.T) {
+	o, upstream, originRoots := startGRPCOrigin(t, grpcName)
+	s := newSidecar(t, &schema.Egress{
+		Default: schema.ModeBlock,
+		Rules: []schema.EgressRule{{
+			Host: grpcName, Mode: schema.ModeSandbox,
+			Credential: "TEST_KEY", Paths: []string{"/"},
+		}},
+	})
+	const substituted = "sk" + "_" + "test" + "_" + "substituted00000000"
+	s.credentials["TEST_KEY"] = substituted
+	envRoots := environmentCA(t, s)
+	pointSidecarAt(t, s, upstream, originRoots)
+	front := frontDoor(t, s.serveTransparentTLS)
+
+	client := grpcClient(t, front, envRoots)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	sent := metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer the-applications-own-key")
+	_, err := client.UnaryCall(sent, &grpc_testing.SimpleRequest{Payload: payload("charge")})
+	require.NoError(t, err)
+	require.Equal(t, 1, o.count())
+	require.Equal(t, "Bearer "+substituted, o.lastAuth(),
+		"the application's own credential was forwarded over gRPC rather than replaced")
+}
+
+// Cleartext HTTP/2, which is what an insecure gRPC client speaks.
+//
+// Every emulator's documented setup uses insecure credentials, so this is the
+// shape a local Pub/Sub or Spanner client arrives in. It reached the plain
+// transparent listener, whose HTTP/1.1 reader turned the connection preface
+// into a request with the method PRI and no Host header and refused it for
+// naming no host.
+func TestGRPC_AnInsecureClientOverCleartextHTTP2IsCarried(t *testing.T) {
+	o, upstream := startPlainGRPCOrigin(t)
+	s := newSidecar(t, &schema.Egress{
+		Default: schema.ModeBlock,
+		Rules: []schema.EgressRule{
+			{Host: grpcName, Mode: schema.ModeAllow, Paths: []string{"/"}},
+		},
+	})
+	pointSidecarAt(t, s, upstream, nil)
+	front := frontDoor(t, s.serveTransparentHTTP)
+
+	cc, err := grpc.NewClient("passthrough:///"+grpcName+":80",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "tcp", front)
+		}))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cc.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	resp, err := grpc_testing.NewTestServiceClient(cc).UnaryCall(ctx,
+		&grpc_testing.SimpleRequest{Payload: payload("cleartext")})
+	require.NoError(t, err, "an insecure gRPC client cannot reach anything through this sidecar")
+	require.Equal(t, "cleartext", string(resp.GetPayload().GetBody()))
+	require.Equal(t, 1, o.count())
+
+	rec := s.waitFor(t, func(r record) bool { return r.Host == grpcName && r.Path != "" })
+	require.True(t, rec.Allowed)
+	require.Equal(t, "transparent", rec.Via)
+	require.Equal(t, "/grpc.testing.TestService/UnaryCall", rec.Path)
+}
+
+// The cleartext control.
+//
+// A blocked rule on the same listener must still refuse, or the h2c reader is
+// a way around the policy rather than a protocol the policy can see.
+func TestGRPC_ACleartextCallToABlockedHostIsRefused(t *testing.T) {
+	o, upstream := startPlainGRPCOrigin(t)
+	s := newSidecar(t, &schema.Egress{
+		Default: schema.ModeBlock,
+		Rules: []schema.EgressRule{
+			{Host: grpcName, Mode: schema.ModeBlock, Paths: []string{"/"}},
+		},
+	})
+	pointSidecarAt(t, s, upstream, nil)
+	front := frontDoor(t, s.serveTransparentHTTP)
+
+	cc, err := grpc.NewClient("passthrough:///"+grpcName+":80",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "tcp", front)
+		}))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cc.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	_, err = grpc_testing.NewTestServiceClient(cc).UnaryCall(ctx,
+		&grpc_testing.SimpleRequest{Payload: payload("cleartext")})
+	require.Error(t, err, "a blocked host answered a cleartext gRPC call")
+	require.Zero(t, o.count())
+
+	rec := s.waitFor(t, func(r record) bool { return r.Host == grpcName && r.Path != "" })
+	require.False(t, rec.Allowed)
+	require.Equal(t, "transparent", rec.Via)
+}
+
+// The handshake itself, stated without gRPC in the way.
+//
+// This is the one line of the finding: a client that offers h2 must be told h2
+// was selected. It is kept separate from the calls above because when they all
+// fail together this says which half broke.
+func TestGRPC_TheTerminatorSelectsH2WhenTheClientOffersIt(t *testing.T) {
+	s := newSidecar(t, inspectedEgress(schema.ModeAllow))
+	envRoots := environmentCA(t, s)
+	front := frontDoor(t, s.serveTransparentTLS)
+
+	conn, err := net.Dial("tcp", front)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+	client := tls.Client(conn, &tls.Config{
+		ServerName: grpcName, RootCAs: envRoots, MinVersion: tls.VersionTLS12,
+		NextProtos: []string{"h2"},
+	})
+	require.NoError(t, client.Handshake())
+	require.Equal(t, "h2", client.ConnectionState().NegotiatedProtocol,
+		"the terminator selected no protocol, which every gRPC client refuses")
+}
+
+// An HTTP/1.1 client offered the same connection must still get HTTP/1.1.
+//
+// Offering h2 first would be a downgrade in the other direction if it were
+// ever selected for a client that did not ask, and the whole HTTP/1.1 suite
+// runs through this path.
+func TestGRPC_AnHTTP11ClientStillGetsHTTP11(t *testing.T) {
+	s := newSidecar(t, inspectedEgress(schema.ModeAllow))
+	envRoots := environmentCA(t, s)
+	front := frontDoor(t, s.serveTransparentTLS)
+
+	conn, err := net.Dial("tcp", front)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+	client := tls.Client(conn, &tls.Config{
+		ServerName: grpcName, RootCAs: envRoots, MinVersion: tls.VersionTLS12,
+		NextProtos: []string{"http/1.1"},
+	})
+	require.NoError(t, client.Handshake())
+	require.Equal(t, "http/1.1", client.ConnectionState().NegotiatedProtocol)
+}

--- a/engine/cmd/af-proxy/grpc_test.go
+++ b/engine/cmd/af-proxy/grpc_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -594,4 +595,96 @@ func TestGRPC_AnHTTP11ClientStillGetsHTTP11(t *testing.T) {
 	})
 	require.NoError(t, client.Handshake())
 	require.Equal(t, "http/1.1", client.ConnectionState().NegotiatedProtocol)
+}
+
+// startH2Origin runs an ordinary HTTPS server that offers h2, and reports what
+// it saw, so the forwarding half can be read from the answer.
+func startH2Origin(t *testing.T, name string) (string, *x509.CertPool) {
+	t.Helper()
+	certPEM, keyPEM, err := GenerateAuthority("h2-origin-fixture", time.Now())
+	require.NoError(t, err)
+	ca, err := newCertAuthority(certPEM, keyPEM)
+	require.NoError(t, err)
+	leaf, err := ca.leaf(name)
+	require.NoError(t, err)
+
+	roots := x509.NewCertPool()
+	require.True(t, roots.AppendCertsFromPEM([]byte(certPEM)))
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, "the origin was asked HTTP/%d %s %s", r.ProtoMajor, r.Method, r.URL.Path)
+		}),
+		TLSConfig: &tls.Config{
+			Certificates: []tls.Certificate{*leaf},
+			MinVersion:   tls.VersionTLS12,
+			NextProtos:   []string{"h2", "http/1.1"},
+		},
+		ReadHeaderTimeout: 20 * time.Second,
+	}
+	go func() { _ = srv.ServeTLS(ln, "", "") }()
+	t.Cleanup(func() { _ = srv.Close() })
+	return ln.Addr().String(), roots
+}
+
+// An ordinary HTTPS client that speaks HTTP/2, which is most of them.
+//
+// gRPC is not the only thing that negotiates h2 once the terminator offers it.
+// Go's own client does, and so does every runtime with a modern HTTP stack, so
+// offering h2 moved the product's ordinary inspected traffic onto this reader
+// rather than only its gRPC traffic. That is worth its own test because the
+// whole HTTP/1.1 suite in this package kept passing while this path was
+// broken: those tests write a request onto a socket by hand and negotiate
+// nothing, so not one of them ever reached the code that was wrong.
+//
+// Three claims, and they fail separately. The answer came back at all and it
+// came back framed as HTTP/2, which is the reading half. The origin was asked
+// in HTTP/2, which is the forwarding half, and an HTTP/1.1 forward here is
+// what drops the trailers a gRPC status travels in. And the request was
+// decided by name and path, which is the policy still being applied to a
+// protocol it did not previously see.
+func TestGRPC_AnOrdinaryHTTP2ClientIsCarriedAndPoliced(t *testing.T) {
+	upstream, originRoots := startH2Origin(t, grpcName)
+	s := newSidecar(t, inspectedEgress(schema.ModeAllow))
+	envRoots := environmentCA(t, s)
+	pointSidecarAt(t, s, upstream, originRoots)
+	front := frontDoor(t, s.serveTransparentTLS)
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{RootCAs: envRoots, MinVersion: tls.VersionTLS12},
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "tcp", front)
+		},
+		// A transport carrying its own dialer has HTTP/2 off unless it is
+		// asked for, and a client that never offers h2 would take the
+		// HTTP/1.1 path and prove nothing about this one.
+		ForceAttemptHTTP2: true,
+	}
+	t.Cleanup(tr.CloseIdleConnections)
+	client := &http.Client{Transport: tr, Timeout: 20 * time.Second}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://"+grpcName+"/things", nil)
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	require.NoError(t, err, "an HTTP/2 client cannot reach anything through this sidecar")
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, 2, resp.ProtoMajor,
+		"the answer was not framed as HTTP/2, so the connection was read as HTTP/1.1")
+	require.Equal(t, "the origin was asked HTTP/2 GET /things", string(body),
+		"the sidecar did not forward this request over HTTP/2")
+
+	rec := s.waitFor(t, func(r record) bool { return r.Host == grpcName && r.Path != "" })
+	require.True(t, rec.Allowed)
+	require.Equal(t, "inspect", rec.Via)
+	require.Equal(t, http.MethodGet, rec.Method,
+		"the sidecar decided about the connection preface rather than about the request")
+	require.Equal(t, "/things", rec.Path)
 }

--- a/engine/cmd/af-proxy/h2.go
+++ b/engine/cmd/af-proxy/h2.go
@@ -142,6 +142,7 @@ func (p *proxy) serveH2Conn(
 	conn net.Conn, sni string, port int, isTLS bool, via string,
 	transport *http.Transport, scheme string,
 ) {
+	ln := &oneConnListener{conn: conn, closed: make(chan struct{})}
 	srv := &http.Server{
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// The authority the client wrote, not the name in the handshake.
@@ -159,11 +160,26 @@ func (p *proxy) serveH2Conn(
 		// call is unaffected by this.
 		ReadHeaderTimeout: 20 * time.Second,
 		IdleTimeout:       90 * time.Second,
+		// The end of the connection is reported here rather than by a wrapper
+		// around it, and that is the whole reason this hook exists. net/http
+		// decides a terminated connection's protocol by asking the connection
+		// it was handed for its ConnectionState, and a struct that embeds
+		// net.Conn does not carry that method however faithfully it forwards
+		// everything else. Wrapping the connection to learn when it closed
+		// therefore left net/http unable to see that h2 had been negotiated,
+		// so it read the HTTP/2 frame stream as an HTTP/1.1 request line and
+		// forwarded the connection preface upstream as a request whose method
+		// was PRI. Nothing in the wrapper looked wrong and every gRPC call
+		// through the sidecar failed.
+		ConnState: func(_ net.Conn, state http.ConnState) {
+			if state == http.StateClosed || state == http.StateHijacked {
+				ln.finished()
+			}
+		},
 	}
 	if !isTLS {
 		srv.Protocols = h2cPriorKnowledge()
 	}
-	ln := &oneConnListener{conn: conn, closed: make(chan struct{})}
 	// Serve returns once the listener refuses a second connection, which it
 	// does only after this one is closed, so this call spans the life of the
 	// connection exactly as the HTTP/1.1 read loop does.
@@ -430,6 +446,13 @@ var errConnectionFinished = errors.New("this connection has been served")
 // closed rather than returning at once, so Serve outlives the connection it
 // was given and the caller can wait on Serve instead of inventing its own
 // signal for when the last stream ended.
+//
+// The connection is handed over exactly as it arrived, with nothing wrapped
+// around it. What net/http is given here is a *tls.Conn and it has to stay
+// one: the protocol dispatch asserts ConnectionState on it, and both the
+// HTTP/2 server it selects on that basis and the older ALPN hook behind it
+// read the connection's own type. Serve is told the connection ended through
+// the server's ConnState hook instead.
 type oneConnListener struct {
 	conn net.Conn
 	// handed is read and written only by Serve's accept loop, which is one
@@ -442,7 +465,7 @@ type oneConnListener struct {
 func (l *oneConnListener) Accept() (net.Conn, error) {
 	if !l.handed {
 		l.handed = true
-		return &closeNotifyConn{Conn: l.conn, listener: l}, nil
+		return l.conn, nil
 	}
 	<-l.closed
 	return nil, errConnectionFinished
@@ -452,14 +475,11 @@ func (l *oneConnListener) Close() error { return nil }
 
 func (l *oneConnListener) Addr() net.Addr { return l.conn.LocalAddr() }
 
-// closeNotifyConn reports when the served connection is closed.
-type closeNotifyConn struct {
-	net.Conn
-	listener *oneConnListener
-}
-
-func (c *closeNotifyConn) Close() error {
-	err := c.Conn.Close()
-	c.listener.once.Do(func() { close(c.listener.closed) })
-	return err
+// finished releases the accept loop that is waiting for this connection to
+// end.
+//
+// Guarded by a sync.Once because the caller watches two terminal states and
+// should not have to know that net/http reports exactly one of them.
+func (l *oneConnListener) finished() {
+	l.once.Do(func() { close(l.closed) })
 }

--- a/engine/cmd/af-proxy/h2.go
+++ b/engine/cmd/af-proxy/h2.go
@@ -1,0 +1,465 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/antifailure/antifailure/engine/internal/policy"
+	"github.com/antifailure/antifailure/engine/pkg/livekey"
+	"github.com/antifailure/antifailure/engine/pkg/schema"
+)
+
+// HTTP/2, which is the protocol gRPC is defined over.
+//
+// The sidecar terminated TLS and then read HTTP/1.1 out of the connection
+// unconditionally, with no ALPN offered at all. Two things followed from that
+// and both of them break gRPC outright.
+//
+// The first is the handshake. gRPC is HTTP/2 and HTTP/2 over TLS is negotiated
+// with ALPN, so every gRPC client offers h2 and requires the server to select
+// it. A terminator that names no protocol leaves the negotiated protocol
+// empty, and grpc-go refuses the connection there with "missing selected ALPN
+// property" before a single request is written. The application does not see a
+// policy refusal or a network error it can attribute; it sees its own client
+// library declining to talk to what it believes is the origin.
+//
+// The second is the read. Negotiating h2 without changing how the connection
+// is read would be worse than not negotiating it, because the client would
+// then commit to HTTP/2 and the sidecar would try to parse an HTTP/2 frame
+// stream as an HTTP/1.1 request line. So the negotiated protocol decides the
+// reader, here, and the two are set in one place.
+//
+// Everything the sidecar decides for an HTTP/1.1 request is decided here for
+// an HTTP/2 one: the host match, the mode, the live credential tripwire, the
+// sandbox substitution, the rate limit and the decision record. A protocol
+// that reached the network without passing the policy would be a containment
+// hole far larger than the gap it closed.
+//
+// What is NOT the same is the shape of the answer. The HTTP/1.1 paths hold a
+// raw connection and write a whole response onto it by hand; an HTTP/2 stream
+// is written through an http.ResponseWriter. Rather than a second copy of
+// capture, mock and synth for this path, the one implementation writes onto a
+// pipe and its response is relayed, so a mode cannot behave differently
+// depending on which protocol the application happened to speak.
+
+// h2ALPN is the protocol set for a transport that may use HTTP/2 over TLS.
+//
+// HTTP/1.1 stays in the set. An upstream that does not offer h2 selects
+// http/1.1 during the handshake and the request is forwarded over that, which
+// is what should happen: the client's protocol and the origin's are separate
+// negotiations and nothing requires them to agree.
+func h2ALPN() *http.Protocols {
+	var p http.Protocols
+	p.SetHTTP1(true)
+	p.SetHTTP2(true)
+	return &p
+}
+
+// h2cPriorKnowledge is the protocol set for a transport that speaks HTTP/2 on
+// a plain connection.
+//
+// There is no ALPN on a cleartext connection, so this is prior knowledge: the
+// client committed to HTTP/2 by sending the connection preface and the
+// upstream is expected to speak it too. HTTP/1.1 is left out on purpose,
+// because a silent downgrade here would hand an HTTP/1.1 response to a client
+// that has already framed its side as HTTP/2.
+func h2cPriorKnowledge() *http.Protocols {
+	var p http.Protocols
+	p.SetUnencryptedHTTP2(true)
+	return &p
+}
+
+// newForwardTransport builds a transport that re-originates a request.
+//
+// A nil protocol set is the historical behaviour and is deliberate rather
+// than incidental: net/http disables HTTP/2 on any transport carrying a custom
+// dialer, and this one carries the address guard, so the forwarding half was
+// HTTP/1.1 only whatever the client spoke. Terminating h2 and then forwarding
+// over HTTP/1.1 would strip the trailers a gRPC status travels in, so the
+// protocol has to be asked for explicitly on both halves.
+func newForwardTransport(protocols *http.Protocols) *http.Transport {
+	return &http.Transport{
+		MaxIdleConnsPerHost: 16,
+		IdleConnTimeout:     60 * time.Second,
+		// The origin's certificate is verified normally. Reading inside a
+		// connection is not a licence to stop checking who is on the other
+		// end of it; if anything it makes the check more important, because
+		// the client can no longer do it itself.
+		TLSHandshakeTimeout: 20 * time.Second,
+		Protocols:           protocols,
+	}
+}
+
+// h2Preface is the first thing a client sends on a cleartext HTTP/2
+// connection, before any frame.
+const h2Preface = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
+
+// looksLikeH2C reports whether a plain connection is about to speak HTTP/2.
+//
+// Three bytes are peeked before twenty four, and that ordering is the whole
+// care in this function. Peeking the full preface up front would block until
+// twenty four bytes arrived, and a client that writes its request line and its
+// headers in separate packets has sent fewer than that when it stops to draw
+// breath. PRI is not the start of any HTTP/1.1 method, so three bytes settle
+// it for every request that is not one, and only a connection that really does
+// begin with PRI waits for the rest.
+func looksLikeH2C(br *bufio.Reader) bool {
+	head, err := br.Peek(3)
+	if err != nil || string(head) != "PRI" {
+		return false
+	}
+	full, err := br.Peek(len(h2Preface))
+	return err == nil && string(full) == h2Preface
+}
+
+// serveInspectedH2 serves one terminated connection that negotiated h2.
+func (p *proxy) serveInspectedH2(conn net.Conn, sni string) {
+	p.serveH2Conn(conn, sni, 443, true, "inspect", p.transportH2, "https")
+}
+
+// serveTransparentH2C serves one cleartext connection that opened with the
+// HTTP/2 preface.
+//
+// A gRPC client built with insecure credentials, which is what every local
+// emulator's documented setup uses, speaks exactly this. It arrived on the
+// transparent port 80 listener, where the HTTP/1.1 reader turned the preface
+// into a request whose method was PRI and whose Host header was absent, and
+// refused it for carrying no host. The refusal was correct about what it saw
+// and said nothing about what had actually happened.
+func (p *proxy) serveTransparentH2C(conn net.Conn, br *bufio.Reader) {
+	p.serveH2Conn(&prefixedConn{Conn: conn, r: br}, "", 80, false, "transparent", p.transportH2C, "http")
+}
+
+// serveH2Conn runs an HTTP/2 server over one connection and decides every
+// request on it.
+func (p *proxy) serveH2Conn(
+	conn net.Conn, sni string, port int, isTLS bool, via string,
+	transport *http.Transport, scheme string,
+) {
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// The authority the client wrote, not the name in the handshake.
+			// The two can disagree, and the request is going where the
+			// authority says, which is the same reason the HTTP/1.1 reader
+			// prefers the Host header over the server name.
+			host := sni
+			if r.Host != "" {
+				host, _ = splitHostPort(r.Host, port)
+			}
+			p.decideH2(w, r, host, port, isTLS, via, transport, scheme)
+		}),
+		// A connection that never finishes a request must not hold a
+		// goroutine forever. An open gRPC stream is not idle, so a long lived
+		// call is unaffected by this.
+		ReadHeaderTimeout: 20 * time.Second,
+		IdleTimeout:       90 * time.Second,
+	}
+	if !isTLS {
+		srv.Protocols = h2cPriorKnowledge()
+	}
+	ln := &oneConnListener{conn: conn, closed: make(chan struct{})}
+	// Serve returns once the listener refuses a second connection, which it
+	// does only after this one is closed, so this call spans the life of the
+	// connection exactly as the HTTP/1.1 read loop does.
+	_ = srv.Serve(ln)
+}
+
+// decideH2 applies the whole policy to one HTTP/2 request.
+//
+// It is the same sequence as the HTTP/1.1 reader, in the same order, and the
+// order is load bearing in the same place: the tripwire runs before the mode
+// is acted on, so a credential that can act on production is refused whatever
+// the rule says should happen to the host.
+func (p *proxy) decideH2(
+	w http.ResponseWriter, r *http.Request, host string, port int, isTLS bool, via string,
+	transport *http.Transport, scheme string,
+) {
+	started := time.Now()
+	preq := policy.Request{Host: host, Port: port, Method: r.Method, Path: r.URL.Path, TLS: isTLS}
+	d := p.engine.Evaluate(preq)
+
+	rec := record{
+		Event: "decision", Method: r.Method, Host: host, Port: port, Path: r.URL.Path,
+		TLS: isTLS, Mode: string(d.Mode), Rule: d.RuleHost, Reason: d.Reason(),
+		Allowed: d.Allowed(), Via: via,
+	}
+	if found := p.tripwire(r, host); len(found) > 0 {
+		rec.Status = http.StatusForbidden
+		rec.Allowed = false
+		rec.Reason = "This request carries a live credential: " + livekey.Describe(found)
+		rec.Duration = time.Since(started).String()
+		p.emit(rec)
+		relayRaw(w, func(raw io.Writer) {
+			writeRawForbidden(raw, refusalForLiveCredential(preq, found))
+		})
+		return
+	}
+
+	switch d.Mode {
+	case schema.ModeCapture:
+		// Emitted after the answer rather than before it, so a capture this
+		// build refuses is logged as the refusal it was, exactly as on the
+		// other paths.
+		relayRaw(w, func(raw io.Writer) { p.capture(raw, r, preq, d, &rec) })
+		rec.Duration = time.Since(started).String()
+		p.emit(rec)
+		return
+	case schema.ModeSynth:
+		relayRaw(w, func(raw io.Writer) { p.serveSynth(raw, r, host, &rec) })
+		rec.Duration = time.Since(started).String()
+		p.emit(rec)
+		return
+	case schema.ModeMock:
+		relayRaw(w, func(raw io.Writer) { p.serveMock(raw, r, host, &rec) })
+		rec.Duration = time.Since(started).String()
+		p.emit(rec)
+		return
+	}
+
+	if !d.Allowed() {
+		rec.Status = http.StatusForbidden
+		rec.Duration = time.Since(started).String()
+		p.emit(rec)
+		relayRaw(w, func(raw io.Writer) { writeRefusalRaw(raw, d, preq) })
+		return
+	}
+
+	outbound := r.Clone(r.Context())
+	outbound.RequestURI = ""
+	outbound.URL.Scheme = scheme
+	outbound.URL.Host = host
+	// TE is hop by hop everywhere else and is the one exception HTTP/2 makes,
+	// under RFC 9113 section 8.2.2, for the single value "trailers". Every
+	// gRPC client sends it, so it is put back after the hop by hop sweep
+	// rather than left out of the sweep, which would let any other value
+	// through.
+	trailers := strings.EqualFold(strings.TrimSpace(outbound.Header.Get("Te")), "trailers")
+	for _, h := range hopByHop {
+		outbound.Header.Del(h)
+	}
+	if trailers {
+		outbound.Header.Set("Te", "trailers")
+	}
+	if d.Mode == schema.ModeSandbox {
+		applySandbox(outbound, host, p.credentials[d.Credential])
+		rec.Substituted = p.credentials[d.Credential] != ""
+	}
+	if d.RateLimit != "" {
+		if waited := p.limits.wait(d.RuleHost, d.RateLimit); waited > 0 {
+			rec.WaitedMs = waited.Milliseconds()
+			rec.Limit = describeRate(d.RateLimit)
+		}
+	}
+
+	resp, err := transport.RoundTrip(outbound)
+	if err != nil {
+		rec.Error = err.Error()
+		rec.Status = http.StatusBadGateway
+		rec.Duration = time.Since(started).String()
+		p.emit(rec)
+		http.Error(w, "af-proxy: could not reach "+host+": "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	rec.Status = resp.StatusCode
+	rec.Bytes = relayH2Response(w, resp)
+	rec.Duration = time.Since(started).String()
+	p.emit(rec)
+}
+
+// relayH2Response copies an upstream response onto an HTTP/2 stream.
+//
+// The body is streamed and flushed rather than read into memory. A gRPC call
+// can be open for hours and can carry more than fits anywhere, so a bounded
+// read here would be a truncation on a path where truncation is silent: the
+// stream would simply end early and the client would report a status the
+// server never sent.
+func relayH2Response(w http.ResponseWriter, resp *http.Response) int64 {
+	// A gRPC server that fails before sending a message answers with one
+	// headers frame carrying grpc-status and closing the stream. Go's client
+	// surfaces those as ordinary response headers, because that is what they
+	// are on the wire. Relaying them as headers would end this stream with no
+	// trailers at all, and every gRPC client reads a missing trailer as a
+	// broken server rather than as the error the server actually sent, so a
+	// NotFound would reach the application as an internal protocol failure.
+	deferred := http.Header{}
+	if resp.Header.Get("Grpc-Status") != "" {
+		for _, k := range []string{"Grpc-Status", "Grpc-Message", "Grpc-Status-Details-Bin"} {
+			for _, v := range resp.Header.Values(k) {
+				deferred.Add(k, v)
+			}
+			resp.Header.Del(k)
+		}
+	}
+	for k, vs := range resp.Header {
+		if isHopByHop(k) {
+			continue
+		}
+		for _, v := range vs {
+			w.Header().Add(k, v)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+	// Flushed before the body, because a gRPC client waits for the response
+	// headers before it will send anything more on a bidirectional stream.
+	// Holding them until the first frame of the body deadlocks a call whose
+	// next message depends on the one before it.
+	flush(w)
+
+	n := copyFlushing(w, resp.Body)
+
+	for k, vs := range deferred {
+		for _, v := range vs {
+			w.Header().Add(http.TrailerPrefix+k, v)
+		}
+	}
+	for k, vs := range resp.Trailer {
+		for _, v := range vs {
+			w.Header().Add(http.TrailerPrefix+k, v)
+		}
+	}
+	return n
+}
+
+// copyFlushing copies a body and flushes each piece as it arrives.
+//
+// io.Copy alone is wrong on this path. The HTTP/2 writer buffers, so a
+// streaming response arrives at the application in whatever chunks the buffer
+// happened to fill, and a server sending one message a second would be read as
+// a server sending nothing for a minute.
+func copyFlushing(w http.ResponseWriter, r io.Reader) int64 {
+	buf := make([]byte, 32<<10)
+	var total int64
+	for {
+		n, readErr := r.Read(buf)
+		if n > 0 {
+			written, writeErr := w.Write(buf[:n])
+			total += int64(written)
+			flush(w)
+			if writeErr != nil {
+				return total
+			}
+		}
+		if readErr != nil {
+			return total
+		}
+	}
+}
+
+func flush(w http.ResponseWriter) {
+	if f, ok := w.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// relayRaw runs a handler that writes a whole HTTP/1.1 response and relays
+// what it wrote onto an HTTP/2 stream.
+//
+// Capture, mock, synth and every refusal write onto a raw connection, because
+// the two HTTP/1.1 paths hold one and have nothing else to write onto. This
+// adapter is what keeps a single implementation of each of those: a second
+// copy written against ResponseWriter is a second thing to keep correct, and
+// the two would disagree about a provider's shape long before anybody noticed.
+//
+// The response is piped rather than buffered, so a large mocked body is not
+// held in memory, and the writer is joined before this returns, so the decision
+// record the handler filled in is safe to read afterwards.
+func relayRaw(w http.ResponseWriter, write func(io.Writer)) {
+	pr, pw := io.Pipe()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		write(pw)
+		_ = pw.Close()
+	}()
+
+	resp, err := http.ReadResponse(bufio.NewReader(pr), nil)
+	if err != nil {
+		_ = pr.CloseWithError(err)
+		<-done
+		http.Error(w, "af-proxy: the answer for this request could not be written", http.StatusBadGateway)
+		return
+	}
+	for k, vs := range resp.Header {
+		if isHopByHop(k) {
+			continue
+		}
+		for _, v := range vs {
+			w.Header().Add(k, v)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+	flush(w)
+	copyFlushing(w, resp.Body)
+	_ = resp.Body.Close()
+	_ = pr.Close()
+	<-done
+}
+
+// isHopByHop reports whether a header belongs to one connection rather than to
+// the message.
+//
+// It matters more here than on the HTTP/1.1 paths. Connection, Keep-Alive and
+// Transfer-Encoding are not merely pointless on an HTTP/2 stream, they are
+// forbidden by RFC 9113 section 8.2.2, and a client is entitled to treat one
+// as a protocol error and drop the whole connection.
+func isHopByHop(header string) bool {
+	for _, h := range hopByHop {
+		if strings.EqualFold(h, header) {
+			return true
+		}
+	}
+	return false
+}
+
+// errConnectionFinished ends the one connection server's accept loop.
+var errConnectionFinished = errors.New("this connection has been served")
+
+// oneConnListener hands an already accepted connection to an http.Server.
+//
+// net/http will only run its HTTP/2 server for a connection that arrives
+// through a listener, and this connection arrived through a TLS handshake the
+// sidecar performed itself. The second Accept blocks until the connection is
+// closed rather than returning at once, so Serve outlives the connection it
+// was given and the caller can wait on Serve instead of inventing its own
+// signal for when the last stream ended.
+type oneConnListener struct {
+	conn net.Conn
+	// handed is read and written only by Serve's accept loop, which is one
+	// goroutine, so it needs no lock.
+	handed bool
+	once   sync.Once
+	closed chan struct{}
+}
+
+func (l *oneConnListener) Accept() (net.Conn, error) {
+	if !l.handed {
+		l.handed = true
+		return &closeNotifyConn{Conn: l.conn, listener: l}, nil
+	}
+	<-l.closed
+	return nil, errConnectionFinished
+}
+
+func (l *oneConnListener) Close() error { return nil }
+
+func (l *oneConnListener) Addr() net.Addr { return l.conn.LocalAddr() }
+
+// closeNotifyConn reports when the served connection is closed.
+type closeNotifyConn struct {
+	net.Conn
+	listener *oneConnListener
+}
+
+func (c *closeNotifyConn) Close() error {
+	err := c.Conn.Close()
+	c.listener.once.Do(func() { close(c.listener.closed) })
+	return err
+}

--- a/engine/cmd/af-proxy/main.go
+++ b/engine/cmd/af-proxy/main.go
@@ -101,21 +101,24 @@ func main() {
 		// Read from this process's environment rather than from the
 		// configuration file, so a key never passes through something the
 		// engine wrote to disk.
-		synth: synthFromEnvironment(os.Getenv),
-		transport: &http.Transport{
-			MaxIdleConnsPerHost: 16,
-			IdleConnTimeout:     60 * time.Second,
-			// The origin's certificate is verified normally. Reading inside a
-			// connection is not a licence to stop checking who is on the other
-			// end of it; if anything it makes the check more important,
-			// because the client can no longer do it itself.
-			TLSHandshakeTimeout: 20 * time.Second,
-		},
+		synth:       synthFromEnvironment(os.Getenv),
+		transport:   newForwardTransport(nil),
+		transportH2: newForwardTransport(h2ALPN()),
+		// Three transports rather than one, because the protocol the client
+		// spoke is the protocol its answer has to be framed in. A gRPC status
+		// travels in HTTP/2 trailers and an HTTP/1.1 forward would drop it,
+		// and an HTTP/2 response written onto an HTTP/1.1 connection carries
+		// its own version into the status line. Which one is used follows the
+		// connection the request arrived on and nothing else.
+		transportH2C: newForwardTransport(h2cPriorKnowledge()),
 	}
 	// Set after construction because the dialer is a method on the proxy it
 	// belongs to. Every re-originated request goes through it, so the address
-	// guard applies to the inspected path as well as to the tunnelled one.
+	// guard applies to the inspected path as well as to the tunnelled one, and
+	// to every protocol rather than to the one that existed first.
 	p.transport.DialContext = p.dialGuarded
+	p.transportH2.DialContext = p.dialGuarded
+	p.transportH2C.DialContext = p.dialGuarded
 
 	packs, err := mockpack.Builtin()
 	if err != nil {
@@ -320,8 +323,14 @@ type proxy struct {
 	// to read inside. Nil when the environment has no authority, in which
 	// case every TLS connection is tunnelled.
 	ca *certAuthority
-	// transport re-originates inspected requests.
+	// transport re-originates inspected requests over HTTP/1.1.
 	transport *http.Transport
+	// transportH2 re-originates a request that arrived over HTTP/2 inside a
+	// terminated TLS connection, negotiating h2 with the origin.
+	transportH2 *http.Transport
+	// transportH2C re-originates a request that arrived over cleartext
+	// HTTP/2, which has no handshake to negotiate in.
+	transportH2C *http.Transport
 	// credentials are the sandbox values, by the name a rule refers to.
 	credentials map[string]string
 	// mocks answers requests for hosts set to mock.

--- a/engine/cmd/af-proxy/mitm.go
+++ b/engine/cmd/af-proxy/mitm.go
@@ -184,6 +184,12 @@ func (p *proxy) inspectTLS(conn net.Conn, br *bufio.Reader, sni string) {
 	server := tls.Server(&prefixedConn{Conn: conn, r: br}, &tls.Config{
 		Certificates: []tls.Certificate{*leaf},
 		MinVersion:   tls.VersionTLS12,
+		// Offered in preference order, and the negotiated protocol decides
+		// how the connection is read below. Naming none of them left the
+		// negotiated protocol empty, which every gRPC client refuses outright:
+		// HTTP/2 over TLS is negotiated with ALPN, gRPC is HTTP/2, so a
+		// terminator that selects no protocol is one gRPC will not talk to.
+		NextProtos: []string{"h2", "http/1.1"},
 	})
 	_ = server.SetDeadline(time.Now().Add(30 * time.Second))
 	if err := server.Handshake(); err != nil {
@@ -202,6 +208,15 @@ func (p *proxy) inspectTLS(conn net.Conn, br *bufio.Reader, sni string) {
 	}
 	_ = server.SetDeadline(time.Time{})
 	defer func() { _ = server.Close() }()
+
+	// The reader follows the handshake. Negotiating h2 and then reading
+	// HTTP/1.1 anyway would be worse than negotiating nothing, because the
+	// client would have committed to HTTP/2 and every frame it sent would be
+	// misparsed as a request line.
+	if server.ConnectionState().NegotiatedProtocol == "h2" {
+		p.serveInspectedH2(server, sni)
+		return
+	}
 
 	// One connection can carry many requests, and each is decided on its own.
 	// A client that keeps a connection open to an allowed path and then asks

--- a/engine/cmd/af-proxy/transparent.go
+++ b/engine/cmd/af-proxy/transparent.go
@@ -39,6 +39,17 @@ func (p *proxy) serveTransparentHTTP(conn net.Conn) {
 	_ = conn.SetReadDeadline(time.Now().Add(30 * time.Second))
 
 	br := bufio.NewReader(conn)
+	// Before the HTTP/1.1 reader, because a cleartext HTTP/2 connection opens
+	// with a preface that reads as a request whose method is PRI and which
+	// carries no Host header at all. That was refused for naming no host,
+	// which was true about what the reader saw and said nothing about what had
+	// happened, and it is how every gRPC client built with insecure
+	// credentials met this sidecar.
+	if looksLikeH2C(br) {
+		_ = conn.SetReadDeadline(time.Time{})
+		p.serveTransparentH2C(conn, br)
+		return
+	}
 	req, err := http.ReadRequest(br)
 	if err != nil {
 		return
@@ -337,7 +348,11 @@ func parseServerName(b []byte) (string, error) {
 
 // writeRefusalRaw writes the refusal onto a connection that is not being
 // served by net/http.
-func writeRefusalRaw(conn net.Conn, d policy.Decision, req policy.Request) {
+//
+// An io.Writer rather than a net.Conn because the HTTP/2 path relays what this
+// writes rather than handing it a socket, and one refusal that both paths use
+// is what keeps them from disagreeing about what a refusal says.
+func writeRefusalRaw(conn io.Writer, d policy.Decision, req policy.Request) {
 	body := refusalBody(d, req)
 	// Not checked: the refusal is best effort on a connection that is about
 	// to be closed either way.

--- a/engine/go.mod
+++ b/engine/go.mod
@@ -20,6 +20,7 @@ require (
 	golang.org/x/crypto v0.56.0
 	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0
+	google.golang.org/grpc v1.83.1
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.58.0
 	pgregory.net/rapid v1.3.0
@@ -54,6 +55,7 @@ require (
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	golang.org/x/net v0.58.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260819154853-08b0e4226688 // indirect
 	google.golang.org/protobuf v1.36.12 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/engine/go.sum
+++ b/engine/go.sum
@@ -92,6 +92,8 @@ github.com/go-openapi/testify/enable/yaml/v2 v2.6.0 h1:gGHwAJ0R/5jU8BEGDbfRNR3hL
 github.com/go-openapi/testify/enable/yaml/v2 v2.6.0/go.mod h1:tY+St1SGq4NFl0QIqdTY4aEdbChAHxhyB77XQi9iJCo=
 github.com/go-openapi/testify/v2 v2.6.0 h1:5PKH2HE7YJ/LuRPQGvSxBRlFXNQhSetBLlGAgUEu3ug=
 github.com/go-openapi/testify/v2 v2.6.0/go.mod h1:SgsVHtfooshd0tublTtJ50FPKhujf47YRqauXXOUxfw=
+github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
+github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/gnostic-models v0.7.0 h1:qwTtogB15McXDaNqTZdzPJRHvaVJlAl+HVQnLmJEJxo=
 github.com/google/gnostic-models v0.7.0/go.mod h1:whL5G0m6dmc5cPxKc5bdKdEN3UjI7OUGxBlw57miDrQ=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
@@ -239,6 +241,8 @@ golang.org/x/time v0.15.0 h1:bbrp8t3bGUeFOx08pvsMYRTCVSMk89u4tKbNOZbp88U=
 golang.org/x/time v0.15.0/go.mod h1:Y4YMaQmXwGQZoFaVFk4YpCt4FLQMYKZe9oeV/f4MSno=
 golang.org/x/tools v0.48.0 h1:3+hClM1aLL5mjMKm5ovokw9epgRXPuu2tILgismM6RE=
 golang.org/x/tools v0.48.0/go.mod h1:08xX0orndb/F7jJxGDicx061tyd5pcMto75YMAXr6lk=
+gonum.org/v1/gonum v0.17.0 h1:VbpOemQlsSMrYmn7T2OUvQ4dqxQXU+ouZFQsZOx50z4=
+gonum.org/v1/gonum v0.17.0/go.mod h1:El3tOrEuMpv2UdMrbNlKEh9vd86bmQ6vqIcDwxEOc1E=
 google.golang.org/genproto/googleapis/api v0.0.0-20260819154853-08b0e4226688 h1:ax2KzoSRIZU/M0cIxri3pKxy99vniH1PVxWC6si/eZI=
 google.golang.org/genproto/googleapis/api v0.0.0-20260819154853-08b0e4226688/go.mod h1:1RJ9BQGyNdZwkGc1eTqkErfRZ6RJyYPHZo73BZ1vQqI=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260819154853-08b0e4226688 h1:cYNAzI2sUwhmCcoj9TxvihSrqsxt6uIkj3rDRhSDmW4=

--- a/engine/internal/proxyimage/sources.gen.go
+++ b/engine/internal/proxyimage/sources.gen.go
@@ -761,6 +761,7 @@ func (p *proxy) serveH2Conn(
 	conn net.Conn, sni string, port int, isTLS bool, via string,
 	transport *http.Transport, scheme string,
 ) {
+	ln := &oneConnListener{conn: conn, closed: make(chan struct{})}
 	srv := &http.Server{
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// The authority the client wrote, not the name in the handshake.
@@ -778,11 +779,26 @@ func (p *proxy) serveH2Conn(
 		// call is unaffected by this.
 		ReadHeaderTimeout: 20 * time.Second,
 		IdleTimeout:       90 * time.Second,
+		// The end of the connection is reported here rather than by a wrapper
+		// around it, and that is the whole reason this hook exists. net/http
+		// decides a terminated connection's protocol by asking the connection
+		// it was handed for its ConnectionState, and a struct that embeds
+		// net.Conn does not carry that method however faithfully it forwards
+		// everything else. Wrapping the connection to learn when it closed
+		// therefore left net/http unable to see that h2 had been negotiated,
+		// so it read the HTTP/2 frame stream as an HTTP/1.1 request line and
+		// forwarded the connection preface upstream as a request whose method
+		// was PRI. Nothing in the wrapper looked wrong and every gRPC call
+		// through the sidecar failed.
+		ConnState: func(_ net.Conn, state http.ConnState) {
+			if state == http.StateClosed || state == http.StateHijacked {
+				ln.finished()
+			}
+		},
 	}
 	if !isTLS {
 		srv.Protocols = h2cPriorKnowledge()
 	}
-	ln := &oneConnListener{conn: conn, closed: make(chan struct{})}
 	// Serve returns once the listener refuses a second connection, which it
 	// does only after this one is closed, so this call spans the life of the
 	// connection exactly as the HTTP/1.1 read loop does.
@@ -1049,6 +1065,13 @@ var errConnectionFinished = errors.New("this connection has been served")
 // closed rather than returning at once, so Serve outlives the connection it
 // was given and the caller can wait on Serve instead of inventing its own
 // signal for when the last stream ended.
+//
+// The connection is handed over exactly as it arrived, with nothing wrapped
+// around it. What net/http is given here is a *tls.Conn and it has to stay
+// one: the protocol dispatch asserts ConnectionState on it, and both the
+// HTTP/2 server it selects on that basis and the older ALPN hook behind it
+// read the connection's own type. Serve is told the connection ended through
+// the server's ConnState hook instead.
 type oneConnListener struct {
 	conn net.Conn
 	// handed is read and written only by Serve's accept loop, which is one
@@ -1061,7 +1084,7 @@ type oneConnListener struct {
 func (l *oneConnListener) Accept() (net.Conn, error) {
 	if !l.handed {
 		l.handed = true
-		return &closeNotifyConn{Conn: l.conn, listener: l}, nil
+		return l.conn, nil
 	}
 	<-l.closed
 	return nil, errConnectionFinished
@@ -1071,16 +1094,13 @@ func (l *oneConnListener) Close() error { return nil }
 
 func (l *oneConnListener) Addr() net.Addr { return l.conn.LocalAddr() }
 
-// closeNotifyConn reports when the served connection is closed.
-type closeNotifyConn struct {
-	net.Conn
-	listener *oneConnListener
-}
-
-func (c *closeNotifyConn) Close() error {
-	err := c.Conn.Close()
-	c.listener.once.Do(func() { close(c.listener.closed) })
-	return err
+// finished releases the accept loop that is waiting for this connection to
+// end.
+//
+// Guarded by a sync.Once because the caller watches two terminal states and
+// should not have to know that net/http reports exactly one of them.
+func (l *oneConnListener) finished() {
+	l.once.Do(func() { close(l.closed) })
 }
 `,
 	"cmd/af-proxy/internal.go": `package main

--- a/engine/internal/proxyimage/sources.gen.go
+++ b/engine/internal/proxyimage/sources.gen.go
@@ -617,6 +617,472 @@ func describeDNS(self net.IP, internal []string) string {
 		self, strings.Join(internal, ", "))
 }
 `,
+	"cmd/af-proxy/h2.go": `package main
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/antifailure/antifailure/engine/internal/policy"
+	"github.com/antifailure/antifailure/engine/pkg/livekey"
+	"github.com/antifailure/antifailure/engine/pkg/schema"
+)
+
+// HTTP/2, which is the protocol gRPC is defined over.
+//
+// The sidecar terminated TLS and then read HTTP/1.1 out of the connection
+// unconditionally, with no ALPN offered at all. Two things followed from that
+// and both of them break gRPC outright.
+//
+// The first is the handshake. gRPC is HTTP/2 and HTTP/2 over TLS is negotiated
+// with ALPN, so every gRPC client offers h2 and requires the server to select
+// it. A terminator that names no protocol leaves the negotiated protocol
+// empty, and grpc-go refuses the connection there with "missing selected ALPN
+// property" before a single request is written. The application does not see a
+// policy refusal or a network error it can attribute; it sees its own client
+// library declining to talk to what it believes is the origin.
+//
+// The second is the read. Negotiating h2 without changing how the connection
+// is read would be worse than not negotiating it, because the client would
+// then commit to HTTP/2 and the sidecar would try to parse an HTTP/2 frame
+// stream as an HTTP/1.1 request line. So the negotiated protocol decides the
+// reader, here, and the two are set in one place.
+//
+// Everything the sidecar decides for an HTTP/1.1 request is decided here for
+// an HTTP/2 one: the host match, the mode, the live credential tripwire, the
+// sandbox substitution, the rate limit and the decision record. A protocol
+// that reached the network without passing the policy would be a containment
+// hole far larger than the gap it closed.
+//
+// What is NOT the same is the shape of the answer. The HTTP/1.1 paths hold a
+// raw connection and write a whole response onto it by hand; an HTTP/2 stream
+// is written through an http.ResponseWriter. Rather than a second copy of
+// capture, mock and synth for this path, the one implementation writes onto a
+// pipe and its response is relayed, so a mode cannot behave differently
+// depending on which protocol the application happened to speak.
+
+// h2ALPN is the protocol set for a transport that may use HTTP/2 over TLS.
+//
+// HTTP/1.1 stays in the set. An upstream that does not offer h2 selects
+// http/1.1 during the handshake and the request is forwarded over that, which
+// is what should happen: the client's protocol and the origin's are separate
+// negotiations and nothing requires them to agree.
+func h2ALPN() *http.Protocols {
+	var p http.Protocols
+	p.SetHTTP1(true)
+	p.SetHTTP2(true)
+	return &p
+}
+
+// h2cPriorKnowledge is the protocol set for a transport that speaks HTTP/2 on
+// a plain connection.
+//
+// There is no ALPN on a cleartext connection, so this is prior knowledge: the
+// client committed to HTTP/2 by sending the connection preface and the
+// upstream is expected to speak it too. HTTP/1.1 is left out on purpose,
+// because a silent downgrade here would hand an HTTP/1.1 response to a client
+// that has already framed its side as HTTP/2.
+func h2cPriorKnowledge() *http.Protocols {
+	var p http.Protocols
+	p.SetUnencryptedHTTP2(true)
+	return &p
+}
+
+// newForwardTransport builds a transport that re-originates a request.
+//
+// A nil protocol set is the historical behaviour and is deliberate rather
+// than incidental: net/http disables HTTP/2 on any transport carrying a custom
+// dialer, and this one carries the address guard, so the forwarding half was
+// HTTP/1.1 only whatever the client spoke. Terminating h2 and then forwarding
+// over HTTP/1.1 would strip the trailers a gRPC status travels in, so the
+// protocol has to be asked for explicitly on both halves.
+func newForwardTransport(protocols *http.Protocols) *http.Transport {
+	return &http.Transport{
+		MaxIdleConnsPerHost: 16,
+		IdleConnTimeout:     60 * time.Second,
+		// The origin's certificate is verified normally. Reading inside a
+		// connection is not a licence to stop checking who is on the other
+		// end of it; if anything it makes the check more important, because
+		// the client can no longer do it itself.
+		TLSHandshakeTimeout: 20 * time.Second,
+		Protocols:           protocols,
+	}
+}
+
+// h2Preface is the first thing a client sends on a cleartext HTTP/2
+// connection, before any frame.
+const h2Preface = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
+
+// looksLikeH2C reports whether a plain connection is about to speak HTTP/2.
+//
+// Three bytes are peeked before twenty four, and that ordering is the whole
+// care in this function. Peeking the full preface up front would block until
+// twenty four bytes arrived, and a client that writes its request line and its
+// headers in separate packets has sent fewer than that when it stops to draw
+// breath. PRI is not the start of any HTTP/1.1 method, so three bytes settle
+// it for every request that is not one, and only a connection that really does
+// begin with PRI waits for the rest.
+func looksLikeH2C(br *bufio.Reader) bool {
+	head, err := br.Peek(3)
+	if err != nil || string(head) != "PRI" {
+		return false
+	}
+	full, err := br.Peek(len(h2Preface))
+	return err == nil && string(full) == h2Preface
+}
+
+// serveInspectedH2 serves one terminated connection that negotiated h2.
+func (p *proxy) serveInspectedH2(conn net.Conn, sni string) {
+	p.serveH2Conn(conn, sni, 443, true, "inspect", p.transportH2, "https")
+}
+
+// serveTransparentH2C serves one cleartext connection that opened with the
+// HTTP/2 preface.
+//
+// A gRPC client built with insecure credentials, which is what every local
+// emulator's documented setup uses, speaks exactly this. It arrived on the
+// transparent port 80 listener, where the HTTP/1.1 reader turned the preface
+// into a request whose method was PRI and whose Host header was absent, and
+// refused it for carrying no host. The refusal was correct about what it saw
+// and said nothing about what had actually happened.
+func (p *proxy) serveTransparentH2C(conn net.Conn, br *bufio.Reader) {
+	p.serveH2Conn(&prefixedConn{Conn: conn, r: br}, "", 80, false, "transparent", p.transportH2C, "http")
+}
+
+// serveH2Conn runs an HTTP/2 server over one connection and decides every
+// request on it.
+func (p *proxy) serveH2Conn(
+	conn net.Conn, sni string, port int, isTLS bool, via string,
+	transport *http.Transport, scheme string,
+) {
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// The authority the client wrote, not the name in the handshake.
+			// The two can disagree, and the request is going where the
+			// authority says, which is the same reason the HTTP/1.1 reader
+			// prefers the Host header over the server name.
+			host := sni
+			if r.Host != "" {
+				host, _ = splitHostPort(r.Host, port)
+			}
+			p.decideH2(w, r, host, port, isTLS, via, transport, scheme)
+		}),
+		// A connection that never finishes a request must not hold a
+		// goroutine forever. An open gRPC stream is not idle, so a long lived
+		// call is unaffected by this.
+		ReadHeaderTimeout: 20 * time.Second,
+		IdleTimeout:       90 * time.Second,
+	}
+	if !isTLS {
+		srv.Protocols = h2cPriorKnowledge()
+	}
+	ln := &oneConnListener{conn: conn, closed: make(chan struct{})}
+	// Serve returns once the listener refuses a second connection, which it
+	// does only after this one is closed, so this call spans the life of the
+	// connection exactly as the HTTP/1.1 read loop does.
+	_ = srv.Serve(ln)
+}
+
+// decideH2 applies the whole policy to one HTTP/2 request.
+//
+// It is the same sequence as the HTTP/1.1 reader, in the same order, and the
+// order is load bearing in the same place: the tripwire runs before the mode
+// is acted on, so a credential that can act on production is refused whatever
+// the rule says should happen to the host.
+func (p *proxy) decideH2(
+	w http.ResponseWriter, r *http.Request, host string, port int, isTLS bool, via string,
+	transport *http.Transport, scheme string,
+) {
+	started := time.Now()
+	preq := policy.Request{Host: host, Port: port, Method: r.Method, Path: r.URL.Path, TLS: isTLS}
+	d := p.engine.Evaluate(preq)
+
+	rec := record{
+		Event: "decision", Method: r.Method, Host: host, Port: port, Path: r.URL.Path,
+		TLS: isTLS, Mode: string(d.Mode), Rule: d.RuleHost, Reason: d.Reason(),
+		Allowed: d.Allowed(), Via: via,
+	}
+	if found := p.tripwire(r, host); len(found) > 0 {
+		rec.Status = http.StatusForbidden
+		rec.Allowed = false
+		rec.Reason = "This request carries a live credential: " + livekey.Describe(found)
+		rec.Duration = time.Since(started).String()
+		p.emit(rec)
+		relayRaw(w, func(raw io.Writer) {
+			writeRawForbidden(raw, refusalForLiveCredential(preq, found))
+		})
+		return
+	}
+
+	switch d.Mode {
+	case schema.ModeCapture:
+		// Emitted after the answer rather than before it, so a capture this
+		// build refuses is logged as the refusal it was, exactly as on the
+		// other paths.
+		relayRaw(w, func(raw io.Writer) { p.capture(raw, r, preq, d, &rec) })
+		rec.Duration = time.Since(started).String()
+		p.emit(rec)
+		return
+	case schema.ModeSynth:
+		relayRaw(w, func(raw io.Writer) { p.serveSynth(raw, r, host, &rec) })
+		rec.Duration = time.Since(started).String()
+		p.emit(rec)
+		return
+	case schema.ModeMock:
+		relayRaw(w, func(raw io.Writer) { p.serveMock(raw, r, host, &rec) })
+		rec.Duration = time.Since(started).String()
+		p.emit(rec)
+		return
+	}
+
+	if !d.Allowed() {
+		rec.Status = http.StatusForbidden
+		rec.Duration = time.Since(started).String()
+		p.emit(rec)
+		relayRaw(w, func(raw io.Writer) { writeRefusalRaw(raw, d, preq) })
+		return
+	}
+
+	outbound := r.Clone(r.Context())
+	outbound.RequestURI = ""
+	outbound.URL.Scheme = scheme
+	outbound.URL.Host = host
+	// TE is hop by hop everywhere else and is the one exception HTTP/2 makes,
+	// under RFC 9113 section 8.2.2, for the single value "trailers". Every
+	// gRPC client sends it, so it is put back after the hop by hop sweep
+	// rather than left out of the sweep, which would let any other value
+	// through.
+	trailers := strings.EqualFold(strings.TrimSpace(outbound.Header.Get("Te")), "trailers")
+	for _, h := range hopByHop {
+		outbound.Header.Del(h)
+	}
+	if trailers {
+		outbound.Header.Set("Te", "trailers")
+	}
+	if d.Mode == schema.ModeSandbox {
+		applySandbox(outbound, host, p.credentials[d.Credential])
+		rec.Substituted = p.credentials[d.Credential] != ""
+	}
+	if d.RateLimit != "" {
+		if waited := p.limits.wait(d.RuleHost, d.RateLimit); waited > 0 {
+			rec.WaitedMs = waited.Milliseconds()
+			rec.Limit = describeRate(d.RateLimit)
+		}
+	}
+
+	resp, err := transport.RoundTrip(outbound)
+	if err != nil {
+		rec.Error = err.Error()
+		rec.Status = http.StatusBadGateway
+		rec.Duration = time.Since(started).String()
+		p.emit(rec)
+		http.Error(w, "af-proxy: could not reach "+host+": "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	rec.Status = resp.StatusCode
+	rec.Bytes = relayH2Response(w, resp)
+	rec.Duration = time.Since(started).String()
+	p.emit(rec)
+}
+
+// relayH2Response copies an upstream response onto an HTTP/2 stream.
+//
+// The body is streamed and flushed rather than read into memory. A gRPC call
+// can be open for hours and can carry more than fits anywhere, so a bounded
+// read here would be a truncation on a path where truncation is silent: the
+// stream would simply end early and the client would report a status the
+// server never sent.
+func relayH2Response(w http.ResponseWriter, resp *http.Response) int64 {
+	// A gRPC server that fails before sending a message answers with one
+	// headers frame carrying grpc-status and closing the stream. Go's client
+	// surfaces those as ordinary response headers, because that is what they
+	// are on the wire. Relaying them as headers would end this stream with no
+	// trailers at all, and every gRPC client reads a missing trailer as a
+	// broken server rather than as the error the server actually sent, so a
+	// NotFound would reach the application as an internal protocol failure.
+	deferred := http.Header{}
+	if resp.Header.Get("Grpc-Status") != "" {
+		for _, k := range []string{"Grpc-Status", "Grpc-Message", "Grpc-Status-Details-Bin"} {
+			for _, v := range resp.Header.Values(k) {
+				deferred.Add(k, v)
+			}
+			resp.Header.Del(k)
+		}
+	}
+	for k, vs := range resp.Header {
+		if isHopByHop(k) {
+			continue
+		}
+		for _, v := range vs {
+			w.Header().Add(k, v)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+	// Flushed before the body, because a gRPC client waits for the response
+	// headers before it will send anything more on a bidirectional stream.
+	// Holding them until the first frame of the body deadlocks a call whose
+	// next message depends on the one before it.
+	flush(w)
+
+	n := copyFlushing(w, resp.Body)
+
+	for k, vs := range deferred {
+		for _, v := range vs {
+			w.Header().Add(http.TrailerPrefix+k, v)
+		}
+	}
+	for k, vs := range resp.Trailer {
+		for _, v := range vs {
+			w.Header().Add(http.TrailerPrefix+k, v)
+		}
+	}
+	return n
+}
+
+// copyFlushing copies a body and flushes each piece as it arrives.
+//
+// io.Copy alone is wrong on this path. The HTTP/2 writer buffers, so a
+// streaming response arrives at the application in whatever chunks the buffer
+// happened to fill, and a server sending one message a second would be read as
+// a server sending nothing for a minute.
+func copyFlushing(w http.ResponseWriter, r io.Reader) int64 {
+	buf := make([]byte, 32<<10)
+	var total int64
+	for {
+		n, readErr := r.Read(buf)
+		if n > 0 {
+			written, writeErr := w.Write(buf[:n])
+			total += int64(written)
+			flush(w)
+			if writeErr != nil {
+				return total
+			}
+		}
+		if readErr != nil {
+			return total
+		}
+	}
+}
+
+func flush(w http.ResponseWriter) {
+	if f, ok := w.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// relayRaw runs a handler that writes a whole HTTP/1.1 response and relays
+// what it wrote onto an HTTP/2 stream.
+//
+// Capture, mock, synth and every refusal write onto a raw connection, because
+// the two HTTP/1.1 paths hold one and have nothing else to write onto. This
+// adapter is what keeps a single implementation of each of those: a second
+// copy written against ResponseWriter is a second thing to keep correct, and
+// the two would disagree about a provider's shape long before anybody noticed.
+//
+// The response is piped rather than buffered, so a large mocked body is not
+// held in memory, and the writer is joined before this returns, so the decision
+// record the handler filled in is safe to read afterwards.
+func relayRaw(w http.ResponseWriter, write func(io.Writer)) {
+	pr, pw := io.Pipe()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		write(pw)
+		_ = pw.Close()
+	}()
+
+	resp, err := http.ReadResponse(bufio.NewReader(pr), nil)
+	if err != nil {
+		_ = pr.CloseWithError(err)
+		<-done
+		http.Error(w, "af-proxy: the answer for this request could not be written", http.StatusBadGateway)
+		return
+	}
+	for k, vs := range resp.Header {
+		if isHopByHop(k) {
+			continue
+		}
+		for _, v := range vs {
+			w.Header().Add(k, v)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+	flush(w)
+	copyFlushing(w, resp.Body)
+	_ = resp.Body.Close()
+	_ = pr.Close()
+	<-done
+}
+
+// isHopByHop reports whether a header belongs to one connection rather than to
+// the message.
+//
+// It matters more here than on the HTTP/1.1 paths. Connection, Keep-Alive and
+// Transfer-Encoding are not merely pointless on an HTTP/2 stream, they are
+// forbidden by RFC 9113 section 8.2.2, and a client is entitled to treat one
+// as a protocol error and drop the whole connection.
+func isHopByHop(header string) bool {
+	for _, h := range hopByHop {
+		if strings.EqualFold(h, header) {
+			return true
+		}
+	}
+	return false
+}
+
+// errConnectionFinished ends the one connection server's accept loop.
+var errConnectionFinished = errors.New("this connection has been served")
+
+// oneConnListener hands an already accepted connection to an http.Server.
+//
+// net/http will only run its HTTP/2 server for a connection that arrives
+// through a listener, and this connection arrived through a TLS handshake the
+// sidecar performed itself. The second Accept blocks until the connection is
+// closed rather than returning at once, so Serve outlives the connection it
+// was given and the caller can wait on Serve instead of inventing its own
+// signal for when the last stream ended.
+type oneConnListener struct {
+	conn net.Conn
+	// handed is read and written only by Serve's accept loop, which is one
+	// goroutine, so it needs no lock.
+	handed bool
+	once   sync.Once
+	closed chan struct{}
+}
+
+func (l *oneConnListener) Accept() (net.Conn, error) {
+	if !l.handed {
+		l.handed = true
+		return &closeNotifyConn{Conn: l.conn, listener: l}, nil
+	}
+	<-l.closed
+	return nil, errConnectionFinished
+}
+
+func (l *oneConnListener) Close() error { return nil }
+
+func (l *oneConnListener) Addr() net.Addr { return l.conn.LocalAddr() }
+
+// closeNotifyConn reports when the served connection is closed.
+type closeNotifyConn struct {
+	net.Conn
+	listener *oneConnListener
+}
+
+func (c *closeNotifyConn) Close() error {
+	err := c.Conn.Close()
+	c.listener.once.Do(func() { close(c.listener.closed) })
+	return err
+}
+`,
 	"cmd/af-proxy/internal.go": `package main
 
 import (
@@ -899,7 +1365,7 @@ func describeRate(spec string) string {
 	return fmt.Sprintf("%.3g a second, bursting to %.0f", per, burst)
 }
 `,
-	"cmd/af-proxy/main.go": "// Command af-proxy is the sidecar that decides what an environment may reach.\n//\n// It runs inside the environment on both networks: the inner one, which has no\n// route to the internet, and the outer one, which does. Services are told to\n// use it through the standard proxy variables. The thing that makes that\n// trustworthy is not the variables, which any library is free to ignore, but\n// the network: a service that ignores them has nowhere to send the packet. The\n// failure mode of a badly behaved SDK is a connection error, not silent\n// egress.\n//\n// It imports the same policy package the command line uses, so af net explain\n// and this program cannot disagree about what a rule means. That is the whole\n// reason the policy package has no dependencies beyond the standard library.\npackage main\n\nimport (\n\t\"bytes\"\n\t\"context\"\n\t\"encoding/json\"\n\t\"flag\"\n\t\"fmt\"\n\t\"io\"\n\t\"log\"\n\t\"net\"\n\t\"net/http\"\n\t\"os\"\n\t\"strconv\"\n\t\"strings\"\n\t\"sync\"\n\t\"sync/atomic\"\n\t\"time\"\n\n\t\"github.com/antifailure/antifailure/engine/internal/mockpack\"\n\t\"github.com/antifailure/antifailure/engine/internal/policy\"\n\t\"github.com/antifailure/antifailure/engine/pkg/livekey\"\n\t\"github.com/antifailure/antifailure/engine/pkg/schema\"\n)\n\n// Config is what the runtime writes into the sidecar before it starts.\n//\n// A file rather than flags, because the sidecar's own address on the\n// environment's network is only known after the container is created and\n// attached, which is after its command line is fixed.\ntype Config struct {\n\t// Egress is the policy to enforce.\n\tEgress schema.Egress `json:\"egress\"`\n\t// Subnet is the environment's inner network in CIDR form.\n\t//\n\t// The sidecar finds its own address inside it rather than being told the\n\t// address, because Docker does not assign one until the container starts,\n\t// which is after the moment this file has to be written.\n\tSubnet string `json:\"subnet\"`\n\t// Internal are the names that must resolve normally rather than to this\n\t// sidecar: other services, the database, and the sidecar itself.\n\tInternal []string `json:\"internal\"`\n\t// EnvID identifies the environment in the decision log.\n\tEnvID string `json:\"env_id\"`\n\t// MockPacks are extra packs supplied by the manifest, as raw JSON. The\n\t// built in ones are compiled into the sidecar and always available.\n\tMockPacks []string `json:\"mock_packs,omitempty\"`\n\t// Credentials maps a rule's credential name to the sandbox value the\n\t// sidecar substitutes. Values never appear in a log line.\n\tCredentials map[string]string `json:\"credentials,omitempty\"`\n\t// Resolver is where internal names are forwarded, as host:port.\n\t//\n\t// Empty means Docker's embedded resolver, which is correct for the local\n\t// runtime and meaningless anywhere else. It is a name to forward to and\n\t// never a route out: an external name is still answered by this sidecar\n\t// whatever this is set to, so pointing it somewhere unexpected cannot\n\t// turn into a way around the policy.\n\tResolver string `json:\"resolver,omitempty\"`\n\t// CACert and CAKey are the environment's certificate authority, in PEM.\n\t//\n\t// Present only when something in the policy needs to read inside TLS. An\n\t// environment whose rules are all plain allow or block never terminates a\n\t// connection and never needs one.\n\tCACert string `json:\"ca_cert,omitempty\"`\n\tCAKey  string `json:\"ca_key,omitempty\"`\n}\n\nfunc main() {\n\tconfigPath := flag.String(\"config\", \"/etc/antifailure/proxy.json\", \"path to the sidecar configuration\")\n\tflag.Parse()\n\n\tcfg, err := loadConfig(*configPath)\n\tif err != nil {\n\t\tlog.Fatalf(\"af-proxy: %v\", err)\n\t}\n\tengine, err := policy.New(&cfg.Egress)\n\tif err != nil {\n\t\tlog.Fatalf(\"af-proxy: %v\", err)\n\t}\n\n\tp := &proxy{\n\t\tengine: engine, envID: cfg.EnvID, out: json.NewEncoder(os.Stdout),\n\t\tcredentials: cfg.Credentials,\n\t\tlimits:      newLimiter(),\n\t\tdestinations: newDestinations(\n\t\t\tengine.Rules(), cfg.Subnet, engine.AllowsIPv6()),\n\t\tinternal: newInside(cfg.Internal),\n\t\t// Read from this process's environment rather than from the\n\t\t// configuration file, so a key never passes through something the\n\t\t// engine wrote to disk.\n\t\tsynth: synthFromEnvironment(os.Getenv),\n\t\ttransport: &http.Transport{\n\t\t\tMaxIdleConnsPerHost: 16,\n\t\t\tIdleConnTimeout:     60 * time.Second,\n\t\t\t// The origin's certificate is verified normally. Reading inside a\n\t\t\t// connection is not a licence to stop checking who is on the other\n\t\t\t// end of it; if anything it makes the check more important,\n\t\t\t// because the client can no longer do it itself.\n\t\t\tTLSHandshakeTimeout: 20 * time.Second,\n\t\t},\n\t}\n\t// Set after construction because the dialer is a method on the proxy it\n\t// belongs to. Every re-originated request goes through it, so the address\n\t// guard applies to the inspected path as well as to the tunnelled one.\n\tp.transport.DialContext = p.dialGuarded\n\n\tpacks, err := mockpack.Builtin()\n\tif err != nil {\n\t\tlog.Fatalf(\"af-proxy: %v\", err)\n\t}\n\tfor _, raw := range cfg.MockPacks {\n\t\tpack, parseErr := mockpack.Parse([]byte(raw))\n\t\tif parseErr != nil {\n\t\t\t// Refused rather than skipped. A pack that silently did not load\n\t\t\t// would leave its host answering nothing, and the failure would\n\t\t\t// look like a missing route rather than a broken file.\n\t\t\tlog.Fatalf(\"af-proxy: %v\", parseErr)\n\t\t}\n\t\tpacks = append(packs, pack)\n\t}\n\tp.mocks = mockpack.New(packs)\n\n\tif cfg.CACert != \"\" {\n\t\tca, caErr := newCertAuthority(cfg.CACert, cfg.CAKey)\n\t\tif caErr != nil {\n\t\t\tlog.Fatalf(\"af-proxy: %v\", caErr)\n\t\t}\n\t\tp.ca = ca\n\t}\n\n\tself, err := addressInside(cfg.Subnet)\n\tif err != nil {\n\t\tlog.Fatalf(\"af-proxy: %v\", err)\n\t}\n\tresolver := cfg.Resolver\n\tif resolver == \"\" {\n\t\tresolver = dockerResolver\n\t}\n\tdns := newDNSServer(self, cfg.Internal, resolver, p.emit)\n\n\t// Every listener is started before anything is announced as ready, so a\n\t// service that begins its first outbound call the instant it starts finds\n\t// a decision rather than a closed port.\n\terrs := make(chan error, 4)\n\tudp, err := net.ListenPacket(\"udp\", \":53\")\n\tif err != nil {\n\t\tlog.Fatalf(\"af-proxy: %v\", err)\n\t}\n\tgo func() { errs <- dns.serve(udp) }()\n\n\tgo func() { errs <- p.listen(\":80\", p.serveTransparentHTTP) }()\n\tgo func() { errs <- p.listen(\":443\", p.serveTransparentTLS) }()\n\n\t// The explicit proxy port stays, for clients that do read their proxy\n\t// variables. It is the same policy either way; this one can see the full\n\t// request on an HTTPS call's CONNECT line, which the transparent path\n\t// cannot, so a client that opts in gets a slightly better decision.\n\tgo func() {\n\t\tsrv := &http.Server{\n\t\t\tAddr:    \":\" + strconv.Itoa(3128),\n\t\t\tHandler: p,\n\t\t\t// A request that is never finished must not hold a connection\n\t\t\t// forever, and an environment under load will have thousands.\n\t\t\tReadHeaderTimeout: 20 * time.Second,\n\t\t\tIdleTimeout:       90 * time.Second,\n\t\t}\n\t\terrs <- srv.ListenAndServe()\n\t}()\n\n\tp.emit(record{\n\t\tEvent: \"ready\", Rules: len(engine.Rules()), Default: string(engine.Default()),\n\t\tReason: describeDNS(self, cfg.Internal),\n\t\t// The count, never the values. A sandbox rule whose credential never\n\t\t// arrived forwards whatever the application sent, and the only way to\n\t\t// notice is a number that says zero.\n\t\tCredentials: len(cfg.Credentials),\n\t})\n\n\tlog.Fatalf(\"af-proxy: %v\", <-errs)\n}\n\n// addressInside finds this container's address on a given network.\n//\n// A sidecar with no address on the environment's network cannot intercept\n// anything, and starting anyway would produce an environment that looks\n// contained and is not, so this is fatal rather than a warning.\nfunc addressInside(cidr string) (net.IP, error) {\n\tif cidr == \"\" {\n\t\treturn nil, fmt.Errorf(\"no network was named for this sidecar to answer on\")\n\t}\n\t_, subnet, err := net.ParseCIDR(cidr)\n\tif err != nil {\n\t\treturn nil, fmt.Errorf(\"%q is not a network: %w\", cidr, err)\n\t}\n\taddrs, err := net.InterfaceAddrs()\n\tif err != nil {\n\t\treturn nil, err\n\t}\n\tfor _, a := range addrs {\n\t\tipnet, ok := a.(*net.IPNet)\n\t\tif !ok {\n\t\t\tcontinue\n\t\t}\n\t\tif v4 := ipnet.IP.To4(); v4 != nil && subnet.Contains(v4) {\n\t\t\treturn v4, nil\n\t\t}\n\t}\n\treturn nil, fmt.Errorf(\"this sidecar has no address on %s\", cidr)\n}\n\n// listen accepts connections and hands each to a handler.\nfunc (p *proxy) listen(addr string, handle func(net.Conn)) error {\n\tln, err := net.Listen(\"tcp\", addr)\n\tif err != nil {\n\t\treturn err\n\t}\n\tfor {\n\t\tconn, err := ln.Accept()\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\tgo handle(conn)\n\t}\n}\n\nfunc loadConfig(path string) (*Config, error) {\n\tbody, err := os.ReadFile(path)\n\tif err != nil {\n\t\treturn nil, fmt.Errorf(\"reading the configuration: %w\", err)\n\t}\n\tvar c Config\n\tif err := json.Unmarshal(body, &c); err != nil {\n\t\treturn nil, fmt.Errorf(\"parsing the configuration: %w\", err)\n\t}\n\tif c.Egress.Default == \"\" {\n\t\t// An absent default is block, the same as everywhere else. Defaulting\n\t\t// to allow here would make a malformed configuration open rather than\n\t\t// closed, which is the wrong direction for the one component whose\n\t\t// job is to refuse things.\n\t\tc.Egress.Default = schema.ModeBlock\n\t}\n\treturn &c, nil\n}\n\n// record is one line of the decision log.\n//\n// Every request produces one, allowed or not. A log that only records refusals\n// answers \"why was this blocked\" and not \"did anything reach Stripe\", and the\n// second question is the one somebody asks after an incident.\ntype record struct {\n\tEvent    string `json:\"event\"`\n\tEnv      string `json:\"env,omitempty\"`\n\tAt       string `json:\"at,omitempty\"`\n\tMethod   string `json:\"method,omitempty\"`\n\tHost     string `json:\"host,omitempty\"`\n\tPort     int    `json:\"port,omitempty\"`\n\tPath     string `json:\"path,omitempty\"`\n\tTLS      bool   `json:\"tls,omitempty\"`\n\tMode     string `json:\"mode,omitempty\"`\n\tRule     string `json:\"rule,omitempty\"`\n\tReason   string `json:\"reason,omitempty\"`\n\tAllowed  bool   `json:\"allowed\"`\n\tStatus   int    `json:\"status,omitempty\"`\n\tBytes    int64  `json:\"bytes,omitempty\"`\n\tDuration string `json:\"duration,omitempty\"`\n\tError    string `json:\"error,omitempty\"`\n\tRules    int    `json:\"rules,omitempty\"`\n\tDefault  string `json:\"default,omitempty\"`\n\tSeq      uint64 `json:\"seq,omitempty\"`\n\t// Via says how the request arrived: as a proxy request from a client that\n\t// read its proxy variables, or transparently from one that did not.\n\tVia string `json:\"via,omitempty\"`\n\t// Substituted marks a request whose credential was replaced on the way\n\t// out, so a reader can tell a sandbox call from a live one.\n\tSubstituted bool `json:\"substituted,omitempty\"`\n\t// Synthesized marks a response a model invented, so a workflow that\n\t// touched one reports unverified rather than passed.\n\tSynthesized bool `json:\"synthesized,omitempty\"`\n\t// WaitedMs is how long a rate limit held this request. Recorded because a\n\t// request that took a second is a request somebody will otherwise blame\n\t// on the application.\n\tWaitedMs int64 `json:\"waited_ms,omitempty\"`\n\t// Limit is that rate in words, \"10 a second, bursting to 10\". The\n\t// milliseconds alone say a request was slow and not what slowed it, and\n\t// the rule's raw spec is in the manifest rather than in front of whoever\n\t// is reading the log.\n\tLimit string `json:\"limit,omitempty\"`\n\t// Credentials counts the sandbox values loaded, on the ready line.\n\tCredentials int `json:\"credentials,omitempty\"`\n\t// Pack and Fixture name what answered a mocked request. A mock that\n\t// cannot say which fixture produced a response is a mock nobody can\n\t// debug.\n\tPack    string `json:\"pack,omitempty\"`\n\tFixture string `json:\"fixture,omitempty\"`\n\t// HostOnly marks a decision made without seeing the path or the method,\n\t// which is every HTTPS request until the environment certificate lands.\n\t// Recorded rather than assumed away, so a reader can tell the difference\n\t// between a rule that matched and a rule that could only half apply.\n\tHostOnly bool `json:\"host_only,omitempty\"`\n}\n\ntype proxy struct {\n\tengine *policy.Engine\n\tenvID  string\n\tout    *json.Encoder\n\t// ca signs a certificate per host, for the connections the policy needs\n\t// to read inside. Nil when the environment has no authority, in which\n\t// case every TLS connection is tunnelled.\n\tca *certAuthority\n\t// transport re-originates inspected requests.\n\ttransport *http.Transport\n\t// credentials are the sandbox values, by the name a rule refers to.\n\tcredentials map[string]string\n\t// mocks answers requests for hosts set to mock.\n\tmocks *mockpack.Engine\n\t// limits shape traffic to a rule's declared rate, so a load run does not\n\t// get somebody's sandbox account throttled.\n\tlimits *limiter\n\t// destinations refuse the addresses the environment must not reach\n\t// through this sidecar, whatever the policy says about the name.\n\tdestinations *destinations\n\t// internal are the environment's own names, and a request for one is not\n\t// egress. It is the SAME predicate the resolver uses, which is the point:\n\t// a name the resolver sends to the real container and the proxy refuses is\n\t// one the sidecar has two opinions about.\n\tinternal inside\n\t// resolve turns a name into addresses. Nil means the system resolver,\n\t// which is what the sidecar always uses; a test sets it to say what a\n\t// name resolves to.\n\tresolve func(context.Context, string) ([]net.IP, error)\n\t// synth invents a response when a rule asks for one. Nil when no model\n\t// key is available, in which case a synth rule refuses and says so.\n\tsynth *synthConfig\n\tseq   atomic.Uint64\n\t// mu serialises writes to the encoder. A JSON encoder is not safe for\n\t// concurrent use, and every request writes a line, so without it a busy\n\t// environment produces a decision log with interleaved bytes: the one\n\t// artifact whose whole value is that it can be trusted after the fact.\n\tmu sync.Mutex\n}\n\nfunc (p *proxy) emit(r record) {\n\tr.Env = p.envID\n\tif r.At == \"\" {\n\t\tr.At = time.Now().UTC().Format(time.RFC3339Nano)\n\t}\n\tr.Seq = p.seq.Add(1)\n\tp.mu.Lock()\n\tdefer p.mu.Unlock()\n\t_ = p.out.Encode(r)\n}\n\n// emitMessage writes a captured message to the log.\n//\n// It shares the encoder's lock with the decisions, so the two streams\n// interleave by line rather than by byte, and a reader can take the log apart\n// with nothing more than a JSON decoder per line.\nfunc (p *proxy) emitMessage(m message) {\n\tm.Env = p.envID\n\tif m.At == \"\" {\n\t\tm.At = time.Now().UTC().Format(time.RFC3339Nano)\n\t}\n\tm.Seq = p.seq.Add(1)\n\tp.mu.Lock()\n\tdefer p.mu.Unlock()\n\t_ = p.out.Encode(m)\n}\n\nfunc (p *proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {\n\tif r.Method == http.MethodConnect {\n\t\tp.serveConnect(w, r)\n\t\treturn\n\t}\n\tp.serveHTTP(w, r)\n}\n\n// serveConnect handles the tunnel every HTTPS request opens.\n//\n// Only the host and port are visible here, which is a real limitation and is\n// stated rather than hidden: a rule that names paths or methods cannot be\n// enforced on an HTTPS request until the environment certificate lands, so\n// such a rule is evaluated on its host alone. A rule that would have matched\n// on the path is reported in the decision log as host-only, so the difference\n// is visible to whoever reads it rather than silently assumed away.\nfunc (p *proxy) serveConnect(w http.ResponseWriter, r *http.Request) {\n\tstarted := time.Now()\n\thost, port := splitHostPort(r.Host, 443)\n\n\t// Inside the environment, so not egress. The same reasoning as the plain\n\t// path, and the tunnel is opened without reading inside it: an internal\n\t// connection is not something the policy has an opinion about, and\n\t// terminating one would need a certificate for a name that is not on the\n\t// public internet.\n\tif p.internal.has(host) && p.resolvesInside(r.Context(), host) {\n\t\tp.tunnelInternal(w, host, port, started)\n\t\treturn\n\t}\n\n\treq := policy.Request{Host: host, Port: port, Method: http.MethodConnect, Path: \"/\", TLS: true}\n\td := p.engine.Evaluate(req)\n\n\trec := record{\n\t\tEvent: \"decision\", Method: http.MethodConnect, Host: host, Port: port,\n\t\tTLS: true, Mode: string(d.Mode), Rule: d.RuleHost,\n\t\tReason: d.Reason(), Allowed: d.Allowed(), Via: \"proxy\",\n\t}\n\t// Whether to read inside comes before whether to allow, and the order is\n\t// load bearing. Capture, mock, and sandbox all answer from inside the\n\t// tunnel and none of them counts as reaching out, so testing Allowed first\n\t// refuses the CONNECT and the request that would have been captured never\n\t// exists. That is exactly what happened: a client that honoured its proxy\n\t// variables got a 403 for a host set to capture, while a client that\n\t// ignored them was captured correctly, so the mode worked or did not\n\t// depending on which HTTP library the application happened to use.\n\tinspect := p.ca != nil && p.engine.InspectsHost(host, port)\n\t// A tunnel nobody reads inside was decided from the host and the port and\n\t// nothing else, exactly as the transparent one was, so it is recorded the\n\t// same way. The inspected tunnel is not marked, because the requests\n\t// inside it are decided on their paths and carry their own records.\n\trec.HostOnly = !inspect\n\n\tif !inspect && !d.Allowed() {\n\t\trec.Status = http.StatusForbidden\n\t\trec.Duration = time.Since(started).String()\n\t\tp.emit(rec)\n\t\t// A refused CONNECT gets a body even though most clients discard it,\n\t\t// because the ones that show it turn a mystifying failure into a\n\t\t// readable one at no cost.\n\t\twriteRefusal(w, d, req)\n\t\treturn\n\t}\n\n\thijacker, ok := w.(http.Hijacker)\n\tif !ok {\n\t\trec.Error = \"the connection cannot be hijacked\"\n\t\tp.emit(rec)\n\t\thttp.Error(w, \"af-proxy: cannot tunnel\", http.StatusInternalServerError)\n\t\treturn\n\t}\n\tclient, buffered, err := hijacker.Hijack()\n\tif err != nil {\n\t\trec.Error = err.Error()\n\t\tp.emit(rec)\n\t\treturn\n\t}\n\tdefer func() { _ = client.Close() }()\n\n\tif _, err := io.WriteString(client, \"HTTP/1.1 200 Connection Established\\r\\n\\r\\n\"); err != nil {\n\t\trec.Error = err.Error()\n\t\tp.emit(rec)\n\t\treturn\n\t}\n\n\t// A client that opted into the proxy still gets its request read when the\n\t// policy needs it read. The tunnel it just opened carries a TLS handshake\n\t// like any other, and the same rule decides what happens to it.\n\tif inspect {\n\t\trec.Status = http.StatusOK\n\t\trec.Duration = time.Since(started).String()\n\t\tp.emit(rec)\n\t\tp.inspectTLS(client, buffered.Reader, host)\n\t\treturn\n\t}\n\n\t// Background rather than the request's context. The connection was\n\t// hijacked a few lines up, so this handler owns it now and no longer\n\t// wants a deadline that belongs to a request net/http considers finished.\n\tupstream, err := p.dialGuarded(context.Background(), \"tcp\", net.JoinHostPort(host, strconv.Itoa(port)))\n\tif err != nil {\n\t\trec.Error = err.Error()\n\t\trec.Status = http.StatusBadGateway\n\t\trec.Duration = time.Since(started).String()\n\t\tp.emit(rec)\n\t\treturn\n\t}\n\tdefer func() { _ = upstream.Close() }()\n\n\trec.Status = http.StatusOK\n\trec.Bytes = pipe(client, upstream)\n\trec.Duration = time.Since(started).String()\n\tp.emit(rec)\n}\n\n// pipe copies in both directions and returns the bytes sent upstream.\nfunc pipe(client, upstream net.Conn) int64 {\n\tdone := make(chan struct{})\n\tgo func() {\n\t\t_, _ = io.Copy(client, upstream)\n\t\t// Closing the write side rather than the whole connection lets the\n\t\t// other direction finish, which is what a half closed TCP stream is\n\t\t// for and what a plain Close would cut off mid response.\n\t\tif c, ok := client.(*net.TCPConn); ok {\n\t\t\t_ = c.CloseWrite()\n\t\t}\n\t\tclose(done)\n\t}()\n\tsent, _ := io.Copy(upstream, client)\n\tif c, ok := upstream.(*net.TCPConn); ok {\n\t\t_ = c.CloseWrite()\n\t}\n\t<-done\n\treturn sent\n}\n\n// serveHTTP handles a plain request, where the whole thing is visible.\n//\n// This is the path a client that reads its proxy variables takes for an http\n// URL, and until this was written it was the one path that did not enforce the\n// whole policy. It read the mode and forwarded: the live credential tripwire\n// never ran, a sandbox rule sent the application's own credential to the\n// provider untouched, and capture, mock and synth were refused with a body\n// claiming they were not wired up in this build. Which of those happened\n// depended on whether the application's HTTP library honoured http_proxy,\n// which is not a property anybody reasons about while writing a rule. The\n// same defect was found and fixed on the CONNECT path and left here.\nfunc (p *proxy) serveHTTP(w http.ResponseWriter, r *http.Request) {\n\tstarted := time.Now()\n\tif !r.URL.IsAbs() {\n\t\t// A request that is not in absolute form was sent to the proxy as if\n\t\t// it were an origin server, which means something is pointed at the\n\t\t// wrong address rather than proxying through it.\n\t\thttp.Error(w,\n\t\t\t\"af-proxy: this is a proxy, not an origin server. Set HTTP_PROXY and HTTPS_PROXY to reach it.\",\n\t\t\thttp.StatusBadRequest)\n\t\treturn\n\t}\n\thost, port := splitHostPort(r.URL.Host, 80)\n\n\t// A request for something inside the environment is not egress, whichever\n\t// door it arrived through.\n\t//\n\t// A well behaved client never sends one here at all: the name resolves to\n\t// the real container and no_proxy keeps it off this port. A client that\n\t// reads http_proxy and ignores no_proxy sends it anyway, and until this\n\t// existed it was evaluated against the egress policy and refused, so\n\t// whether one service could reach another depended on which HTTP library\n\t// the application happened to use. It is the same defect the CONNECT path\n\t// and the plain path each had for the modes, arriving a third time.\n\t//\n\t// Nothing is reachable here that was not reachable already: this is the\n\t// same connection the client would have made directly, made on its behalf.\n\tif p.internal.has(host) && p.resolvesInside(r.Context(), host) {\n\t\tp.serveInternal(w, r, host, port, started)\n\t\treturn\n\t}\n\n\treq := policy.Request{Host: host, Port: port, Method: r.Method, Path: r.URL.Path, TLS: false}\n\td := p.engine.Evaluate(req)\n\n\trec := record{\n\t\tEvent: \"decision\", Method: r.Method, Host: host, Port: port, Path: r.URL.Path,\n\t\tMode: string(d.Mode), Rule: d.RuleHost, Reason: d.Reason(), Allowed: d.Allowed(),\n\t\tVia: \"proxy\",\n\t}\n\n\t// Before anything is forwarded and before the mode is acted on, in every\n\t// mode, exactly as on the other two paths. A credential that can act on\n\t// production must not leave an environment running unreviewed code against\n\t// a copy of production data, and which HTTP library the application chose\n\t// has nothing to do with that.\n\tif found := p.tripwire(r, host); len(found) > 0 {\n\t\trec.Status = http.StatusForbidden\n\t\trec.Allowed = false\n\t\trec.Reason = \"This request carries a live credential: \" + livekey.Describe(found)\n\t\trec.Duration = time.Since(started).String()\n\t\tp.emit(rec)\n\t\tw.Header().Set(\"Content-Type\", \"text/plain; charset=utf-8\")\n\t\tw.Header().Set(\"X-Antifailure-Decision\", \"block\")\n\t\tw.WriteHeader(http.StatusForbidden)\n\t\t_, _ = io.WriteString(w, refusalForLiveCredential(req, found))\n\t\treturn\n\t}\n\n\tswitch d.Mode {\n\tcase schema.ModeCapture, schema.ModeMock, schema.ModeSynth:\n\t\tp.serveInsideTheEnvironment(w, r, req, d, &rec, started)\n\t\treturn\n\t}\n\n\tif !d.Allowed() {\n\t\trec.Status = http.StatusForbidden\n\t\trec.Duration = time.Since(started).String()\n\t\tp.emit(rec)\n\t\twriteRefusal(w, d, req)\n\t\treturn\n\t}\n\n\tif d.RateLimit != \"\" {\n\t\tif waited := p.limits.wait(d.RuleHost, d.RateLimit); waited > 0 {\n\t\t\trec.WaitedMs = waited.Milliseconds()\n\t\t\trec.Limit = describeRate(d.RateLimit)\n\t\t}\n\t}\n\n\toutbound := r.Clone(r.Context())\n\toutbound.RequestURI = \"\"\n\t// Hop by hop headers are ours, not the origin's, and forwarding them is\n\t// how a proxy ends up asking an upstream to keep a connection alive that\n\t// only makes sense between the client and the proxy.\n\tfor _, h := range hopByHop {\n\t\toutbound.Header.Del(h)\n\t}\n\tif d.Mode == schema.ModeSandbox {\n\t\t// Whatever the application sent is discarded before the request\n\t\t// leaves, which is the whole difference between sandbox mode and\n\t\t// asking somebody to configure a sandbox key correctly.\n\t\tapplySandbox(outbound, host, p.credentials[d.Credential])\n\t\trec.Substituted = p.credentials[d.Credential] != \"\"\n\t}\n\n\t// p.transport rather than http.DefaultTransport, because the address\n\t// guard hangs off its dialer and the default one has no guard at all.\n\tresp, err := p.transport.RoundTrip(outbound)\n\tif err != nil {\n\t\trec.Error = err.Error()\n\t\trec.Status = http.StatusBadGateway\n\t\trec.Duration = time.Since(started).String()\n\t\tp.emit(rec)\n\t\thttp.Error(w, \"af-proxy: \"+err.Error(), http.StatusBadGateway)\n\t\treturn\n\t}\n\tdefer func() { _ = resp.Body.Close() }()\n\n\tfor k, vs := range resp.Header {\n\t\tfor _, v := range vs {\n\t\t\tw.Header().Add(k, v)\n\t\t}\n\t}\n\tw.WriteHeader(resp.StatusCode)\n\tn, _ := io.Copy(w, resp.Body)\n\n\trec.Status = resp.StatusCode\n\trec.Bytes = n\n\trec.Duration = time.Since(started).String()\n\tp.emit(rec)\n}\n\n// serveInsideTheEnvironment answers a capture, mock or synth request that\n// arrived through the explicit proxy port.\n//\n// All three write a whole HTTP response rather than filling in a\n// ResponseWriter, because the other two paths hold a raw connection and have\n// nothing else to write onto. Rather than a second implementation of each\n// mode for this path, the connection is taken over and handed to the same\n// code. The body is read first, because a hijacked request's Body is no\n// longer safe to touch.\nfunc (p *proxy) serveInsideTheEnvironment(\n\tw http.ResponseWriter, r *http.Request, preq policy.Request, d policy.Decision,\n\trec *record, started time.Time,\n) {\n\thost := preq.Host\n\t// The larger of the two limits the modes below apply, so neither is\n\t// handed a body this function truncated first. Each still applies its own.\n\tbody, _ := io.ReadAll(io.LimitReader(r.Body, 1<<20))\n\t_ = r.Body.Close()\n\tr.Body = io.NopCloser(bytes.NewReader(body))\n\n\thijacker, ok := w.(http.Hijacker)\n\tif !ok {\n\t\trec.Error = \"the connection cannot be taken over\"\n\t\trec.Duration = time.Since(started).String()\n\t\tp.emit(*rec)\n\t\thttp.Error(w, \"af-proxy: cannot answer this request\", http.StatusInternalServerError)\n\t\treturn\n\t}\n\tconn, _, err := hijacker.Hijack()\n\tif err != nil {\n\t\trec.Error = err.Error()\n\t\trec.Duration = time.Since(started).String()\n\t\tp.emit(*rec)\n\t\treturn\n\t}\n\tdefer func() { _ = conn.Close() }()\n\n\tswitch d.Mode {\n\tcase schema.ModeCapture:\n\t\tp.capture(conn, r, preq, d, rec)\n\tcase schema.ModeMock:\n\t\tp.serveMock(conn, r, host, rec)\n\tcase schema.ModeSynth:\n\t\tp.serveSynth(conn, r, host, rec)\n\t}\n\trec.Duration = time.Since(started).String()\n\tp.emit(*rec)\n}\n\n// writeRefusal explains a refusal in the response body.\n//\n// The audience is a developer reading a stack trace at three in the afternoon,\n// so it says what was refused, which rule refused it, and what to change. A\n// bare 403 sends them to the wrong place every time.\nfunc writeRefusal(w http.ResponseWriter, d policy.Decision, req policy.Request) {\n\tw.Header().Set(\"Content-Type\", \"text/plain; charset=utf-8\")\n\tw.Header().Set(\"X-Antifailure-Decision\", string(d.Mode))\n\tif d.RuleHost != \"\" {\n\t\tw.Header().Set(\"X-Antifailure-Rule\", d.RuleHost)\n\t}\n\tw.WriteHeader(http.StatusForbidden)\n\t_, _ = io.WriteString(w, refusalBody(d, req))\n}\n\n// refusalBody is what a developer reads in a stack trace at three in the\n// afternoon: what was refused, which rule refused it, and what to change. A\n// bare 403 sends them to the wrong place every time.\nfunc refusalBody(d policy.Decision, req policy.Request) string {\n\tvar b strings.Builder\n\tfmt.Fprintf(&b, \"Antifailure refused this request.\\n\\n\")\n\tfmt.Fprintf(&b, \"  %s\\n\\n\", req.String())\n\tfmt.Fprintf(&b, \"%s\\n\\n\", d.Reason())\n\tfmt.Fprintf(&b, \"Ask about it with:\\n\\n  af net explain %s %s\\n\",\n\t\treq.Method, schemeOf(req)+\"://\"+req.Host+req.Path)\n\treturn b.String()\n}\n\nfunc schemeOf(r policy.Request) string {\n\tif r.TLS {\n\t\treturn \"https\"\n\t}\n\treturn \"http\"\n}\n\nfunc splitHostPort(hostport string, fallback int) (string, int) {\n\tif h, p, err := net.SplitHostPort(hostport); err == nil {\n\t\tif n, convErr := strconv.Atoi(p); convErr == nil {\n\t\t\treturn h, n\n\t\t}\n\t\treturn h, fallback\n\t}\n\treturn hostport, fallback\n}\n",
+	"cmd/af-proxy/main.go": "// Command af-proxy is the sidecar that decides what an environment may reach.\n//\n// It runs inside the environment on both networks: the inner one, which has no\n// route to the internet, and the outer one, which does. Services are told to\n// use it through the standard proxy variables. The thing that makes that\n// trustworthy is not the variables, which any library is free to ignore, but\n// the network: a service that ignores them has nowhere to send the packet. The\n// failure mode of a badly behaved SDK is a connection error, not silent\n// egress.\n//\n// It imports the same policy package the command line uses, so af net explain\n// and this program cannot disagree about what a rule means. That is the whole\n// reason the policy package has no dependencies beyond the standard library.\npackage main\n\nimport (\n\t\"bytes\"\n\t\"context\"\n\t\"encoding/json\"\n\t\"flag\"\n\t\"fmt\"\n\t\"io\"\n\t\"log\"\n\t\"net\"\n\t\"net/http\"\n\t\"os\"\n\t\"strconv\"\n\t\"strings\"\n\t\"sync\"\n\t\"sync/atomic\"\n\t\"time\"\n\n\t\"github.com/antifailure/antifailure/engine/internal/mockpack\"\n\t\"github.com/antifailure/antifailure/engine/internal/policy\"\n\t\"github.com/antifailure/antifailure/engine/pkg/livekey\"\n\t\"github.com/antifailure/antifailure/engine/pkg/schema\"\n)\n\n// Config is what the runtime writes into the sidecar before it starts.\n//\n// A file rather than flags, because the sidecar's own address on the\n// environment's network is only known after the container is created and\n// attached, which is after its command line is fixed.\ntype Config struct {\n\t// Egress is the policy to enforce.\n\tEgress schema.Egress `json:\"egress\"`\n\t// Subnet is the environment's inner network in CIDR form.\n\t//\n\t// The sidecar finds its own address inside it rather than being told the\n\t// address, because Docker does not assign one until the container starts,\n\t// which is after the moment this file has to be written.\n\tSubnet string `json:\"subnet\"`\n\t// Internal are the names that must resolve normally rather than to this\n\t// sidecar: other services, the database, and the sidecar itself.\n\tInternal []string `json:\"internal\"`\n\t// EnvID identifies the environment in the decision log.\n\tEnvID string `json:\"env_id\"`\n\t// MockPacks are extra packs supplied by the manifest, as raw JSON. The\n\t// built in ones are compiled into the sidecar and always available.\n\tMockPacks []string `json:\"mock_packs,omitempty\"`\n\t// Credentials maps a rule's credential name to the sandbox value the\n\t// sidecar substitutes. Values never appear in a log line.\n\tCredentials map[string]string `json:\"credentials,omitempty\"`\n\t// Resolver is where internal names are forwarded, as host:port.\n\t//\n\t// Empty means Docker's embedded resolver, which is correct for the local\n\t// runtime and meaningless anywhere else. It is a name to forward to and\n\t// never a route out: an external name is still answered by this sidecar\n\t// whatever this is set to, so pointing it somewhere unexpected cannot\n\t// turn into a way around the policy.\n\tResolver string `json:\"resolver,omitempty\"`\n\t// CACert and CAKey are the environment's certificate authority, in PEM.\n\t//\n\t// Present only when something in the policy needs to read inside TLS. An\n\t// environment whose rules are all plain allow or block never terminates a\n\t// connection and never needs one.\n\tCACert string `json:\"ca_cert,omitempty\"`\n\tCAKey  string `json:\"ca_key,omitempty\"`\n}\n\nfunc main() {\n\tconfigPath := flag.String(\"config\", \"/etc/antifailure/proxy.json\", \"path to the sidecar configuration\")\n\tflag.Parse()\n\n\tcfg, err := loadConfig(*configPath)\n\tif err != nil {\n\t\tlog.Fatalf(\"af-proxy: %v\", err)\n\t}\n\tengine, err := policy.New(&cfg.Egress)\n\tif err != nil {\n\t\tlog.Fatalf(\"af-proxy: %v\", err)\n\t}\n\n\tp := &proxy{\n\t\tengine: engine, envID: cfg.EnvID, out: json.NewEncoder(os.Stdout),\n\t\tcredentials: cfg.Credentials,\n\t\tlimits:      newLimiter(),\n\t\tdestinations: newDestinations(\n\t\t\tengine.Rules(), cfg.Subnet, engine.AllowsIPv6()),\n\t\tinternal: newInside(cfg.Internal),\n\t\t// Read from this process's environment rather than from the\n\t\t// configuration file, so a key never passes through something the\n\t\t// engine wrote to disk.\n\t\tsynth:       synthFromEnvironment(os.Getenv),\n\t\ttransport:   newForwardTransport(nil),\n\t\ttransportH2: newForwardTransport(h2ALPN()),\n\t\t// Three transports rather than one, because the protocol the client\n\t\t// spoke is the protocol its answer has to be framed in. A gRPC status\n\t\t// travels in HTTP/2 trailers and an HTTP/1.1 forward would drop it,\n\t\t// and an HTTP/2 response written onto an HTTP/1.1 connection carries\n\t\t// its own version into the status line. Which one is used follows the\n\t\t// connection the request arrived on and nothing else.\n\t\ttransportH2C: newForwardTransport(h2cPriorKnowledge()),\n\t}\n\t// Set after construction because the dialer is a method on the proxy it\n\t// belongs to. Every re-originated request goes through it, so the address\n\t// guard applies to the inspected path as well as to the tunnelled one, and\n\t// to every protocol rather than to the one that existed first.\n\tp.transport.DialContext = p.dialGuarded\n\tp.transportH2.DialContext = p.dialGuarded\n\tp.transportH2C.DialContext = p.dialGuarded\n\n\tpacks, err := mockpack.Builtin()\n\tif err != nil {\n\t\tlog.Fatalf(\"af-proxy: %v\", err)\n\t}\n\tfor _, raw := range cfg.MockPacks {\n\t\tpack, parseErr := mockpack.Parse([]byte(raw))\n\t\tif parseErr != nil {\n\t\t\t// Refused rather than skipped. A pack that silently did not load\n\t\t\t// would leave its host answering nothing, and the failure would\n\t\t\t// look like a missing route rather than a broken file.\n\t\t\tlog.Fatalf(\"af-proxy: %v\", parseErr)\n\t\t}\n\t\tpacks = append(packs, pack)\n\t}\n\tp.mocks = mockpack.New(packs)\n\n\tif cfg.CACert != \"\" {\n\t\tca, caErr := newCertAuthority(cfg.CACert, cfg.CAKey)\n\t\tif caErr != nil {\n\t\t\tlog.Fatalf(\"af-proxy: %v\", caErr)\n\t\t}\n\t\tp.ca = ca\n\t}\n\n\tself, err := addressInside(cfg.Subnet)\n\tif err != nil {\n\t\tlog.Fatalf(\"af-proxy: %v\", err)\n\t}\n\tresolver := cfg.Resolver\n\tif resolver == \"\" {\n\t\tresolver = dockerResolver\n\t}\n\tdns := newDNSServer(self, cfg.Internal, resolver, p.emit)\n\n\t// Every listener is started before anything is announced as ready, so a\n\t// service that begins its first outbound call the instant it starts finds\n\t// a decision rather than a closed port.\n\terrs := make(chan error, 4)\n\tudp, err := net.ListenPacket(\"udp\", \":53\")\n\tif err != nil {\n\t\tlog.Fatalf(\"af-proxy: %v\", err)\n\t}\n\tgo func() { errs <- dns.serve(udp) }()\n\n\tgo func() { errs <- p.listen(\":80\", p.serveTransparentHTTP) }()\n\tgo func() { errs <- p.listen(\":443\", p.serveTransparentTLS) }()\n\n\t// The explicit proxy port stays, for clients that do read their proxy\n\t// variables. It is the same policy either way; this one can see the full\n\t// request on an HTTPS call's CONNECT line, which the transparent path\n\t// cannot, so a client that opts in gets a slightly better decision.\n\tgo func() {\n\t\tsrv := &http.Server{\n\t\t\tAddr:    \":\" + strconv.Itoa(3128),\n\t\t\tHandler: p,\n\t\t\t// A request that is never finished must not hold a connection\n\t\t\t// forever, and an environment under load will have thousands.\n\t\t\tReadHeaderTimeout: 20 * time.Second,\n\t\t\tIdleTimeout:       90 * time.Second,\n\t\t}\n\t\terrs <- srv.ListenAndServe()\n\t}()\n\n\tp.emit(record{\n\t\tEvent: \"ready\", Rules: len(engine.Rules()), Default: string(engine.Default()),\n\t\tReason: describeDNS(self, cfg.Internal),\n\t\t// The count, never the values. A sandbox rule whose credential never\n\t\t// arrived forwards whatever the application sent, and the only way to\n\t\t// notice is a number that says zero.\n\t\tCredentials: len(cfg.Credentials),\n\t})\n\n\tlog.Fatalf(\"af-proxy: %v\", <-errs)\n}\n\n// addressInside finds this container's address on a given network.\n//\n// A sidecar with no address on the environment's network cannot intercept\n// anything, and starting anyway would produce an environment that looks\n// contained and is not, so this is fatal rather than a warning.\nfunc addressInside(cidr string) (net.IP, error) {\n\tif cidr == \"\" {\n\t\treturn nil, fmt.Errorf(\"no network was named for this sidecar to answer on\")\n\t}\n\t_, subnet, err := net.ParseCIDR(cidr)\n\tif err != nil {\n\t\treturn nil, fmt.Errorf(\"%q is not a network: %w\", cidr, err)\n\t}\n\taddrs, err := net.InterfaceAddrs()\n\tif err != nil {\n\t\treturn nil, err\n\t}\n\tfor _, a := range addrs {\n\t\tipnet, ok := a.(*net.IPNet)\n\t\tif !ok {\n\t\t\tcontinue\n\t\t}\n\t\tif v4 := ipnet.IP.To4(); v4 != nil && subnet.Contains(v4) {\n\t\t\treturn v4, nil\n\t\t}\n\t}\n\treturn nil, fmt.Errorf(\"this sidecar has no address on %s\", cidr)\n}\n\n// listen accepts connections and hands each to a handler.\nfunc (p *proxy) listen(addr string, handle func(net.Conn)) error {\n\tln, err := net.Listen(\"tcp\", addr)\n\tif err != nil {\n\t\treturn err\n\t}\n\tfor {\n\t\tconn, err := ln.Accept()\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\tgo handle(conn)\n\t}\n}\n\nfunc loadConfig(path string) (*Config, error) {\n\tbody, err := os.ReadFile(path)\n\tif err != nil {\n\t\treturn nil, fmt.Errorf(\"reading the configuration: %w\", err)\n\t}\n\tvar c Config\n\tif err := json.Unmarshal(body, &c); err != nil {\n\t\treturn nil, fmt.Errorf(\"parsing the configuration: %w\", err)\n\t}\n\tif c.Egress.Default == \"\" {\n\t\t// An absent default is block, the same as everywhere else. Defaulting\n\t\t// to allow here would make a malformed configuration open rather than\n\t\t// closed, which is the wrong direction for the one component whose\n\t\t// job is to refuse things.\n\t\tc.Egress.Default = schema.ModeBlock\n\t}\n\treturn &c, nil\n}\n\n// record is one line of the decision log.\n//\n// Every request produces one, allowed or not. A log that only records refusals\n// answers \"why was this blocked\" and not \"did anything reach Stripe\", and the\n// second question is the one somebody asks after an incident.\ntype record struct {\n\tEvent    string `json:\"event\"`\n\tEnv      string `json:\"env,omitempty\"`\n\tAt       string `json:\"at,omitempty\"`\n\tMethod   string `json:\"method,omitempty\"`\n\tHost     string `json:\"host,omitempty\"`\n\tPort     int    `json:\"port,omitempty\"`\n\tPath     string `json:\"path,omitempty\"`\n\tTLS      bool   `json:\"tls,omitempty\"`\n\tMode     string `json:\"mode,omitempty\"`\n\tRule     string `json:\"rule,omitempty\"`\n\tReason   string `json:\"reason,omitempty\"`\n\tAllowed  bool   `json:\"allowed\"`\n\tStatus   int    `json:\"status,omitempty\"`\n\tBytes    int64  `json:\"bytes,omitempty\"`\n\tDuration string `json:\"duration,omitempty\"`\n\tError    string `json:\"error,omitempty\"`\n\tRules    int    `json:\"rules,omitempty\"`\n\tDefault  string `json:\"default,omitempty\"`\n\tSeq      uint64 `json:\"seq,omitempty\"`\n\t// Via says how the request arrived: as a proxy request from a client that\n\t// read its proxy variables, or transparently from one that did not.\n\tVia string `json:\"via,omitempty\"`\n\t// Substituted marks a request whose credential was replaced on the way\n\t// out, so a reader can tell a sandbox call from a live one.\n\tSubstituted bool `json:\"substituted,omitempty\"`\n\t// Synthesized marks a response a model invented, so a workflow that\n\t// touched one reports unverified rather than passed.\n\tSynthesized bool `json:\"synthesized,omitempty\"`\n\t// WaitedMs is how long a rate limit held this request. Recorded because a\n\t// request that took a second is a request somebody will otherwise blame\n\t// on the application.\n\tWaitedMs int64 `json:\"waited_ms,omitempty\"`\n\t// Limit is that rate in words, \"10 a second, bursting to 10\". The\n\t// milliseconds alone say a request was slow and not what slowed it, and\n\t// the rule's raw spec is in the manifest rather than in front of whoever\n\t// is reading the log.\n\tLimit string `json:\"limit,omitempty\"`\n\t// Credentials counts the sandbox values loaded, on the ready line.\n\tCredentials int `json:\"credentials,omitempty\"`\n\t// Pack and Fixture name what answered a mocked request. A mock that\n\t// cannot say which fixture produced a response is a mock nobody can\n\t// debug.\n\tPack    string `json:\"pack,omitempty\"`\n\tFixture string `json:\"fixture,omitempty\"`\n\t// HostOnly marks a decision made without seeing the path or the method,\n\t// which is every HTTPS request until the environment certificate lands.\n\t// Recorded rather than assumed away, so a reader can tell the difference\n\t// between a rule that matched and a rule that could only half apply.\n\tHostOnly bool `json:\"host_only,omitempty\"`\n}\n\ntype proxy struct {\n\tengine *policy.Engine\n\tenvID  string\n\tout    *json.Encoder\n\t// ca signs a certificate per host, for the connections the policy needs\n\t// to read inside. Nil when the environment has no authority, in which\n\t// case every TLS connection is tunnelled.\n\tca *certAuthority\n\t// transport re-originates inspected requests over HTTP/1.1.\n\ttransport *http.Transport\n\t// transportH2 re-originates a request that arrived over HTTP/2 inside a\n\t// terminated TLS connection, negotiating h2 with the origin.\n\ttransportH2 *http.Transport\n\t// transportH2C re-originates a request that arrived over cleartext\n\t// HTTP/2, which has no handshake to negotiate in.\n\ttransportH2C *http.Transport\n\t// credentials are the sandbox values, by the name a rule refers to.\n\tcredentials map[string]string\n\t// mocks answers requests for hosts set to mock.\n\tmocks *mockpack.Engine\n\t// limits shape traffic to a rule's declared rate, so a load run does not\n\t// get somebody's sandbox account throttled.\n\tlimits *limiter\n\t// destinations refuse the addresses the environment must not reach\n\t// through this sidecar, whatever the policy says about the name.\n\tdestinations *destinations\n\t// internal are the environment's own names, and a request for one is not\n\t// egress. It is the SAME predicate the resolver uses, which is the point:\n\t// a name the resolver sends to the real container and the proxy refuses is\n\t// one the sidecar has two opinions about.\n\tinternal inside\n\t// resolve turns a name into addresses. Nil means the system resolver,\n\t// which is what the sidecar always uses; a test sets it to say what a\n\t// name resolves to.\n\tresolve func(context.Context, string) ([]net.IP, error)\n\t// synth invents a response when a rule asks for one. Nil when no model\n\t// key is available, in which case a synth rule refuses and says so.\n\tsynth *synthConfig\n\tseq   atomic.Uint64\n\t// mu serialises writes to the encoder. A JSON encoder is not safe for\n\t// concurrent use, and every request writes a line, so without it a busy\n\t// environment produces a decision log with interleaved bytes: the one\n\t// artifact whose whole value is that it can be trusted after the fact.\n\tmu sync.Mutex\n}\n\nfunc (p *proxy) emit(r record) {\n\tr.Env = p.envID\n\tif r.At == \"\" {\n\t\tr.At = time.Now().UTC().Format(time.RFC3339Nano)\n\t}\n\tr.Seq = p.seq.Add(1)\n\tp.mu.Lock()\n\tdefer p.mu.Unlock()\n\t_ = p.out.Encode(r)\n}\n\n// emitMessage writes a captured message to the log.\n//\n// It shares the encoder's lock with the decisions, so the two streams\n// interleave by line rather than by byte, and a reader can take the log apart\n// with nothing more than a JSON decoder per line.\nfunc (p *proxy) emitMessage(m message) {\n\tm.Env = p.envID\n\tif m.At == \"\" {\n\t\tm.At = time.Now().UTC().Format(time.RFC3339Nano)\n\t}\n\tm.Seq = p.seq.Add(1)\n\tp.mu.Lock()\n\tdefer p.mu.Unlock()\n\t_ = p.out.Encode(m)\n}\n\nfunc (p *proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {\n\tif r.Method == http.MethodConnect {\n\t\tp.serveConnect(w, r)\n\t\treturn\n\t}\n\tp.serveHTTP(w, r)\n}\n\n// serveConnect handles the tunnel every HTTPS request opens.\n//\n// Only the host and port are visible here, which is a real limitation and is\n// stated rather than hidden: a rule that names paths or methods cannot be\n// enforced on an HTTPS request until the environment certificate lands, so\n// such a rule is evaluated on its host alone. A rule that would have matched\n// on the path is reported in the decision log as host-only, so the difference\n// is visible to whoever reads it rather than silently assumed away.\nfunc (p *proxy) serveConnect(w http.ResponseWriter, r *http.Request) {\n\tstarted := time.Now()\n\thost, port := splitHostPort(r.Host, 443)\n\n\t// Inside the environment, so not egress. The same reasoning as the plain\n\t// path, and the tunnel is opened without reading inside it: an internal\n\t// connection is not something the policy has an opinion about, and\n\t// terminating one would need a certificate for a name that is not on the\n\t// public internet.\n\tif p.internal.has(host) && p.resolvesInside(r.Context(), host) {\n\t\tp.tunnelInternal(w, host, port, started)\n\t\treturn\n\t}\n\n\treq := policy.Request{Host: host, Port: port, Method: http.MethodConnect, Path: \"/\", TLS: true}\n\td := p.engine.Evaluate(req)\n\n\trec := record{\n\t\tEvent: \"decision\", Method: http.MethodConnect, Host: host, Port: port,\n\t\tTLS: true, Mode: string(d.Mode), Rule: d.RuleHost,\n\t\tReason: d.Reason(), Allowed: d.Allowed(), Via: \"proxy\",\n\t}\n\t// Whether to read inside comes before whether to allow, and the order is\n\t// load bearing. Capture, mock, and sandbox all answer from inside the\n\t// tunnel and none of them counts as reaching out, so testing Allowed first\n\t// refuses the CONNECT and the request that would have been captured never\n\t// exists. That is exactly what happened: a client that honoured its proxy\n\t// variables got a 403 for a host set to capture, while a client that\n\t// ignored them was captured correctly, so the mode worked or did not\n\t// depending on which HTTP library the application happened to use.\n\tinspect := p.ca != nil && p.engine.InspectsHost(host, port)\n\t// A tunnel nobody reads inside was decided from the host and the port and\n\t// nothing else, exactly as the transparent one was, so it is recorded the\n\t// same way. The inspected tunnel is not marked, because the requests\n\t// inside it are decided on their paths and carry their own records.\n\trec.HostOnly = !inspect\n\n\tif !inspect && !d.Allowed() {\n\t\trec.Status = http.StatusForbidden\n\t\trec.Duration = time.Since(started).String()\n\t\tp.emit(rec)\n\t\t// A refused CONNECT gets a body even though most clients discard it,\n\t\t// because the ones that show it turn a mystifying failure into a\n\t\t// readable one at no cost.\n\t\twriteRefusal(w, d, req)\n\t\treturn\n\t}\n\n\thijacker, ok := w.(http.Hijacker)\n\tif !ok {\n\t\trec.Error = \"the connection cannot be hijacked\"\n\t\tp.emit(rec)\n\t\thttp.Error(w, \"af-proxy: cannot tunnel\", http.StatusInternalServerError)\n\t\treturn\n\t}\n\tclient, buffered, err := hijacker.Hijack()\n\tif err != nil {\n\t\trec.Error = err.Error()\n\t\tp.emit(rec)\n\t\treturn\n\t}\n\tdefer func() { _ = client.Close() }()\n\n\tif _, err := io.WriteString(client, \"HTTP/1.1 200 Connection Established\\r\\n\\r\\n\"); err != nil {\n\t\trec.Error = err.Error()\n\t\tp.emit(rec)\n\t\treturn\n\t}\n\n\t// A client that opted into the proxy still gets its request read when the\n\t// policy needs it read. The tunnel it just opened carries a TLS handshake\n\t// like any other, and the same rule decides what happens to it.\n\tif inspect {\n\t\trec.Status = http.StatusOK\n\t\trec.Duration = time.Since(started).String()\n\t\tp.emit(rec)\n\t\tp.inspectTLS(client, buffered.Reader, host)\n\t\treturn\n\t}\n\n\t// Background rather than the request's context. The connection was\n\t// hijacked a few lines up, so this handler owns it now and no longer\n\t// wants a deadline that belongs to a request net/http considers finished.\n\tupstream, err := p.dialGuarded(context.Background(), \"tcp\", net.JoinHostPort(host, strconv.Itoa(port)))\n\tif err != nil {\n\t\trec.Error = err.Error()\n\t\trec.Status = http.StatusBadGateway\n\t\trec.Duration = time.Since(started).String()\n\t\tp.emit(rec)\n\t\treturn\n\t}\n\tdefer func() { _ = upstream.Close() }()\n\n\trec.Status = http.StatusOK\n\trec.Bytes = pipe(client, upstream)\n\trec.Duration = time.Since(started).String()\n\tp.emit(rec)\n}\n\n// pipe copies in both directions and returns the bytes sent upstream.\nfunc pipe(client, upstream net.Conn) int64 {\n\tdone := make(chan struct{})\n\tgo func() {\n\t\t_, _ = io.Copy(client, upstream)\n\t\t// Closing the write side rather than the whole connection lets the\n\t\t// other direction finish, which is what a half closed TCP stream is\n\t\t// for and what a plain Close would cut off mid response.\n\t\tif c, ok := client.(*net.TCPConn); ok {\n\t\t\t_ = c.CloseWrite()\n\t\t}\n\t\tclose(done)\n\t}()\n\tsent, _ := io.Copy(upstream, client)\n\tif c, ok := upstream.(*net.TCPConn); ok {\n\t\t_ = c.CloseWrite()\n\t}\n\t<-done\n\treturn sent\n}\n\n// serveHTTP handles a plain request, where the whole thing is visible.\n//\n// This is the path a client that reads its proxy variables takes for an http\n// URL, and until this was written it was the one path that did not enforce the\n// whole policy. It read the mode and forwarded: the live credential tripwire\n// never ran, a sandbox rule sent the application's own credential to the\n// provider untouched, and capture, mock and synth were refused with a body\n// claiming they were not wired up in this build. Which of those happened\n// depended on whether the application's HTTP library honoured http_proxy,\n// which is not a property anybody reasons about while writing a rule. The\n// same defect was found and fixed on the CONNECT path and left here.\nfunc (p *proxy) serveHTTP(w http.ResponseWriter, r *http.Request) {\n\tstarted := time.Now()\n\tif !r.URL.IsAbs() {\n\t\t// A request that is not in absolute form was sent to the proxy as if\n\t\t// it were an origin server, which means something is pointed at the\n\t\t// wrong address rather than proxying through it.\n\t\thttp.Error(w,\n\t\t\t\"af-proxy: this is a proxy, not an origin server. Set HTTP_PROXY and HTTPS_PROXY to reach it.\",\n\t\t\thttp.StatusBadRequest)\n\t\treturn\n\t}\n\thost, port := splitHostPort(r.URL.Host, 80)\n\n\t// A request for something inside the environment is not egress, whichever\n\t// door it arrived through.\n\t//\n\t// A well behaved client never sends one here at all: the name resolves to\n\t// the real container and no_proxy keeps it off this port. A client that\n\t// reads http_proxy and ignores no_proxy sends it anyway, and until this\n\t// existed it was evaluated against the egress policy and refused, so\n\t// whether one service could reach another depended on which HTTP library\n\t// the application happened to use. It is the same defect the CONNECT path\n\t// and the plain path each had for the modes, arriving a third time.\n\t//\n\t// Nothing is reachable here that was not reachable already: this is the\n\t// same connection the client would have made directly, made on its behalf.\n\tif p.internal.has(host) && p.resolvesInside(r.Context(), host) {\n\t\tp.serveInternal(w, r, host, port, started)\n\t\treturn\n\t}\n\n\treq := policy.Request{Host: host, Port: port, Method: r.Method, Path: r.URL.Path, TLS: false}\n\td := p.engine.Evaluate(req)\n\n\trec := record{\n\t\tEvent: \"decision\", Method: r.Method, Host: host, Port: port, Path: r.URL.Path,\n\t\tMode: string(d.Mode), Rule: d.RuleHost, Reason: d.Reason(), Allowed: d.Allowed(),\n\t\tVia: \"proxy\",\n\t}\n\n\t// Before anything is forwarded and before the mode is acted on, in every\n\t// mode, exactly as on the other two paths. A credential that can act on\n\t// production must not leave an environment running unreviewed code against\n\t// a copy of production data, and which HTTP library the application chose\n\t// has nothing to do with that.\n\tif found := p.tripwire(r, host); len(found) > 0 {\n\t\trec.Status = http.StatusForbidden\n\t\trec.Allowed = false\n\t\trec.Reason = \"This request carries a live credential: \" + livekey.Describe(found)\n\t\trec.Duration = time.Since(started).String()\n\t\tp.emit(rec)\n\t\tw.Header().Set(\"Content-Type\", \"text/plain; charset=utf-8\")\n\t\tw.Header().Set(\"X-Antifailure-Decision\", \"block\")\n\t\tw.WriteHeader(http.StatusForbidden)\n\t\t_, _ = io.WriteString(w, refusalForLiveCredential(req, found))\n\t\treturn\n\t}\n\n\tswitch d.Mode {\n\tcase schema.ModeCapture, schema.ModeMock, schema.ModeSynth:\n\t\tp.serveInsideTheEnvironment(w, r, req, d, &rec, started)\n\t\treturn\n\t}\n\n\tif !d.Allowed() {\n\t\trec.Status = http.StatusForbidden\n\t\trec.Duration = time.Since(started).String()\n\t\tp.emit(rec)\n\t\twriteRefusal(w, d, req)\n\t\treturn\n\t}\n\n\tif d.RateLimit != \"\" {\n\t\tif waited := p.limits.wait(d.RuleHost, d.RateLimit); waited > 0 {\n\t\t\trec.WaitedMs = waited.Milliseconds()\n\t\t\trec.Limit = describeRate(d.RateLimit)\n\t\t}\n\t}\n\n\toutbound := r.Clone(r.Context())\n\toutbound.RequestURI = \"\"\n\t// Hop by hop headers are ours, not the origin's, and forwarding them is\n\t// how a proxy ends up asking an upstream to keep a connection alive that\n\t// only makes sense between the client and the proxy.\n\tfor _, h := range hopByHop {\n\t\toutbound.Header.Del(h)\n\t}\n\tif d.Mode == schema.ModeSandbox {\n\t\t// Whatever the application sent is discarded before the request\n\t\t// leaves, which is the whole difference between sandbox mode and\n\t\t// asking somebody to configure a sandbox key correctly.\n\t\tapplySandbox(outbound, host, p.credentials[d.Credential])\n\t\trec.Substituted = p.credentials[d.Credential] != \"\"\n\t}\n\n\t// p.transport rather than http.DefaultTransport, because the address\n\t// guard hangs off its dialer and the default one has no guard at all.\n\tresp, err := p.transport.RoundTrip(outbound)\n\tif err != nil {\n\t\trec.Error = err.Error()\n\t\trec.Status = http.StatusBadGateway\n\t\trec.Duration = time.Since(started).String()\n\t\tp.emit(rec)\n\t\thttp.Error(w, \"af-proxy: \"+err.Error(), http.StatusBadGateway)\n\t\treturn\n\t}\n\tdefer func() { _ = resp.Body.Close() }()\n\n\tfor k, vs := range resp.Header {\n\t\tfor _, v := range vs {\n\t\t\tw.Header().Add(k, v)\n\t\t}\n\t}\n\tw.WriteHeader(resp.StatusCode)\n\tn, _ := io.Copy(w, resp.Body)\n\n\trec.Status = resp.StatusCode\n\trec.Bytes = n\n\trec.Duration = time.Since(started).String()\n\tp.emit(rec)\n}\n\n// serveInsideTheEnvironment answers a capture, mock or synth request that\n// arrived through the explicit proxy port.\n//\n// All three write a whole HTTP response rather than filling in a\n// ResponseWriter, because the other two paths hold a raw connection and have\n// nothing else to write onto. Rather than a second implementation of each\n// mode for this path, the connection is taken over and handed to the same\n// code. The body is read first, because a hijacked request's Body is no\n// longer safe to touch.\nfunc (p *proxy) serveInsideTheEnvironment(\n\tw http.ResponseWriter, r *http.Request, preq policy.Request, d policy.Decision,\n\trec *record, started time.Time,\n) {\n\thost := preq.Host\n\t// The larger of the two limits the modes below apply, so neither is\n\t// handed a body this function truncated first. Each still applies its own.\n\tbody, _ := io.ReadAll(io.LimitReader(r.Body, 1<<20))\n\t_ = r.Body.Close()\n\tr.Body = io.NopCloser(bytes.NewReader(body))\n\n\thijacker, ok := w.(http.Hijacker)\n\tif !ok {\n\t\trec.Error = \"the connection cannot be taken over\"\n\t\trec.Duration = time.Since(started).String()\n\t\tp.emit(*rec)\n\t\thttp.Error(w, \"af-proxy: cannot answer this request\", http.StatusInternalServerError)\n\t\treturn\n\t}\n\tconn, _, err := hijacker.Hijack()\n\tif err != nil {\n\t\trec.Error = err.Error()\n\t\trec.Duration = time.Since(started).String()\n\t\tp.emit(*rec)\n\t\treturn\n\t}\n\tdefer func() { _ = conn.Close() }()\n\n\tswitch d.Mode {\n\tcase schema.ModeCapture:\n\t\tp.capture(conn, r, preq, d, rec)\n\tcase schema.ModeMock:\n\t\tp.serveMock(conn, r, host, rec)\n\tcase schema.ModeSynth:\n\t\tp.serveSynth(conn, r, host, rec)\n\t}\n\trec.Duration = time.Since(started).String()\n\tp.emit(*rec)\n}\n\n// writeRefusal explains a refusal in the response body.\n//\n// The audience is a developer reading a stack trace at three in the afternoon,\n// so it says what was refused, which rule refused it, and what to change. A\n// bare 403 sends them to the wrong place every time.\nfunc writeRefusal(w http.ResponseWriter, d policy.Decision, req policy.Request) {\n\tw.Header().Set(\"Content-Type\", \"text/plain; charset=utf-8\")\n\tw.Header().Set(\"X-Antifailure-Decision\", string(d.Mode))\n\tif d.RuleHost != \"\" {\n\t\tw.Header().Set(\"X-Antifailure-Rule\", d.RuleHost)\n\t}\n\tw.WriteHeader(http.StatusForbidden)\n\t_, _ = io.WriteString(w, refusalBody(d, req))\n}\n\n// refusalBody is what a developer reads in a stack trace at three in the\n// afternoon: what was refused, which rule refused it, and what to change. A\n// bare 403 sends them to the wrong place every time.\nfunc refusalBody(d policy.Decision, req policy.Request) string {\n\tvar b strings.Builder\n\tfmt.Fprintf(&b, \"Antifailure refused this request.\\n\\n\")\n\tfmt.Fprintf(&b, \"  %s\\n\\n\", req.String())\n\tfmt.Fprintf(&b, \"%s\\n\\n\", d.Reason())\n\tfmt.Fprintf(&b, \"Ask about it with:\\n\\n  af net explain %s %s\\n\",\n\t\treq.Method, schemeOf(req)+\"://\"+req.Host+req.Path)\n\treturn b.String()\n}\n\nfunc schemeOf(r policy.Request) string {\n\tif r.TLS {\n\t\treturn \"https\"\n\t}\n\treturn \"http\"\n}\n\nfunc splitHostPort(hostport string, fallback int) (string, int) {\n\tif h, p, err := net.SplitHostPort(hostport); err == nil {\n\t\tif n, convErr := strconv.Atoi(p); convErr == nil {\n\t\t\treturn h, n\n\t\t}\n\t\treturn h, fallback\n\t}\n\treturn hostport, fallback\n}\n",
 	"cmd/af-proxy/mitm.go": `package main
 
 import (
@@ -1086,6 +1552,12 @@ func (p *proxy) inspectTLS(conn net.Conn, br *bufio.Reader, sni string) {
 	server := tls.Server(&prefixedConn{Conn: conn, r: br}, &tls.Config{
 		Certificates: []tls.Certificate{*leaf},
 		MinVersion:   tls.VersionTLS12,
+		// Offered in preference order, and the negotiated protocol decides
+		// how the connection is read below. Naming none of them left the
+		// negotiated protocol empty, which every gRPC client refuses outright:
+		// HTTP/2 over TLS is negotiated with ALPN, gRPC is HTTP/2, so a
+		// terminator that selects no protocol is one gRPC will not talk to.
+		NextProtos: []string{"h2", "http/1.1"},
 	})
 	_ = server.SetDeadline(time.Now().Add(30 * time.Second))
 	if err := server.Handshake(); err != nil {
@@ -1104,6 +1576,15 @@ func (p *proxy) inspectTLS(conn net.Conn, br *bufio.Reader, sni string) {
 	}
 	_ = server.SetDeadline(time.Time{})
 	defer func() { _ = server.Close() }()
+
+	// The reader follows the handshake. Negotiating h2 and then reading
+	// HTTP/1.1 anyway would be worse than negotiating nothing, because the
+	// client would have committed to HTTP/2 and every frame it sent would be
+	// misparsed as a request line.
+	if server.ConnectionState().NegotiatedProtocol == "h2" {
+		p.serveInspectedH2(server, sni)
+		return
+	}
 
 	// One connection can carry many requests, and each is decided on its own.
 	// A client that keeps a connection open to an allowed path and then asks
@@ -1460,6 +1941,17 @@ func (p *proxy) serveTransparentHTTP(conn net.Conn) {
 	_ = conn.SetReadDeadline(time.Now().Add(30 * time.Second))
 
 	br := bufio.NewReader(conn)
+	// Before the HTTP/1.1 reader, because a cleartext HTTP/2 connection opens
+	// with a preface that reads as a request whose method is PRI and which
+	// carries no Host header at all. That was refused for naming no host,
+	// which was true about what the reader saw and said nothing about what had
+	// happened, and it is how every gRPC client built with insecure
+	// credentials met this sidecar.
+	if looksLikeH2C(br) {
+		_ = conn.SetReadDeadline(time.Time{})
+		p.serveTransparentH2C(conn, br)
+		return
+	}
 	req, err := http.ReadRequest(br)
 	if err != nil {
 		return
@@ -1758,7 +2250,11 @@ func parseServerName(b []byte) (string, error) {
 
 // writeRefusalRaw writes the refusal onto a connection that is not being
 // served by net/http.
-func writeRefusalRaw(conn net.Conn, d policy.Decision, req policy.Request) {
+//
+// An io.Writer rather than a net.Conn because the HTTP/2 path relays what this
+// writes rather than handing it a socket, and one refusal that both paths use
+// is what keeps them from disagreeing about what a refusal says.
+func writeRefusalRaw(conn io.Writer, d policy.Decision, req policy.Request) {
 	body := refusalBody(d, req)
 	// Not checked: the refusal is best effort on a connection that is about
 	// to be closed either way.

--- a/tools/proxysrc/main.go
+++ b/tools/proxysrc/main.go
@@ -40,6 +40,7 @@ var sources = []string{
 	"cmd/af-proxy/dns.go",
 	"cmd/af-proxy/transparent.go",
 	"cmd/af-proxy/mitm.go",
+	"cmd/af-proxy/h2.go",
 	"cmd/af-proxy/capture.go",
 	"cmd/af-proxy/sandbox.go",
 	"cmd/af-proxy/limit.go",


### PR DESCRIPTION
## The failure

The sidecar terminated TLS on its inspected path with no `ALPNProtocols` set,
then read HTTP/1.1 out of the connection. gRPC is defined over HTTP/2, and
HTTP/2 over TLS is negotiated with ALPN, so a gRPC client closed the connection
during the handshake with `missing selected ALPN property` before it wrote a
single request. `EnforceALPNEnabled` has defaulted to true in grpc-go since
1.67, so this is not a warning anybody could ignore.

Nothing in the decision log explained it, because nothing had been decided: the
refusal came from inside the application's own client library, about a server
it believed was the origin.

This is a statement about the product's central claim rather than about one
cloud. Antifailure's thesis is that an unmodified application runs inside a
contained environment with every outbound call named and decided. An
application that speaks gRPC to anything, a cloud service, a vendor API or its
own dependency, met a sidecar that could not carry its protocol. Five of the
six Google Cloud services a vendor SDK reaches by default are gRPC, which is
how it surfaced, but the reach is every gRPC client anywhere.

## Three holes, not one

**The terminator offered no protocol.** Fixed by offering `h2` and `http/1.1`
and letting the negotiated protocol decide the reader. Negotiating h2 and then
reading HTTP/1.1 anyway would have been worse than negotiating nothing, because
the client would have committed to HTTP/2 and every frame it sent would have
been misparsed as a request line.

**The forwarding half was HTTP/1.1 only, and not by accident.**
`net/http/transport.go` disables HTTP/2 on any transport carrying a custom
`DialContext`, and the sidecar sets one because the address guard hangs off it.
A gRPC status travels in HTTP/2 trailers, so a request terminated as h2 and
forwarded as HTTP/1.1 loses the status the origin sent. The protocol has to be
asked for explicitly on both halves, so there are now three transports: one per
protocol the client can arrive on.

**The plain listener had the same hole in cleartext.** A gRPC client built with
insecure credentials, which is what every emulator's documented setup uses,
opens with the HTTP/2 connection preface. `http.ReadRequest` parsed that as a
request whose method was `PRI` and which carried no `Host` header, and it was
refused for naming no host: correct about what it saw and silent about what had
happened. This one was not in the lane's row and is closed here rather than
reported.

## The policy is not weakened

Every decision the sidecar makes for an HTTP/1.1 request is made for an HTTP/2
one, in the same order:

- the host comes from the `:authority` the client wrote, not from the name in
  the handshake, for the same reason the HTTP/1.1 reader prefers the `Host`
  header: that is where the request is actually going
- the live credential tripwire runs before the mode is acted on, in every mode
- a blocked host is still blocked, over gRPC, and the origin is proved not to
  have been reached
- the sandbox substitution still replaces the application's own credential
- capture, mock, synth and every refusal go through the ONE implementation each
  already has, relayed through a pipe, rather than a second copy written
  against `ResponseWriter` that would drift

Bodies stream in both directions and are flushed per chunk. A gRPC call can be
open for hours, so a bounded read would end the stream early and leave the
client reporting a status the server never sent. The bidirectional test sends
and receives one message at a time, which a proxy that buffered the request
body would deadlock on rather than answer wrongly.

## The constraint that decided the design

`tools/proxysrc` carries a fixed list of files into the sidecar's build context
with a `go.mod` that has no requirements, which is what lets the image build
with no network. So none of this could use `golang.org/x/net/http2`. Go 1.24's
`http.Protocols`, plus an `http.Server` over a one connection listener, gives
both h2 and h2c from the standard library alone. `h2.go` is added to the
packaged list, which is now 17 files, and imports nothing the sidecar could not
already see.

## Corroborated independently, and the middle row is the one that matters

L3.3 ran an unmodified `@google-cloud/pubsub` 6.0.1 with no endpoint override
against a stand in for the sidecar, changing one thing per run:

    reads HTTP/1.1, no ALPN, which is what mitm.go did   14 UNAVAILABLE    80.5 s
    reads HTTP/1.1, offers ALPN h2                       14 UNAVAILABLE    77.0 s
    forwards the terminated socket to an HTTP/2 backend  12 UNIMPLEMENTED   2.6 s

The middle row is the control that isolates the second hole above. Offering
ALPN alone changed nothing: the client still spent its whole deadline and the
proxy still logged `Parse Error: Pause on PRI/Upgrade` on every attempt, which
is an HTTP/1.1 parser meeting the HTTP/2 connection preface. A lane that had
only read its row would have added `ALPNProtocols`, watched a handshake
succeed, and shipped something that still did not work.

L3.3's own caveat is worth carrying: its third row answers from a bare HTTP/2
server returning a trailers only status, not from a real Google emulator, so it
proves the transport reaches a server and not that an emulator behaves.

## The honest before sentence

gRPC over TLS was not simply broken. `serveTransparentTLS` terminates only when
`InspectsHost` is true, meaning the rule names paths or methods or the mode is
capture, mock, sandbox or synth. A plain `allow` rule with no paths is tunnelled
untouched, so gRPC flowed through it, with a host only decision: no path, no
method, and no live credential tripwire, because the tripwire lives inside the
terminated connection.

> gRPC worked only where the policy made no decision beyond the hostname, and
> broke completely the moment anybody wrote a rule that looked inside.

## The new dependency is test only

`google.golang.org/grpc v1.83.1` is added to `engine/go.mod` and is imported by
`cmd/af-proxy/grpc_test.go` and nothing else. Hand rolling a gRPC client here
would have avoided the ALPN enforcement that IS the bug, and a test that avoids
the thing under test is one of the four shapes of unfailable test this
repository found this week.

It does NOT appear in `THIRD_PARTY_NOTICES.md`, and that is correct rather than
an omission: `tools/notices` lists `go list -deps ./cmd/af`, which is what the
release links, and a test dependency is not linked into the shipped binary. It
is still scanned for vulnerabilities, so the `known vulnerabilities` context
covers it.

## What is NOT closed

AMQP 1.0, which is what Azure's Service Bus emulator speaks. It is not HTTP at
all, so no HTTP proxy path carries it however good: it needs a byte stream path
with its own destination extraction and its own policy model. Named here rather
than absorbed, and dispatched as its own lane.
