### PR TITLE
engine: the masking policy was checked against a list nothing ever filled

### DIFF
--- a/.changes/a-masking-policy-checked-against-a-list-nothing-filled.md
+++ b/.changes/a-masking-policy-checked-against-a-list-nothing-filled.md
@@ -1,0 +1,34 @@
+# fixed
+
+The organization rule requiring a column to be masked was checked against a list
+the engine never filled.
+
+`extension.EnvironmentRequest` carried `MaskedColumns`, the enterprise policy
+read it, and no code anywhere wrote to it. So `required_masked_columns` was
+evaluated against an empty list on every environment. An organization that
+configured the rule got a licence that granted the feature, a startup line that
+printed the rule, and no refusal on any repository ever. The only thing that
+kept it from refusing everything instead is that a policy naming no columns
+returns before it looks.
+
+It could not be filled where it was read. The policy hook is asked before
+anything is created, deliberately, so that a refusal leaves nothing behind, and
+what it has at that point is a manifest. A manifest enumerates services, not
+columns. Expanding a pattern like `*.email` against the tables a manifest
+happens to name would have refused every repository whose masking rules reach a
+table the manifest does not mention, which is most of them.
+
+So there is now a second socket, `extension.MaskingHook`, asked during a golden
+refresh: after the engine has read the database catalogue and assigned its rules
+to it, and before the executor rewrites the first row. It carries the columns the
+plan will rewrite and the whole catalogue they were read from. A refusal there
+means the golden is never published, and an unverified golden cannot be branched,
+so no environment can hold data the policy refused.
+
+Having the catalogue also makes the rule mean what it says. `*.email` is now
+satisfied only when every email column in the database is masked; before, one
+match anywhere was enough, so a plan that masked `users.email` and left
+`contacts.email` readable passed a policy written to stop exactly that.
+
+A golden published before a policy was tightened is not re-examined. Refresh it,
+and the new rule decides whether it may be published.

--- a/docs/src/content/docs/enterprise/policy.md
+++ b/docs/src/content/docs/enterprise/policy.md
@@ -45,10 +45,18 @@ allowed_regions:
   - westeurope
 ```
 
-`required_masked_columns` is `table.column` with `*` allowed in either part. A
-pattern that matches no column in the database counts as unsatisfied, because a
-policy that quietly passes when the thing it protects is absent stops protecting
-the moment somebody renames a table.
+`required_masked_columns` is `table.column` with `*` allowed in either part.
+Write the schema too, as `public.users.email`, when you mean one schema in
+particular; a pattern without one names that table in whichever schema holds
+it.
+
+The rule is checked against the database's own catalogue, so it means every
+column it names. `"*.email"` is satisfied when every email column in the
+database is masked, and a plan that masks `users.email` and leaves
+`contacts.email` readable is refused by name. A pattern that matches no column
+at all counts as unsatisfied too, because a policy that quietly passes when the
+thing it protects is absent stops protecting the moment somebody renames a
+table.
 
 `denied_hosts` refuses a host named in any mode other than `block`. A repository
 may still write a `block` rule for one, so that it can document what it
@@ -77,13 +85,33 @@ ask would turn the rule into decoration.
 
 ## Where it runs
 
-The check happens before anything is created, not after. A policy that refused
-an environment halfway through would leave resources behind and a decision
-nobody can act on.
+Most of the policy is checked before anything is created, not after. A policy
+that refused an environment halfway through would leave resources behind and a
+decision nobody can act on.
 
-The extension point it uses is in the community edition, in
-`engine/pkg/extension`. That is deliberate: the socket is MIT so that anybody
-can write a hook, and the enterprise edition supplies one implementation of it.
+`required_masked_columns` is the exception, and the reason is worth knowing
+before you write one. At creation time the engine has read a manifest, and a
+manifest enumerates services rather than columns. Expanding a column pattern
+there would mean expanding it against the tables a manifest happens to mention,
+which is not the set of tables that exist, and a required pattern that matched
+nothing in that smaller set would refuse a repository whose schema satisfies it
+perfectly.
+
+So the masking rule is checked during a golden refresh instead, after the
+engine has read the database's catalogue and worked out which columns its rules
+will rewrite, and before the first row is rewritten. A refusal there means the
+golden is never published, and an unverified golden cannot be branched, so no
+environment can hold data the policy refused. It is later than the other rules
+and it is still before the data exists.
+
+One consequence to plan for: a golden published before you tightened the policy
+is not re-examined. Refresh the golden after a policy change, with
+`af golden refresh`, and the new rule decides whether it may be published.
+
+The extension points it uses are in the community edition, in
+`engine/pkg/extension`. That is deliberate: the sockets are MIT so that anybody
+can write a hook, and the enterprise edition supplies one implementation of
+them.
 
 ## Hooks can only refuse
 
@@ -100,11 +128,22 @@ that lives in somebody's plugin.
 ```go
 type PolicyHook interface {
     // Returns an error to refuse. Nil permits nothing; it declines to object.
-    Check(ctx context.Context, req Request) error
+    Check(ctx context.Context, req EnvironmentRequest) error
+}
+
+type MaskingHook interface {
+    // Asked during a golden refresh, with the columns a plan will rewrite and
+    // the whole catalogue it read them from.
+    CheckMasking(ctx context.Context, req MaskingRequest) error
 }
 ```
 
+A hook may implement either or both. `MaskingRequest` carries two column lists
+and a hook needs both: masked columns alone cannot tell a database that has no
+email column from one that has three and masks none of them, and those deserve
+opposite answers.
+
 Register it with the engine's extension registry. The community build registers
-nothing, so the check iterates an empty slice and returns nil.
+nothing, so each check iterates an empty slice and returns nil.
 
 Related: [licensing](/docs/enterprise/licensing), [egress](/docs/concepts/egress).

--- a/ee/engine/policyenforce/configure.go
+++ b/ee/engine/policyenforce/configure.go
@@ -147,11 +147,20 @@ func Rules(h *Hook) []string {
 // print which rules are in force, and so that a binary that forgot to print
 // them still cannot forget to register them: there is no way to get the hook
 // out of here without it already being in the registry.
+//
+// BOTH sockets, from one call, and that is not a convenience. The hook answers
+// two questions at two moments: whether an environment may be created, from a
+// manifest, and whether a masking plan may run, from a catalogue. An
+// administrator who wrote required_masked_columns configured one policy and
+// would have no way to tell that half of it had not been plugged in, because
+// the half that was missing is the half that never refuses. Registering both
+// here is what stops that being possible to forget.
 func RegisterFromEnvironment(reg *extension.Registry, getenv func(string) string) (*Hook, error) {
 	hook, err := FromEnvironment(getenv)
 	if err != nil || hook == nil {
 		return nil, err
 	}
 	reg.AddPolicy(hook)
+	reg.AddMasking(hook)
 	return hook, nil
 }

--- a/ee/engine/policyenforce/configure_test.go
+++ b/ee/engine/policyenforce/configure_test.go
@@ -80,7 +80,12 @@ func TestTheRegisteredHookIsNamedInTheRegistry(t *testing.T) {
 	_, err := policyenforce.RegisterFromEnvironment(registry, write(t, "denied_hosts: [evil.example]\n"))
 	require.NoError(t, err)
 
-	require.Equal(t, []string{"policy:organization-policy"}, registry.Registered())
+	// Both sockets. One entry would mean half the policy was plugged in, and
+	// the half that goes missing is the half that never refuses.
+	require.Equal(t, []string{
+		"masking:organization-policy",
+		"policy:organization-policy",
+	}, registry.Registered())
 }
 
 // ---------------------------------------------------------------------------
@@ -162,12 +167,17 @@ func TestEveryParsedRuleIsAskedOfAnEnvironment(t *testing.T) {
 		name     string
 		document string
 		expect   string
+		// masking says the rule is decided during a golden refresh rather than
+		// before creation, so the registry call that carries it is
+		// CheckMasking. Asking CheckPolicy for it is how the rule came to be
+		// evaluated against a field nothing filled.
+		masking bool
 	}{
-		{"required masking", "required_masked_columns: [\"*.card_number\"]", "required masking"},
-		{"egress deny list", "denied_hosts: [api.stripe.com]", "egress deny list"},
-		{"allowed egress modes", "allowed_modes: [block]", "allowed egress modes"},
-		{"allowed providers", "allowed_providers: [neon]", "allowed database providers"},
-		{"data residency", "allowed_regions: [westeurope]", "data residency"},
+		{"required masking", "required_masked_columns: [\"*.card_number\"]", "required masking", true},
+		{"egress deny list", "denied_hosts: [api.stripe.com]", "egress deny list", false},
+		{"allowed egress modes", "allowed_modes: [block]", "allowed egress modes", false},
+		{"allowed providers", "allowed_providers: [neon]", "allowed database providers", false},
+		{"data residency", "allowed_regions: [westeurope]", "data residency", false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -175,13 +185,38 @@ func TestEveryParsedRuleIsAskedOfAnEnvironment(t *testing.T) {
 			_, err := policyenforce.RegisterFromEnvironment(registry, write(t, tc.document+"\n"))
 			require.NoError(t, err)
 
-			req := request()
-			req.Region = "eastus"
-			err = registry.CheckPolicy(ctx, req)
+			if tc.masking {
+				plan := maskingRequest()
+				plan.CatalogColumns = append(plan.CatalogColumns, "public.orders.card_number")
+				err = registry.CheckMasking(ctx, plan)
+			} else {
+				req := request()
+				req.Region = "eastus"
+				err = registry.CheckPolicy(ctx, req)
+			}
 			require.Error(t, err, "%s parsed and refused nothing", tc.name)
 			require.ErrorContains(t, err, tc.expect)
 		})
 	}
+}
+
+// The negative control for the masking half of the registration.
+//
+// RegisterFromEnvironment adds the hook to two sockets and forgetting either
+// one is silent: the rule still parses, Rules still prints it, and nothing
+// refuses. Dropping the AddMasking call leaves the whole rest of this file
+// green.
+func TestAnUnregisteredMaskingPolicyRefusesNothing(t *testing.T) {
+	t.Parallel()
+	registry := extension.NewRegistry()
+	require.NoError(t, registry.CheckMasking(licensed(t), maskingRequest()),
+		"an empty registry refused a masking plan")
+
+	_, err := policyenforce.RegisterFromEnvironment(registry,
+		write(t, "required_masked_columns: [\"*.ssn\"]\n"))
+	require.NoError(t, err)
+	require.ErrorContains(t, registry.CheckMasking(licensed(t), maskingRequest()),
+		"AF-EE-010", "the masking policy was read and plugged into nothing")
 }
 
 func TestSynthRequiresApprovalReachesTheHook(t *testing.T) {

--- a/ee/engine/policyenforce/policyenforce.go
+++ b/ee/engine/policyenforce/policyenforce.go
@@ -142,9 +142,6 @@ func (h *Hook) Check(ctx context.Context, req extension.EnvironmentRequest) erro
 	if violation := h.checkSynth(req); violation != nil {
 		return violation
 	}
-	if violation := h.checkMasking(req); violation != nil {
-		return violation
-	}
 	if violation := h.checkPlacement(req); violation != nil {
 		return violation
 	}
@@ -220,28 +217,134 @@ func (h *Hook) checkSynth(req extension.EnvironmentRequest) error {
 	}
 }
 
-func (h *Hook) checkMasking(req extension.EnvironmentRequest) error {
+// CheckMasking refuses a masking plan that leaves a required column readable.
+//
+// A separate entry point from Check, and the separation is the point rather
+// than a tidying. Check is asked before an environment is created, from a
+// manifest, and a manifest names no columns: the required_masked_columns rule
+// used to be evaluated there against a field the engine never filled, so it
+// read every repository's plan as masking nothing, and the only reason it did
+// not refuse everything is that a policy naming no columns returns early.
+//
+// This is asked during a golden refresh, from a catalogue the engine has read
+// and a plan assigned against it, before the first row is rewritten. A refusal
+// here means the golden is never published and never branched.
+func (h *Hook) CheckMasking(ctx context.Context, req extension.MaskingRequest) error {
+	// The same licence gate as Check, for the same reason: a licence that
+	// lapses mid-process must stop the enforcement it paid for, and a second
+	// entry point that skipped the check would be a way to keep the feature
+	// after the licence went.
+	if !feature.Enabled(ctx, license.FeaturePolicy) {
+		return nil
+	}
 	if len(h.policy.RequiredMaskedColumns) == 0 {
 		return nil
 	}
-	masked := make(map[string]bool, len(req.MaskedColumns))
-	for _, column := range req.MaskedColumns {
-		masked[strings.ToLower(strings.TrimSpace(column))] = true
-	}
+
+	masked := normalizeColumns(req.MaskedColumns)
+	catalog := normalizeColumns(req.CatalogColumns)
 
 	for _, pattern := range h.policy.RequiredMaskedColumns {
-		if coveredBy(pattern, masked) {
+		normalized := strings.ToLower(strings.TrimSpace(pattern))
+		matches := matching(normalized, catalog)
+		if len(matches) == 0 {
+			return &Refusal{
+				Policy: "required masking",
+				Detail: fmt.Sprintf(
+					"this organization requires %s to be masked and this database has no column it names. "+
+						"A policy that quietly passes when the thing it protects is absent stops protecting "+
+						"the moment somebody renames a table, so this is refused rather than skipped. "+
+						"Ask an administrator to narrow the rule, or add the column back.",
+					pattern),
+			}
+		}
+		unmasked := notIn(matches, masked)
+		if len(unmasked) == 0 {
 			continue
 		}
 		return &Refusal{
 			Policy: "required masking",
 			Detail: fmt.Sprintf(
-				"this organization requires %s to be masked and no rule in this repository covers it. "+
-					"Add a masking rule and commit it, then start the environment again.",
-				pattern),
+				"this organization requires %s to be masked and no rule in this repository covers %s. "+
+					"Add a masking rule and commit it, then refresh the golden.",
+				pattern, strings.Join(unmasked, ", ")),
 		}
 	}
 	return nil
+}
+
+// normalizeColumns lowercases and trims a column list, dropping empties.
+//
+// Sorted on the way out, so that a plan violating the policy for two columns
+// names them in the same order every time rather than in whichever order the
+// catalogue was read.
+func normalizeColumns(columns []string) []string {
+	out := make([]string, 0, len(columns))
+	for _, column := range columns {
+		normalized := strings.ToLower(strings.TrimSpace(column))
+		if normalized == "" {
+			continue
+		}
+		out = append(out, normalized)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// matching returns every column a required pattern names.
+//
+// A pattern is matched against the schema qualified name and against the name
+// without its schema, which is the same rule masking.Rule already uses for its
+// table patterns. An administrator writes users.email and means the users
+// table wherever it lives; one who writes public.users.email means that one.
+// Accepting only the long form would refuse every policy anybody has written,
+// and accepting only the short form would make a policy unable to distinguish
+// two schemas.
+func matching(pattern string, catalog []string) []string {
+	var out []string
+	for _, column := range catalog {
+		if matchesColumn(pattern, column) {
+			out = append(out, column)
+		}
+	}
+	return out
+}
+
+func matchesColumn(pattern, column string) bool {
+	if pattern == column {
+		return true
+	}
+	if ok, err := path.Match(pattern, column); err == nil && ok {
+		return true
+	}
+	// The unqualified form. Cutting at the FIRST dot is what strips the
+	// schema: a column is schema.table.column, so what follows the first dot
+	// is table.column. Cutting at the last would leave the column name alone
+	// and make every pattern with a table in it fail.
+	if _, rest, found := strings.Cut(column, "."); found {
+		if pattern == rest {
+			return true
+		}
+		if ok, err := path.Match(pattern, rest); err == nil && ok {
+			return true
+		}
+	}
+	return false
+}
+
+// notIn returns the columns of want that are absent from have.
+func notIn(want, have []string) []string {
+	present := make(map[string]bool, len(have))
+	for _, column := range have {
+		present[column] = true
+	}
+	var out []string
+	for _, column := range want {
+		if !present[column] {
+			out = append(out, column)
+		}
+	}
+	return out
 }
 
 func (h *Hook) checkPlacement(req extension.EnvironmentRequest) error {
@@ -264,32 +367,6 @@ func (h *Hook) checkPlacement(req extension.EnvironmentRequest) error {
 		}
 	}
 	return nil
-}
-
-// coveredBy reports whether a required pattern is satisfied by some masked
-// column.
-//
-// A pattern with a wildcard is satisfied by at least one match, not by all of
-// them. "*.email must be masked" means every email column, and the catalog the
-// engine builds lists the columns that exist, so a required pattern matching
-// nothing at all is a policy about a column this database does not have. That
-// is treated as unsatisfied deliberately: a policy that quietly passes when the
-// thing it protects is absent is a policy that stops protecting the moment
-// somebody renames a table.
-func coveredBy(pattern string, masked map[string]bool) bool {
-	normalized := strings.ToLower(strings.TrimSpace(pattern))
-	if masked[normalized] {
-		return true
-	}
-	if !strings.Contains(normalized, "*") {
-		return false
-	}
-	for column := range masked {
-		if ok, err := path.Match(normalized, column); err == nil && ok {
-			return true
-		}
-	}
-	return false
 }
 
 // matchesAny reports whether a host matches a deny entry, treating a wildcard

--- a/ee/engine/policyenforce/policyenforce_test.go
+++ b/ee/engine/policyenforce/policyenforce_test.go
@@ -36,8 +36,24 @@ func request() extension.EnvironmentRequest {
 			"api.stripe.com": "sandbox",
 			"api.resend.com": "capture",
 		},
-		MaskedColumns: []string{"users.email", "users.name"},
-		Provider:      "docker",
+		Provider: "docker",
+	}
+}
+
+// maskingRequest is what the engine hands a masking hook during a golden
+// refresh: the columns a plan will rewrite, and the whole catalogue it read
+// them from.
+//
+// Both lists are schema qualified, because that is what the engine sends. A
+// test that used bare names would pass while the engine's own format failed.
+func maskingRequest() extension.MaskingRequest {
+	return extension.MaskingRequest{
+		Repository: "acme/app", Branch: "main", EnvID: "af-1", RulesHash: "h1",
+		MaskedColumns: []string{"public.users.email", "public.users.name"},
+		CatalogColumns: []string{
+			"public.orders.id", "public.orders.total",
+			"public.users.email", "public.users.id", "public.users.name",
+		},
 	}
 }
 
@@ -211,49 +227,136 @@ func TestANilApprovalLookupApprovesNothing(t *testing.T) {
 // Masking
 // ---------------------------------------------------------------------------
 
-func TestARequiredColumnMustBeCovered(t *testing.T) {
+func TestAColumnTheDatabaseHasAndTheRulesMissIsRefused(t *testing.T) {
 	t.Parallel()
+	req := maskingRequest()
+	req.CatalogColumns = append(req.CatalogColumns, "public.users.ssn")
+
 	hook := policyenforce.NewHook(policyenforce.Policy{
 		RequiredMaskedColumns: []string{"users.ssn"},
 	}, nil)
 
-	err := hook.Check(licensed(t), request())
+	err := hook.CheckMasking(licensed(t), req)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "users.ssn")
 	// It says what to do, and where: the rule lives in the repository.
 	require.Contains(t, err.Error(), "commit it")
 }
 
-func TestAWildcardRequirementIsSatisfiedByAMatch(t *testing.T) {
+func TestAWildcardRequirementIsSatisfiedWhenEveryColumnItNamesIsMasked(t *testing.T) {
 	t.Parallel()
 	hook := policyenforce.NewHook(policyenforce.Policy{
 		RequiredMaskedColumns: []string{"*.email"},
 	}, nil)
-	require.NoError(t, hook.Check(licensed(t), request()))
+	require.NoError(t, hook.CheckMasking(licensed(t), maskingRequest()))
 }
 
-func TestARequirementMatchingNothingIsTreatedAsUnsatisfied(t *testing.T) {
+func TestAWildcardRequirementIsNotSatisfiedByMaskingOneOfTheColumnsItNames(t *testing.T) {
+	t.Parallel()
+	// The reason the catalogue is worth sending. "*.email must be masked"
+	// means every email column, and a check that stopped at the first match
+	// passed a database that masked one of two. Reading the catalogue is what
+	// makes the difference between those two visible at all.
+	req := maskingRequest()
+	req.CatalogColumns = append(req.CatalogColumns, "public.contacts.email")
+
+	hook := policyenforce.NewHook(policyenforce.Policy{
+		RequiredMaskedColumns: []string{"*.email"},
+	}, nil)
+
+	err := hook.CheckMasking(licensed(t), req)
+	require.Error(t, err, "a plan masking one of two email columns satisfied *.email")
+	require.Contains(t, err.Error(), "public.contacts.email")
+}
+
+func TestARequirementNamingAColumnThisDatabaseDoesNotHaveIsRefused(t *testing.T) {
 	t.Parallel()
 	// A policy that quietly passes when the thing it protects is absent stops
 	// protecting the moment somebody renames a table.
-	req := request()
-	req.MaskedColumns = []string{"orders.total"}
-
 	hook := policyenforce.NewHook(policyenforce.Policy{
 		RequiredMaskedColumns: []string{"*.ssn"},
 	}, nil)
-	require.Error(t, hook.Check(licensed(t), req))
+
+	err := hook.CheckMasking(licensed(t), maskingRequest())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no column it names")
+}
+
+func TestAnUnqualifiedPatternNamesTheTableInWhicheverSchemaHoldsIt(t *testing.T) {
+	t.Parallel()
+	// An administrator writes users.email. The engine sends
+	// public.users.email, because a catalogue is schema qualified. Refusing
+	// that would refuse every policy anybody has actually written.
+	hook := policyenforce.NewHook(policyenforce.Policy{
+		RequiredMaskedColumns: []string{"users.email"},
+	}, nil)
+	require.NoError(t, hook.CheckMasking(licensed(t), maskingRequest()))
+}
+
+func TestASchemaQualifiedPatternDoesNotReachAnotherSchema(t *testing.T) {
+	t.Parallel()
+	// The other half of the rule above. An administrator who writes the schema
+	// meant that schema, and a policy that cannot tell public.users.email from
+	// staging.users.email is a policy about whichever one came first.
+	req := maskingRequest()
+	req.CatalogColumns = append(req.CatalogColumns, "staging.users.email")
+	req.MaskedColumns = []string{"staging.users.email"}
+
+	hook := policyenforce.NewHook(policyenforce.Policy{
+		RequiredMaskedColumns: []string{"public.users.email"},
+	}, nil)
+
+	err := hook.CheckMasking(licensed(t), req)
+	require.Error(t, err, "masking staging.users.email satisfied a rule about public")
+	require.Contains(t, err.Error(), "public.users.email")
 }
 
 func TestMaskingComparisonIgnoresCase(t *testing.T) {
 	t.Parallel()
-	req := request()
-	req.MaskedColumns = []string{"Users.Email"}
+	req := maskingRequest()
+	req.MaskedColumns = []string{"Public.Users.Email"}
+	req.CatalogColumns = []string{"Public.Users.Email"}
 
 	hook := policyenforce.NewHook(policyenforce.Policy{
 		RequiredMaskedColumns: []string{"users.email"},
 	}, nil)
-	require.NoError(t, hook.Check(licensed(t), req))
+	require.NoError(t, hook.CheckMasking(licensed(t), req))
+}
+
+// The false refusal this check exists to avoid, and the reason it is asked
+// during a refresh rather than before creation.
+//
+// A manifest enumerates services, not tables. Expanding a required pattern
+// against the tables a manifest happens to name would refuse this repository:
+// nothing in its manifest mentions contacts, its masking rules reach the table
+// anyway, and the column is masked. The catalogue is read from the database,
+// so a table the manifest never names is an ordinary table here.
+func TestATableNoManifestNamesIsStillCovered(t *testing.T) {
+	t.Parallel()
+	req := extension.MaskingRequest{
+		Repository: "acme/app", EnvID: "af-1", RulesHash: "h1",
+		MaskedColumns: []string{"public.contacts.email", "public.users.email"},
+		CatalogColumns: []string{
+			"public.contacts.email", "public.contacts.id",
+			"public.users.email", "public.users.id",
+		},
+	}
+	hook := policyenforce.NewHook(policyenforce.Policy{
+		RequiredMaskedColumns: []string{"*.email"},
+	}, nil)
+	require.NoError(t, hook.CheckMasking(licensed(t), req),
+		"a table the manifest does not enumerate was refused for that reason alone")
+}
+
+func TestWithoutTheLicenceNoMaskingPlanIsRefused(t *testing.T) {
+	t.Parallel()
+	// The same lapse rule as Check. A second entry point that skipped the gate
+	// would be a way to keep enforcing after the licence went.
+	hook := policyenforce.NewHook(policyenforce.Policy{
+		RequiredMaskedColumns: []string{"*.ssn"},
+	}, nil)
+	require.NoError(t, hook.CheckMasking(context.Background(), maskingRequest()),
+		"a masking plan was refused with no licence in the context")
 }
 
 // ---------------------------------------------------------------------------
@@ -320,9 +423,17 @@ func TestAStricterPolicyNeverPermitsMore(t *testing.T) {
 			req.EgressHosts = append(req.EgressHosts, host)
 			req.EgressModes[host] = modes[rng.IntN(len(modes))]
 		}
+		// The masking plan the same random draw would produce. Every column
+		// exists; a random subset of them is masked. Both entry points are
+		// exercised below, because the masking rule is no longer decided from
+		// the environment request and a property test that only asked Check
+		// would leave case 1 proving nothing.
+		plan := extension.MaskingRequest{
+			Repository: "acme/app", EnvID: "af-1", CatalogColumns: columns,
+		}
 		for _, column := range columns {
 			if rng.IntN(2) == 0 {
-				req.MaskedColumns = append(req.MaskedColumns, column)
+				plan.MaskedColumns = append(plan.MaskedColumns, column)
 			}
 		}
 
@@ -347,13 +458,15 @@ func TestAStricterPolicyNeverPermitsMore(t *testing.T) {
 
 		require.True(t, policyenforce.Stricter(base, stricter))
 
-		basePermits := policyenforce.NewHook(base, nil).Check(ctx, req) == nil
-		stricterPermits := policyenforce.NewHook(stricter, nil).Check(ctx, req) == nil
+		permits := func(p policyenforce.Policy) bool {
+			hook := policyenforce.NewHook(p, nil)
+			return hook.Check(ctx, req) == nil && hook.CheckMasking(ctx, plan) == nil
+		}
 
-		if stricterPermits {
-			require.Truef(t, basePermits,
-				"a stricter policy permitted an environment the looser one refused\nrequest: %+v\nbase: %+v\nstricter: %+v",
-				req, base, stricter)
+		if permits(stricter) {
+			require.Truef(t, permits(base),
+				"a stricter policy permitted an environment the looser one refused\nrequest: %+v\nplan: %+v\nbase: %+v\nstricter: %+v",
+				req, plan, base, stricter)
 		}
 	}
 }
@@ -371,6 +484,8 @@ func TestAnEmptyPolicyRefusesNothing(t *testing.T) {
 		req.EgressModes["api.stripe.com"] = mode
 		require.NoErrorf(t, hook.Check(ctx, req), "an empty policy refused %s mode", mode)
 	}
+	require.NoError(t, hook.CheckMasking(ctx, maskingRequest()),
+		"an empty policy refused a masking plan")
 }
 
 // ---------------------------------------------------------------------------
@@ -397,6 +512,28 @@ func TestItPlugsIntoTheCommunityExtensionPoint(t *testing.T) {
 	require.Contains(t, err.Error(), "AF-EE-010")
 }
 
+func TestItPlugsIntoTheMaskingExtensionPoint(t *testing.T) {
+	t.Parallel()
+	// The same proof for the second socket. The masking rule is decided in a
+	// different call at a different moment, so a hook that satisfies
+	// PolicyHook and not MaskingHook enforces everything except the one rule
+	// that needed a database to answer.
+	var hook extension.MaskingHook = policyenforce.NewHook(
+		policyenforce.Policy{RequiredMaskedColumns: []string{"*.ssn"}}, nil)
+
+	registry := extension.NewRegistry()
+	registry.AddMasking(hook)
+	require.False(t, registry.Empty())
+	require.Equal(t, []string{"masking:organization-policy"}, registry.Registered())
+
+	err := registry.CheckMasking(licensed(t), maskingRequest())
+	require.Error(t, err)
+
+	var refusal *policyenforce.Refusal
+	require.True(t, errors.As(err, &refusal), "the refusal did not survive the registry")
+	require.Contains(t, err.Error(), "AF-EE-010")
+}
+
 func TestTheRefusalCarriesTheDocumentedErrorCode(t *testing.T) {
 	t.Parallel()
 	// AF-EE-010 is in the error catalog with a cause and a next step, so the
@@ -404,7 +541,7 @@ func TestTheRefusalCarriesTheDocumentedErrorCode(t *testing.T) {
 	hook := policyenforce.NewHook(policyenforce.Policy{
 		RequiredMaskedColumns: []string{"users.ssn"},
 	}, nil)
-	err := hook.Check(licensed(t), request())
+	err := hook.CheckMasking(licensed(t), maskingRequest())
 	require.ErrorContains(t, err, "AF-EE-010")
 }
 

--- a/engine/internal/docs/pages.gen.go
+++ b/engine/internal/docs/pages.gen.go
@@ -4731,10 +4731,18 @@ allowed_regions:
   - westeurope
 ` + "`" + "`" + "`" + `
 
-` + "`" + `required_masked_columns` + "`" + ` is ` + "`" + `table.column` + "`" + ` with ` + "`" + `*` + "`" + ` allowed in either part. A
-pattern that matches no column in the database counts as unsatisfied, because a
-policy that quietly passes when the thing it protects is absent stops protecting
-the moment somebody renames a table.
+` + "`" + `required_masked_columns` + "`" + ` is ` + "`" + `table.column` + "`" + ` with ` + "`" + `*` + "`" + ` allowed in either part.
+Write the schema too, as ` + "`" + `public.users.email` + "`" + `, when you mean one schema in
+particular; a pattern without one names that table in whichever schema holds
+it.
+
+The rule is checked against the database's own catalogue, so it means every
+column it names. ` + "`" + `"*.email"` + "`" + ` is satisfied when every email column in the
+database is masked, and a plan that masks ` + "`" + `users.email` + "`" + ` and leaves
+` + "`" + `contacts.email` + "`" + ` readable is refused by name. A pattern that matches no column
+at all counts as unsatisfied too, because a policy that quietly passes when the
+thing it protects is absent stops protecting the moment somebody renames a
+table.
 
 ` + "`" + `denied_hosts` + "`" + ` refuses a host named in any mode other than ` + "`" + `block` + "`" + `. A repository
 may still write a ` + "`" + `block` + "`" + ` rule for one, so that it can document what it
@@ -4763,13 +4771,33 @@ ask would turn the rule into decoration.
 
 ## Where it runs
 
-The check happens before anything is created, not after. A policy that refused
-an environment halfway through would leave resources behind and a decision
-nobody can act on.
+Most of the policy is checked before anything is created, not after. A policy
+that refused an environment halfway through would leave resources behind and a
+decision nobody can act on.
 
-The extension point it uses is in the community edition, in
-` + "`" + `engine/pkg/extension` + "`" + `. That is deliberate: the socket is MIT so that anybody
-can write a hook, and the enterprise edition supplies one implementation of it.
+` + "`" + `required_masked_columns` + "`" + ` is the exception, and the reason is worth knowing
+before you write one. At creation time the engine has read a manifest, and a
+manifest enumerates services rather than columns. Expanding a column pattern
+there would mean expanding it against the tables a manifest happens to mention,
+which is not the set of tables that exist, and a required pattern that matched
+nothing in that smaller set would refuse a repository whose schema satisfies it
+perfectly.
+
+So the masking rule is checked during a golden refresh instead, after the
+engine has read the database's catalogue and worked out which columns its rules
+will rewrite, and before the first row is rewritten. A refusal there means the
+golden is never published, and an unverified golden cannot be branched, so no
+environment can hold data the policy refused. It is later than the other rules
+and it is still before the data exists.
+
+One consequence to plan for: a golden published before you tightened the policy
+is not re-examined. Refresh the golden after a policy change, with
+` + "`" + `af golden refresh` + "`" + `, and the new rule decides whether it may be published.
+
+The extension points it uses are in the community edition, in
+` + "`" + `engine/pkg/extension` + "`" + `. That is deliberate: the sockets are MIT so that anybody
+can write a hook, and the enterprise edition supplies one implementation of
+them.
 
 ## Hooks can only refuse
 
@@ -4786,12 +4814,23 @@ that lives in somebody's plugin.
 ` + "`" + "`" + "`" + `go
 type PolicyHook interface {
     // Returns an error to refuse. Nil permits nothing; it declines to object.
-    Check(ctx context.Context, req Request) error
+    Check(ctx context.Context, req EnvironmentRequest) error
+}
+
+type MaskingHook interface {
+    // Asked during a golden refresh, with the columns a plan will rewrite and
+    // the whole catalogue it read them from.
+    CheckMasking(ctx context.Context, req MaskingRequest) error
 }
 ` + "`" + "`" + "`" + `
 
+A hook may implement either or both. ` + "`" + `MaskingRequest` + "`" + ` carries two column lists
+and a hook needs both: masked columns alone cannot tell a database that has no
+email column from one that has three and masks none of them, and those deserve
+opposite answers.
+
 Register it with the engine's extension registry. The community build registers
-nothing, so the check iterates an empty slice and returns nil.
+nothing, so each check iterates an empty slice and returns nil.
 
 Related: [licensing](/docs/enterprise/licensing), [egress](/docs/concepts/egress).
 `,

--- a/engine/internal/env/golden.go
+++ b/engine/internal/env/golden.go
@@ -26,6 +26,7 @@ import (
 	"github.com/antifailure/antifailure/engine/internal/secrets"
 	"github.com/antifailure/antifailure/engine/internal/subset"
 	"github.com/antifailure/antifailure/engine/internal/verify"
+	"github.com/antifailure/antifailure/engine/pkg/extension"
 	"github.com/antifailure/antifailure/engine/pkg/provider"
 )
 
@@ -601,6 +602,78 @@ func (o *Orchestrator) sourceURL(ctx context.Context) (secrets.Value, error) {
 	return value, nil
 }
 
+// checkMasking asks the registered hooks whether this plan may run.
+//
+// The community build registers nothing, so this returns nil after one pass
+// over an empty slice, and the community suite runs byte for byte as it did
+// before the call existed. The socket is here rather than in the enterprise
+// edition for the same reason the policy socket is: a hook that only exists in
+// a build nobody runs is a hook nobody has tested.
+func (o *Orchestrator) checkMasking(
+	ctx context.Context, tables []masking.Table, plan masking.Plan,
+) error {
+	registry := o.opts.Extensions
+	if registry == nil {
+		registry = extension.Default
+	}
+	if registry.Empty() {
+		return nil
+	}
+	return registry.CheckMasking(ctx, o.maskingRequest(tables, plan))
+}
+
+// maskingRequest describes a plan in the two lists a hook needs.
+//
+// Split out and pure so that the mapping is testable without a database, and
+// because getting it wrong is silent: a request whose MaskedColumns were built
+// from the rules rather than from the plan would name columns no executor is
+// going to touch, and a hook reading it would approve a database that still
+// holds them.
+//
+// Every column carries its schema. The alternative, a bare table.column, is
+// ambiguous the moment two schemas hold a table of the same name, and a policy
+// that cannot tell public.users.email from staging.users.email is a policy
+// about whichever one the map iterated first.
+func (o *Orchestrator) maskingRequest(
+	tables []masking.Table, plan masking.Plan,
+) extension.MaskingRequest {
+	req := extension.MaskingRequest{
+		Branch:    o.opts.Branch,
+		EnvID:     o.envID,
+		RulesHash: plan.RulesHash,
+	}
+	if o.opts.Manifest != nil {
+		req.Repository = o.opts.Manifest.Name
+	}
+	// The plan is what will run, so this is the list of columns that are about
+	// to be rewritten and not a wider one. A table the plan skipped
+	// contributes nothing here even though its columns were assigned, which is
+	// correct: a skipped table is a table whose data survives.
+	for _, tp := range plan.Tables {
+		if tp.Skipped != "" {
+			continue
+		}
+		for _, col := range tp.Columns {
+			req.MaskedColumns = append(req.MaskedColumns,
+				tp.Table.String()+"."+col.Column.Name)
+		}
+	}
+	sort.Strings(req.MaskedColumns)
+
+	// The whole catalogue, from the catalogue rather than from the plan. The
+	// plan holds only the tables it will rewrite, so a database whose email
+	// column matched no rule contributes that column to neither list if this
+	// is read off the plan, and a hook cannot then tell an absent column from
+	// an unmasked one.
+	for _, t := range tables {
+		for _, col := range t.Columns {
+			req.CatalogColumns = append(req.CatalogColumns, t.String()+"."+col.Name)
+		}
+	}
+	sort.Strings(req.CatalogColumns)
+	return req
+}
+
 // maskDatabase applies the rules to a database.
 //
 // It takes the session because masking is the longest and least visible part of
@@ -644,6 +717,20 @@ func (o *Orchestrator) maskDatabase(
 		o.progress(fmt.Sprintf(
 			"%d columns matched no rule and may hold something: %s",
 			len(plan.Unclassified), masking.DescribeColumns(plan.Unclassified, 6)))
+	}
+
+	// Asked here and nowhere else, because here is the only place the answer
+	// is a fact. The policy hook runs before anything is created and is given
+	// a manifest, which names no columns; this is given a catalogue that was
+	// read from the database eleven lines up and a plan assigned against it.
+	//
+	// Before the executor rather than after it, so a refusal costs the rows
+	// nothing: the candidate is not masked, not verified and never published,
+	// and provider.Branch refuses a version that was not published. A hook
+	// that answered after Apply would be reviewing a database it could no
+	// longer stop anybody from branching.
+	if err := o.checkMasking(ctx, tables, plan); err != nil {
+		return 0, 0, err
 	}
 	if copied := plan.CopiedUnchanged(); len(copied) > 0 {
 		// The half of that list the default could not empty. These hold

--- a/engine/internal/env/maskpolicy_test.go
+++ b/engine/internal/env/maskpolicy_test.go
@@ -1,0 +1,165 @@
+package env
+
+// What a masking hook is told, and when.
+//
+// extension.EnvironmentRequest carried a MaskedColumns field that nothing ever
+// filled. The enterprise policy read it, so required_masked_columns was
+// evaluated against an empty list on every environment: an organization that
+// configured the rule got a licence, a compliance control that printed the
+// rule, and no refusal on any repository ever.
+//
+// It could not be filled where it was. checkPolicy runs before anything is
+// created, deliberately, and what it has is a manifest. A manifest enumerates
+// services and does not enumerate columns, so the only list that could be
+// built there is the repository's masking rules expanded against the tables
+// the manifest happens to name, which is not the set of tables that exist.
+//
+// So the question moved to the one place the answer is a fact: during a golden
+// refresh, after masking.ReadCatalog has read the schema and after the rules
+// have been assigned to it, and before the executor rewrites the first row.
+// These tests run against a real Postgres for the same reason the event tests
+// next door do: the columns come from a real catalogue, and a test that
+// asserted the hook was called would pass on a plan with no tables in it.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/internal/events"
+	"github.com/antifailure/antifailure/engine/pkg/extension"
+)
+
+// spyMasking records what it was asked and answers with what it was told to.
+type spyMasking struct {
+	err  error
+	seen *extension.MaskingRequest
+}
+
+func (s *spyMasking) Name() string { return "spy" }
+
+func (s *spyMasking) CheckMasking(_ context.Context, req extension.MaskingRequest) error {
+	copied := req
+	s.seen = &copied
+	return s.err
+}
+
+// registerMasking plugs a hook into an orchestrator's own registry.
+//
+// Its own rather than extension.Default, because the default is the shipped
+// community registry and a test that registered into it would change what
+// every other test in this package runs against.
+func registerMasking(o *Orchestrator, hook extension.MaskingHook) {
+	registry := extension.NewRegistry()
+	registry.AddMasking(hook)
+	o.opts.Extensions = registry
+}
+
+// maskPolicySession is the smallest session maskDatabase touches: somewhere
+// for its events to go and nothing else.
+func maskPolicySession(t *testing.T, o *Orchestrator) *session {
+	t.Helper()
+	bus := events.NewBus(o.opts.Clock)
+	t.Cleanup(func() { _ = bus.Close() })
+	return &session{bus: bus}
+}
+
+// The test that would have caught it. Before this change no masking hook was
+// called at all, so seen stays nil and every assertion below fails.
+func TestMaskDatabase_AsksTheHookWithTheColumnsTheCatalogueActuallyHas(t *testing.T) {
+	url := maskEventsDatabase(t, maskEventsSchema)
+	o := maskEventsOrchestrator(t)
+	spy := &spyMasking{}
+	registerMasking(o, spy)
+
+	_, _, err := o.maskDatabase(
+		t.Context(), maskPolicySession(t, o), url,
+		maskEventsKey(t), maskEventsRules(t), "h1")
+	require.NoError(t, err)
+
+	require.NotNil(t, spy.seen, "the masking hook was never asked")
+
+	// The columns the plan will rewrite, schema qualified, read off the plan
+	// rather than off the rules.
+	require.Contains(t, spy.seen.MaskedColumns, "public.customers.email")
+	require.Contains(t, spy.seen.MaskedColumns, "public.customers.name")
+	require.Contains(t, spy.seen.MaskedColumns, "public.orders.email")
+
+	// A structural column is not masked, and a hook that could not tell that
+	// from an absent column would have to guess.
+	require.NotContains(t, spy.seen.MaskedColumns, "public.customers.id")
+	require.Contains(t, spy.seen.CatalogColumns, "public.customers.id")
+	require.Contains(t, spy.seen.CatalogColumns, "public.orders.customer_id")
+
+	require.Equal(t, "h1", spy.seen.RulesHash)
+	require.Equal(t, o.envID, spy.seen.EnvID)
+}
+
+// The false refusal this design exists to avoid.
+//
+// This orchestrator's manifest names no tables at all, which is the ordinary
+// case: a manifest enumerates services. A check that expanded a required
+// pattern against the manifest would see nothing and refuse a repository whose
+// database holds two perfectly masked email columns. The catalogue comes from
+// the database, so both tables are here.
+func TestMaskDatabase_ATableNoManifestNamesIsStillInTheRequest(t *testing.T) {
+	url := maskEventsDatabase(t, maskEventsSchema)
+	o := maskEventsOrchestrator(t)
+	require.Nil(t, o.opts.Manifest, "the fixture stopped being the no-manifest case")
+	spy := &spyMasking{}
+	registerMasking(o, spy)
+
+	_, _, err := o.maskDatabase(
+		t.Context(), maskPolicySession(t, o), url,
+		maskEventsKey(t), maskEventsRules(t), "h1")
+	require.NoError(t, err, "a plan was refused for naming a table the manifest does not")
+
+	require.NotNil(t, spy.seen)
+	require.Contains(t, spy.seen.MaskedColumns, "public.customers.email")
+	require.Contains(t, spy.seen.MaskedColumns, "public.orders.email")
+}
+
+// A refusal has to arrive before the rows are gone.
+//
+// Masking is destructive and irreversible. A hook asked after the executor ran
+// would be reviewing a database it could no longer stop anybody from
+// branching, and the refusal would cost the data it was protecting.
+func TestMaskDatabase_ARefusalStopsTheRunWithTheRowsIntact(t *testing.T) {
+	url := maskEventsDatabase(t, maskEventsSchema)
+	o := maskEventsOrchestrator(t)
+	refusal := errors.New("organization policy requires customers.email to be masked")
+	registerMasking(o, &spyMasking{err: refusal})
+
+	_, _, err := o.maskDatabase(
+		t.Context(), maskPolicySession(t, o), url,
+		maskEventsKey(t), maskEventsRules(t), "h1")
+	require.ErrorIs(t, err, refusal, "the refusal did not reach the caller")
+
+	conn, connErr := pgx.Connect(t.Context(), url.Reveal())
+	require.NoError(t, connErr)
+	defer func() { _ = conn.Close(context.Background()) }()
+
+	var email string
+	require.NoError(t, conn.QueryRow(t.Context(),
+		"SELECT email FROM customers ORDER BY id LIMIT 1").Scan(&email))
+	require.Equal(t, "ada@example.com", email,
+		"the executor ran anyway, so the refusal arrived after the data was gone")
+}
+
+// The community build registers nothing, and with nothing registered the call
+// has to be indistinguishable from its absence.
+func TestMaskDatabase_WithNothingRegisteredNothingIsAsked(t *testing.T) {
+	url := maskEventsDatabase(t, maskEventsSchema)
+	o := maskEventsOrchestrator(t)
+	o.opts.Extensions = extension.NewRegistry()
+
+	rows, tables, err := o.maskDatabase(
+		t.Context(), maskPolicySession(t, o), url,
+		maskEventsKey(t), maskEventsRules(t), "h1")
+	require.NoError(t, err)
+	require.Positive(t, rows, "an empty registry changed what masking did")
+	require.Positive(t, tables)
+}

--- a/engine/pkg/extension/extension.go
+++ b/engine/pkg/extension/extension.go
@@ -44,9 +44,6 @@ type EnvironmentRequest struct {
 	EgressHosts []string
 	// EgressModes is the mode each host is permitted in, keyed by host.
 	EgressModes map[string]string
-	// MaskedColumns is table.column for every column the plan will mask, so a
-	// hook can require that a column pattern is covered.
-	MaskedColumns []string
 	// Provider is the database provider the environment will use.
 	Provider string
 	// Region is where it will run, when the runtime reports one.
@@ -65,6 +62,62 @@ type PolicyHook interface {
 	// Check returns an error to refuse. The error reaches the user, so it says
 	// which policy refused and what would satisfy it.
 	Check(ctx context.Context, req EnvironmentRequest) error
+}
+
+// MaskingRequest is what a masking hook is asked about, at the one moment the
+// answer is a fact rather than a guess.
+//
+// It carries columns and EnvironmentRequest deliberately does not, and the
+// difference is the whole reason this second request exists. A policy hook is
+// asked before anything is created, so that a refusal leaves nothing behind,
+// and at that point the engine has read a manifest and has not read a
+// database. A manifest does not enumerate columns. Filling a column list there
+// would mean expanding the repository's masking rules against the tables the
+// manifest happens to name, which is a different set from the tables that
+// exist, and a required pattern that matched nothing in that set would refuse a
+// repository whose schema satisfies it perfectly.
+//
+// So the column list is asked for here instead, during a golden refresh, after
+// masking.ReadCatalog has read the real schema and after the rules have been
+// assigned to it, and before one row has been rewritten. A refusal at this
+// point stops the golden being published, and an unpublished golden cannot be
+// branched, so no environment can ever hold data that this refused. That is
+// later than the policy hook and it is still before the data exists.
+type MaskingRequest struct {
+	Repository string
+	Branch     string
+	EnvID      string
+	// RulesHash identifies the masking configuration that produced this plan,
+	// so a hook can record which rule set it approved.
+	RulesHash string
+	// MaskedColumns is schema.table.column for every column the plan will
+	// rewrite. Read off the plan, so it is the columns that are about to be
+	// masked rather than the columns somebody hoped a rule would reach.
+	MaskedColumns []string
+	// CatalogColumns is schema.table.column for every column the catalogue
+	// holds, masked or not.
+	//
+	// A hook needs both lists and neither on its own is enough. MaskedColumns
+	// alone cannot tell "this database has no email column" from "this
+	// database has three and none of them is masked", and those deserve
+	// opposite answers. With the catalogue a rule about a column that does not
+	// exist is answerable as such, and a rule about three columns is not
+	// satisfied by masking one of them.
+	CatalogColumns []string
+}
+
+// MaskingHook may refuse a masking plan before it runs.
+//
+// It can only refuse, for the same reason PolicyHook can only refuse: there is
+// no return value that masks something the rules did not, because a hook that
+// could add a transform would be a way to change what a golden contains
+// without changing the repository.
+type MaskingHook interface {
+	// Name identifies the hook in the refusal.
+	Name() string
+	// CheckMasking returns an error to refuse the plan. The error reaches the
+	// user, so it says which policy refused and what would satisfy it.
+	CheckMasking(ctx context.Context, req MaskingRequest) error
 }
 
 // LifecycleEvent is something that happened to an environment, for hooks that
@@ -460,6 +513,7 @@ type Emulator interface {
 type Registry struct {
 	mu        sync.RWMutex
 	policy    []PolicyHook
+	masking   []MaskingHook
 	lifecycle []LifecycleHook
 	audit     []AuditSink
 	secrets   []SecretSource
@@ -482,6 +536,13 @@ func (r *Registry) AddPolicy(h PolicyHook) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.policy = append(r.policy, h)
+}
+
+// AddMasking registers a hook that may refuse a masking plan.
+func (r *Registry) AddMasking(h MaskingHook) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.masking = append(r.masking, h)
 }
 
 // AddLifecycle registers a hook that observes environments.
@@ -538,6 +599,23 @@ func (r *Registry) CheckPolicy(ctx context.Context, req EnvironmentRequest) erro
 
 	for _, h := range hooks {
 		if err := h.Check(ctx, req); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// CheckMasking runs every masking hook and returns the first refusal.
+//
+// Registration order and first refusal wins, the same as CheckPolicy, and with
+// nothing registered it returns nil after one pass over an empty slice.
+func (r *Registry) CheckMasking(ctx context.Context, req MaskingRequest) error {
+	r.mu.RLock()
+	hooks := append([]MaskingHook(nil), r.masking...)
+	r.mu.RUnlock()
+
+	for _, h := range hooks {
+		if err := h.CheckMasking(ctx, req); err != nil {
 			return err
 		}
 	}
@@ -856,6 +934,9 @@ func (r *Registry) Registered() []string {
 	for _, h := range r.policy {
 		out = append(out, "policy:"+h.Name())
 	}
+	for _, h := range r.masking {
+		out = append(out, "masking:"+h.Name())
+	}
 	for _, h := range r.lifecycle {
 		out = append(out, "lifecycle:"+h.Name())
 	}
@@ -888,7 +969,7 @@ func (r *Registry) Registered() []string {
 func (r *Registry) Empty() bool {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return len(r.policy) == 0 && len(r.lifecycle) == 0 &&
+	return len(r.policy) == 0 && len(r.masking) == 0 && len(r.lifecycle) == 0 &&
 		len(r.audit) == 0 && len(r.secrets) == 0 &&
 		len(r.databases) == 0 && len(r.datastores) == 0 &&
 		len(r.runtimes) == 0 && len(r.stores) == 0 && len(r.emulators) == 0

--- a/engine/pkg/extension/extension_test.go
+++ b/engine/pkg/extension/extension_test.go
@@ -166,6 +166,31 @@ func TestAMaskingHookSeesTheColumnsAndTheCatalogue(t *testing.T) {
 	require.Equal(t, req, *spy.seen)
 }
 
+func TestASecondMaskingHookUnderTheSameNameIsStillAsked(t *testing.T) {
+	t.Parallel()
+	// The question #335 raised about the runtime socket, asked of this one.
+	// RuntimeProviderNamed is a name keyed lookup that returns the FIRST
+	// match, so a second registration under one name is unreachable and reads
+	// as a feature. This socket has no lookup by name: every registration is
+	// consulted, in order. A masking hook that was silently dropped would be a
+	// policy that never runs, which is the failure this whole package is here
+	// to stop, so it is checked rather than reasoned about.
+	r := extension.NewRegistry()
+	first := &refusingMasking{name: "organization-policy"}
+	second := &refusingMasking{name: "organization-policy"}
+	r.AddMasking(first)
+	r.AddMasking(second)
+
+	require.NoError(t, r.CheckMasking(context.Background(),
+		extension.MaskingRequest{Repository: "acme/app"}))
+	require.NotNil(t, first.seen, "the first registration was not asked")
+	require.NotNil(t, second.seen, "a second registration under one name was silently dropped")
+	require.Equal(t, []string{
+		"masking:organization-policy",
+		"masking:organization-policy",
+	}, r.Registered(), "a registration that is consulted was not listed")
+}
+
 func TestAMaskingHookIsNamedInTheRegistrations(t *testing.T) {
 	t.Parallel()
 	// af doctor prints this. A hook that refuses environments and appears in

--- a/engine/pkg/extension/extension_test.go
+++ b/engine/pkg/extension/extension_test.go
@@ -26,6 +26,15 @@ func TestAnEmptyRegistryRefusesNothing(t *testing.T) {
 	}))
 }
 
+func TestAnEmptyRegistryRefusesNoMaskingPlan(t *testing.T) {
+	t.Parallel()
+	r := extension.NewRegistry()
+	require.True(t, r.Empty())
+	require.NoError(t, r.CheckMasking(context.Background(), extension.MaskingRequest{
+		Repository: "acme/app", MaskedColumns: []string{"public.users.email"},
+	}))
+}
+
 func TestAnEmptyRegistryObservesNothingAndReportsNoProblems(t *testing.T) {
 	t.Parallel()
 	r := extension.NewRegistry()
@@ -93,13 +102,78 @@ func TestAPolicyHookSeesWhatItNeedsToDecide(t *testing.T) {
 
 	req := extension.EnvironmentRequest{
 		Org: "acme", Repository: "acme/app", Branch: "feature/x", EnvID: "af-1",
-		EgressHosts:   []string{"api.stripe.com"},
-		EgressModes:   map[string]string{"api.stripe.com": "sandbox"},
-		MaskedColumns: []string{"users.email"},
-		Provider:      "neon", Region: "weu",
+		EgressHosts: []string{"api.stripe.com"},
+		EgressModes: map[string]string{"api.stripe.com": "sandbox"},
+		Provider:    "neon", Region: "weu",
 	}
 	require.NoError(t, r.CheckPolicy(context.Background(), req))
 	require.Equal(t, req, *spy.seen)
+}
+
+// ---------------------------------------------------------------------------
+
+type refusingMasking struct {
+	name string
+	err  error
+	seen *extension.MaskingRequest
+}
+
+func (r *refusingMasking) Name() string { return r.name }
+func (r *refusingMasking) CheckMasking(_ context.Context, req extension.MaskingRequest) error {
+	copied := req
+	r.seen = &copied
+	return r.err
+}
+
+func TestAMaskingHookCanRefuseAndTheRefusalReachesTheCaller(t *testing.T) {
+	t.Parallel()
+	r := extension.NewRegistry()
+	refusal := errors.New("organization policy requires users.email to be masked")
+	r.AddMasking(&refusingMasking{name: "masking", err: refusal})
+
+	err := r.CheckMasking(context.Background(), extension.MaskingRequest{Repository: "acme/app"})
+	require.ErrorIs(t, err, refusal)
+}
+
+func TestTheFirstMaskingRefusalWinsAndLaterHooksDoNotRun(t *testing.T) {
+	t.Parallel()
+	r := extension.NewRegistry()
+	first := &refusingMasking{name: "first", err: errors.New("no")}
+	second := &refusingMasking{name: "second", err: errors.New("also no")}
+	r.AddMasking(first)
+	r.AddMasking(second)
+
+	err := r.CheckMasking(context.Background(), extension.MaskingRequest{Repository: "acme/app"})
+	require.ErrorIs(t, err, first.err)
+	require.Nil(t, second.seen, "a later hook ran after an earlier one refused")
+}
+
+func TestAMaskingHookSeesTheColumnsAndTheCatalogue(t *testing.T) {
+	t.Parallel()
+	// Both lists, because neither answers the question on its own. Masked
+	// columns alone cannot tell a database with no email column from one with
+	// three unmasked ones, and those deserve opposite answers.
+	r := extension.NewRegistry()
+	spy := &refusingMasking{name: "spy"}
+	r.AddMasking(spy)
+
+	req := extension.MaskingRequest{
+		Repository: "acme/app", Branch: "feature/x", EnvID: "af-1", RulesHash: "h1",
+		MaskedColumns:  []string{"public.users.email"},
+		CatalogColumns: []string{"public.users.email", "public.users.id"},
+	}
+	require.NoError(t, r.CheckMasking(context.Background(), req))
+	require.Equal(t, req, *spy.seen)
+}
+
+func TestAMaskingHookIsNamedInTheRegistrations(t *testing.T) {
+	t.Parallel()
+	// af doctor prints this. A hook that refuses environments and appears in
+	// no listing is one nobody debugging a refusal can find.
+	r := extension.NewRegistry()
+	r.AddMasking(&refusingMasking{name: "organization-policy"})
+	require.Equal(t, []string{"masking:organization-policy"}, r.Registered())
+	require.False(t, r.Empty())
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## The failure

`extension.EnvironmentRequest` carried `MaskedColumns`, the enterprise policy
read it in `checkMasking`, and no code anywhere wrote to it. So
`required_masked_columns` was evaluated against an empty list on every
environment. An organization that configured the rule got a licence granting the
feature, a startup line printing the rule, and no refusal on any repository ever.
The only reason it did not refuse everything instead is that a policy naming no
columns returns before it looks.

## Why it could not be filled where it was read

`checkPolicy` runs before anything is created, deliberately, so that a refusal
leaves nothing behind. What it holds at that point is a manifest, and a manifest
enumerates services rather than columns. The only list buildable there is the
repository's masking rules expanded against the tables the manifest happens to
mention, which is a different set from the tables that exist, and `coveredBy`
treats a pattern matching nothing as unsatisfied on purpose. A manifest-only
expansion would therefore refuse every repository whose rules reach a table its
manifest never names. A false refusal in a masking gate is worse than a missing
field.

## What this builds

A second socket, `extension.MaskingHook`, consulted from `maskDatabase` after
`masking.ReadCatalog` has read the schema and after the rules have been assigned
to it, and before the executor rewrites the first row. It carries the columns the
plan will rewrite and the whole catalogue they came from. A refusal there means
the golden is never published, and `provider.Branch` refuses a version that was
not published, so no environment can hold data the policy refused. That is later
than the policy hook and it is still before the data exists.

`RegisterFromEnvironment` plugs the enterprise hook into both sockets, because
forgetting one is silent: the rule still parses, the startup line still prints
it, and nothing refuses.

Having the catalogue also makes the rule mean what an administrator wrote.
`coveredBy` was satisfied by one match, so a plan that masked `users.email` and
left `contacts.email` readable passed a policy that says every email column must
be masked. `CheckMasking` now requires every catalogue column a pattern names to
be masked, and names the ones that are not. A pattern matching no column at all
is still unsatisfied, for the reason `coveredBy` gave.

## The reader

`ee/engine/policyenforce.Hook.CheckMasking` reads both lists.
`tools/socketcheck` reports it independently:

```
MaskingHook          CheckMasking, at engine/internal/env/golden.go:622
```

## What this does not close

A golden published before a policy was tightened is not re-examined, because
nothing on a published golden records which columns were masked. The masking
rules digest is part of a golden's provenance and selection already refuses a
golden made under different rules, so the exposure is a policy that changed while
the rules did not. Closing it means recording the masked column list in the
signed attestation and re-checking it at selection, which is a change to what
`verify.Sign` covers. The documentation says to refresh the golden after a policy
change.
