### PR TITLE
github: the site smoke installed a browser that nothing would ever launch

### DIFF
--- a/.changes/the-site-smoke-installed-a-browser-nothing-would-launch.md
+++ b/.changes/the-site-smoke-installed-a-browser-nothing-would-launch.md
@@ -1,0 +1,18 @@
+# fixed
+
+The scheduled site smoke installed a browser the runner would never launch.
+
+`sitesmoke.yml` installed the runner with `npm --prefix runner ci` and then ran
+`npx playwright install` from the repository root. There is no `package.json` at
+the root, so npx did not resolve the runner's pinned playwright at all. It
+fetched the newest one from the registry and downloaded browsers for that
+version instead. The runner then launched its own pinned playwright, looked for
+a revision nothing had installed, and could not start a browser on either
+hostname.
+
+The smoke reported COULD NOT TELL and exited non zero rather than passing, which
+is the behaviour it was built for, so this cost a red rather than a false green.
+`deploy.yml` already carried this fix and its explanation, and `ci.yml`,
+`dogfood.yml` and `antifailure.yml` have run both commands under
+`working-directory: runner` since they were written. This file was the one site
+that still installed from the root.

--- a/.github/workflows/sitesmoke.yml
+++ b/.github/workflows/sitesmoke.yml
@@ -80,9 +80,24 @@ jobs:
         # `af runner install` resolves the same dependencies; this job installs
         # them directly because it has no engine binary and needs no
         # environment.
+        #
+        # BOTH COMMANDS RUN INSIDE runner, and that is the whole of this fix.
+        # This step used to install the runner with `npm --prefix runner ci`
+        # and then run `npx playwright install` from the repository ROOT.
+        # There is no package.json at the root, so npx did not resolve the
+        # runner's pinned playwright at all: it fetched the newest one from
+        # the registry and downloaded browsers for THAT version. The runner
+        # then launched its own and looked for a revision nothing had
+        # installed, `chromium_headless_shell-1234`.
+        #
+        # deploy.yml carries this same fix and the same explanation, and
+        # ci.yml, dogfood.yml and antifailure.yml have all run both commands
+        # under `working-directory: runner` since they were written. This file
+        # was the one site that still installed from the root.
         run: |
-          npm --prefix runner ci --no-audit --no-fund
+          npm ci --no-audit --no-fund
           npx playwright install --with-deps chromium
+        working-directory: runner
 
       - name: Drive the careers form on every hostname
         # EXPECT www TO BE RED UNTIL A TAG SHIPS THE ORIGIN FIX, and do not


### PR DESCRIPTION
`sitesmoke.yml` ran `npm --prefix runner ci` to install the runner, and then ran
`npx playwright install --with-deps chromium` from the repository ROOT. There is
no `package.json` at the root, so npx resolved nothing local: it fetched the
newest playwright from the registry and downloaded browsers for THAT version.
The runner then launched its own pinned playwright, went looking for
`chromium_headless_shell-1234`, and found nothing there.

## What the failure actually said, and why it is worth reading

Both origins came back `COULD NOT TELL`, and the tool printed its own reason:

> sitesmoke: this run did not find out. That is not a pass: it is reported as
> its own answer rather than rounded to one, because a smoke that cannot say
> "I did not find out" says "fine" instead.

That refusal is why this was a red on a schedule rather than a green that had
checked nothing. The honest reading of the red is that **the careers form on
production has not actually been driven by this workflow**, and the workflow
said so rather than implying otherwise.

## The fix is to match the other five, not to invent anything

`deploy.yml` already carries this exact fix and this exact explanation, naming
the same revision `chromium_headless_shell-1234`. `ci.yml` at two sites,
`dogfood.yml` at two sites and `antifailure.yml` have all run both commands
under `working-directory: runner` since they were written.

| Workflow | Installs from |
| --- | --- |
| `ci.yml`, both sites | `runner` |
| `dogfood.yml`, both sites | `runner` |
| `antifailure.yml` | `runner` |
| `deploy.yml` | `runner`, with the explanation this comment is copied from |
| `sitesmoke.yml`, before this | **the repository root** |

Six places install this browser and this file was the only one still installing
it from the root, so the fix is the one the other five already made.

## What was checked

`actionlint` parses the file and checks the step shape: OK. `prosecheck`: 926
files, 0 places where the punctuation gives it away.

## What was NOT checked

The workflow runs on a schedule, so nothing here proves the browser launches on
a real runner until the next scheduled run or a manual dispatch. The fix is a
copy of a shape that is already working in five other jobs, which is the
strongest evidence available without waiting for the schedule.
