### PR TITLE
infra: a required context reported a verdict about a change it never read

### DIFF
--- a/.changes/a-required-gate-that-failed-on-a-registry-race.md
+++ b/.changes/a-required-gate-that-failed-on-a-registry-race.md
@@ -1,0 +1,16 @@
+# fixed
+
+The spelling gate failed for twenty minutes because npm was mid publish.
+
+`npx --yes cspell` resolved whatever the tag pointed at, and on 2026-09-08 that
+was a version whose own sibling package was not published yet. The step died
+with "No matching version found for cspell-gitignore@10.3.0", the required
+context `www` went red on a pull request whose prose was clean, and the same
+command passed on the next pull request twenty minutes later. Nothing was
+checked in between and nothing said so.
+
+Every action in this workflow is pinned to a commit and vale is pinned to a
+version and a checksum. cspell was the one gate left floating, so it was the
+one that could report a verdict about a change without having read it. It is
+now pinned to 10.3.0 in the workflow and in the justfile recipe that has to
+match it.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -890,7 +890,16 @@ jobs:
         # cspell owns spelling, with the project dictionary in
         # tools/docs/dictionary.txt. Adding a word is a one line diff a
         # reviewer can read.
-        run: npx --yes cspell --no-progress "docs/src/content/docs/**/*.md" "examples/**/*.md" README.md CONTRIBUTING.md SECURITY.md
+        #
+        # Pinned, like vale below and like every action in this file. Floating
+        # on the tag resolved a version whose own sibling package was not
+        # published yet: on 2026-09-08 this step died with "No matching version
+        # found for cspell-gitignore@10.3.0" on one pull request, and passed on
+        # the next twenty minutes later, having checked nothing in between. A
+        # required context that reports failure because a registry was mid
+        # publish is a check nobody can read, and it is the same class of red
+        # this repository keeps mistaking for a test failure.
+        run: npx --yes cspell@10.3.0 --no-progress "docs/src/content/docs/**/*.md" "examples/**/*.md" README.md CONTRIBUTING.md SECURITY.md
 
       - name: Prose style
         # The Google developer documentation style at error level, plus the

--- a/justfile
+++ b/justfile
@@ -746,9 +746,11 @@ classcheck:
 motioncheck:
     go run ./tools/motioncheck .
 
-# Spelling, with the project dictionary in tools/docs/dictionary.txt.
+# Spelling, with the project dictionary in tools/docs/dictionary.txt. Pinned,
+# because floating on the tag once resolved a version whose sibling package was
+# not published yet and the gate failed having checked nothing.
 spell:
-    npx --yes cspell --no-progress "docs/src/content/docs/**/*.md" "examples/**/*.md" README.md CONTRIBUTING.md SECURITY.md
+    npx --yes cspell@10.3.0 --no-progress "docs/src/content/docs/**/*.md" "examples/**/*.md" README.md CONTRIBUTING.md SECURITY.md
 
 # Prose style: the Google developer documentation style, plus the rule about
 # em dashes. `vale sync` fetches the style package named in .vale.ini.


### PR DESCRIPTION
## The failure

`npx --yes cspell` floats on the dist tag. On 2026-09-08 it resolved a version
whose own sibling package had not finished publishing, and the Spelling step of
the `www` job died with:

```
npm error code ETARGET
npm error notarget No matching version found for cspell-gitignore@10.3.0.
```

`www` is a required context, so #322 read as failing its prose gate with clean
prose, and the identical command passed on #306 twenty minutes later. Between
those two runs the gate checked nothing and did not say so.

## Why this one matters more than a flake

CLAUDE.md already names five things that render as a red check where only one
means a test failed. This is a sixth, and it is the worst shaped of them: it is
indistinguishable from a real spelling failure in the summary view, and it
heals itself, so the next person re-runs the job, sees green, and learns that
re-running a red job is how you fix it.

Every action in this workflow is pinned to a commit sha and vale is pinned to a
version and a checksum. cspell was the only gate still resolving at run time.

## What changed

Pinned to `cspell@10.3.0` in `.github/workflows/ci.yml` and in the `spell`
recipe in `justfile`, which `tools/gatecheck` compares against it string for
string, so the two cannot drift.

## Verified

- `npx --yes cspell@10.3.0 --no-progress ...` on this tree: `Files checked: 98,
  Issues found: 0 in 0 files.`
- `cspell-gitignore@10.3.0` is published now, which is why the same command
  passes today and is exactly why it must not be resolved at run time again.

## Unblocks

#322's `www`, which is this failure and nothing else.
