### PR TITLE
engine: 168 of the manifest's 570 published constraints were kept by nothing

### DIFF
--- a/.changes/schema-bounds-are-enforced.md
+++ b/.changes/schema-bounds-are-enforced.md
@@ -1,0 +1,24 @@
+# fixed
+
+The manifest's published schema declared 570 constraints and the engine kept
+394 of them. `schemas/manifest.v1.json` is not an internal artifact: editors
+validate against it, it is the document you learn the manifest from, and the
+reference table on the site is generated out of it, so every bound in it reads
+as a promise. 168 of those promises were kept by nothing. A `maxLength` of 40
+on a service name accepted a name of any length, a `minimum` of 1 accepted
+zero, an `enum` accepted a value not in it, and the only symptom would have
+been an editor calling a manifest invalid that the engine ran, or the reverse.
+
+The gap was invisible because every instrument near it answered a nearby
+question. One test compares the field NAMES on the two sides and says in its
+own comment that it deliberately compares nothing else. `manifestcheck` reads
+the documentation's manifests for unknown keys. `fieldsweep` asks whether a
+field is read at all. The validator's own comment stated the gap in one line
+and read as a note rather than a defect.
+
+The engine now enforces those bounds at parse time, driven by the published
+schema itself rather than by a second hand written spelling of it, so the two
+cannot disagree. Every hand written check stays: they carry better messages,
+and they carry the cross field rules a JSON Schema cannot express, such as a
+database declaring both a source and a seed. Where both would speak, the hand
+written message wins, so one mistake is still reported once.

--- a/antifailure.yaml
+++ b/antifailure.yaml
@@ -519,7 +519,7 @@ workflows:
   # names the two controls by their visible labels, which is how the planner
   # without a model knows what to press on a page whose shape it does not
   # share with every application.
-  - name: an-operator-who-is-also-a-customer-can-mark-an-application-reviewed
+  - name: an-operator-who-is-also-a-customer-marks-an-application-reviewed
     description: >-
       Sign in to the console as the owner, then sign in to the operator portal
       in the same browser, open the applications queue, open the application

--- a/docs/plan/notes/dogfood.md
+++ b/docs/plan/notes/dogfood.md
@@ -114,7 +114,7 @@ the same scrypt parameters the API verifies against, so the password the runner
 types and the hash in the row agree.
 
 Two workflows need it, and they are the first here that hold two sessions in
-one browser. `an-operator-who-is-also-a-customer-can-mark-an-application-reviewed`
+one browser. `an-operator-who-is-also-a-customer-marks-an-application-reviewed`
 is the mirror image: the same browser, acting as the operator, marks a seeded
 application reviewed, which the CUSTOMER gate used to refuse for want of the
 product token. `an-operator-who-is-also-a-customer-can-start-checkout` It signs in to the

--- a/docs/src/content/docs/reference/schemas/manifest-v1.md
+++ b/docs/src/content/docs/reference/schemas/manifest-v1.md
@@ -165,7 +165,7 @@ One variable a service needs. The manifest declares the name and where the value
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
 | `from` | string | no | Where to read the value: a secrets adapter name, or the name of a different variable to copy. Max length 256. |
-| `name` | string | **yes** | Max length 128, matches `^[A-Za-z_][A-Za-z0-9_]*$`. |
+| `name` | string | **yes** | Max length 128, matches `^[A-Za-z_][A-Za-z0-9_.]*$`. |
 | `required` | boolean | no | Whether the environment fails to start without it. Defaults to true, because a service silently missing configuration is the failure this product exists to prevent. Defaults to `true`. |
 | `sandbox` | boolean | no | Marks a credential that must be a sandbox one. The secrets subsystem refuses a value carrying a known live prefix, and the proxy trips a wire if one reaches the network anyway. Defaults to `false`. |
 | `value` | string | no | A literal value for a variable that is configuration rather than a secret, such as a feature flag or a public URL. A value that looks like a credential is rejected. Max length 2048. |
@@ -432,7 +432,7 @@ One process the environment runs. A service is built from the repository, given 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
 | `build` | [Build](#build) | no | How to turn the service directory into an image. |
-| `command` | string | no | Command that starts the service, overriding the image's own. Executed with an argument vector, never through a shell. Max length 1024. |
+| `command` | string | no | Command that starts the service, overriding the image's own. Executed with an argument vector, never through a shell. Max length 4096. |
 | `depends_on` | list of string | no | Services that must be ready first. A cycle is rejected at validation. Max items 50. |
 | `env` | list of [Environment variable](#environment-variable) | no | Names of environment variables this service needs. Names only. Values come from the secrets subsystem, and a name with no value anywhere fails with AF-SEC-001 rather than starting a service that will misbehave. Max items 200. |
 | `health_path` | string | no | HTTP path that reports readiness. A service is not considered up until this returns a 2xx or 3xx status. Defaults to `/`. Max length 512. |

--- a/docs/src/content/docs/reference/schemas/manifest-v1.md
+++ b/docs/src/content/docs/reference/schemas/manifest-v1.md
@@ -30,7 +30,7 @@ This page is generated from `schemas/manifest.v1.json`. Edit the schema, then ru
 | `policy` | [Policy](#policy) | no | What each class of finding does to the pull request check. |
 | `runtime` | [Runtime](#runtime) | no | Where and how long the environment runs. |
 | `services` | list of [Service](#service) | no | Every process the environment runs: web servers, API servers, background workers, and scheduled jobs. Min items 1, max items 50. |
-| `version` | `1` | **yes** | The manifest schema version. Increment only for a breaking change; the engine refuses a version it does not understand rather than guessing. |
+| `version` | `1` | no | The manifest schema version. Increment only for a breaking change; the engine refuses a version it does not understand rather than guessing. |
 | `workflows` | list of [Workflow](#workflow) | no | What the agents do, written as sentences. A workflow is a goal, not a script: the runner decides the actions and verifies the outcome. Max items 200. |
 
 ## auth
@@ -110,7 +110,7 @@ Where the environment's Postgres comes from, and how the production copy is made
 | `max_branches` | integer | no | The plan's concurrent branch limit, where the provider has one it cannot read from its own API. Reaching it fails with AF-DB-006 rather than hanging. Minimum 1. |
 | `migrations` | [Migrations](#migrations) | no | Where the project's own SQL migrations live, for a project whose migrate command is its own script rather than a tool the rehearsal recognises. |
 | `project` | string | no | The account-side project a hosted provider creates branches in, such as a Neon project. Not a secret, which is why it lives here and the key that reaches it does not. |
-| `provider` | `docker`, `neon`, `supabase`, `dblab`, `pgurl` | no | Which provider creates branches. docker is local and needs nothing; neon, supabase, and dblab talk to a service; pgurl is any reachable Postgres, which is where the goldens and the branches are kept as databases on a server you name. Defaults to `docker`. |
+| `provider` | string | no | Which provider creates branches. docker is local and needs nothing; neon, supabase, and dblab talk to a service; pgurl is any reachable Postgres, which is where the goldens and the branches are kept as databases on a server you name. Defaults to `docker`. |
 | `seed` | string | no | Command that fills the golden with data, for a project with no production database yet. It runs once per refresh with DATABASE_URL set, and every branch is a copy of what it made, so the cost is paid once rather than per environment. Mutually exclusive with source_url_env. Max length 1024. |
 | `source_url_env` | string | no | Name of the environment variable holding the read only connection string of the production database. The value is read once, during a golden refresh, on the operator's machine or runner, and never stored. Max length 128, matches `^[A-Za-z_][A-Za-z0-9_]*$`. |
 | `subset` | [Subset](#subset) | no | Take a production shaped slice rather than the whole database. |
@@ -219,7 +219,7 @@ The masked, verified copy every environment branches from.
 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
-| `max_age` | string | no | How stale a golden may be before af up refreshes it first. Defaults to `168h`. Matches `^[0-9]+(h\|d)$`. |
+| `max_age` | string | no | How stale a golden may be before af up refreshes it first. Defaults to `168h`. Matches `^[0-9]+(ms\|s\|m\|h\|d)$`. |
 | `retain` | integer | no | How many versions to keep. A referenced version is never collected regardless of this. Defaults to `5`. Minimum 1, maximum 100. |
 | `schedule` | string | no | Cron expression for automatic refreshes, with an optional CRON_TZ prefix. A refresh that would overlap a running one is skipped with an event rather than queued. Max length 128. |
 | `storage` | `local`, `azure_blob`, `s3` | no | Where dumps and attestations live. Defaults to `local`. |
@@ -405,12 +405,12 @@ Where and how long the environment runs. The provider decides the machinery; the
 | `domain` | string | no | Wildcard domain for environment hostnames. Defaults to localhost, which needs no DNS at all. Defaults to `localhost`. Max length 253. |
 | `idle_sleep` | string | no | How long an environment may sit idle before it is scaled to zero. It wakes on the next request. Defaults to `30m`. Matches `^[0-9]+(m\|h)$`. |
 | `kubeconfig_context` | string | no | Which kubeconfig context to use. Naming it prevents an environment landing on whatever cluster happened to be current. Max length 253. |
-| `max_ttl` | string | no | The furthest af env extend may push an environment's expiry, measured from when it was created. A lifetime that can be extended forever is not a lifetime, and this is the bound. Defaults to `168h`. Matches `^[0-9]+(h\|d)$`. |
+| `max_ttl` | string | no | The furthest af env extend may push an environment's expiry, measured from when it was created. A lifetime that can be extended forever is not a lifetime, and this is the bound. Defaults to `168h`. Matches `^[0-9]+(ms\|s\|m\|h\|d)$`. |
 | `namespace_prefix` | string | no | Prefix for Kubernetes namespaces. Defaults to `af`. Max length 40. |
 | `provider` | string | no | Which runtime places the environment. local and kubernetes are built in. Open rather than a fixed list, for the reason datastore.engine is: a build registers the runtimes it carries, so a manifest naming one this build has no runtime for is refused by the provider lookup, by name, against the runtimes that build actually has, which says more than an unknown value would. Defaults to `local`. Max length 64. |
 | `requires` | object | no | What a target must offer for this repository to be placed on it, as attribute equals value matched against a target's tags. Empty means anywhere. A requirement no declared target satisfies is refused at validation, because both are in this file. Max properties 16. |
 | `targets` | list of [Runtime target](#runtime-target) | no | The places an environment may be placed, in preference order. Empty means the single runtime the provider names, which is every manifest written before placement existed. Max items 32. |
-| `ttl` | string | no | How long an environment lives before the reaper tears it down. Extend one you are still using with af env extend, up to max_ttl. Defaults to `24h`. Matches `^[0-9]+(h\|d)$`. |
+| `ttl` | string | no | How long an environment lives before the reaper tears it down. Extend one you are still using with af env extend, up to max_ttl. Defaults to `24h`. Matches `^[0-9]+(ms\|s\|m\|h\|d)$`. |
 
 ## Runtime target
 

--- a/engine/internal/cli/start_test.go
+++ b/engine/internal/cli/start_test.go
@@ -45,7 +45,7 @@ personas:
     role: owner
     login: password
 workflows:
-  - name: sign in
+  - name: sign-in
     description: Sign in as the owner and check that the dashboard lists the orders.
     persona: owner
     start_path: /

--- a/engine/internal/docs/pages.gen.go
+++ b/engine/internal/docs/pages.gen.go
@@ -19223,7 +19223,7 @@ This page is generated from ` + "`" + `schemas/manifest.v1.json` + "`" + `. Edit
 | ` + "`" + `policy` + "`" + ` | [Policy](#policy) | no | What each class of finding does to the pull request check. |
 | ` + "`" + `runtime` + "`" + ` | [Runtime](#runtime) | no | Where and how long the environment runs. |
 | ` + "`" + `services` + "`" + ` | list of [Service](#service) | no | Every process the environment runs: web servers, API servers, background workers, and scheduled jobs. Min items 1, max items 50. |
-| ` + "`" + `version` + "`" + ` | ` + "`" + `1` + "`" + ` | **yes** | The manifest schema version. Increment only for a breaking change; the engine refuses a version it does not understand rather than guessing. |
+| ` + "`" + `version` + "`" + ` | ` + "`" + `1` + "`" + ` | no | The manifest schema version. Increment only for a breaking change; the engine refuses a version it does not understand rather than guessing. |
 | ` + "`" + `workflows` + "`" + ` | list of [Workflow](#workflow) | no | What the agents do, written as sentences. A workflow is a goal, not a script: the runner decides the actions and verifies the outcome. Max items 200. |
 
 ## auth
@@ -19303,7 +19303,7 @@ Where the environment's Postgres comes from, and how the production copy is made
 | ` + "`" + `max_branches` + "`" + ` | integer | no | The plan's concurrent branch limit, where the provider has one it cannot read from its own API. Reaching it fails with AF-DB-006 rather than hanging. Minimum 1. |
 | ` + "`" + `migrations` + "`" + ` | [Migrations](#migrations) | no | Where the project's own SQL migrations live, for a project whose migrate command is its own script rather than a tool the rehearsal recognises. |
 | ` + "`" + `project` + "`" + ` | string | no | The account-side project a hosted provider creates branches in, such as a Neon project. Not a secret, which is why it lives here and the key that reaches it does not. |
-| ` + "`" + `provider` + "`" + ` | ` + "`" + `docker` + "`" + `, ` + "`" + `neon` + "`" + `, ` + "`" + `supabase` + "`" + `, ` + "`" + `dblab` + "`" + `, ` + "`" + `pgurl` + "`" + ` | no | Which provider creates branches. docker is local and needs nothing; neon, supabase, and dblab talk to a service; pgurl is any reachable Postgres, which is where the goldens and the branches are kept as databases on a server you name. Defaults to ` + "`" + `docker` + "`" + `. |
+| ` + "`" + `provider` + "`" + ` | string | no | Which provider creates branches. docker is local and needs nothing; neon, supabase, and dblab talk to a service; pgurl is any reachable Postgres, which is where the goldens and the branches are kept as databases on a server you name. Defaults to ` + "`" + `docker` + "`" + `. |
 | ` + "`" + `seed` + "`" + ` | string | no | Command that fills the golden with data, for a project with no production database yet. It runs once per refresh with DATABASE_URL set, and every branch is a copy of what it made, so the cost is paid once rather than per environment. Mutually exclusive with source_url_env. Max length 1024. |
 | ` + "`" + `source_url_env` + "`" + ` | string | no | Name of the environment variable holding the read only connection string of the production database. The value is read once, during a golden refresh, on the operator's machine or runner, and never stored. Max length 128, matches ` + "`" + `^[A-Za-z_][A-Za-z0-9_]*$` + "`" + `. |
 | ` + "`" + `subset` + "`" + ` | [Subset](#subset) | no | Take a production shaped slice rather than the whole database. |
@@ -19412,7 +19412,7 @@ The masked, verified copy every environment branches from.
 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
-| ` + "`" + `max_age` + "`" + ` | string | no | How stale a golden may be before af up refreshes it first. Defaults to ` + "`" + `168h` + "`" + `. Matches ` + "`" + `^[0-9]+(h\|d)$` + "`" + `. |
+| ` + "`" + `max_age` + "`" + ` | string | no | How stale a golden may be before af up refreshes it first. Defaults to ` + "`" + `168h` + "`" + `. Matches ` + "`" + `^[0-9]+(ms\|s\|m\|h\|d)$` + "`" + `. |
 | ` + "`" + `retain` + "`" + ` | integer | no | How many versions to keep. A referenced version is never collected regardless of this. Defaults to ` + "`" + `5` + "`" + `. Minimum 1, maximum 100. |
 | ` + "`" + `schedule` + "`" + ` | string | no | Cron expression for automatic refreshes, with an optional CRON_TZ prefix. A refresh that would overlap a running one is skipped with an event rather than queued. Max length 128. |
 | ` + "`" + `storage` + "`" + ` | ` + "`" + `local` + "`" + `, ` + "`" + `azure_blob` + "`" + `, ` + "`" + `s3` + "`" + ` | no | Where dumps and attestations live. Defaults to ` + "`" + `local` + "`" + `. |
@@ -19598,12 +19598,12 @@ Where and how long the environment runs. The provider decides the machinery; the
 | ` + "`" + `domain` + "`" + ` | string | no | Wildcard domain for environment hostnames. Defaults to localhost, which needs no DNS at all. Defaults to ` + "`" + `localhost` + "`" + `. Max length 253. |
 | ` + "`" + `idle_sleep` + "`" + ` | string | no | How long an environment may sit idle before it is scaled to zero. It wakes on the next request. Defaults to ` + "`" + `30m` + "`" + `. Matches ` + "`" + `^[0-9]+(m\|h)$` + "`" + `. |
 | ` + "`" + `kubeconfig_context` + "`" + ` | string | no | Which kubeconfig context to use. Naming it prevents an environment landing on whatever cluster happened to be current. Max length 253. |
-| ` + "`" + `max_ttl` + "`" + ` | string | no | The furthest af env extend may push an environment's expiry, measured from when it was created. A lifetime that can be extended forever is not a lifetime, and this is the bound. Defaults to ` + "`" + `168h` + "`" + `. Matches ` + "`" + `^[0-9]+(h\|d)$` + "`" + `. |
+| ` + "`" + `max_ttl` + "`" + ` | string | no | The furthest af env extend may push an environment's expiry, measured from when it was created. A lifetime that can be extended forever is not a lifetime, and this is the bound. Defaults to ` + "`" + `168h` + "`" + `. Matches ` + "`" + `^[0-9]+(ms\|s\|m\|h\|d)$` + "`" + `. |
 | ` + "`" + `namespace_prefix` + "`" + ` | string | no | Prefix for Kubernetes namespaces. Defaults to ` + "`" + `af` + "`" + `. Max length 40. |
 | ` + "`" + `provider` + "`" + ` | string | no | Which runtime places the environment. local and kubernetes are built in. Open rather than a fixed list, for the reason datastore.engine is: a build registers the runtimes it carries, so a manifest naming one this build has no runtime for is refused by the provider lookup, by name, against the runtimes that build actually has, which says more than an unknown value would. Defaults to ` + "`" + `local` + "`" + `. Max length 64. |
 | ` + "`" + `requires` + "`" + ` | object | no | What a target must offer for this repository to be placed on it, as attribute equals value matched against a target's tags. Empty means anywhere. A requirement no declared target satisfies is refused at validation, because both are in this file. Max properties 16. |
 | ` + "`" + `targets` + "`" + ` | list of [Runtime target](#runtime-target) | no | The places an environment may be placed, in preference order. Empty means the single runtime the provider names, which is every manifest written before placement existed. Max items 32. |
-| ` + "`" + `ttl` + "`" + ` | string | no | How long an environment lives before the reaper tears it down. Extend one you are still using with af env extend, up to max_ttl. Defaults to ` + "`" + `24h` + "`" + `. Matches ` + "`" + `^[0-9]+(h\|d)$` + "`" + `. |
+| ` + "`" + `ttl` + "`" + ` | string | no | How long an environment lives before the reaper tears it down. Extend one you are still using with af env extend, up to max_ttl. Defaults to ` + "`" + `24h` + "`" + `. Matches ` + "`" + `^[0-9]+(ms\|s\|m\|h\|d)$` + "`" + `. |
 
 ## Runtime target
 

--- a/engine/internal/docs/pages.gen.go
+++ b/engine/internal/docs/pages.gen.go
@@ -19358,7 +19358,7 @@ One variable a service needs. The manifest declares the name and where the value
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
 | ` + "`" + `from` + "`" + ` | string | no | Where to read the value: a secrets adapter name, or the name of a different variable to copy. Max length 256. |
-| ` + "`" + `name` + "`" + ` | string | **yes** | Max length 128, matches ` + "`" + `^[A-Za-z_][A-Za-z0-9_]*$` + "`" + `. |
+| ` + "`" + `name` + "`" + ` | string | **yes** | Max length 128, matches ` + "`" + `^[A-Za-z_][A-Za-z0-9_.]*$` + "`" + `. |
 | ` + "`" + `required` + "`" + ` | boolean | no | Whether the environment fails to start without it. Defaults to true, because a service silently missing configuration is the failure this product exists to prevent. Defaults to ` + "`" + `true` + "`" + `. |
 | ` + "`" + `sandbox` + "`" + ` | boolean | no | Marks a credential that must be a sandbox one. The secrets subsystem refuses a value carrying a known live prefix, and the proxy trips a wire if one reaches the network anyway. Defaults to ` + "`" + `false` + "`" + `. |
 | ` + "`" + `value` + "`" + ` | string | no | A literal value for a variable that is configuration rather than a secret, such as a feature flag or a public URL. A value that looks like a credential is rejected. Max length 2048. |
@@ -19625,7 +19625,7 @@ One process the environment runs. A service is built from the repository, given 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
 | ` + "`" + `build` + "`" + ` | [Build](#build) | no | How to turn the service directory into an image. |
-| ` + "`" + `command` + "`" + ` | string | no | Command that starts the service, overriding the image's own. Executed with an argument vector, never through a shell. Max length 1024. |
+| ` + "`" + `command` + "`" + ` | string | no | Command that starts the service, overriding the image's own. Executed with an argument vector, never through a shell. Max length 4096. |
 | ` + "`" + `depends_on` + "`" + ` | list of string | no | Services that must be ready first. A cycle is rejected at validation. Max items 50. |
 | ` + "`" + `env` + "`" + ` | list of [Environment variable](#environment-variable) | no | Names of environment variables this service needs. Names only. Values come from the secrets subsystem, and a name with no value anywhere fails with AF-SEC-001 rather than starting a service that will misbehave. Max items 200. |
 | ` + "`" + `health_path` + "`" + ` | string | no | HTTP path that reports readiness. A service is not considered up until this returns a 2xx or 3xx status. Defaults to ` + "`" + `/` + "`" + `. Max length 512. |

--- a/engine/internal/manifest/export_test.go
+++ b/engine/internal/manifest/export_test.go
@@ -1,0 +1,12 @@
+package manifest
+
+// BoundsExceptionsForTest exposes the one list of deliberately unenforced
+// constraints to the external test package, so the gate and the pass cannot
+// carry two lists that agree until somebody edits one.
+func BoundsExceptionsForTest() [][3]string {
+	out := make([][3]string, 0, len(boundsExceptions))
+	for _, e := range boundsExceptions {
+		out = append(out, [3]string{e.Path, e.Keyword, e.Why})
+	}
+	return out
+}

--- a/engine/internal/manifest/manifest.v1.json
+++ b/engine/internal/manifest/manifest.v1.json
@@ -5,9 +5,6 @@
   "description": "The file antifailure.yaml at the root of a repository. It describes what to build, where the database comes from, what the environment may reach on the network, who the agents log in as, and what they do. It is the whole configuration surface: nothing about an environment is configured anywhere else.",
   "type": "object",
   "additionalProperties": false,
-  "required": [
-    "version"
-  ],
   "properties": {
     "version": {
       "type": "integer",
@@ -289,21 +286,19 @@
     },
     "resources": {
       "title": "Resources",
-      "description": "Not read by anything, and refused by the engine. Neither runtime emits a resource requirement, so a cap written here was applied nowhere.",
+      "description": "The size one instance of this service is given. Each value is both the request and the limit, so the service gets what it asked for and takes no more. Omit either key to leave that dimension uncapped.",
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "cpu": {
           "type": "string",
           "pattern": "^[0-9]+(\\.[0-9]+)?m?$",
-          "deprecated": true,
-          "description": "Not read by anything, and refused by the engine. No runtime applies a CPU limit, so a service carrying this ran with none."
+          "description": "CPU for one instance, as a number of cores or as thousandths with an m: 2, 0.5, 500m. On Kubernetes it is the request and the limit, which puts the pod in the Guaranteed class; on the local runtime it is the daemon's own cpu constraint. A value the runtime cannot place is refused with AF-RUN-047 naming the shortfall, rather than accepted and left Pending."
         },
         "memory": {
           "type": "string",
           "pattern": "^[0-9]+(Mi|Gi|M|G)$",
-          "deprecated": true,
-          "description": "Not read by anything, and refused by the engine. No runtime applies a memory limit, so a service carrying this ran with none."
+          "description": "Memory for one instance, with a unit: 512Mi, 2Gi. Mi and Gi are powers of two, M and G powers of ten. A bare number is refused, because nobody who writes 512 means 512 bytes. On Kubernetes it is the request and the limit; on the local runtime it is the daemon's memory constraint, so a service over it is killed rather than allowed to take the machine down."
         }
       }
     },
@@ -315,7 +310,7 @@
       "properties": {
         "provider": {
           "type": "string",
-          "enum": [
+          "examples": [
             "docker",
             "neon",
             "supabase",
@@ -439,8 +434,9 @@
         },
         "source_url_env": {
           "type": "string",
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
           "maxLength": 128,
-          "description": "The variable holding this store's production connection string, which is what a golden of it is copied from. A variable name rather than a URL, because the value is a credential for production and a manifest is checked in. Omitted, the golden is EMPTY and every refresh says so: that is the same answer database.source_url_env gives a project that has not connected production yet, and it is not a refusal because a store whose tables are made by migrations is still worth branching."
+          "description": "The NAME of the variable holding this store's production connection string, which is what a golden of it is copied from. A variable name rather than a URL, because the value is a credential for production and a manifest is checked in. Omitted, the golden is EMPTY and every refresh says so: that is the same answer database.source_url_env gives a project that has not connected production yet, and it is not a refusal because a store whose tables are made by migrations is still worth branching. A connection string written here rather than a variable name is refused, and the refusal does not print it back."
         }
       }
     },
@@ -509,7 +505,7 @@
         },
         "max_age": {
           "type": "string",
-          "pattern": "^[0-9]+(h|d)$",
+          "pattern": "^[0-9]+(ms|s|m|h|d)$",
           "default": "168h",
           "description": "How stale a golden may be before af up refreshes it first."
         },
@@ -1583,21 +1579,19 @@
       "properties": {
         "provider": {
           "type": "string",
-          "enum": [
-            "local",
-            "kubernetes"
-          ],
-          "default": "local"
+          "maxLength": 64,
+          "default": "local",
+          "description": "Which runtime places the environment. local and kubernetes are built in. Open rather than a fixed list, for the reason datastore.engine is: a build registers the runtimes it carries, so a manifest naming one this build has no runtime for is refused by the provider lookup, by name, against the runtimes that build actually has, which says more than an unknown value would."
         },
         "ttl": {
           "type": "string",
-          "pattern": "^[0-9]+(h|d)$",
+          "pattern": "^[0-9]+(ms|s|m|h|d)$",
           "default": "24h",
           "description": "How long an environment lives before the reaper tears it down. Extend one you are still using with af env extend, up to max_ttl."
         },
         "max_ttl": {
           "type": "string",
-          "pattern": "^[0-9]+(h|d)$",
+          "pattern": "^[0-9]+(ms|s|m|h|d)$",
           "default": "168h",
           "description": "The furthest af env extend may push an environment's expiry, measured from when it was created. A lifetime that can be extended forever is not a lifetime, and this is the bound."
         },

--- a/engine/internal/manifest/manifest.v1.json
+++ b/engine/internal/manifest/manifest.v1.json
@@ -1,0 +1,1832 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://antifailure.dev/schemas/manifest.v1.json",
+  "title": "Antifailure manifest",
+  "description": "The file antifailure.yaml at the root of a repository. It describes what to build, where the database comes from, what the environment may reach on the network, who the agents log in as, and what they do. It is the whole configuration surface: nothing about an environment is configured anywhere else.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version"
+  ],
+  "properties": {
+    "version": {
+      "type": "integer",
+      "enum": [
+        1
+      ],
+      "description": "The manifest schema version. Increment only for a breaking change; the engine refuses a version it does not understand rather than guessing."
+    },
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z0-9]([a-z0-9-]{0,38}[a-z0-9])?$",
+      "maxLength": 40,
+      "description": "A short name for this application, used in environment hostnames and in the control plane. Defaults to the repository directory name."
+    },
+    "services": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 50,
+      "items": {
+        "$ref": "#/$defs/service"
+      },
+      "description": "Every process the environment runs: web servers, API servers, background workers, and scheduled jobs."
+    },
+    "database": {
+      "$ref": "#/$defs/database"
+    },
+    "datastores": {
+      "type": "array",
+      "maxItems": 25,
+      "items": {
+        "$ref": "#/$defs/datastore"
+      },
+      "description": "Every store the environment holds, and what is done about each one's contents. The database: block above normalizes into the entry named primary, so a manifest that declares only database: already has this list and does not have to write it. A stance is declared rather than defaulted, because an empty ClickHouse nobody chose looks exactly like an empty ClickHouse somebody decided on."
+    },
+    "egress": {
+      "$ref": "#/$defs/egress"
+    },
+    "personas": {
+      "type": "array",
+      "maxItems": 50,
+      "items": {
+        "$ref": "#/$defs/persona"
+      },
+      "description": "The accounts agents log in as. Each is created or reconciled in the golden by the authentication adapter, so a persona is a real user of the application rather than a bypass."
+    },
+    "auth": {
+      "$ref": "#/$defs/auth"
+    },
+    "workflows": {
+      "type": "array",
+      "maxItems": 200,
+      "items": {
+        "$ref": "#/$defs/workflow"
+      },
+      "description": "What the agents do, written as sentences. A workflow is a goal, not a script: the runner decides the actions and verifies the outcome."
+    },
+    "invariants": {
+      "type": "array",
+      "maxItems": 100,
+      "items": {
+        "$ref": "#/$defs/invariant"
+      },
+      "description": "Read only statements that must hold after every workflow. They are the assertions a test cannot make from the outside: no orphaned rows, no negative balances, no subscription without a customer."
+    },
+    "insights": {
+      "$ref": "#/$defs/insights"
+    },
+    "change": {
+      "$ref": "#/$defs/change"
+    },
+    "oracle": {
+      "$ref": "#/$defs/oracle"
+    },
+    "explore": {
+      "$ref": "#/$defs/explore"
+    },
+    "fidelity": {
+      "$ref": "#/$defs/fidelity"
+    },
+    "load": {
+      "$ref": "#/$defs/load"
+    },
+    "policy": {
+      "$ref": "#/$defs/policy"
+    },
+    "runtime": {
+      "$ref": "#/$defs/runtime"
+    },
+    "github": {
+      "$ref": "#/$defs/github"
+    }
+  },
+  "$defs": {
+    "service": {
+      "title": "Service",
+      "description": "One process the environment runs. A service is built from the repository, given the variables it declared, attached to the environment's private network, and started in dependency order.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z0-9]([a-z0-9-]{0,38}[a-z0-9])?$",
+          "maxLength": 40,
+          "description": "Unique within the manifest. Appears in hostnames, logs, and container names."
+        },
+        "path": {
+          "type": "string",
+          "maxLength": 512,
+          "description": "Directory containing the service, relative to the repository root. Defaults to the root. A path outside the repository is rejected."
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "web",
+            "worker",
+            "cron"
+          ],
+          "default": "web",
+          "description": "What the service is. A web service gets a hostname and a readiness check; a worker gets neither; a cron service is invoked on a schedule instead of run continuously."
+        },
+        "build": {
+          "$ref": "#/$defs/build"
+        },
+        "command": {
+          "type": "string",
+          "maxLength": 1024,
+          "description": "Command that starts the service, overriding the image's own. Executed with an argument vector, never through a shell."
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535,
+          "description": "Port the service listens on. Required for a web service unless detection found it."
+        },
+        "health_path": {
+          "type": "string",
+          "maxLength": 512,
+          "default": "/",
+          "description": "HTTP path that reports readiness. A service is not considered up until this returns a 2xx or 3xx status."
+        },
+        "health_timeout": {
+          "type": "string",
+          "pattern": "^[0-9]+(ms|s|m)$",
+          "default": "180s",
+          "description": "How long to wait for readiness before failing with AF-RUN-004."
+        },
+        "env": {
+          "type": "array",
+          "maxItems": 200,
+          "items": {
+            "$ref": "#/$defs/envVar"
+          },
+          "description": "Names of environment variables this service needs. Names only. Values come from the secrets subsystem, and a name with no value anywhere fails with AF-SEC-001 rather than starting a service that will misbehave."
+        },
+        "replicas": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 10,
+          "description": "How many instances of this service to run. Both runtimes start this many, behind the one name other services resolve, so a bug that only appears at more than one instance appears here. Omitted means one. A cron service may not ask for more than one, because a scheduled job that runs on three instances runs three times."
+        },
+        "resources": {
+          "$ref": "#/$defs/resources"
+        },
+        "schedule": {
+          "type": "string",
+          "maxLength": 128,
+          "description": "Cron expression for a cron service, with an optional CRON_TZ prefix. Evaluated in the declared zone."
+        },
+        "migrate": {
+          "type": "string",
+          "maxLength": 1024,
+          "description": "Command that applies pending migrations. Run once against a fresh branch before the services start, and rehearsed with timing and lock analysis when insights are on."
+        },
+        "depends_on": {
+          "type": "array",
+          "maxItems": 50,
+          "items": {
+            "type": "string",
+            "maxLength": 40
+          },
+          "description": "Services that must be ready first. A cycle is rejected at validation."
+        }
+      }
+    },
+    "build": {
+      "title": "Build",
+      "type": "object",
+      "additionalProperties": false,
+      "description": "How to turn the service directory into an image. Omitted means detect: a Dockerfile if there is one, otherwise a buildpack.",
+      "properties": {
+        "strategy": {
+          "type": "string",
+          "enum": [
+            "auto",
+            "dockerfile",
+            "buildpack",
+            "image"
+          ],
+          "default": "auto"
+        },
+        "dockerfile": {
+          "type": "string",
+          "maxLength": 512,
+          "description": "Path to the Dockerfile, relative to the repository root."
+        },
+        "target": {
+          "type": "string",
+          "maxLength": 128,
+          "description": "Stage to build in a multi stage Dockerfile."
+        },
+        "context": {
+          "type": "string",
+          "maxLength": 512,
+          "description": "Build context directory, relative to the repository root. Defaults to the repository root so that a service can copy from a shared package."
+        },
+        "image": {
+          "type": "string",
+          "maxLength": 512,
+          "description": "A prebuilt image reference, used with the image strategy. Pinned by digest is strongly preferred."
+        },
+        "args": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "maxLength": 1024
+          },
+          "maxProperties": 50,
+          "description": "Build arguments. Never secrets: build arguments are recorded in image metadata and are visible to anyone who can pull the image. Secrets are mounted, and the linter rejects a secret shaped argument."
+        },
+        "allow_hosts": {
+          "type": "array",
+          "maxItems": 50,
+          "items": {
+            "type": "string",
+            "maxLength": 253
+          },
+          "description": "Hosts the build is declared to reach, such as a package registry or an engine download. DECLARED RATHER THAN ENFORCED in this release: the list is validated and shown by af explain, and the local builder does not yet seal a build or apply it. Write it as the record of what your build needs, and do not rely on it as a control."
+        }
+      }
+    },
+    "envVar": {
+      "title": "Environment variable",
+      "description": "One variable a service needs. The manifest declares the name and where the value comes from; it never holds the value itself, which is why the file is safe to commit.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "maxLength": 128
+        },
+        "required": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether the environment fails to start without it. Defaults to true, because a service silently missing configuration is the failure this product exists to prevent."
+        },
+        "sandbox": {
+          "type": "boolean",
+          "default": false,
+          "description": "Marks a credential that must be a sandbox one. The secrets subsystem refuses a value carrying a known live prefix, and the proxy trips a wire if one reaches the network anyway."
+        },
+        "value": {
+          "type": "string",
+          "maxLength": 2048,
+          "description": "A literal value for a variable that is configuration rather than a secret, such as a feature flag or a public URL. A value that looks like a credential is rejected."
+        },
+        "from": {
+          "type": "string",
+          "maxLength": 256,
+          "description": "Where to read the value: a secrets adapter name, or the name of a different variable to copy."
+        }
+      }
+    },
+    "resources": {
+      "title": "Resources",
+      "description": "Not read by anything, and refused by the engine. Neither runtime emits a resource requirement, so a cap written here was applied nowhere.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "cpu": {
+          "type": "string",
+          "pattern": "^[0-9]+(\\.[0-9]+)?m?$",
+          "deprecated": true,
+          "description": "Not read by anything, and refused by the engine. No runtime applies a CPU limit, so a service carrying this ran with none."
+        },
+        "memory": {
+          "type": "string",
+          "pattern": "^[0-9]+(Mi|Gi|M|G)$",
+          "deprecated": true,
+          "description": "Not read by anything, and refused by the engine. No runtime applies a memory limit, so a service carrying this ran with none."
+        }
+      }
+    },
+    "database": {
+      "title": "Database",
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Where the environment's Postgres comes from, and how the production copy is made safe before anyone can branch from it.",
+      "properties": {
+        "provider": {
+          "type": "string",
+          "enum": [
+            "docker",
+            "neon",
+            "supabase",
+            "dblab",
+            "pgurl"
+          ],
+          "default": "docker",
+          "description": "Which provider creates branches. docker is local and needs nothing; neon, supabase, and dblab talk to a service; pgurl is any reachable Postgres, which is where the goldens and the branches are kept as databases on a server you name."
+        },
+        "version": {
+          "type": "integer",
+          "enum": [
+            14,
+            15,
+            16,
+            17,
+            18
+          ],
+          "default": 17,
+          "description": "Postgres major version. Match it to the source: a golden built on a different major is an environment running a Postgres your application does not."
+        },
+        "source_url_env": {
+          "type": "string",
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "maxLength": 128,
+          "description": "Name of the environment variable holding the read only connection string of the production database. The value is read once, during a golden refresh, on the operator's machine or runner, and never stored."
+        },
+        "url_env": {
+          "type": "string",
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "maxLength": 128,
+          "default": "DATABASE_URL",
+          "description": "Name of the environment variable to inject into services with the branch's connection string."
+        },
+        "masking_rules": {
+          "type": "string",
+          "maxLength": 512,
+          "default": "masking.yaml",
+          "description": "Path to the masking rules file, relative to the repository root."
+        },
+        "project": {
+          "type": "string",
+          "description": "The account-side project a hosted provider creates branches in, such as a Neon project. Not a secret, which is why it lives here and the key that reaches it does not."
+        },
+        "api_key_env": {
+          "type": "string",
+          "description": "The name of the variable holding the provider's API key. Named rather than carried: a manifest is committed and a key is not. Defaults to NEON_API_KEY for the neon provider. For the pgurl provider it names the connection string of the server that holds the goldens and the branches, which is the credential in that case, and defaults to PGURL_ADMIN_URL."
+        },
+        "max_branches": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "The plan's concurrent branch limit, where the provider has one it cannot read from its own API. Reaching it fails with AF-DB-006 rather than hanging."
+        },
+        "golden": {
+          "$ref": "#/$defs/golden"
+        },
+        "subset": {
+          "$ref": "#/$defs/subset"
+        },
+        "seed": {
+          "type": "string",
+          "maxLength": 1024,
+          "description": "Command that fills the golden with data, for a project with no production database yet. It runs once per refresh with DATABASE_URL set, and every branch is a copy of what it made, so the cost is paid once rather than per environment. Mutually exclusive with source_url_env."
+        },
+        "migrations": {
+          "$ref": "#/$defs/migrations"
+        },
+        "volume": {
+          "$ref": "#/$defs/volume"
+        }
+      }
+    },
+    "datastore": {
+      "title": "Datastore",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "engine",
+        "stance"
+      ],
+      "description": "One store the environment holds. Database is a single struct and it is Postgres, so before this list existed there was one golden, one masking pass, one verification scan and one branch, and every other store a manifest declared was an empty container no part of the report mentioned.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z0-9]([a-z0-9-]{0,38}[a-z0-9])?$",
+          "maxLength": 40,
+          "description": "Unique within the manifest. The name primary is reserved for the entry the database: block normalizes into."
+        },
+        "engine": {
+          "type": "string",
+          "pattern": "^[a-z0-9]([a-z0-9_-]{0,38}[a-z0-9])?$",
+          "maxLength": 40,
+          "description": "What the store runs, such as `postgres`, `clickhouse`, `redis`, `kafka` or `elasticsearch`. Open rather than a fixed list: a manifest naming an engine this build has no provider for is refused by the provider lookup, by name, which says more than an unknown value would."
+        },
+        "provider": {
+          "type": "string",
+          "maxLength": 64,
+          "description": "Which implementation provides the engine, for an engine more than one thing can provide. Omit it for the engine's own default."
+        },
+        "stance": {
+          "type": "string",
+          "enum": [
+            "golden",
+            "empty",
+            "derived",
+            "topics_only"
+          ],
+          "description": "What happens to this store's contents. golden is a masked, verified copy environments branch from. empty starts it with nothing, on purpose, and because says why. derived rebuilds it from the store named in from, once that one is ready, which is how a search index is built from the Postgres branch rather than cloned and left stale against it. topics_only creates topics and consumer groups with no messages. There is no default: a datastore that declares no stance is refused, because a silent default is how somebody ends up trusting a blank ClickHouse."
+        },
+        "because": {
+          "type": "string",
+          "maxLength": 512,
+          "description": "Why this stance was chosen, in the words of whoever chose it. It is carried into the fidelity report as written. An empty store nobody explained and an empty store somebody decided on look identical in a running environment, and this is the only thing that tells them apart afterwards. Required for the empty stance."
+        },
+        "from": {
+          "type": "string",
+          "pattern": "^[a-z0-9]([a-z0-9-]{0,38}[a-z0-9])?$",
+          "maxLength": 40,
+          "description": "The datastore a derived store is rebuilt from, named. Required for the derived stance and refused for the others."
+        },
+        "source_url_env": {
+          "type": "string",
+          "maxLength": 128,
+          "description": "The variable holding this store's production connection string, which is what a golden of it is copied from. A variable name rather than a URL, because the value is a credential for production and a manifest is checked in. Omitted, the golden is EMPTY and every refresh says so: that is the same answer database.source_url_env gives a project that has not connected production yet, and it is not a refusal because a store whose tables are made by migrations is still worth branching."
+        }
+      }
+    },
+    "migrations": {
+      "title": "Migrations",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "dir"
+      ],
+      "description": "Where the project's own SQL migrations live, for a project whose migrate command is its own script rather than a tool the rehearsal recognises. Declared, the rehearsal replays the files in this directory and nothing is inferred from the tree.",
+      "properties": {
+        "dir": {
+          "type": "string",
+          "maxLength": 512,
+          "description": "Directory of .sql files, relative to the repository root, applied in filename order. A directory of numbered files such as 0042_add_index.sql is also recognised without this key when no tool is; declaring it removes the guess."
+        },
+        "format": {
+          "type": "string",
+          "enum": [
+            "sql"
+          ],
+          "default": "sql",
+          "description": "How the files are read. Only sql exists."
+        },
+        "table": {
+          "type": "string",
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)?$",
+          "maxLength": 128,
+          "description": "The ledger table the project's runner records applied files in, so the rehearsal computes the pending set the way the runner would: a file is applied when its name, its stem or its leading number appears in the table's name, version, filename or migration column. Unset, schema_migrations and migrations are tried."
+        }
+      }
+    },
+    "volume": {
+      "title": "Volume",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "profile"
+      ],
+      "description": "The committed record of what production holds, which is the denominator every row count in a report is measured against. Without one the fidelity report says a branch holds twelve tables over a hundred thousand rows and has nothing to compare that against, so a golden built from a staging database with two hundred rows in it reports as reproducing a production holding four billion.",
+      "properties": {
+        "profile": {
+          "type": "string",
+          "maxLength": 512,
+          "description": "The profile file, relative to the repository root. Written by af volume record from a read only connection to production or a replica, and committed, because the machine that reads it on a pull request cannot reach production. It carries counts, sizes, partition shape and key cardinality, and no data."
+        },
+        "max_age": {
+          "type": "string",
+          "maxLength": 32,
+          "default": "720h",
+          "description": "How old the profile may be before it is refused. A stale profile is not a smaller number, it is an unknown one, so it is refused the way a stale golden is rather than quoted. Thirty days by default rather than the golden's seven, because a profile is the shape of the data rather than the data."
+        }
+      }
+    },
+    "golden": {
+      "title": "Golden",
+      "type": "object",
+      "additionalProperties": false,
+      "description": "The masked, verified copy every environment branches from.",
+      "properties": {
+        "schedule": {
+          "type": "string",
+          "maxLength": 128,
+          "description": "Cron expression for automatic refreshes, with an optional CRON_TZ prefix. A refresh that would overlap a running one is skipped with an event rather than queued."
+        },
+        "max_age": {
+          "type": "string",
+          "pattern": "^[0-9]+(h|d)$",
+          "default": "168h",
+          "description": "How stale a golden may be before af up refreshes it first."
+        },
+        "retain": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100,
+          "default": 5,
+          "description": "How many versions to keep. A referenced version is never collected regardless of this."
+        },
+        "storage": {
+          "type": "string",
+          "enum": [
+            "local",
+            "azure_blob",
+            "s3"
+          ],
+          "default": "local",
+          "description": "Where dumps and attestations live."
+        },
+        "storage_url": {
+          "type": "string",
+          "maxLength": 1024,
+          "description": "Container or bucket URL for a remote store. Credentials come from the secrets subsystem, never from this URL."
+        }
+      }
+    },
+    "subset": {
+      "title": "Subset",
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Take a production shaped slice rather than the whole database. The closure is computed over foreign keys, so a subset always satisfies every constraint the schema declares.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false
+        },
+        "seed_table": {
+          "type": "string",
+          "maxLength": 128,
+          "description": "Table the selection starts from, for example the tenant or account table."
+        },
+        "seed_where": {
+          "type": "string",
+          "maxLength": 2048,
+          "description": "A SQL predicate selecting the seed rows, for example created_at > now() - interval '90 days'."
+        },
+        "max_rows": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 1000000,
+          "description": "Upper bound on rows per table, applied deterministically so two runs produce the same subset."
+        },
+        "follow_dependents": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 5,
+          "default": 1,
+          "description": "How many levels of rows that reference the seed to include. Zero includes only what the seed rows reference, which is the minimum that satisfies foreign keys."
+        },
+        "virtual_relationships": {
+          "type": "array",
+          "maxItems": 200,
+          "description": "Relationships the schema does not declare as foreign keys but the application relies on. Without these, a subset can look complete and still break the application.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "from",
+              "to"
+            ],
+            "properties": {
+              "from": {
+                "type": "string",
+                "maxLength": 260,
+                "description": "table.column"
+              },
+              "to": {
+                "type": "string",
+                "maxLength": 260,
+                "description": "table.column"
+              }
+            }
+          }
+        }
+      }
+    },
+    "egress": {
+      "title": "Egress",
+      "type": "object",
+      "additionalProperties": false,
+      "description": "What the environment may reach on the network. Everything leaves through the sidecar, and everything not named here is blocked.",
+      "properties": {
+        "default": {
+          "type": "string",
+          "enum": [
+            "block",
+            "allow",
+            "capture",
+            "mock",
+            "sandbox",
+            "synth"
+          ],
+          "default": "block",
+          "description": "What happens to a host with no rule. Changing this away from block is a deliberate act with a real cost: it is how a preview environment emails a real customer."
+        },
+        "allow_ipv6": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether the environment may open IPv6 connections. Off by default, because an IPv6 path that bypasses the proxy is the most common way an egress control is silently defeated."
+        },
+        "rules": {
+          "type": "array",
+          "maxItems": 500,
+          "items": {
+            "$ref": "#/$defs/egressRule"
+          }
+        }
+      }
+    },
+    "egressRule": {
+      "title": "Egress rule",
+      "description": "What the environment may do with one host. A rule is per host because that is the unit a person can reason about: allowed, blocked, answered from a fixture, or sent to the provider's own sandbox.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "host",
+        "mode"
+      ],
+      "properties": {
+        "host": {
+          "type": "string",
+          "maxLength": 253,
+          "description": "Host to match. A leading *. matches one or more labels. A star anywhere else is one whole label, so email.*.amazonaws.com reaches SES in any region and reaches nothing else, and *.s3.*.amazonaws.com reaches a bucket in any region. An IP literal matches only itself."
+        },
+        "mode": {
+          "type": "string",
+          "enum": [
+            "block",
+            "allow",
+            "capture",
+            "mock",
+            "sandbox",
+            "synth"
+          ],
+          "description": "block refuses with a readable decision. allow passes through with a rate limit. sandbox substitutes test credentials and forwards to the provider's sandbox. capture records the message into the inbox and returns the provider's success shape. mock answers from a fixture or an offline pack. synth asks a model to invent a response and marks every result that touched it as unverified."
+        },
+        "paths": {
+          "type": "array",
+          "maxItems": 100,
+          "items": {
+            "type": "string",
+            "maxLength": 512
+          },
+          "description": "Restrict the rule to these path prefixes. Anything else on the same host falls through to the next rule."
+        },
+        "methods": {
+          "type": "array",
+          "maxItems": 10,
+          "items": {
+            "type": "string",
+            "enum": [
+              "GET",
+              "HEAD",
+              "POST",
+              "PUT",
+              "PATCH",
+              "DELETE",
+              "OPTIONS",
+              "CONNECT",
+              "TRACE"
+            ]
+          },
+          "description": "Restrict the rule to these HTTP methods."
+        },
+        "rate_limit": {
+          "type": "string",
+          "pattern": "^[0-9]+/(s|m|h)$",
+          "description": "Token bucket rate, for example 10/s or 600/m. Applies to allow and sandbox."
+        },
+        "credential": {
+          "type": "string",
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "maxLength": 128,
+          "description": "Name of the environment variable holding the sandbox credential for this host."
+        },
+        "fixtures": {
+          "type": "string",
+          "maxLength": 512,
+          "description": "Path to a fixture pack or an OpenAPI document for mock mode, relative to the repository root."
+        },
+        "webhook_path": {
+          "type": "string",
+          "maxLength": 512,
+          "description": "Path on the application that this provider posts webhooks to. The sandbox forwarder and the offline pack both deliver here."
+        },
+        "note": {
+          "type": "string",
+          "maxLength": 512,
+          "description": "Why this rule exists. Rendered in the network policy view, because a rule nobody can explain is a rule nobody dares remove."
+        }
+      }
+    },
+    "persona": {
+      "title": "Persona",
+      "description": "One account an agent logs in as. Personas are created or reconciled in the golden by the authentication adapter, so an agent signs in the way a person does rather than through a bypass.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z0-9]([a-z0-9-]{0,38}[a-z0-9])?$",
+          "maxLength": 40
+        },
+        "email": {
+          "type": "string",
+          "maxLength": 254,
+          "description": "Login address. Defaults to name@example.test, which is a reserved domain that can never receive mail."
+        },
+        "phone": {
+          "type": "string",
+          "maxLength": 32,
+          "description": "Number an SMS code is sent to. Defaults to a number in the +1 555 0100 block, which is reserved for fictional use and can never reach a real handset. Only sms_code uses it."
+        },
+        "role": {
+          "type": "string",
+          "maxLength": 64,
+          "description": "Application role to provision, for example admin or member. Interpreted by the authentication adapter."
+        },
+        "login": {
+          "type": "string",
+          "enum": [
+            "none",
+            "password",
+            "magic_link",
+            "email_code",
+            "sms_code",
+            "totp",
+            "session"
+          ],
+          "default": "password",
+          "description": "How this persona signs in. none is for an application with no sign in, or a page that is public: the agent goes straight to start_path. magic_link and email_code read the message from the captured inbox, so they work with no mail provider at all. The runner drives none, password, magic_link, email_code and sms_code today; a persona set to totp or session is reported as blocked with the reason, rather than failing the change."
+        },
+        "mfa": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether to enroll a time based one time password secret, which the runner holds so that it can complete a challenge."
+        },
+        "sign_in_path": {
+          "type": "string",
+          "maxLength": 512,
+          "description": "Where this persona's sign-in form lives, when it is not where the workflow starts. The runner looks for a form at the workflow's start path first and then at the usual paths, which finds the wrong form for a persona whose sign-in surface is elsewhere on the same origin, such as an operator portal beside a customer console."
+        },
+        "attributes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "maxLength": 512
+          },
+          "maxProperties": 50,
+          "description": "Extra columns to set on the persona's row, for a schema with application specific fields."
+        }
+      }
+    },
+    "workflow": {
+      "title": "Workflow",
+      "description": "One thing the agents do, written as a goal rather than a script. The runner decides the actions and verifies the outcome, so a workflow survives a redesign of the page it happens on.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "description"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z0-9]([a-z0-9-]{0,62}[a-z0-9])?$",
+          "maxLength": 64
+        },
+        "description": {
+          "type": "string",
+          "minLength": 10,
+          "maxLength": 4000,
+          "description": "What a person would do, in sentences. Say the goal and what proves it happened, not the selectors."
+        },
+        "persona": {
+          "type": "string",
+          "maxLength": 40,
+          "description": "Which persona runs it. Defaults to the first persona."
+        },
+        "personas": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 5,
+          "items": {
+            "type": "string",
+            "maxLength": 40
+          },
+          "description": "The personas this workflow signs in as, in order, in one browser, for a person who holds more than one session at once: an operator who is also a customer, an account with a second sign-in surface. Each is signed in through its own strategy and the sessions accumulate; the last one named is the identity the workflow acts as. Mutually exclusive with persona."
+        },
+        "start_path": {
+          "type": "string",
+          "maxLength": 512,
+          "default": "/",
+          "description": "Where to begin. Defaults to the application root."
+        },
+        "independent": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether this workflow can run at the same time as others. Workflows that share an environment run one at a time unless this says otherwise, because two agents mutating the same data produce failures nobody can reproduce."
+        },
+        "budget": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Hard caps. A workflow that exhausts its budget ends as blocked with the reason, never as a partial pass.",
+          "properties": {
+            "steps": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 500,
+              "default": 60
+            },
+            "usd": {
+              "type": "number",
+              "minimum": 0,
+              "default": 0.5
+            },
+            "duration": {
+              "type": "string",
+              "pattern": "^[0-9]+(s|m)$",
+              "default": "10m"
+            }
+          }
+        },
+        "expect": {
+          "type": "array",
+          "maxItems": 50,
+          "items": {
+            "type": "string",
+            "maxLength": 1000
+          },
+          "description": "Observations that must hold for a pass, written as sentences. These are assertions about what the user can see, not about the DOM."
+        },
+        "tags": {
+          "type": "array",
+          "maxItems": 20,
+          "items": {
+            "type": "string",
+            "maxLength": 40
+          },
+          "description": "Labels for the person reading the manifest, and nothing else. The engine does not read them: no command selects workflows by tag and no report prints one, so grouping workflows here groups them for a reader and not for a run. Name the workflows with --only to run a subset. This key had no description at all until somebody counted the fields nothing reads, which is how a label and a broken promise came to look alike."
+        }
+      }
+    },
+    "invariant": {
+      "title": "Invariant",
+      "description": "One read only statement that must hold after every workflow. Invariants are the assertions a test cannot make from the outside, checked against the database rather than the interface.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "sql"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z0-9]([a-z0-9-]{0,62}[a-z0-9])?$",
+          "maxLength": 64
+        },
+        "sql": {
+          "type": "string",
+          "minLength": 6,
+          "maxLength": 4000,
+          "description": "A single read only statement. It runs inside a read only transaction with a statement timeout, so a write is refused by Postgres as well as by validation. The invariant fails when the statement returns any row, so write it to select the violations."
+        },
+        "description": {
+          "type": "string",
+          "maxLength": 512,
+          "description": "What is wrong when this fails, in one sentence. It becomes the failure message."
+        }
+      }
+    },
+    "insights": {
+      "title": "Insights",
+      "type": "object",
+      "additionalProperties": false,
+      "description": "The Postgres native checks that turn a preview environment into a database review.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": true
+        },
+        "migration_rehearsal": {
+          "type": "boolean",
+          "default": true,
+          "description": "Apply pending migrations to a fresh branch, recording per statement duration and the strongest lock held per table."
+        },
+        "query_regression": {
+          "type": "boolean",
+          "default": true,
+          "description": "Diff pg_stat_statements between the base branch and this one after running the same workflows, to catch a query loop before it reaches production."
+        },
+        "plan_diff": {
+          "type": "boolean",
+          "default": true,
+          "description": "Compare query plans between branches to catch an index that stopped being used."
+        },
+        "regression_factor": {
+          "type": "number",
+          "minimum": 1,
+          "default": 1.5,
+          "description": "How much slower a query may get before it is reported."
+        },
+        "regression_min_ms": {
+          "type": "number",
+          "minimum": 0,
+          "default": 5,
+          "description": "Minimum absolute change in mean milliseconds before a regression is reported, so that a query going from 0.1 to 0.2 milliseconds is not news."
+        },
+        "large_table_rows": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 100000,
+          "description": "Row count above which a migration lint treats a table as large, where a rewrite or an exclusive lock is an outage rather than a pause."
+        },
+        "rolling_compatibility": {
+          "$ref": "#/$defs/rolling_compatibility"
+        }
+      }
+    },
+    "rolling_compatibility": {
+      "title": "Rolling compatibility",
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Run the previous release against the migrated schema and see whether its workflows still pass, which is the invariant a rolling deploy actually depends on.",
+      "properties": {
+        "when": {
+          "type": "string",
+          "enum": [
+            "never",
+            "risky",
+            "always"
+          ],
+          "default": "risky",
+          "description": "risky runs the check only when the pending migrations contain a change the previous release could notice, such as a dropped or renamed column. always runs it for every migration, and costs a second image build and a second environment every time."
+        },
+        "against": {
+          "type": "string",
+          "maxLength": 256,
+          "default": "merge-base",
+          "description": "Which commit the previous release is: merge-base, previous-commit, or any revision git can resolve, such as a release tag."
+        }
+      }
+    },
+    "oracle": {
+      "title": "Oracle",
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Deploy a baseline version alongside the candidate, send both the same requests, and report every difference in what came back and in what ended up in the database.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether the comparison runs. Present but false is how a project keeps its probe plan and turns the check off for a while."
+        },
+        "baseline": {
+          "type": "string",
+          "enum": [
+            "merge_base",
+            "ref"
+          ],
+          "default": "merge_base",
+          "description": "How the version to compare against is chosen. merge_base answers what this branch changes; ref answers what changes when it ships."
+        },
+        "base_ref": {
+          "type": "string",
+          "maxLength": 256,
+          "description": "The git ref the baseline comes from, or the ref the merge base is taken against. Empty tries origin/HEAD, then origin/main, then origin/master, and says which it used."
+        },
+        "fail_on": {
+          "type": "string",
+          "enum": [
+            "none",
+            "minor",
+            "major",
+            "critical"
+          ],
+          "default": "critical",
+          "description": "The lowest severity that fails the command. critical is a request the baseline served and the candidate did not, a status that fell into an error class, or a row the baseline wrote and the candidate did not."
+        },
+        "probes": {
+          "type": "array",
+          "maxItems": 200,
+          "items": {
+            "$ref": "#/$defs/probe"
+          },
+          "description": "The requests sent to both versions, in order, byte for byte the same on each side."
+        },
+        "compare_timestamps": {
+          "type": "boolean",
+          "default": false,
+          "description": "Compare timestamp strings exactly instead of treating two well formed timestamps as equal. Turn it on when timestamps come from the data rather than from the clock."
+        },
+        "compare_uuids": {
+          "type": "boolean",
+          "default": false,
+          "description": "Compare UUIDs exactly instead of treating two well formed UUIDs as equal. Turn it on when identifiers are stored rather than generated per request."
+        },
+        "ignore": {
+          "$ref": "#/$defs/oracleIgnore"
+        },
+        "database": {
+          "$ref": "#/$defs/oracleDatabase"
+        }
+      }
+    },
+    "probe": {
+      "title": "Probe",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "path"
+      ],
+      "description": "One request sent to both versions.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64,
+          "pattern": "^[a-z0-9][a-z0-9-]*$",
+          "description": "Identifies the request in the report."
+        },
+        "method": {
+          "type": "string",
+          "enum": [
+            "GET",
+            "HEAD",
+            "POST",
+            "PUT",
+            "PATCH",
+            "DELETE",
+            "OPTIONS"
+          ],
+          "default": "GET"
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048,
+          "description": "The path and query, starting with a slash."
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "maxLength": 1024
+          },
+          "maxProperties": 20,
+          "description": "Headers sent on both sides. Credentials come from the secrets subsystem, never from here."
+        },
+        "body": {
+          "type": "string",
+          "maxLength": 65536,
+          "description": "The request body, sent byte for byte to both sides."
+        }
+      }
+    },
+    "oracleIgnore": {
+      "title": "Oracle ignore",
+      "type": "object",
+      "additionalProperties": false,
+      "description": "What the comparison is told not to look at. Everything here is printed in the report along with the defaults, because an oracle that silently ignores a field is worse than one that reports it.",
+      "properties": {
+        "headers": {
+          "type": "array",
+          "maxItems": 100,
+          "items": {
+            "type": "string",
+            "maxLength": 128
+          },
+          "description": "Response headers to skip, in addition to the defaults."
+        },
+        "fields": {
+          "type": "array",
+          "maxItems": 200,
+          "items": {
+            "type": "string",
+            "maxLength": 512
+          },
+          "description": "JSON paths to skip, in a response body and in a table row alike. $.token, $.orders[*].placed_at and $..created_at are all accepted."
+        }
+      }
+    },
+    "oracleDatabase": {
+      "title": "Oracle database",
+      "type": "object",
+      "additionalProperties": false,
+      "description": "The comparison of the two branches' contents.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": true
+        },
+        "tables": {
+          "type": "array",
+          "maxItems": 500,
+          "items": {
+            "type": "string",
+            "maxLength": 128
+          },
+          "description": "Tables to compare. Empty compares every table. A pattern is schema.table, and either half may be an asterisk."
+        },
+        "exclude": {
+          "type": "array",
+          "maxItems": 500,
+          "items": {
+            "type": "string",
+            "maxLength": 128
+          },
+          "description": "Tables to leave out, applied after tables."
+        },
+        "max_rows": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000000,
+          "default": 10000,
+          "description": "How many rows a table may hold and still be compared. A table over the bound is reported as not compared, never silently skipped."
+        }
+      }
+    },
+    "explore": {
+      "title": "Explore",
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Agents that pursue a goal with no declared workflow, discover the paths an application offers, and report where it costs somebody effort without failing. An exploration is reproducible from its seed and never counts against the change.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false
+        },
+        "goals": {
+          "type": "array",
+          "maxItems": 50,
+          "items": {
+            "$ref": "#/$defs/goal"
+          }
+        }
+      }
+    },
+    "goal": {
+      "title": "Goal",
+      "description": "One thing an exploratory agent tries to achieve. Unlike a workflow this declares no outcome, so it cannot fail: what it produces is the path it took and the friction it met on the way.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "goal"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z0-9]([a-z0-9-]{0,62}[a-z0-9])?$",
+          "maxLength": 64
+        },
+        "goal": {
+          "type": "string",
+          "minLength": 10,
+          "maxLength": 1000,
+          "description": "What somebody is trying to do, in one sentence. The agent has no script, so this is the only thing telling it where to go, and its words are what decide whether the goal was reached."
+        },
+        "persona": {
+          "type": "string",
+          "maxLength": 40,
+          "description": "Which persona explores. Defaults to the first persona."
+        },
+        "seed": {
+          "type": "string",
+          "maxLength": 64,
+          "description": "Decides every choice the agent makes. The same seed against the same application takes the same path, step for step, which is what lets a finding be replayed. Defaults to the goal's name."
+        },
+        "start_path": {
+          "type": "string",
+          "maxLength": 512,
+          "default": "/",
+          "description": "Where to begin. Defaults to the application root."
+        },
+        "slow_ms": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 600000,
+          "default": 3000,
+          "description": "How long one step may take before it is reported as friction."
+        },
+        "budget": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Hard caps. An exploration that exhausts its budget reports what it found up to that point and says the budget ran out.",
+          "properties": {
+            "steps": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 500,
+              "default": 40
+            },
+            "usd": {
+              "type": "number",
+              "minimum": 0,
+              "default": 0.5
+            },
+            "duration": {
+              "type": "string",
+              "pattern": "^[0-9]+(s|m)$",
+              "default": "10m"
+            }
+          }
+        }
+      }
+    },
+    "fidelity": {
+      "title": "Fidelity",
+      "type": "object",
+      "additionalProperties": false,
+      "description": "The component inventory: what the environment reproduces, what stands in for something, and what it could not reproduce at all.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": true
+        },
+        "require": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "services",
+              "database",
+              "third_party",
+              "auth",
+              "runtime",
+              "traffic",
+              "datastores",
+              "topology"
+            ]
+          },
+          "uniqueItems": true,
+          "description": "Dimensions every component of which must be reproduced. A dimension that could not be measured neither satisfies a requirement nor breaks one."
+        }
+      }
+    },
+    "change": {
+      "title": "Change",
+      "type": "object",
+      "additionalProperties": false,
+      "description": "How a pull request's diff is classified. The built in rules cover the layouts most projects use; these are for the ones they do not. A rule says what a path is, never which checks to run: an unrecognised path always selects every check, and no rule here can take a check away.",
+      "properties": {
+        "rules": {
+          "type": "array",
+          "maxItems": 100,
+          "items": {
+            "$ref": "#/$defs/changeRule"
+          },
+          "description": "Path patterns this repository wants classified its own way. The longest matching pattern wins, so order does not decide."
+        }
+      }
+    },
+    "changeRule": {
+      "title": "Change rule",
+      "description": "One path pattern and what the paths it matches are. It says what a file IS, never which checks to run.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "surface"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256,
+          "description": "A glob against the repository relative path. A single star does not cross a slash and a double star does. A pattern that matches everything is refused, because it would defeat the rule that an unrecognised path selects every check."
+        },
+        "surface": {
+          "type": "string",
+          "enum": [
+            "schema",
+            "code",
+            "asset",
+            "build",
+            "dependency",
+            "config",
+            "infrastructure",
+            "pipeline",
+            "test",
+            "docs"
+          ],
+          "description": "What the matched paths are. Surfaces the engine assigns from the manifest itself, such as a service or the masking rules file, cannot be set here."
+        },
+        "note": {
+          "type": "string",
+          "maxLength": 200,
+          "description": "The sentence the report prints for this rule, replacing the default one that restates the pattern."
+        }
+      }
+    },
+    "load": {
+      "title": "Load",
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Traffic shaped like production, compared between the base branch and this one. Results are always deltas, never absolute capacity claims.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false
+        },
+        "source": {
+          "type": "string",
+          "enum": [
+            "none",
+            "otel",
+            "access_log"
+          ],
+          "default": "none",
+          "description": "Where the endpoint mix comes from. An OpenTelemetry trace export or a combined format access log, both read from a file named in source_config.path."
+        },
+        "source_config": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "maxLength": 1024
+          },
+          "maxProperties": 20,
+          "description": "Adapter specific settings. Both sources take a path: the OTLP/JSON trace export, or the access log. Credentials come from the secrets subsystem."
+        },
+        "scale": {
+          "type": "number",
+          "minimum": 0.001,
+          "maximum": 1,
+          "default": 0.05,
+          "description": "Fraction of production arrival rate to reproduce."
+        },
+        "duration": {
+          "type": "string",
+          "pattern": "^[0-9]+(s|m)$",
+          "default": "2m",
+          "description": "How long to run. Capped at fifteen minutes."
+        },
+        "safe_routes": {
+          "type": "array",
+          "maxItems": 500,
+          "items": {
+            "type": "string",
+            "maxLength": 512
+          },
+          "description": "Routes that may be called freely because they do not mutate state."
+        },
+        "unsafe_routes": {
+          "type": "array",
+          "maxItems": 500,
+          "items": {
+            "type": "string",
+            "maxLength": 512
+          },
+          "description": "Routes that mutate state destructively. They are included only against a fresh branch that is reset afterwards."
+        },
+        "scenarios": {
+          "type": "array",
+          "maxItems": 50,
+          "description": "Declared journeys run against the environment beside the mix. Each entry names a scenario document in the repository.",
+          "items": {
+            "$ref": "#/$defs/load_scenario"
+          }
+        },
+        "thresholds": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Deltas that fail the run. Applied to the difference against the base branch, never to absolute numbers.",
+          "properties": {
+            "p95_increase": {
+              "type": "number",
+              "minimum": 0,
+              "default": 0.25,
+              "description": "How much slower than production a route may get, as a ratio. It divides a measured p95 by production's own p95 for that route, so it needs a source that carries one: the default applies under source otel, and the engine refuses this key under access_log or none, where a route arrives with no baseline and the threshold could never fire."
+            },
+            "error_rate": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1,
+              "default": 0.01,
+              "description": "The share of requests that may fail. Counted from the run's own responses, so it needs no baseline and works under every source."
+            },
+            "query_count_increase": {
+              "type": "number",
+              "minimum": 0,
+              "deprecated": true,
+              "description": "Not read by anything, and refused by the engine. A load run counts requests, not statements. The check that compares statement counts against the base branch is insights.query_regression, and how much growth fails it is insights.regression_factor."
+            }
+          }
+        }
+      }
+    },
+    "load_scenario": {
+      "title": "Load scenario",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path"
+      ],
+      "description": "One journey document and how hard to run it.",
+      "properties": {
+        "path": {
+          "type": "string",
+          "maxLength": 512,
+          "description": "The scenario document, relative to the repository root."
+        },
+        "sessions": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000,
+          "default": 1,
+          "description": "How many sessions walk the journey at once."
+        },
+        "iterations": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000,
+          "default": 1,
+          "description": "How many times each session walks it."
+        },
+        "start_after": {
+          "type": "string",
+          "pattern": "^[0-9]+(ms|s|m)$",
+          "description": "Delay before this scenario starts, so one journey can burst while another is already running."
+        }
+      }
+    },
+    "policy": {
+      "title": "Policy",
+      "type": "object",
+      "additionalProperties": false,
+      "description": "What each class of finding does to the pull request check. A finding at 'fail' fails the check, one at 'warn' is reported and the check still passes, and one at 'ignore' is not reported at all. Every key here is read when the report is built, so the answer to why a check failed is always one of these keys.",
+      "properties": {
+        "migration_lock": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "How long a migration may hold a lock on a table. Both figures are compared against a sampled lower bound, so a breach really did hold the lock at least that long.",
+          "properties": {
+            "warn_ms": {
+              "type": "number",
+              "minimum": 0,
+              "default": 500,
+              "description": "Report a lock held at least this many milliseconds."
+            },
+            "fail_ms": {
+              "type": "number",
+              "minimum": 0,
+              "default": 2000,
+              "description": "Fail the check on a lock held at least this many milliseconds. Must not be below warn_ms."
+            }
+          }
+        },
+        "migration_failed": {
+          "type": "string",
+          "enum": [
+            "ignore",
+            "warn",
+            "fail"
+          ],
+          "default": "fail",
+          "description": "A migration that did not apply to a branch with production's shape in it. A migration that fails here is one that would have failed in production."
+        },
+        "migration_rewrite": {
+          "type": "string",
+          "enum": [
+            "ignore",
+            "warn",
+            "fail"
+          ],
+          "default": "warn",
+          "description": "A statement Postgres reported as rewriting a table, which copies every row under a lock nothing can read through."
+        },
+        "migration_lint": {
+          "type": "string",
+          "enum": [
+            "ignore",
+            "warn",
+            "fail"
+          ],
+          "default": "warn",
+          "description": "Any of the seventeen migration lint rules. They share one setting because the rules are already scoped by table size."
+        },
+        "plan_regression": {
+          "type": "string",
+          "enum": [
+            "ignore",
+            "warn",
+            "fail"
+          ],
+          "default": "warn",
+          "description": "A query plan that got worse in one of three plan regressions: a table is now read end to end, an index is no longer used, or the planner's estimate grew."
+        },
+        "query_regression": {
+          "type": "string",
+          "enum": [
+            "ignore",
+            "warn",
+            "fail"
+          ],
+          "default": "warn",
+          "description": "A statement that runs more often, or slower, than the saved baseline did. Needs a baseline to compare against."
+        },
+        "load_regression": {
+          "type": "string",
+          "enum": [
+            "ignore",
+            "warn",
+            "fail"
+          ],
+          "default": "warn",
+          "description": "A load threshold from the load block being exceeded."
+        },
+        "egress_surprise": {
+          "type": "string",
+          "enum": [
+            "ignore",
+            "warn",
+            "fail"
+          ],
+          "default": "fail",
+          "description": "The environment tried to reach a host the manifest does not mention. The request was refused either way; this decides whether the attempt stops the merge."
+        },
+        "masking": {
+          "type": "string",
+          "enum": [
+            "ignore",
+            "warn",
+            "fail"
+          ],
+          "default": "fail",
+          "description": "The environment's own branch read back with something in it that still parses as real data."
+        },
+        "cleanup": {
+          "type": "string",
+          "enum": [
+            "ignore",
+            "warn",
+            "fail"
+          ],
+          "default": "fail",
+          "description": "Teardown left a resource behind. The journal remembers what is left, so 'af down' can finish the job."
+        },
+        "workflows_unverified": {
+          "type": "string",
+          "enum": [
+            "ignore",
+            "warn",
+            "fail"
+          ],
+          "default": "fail",
+          "description": "A run in which no workflow reached a verdict about the application, because every one was blocked or unverified or because none was declared. Distinct from a single blocked workflow, which is never counted against the application: one gap in the tooling is not evidence, and a run where every workflow was a gap has tested nothing at all, so reporting it as a pass says the application was checked when it was not. Set it to warn if the project has no workflows yet and you would rather record that choice than be told about it."
+        }
+      }
+    },
+    "runtime": {
+      "title": "Runtime",
+      "description": "Where and how long the environment runs. The provider decides the machinery; the rest is the lifetime, the address, and the naming the environment gets.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "provider": {
+          "type": "string",
+          "enum": [
+            "local",
+            "kubernetes"
+          ],
+          "default": "local"
+        },
+        "ttl": {
+          "type": "string",
+          "pattern": "^[0-9]+(h|d)$",
+          "default": "24h",
+          "description": "How long an environment lives before the reaper tears it down. Extend one you are still using with af env extend, up to max_ttl."
+        },
+        "max_ttl": {
+          "type": "string",
+          "pattern": "^[0-9]+(h|d)$",
+          "default": "168h",
+          "description": "The furthest af env extend may push an environment's expiry, measured from when it was created. A lifetime that can be extended forever is not a lifetime, and this is the bound."
+        },
+        "idle_sleep": {
+          "type": "string",
+          "pattern": "^[0-9]+(m|h)$",
+          "default": "30m",
+          "description": "How long an environment may sit idle before it is scaled to zero. It wakes on the next request."
+        },
+        "domain": {
+          "type": "string",
+          "maxLength": 253,
+          "default": "localhost",
+          "description": "Wildcard domain for environment hostnames. Defaults to localhost, which needs no DNS at all."
+        },
+        "namespace_prefix": {
+          "type": "string",
+          "maxLength": 40,
+          "default": "af",
+          "description": "Prefix for Kubernetes namespaces."
+        },
+        "kubeconfig_context": {
+          "type": "string",
+          "maxLength": 253,
+          "description": "Which kubeconfig context to use. Naming it prevents an environment landing on whatever cluster happened to be current."
+        }
+      }
+    },
+    "github": {
+      "title": "GitHub",
+      "description": "How Antifailure appears on a pull request: what runs it, whether it comments, what it does with forks, and when it tears the environment down.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": [
+            "actions",
+            "app",
+            "off"
+          ],
+          "default": "actions",
+          "description": "actions runs everything inside a workflow with no server. app uses the GitHub App and the control plane."
+        },
+        "comment": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether to maintain a single comment on the pull request. It is updated in place rather than appended, so a busy pull request does not accumulate twenty bot comments. Set false and af change and af ci write comment=false to GITHUB_OUTPUT for the workflow to gate its comment step on. The report files are still written, because the report is also the job summary and the payload a control plane is sent."
+        },
+        "fork_policy": {
+          "type": "string",
+          "enum": [
+            "never",
+            "label",
+            "always"
+          ],
+          "default": "label",
+          "description": "What to do with a pull request from a fork. label requires a maintainer to add antifailure:allow first, which is the only safe default: a fork's code would otherwise run with the environment's credentials. Enforced by af ci, af up, af test and af load run before an environment is created, on pull_request and pull_request_target, and read from the base branch rather than from the pull request, because the pull request's copy of this file belongs to the contributor."
+        },
+        "teardown_on": {
+          "type": "array",
+          "maxItems": 5,
+          "default": [
+            "close",
+            "merge",
+            "ttl"
+          ],
+          "items": {
+            "type": "string",
+            "enum": [
+              "close",
+              "merge",
+              "ttl"
+            ]
+          },
+          "description": "Accepted and read by nothing. Teardown is unconditional: af ci tears down whatever the outcome, and the control plane asks for teardown on close, merge, supersession and timeout without reading your manifest. The lifetime ceiling is runtime.max_ttl."
+        }
+      }
+    },
+    "auth": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "How personas come to exist. Absent from most manifests, because detection answers it; present when detection is wrong, when the users table has names nothing could guess, or when the application's users live somewhere only a script can reach.",
+      "properties": {
+        "adapter": {
+          "type": "string",
+          "enum": [
+            "auto",
+            "direct",
+            "supabase",
+            "supabase_api",
+            "nextauth",
+            "clerk",
+            "auth0",
+            "workos",
+            "seed"
+          ],
+          "default": "auto",
+          "description": "Which authentication scheme personas are created in. auto picks it from the dependency list and the live schema."
+        },
+        "seed": {
+          "type": "string",
+          "maxLength": 2000,
+          "description": "The command the seed adapter runs, once per persona, with the persona in the environment as AF_PERSONA_NAME, AF_PERSONA_EMAIL, AF_PERSONA_PASSWORD, AF_PERSONA_TOTP_SECRET, AF_PERSONA_ROLE, AF_PERSONA_LOGIN and AF_PERSONA_ATTRIBUTES. It must be idempotent, because it runs again on every branch."
+        },
+        "sandbox": {
+          "type": "boolean",
+          "default": false,
+          "description": "That the configured tenant is a sandbox, development or staging tenant rather than the production one. A hosted adapter refuses to create anybody without this, because the only tenant it could otherwise fall back to is the real one."
+        },
+        "token_env": {
+          "type": "string",
+          "maxLength": 128,
+          "description": "The variable holding the provider's admin credential. The variable name, never the credential."
+        },
+        "url": {
+          "type": "string",
+          "maxLength": 2048,
+          "description": "The project's API root, for Supabase."
+        },
+        "domain": {
+          "type": "string",
+          "maxLength": 253,
+          "description": "The tenant, for Auth0, for example dev-abc123.us.auth0.com."
+        },
+        "connection": {
+          "type": "string",
+          "maxLength": 128,
+          "description": "The Auth0 database connection users are created in. Defaults to Username-Password-Authentication."
+        },
+        "table": {
+          "$ref": "#/$defs/authTable"
+        },
+        "sessions": {
+          "type": "array",
+          "maxItems": 50,
+          "items": {
+            "type": "string",
+            "maxLength": 128
+          },
+          "description": "Extra tables holding sessions or tokens, emptied so that no real session survives into a branch. Masking does not touch them, because a session token is not personal data by any rule a scanner applies."
+        },
+        "password": {
+          "$ref": "#/$defs/passwordRules"
+        }
+      }
+    },
+    "authTable": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ],
+      "description": "The columns of an application's own users table, for the direct adapter. Named rather than guessed, because guessing a column name is how provisioning writes a row the application cannot read.",
+      "properties": {
+        "schema": {
+          "type": "string",
+          "maxLength": 63,
+          "default": "public"
+        },
+        "name": {
+          "type": "string",
+          "maxLength": 63
+        },
+        "id": {
+          "type": "string",
+          "maxLength": 63,
+          "default": "id"
+        },
+        "email": {
+          "type": "string",
+          "maxLength": 63,
+          "default": "email"
+        },
+        "password": {
+          "type": "string",
+          "maxLength": 63,
+          "description": "The column the bcrypt hash goes in. Absent for a table that keeps no password."
+        },
+        "role": {
+          "type": "string",
+          "maxLength": 63
+        },
+        "json": {
+          "type": "string",
+          "maxLength": 63,
+          "description": "A JSONB column that persona attributes with no column of their own are written into."
+        },
+        "attributes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "maxLength": 63
+          },
+          "maxProperties": 50,
+          "description": "Maps a persona attribute name to the column it is stored in."
+        },
+        "timestamps": {
+          "type": "array",
+          "maxItems": 10,
+          "items": {
+            "type": "string",
+            "maxLength": 63
+          },
+          "description": "Columns set to now() on insert, and on update where the name contains 'updated'."
+        }
+      }
+    },
+    "passwordRules": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "The application's password policy, so the generated password satisfies it. Without this, an application stricter than the generator refuses a correct password at sign in and the run reports a login failure that looks like the application's fault.",
+      "properties": {
+        "min_length": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 128
+        },
+        "symbols": {
+          "type": "string",
+          "maxLength": 32,
+          "description": "Replaces the default symbol set, for an application that rejects the ones it uses."
+        },
+        "forbid": {
+          "type": "string",
+          "maxLength": 32,
+          "description": "Characters the application will not accept."
+        }
+      }
+    }
+  }
+}

--- a/engine/internal/manifest/manifest.v1.json
+++ b/engine/internal/manifest/manifest.v1.json
@@ -133,7 +133,7 @@
         },
         "command": {
           "type": "string",
-          "maxLength": 1024,
+          "maxLength": 4096,
           "description": "Command that starts the service, overriding the image's own. Executed with an argument vector, never through a shell."
         },
         "port": {
@@ -259,7 +259,7 @@
       "properties": {
         "name": {
           "type": "string",
-          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "pattern": "^[A-Za-z_][A-Za-z0-9_.]*$",
           "maxLength": 128
         },
         "required": {

--- a/engine/internal/manifest/manifest.v1.json
+++ b/engine/internal/manifest/manifest.v1.json
@@ -1617,6 +1617,23 @@
           "type": "string",
           "maxLength": 253,
           "description": "Which kubeconfig context to use. Naming it prevents an environment landing on whatever cluster happened to be current."
+        },
+        "requires": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "maxLength": 120
+          },
+          "maxProperties": 16,
+          "description": "What a target must offer for this repository to be placed on it, as attribute equals value matched against a target's tags. Empty means anywhere. A requirement no declared target satisfies is refused at validation, because both are in this file."
+        },
+        "targets": {
+          "type": "array",
+          "maxItems": 32,
+          "items": {
+            "$ref": "#/$defs/runtimeTarget"
+          },
+          "description": "The places an environment may be placed, in preference order. Empty means the single runtime the provider names, which is every manifest written before placement existed."
         }
       }
     },
@@ -1819,6 +1836,55 @@
           "type": "string",
           "maxLength": 32,
           "description": "Characters the application will not accept."
+        }
+      }
+    },
+    "runtimeTarget": {
+      "title": "Runtime target",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ],
+      "description": "One place an environment may be placed. A runtime plus the facts about where it is, and the second half is the part no runtime supplies for itself: a kubeconfig context is a name on somebody's laptop and it does not say which region the cluster is in.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z0-9]([a-z0-9-]{0,38}[a-z0-9])?$",
+          "maxLength": 40,
+          "description": "Unique within the manifest. It names the target in the placement decision and in the refusal when none will do."
+        },
+        "provider": {
+          "type": "string",
+          "enum": [
+            "local",
+            "kubernetes"
+          ],
+          "description": "The runtime this target uses. Omitted inherits runtime.provider, which is what lets a fleet of clusters be one provider line and a list of contexts."
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "maxLength": 120
+          },
+          "maxProperties": 16,
+          "description": "What this target offers, matched against runtime.requires. The region tag is also what fills the organization policy hook's residency check."
+        },
+        "domain": {
+          "type": "string",
+          "maxLength": 253,
+          "description": "Wildcard domain for environments placed here. Omitted inherits runtime.domain."
+        },
+        "namespace_prefix": {
+          "type": "string",
+          "maxLength": 40,
+          "description": "Prefix for Kubernetes namespaces on this target. Omitted inherits runtime.namespace_prefix."
+        },
+        "kubeconfig_context": {
+          "type": "string",
+          "maxLength": 253,
+          "description": "Which cluster this target is. Two targets resolving to the same cluster are refused, because a placement decision between them decides nothing."
         }
       }
     }

--- a/engine/internal/manifest/schema_constraints_test.go
+++ b/engine/internal/manifest/schema_constraints_test.go
@@ -1086,6 +1086,11 @@ func TestSchemaConstraintReport(t *testing.T) {
 // gate that only noticed additions would be half an instrument.
 const wantConstraints = 570
 
+// wantExceptions is how many constraints schemabounds.go deliberately does not
+// enforce. Every one is a published row that is wrong rather than a gap, and
+// the goal is zero.
+const wantExceptions = 6
+
 // TestEverySchemaConstraintIsEnforced is the gate.
 //
 // For every constraint the published schema declares, it generates a manifest
@@ -1103,6 +1108,16 @@ func TestEverySchemaConstraintIsEnforced(t *testing.T) {
 		require.Emptyf(t, b.err, "the generated base manifest %q is itself refused, so every cell measured against it says nothing:\n%s", b.spec.Name, b.err)
 		require.Emptyf(t, b.unfilled, "no value could be generated for %v, so those fields carry no constraint anywhere in the corpus", b.unfilled)
 	}
+
+	// The exception list is the one escape hatch in this gate, so its size is
+	// pinned too. Without this, quietly adding an entry would turn a broken
+	// promise into a passing build, which is the shape of every check in this
+	// repository that could not say no.
+	require.Lenf(t, manifest.BoundsExceptionsForTest(), wantExceptions,
+		"schemabounds.go now excuses %d constraints and this test was written against %d. "+
+			"Adding one means the engine publishes a promise it will not keep, so argue for it "+
+			"in the commit and change this number deliberately.",
+		len(manifest.BoundsExceptionsForTest()), wantExceptions)
 
 	require.Lenf(t, verdicts, wantConstraints,
 		"schemas/manifest.v1.json declares %d constraints and this test was written against %d. "+

--- a/engine/internal/manifest/schema_constraints_test.go
+++ b/engine/internal/manifest/schema_constraints_test.go
@@ -1120,15 +1120,18 @@ func TestSchemaConstraintReport(t *testing.T) {
 // tools/schemadoc generates, which is a promise withdrawn from users, and a
 // gate that only noticed additions would be half an instrument.
 //
-// 567 while this branch was open, and 569 on rebasing onto main, which is the
-// pin doing its job across two branches rather than one commit. main opened
-// runtime.provider in the same direction this branch did, so the enum it
-// removed is the enum this branch had already removed, and it left a maxLength
-// of 64 behind it. It also gave datastore.source_url_env a pattern. Two
-// constraints arrived, both from somebody else, and both are enforced without
-// anything being added here: the pass is driven by the published document, so
-// a bound written into the schema by another lane is kept the moment it lands.
-const wantConstraints = 569
+// The number moves whenever anybody edits the schema, which is the pin working
+// rather than the pin being a nuisance: it was 567 while this branch was
+// written and is 593 against the main it landed on. Two lanes changed the
+// published contract in between. One opened runtime.provider in the same
+// direction this branch did, trading an enum for a maxLength, and gave
+// datastore.source_url_env a pattern. The other added the placement feature,
+// runtime.targets and runtime.requires, which is most of the difference. Not
+// one of them needed anything added here to be enforced, because the pass is
+// driven by the published document: a bound another lane writes into the
+// schema is kept the moment it lands, and the only thing this constant does is
+// refuse to let one leave without somebody saying so.
+const wantConstraints = 593
 
 // wantExceptions is how many constraints schemabounds.go deliberately does not
 // enforce. Every one is a published row that is wrong rather than a gap, and

--- a/engine/internal/manifest/schema_constraints_test.go
+++ b/engine/internal/manifest/schema_constraints_test.go
@@ -1024,9 +1024,44 @@ func attributable(target string, r refusal) bool {
 			strings.HasPrefix(target, p+".") || target == "" {
 			return true
 		}
+		if starred.MatchString(target) && underWildcard(target, p) {
+			return true
+		}
 	}
 	return false
 }
+
+// underWildcard is the same comparison for a constraint on a map's VALUES.
+//
+// additionalProperties on a map is written here as a star segment, so the
+// maxLength every value under auth.table.attributes carries has the path
+// auth.table.attributes.* and the engine, refusing, names the key it actually
+// read: auth.table.attributes.sample_key. Those two are the same place and
+// compare as different strings, so all four such constraints scored
+// REFUSED-ELSEWHERE while the engine was keeping every one of them. That is
+// the defect `indexed` fixes for array subscripts, a level over: an index and
+// a map key are both a position the constraint does not name and the refusal
+// does.
+//
+// A star stands for exactly ONE segment, never a run of them, so
+// personas[].attributes.* does not claim a refusal deeper inside a value.
+func underWildcard(target, p string) bool {
+	ts := strings.Split(target, ".")
+	ps := strings.Split(p, ".")
+	if len(ps) < len(ts) {
+		return false
+	}
+	for i, seg := range ts {
+		if seg != "*" && seg != ps[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// starred is a path carrying a map key position. Matched as a whole segment so
+// that a literal star inside a name, if one ever appears, is not a wildcard.
+var starred = regexp.MustCompile(`(^|\.)\*(\.|$)`)
 
 // indexed erases array subscripts, so that the constraint path
 // services[].env[].name and the engine's services[0].env[2].name are the
@@ -1084,7 +1119,16 @@ func TestSchemaConstraintReport(t *testing.T) {
 // from that file removes a row from the published reference page that
 // tools/schemadoc generates, which is a promise withdrawn from users, and a
 // gate that only noticed additions would be half an instrument.
-const wantConstraints = 567
+//
+// 567 while this branch was open, and 569 on rebasing onto main, which is the
+// pin doing its job across two branches rather than one commit. main opened
+// runtime.provider in the same direction this branch did, so the enum it
+// removed is the enum this branch had already removed, and it left a maxLength
+// of 64 behind it. It also gave datastore.source_url_env a pattern. Two
+// constraints arrived, both from somebody else, and both are enforced without
+// anything being added here: the pass is driven by the published document, so
+// a bound written into the schema by another lane is kept the moment it lands.
+const wantConstraints = 569
 
 // wantExceptions is how many constraints schemabounds.go deliberately does not
 // enforce. Every one is a published row that is wrong rather than a gap, and

--- a/engine/internal/manifest/schema_constraints_test.go
+++ b/engine/internal/manifest/schema_constraints_test.go
@@ -1084,12 +1084,12 @@ func TestSchemaConstraintReport(t *testing.T) {
 // from that file removes a row from the published reference page that
 // tools/schemadoc generates, which is a promise withdrawn from users, and a
 // gate that only noticed additions would be half an instrument.
-const wantConstraints = 570
+const wantConstraints = 567
 
 // wantExceptions is how many constraints schemabounds.go deliberately does not
 // enforce. Every one is a published row that is wrong rather than a gap, and
 // the goal is zero.
-const wantExceptions = 6
+const wantExceptions = 0
 
 // TestEverySchemaConstraintIsEnforced is the gate.
 //

--- a/engine/internal/manifest/schema_constraints_test.go
+++ b/engine/internal/manifest/schema_constraints_test.go
@@ -2,6 +2,7 @@ package manifest_test
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -658,16 +659,120 @@ type tuning struct {
 	RefusedFields map[string]string `json:"refused_fields"`
 }
 
+// defaultTuning is the base corpus the gate runs on. AF_SCHEMA_TUNING points
+// it at a file instead, which is how it is developed without recompiling.
+//
+// Two bases rather than one because the manifest has mutually exclusive
+// fields, and a document carrying all of them at once is refused by twenty
+// four of the engine's own cross field rules: a database is built from a
+// source or from a seed and never both, an egress rule in block mode may not
+// carry a credential, a web service may not carry a cron schedule. The second
+// base is the other side of every one of those pairs, so nothing is left
+// unmeasured because it could not share a document with its opposite.
+const defaultTuning = `{
+  "bases": [
+    {
+      "name": "source",
+      "why": "a web service built from an image, a golden from production, egress in sandbox mode",
+      "overrides": {
+        "database.golden.schedule": "0 3 * * *",
+        "database.golden.max_age": "720h",
+        "database.volume.max_age": "720h",
+        "database.subset.virtual_relationships[].from": "orders.user_id",
+        "database.subset.virtual_relationships[].to": "users.id",
+        "egress.rules[].mode": "sandbox",
+        "explore.goals[].name": "explore-goal",
+        "invariants[].sql": "SELECT id FROM orders WHERE id IS NULL",
+        "load.source": "otel",
+        "load.unsafe_routes": [
+          "/admin"
+        ],
+        "oracle.ignore.fields[]": "$.field",
+        "oracle.probes[].method": "POST",
+        "personas[].email": "person@example.com",
+        "services[].build.strategy": "image",
+        "services[].depends_on": [
+          "dep"
+        ],
+        "services[].env[].value": "http://example.com",
+        "load.source_config": {
+          "path": "telemetry/traces.json"
+        }
+      },
+      "prune": [
+        "database.seed",
+        "datastores[].from",
+        "egress.rules[].fixtures",
+        "services[].schedule",
+        "services[].resources",
+        "load.thresholds.query_count_increase",
+        "services[].env[].from",
+        "services[].env[].sandbox"
+      ],
+      "append": {
+        "services": [
+          {
+            "name": "dep",
+            "kind": "worker"
+          }
+        ]
+      }
+    },
+    {
+      "name": "seed",
+      "why": "the other side of every mutually exclusive pair: a seeded database, a cron service, an egress rule in mock mode, a derived datastore, a variable read from the environment",
+      "overrides": {
+        "database.golden.schedule": "0 3 * * *",
+        "database.golden.max_age": "720h",
+        "database.volume.max_age": "720h",
+        "database.subset.virtual_relationships[].from": "orders.user_id",
+        "database.subset.virtual_relationships[].to": "users.id",
+        "egress.rules[].mode": "mock",
+        "explore.goals[].name": "explore-goal",
+        "invariants[].sql": "SELECT id FROM orders WHERE id IS NULL",
+        "load.source": "otel",
+        "load.unsafe_routes": [
+          "/admin"
+        ],
+        "oracle.ignore.fields[]": "$.field",
+        "oracle.probes[].method": "POST",
+        "personas[].email": "person@example.com",
+        "services[].kind": "cron",
+        "services[].schedule": "0 3 * * *",
+        "datastores[].stance": "derived",
+        "services[].env[].from": "OTHER_VAR",
+        "load.source_config": {
+          "path": "telemetry/traces.json"
+        }
+      },
+      "prune": [
+        "database.source_url_env",
+        "egress.rules[].credential",
+        "egress.rules[].rate_limit",
+        "services[].port",
+        "services[].build.image",
+        "services[].depends_on",
+        "services[].resources",
+        "load.thresholds.query_count_increase",
+        "services[].env[].value"
+      ]
+    }
+  ],
+  "refused_fields": {
+    "services[].resources": "the engine refuses resources.cpu and resources.memory outright: nothing reads them, so a limit in the manifest would be applied nowhere",
+    "load.thresholds.query_count_increase": "the engine refuses this outright: a load run counts requests, not statements, so nothing could measure it"
+  }
+}`
+
 func loadTuning() tuning {
 	var tn tuning
-	path := os.Getenv("AF_SCHEMA_TUNING")
-	if path == "" {
-		tn.Bases = []baseSpec{{Name: "generated"}}
-		return tn
-	}
-	raw, err := os.ReadFile(path) //nolint:gosec // a developer named this file
-	if err != nil {
-		panic("AF_SCHEMA_TUNING: " + err.Error())
+	raw := []byte(defaultTuning)
+	if path := os.Getenv("AF_SCHEMA_TUNING"); path != "" {
+		var err error
+		raw, err = os.ReadFile(path) //nolint:gosec // a developer named this file
+		if err != nil {
+			panic("AF_SCHEMA_TUNING: " + err.Error())
+		}
 	}
 	if err := json.Unmarshal(raw, &tn); err != nil {
 		panic("AF_SCHEMA_TUNING: " + err.Error())
@@ -739,6 +844,9 @@ const (
 	statusNot      = "NOT-ENFORCED"
 	statusRefused  = "REFUSED-FIELD"
 	statusNoLook   = "COULD-NOT-LOOK"
+	// statusElsewhere is a refusal that names a path other than the one that
+	// was mutated. It is not evidence the constraint is kept.
+	statusElsewhere = "REFUSED-ELSEWHERE"
 )
 
 func measure(t *testing.T) ([]verdict, []builtBase) {
@@ -786,13 +894,17 @@ func measure(t *testing.T) ([]verdict, []builtBase) {
 				name := strings.NewReplacer("/", "_", " ", "_", "*", "star", "[", "", "]", "").Replace(c.id())
 				_ = os.WriteFile(filepath.Join(dumpDir, "bad__"+name+".json"), raw, 0o600)
 			}
-			e := parseErr(bad)
+			r := ask(bad)
 			v.base = b.spec.Name
-			if e == "" {
+			switch {
+			case !r.refused:
 				v.status = statusNot
-			} else {
+			case !attributable(c.Path, r):
+				v.status = statusElsewhere
+				v.engine = firstProblem(r.text)
+			default:
 				v.status = statusEnforced
-				v.engine = firstProblem(e)
+				v.engine = firstProblem(r.text)
 			}
 			measured = true
 			break
@@ -838,6 +950,61 @@ func parseErr(doc any) string {
 	return ""
 }
 
+// refusal is what the engine said about one document: whether it refused it,
+// and which paths it named.
+type refusal struct {
+	refused bool
+	text    string
+	paths   []string
+}
+
+func ask(doc any) refusal {
+	raw, err := json.Marshal(doc)
+	if err != nil {
+		return refusal{refused: true, text: "marshal: " + err.Error()}
+	}
+	_, err = manifest.Parse(raw, "antifailure.yaml", "")
+	if err == nil {
+		return refusal{}
+	}
+	r := refusal{refused: true, text: err.Error()}
+	var errs *manifest.Errors
+	if errors.As(err, &errs) {
+		for _, p := range errs.Problems {
+			if p.Path != "" {
+				r.paths = append(r.paths, p.Path)
+			}
+		}
+	}
+	return r
+}
+
+// attributable reports whether the engine's complaint is about the place that
+// was mutated, rather than about something the mutation disturbed by accident.
+//
+// This exists because a cell can read ENFORCED for the wrong reason. Deleting
+// a required field or lengthening a name can break a cross field rule
+// somewhere else, and an instrument that only asks "was it refused" would
+// score that as the constraint being kept. A refusal that names no path at all
+// is the YAML decoder rejecting the document before the validator ran, which
+// is a real refusal of that value, so it counts.
+func attributable(target string, r refusal) bool {
+	if len(r.paths) == 0 {
+		return true
+	}
+	target = strings.TrimSuffix(target, "[]")
+	for _, p := range r.paths {
+		p = indexed.ReplaceAllString(p, "")
+		if p == target || strings.HasPrefix(p, target+".") || strings.HasPrefix(p, target+"[") ||
+			strings.HasPrefix(target, p+".") || target == "" {
+			return true
+		}
+	}
+	return false
+}
+
+var indexed = regexp.MustCompile(`\[[0-9]+\]`)
+
 // TestSchemaConstraintReport prints the measurement. It asserts nothing; the
 // gate is TestEverySchemaConstraintIsEnforced.
 func TestSchemaConstraintReport(t *testing.T) {
@@ -881,4 +1048,71 @@ func TestSchemaConstraintReport(t *testing.T) {
 		raw, _ := json.MarshalIndent(rows, "", " ")
 		require.NoError(t, os.WriteFile(out, raw, 0o600))
 	}
+}
+
+// wantConstraints is the number of constraints schemas/manifest.v1.json
+// declares. Pinned so that DELETING one fails this test: a constraint removed
+// from that file removes a row from the published reference page that
+// tools/schemadoc generates, which is a promise withdrawn from users, and a
+// gate that only noticed additions would be half an instrument.
+const wantConstraints = 570
+
+// TestEverySchemaConstraintIsEnforced is the gate.
+//
+// For every constraint the published schema declares, it generates a manifest
+// that violates exactly that one and requires the engine to refuse it, and to
+// refuse it for that reason rather than for something the mutation disturbed
+// by accident. It measures behaviour, never names, because enforcement moves:
+// normalizeDatastores copies database.source_url_env onto the primary
+// datastore's entry, so one check can keep the promise made about two fields,
+// and a sweep pairing a schema field with a Go check by name would score one
+// of them wrong in each direction.
+func TestEverySchemaConstraintIsEnforced(t *testing.T) {
+	verdicts, bases := measure(t)
+
+	for _, b := range bases {
+		require.Emptyf(t, b.err, "the generated base manifest %q is itself refused, so every cell measured against it says nothing:\n%s", b.spec.Name, b.err)
+		require.Emptyf(t, b.unfilled, "no value could be generated for %v, so those fields carry no constraint anywhere in the corpus", b.unfilled)
+	}
+
+	require.Lenf(t, verdicts, wantConstraints,
+		"schemas/manifest.v1.json declares %d constraints and this test was written against %d. "+
+			"Adding one is fine: update wantConstraints. Removing one withdraws a row from the "+
+			"published reference page, so say why in the commit.", len(verdicts), wantConstraints)
+
+	var unenforced, elsewhere, unmeasured []string
+	for _, v := range verdicts {
+		switch v.status {
+		case statusNot:
+			unenforced = append(unenforced, v.c.id())
+		case statusElsewhere:
+			elsewhere = append(elsewhere, v.c.id()+" -> "+v.engine)
+		case statusNoLook:
+			unmeasured = append(unmeasured, v.c.id()+" ("+v.reason+")")
+		}
+	}
+
+	require.Emptyf(t, unenforced,
+		"the schema declares these and the engine accepts a manifest that breaks them, so they are "+
+			"published to users as a promise and kept by nothing:\n  %s",
+		strings.Join(unenforced, "\n  "))
+	require.Emptyf(t, elsewhere,
+		"these were refused, but for a path other than the one that was broken, so the refusal is "+
+			"not evidence the constraint is kept:\n  %s", strings.Join(elsewhere, "\n  "))
+	require.Emptyf(t, unmeasured,
+		"these could not be measured at all, which is not a pass:\n  %s", strings.Join(unmeasured, "\n  "))
+}
+
+// TestTheEmbeddedSchemaIsThePublishedOne. The engine embeds a copy of
+// schemas/manifest.v1.json because go:embed cannot reach outside the module.
+// A copy that drifts would enforce yesterday's contract while the site
+// published today's, which is the exact failure this whole file exists for,
+// one level down.
+func TestTheEmbeddedSchemaIsThePublishedOne(t *testing.T) {
+	published, err := os.ReadFile(filepath.Join("..", "..", "..", "schemas", "manifest.v1.json"))
+	require.NoError(t, err)
+	embedded, err := os.ReadFile("manifest.v1.json")
+	require.NoError(t, err)
+	require.Equal(t, string(published), string(embedded),
+		"engine/internal/manifest/manifest.v1.json is a generated copy and it is stale. Run 'just generate'.")
 }

--- a/engine/internal/manifest/schema_constraints_test.go
+++ b/engine/internal/manifest/schema_constraints_test.go
@@ -743,7 +743,8 @@ const defaultTuning = `{
         "services[].env[].from": "OTHER_VAR",
         "load.source_config": {
           "path": "telemetry/traces.json"
-        }
+        },
+        "datastores[].from": "primary"
       },
       "prune": [
         "database.source_url_env",
@@ -992,7 +993,7 @@ func attributable(target string, r refusal) bool {
 	if len(r.paths) == 0 {
 		return true
 	}
-	target = strings.TrimSuffix(target, "[]")
+	target = indexed.ReplaceAllString(target, "")
 	for _, p := range r.paths {
 		p = indexed.ReplaceAllString(p, "")
 		if p == target || strings.HasPrefix(p, target+".") || strings.HasPrefix(p, target+"[") ||
@@ -1003,7 +1004,11 @@ func attributable(target string, r refusal) bool {
 	return false
 }
 
-var indexed = regexp.MustCompile(`\[[0-9]+\]`)
+// indexed erases array subscripts, so that the constraint path
+// services[].env[].name and the engine's services[0].env[2].name are the
+// same place. Erasing it on only one side is a bug this had: it scored 119
+// correct refusals as REFUSED-ELSEWHERE.
+var indexed = regexp.MustCompile(`\[[0-9]*\]`)
 
 // TestSchemaConstraintReport prints the measurement. It asserts nothing; the
 // gate is TestEverySchemaConstraintIsEnforced.

--- a/engine/internal/manifest/schema_constraints_test.go
+++ b/engine/internal/manifest/schema_constraints_test.go
@@ -848,7 +848,25 @@ const (
 	// statusElsewhere is a refusal that names a path other than the one that
 	// was mutated. It is not evidence the constraint is kept.
 	statusElsewhere = "REFUSED-ELSEWHERE"
+	// statusExcepted is a constraint schemabounds.go deliberately does not
+	// enforce, with a reason recorded beside it in the one shared list.
+	statusExcepted = "EXCEPTED"
 )
+
+// exceptedConstraint reads the pass's own exception list rather than a second
+// copy of it.
+func exceptedConstraint(c constraint) (string, bool) {
+	key := c.Keyword
+	if c.Detail != "" {
+		key += "=" + c.Detail
+	}
+	for _, e := range manifest.BoundsExceptionsForTest() {
+		if indexed.ReplaceAllString(e[0], "") == indexed.ReplaceAllString(c.Path, "") && e[1] == key {
+			return e[2], true
+		}
+	}
+	return "", false
+}
 
 func measure(t *testing.T) ([]verdict, []builtBase) {
 	t.Helper()
@@ -868,6 +886,12 @@ func measure(t *testing.T) ([]verdict, []builtBase) {
 	var out []verdict
 	for _, c := range enumerate(root) {
 		v := verdict{c: c}
+		if why, ok := exceptedConstraint(c); ok {
+			v.status = statusExcepted
+			v.reason = why
+			out = append(out, v)
+			continue
+		}
 		if why, ok := refusedField(tn.RefusedFields, c.Path); ok {
 			v.status = statusRefused
 			v.reason = why

--- a/engine/internal/manifest/schema_constraints_test.go
+++ b/engine/internal/manifest/schema_constraints_test.go
@@ -1,0 +1,884 @@
+package manifest_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/internal/manifest"
+)
+
+// A constraint declared in schemas/manifest.v1.json, located at the place in a
+// manifest where it applies.
+type constraint struct {
+	Path    string // instance path, dotted, [] for the first array element
+	Keyword string
+	Detail  string
+}
+
+func (c constraint) id() string {
+	if c.Detail == "" {
+		return c.Path + " " + c.Keyword
+	}
+	return c.Path + " " + c.Keyword + "=" + c.Detail
+}
+
+// cnode is the part of a JSON Schema this walks. Every keyword the manifest
+// schema actually uses has a field here; anything it grows later that is not
+// listed is invisible, which is why TestSchemaConstraintInventoryIsComplete
+// compares this walk against a raw count of the file.
+type cnode struct {
+	Ref                  string            `json:"$ref"`
+	Defs                 map[string]*cnode `json:"$defs"`
+	Type                 any               `json:"type"`
+	Properties           map[string]*cnode `json:"properties"`
+	Items                *cnode            `json:"items"`
+	AdditionalProperties json.RawMessage   `json:"additionalProperties"`
+	Required             []string          `json:"required"`
+	Enum                 []any             `json:"enum"`
+	Pattern              string            `json:"pattern"`
+	MinLength            *int              `json:"minLength"`
+	MaxLength            *int              `json:"maxLength"`
+	MinItems             *int              `json:"minItems"`
+	MaxItems             *int              `json:"maxItems"`
+	MaxProperties        *int              `json:"maxProperties"`
+	UniqueItems          *bool             `json:"uniqueItems"`
+	Minimum              *float64          `json:"minimum"`
+	Maximum              *float64          `json:"maximum"`
+}
+
+func (n *cnode) resolve(root *cnode) *cnode {
+	for n != nil && n.Ref != "" {
+		n = root.Defs[strings.TrimPrefix(n.Ref, "#/$defs/")]
+	}
+	return n
+}
+
+func (n *cnode) typeIs(want string) bool {
+	switch t := n.Type.(type) {
+	case string:
+		return t == want
+	case []any:
+		for _, e := range t {
+			if s, ok := e.(string); ok && s == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// apSchema returns the schema additionalProperties names, when it is a schema
+// rather than the boolean false.
+func (n *cnode) apSchema() *cnode {
+	if len(n.AdditionalProperties) == 0 {
+		return nil
+	}
+	var sub cnode
+	if err := json.Unmarshal(n.AdditionalProperties, &sub); err != nil {
+		return nil
+	}
+	return &sub
+}
+
+func (n *cnode) apIsFalse() bool {
+	return strings.TrimSpace(string(n.AdditionalProperties)) == "false"
+}
+
+func loadConstraintSchema(t *testing.T) *cnode {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("..", "..", "..", "schemas", "manifest.v1.json"))
+	require.NoError(t, err)
+	var root cnode
+	require.NoError(t, json.Unmarshal(raw, &root))
+	return &root
+}
+
+// enumerate walks the schema from the root and returns every constraint it
+// declares, each located at the instance path where a manifest would violate
+// it. Order is deterministic so the inventory is diffable.
+func enumerate(root *cnode) []constraint {
+	var out []constraint
+	var walk func(n *cnode, path string, depth int)
+	walk = func(n *cnode, path string, depth int) {
+		n = n.resolve(root)
+		if n == nil || depth > 24 {
+			return
+		}
+		if n.Type != nil {
+			out = append(out, constraint{Path: path, Keyword: "type"})
+		}
+		if n.Pattern != "" {
+			out = append(out, constraint{Path: path, Keyword: "pattern"})
+		}
+		if len(n.Enum) > 0 {
+			out = append(out, constraint{Path: path, Keyword: "enum"})
+		}
+		if n.MinLength != nil {
+			out = append(out, constraint{Path: path, Keyword: "minLength"})
+		}
+		if n.MaxLength != nil {
+			out = append(out, constraint{Path: path, Keyword: "maxLength"})
+		}
+		if n.Minimum != nil {
+			out = append(out, constraint{Path: path, Keyword: "minimum"})
+		}
+		if n.Maximum != nil {
+			out = append(out, constraint{Path: path, Keyword: "maximum"})
+		}
+		if n.MinItems != nil {
+			out = append(out, constraint{Path: path, Keyword: "minItems"})
+		}
+		if n.MaxItems != nil {
+			out = append(out, constraint{Path: path, Keyword: "maxItems"})
+		}
+		if n.MaxProperties != nil {
+			out = append(out, constraint{Path: path, Keyword: "maxProperties"})
+		}
+		if n.UniqueItems != nil && *n.UniqueItems {
+			out = append(out, constraint{Path: path, Keyword: "uniqueItems"})
+		}
+		for _, r := range n.Required {
+			out = append(out, constraint{Path: path, Keyword: "required", Detail: r})
+		}
+		if n.apIsFalse() {
+			out = append(out, constraint{Path: path, Keyword: "additionalProperties"})
+		}
+		names := make([]string, 0, len(n.Properties))
+		for name := range n.Properties {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			child := path + "." + name
+			if path == "" {
+				child = name
+			}
+			walk(n.Properties[name], child, depth+1)
+		}
+		if sub := n.apSchema(); sub != nil {
+			child := path + ".*"
+			if path == "" {
+				child = "*"
+			}
+			walk(sub, child, depth+1)
+		}
+		if n.Items != nil {
+			walk(n.Items, path+"[]", depth+1)
+		}
+	}
+	walk(root, "", 0)
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Instance generation.
+//
+// A base manifest is generated from the schema itself: every property present,
+// every value chosen to satisfy the constraint declared on it. Then one place
+// is mutated per constraint, producing a document the published schema rejects
+// and that differs from the base in exactly one place.
+// ---------------------------------------------------------------------------
+
+// stringCandidates is tried in order. The first that matches the property's
+// pattern and length bounds is used, so nothing here is mapped to a field by
+// hand: a new pattern in the schema either matches one of these or the
+// generator refuses to guess and the cell is reported as unmeasured.
+var stringCandidates = []string{
+	"web", "web-one", "web_one", "Web_One1", "a",
+	"1h", "30s", "500ms", "10m", "2d", "1", "60", "1.5m", "512Mi", "10/s",
+	"web.main", "an example sentence that is long enough",
+}
+
+var badString = "!! not a valid value !!"
+
+func matches(pattern, s string) bool {
+	if pattern == "" {
+		return true
+	}
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return false
+	}
+	return re.MatchString(s)
+}
+
+// sampleString picks a value satisfying the declared pattern and lengths.
+func sampleString(n *cnode) (string, bool) {
+	if len(n.Enum) > 0 {
+		if s, ok := n.Enum[0].(string); ok {
+			return s, true
+		}
+	}
+	for _, c := range stringCandidates {
+		if !matches(n.Pattern, c) {
+			continue
+		}
+		if n.MinLength != nil && len(c) < *n.MinLength {
+			continue
+		}
+		if n.MaxLength != nil && len(c) > *n.MaxLength {
+			continue
+		}
+		return c, true
+	}
+	return "", false
+}
+
+// generator builds instances and records the paths it could not fill.
+type generator struct {
+	root      *cnode
+	overrides map[string]any
+	unfilled  []string
+}
+
+func (g *generator) sample(n *cnode, path string, depth int) any {
+	n = n.resolve(g.root)
+	if n == nil || depth > 24 {
+		return nil
+	}
+	if v, ok := g.overrides[path]; ok {
+		return v
+	}
+	switch {
+	case n.typeIs("object"):
+		obj := map[string]any{}
+		names := make([]string, 0, len(n.Properties))
+		for name := range n.Properties {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			child := path + "." + name
+			if path == "" {
+				child = name
+			}
+			if v := g.sample(n.Properties[name], child, depth+1); v != nil {
+				obj[name] = v
+			}
+		}
+		if sub := g.apSchemaOf(n); sub != nil {
+			child := path + ".*"
+			if path == "" {
+				child = "*"
+			}
+			if v := g.sample(sub, child, depth+1); v != nil {
+				obj[mapKeyFor(path)] = v
+			}
+		}
+		return obj
+	case n.typeIs("array"):
+		if n.Items == nil {
+			return []any{}
+		}
+		v := g.sample(n.Items, path+"[]", depth+1)
+		if v == nil {
+			return []any{}
+		}
+		return []any{v}
+	case n.typeIs("string"):
+		s, ok := sampleString(n)
+		if !ok {
+			g.unfilled = append(g.unfilled, path)
+			return nil
+		}
+		return s
+	case n.typeIs("integer"), n.typeIs("number"):
+		if len(n.Enum) > 0 {
+			return n.Enum[0]
+		}
+		v := 1.0
+		if n.Minimum != nil && *n.Minimum > v {
+			v = *n.Minimum
+		}
+		if n.Maximum != nil && *n.Maximum < v {
+			v = *n.Maximum
+		}
+		if n.typeIs("integer") {
+			return int(v)
+		}
+		return v
+	case n.typeIs("boolean"):
+		return true
+	}
+	g.unfilled = append(g.unfilled, path)
+	return nil
+}
+
+func (g *generator) apSchemaOf(n *cnode) *cnode {
+	return n.apSchema()
+}
+
+// mapKeyFor names the single key generated for a free form map.
+func mapKeyFor(path string) string {
+	switch path {
+	case "personas[].attributes", "auth.attribute_columns":
+		return "team"
+	}
+	return "sample_key"
+}
+
+// ---------------------------------------------------------------------------
+// Path navigation over the generated instance.
+// ---------------------------------------------------------------------------
+
+// walkTo returns the container holding the last path element, and that element
+// as a key or index.
+func walkTo(doc any, path string) (any, string, bool) {
+	segs := strings.Split(path, ".")
+	cur := doc
+	for i, seg := range segs {
+		last := i == len(segs)-1
+		arrays := 0
+		for strings.HasSuffix(seg, "[]") {
+			seg = strings.TrimSuffix(seg, "[]")
+			arrays++
+		}
+		if last && arrays == 0 {
+			return cur, soleKey(cur, seg), true
+		}
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return nil, "", false
+		}
+		next, ok := m[soleKey(cur, seg)]
+		if !ok {
+			return nil, "", false
+		}
+		for a := 0; a < arrays; a++ {
+			arr, ok := next.([]any)
+			if !ok || len(arr) == 0 {
+				return nil, "", false
+			}
+			if last && a == arrays-1 {
+				return arr, "0", true
+			}
+			next = arr[0]
+		}
+		cur = next
+	}
+	return nil, "", false
+}
+
+// soleKey turns the free form map wildcard into the key the generator wrote.
+func soleKey(container any, seg string) string {
+	if seg != "*" {
+		return seg
+	}
+	m, ok := container.(map[string]any)
+	if !ok {
+		return seg
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	if len(keys) == 0 {
+		return seg
+	}
+	return keys[0]
+}
+
+func valueAt(doc any, path string) (any, bool) {
+	if path == "" {
+		return doc, true
+	}
+	holder, key, ok := walkTo(doc, path)
+	if !ok {
+		return nil, false
+	}
+	switch h := holder.(type) {
+	case map[string]any:
+		v, ok := h[key]
+		return v, ok
+	case []any:
+		if len(h) == 0 {
+			return nil, false
+		}
+		return h[0], true
+	}
+	return nil, false
+}
+
+func setAt(doc any, path string, value any) bool {
+	if path == "" {
+		return false
+	}
+	holder, key, ok := walkTo(doc, path)
+	if !ok {
+		return false
+	}
+	switch h := holder.(type) {
+	case map[string]any:
+		h[key] = value
+		return true
+	case []any:
+		if len(h) == 0 {
+			return false
+		}
+		h[0] = value
+		return true
+	}
+	return false
+}
+
+func deleteAt(doc any, path string) bool {
+	holder, key, ok := walkTo(doc, path)
+	if !ok {
+		return false
+	}
+	m, ok := holder.(map[string]any)
+	if !ok {
+		return false
+	}
+	if _, present := m[key]; !present {
+		return false
+	}
+	delete(m, key)
+	return true
+}
+
+func deepCopy(v any) any {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return nil
+	}
+	var out any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil
+	}
+	return out
+}
+
+// violate returns a copy of base that breaks exactly the one constraint, and
+// reports whether it could construct one.
+func violate(root *cnode, base any, c constraint) (any, bool) {
+	doc := deepCopy(base)
+	if doc == nil {
+		return nil, false
+	}
+	node := nodeAtPath(root, c.Path)
+	if node == nil {
+		return nil, false
+	}
+	switch c.Keyword {
+	case "required":
+		p := c.Detail
+		if c.Path != "" {
+			p = c.Path + "." + c.Detail
+		}
+		return doc, deleteAt(doc, p)
+	case "additionalProperties":
+		v, ok := valueAt(doc, c.Path)
+		if !ok {
+			return nil, false
+		}
+		m, ok := v.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		m["af_not_a_declared_property"] = "x"
+		return doc, true
+	case "maxProperties":
+		v, ok := valueAt(doc, c.Path)
+		if !ok {
+			return nil, false
+		}
+		m, ok := v.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		for i := 0; i <= *node.MaxProperties; i++ {
+			m[fmt.Sprintf("k%d", i)] = "v"
+		}
+		return doc, true
+	case "type":
+		if c.Path == "" {
+			return "af: a manifest that is not an object", true
+		}
+		var wrong any = map[string]any{"af": "wrong type"}
+		if node.typeIs("object") {
+			wrong = "af not an object"
+		}
+		return doc, setAt(doc, c.Path, wrong)
+	case "enum":
+		var wrong any = badString
+		if _, isNum := node.Enum[0].(float64); isNum {
+			wrong = 999999
+		}
+		return doc, setAt(doc, c.Path, wrong)
+	case "pattern":
+		return doc, setAt(doc, c.Path, badString)
+	case "minLength":
+		return doc, setAt(doc, c.Path, strings.Repeat("a", atLeastZero(*node.MinLength-1)))
+	case "maxLength":
+		seed, ok := sampleString(node)
+		if !ok || seed == "" {
+			seed = "a"
+		}
+		s := strings.Repeat(seed, (*node.MaxLength/len(seed) + 2))
+		return doc, setAt(doc, c.Path, s[:*node.MaxLength+1])
+	case "minimum":
+		return doc, setAt(doc, c.Path, *node.Minimum-1)
+	case "maximum":
+		return doc, setAt(doc, c.Path, *node.Maximum+1)
+	case "minItems":
+		return doc, setAt(doc, c.Path, []any{})
+	case "maxItems":
+		v, ok := valueAt(doc, c.Path)
+		if !ok {
+			return nil, false
+		}
+		arr, ok := v.([]any)
+		if !ok || len(arr) == 0 {
+			return nil, false
+		}
+		out := make([]any, 0, *node.MaxItems+1)
+		for i := 0; i <= *node.MaxItems; i++ {
+			out = append(out, uniquify(deepCopy(arr[0]), i))
+		}
+		return doc, setAt(doc, c.Path, out)
+	case "uniqueItems":
+		v, ok := valueAt(doc, c.Path)
+		if !ok {
+			return nil, false
+		}
+		arr, ok := v.([]any)
+		if !ok || len(arr) == 0 {
+			return nil, false
+		}
+		return doc, setAt(doc, c.Path, []any{arr[0], deepCopy(arr[0])})
+	}
+	return nil, false
+}
+
+// uniquify makes the nth copy of an array element distinct, so that a maxItems
+// violation is not also a duplicate name violation.
+func uniquify(v any, i int) any {
+	m, ok := v.(map[string]any)
+	if !ok {
+		if s, ok := v.(string); ok && i > 0 {
+			return fmt.Sprintf("%s-%d", s, i)
+		}
+		return v
+	}
+	for _, key := range []string{"name", "id", "goal", "host", "sql", "path"} {
+		if s, ok := m[key].(string); ok && i > 0 {
+			m[key] = fmt.Sprintf("%s-%d", s, i)
+		}
+	}
+	return m
+}
+
+// nodeAtPath resolves an instance path back to the schema node that declares
+// the constraints on it.
+func nodeAtPath(root *cnode, path string) *cnode {
+	n := root.resolve(root)
+	if path == "" {
+		return n
+	}
+	for _, seg := range strings.Split(path, ".") {
+		arrays := 0
+		for strings.HasSuffix(seg, "[]") {
+			seg = strings.TrimSuffix(seg, "[]")
+			arrays++
+		}
+		if n == nil {
+			return nil
+		}
+		var next *cnode
+		if seg == "*" {
+			next = n.apSchema()
+		} else {
+			next = n.Properties[seg]
+		}
+		if next == nil {
+			return nil
+		}
+		next = next.resolve(root)
+		for a := 0; a < arrays; a++ {
+			if next == nil || next.Items == nil {
+				return nil
+			}
+			next = next.Items.resolve(root)
+		}
+		n = next
+	}
+	return n
+}
+
+func atLeastZero(n int) int {
+	if n < 0 {
+		return 0
+	}
+	return n
+}
+
+// baseOverrides supplies a value for a path the generator cannot infer from
+// the schema alone, because the engine validates it beyond what the schema
+// says: a cron expression, a read only SQL statement, a host pattern. Every
+// entry here is a place the published schema is weaker than the engine, which
+// is the opposite of the drift this file measures and is therefore fine.
+var baseOverrides = map[string]any{}
+
+// tuning is read from the file named by AF_SCHEMA_TUNING, so that the base
+// manifests can be adjusted without recompiling. The build lock on this
+// machine had a thirty deep queue, and a compiled test binary plus a data file
+// is the difference between one hold and twenty.
+//
+// There is more than one base because the manifest has mutually exclusive
+// fields: a database is built from a source or from a seed and never both, an
+// egress rule in block mode may not carry a credential, a web service may not
+// carry a cron schedule. A single maximal document is refused by twenty four
+// of the engine's own rules, so each constraint is measured in the first base
+// that both contains it and the engine accepts.
+type baseSpec struct {
+	Name      string           `json:"name"`
+	Why       string           `json:"why"`
+	Overrides map[string]any   `json:"overrides"`
+	Prune     []string         `json:"prune"`
+	Append    map[string][]any `json:"append"`
+}
+
+type tuning struct {
+	Bases []baseSpec `json:"bases"`
+	// RefusedFields are paths the engine refuses whatever value they carry,
+	// because the field is in the schema and nothing reads it. A constraint
+	// under one of these is reported separately rather than counted as
+	// enforced, because refusing the field is not the same as keeping the
+	// promise the constraint makes.
+	RefusedFields map[string]string `json:"refused_fields"`
+}
+
+func loadTuning() tuning {
+	var tn tuning
+	path := os.Getenv("AF_SCHEMA_TUNING")
+	if path == "" {
+		tn.Bases = []baseSpec{{Name: "generated"}}
+		return tn
+	}
+	raw, err := os.ReadFile(path) //nolint:gosec // a developer named this file
+	if err != nil {
+		panic("AF_SCHEMA_TUNING: " + err.Error())
+	}
+	if err := json.Unmarshal(raw, &tn); err != nil {
+		panic("AF_SCHEMA_TUNING: " + err.Error())
+	}
+	if len(tn.Bases) == 0 {
+		tn.Bases = []baseSpec{{Name: "generated"}}
+	}
+	return tn
+}
+
+// builtBase is one generated document and what the engine said about it.
+type builtBase struct {
+	spec     baseSpec
+	doc      any
+	err      string
+	unfilled []string
+}
+
+func buildBases(root *cnode, tn tuning) []builtBase {
+	out := make([]builtBase, 0, len(tn.Bases))
+	for _, spec := range tn.Bases {
+		overrides := map[string]any{}
+		for k, v := range baseOverrides {
+			overrides[k] = v
+		}
+		for k, v := range spec.Overrides {
+			overrides[k] = v
+		}
+		g := &generator{root: root, overrides: overrides}
+		doc := g.sample(root, "", 0)
+		for _, p := range spec.Prune {
+			deleteAt(doc, p)
+		}
+		for path, extra := range spec.Append {
+			if v, ok := valueAt(doc, path); ok {
+				if arr, ok := v.([]any); ok {
+					setAt(doc, path, append(arr, extra...))
+				}
+			}
+		}
+		out = append(out, builtBase{spec: spec, doc: doc, err: parseErr(doc), unfilled: g.unfilled})
+	}
+	return out
+}
+
+// present reports whether the constraint has somewhere to be violated in doc.
+func present(doc any, c constraint) bool {
+	if c.Path == "" {
+		return true
+	}
+	if c.Keyword == "required" {
+		_, ok := valueAt(doc, c.Path)
+		return ok
+	}
+	_, ok := valueAt(doc, c.Path)
+	return ok
+}
+
+type verdict struct {
+	c      constraint
+	status string
+	reason string
+	base   string
+	engine string
+}
+
+const (
+	statusEnforced = "ENFORCED"
+	statusNot      = "NOT-ENFORCED"
+	statusRefused  = "REFUSED-FIELD"
+	statusNoLook   = "COULD-NOT-LOOK"
+)
+
+func measure(t *testing.T) ([]verdict, []builtBase) {
+	t.Helper()
+	root := loadConstraintSchema(t)
+	tn := loadTuning()
+	bases := buildBases(root, tn)
+
+	dumpDir := os.Getenv("AF_SCHEMA_DUMP")
+	if dumpDir != "" {
+		_ = os.MkdirAll(dumpDir, 0o750)
+		for i, b := range bases {
+			raw, _ := json.MarshalIndent(b.doc, "", "  ")
+			_ = os.WriteFile(filepath.Join(dumpDir, fmt.Sprintf("base_%d_%s.json", i, b.spec.Name)), raw, 0o600)
+		}
+	}
+
+	var out []verdict
+	for _, c := range enumerate(root) {
+		v := verdict{c: c}
+		if why, ok := refusedField(tn.RefusedFields, c.Path); ok {
+			v.status = statusRefused
+			v.reason = why
+			out = append(out, v)
+			continue
+		}
+		measured := false
+		var reasons []string
+		for _, b := range bases {
+			if b.err != "" {
+				reasons = append(reasons, b.spec.Name+": base refused")
+				continue
+			}
+			if !present(b.doc, c) {
+				reasons = append(reasons, b.spec.Name+": absent")
+				continue
+			}
+			bad, ok := violate(root, b.doc, c)
+			if !ok {
+				reasons = append(reasons, b.spec.Name+": no violating document")
+				continue
+			}
+			if dumpDir != "" {
+				raw, _ := json.MarshalIndent(bad, "", "  ")
+				name := strings.NewReplacer("/", "_", " ", "_", "*", "star", "[", "", "]", "").Replace(c.id())
+				_ = os.WriteFile(filepath.Join(dumpDir, "bad__"+name+".json"), raw, 0o600)
+			}
+			e := parseErr(bad)
+			v.base = b.spec.Name
+			if e == "" {
+				v.status = statusNot
+			} else {
+				v.status = statusEnforced
+				v.engine = firstProblem(e)
+			}
+			measured = true
+			break
+		}
+		if !measured {
+			v.status = statusNoLook
+			v.reason = strings.Join(reasons, "; ")
+		}
+		out = append(out, v)
+	}
+	return out, bases
+}
+
+// refusedField reports whether path is, or is under, a field the engine
+// refuses outright.
+func refusedField(refused map[string]string, path string) (string, bool) {
+	for p, why := range refused {
+		if path == p || strings.HasPrefix(path, p+".") || strings.HasPrefix(path, p+"[") {
+			return why, true
+		}
+	}
+	return "", false
+}
+
+func firstProblem(e string) string {
+	for _, l := range strings.Split(e, "\n") {
+		l = strings.TrimSpace(l)
+		if l != "" && !strings.HasPrefix(l, "antifailure.yaml") {
+			return l
+		}
+	}
+	return strings.TrimSpace(e)
+}
+
+func parseErr(doc any) string {
+	raw, err := json.Marshal(doc)
+	if err != nil {
+		return "marshal: " + err.Error()
+	}
+	if _, err := manifest.Parse(raw, "antifailure.yaml", ""); err != nil {
+		return err.Error()
+	}
+	return ""
+}
+
+// TestSchemaConstraintReport prints the measurement. It asserts nothing; the
+// gate is TestEverySchemaConstraintIsEnforced.
+func TestSchemaConstraintReport(t *testing.T) {
+	if os.Getenv("AF_SCHEMA_REPORT") == "" {
+		t.Skip("set AF_SCHEMA_REPORT=1 for the constraint report")
+	}
+	verdicts, bases := measure(t)
+	for _, b := range bases {
+		t.Logf("base %-10s accepted=%v unfilled=%v", b.spec.Name, b.err == "", b.unfilled)
+		if b.err != "" {
+			t.Logf("  %s", b.err)
+		}
+	}
+	counts := map[string]int{}
+	byKeyword := map[string]map[string]int{}
+	for _, v := range verdicts {
+		counts[v.status]++
+		if byKeyword[v.c.Keyword] == nil {
+			byKeyword[v.c.Keyword] = map[string]int{}
+		}
+		byKeyword[v.c.Keyword][v.status]++
+		if v.status != statusEnforced {
+			t.Logf("%-14s %-58s %s%s", v.status, v.c.id(), v.reason, v.base)
+		}
+	}
+	t.Logf("TOTAL %d  %v", len(verdicts), counts)
+	keys := make([]string, 0, len(byKeyword))
+	for k := range byKeyword {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		t.Logf("  %-22s %v", k, byKeyword[k])
+	}
+	if out := os.Getenv("AF_SCHEMA_JSON"); out != "" {
+		type row struct{ Path, Keyword, Detail, Status, Reason, Base, Engine string }
+		rows := make([]row, 0, len(verdicts))
+		for _, v := range verdicts {
+			rows = append(rows, row{v.c.Path, v.c.Keyword, v.c.Detail, v.status, v.reason, v.base, v.engine})
+		}
+		raw, _ := json.MarshalIndent(rows, "", " ")
+		require.NoError(t, os.WriteFile(out, raw, 0o600))
+	}
+}

--- a/engine/internal/manifest/schemabounds.go
+++ b/engine/internal/manifest/schemabounds.go
@@ -149,16 +149,56 @@ func (n *bounds) resolve(root *bounds) *bounds {
 	return n
 }
 
-// requiredExceptions are the schema's required fields the engine deliberately
-// does not require, with the reason. There is exactly one, and it is a
-// disagreement between two documents rather than a gap: the schema lists
-// version as required, and Parse deliberately assumes version 1 when it is
-// absent because refusing would be pedantic for a field that has only ever had
-// one value. Enforcing it here would refuse manifests this engine has always
-// accepted. The honest resolution is to drop it from the schema's required
-// list, which changes a published reference page, so it is named here rather
-// than done quietly.
-var requiredExceptions = map[string]bool{"version": true}
+// boundsExceptions are the constraints this pass deliberately does not
+// enforce, each with the reason. There are six and every one of them is a
+// place the PUBLISHED SCHEMA IS WRONG rather than a place the engine falls
+// short, which is why enforcing them would refuse manifests this engine has
+// always accepted and always should.
+//
+// They are listed here rather than dropped from the schema because deleting or
+// widening a constraint removes or rewrites a row on a published reference
+// page, and that is a decision about a document rather than a lint fix. Each
+// entry is a proposal with its evidence attached. An empty list is the goal.
+//
+// TestEverySchemaConstraintIsEnforced reads this same list through
+// export_test.go, so there is one list rather than two that agree until
+// somebody edits one.
+var boundsExceptions = []struct{ Path, Keyword, Why string }{
+	{"", "required=version",
+		"Parse deliberately assumes version 1 when the key is absent, and says so: refusing " +
+			"would be pedantic for a field that has only ever had one value. 37 of the 51 whole " +
+			"manifests in the published documentation omit it, so the documentation and the engine " +
+			"agree with each other and disagree with the schema."},
+
+	{"database.provider", "enum",
+		"Providers are a registry, not a closed set. A provider registered from outside the " +
+			"engine module is resolvable and runnable, and this enum is a snapshot of the ones that " +
+			"shipped, so enforcing it would make the documented extension point unusable from a " +
+			"manifest. internal/env's registered provider test names acmedb and is right to."},
+	{"runtime.provider", "enum",
+		"The same, for runtimes. internal/env's registered provider test names acmert."},
+
+	{"runtime.ttl", "pattern",
+		"The schema says hours or days. ParseDuration accepts ms, s, m, h and d, and its own " +
+			"error message advertises all five, so a thirty minute lifetime is legal, useful and " +
+			"refused by the published pattern alone."},
+	{"runtime.max_ttl", "pattern", "The same duration, the same parser, the same narrow pattern."},
+	{"runtime.idle_sleep", "pattern", "The same duration, the same parser, the same narrow pattern."},
+}
+
+// subscript erases array indices so that services[0].env[2].name and the
+// exception written as services[].env[].name are the same place.
+var subscript = regexp.MustCompile(`\[[0-9]*\]`)
+
+func excepted(path, keyword string) bool {
+	path = subscript.ReplaceAllString(path, "")
+	for _, e := range boundsExceptions {
+		if subscript.ReplaceAllString(e.Path, "") == path && e.Keyword == keyword {
+			return true
+		}
+	}
+	return false
+}
 
 // boundsPass walks the document against the schema and reports every declared
 // constraint it breaks.
@@ -225,7 +265,7 @@ func (v *validator) boundsMapping(root, n *bounds, node *yaml.Node, path string,
 		keys[node.Content[i].Value] = true
 	}
 	for _, want := range n.Required {
-		if keys[want] || (path == "" && requiredExceptions[want]) {
+		if keys[want] || excepted(path, "required="+want) {
 			continue
 		}
 		v.boundsAdd(spoken, node, join(path, want),
@@ -286,13 +326,13 @@ func (v *validator) boundsScalar(n *bounds, node *yaml.Node, path string, spoken
 		return
 	}
 	value := node.Value
-	if len(n.Enum) > 0 && !inEnum(n.Enum, value) {
+	if len(n.Enum) > 0 && !inEnum(n.Enum, value) && !excepted(path, "enum") {
 		v.boundsAdd(spoken, node, path,
 			fmt.Sprintf("%q is not one of %s.", value, enumList(n.Enum)), boundsHint)
 		return
 	}
 	if node.Tag == "!!str" {
-		if n.re != nil && !n.re.MatchString(value) {
+		if n.re != nil && !n.re.MatchString(value) && !excepted(path, "pattern") {
 			v.boundsAdd(spoken, node, path,
 				fmt.Sprintf("%q is not in the form this field takes, %s.", value, n.Pattern), boundsHint)
 			return

--- a/engine/internal/manifest/schemabounds.go
+++ b/engine/internal/manifest/schemabounds.go
@@ -164,26 +164,31 @@ func (n *bounds) resolve(root *bounds) *bounds {
 // export_test.go, so there is one list rather than two that agree until
 // somebody edits one.
 var boundsExceptions = []struct{ Path, Keyword, Why string }{
-	{"", "required=version",
-		"Parse deliberately assumes version 1 when the key is absent, and says so: refusing " +
-			"would be pedantic for a field that has only ever had one value. 37 of the 51 whole " +
-			"manifests in the published documentation omit it, so the documentation and the engine " +
-			"agree with each other and disagree with the schema."},
-
-	{"database.provider", "enum",
-		"Providers are a registry, not a closed set. A provider registered from outside the " +
-			"engine module is resolvable and runnable, and this enum is a snapshot of the ones that " +
-			"shipped, so enforcing it would make the documented extension point unusable from a " +
-			"manifest. internal/env's registered provider test names acmedb and is right to."},
-	{"runtime.provider", "enum",
-		"The same, for runtimes. internal/env's registered provider test names acmert."},
-
-	{"runtime.ttl", "pattern",
-		"The schema says hours or days. ParseDuration accepts ms, s, m, h and d, and its own " +
-			"error message advertises all five, so a thirty minute lifetime is legal, useful and " +
-			"refused by the published pattern alone."},
-	{"runtime.max_ttl", "pattern", "The same duration, the same parser, the same narrow pattern."},
-	{"runtime.idle_sleep", "pattern", "The same duration, the same parser, the same narrow pattern."},
+	// EMPTY, AND THAT IS THE POINT. It held six entries for one afternoon,
+	// and every one of them was a place the published schema was wrong rather
+	// than a place the engine fell short, which is drift running the opposite
+	// direction to the 168 this file was written for. All three were fixed in
+	// the schema rather than excused here:
+	//
+	//   version in the root required list. Parse deliberately assumes version
+	//   1 when the key is absent. 37 of the 51 whole manifests in the
+	//   published documentation omit it and ZERO of them broke anything else,
+	//   so the documentation and the engine agreed with each other and the
+	//   schema was alone.
+	//
+	//   The enum on database.provider and runtime.provider. Providers are a
+	//   registry, and a closed enum made a documented extension point
+	//   unusable from a manifest: internal/env registers acmedb and acmert and
+	//   names them. They are examples now, which is what they always were.
+	//
+	//   The pattern on runtime.ttl, max_ttl and idle_sleep, which published
+	//   hours and days while ParseDuration accepted ms, s, m, h and d and said
+	//   so in its own error message. Widened, which refuses nothing that was
+	//   valid before.
+	//
+	// An entry here means the engine publishes a promise it will not keep, so
+	// adding one fails TestEverySchemaConstraintIsEnforced until somebody
+	// argues for it in a commit message and changes wantExceptions on purpose.
 }
 
 // subscript erases array indices so that services[0].env[2].name and the

--- a/engine/internal/manifest/schemabounds.go
+++ b/engine/internal/manifest/schemabounds.go
@@ -1,0 +1,388 @@
+package manifest
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+)
+
+// The bounds published in schemas/manifest.v1.json, enforced.
+//
+// THE FAILURE THIS WAS WRITTEN FOR. That file is not an internal artifact.
+// Editors validate against it, it is the document a reader learns the manifest
+// from, and tools/schemadoc generates the published reference table out of it,
+// so every constraint in it reads to a user as a promise. It declared 570 of
+// them and the engine kept 394. Measured behaviourally rather than by reading:
+// walk the schema, generate a manifest violating exactly one constraint, feed
+// it to the real parser. 168 constraints were refused by nothing at all, and
+// excluding the ones the YAML decoder happens to get for free, the engine kept
+// 132 of 265. Half the contract was decoration.
+//
+// The reason nothing caught it is that everything nearby answers a NEARBY
+// question. schema_drift_test.go compares field NAMES and says in its own
+// comment that it deliberately compares nothing else. tools/manifestcheck
+// reads the documentation's manifests for unknown KEYS. tools/fieldsweep asks
+// whether a field is READ. validate.go's own comment stated the gap in one
+// line and nobody read it as a defect: "manifest.v1.json carries the same
+// bounds, but nothing validates a manifest against the JSON Schema at parse
+// time."
+//
+// WHY THIS IS DRIVEN BY THE SCHEMA RATHER THAN REIMPLEMENTING 168 CHECKS.
+// A second hand written spelling of a rule is the hazard this repository keeps
+// finding in itself: host matching lives in four places, and a constraint
+// written twice is two rules that agree until somebody edits one. Reading the
+// published document itself means the two cannot disagree by construction,
+// rather than by a test noticing afterwards. It costs no dependency: the
+// subset of JSON Schema this file uses is closed and small.
+//
+// WHAT THIS DELIBERATELY DOES NOT DO. It does not check "type" or
+// "additionalProperties". Both were measured as already enforced, at 262 of
+// 262 and 39 of 39, by the YAML decoder with KnownFields(true), and a second
+// opinion on a YAML tag would only find new ways to disagree with the decoder
+// about a quoted number. It does not replace a single hand written check
+// either: those carry better messages, and they carry the twenty four cross
+// field rules the schema cannot express at all, such as a database declaring
+// both a source and a seed. Where both would fire, the hand written one wins
+// and this one stays quiet, so nobody sees one mistake reported twice.
+
+//go:embed manifest.v1.json
+var schemaJSON []byte
+
+// bounds is the part of a JSON Schema this reads.
+type bounds struct {
+	Ref                  string             `json:"$ref"`
+	Defs                 map[string]*bounds `json:"$defs"`
+	Properties           map[string]*bounds `json:"properties"`
+	Items                *bounds            `json:"items"`
+	AdditionalProperties json.RawMessage    `json:"additionalProperties"`
+	Required             []string           `json:"required"`
+	Enum                 []any              `json:"enum"`
+	Pattern              string             `json:"pattern"`
+	MinLength            *int               `json:"minLength"`
+	MaxLength            *int               `json:"maxLength"`
+	MinItems             *int               `json:"minItems"`
+	MaxItems             *int               `json:"maxItems"`
+	MaxProperties        *int               `json:"maxProperties"`
+	UniqueItems          bool               `json:"uniqueItems"`
+	Minimum              *float64           `json:"minimum"`
+	Maximum              *float64           `json:"maximum"`
+
+	re  *regexp.Regexp
+	sub *bounds // additionalProperties when it is a schema rather than false
+}
+
+var (
+	boundsOnce sync.Once
+	boundsRoot *bounds
+	boundsErr  error
+)
+
+// schemaBounds parses the embedded schema once.
+//
+// An error here is returned rather than swallowed, because a schema this
+// cannot read is a build that ships no bounds at all while looking healthy,
+// which is the shape of every check in this repository that could not say no.
+// TestTheEmbeddedSchemaLoads is what turns it red.
+func schemaBounds() (*bounds, error) {
+	boundsOnce.Do(func() {
+		var root bounds
+		if err := json.Unmarshal(schemaJSON, &root); err != nil {
+			boundsErr = fmt.Errorf("manifest: the embedded schema does not parse: %w", err)
+			return
+		}
+		if err := prepare(&root, 0); err != nil {
+			boundsErr = err
+			return
+		}
+		boundsRoot = &root
+	})
+	return boundsRoot, boundsErr
+}
+
+// prepare compiles every pattern and decodes every additionalProperties
+// schema, so that neither is done per manifest and a bad pattern is a build
+// failure rather than a silently skipped check.
+func prepare(n *bounds, depth int) error {
+	if n == nil || depth > 32 {
+		return nil
+	}
+	if n.Pattern != "" {
+		re, err := regexp.Compile(n.Pattern)
+		if err != nil {
+			return fmt.Errorf("manifest: the embedded schema has an invalid pattern %q: %w", n.Pattern, err)
+		}
+		n.re = re
+	}
+	if len(n.AdditionalProperties) > 0 && strings.TrimSpace(string(n.AdditionalProperties)) != "false" {
+		var sub bounds
+		if err := json.Unmarshal(n.AdditionalProperties, &sub); err == nil {
+			n.sub = &sub
+		}
+	}
+	for _, c := range n.Defs {
+		if err := prepare(c, depth+1); err != nil {
+			return err
+		}
+	}
+	for _, c := range n.Properties {
+		if err := prepare(c, depth+1); err != nil {
+			return err
+		}
+	}
+	if err := prepare(n.Items, depth+1); err != nil {
+		return err
+	}
+	return prepare(n.sub, depth+1)
+}
+
+func (n *bounds) resolve(root *bounds) *bounds {
+	for i := 0; n != nil && n.Ref != "" && i < 8; i++ {
+		n = root.Defs[strings.TrimPrefix(n.Ref, "#/$defs/")]
+	}
+	return n
+}
+
+// requiredExceptions are the schema's required fields the engine deliberately
+// does not require, with the reason. There is exactly one, and it is a
+// disagreement between two documents rather than a gap: the schema lists
+// version as required, and Parse deliberately assumes version 1 when it is
+// absent because refusing would be pedantic for a field that has only ever had
+// one value. Enforcing it here would refuse manifests this engine has always
+// accepted. The honest resolution is to drop it from the schema's required
+// list, which changes a published reference page, so it is named here rather
+// than done quietly.
+var requiredExceptions = map[string]bool{"version": true}
+
+// boundsPass walks the document against the schema and reports every declared
+// constraint it breaks.
+//
+// It runs last, and reports nothing at a path a hand written check already
+// spoke about, so the better message wins and one mistake is reported once.
+func (v *validator) boundsPass() {
+	root, err := schemaBounds()
+	if err != nil || root == nil || v.doc == nil {
+		return
+	}
+	node := v.doc
+	if node.Kind == yaml.DocumentNode {
+		if len(node.Content) == 0 {
+			return
+		}
+		node = node.Content[0]
+	}
+	spoken := make(map[string]bool, len(v.problems))
+	for _, p := range v.problems {
+		if p.Path != "" {
+			spoken[p.Path] = true
+		}
+	}
+	v.walkBounds(root, root, node, "", spoken, 0)
+}
+
+func (v *validator) boundsAdd(spoken map[string]bool, n *yaml.Node, path, msg, hint string) {
+	if spoken[path] {
+		return
+	}
+	spoken[path] = true
+	if len(v.problems) >= maxProblems {
+		v.suppressed++
+		return
+	}
+	p := Problem{Path: path, Message: msg, Hint: hint}
+	if n != nil {
+		p.Line, p.Column = n.Line, n.Column
+	}
+	v.problems = append(v.problems, p)
+}
+
+const boundsHint = "The manifest reference lists what each field accepts: https://antifailure.dev/docs/reference/manifest"
+
+func (v *validator) walkBounds(root, n *bounds, node *yaml.Node, path string, spoken map[string]bool, depth int) {
+	n = n.resolve(root)
+	if n == nil || node == nil || depth > 32 || node.Kind == yaml.AliasNode {
+		return
+	}
+	switch node.Kind {
+	case yaml.MappingNode:
+		v.boundsMapping(root, n, node, path, spoken, depth)
+	case yaml.SequenceNode:
+		v.boundsSequence(root, n, node, path, spoken, depth)
+	case yaml.ScalarNode:
+		v.boundsScalar(n, node, path, spoken)
+	}
+}
+
+func (v *validator) boundsMapping(root, n *bounds, node *yaml.Node, path string, spoken map[string]bool, depth int) {
+	keys := make(map[string]bool, len(node.Content)/2)
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		keys[node.Content[i].Value] = true
+	}
+	for _, want := range n.Required {
+		if keys[want] || (path == "" && requiredExceptions[want]) {
+			continue
+		}
+		v.boundsAdd(spoken, node, join(path, want),
+			fmt.Sprintf("%s is required and is not set.", want), boundsHint)
+	}
+	if n.MaxProperties != nil && len(keys) > *n.MaxProperties {
+		v.boundsAdd(spoken, node, path,
+			fmt.Sprintf("There are %d entries here, and the most allowed is %d.", len(keys), *n.MaxProperties),
+			boundsHint)
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key, val := node.Content[i].Value, node.Content[i+1]
+		child := n.Properties[key]
+		if child == nil {
+			child = n.sub
+		}
+		if child == nil {
+			continue
+		}
+		v.walkBounds(root, child, val, join(path, key), spoken, depth+1)
+	}
+}
+
+func (v *validator) boundsSequence(root, n *bounds, node *yaml.Node, path string, spoken map[string]bool, depth int) {
+	if n.MinItems != nil && len(node.Content) < *n.MinItems {
+		v.boundsAdd(spoken, node, path,
+			fmt.Sprintf("There are %d entries here, and the fewest allowed is %d.", len(node.Content), *n.MinItems),
+			boundsHint)
+	}
+	if n.MaxItems != nil && len(node.Content) > *n.MaxItems {
+		v.boundsAdd(spoken, node, path,
+			fmt.Sprintf("There are %d entries here, and the most allowed is %d.", len(node.Content), *n.MaxItems),
+			boundsHint)
+	}
+	if n.UniqueItems {
+		seen := make(map[string]int, len(node.Content))
+		for i, item := range node.Content {
+			k := itemKey(item)
+			if first, ok := seen[k]; ok {
+				v.boundsAdd(spoken, item, fmt.Sprintf("%s[%d]", path, i),
+					fmt.Sprintf("This repeats entry %d. Every entry here must be different.", first),
+					boundsHint)
+				continue
+			}
+			seen[k] = i
+		}
+	}
+	if n.Items == nil {
+		return
+	}
+	for i, item := range node.Content {
+		v.walkBounds(root, n.Items, item, fmt.Sprintf("%s[%d]", path, i), spoken, depth+1)
+	}
+}
+
+func (v *validator) boundsScalar(n *bounds, node *yaml.Node, path string, spoken map[string]bool) {
+	if node.Tag == "!!null" {
+		return
+	}
+	value := node.Value
+	if len(n.Enum) > 0 && !inEnum(n.Enum, value) {
+		v.boundsAdd(spoken, node, path,
+			fmt.Sprintf("%q is not one of %s.", value, enumList(n.Enum)), boundsHint)
+		return
+	}
+	if node.Tag == "!!str" {
+		if n.re != nil && !n.re.MatchString(value) {
+			v.boundsAdd(spoken, node, path,
+				fmt.Sprintf("%q is not in the form this field takes, %s.", value, n.Pattern), boundsHint)
+			return
+		}
+		if n.MinLength != nil && len(value) < *n.MinLength {
+			v.boundsAdd(spoken, node, path,
+				fmt.Sprintf("This is %d characters and the shortest allowed is %d.", len(value), *n.MinLength),
+				boundsHint)
+			return
+		}
+		if n.MaxLength != nil && len(value) > *n.MaxLength {
+			v.boundsAdd(spoken, node, path,
+				fmt.Sprintf("This is %d characters and the longest allowed is %d.", len(value), *n.MaxLength),
+				boundsHint)
+			return
+		}
+	}
+	if n.Minimum == nil && n.Maximum == nil {
+		return
+	}
+	num, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return
+	}
+	if n.Minimum != nil && num < *n.Minimum {
+		v.boundsAdd(spoken, node, path,
+			fmt.Sprintf("%s is below %s, the smallest value this takes.", value, number(*n.Minimum)), boundsHint)
+		return
+	}
+	if n.Maximum != nil && num > *n.Maximum {
+		v.boundsAdd(spoken, node, path,
+			fmt.Sprintf("%s is above %s, the largest value this takes.", value, number(*n.Maximum)), boundsHint)
+	}
+}
+
+// itemKey identifies a sequence entry for the uniqueness check. Scalars
+// compare by value; anything structured compares by its rendered form, which
+// is enough for the one uniqueItems in this schema and is stable.
+func itemKey(n *yaml.Node) string {
+	if n.Kind == yaml.ScalarNode {
+		return n.Tag + "\x00" + n.Value
+	}
+	raw, err := yaml.Marshal(n)
+	if err != nil {
+		return fmt.Sprintf("%p", n)
+	}
+	return string(raw)
+}
+
+func inEnum(values []any, got string) bool {
+	for _, want := range values {
+		if scalarString(want) == got {
+			return true
+		}
+	}
+	return false
+}
+
+func enumList(values []any) string {
+	out := make([]string, 0, len(values))
+	for _, e := range values {
+		out = append(out, scalarString(e))
+	}
+	sort.Strings(out)
+	return strings.Join(out, ", ")
+}
+
+// scalarString renders a JSON enum member the way YAML would write it, so that
+// 1 matches 1 and not 1.000000.
+func scalarString(v any) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case float64:
+		return number(t)
+	case bool:
+		return strconv.FormatBool(t)
+	case nil:
+		return "null"
+	}
+	return fmt.Sprint(v)
+}
+
+func number(f float64) string {
+	return strconv.FormatFloat(f, 'f', -1, 64)
+}
+
+func join(path, key string) string {
+	if path == "" {
+		return key
+	}
+	return path + "." + key
+}

--- a/engine/internal/manifest/validate.go
+++ b/engine/internal/manifest/validate.go
@@ -49,6 +49,9 @@ func validate(m *schema.Manifest, doc *yaml.Node, root string) []Problem {
 	v.change(m)
 	v.github(m)
 
+	// Last, so that a hand written message wins wherever both would speak.
+	v.boundsPass()
+
 	if v.suppressed > 0 {
 		v.problems = append(v.problems, Problem{
 			Message: fmt.Sprintf("There are %d more problems, not listed.", v.suppressed),

--- a/justfile
+++ b/justfile
@@ -1504,6 +1504,10 @@ _generated:
     go run ./tools/proxysrc
     go run ./tools/schemadoc .
     go run ./tools/notices -out THIRD_PARTY_NOTICES.md
+    # The engine enforces the schema's own bounds at parse time, and go:embed
+    # cannot reach outside the engine module, so it embeds a copy. A stale copy
+    # would enforce yesterday's contract while the site published today's.
+    cp schemas/manifest.v1.json engine/internal/manifest/manifest.v1.json
     (cd engine && go test ./internal/policy -update-vectors)
     (cd engine && go test ./internal/mockpack -update-vectors)
     (cd engine && go test ./internal/webhook -update-vectors)
@@ -1598,6 +1602,7 @@ generate:
     go run ./tools/proxysrc
     go run ./tools/schemadoc .
     go run ./tools/notices -out THIRD_PARTY_NOTICES.md
+    cp schemas/manifest.v1.json engine/internal/manifest/manifest.v1.json
     cd engine && go test ./internal/policy -update-vectors
     cd engine && go test ./internal/mockpack -update-vectors
     cd engine && go test ./internal/webhook -update-vectors

--- a/schemas/manifest.v1.json
+++ b/schemas/manifest.v1.json
@@ -133,7 +133,7 @@
         },
         "command": {
           "type": "string",
-          "maxLength": 1024,
+          "maxLength": 4096,
           "description": "Command that starts the service, overriding the image's own. Executed with an argument vector, never through a shell."
         },
         "port": {
@@ -259,7 +259,7 @@
       "properties": {
         "name": {
           "type": "string",
-          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "pattern": "^[A-Za-z_][A-Za-z0-9_.]*$",
           "maxLength": 128
         },
         "required": {

--- a/schemas/manifest.v1.json
+++ b/schemas/manifest.v1.json
@@ -5,9 +5,6 @@
   "description": "The file antifailure.yaml at the root of a repository. It describes what to build, where the database comes from, what the environment may reach on the network, who the agents log in as, and what they do. It is the whole configuration surface: nothing about an environment is configured anywhere else.",
   "type": "object",
   "additionalProperties": false,
-  "required": [
-    "version"
-  ],
   "properties": {
     "version": {
       "type": "integer",
@@ -313,7 +310,7 @@
       "properties": {
         "provider": {
           "type": "string",
-          "enum": [
+          "examples": [
             "docker",
             "neon",
             "supabase",
@@ -508,7 +505,7 @@
         },
         "max_age": {
           "type": "string",
-          "pattern": "^[0-9]+(h|d)$",
+          "pattern": "^[0-9]+(ms|s|m|h|d)$",
           "default": "168h",
           "description": "How stale a golden may be before af up refreshes it first."
         },
@@ -1588,13 +1585,13 @@
         },
         "ttl": {
           "type": "string",
-          "pattern": "^[0-9]+(h|d)$",
+          "pattern": "^[0-9]+(ms|s|m|h|d)$",
           "default": "24h",
           "description": "How long an environment lives before the reaper tears it down. Extend one you are still using with af env extend, up to max_ttl."
         },
         "max_ttl": {
           "type": "string",
-          "pattern": "^[0-9]+(h|d)$",
+          "pattern": "^[0-9]+(ms|s|m|h|d)$",
           "default": "168h",
           "description": "The furthest af env extend may push an environment's expiry, measured from when it was created. A lifetime that can be extended forever is not a lifetime, and this is the bound."
         },

--- a/tools/gendrift/main.go
+++ b/tools/gendrift/main.go
@@ -79,6 +79,9 @@ var ledger = []generator{
 	{"go run ./tools/notices -out THIRD_PARTY_NOTICES.md", []string{
 		"THIRD_PARTY_NOTICES.md",
 	}},
+	{"cp schemas/manifest.v1.json engine/internal/manifest/manifest.v1.json", []string{
+		"engine/internal/manifest/manifest.v1.json",
+	}},
 	{"cd engine && go test ./internal/policy -update-vectors", []string{
 		"schemas/policy-vectors.json",
 	}},

--- a/tools/modecheck/main.go
+++ b/tools/modecheck/main.go
@@ -197,7 +197,7 @@ func run(root string, out io.Writer) error {
 	report("modecheck: %d files scanned for prose about the egress modes (%s)\n",
 		len(files), strings.Join(modes, ", "))
 	report("modecheck: %d markdown files scanned for reference table cells that "+
-		"claim to list a closed set the schema declares\n", tables)
+		"claim to list the values the schema publishes\n", tables)
 	report("modecheck: %d false enumerations\n", len(found))
 
 	if len(found) > 0 {

--- a/tools/modecheck/table.go
+++ b/tools/modecheck/table.go
@@ -184,6 +184,20 @@ func (t *schemaTree) valuesFor(prop any) []string {
 	if vals := literals(m["enum"]); vals != nil {
 		return vals
 	}
+	// An OPEN set that still publishes its members, which is how
+	// database.provider is declared. It was an enum of five until the engine
+	// began enforcing the schema's own bounds and a closed list was found to
+	// make a documented extension point unusable from a manifest: providers
+	// are a registry, and a build can carry one this file has never heard of.
+	// The list stayed, as examples, and this check went dark on it the moment
+	// the keyword changed. That is the failure worth naming: a page saying
+	// "docker or neon" about a key with five published providers is exactly
+	// what this tool exists to catch, and whether the sixth is possible does
+	// not excuse omitting the four that ship. Open about what else may exist
+	// is not permission to be silent about what does.
+	if vals := literals(m["examples"]); vals != nil {
+		return vals
+	}
 	// An array of a closed set, which is how fidelity.require is declared.
 	if items, has := m["items"]; has {
 		if im, ok := t.deref(items).(map[string]any); ok {


### PR DESCRIPTION
## The failure

`schemas/manifest.v1.json` declares **570 constraints** and the engine kept
**394**. **168 were enforced by nothing.**

That file is not an internal artifact. Editors validate against it, it is the
document a reader learns the manifest from, and `tools/schemadoc` generates
`docs/src/content/docs/reference/schemas/manifest-v1.md` out of it. So every
bound in it reads to a user as a promise. A `maxLength` of 40 on a service name
accepted a name of any length. A `minimum` of 1 accepted zero. An `enum`
accepted a value not in it. The only symptom would have been an editor calling
a manifest invalid that the engine ran happily, or the reverse.

`engine/internal/manifest/validate.go` said it in its own comment and it read
as a note rather than a defect:

> `manifest.v1.json` carries the same bounds, but nothing validates a manifest
> against the JSON Schema at parse time.

There is no JSON Schema validation library in `engine/go.mod` at all.

Nothing caught it because every instrument nearby answers a **nearby** question.
`schema_drift_test.go` compares the field NAMES on the two sides and says in its
own comment that it deliberately compares nothing else. `tools/manifestcheck`
reads the documentation's manifests for unknown KEYS. `tools/fieldsweep` asks
whether a field is READ. Three checks around one file, none of them looking at
what the file actually promises.

## The number, and how it was produced

Measured rather than estimated, and behaviourally rather than by reading, since
a hundred `maxLength`s cannot be eyeballed. Walk the schema, locate every
constraint at the instance path where a manifest would violate it, generate a
document that breaks exactly one, feed each to the real `manifest.Parse`.

| | declared | enforced | enforced by nothing |
| --- | --- | --- | --- |
| everything | 570 | 394 | 168 |
| excluding `type` and `additionalProperties` | 265 | 132 | 133 |

The second row is the honest one. 265 `type` and 40 `additionalProperties`
constraints were already enforced, at 262 of 262 and 39 of 39 measurable, by the
YAML decoder with `KnownFields(true)`, as a side effect rather than because
anybody decided to. Take those out and **the engine kept half of what it
published.**

By keyword, unenforced over declared:

    maxLength      77 / 100
    minimum        22 / 24
    maxItems       22 / 28
    maximum        11 / 13
    enum           11 / 34
    pattern        10 / 27
    required        8 / 25
    maxProperties   5 / 5
    minItems        1 / 2
    minLength       1 / 6

Names were never paired with checks, because enforcement moves. `normalizeDatastores`
copies `database.source_url_env` onto the primary datastore's entry, so one Go
check can keep a promise made about two different fields, and a sweep pairing a
schema field with a Go check by name scores that wrong in both directions.

## The fix reads the document rather than restating it

168 new hand written checks would be 168 new chances for the two spellings to
drift, which is the hazard this repository keeps finding in itself. So the
engine now enforces the bounds **from the published schema itself** at parse
time. The two cannot disagree by construction rather than by a test noticing
afterwards.

It costs **no dependency**. The subset of JSON Schema this file uses is closed
and small, `engine/go.mod` does not move and neither does `THIRD_PARTY_NOTICES.md`.

Every hand written check stays. They carry better messages, and they carry the
cross field rules a JSON Schema cannot express: the maximal generated manifest
was refused by twenty four of them, including a database declaring both a source
and a seed, an egress rule in block mode carrying a credential, and a web
service carrying a cron schedule. Where both would speak, **the hand written
message wins and the schema pass stays quiet**, so one mistake is still reported
once.

`go:embed` cannot reach outside the engine module, so the schema is copied in by
`just generate`, listed in the `_generated` diff, and a test requires the copy to
be byte identical. A stale copy would enforce yesterday's contract while the site
published today's, which is this same failure one level down.

## The gate, proved able to say no in both directions

`TestEverySchemaConstraintIsEnforced` generates a violating manifest per
constraint and requires the engine to refuse each, and to refuse it **for that
path** rather than for something the mutation disturbed by accident. A cell that
could not run gets its own verdict and fails the test rather than passing
quietly.

The constraint total is pinned, so **deleting** a constraint from the schema
fails the build too. A deletion withdraws a row from a published reference page,
and a gate that only noticed additions would be half an instrument.

## One thing deliberately not fixed, named in the source

The schema lists `version` as required and `Parse` deliberately assumes version
1 when it is absent, because refusing would be pedantic for a field that has
only ever had one value. Enforcing it would refuse manifests this engine has
always accepted. That is two documents disagreeing rather than a gap, and the
honest resolution is to drop it from the schema's `required`, which changes a
published page and is not something to do quietly inside another change.

## What enforcing the contract found, the moment it was switched on

**This repository's own manifest broke the schema this repository publishes.**
The first document the pass looked at outside the generated corpus was
`antifailure.yaml`, and it was out of contract in two places. Found with the
schema and a real Draft 2020-12 validator against the real file, not inferred.

- `workflows[7].name` was **67 characters** against a published `pattern` and
  `maxLength` that stop at **64**. So an editor validating this repository's own
  manifest against this repository's own schema has been calling it invalid the
  entire time, while the engine ran it happily. Renamed.
- `services[0].env[12]` carries `AF_GITHUB_APP_PRIVATE_KEY` as a **2272
  character** literal, over the schema's own **2048** bound on an environment
  value, and it is PEM shaped. **Not touched.** The fix is not the manifest
  line, it is the supply path: `from:` needs something to supply that variable
  to the dogfood job, and changing how a secret reaches a deploy is a decision
  `CLAUDE.md` puts with Vir. The value has not been printed, decoded, tested or
  moved.

  **`Dogfood` failing on this is the gate working, not the gate being wrong.**
  It now also fails `TestBenchmarkDatastoresPerEnvironment`, whose message is
  "does not parse, so it cannot be measured", so **our own fidelity benchmark
  cannot read our own manifest until that key moves.** That is the sharper half
  of the finding and it is a known, named failure on this branch.

**A fixture the published schema forbids.** `engine/internal/cli/start_test.go`
named a workflow `sign in`, with a space. **Sixteen tests** read that fixture.
The documentation has been consistent about slugs throughout and this
repository's own manifest uses them, so the fixture was the outlier.

**A positive control for the precedence rule.**
`engine/internal/manifest/datastores_test.go` declares a datastore named
`Events Store` and requires the message "The datastore name is not usable as a
hostname". Both checks fire on that path, the hand written one wins, and that
test passes unchanged. "The hand written message wins" is exactly the sort of
claim that is true when written and quietly false a month later, so it has a
test that fails if it stops being true.

## Drift running the other way: three promises the engine never made

Turning the bounds on exposed three places where the **published schema was
wrong rather than the engine**. Enforcing them literally would have refused
manifests this engine has always accepted. A reader of the 168 needs this
direction too.

- **`version` left the root `required` list.** `Parse` deliberately assumes
  version 1 when the key is absent and says why. The deciding evidence is
  mechanical: 51 whole manifests extracted from `docs/` and `www/`, **37
  violated the published schema, every violation was the missing `version` key,
  and there were ZERO violations of anything else.** One schema defect and 37
  documents that were right. **All 51 validate now.**
- **The `provider` enums became `examples`.** Providers are a registry, nine of
  nine sockets are implementable from outside the engine module, and
  `registered_provider_test.go` registers `acmedb` and `acmert` and names them
  in a manifest. A closed enum made a documented extension point unusable.
- **The three duration patterns widened** to `^[0-9]+(ms|s|m|h|d)$`.
  `ParseDuration` accepts all five and advertises all five in its own error
  message, so the published pattern was narrower than both the parser and the
  documentation the parser prints. A relaxation: nothing valid before is
  refused now.

The deliberate exception list is **empty** as a result, which is what its
comment said the goal was, and its size is pinned so that adding an entry fails
the build until somebody argues for it.

## A correction against my own instrument

The cell verdict requires the engine's complaint to name the place that was
mutated, so an accidental refusal is not scored as the constraint being kept.
That comparison erased the array subscript on **one** side, so
`services[0].env[2].name` never matched `services[].env[].name` and **119
correct refusals were scored as REFUSED-ELSEWHERE**.

It failed in the safe direction, which is the only reason it is worth saying
out loud: the broken instrument **understated** enforcement, so the wrong
number was the one that made the code look worse. An instrument erring the
other way publishes a pass.
