### PR TITLE
ci: the edition boundary said edition and meant engine

### DIFF
--- a/.changes/edition-boundary-said-edition-and-meant-engine.md
+++ b/.changes/edition-boundary-said-edition-and-meant-engine.md
@@ -1,0 +1,16 @@
+# fixed
+
+The `edition boundary` check reported a failure it had not tested. The step
+deleted `ee`, ran the whole community suite, and called anything that came back
+red an edition violation. On the night of 2026-09-08 that was 13 of the 25 open
+pull requests, and not one of them was an edition violation: nine distinct
+engine test failures accounted for all thirteen, every one of them reproducible
+with `ee` present, and the `engine` job was red on all thirteen for the same
+reason. Thirteen branches were sent to look for an enterprise import that was
+never there.
+
+The gate now runs the packages it saw fail a second time with `ee` back. One
+that fails both ways is the engine job's finding and is reported as such; one
+that passes with `ee` and fails without it is the violation, and is still
+refused; one that cannot be told apart from a flake is reported as undecided
+rather than as either.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1041,7 +1041,10 @@ jobs:
   edition-boundary:
     name: edition boundary
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # A failing run costs more than a passing one here, because the packages
+    # that failed are run again with ee present to find out whether ee had
+    # anything to do with it. That second look is what the minutes buy.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -1071,14 +1074,18 @@ jobs:
           test -x /usr/lib/postgresql/17/bin/pg_dump
 
       - name: The community build does not need ee
-        # The proof rather than the assertion. ee is deleted and everything
-        # still builds and passes, which is what the community binary is built
-        # from. A comment saying the boundary holds is not evidence.
-        run: |
-          rm -rf ee
-          cd engine
-          go build ./...
-          go test ./internal/... -short -count=1 -timeout 15m
+        # The proof rather than the assertion. ee is taken away and everything
+        # still has to build and pass, which is what the community binary is
+        # built from. A comment saying the boundary holds is not evidence.
+        #
+        # It used to be four lines of shell here, and the shell could not tell
+        # an edition violation from an engine test that was failing anyway. On
+        # 2026-09-08 that made this required context red on 13 of the 25 open
+        # pull requests, none of which were edition violations, and sent
+        # thirteen branches looking for an enterprise import that was not
+        # there. tools/editioncheck runs the packages it saw fail a second
+        # time with ee back, and reports which question it actually answered.
+        run: go run ./tools/editioncheck .
 
       - name: No engine package imports ee
         run: |
@@ -1093,7 +1100,6 @@ jobs:
         # compile error, and this checks the artifact anyway, because the thing
         # a customer runs is the binary and not the source tree.
         run: |
-          git checkout -- . 2>/dev/null || true
           cd engine
           CGO_ENABLED=0 go build -o /tmp/af-community ./cmd/af
           if strings /tmp/af-community | grep -E 'antifailure/(antifailure/)?ee/'; then

--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,7 @@ runner/artifacts/
 /docscheck
 /docsembed
 /dogfood
+/editioncheck
 /errcheck
 /errgen
 /eventcheck

--- a/justfile
+++ b/justfile
@@ -1617,9 +1617,17 @@ lint-platforms:
     cd engine && GOOS=darwin golangci-lint run --timeout 15m
 
 # The community build does not contain or need the enterprise edition.
+#
+# editioncheck is the half CI ran and this recipe did not. `just edition` used
+# to grep and inspect the binary while the workflow also took ee away and ran
+# the whole community suite, so a green run here was never the green CI it
+# reads as. It moves ee aside rather than deleting it, and puts it back on any
+# exit including an interrupt, because unlike a runner your checkout is not
+# thrown away afterwards.
 edition:
     #!/usr/bin/env bash
     set -euo pipefail
+    go run ./tools/editioncheck .
     if grep -rn --include='*.go' 'antifailure/antifailure/ee' engine tools; then
       echo "an engine package imports ee, which the community build does not have"
       exit 1

--- a/tools/editioncheck/main.go
+++ b/tools/editioncheck/main.go
@@ -1,0 +1,349 @@
+// Command editioncheck proves the community tree does not need the enterprise
+// edition, and says why it is red when it is red.
+//
+// The property is real and worth a gate. A stray Go import of `ee` is already
+// a compile error, because `ee/engine` is a separate module outside the
+// workspace, so the interesting violation is the one the compiler cannot see:
+// a package under `engine` that reads a path inside `ee` at test time, or a
+// generator that only works because those files happen to be present. The way
+// to catch that is to take `ee` away and run the community suite.
+//
+// The failure that produced this tool is what happens on the next line. The
+// step used to be `rm -rf ee`, then `go build ./...`, then `go test
+// ./internal/... -short`, and it reported every one of those as "edition
+// boundary". On the night of 2026-09-08, 13 of 25 open pull requests were red
+// on this required context and NOT ONE of them was an edition violation. Nine
+// distinct engine test failures accounted for all thirteen: a stale
+// `pages.gen.go`, a stale `sources.gen.go`, a schema drift, and six emulator
+// and egress suites. Every one of them failed identically with `ee` present,
+// and the `engine` job was red on all thirteen for the same reason. Thirteen
+// lanes were told to look for an enterprise import that was never there.
+//
+// A gate that fails for a reason it did not test is worse than a gate that
+// does not run, because it spends somebody's night on the wrong file. So this
+// runs the suite twice when it has to. A package that fails with `ee` gone and
+// fails the same way with `ee` present has said nothing about the edition
+// boundary: that is the engine job's finding, and this reports it as such and
+// passes. A package that PASSES with `ee` present and fails without it is the
+// violation this gate exists for, and it is refused.
+//
+// It can still say no, which is the whole point, and `main_test.go` proves it
+// against both shapes: a package that fails either way, which must not be
+// called an edition violation, and a package that reads a file under `ee`,
+// which must be. A third verdict exists for the case the instrument could not
+// decide: a package that fails without `ee`, passes with it, and then passes
+// again without it is flaky rather than dependent, and this says so and fails
+// rather than accusing it or waving it through.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"syscall"
+)
+
+// hidden is where `ee` is moved while the community suite runs. A rename keeps
+// the tree restorable when this is run on a developer's checkout, which
+// `rm -rf ee` did not: the CI step it replaces relied on the workspace being
+// thrown away afterwards, and the same command in the justfile would have
+// deleted a contributor's enterprise source.
+const hidden = ".ee-hidden-by-editioncheck"
+
+// The community module and what the community build actually compiles and
+// runs. `./internal/...` rather than `./...` mirrors the step this replaces.
+const (
+	moduleDir = "engine"
+	testScope = "./internal/..."
+)
+
+// buildPseudoPackage names the compile step in a report, so that "the tree
+// does not build without ee" travels through the same classification as a
+// failing package instead of being a separate branch nobody reads.
+const buildPseudoPackage = "(go build " + moduleDir + ")"
+
+// swap moves ee aside and puts it back, and is safe to call from the signal
+// handler as well as from the run.
+type swap struct {
+	mu     sync.Mutex
+	ee     string
+	away   string
+	hidden bool
+}
+
+func (s *swap) hide() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.hidden {
+		return nil
+	}
+	if err := os.Rename(s.ee, s.away); err != nil {
+		return err
+	}
+	s.hidden = true
+	return nil
+}
+
+func (s *swap) restore() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.hidden {
+		return nil
+	}
+	if err := os.Rename(s.away, s.ee); err != nil {
+		return err
+	}
+	s.hidden = false
+	return nil
+}
+
+// recover puts back a tree left aside by a run that died before it could. A
+// previous run that was killed between the two renames is the one state a
+// developer cannot be expected to recognise, and leaving it means the next
+// run reports "no ee directory" about a tree that has one.
+func (s *swap) recover() error {
+	_, hiddenErr := os.Stat(s.away)
+	if hiddenErr != nil {
+		return nil
+	}
+	if _, err := os.Stat(s.ee); err == nil {
+		return fmt.Errorf("both %s and %s exist, so a previous run left something behind "+
+			"and this cannot tell which tree is the real one. Look before deleting either", s.ee, s.away)
+	}
+	if err := os.Rename(s.away, s.ee); err != nil {
+		return fmt.Errorf("a previous run left %s aside and it could not be put back: %w", s.ee, err)
+	}
+	fmt.Fprintf(os.Stderr, "a previous run left %s aside and it has been put back\n", s.ee)
+	return nil
+}
+
+// runner runs a command in a directory under the repository root and returns
+// its combined output and whether it succeeded. It is a parameter so that the
+// classification can be driven against a fixture tree by the tests.
+type runner func(dir string, args ...string) (string, bool)
+
+// report is what the run decided, per package.
+type report struct {
+	// dependent fails without ee and passes with it. The violation.
+	dependent []string
+	// unrelated fails both ways. Not this gate's finding.
+	unrelated []string
+	// unclear could not be decided, which is neither a pass nor a catch.
+	unclear []string
+}
+
+func (r report) ok() bool { return len(r.dependent) == 0 && len(r.unclear) == 0 }
+
+func main() {
+	root := flag.String("root", ".", "repository root")
+	flag.Parse()
+	if args := flag.Args(); len(args) > 0 {
+		*root = args[0]
+	}
+
+	rep, err := check(*root, shell)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "editioncheck could not run: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Print(rep.render())
+	if !rep.ok() {
+		os.Exit(1)
+	}
+}
+
+// shell is the real runner.
+func shell(dir string, args ...string) (string, bool) {
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Dir = dir
+	// The enterprise module is outside the workspace and the community build
+	// must not be handed a workspace that could resolve it. GOFLAGS is cleared
+	// so an ambient one cannot quietly change what is compiled.
+	cmd.Env = append(os.Environ(), "GOFLAGS=")
+	out, err := cmd.CombinedOutput()
+	return string(out), err == nil
+}
+
+// check hides ee, runs the community build and suite, and attributes every
+// failure it finds. ee is restored before it returns, on every path.
+func check(root string, run runner) (report, error) {
+	sw := &swap{ee: filepath.Join(root, "ee"), away: filepath.Join(root, hidden)}
+	if err := sw.recover(); err != nil {
+		return report{}, err
+	}
+	if _, err := os.Stat(sw.ee); err != nil {
+		return report{}, fmt.Errorf("no ee directory at %s, so nothing was taken away and nothing was proved: %w", sw.ee, err)
+	}
+	if err := sw.hide(); err != nil {
+		return report{}, fmt.Errorf("could not take ee away: %w", err)
+	}
+	// A run that is interrupted must not leave somebody's enterprise source
+	// under a dotted name. This is why the tree is moved rather than deleted,
+	// and the deletion is what the step this replaces did: on a runner that is
+	// thrown away it costs nothing, and the same command in the justfile would
+	// have destroyed a contributor's working copy.
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sig)
+	go func() {
+		if _, open := <-sig; !open {
+			return
+		}
+		_ = sw.restore()
+		fmt.Fprintf(os.Stderr, "\ninterrupted, and %s was put back\n", sw.ee)
+		os.Exit(1)
+	}()
+	restore := sw.restore
+	hide := sw.hide
+	defer func() { _ = restore() }()
+
+	mod := filepath.Join(root, moduleDir)
+
+	// Without ee. A build failure is classified through the same path as a
+	// test failure, because "it does not compile without ee" and "it does not
+	// compile at all" are the same two answers and only one of them is ours.
+	var failed []string
+	if _, ok := run(mod, "go", "build", "./..."); !ok {
+		failed = append(failed, buildPseudoPackage)
+	} else {
+		out, ok := run(mod, "go", "test", testScope, "-short", "-count=1", "-timeout", "15m")
+		if !ok {
+			failed = failedPackages(out)
+			if len(failed) == 0 {
+				// The suite said no and named nothing. That is an instrument
+				// that could not look, not a pass.
+				return report{unclear: []string{"the community suite failed without naming a package"}}, nil
+			}
+		}
+	}
+	if len(failed) == 0 {
+		return report{}, nil
+	}
+
+	// With ee. Only the packages that already failed, so the second run costs
+	// what the failure costs rather than what the suite costs.
+	if err := restore(); err != nil {
+		return report{}, fmt.Errorf("could not put ee back: %w", err)
+	}
+	withEE := map[string]bool{}
+	if failed[0] == buildPseudoPackage {
+		if _, ok := run(mod, "go", "build", "./..."); !ok {
+			withEE[buildPseudoPackage] = true
+		}
+	} else {
+		args := append([]string{"go", "test"}, failed...)
+		args = append(args, "-short", "-count=1", "-timeout", "15m")
+		out, ok := run(mod, args...)
+		if !ok {
+			for _, pkg := range failedPackages(out) {
+				withEE[pkg] = true
+			}
+		}
+	}
+
+	var rep report
+	for _, pkg := range failed {
+		if withEE[pkg] {
+			rep.unrelated = append(rep.unrelated, pkg)
+			continue
+		}
+		// Accused. Before naming a package as reaching into ee, reproduce it:
+		// a test that fails once without ee and passes with it is as likely to
+		// be flaky as dependent, and this gate must not turn a flake into an
+		// edition violation.
+		if err := hide(); err != nil {
+			return report{}, fmt.Errorf("could not take ee away for the second look: %w", err)
+		}
+		var again bool
+		if pkg == buildPseudoPackage {
+			_, ok := run(mod, "go", "build", "./...")
+			again = !ok
+		} else {
+			_, ok := run(mod, "go", "test", pkg, "-short", "-count=1", "-timeout", "15m")
+			again = !ok
+		}
+		if err := restore(); err != nil {
+			return report{}, fmt.Errorf("could not put ee back: %w", err)
+		}
+		if again {
+			rep.dependent = append(rep.dependent, pkg)
+		} else {
+			rep.unclear = append(rep.unclear, pkg)
+		}
+	}
+	sort.Strings(rep.dependent)
+	sort.Strings(rep.unrelated)
+	sort.Strings(rep.unclear)
+	return rep, nil
+}
+
+// failedPackages reads the package names out of a `go test` run.
+//
+// It reads the per package summary line rather than the lines a failing test
+// prints, because a package can fail without any test failing: `[build
+// failed]` and `[setup failed]` both arrive on the summary line and on no
+// other, and a gate that only counted failing tests would call a package that
+// could not compile a pass.
+func failedPackages(out string) []string {
+	seen := map[string]bool{}
+	var pkgs []string
+	for _, line := range strings.Split(out, "\n") {
+		if !strings.HasPrefix(line, "FAIL\t") && !strings.HasPrefix(line, "FAIL ") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 || !strings.Contains(fields[1], "/") {
+			continue
+		}
+		if seen[fields[1]] {
+			continue
+		}
+		seen[fields[1]] = true
+		pkgs = append(pkgs, fields[1])
+	}
+	sort.Strings(pkgs)
+	return pkgs
+}
+
+// render says which question was answered and which was not, in the words
+// somebody reading a red required context needs.
+func (r report) render() string {
+	var b strings.Builder
+	if len(r.unrelated) > 0 {
+		b.WriteString("These packages fail with ee present and with ee absent, so they say\n")
+		b.WriteString("nothing about the edition boundary. They are the engine job's finding:\n")
+		for _, p := range r.unrelated {
+			fmt.Fprintf(&b, "  %s\n", p)
+		}
+		b.WriteString("Fix them there. This gate is not what is telling you about them.\n\n")
+	}
+	if len(r.unclear) > 0 {
+		b.WriteString("COULD-NOT-LOOK. These failed without ee, passed with it, and then\n")
+		b.WriteString("passed again without it, so this cannot tell a flake from a package\n")
+		b.WriteString("that reaches into ee:\n")
+		for _, p := range r.unclear {
+			fmt.Fprintf(&b, "  %s\n", p)
+		}
+		b.WriteString("\n")
+	}
+	if len(r.dependent) > 0 {
+		b.WriteString("These pass with ee present and fail with ee absent, so the community\n")
+		b.WriteString("build needs the enterprise edition, which it does not have:\n")
+		for _, p := range r.dependent {
+			fmt.Fprintf(&b, "  %s\n", p)
+		}
+		b.WriteString("\n")
+	}
+	if r.ok() && len(r.unrelated) == 0 {
+		b.WriteString("the community tree builds and passes with ee taken away\n")
+	} else if r.ok() {
+		b.WriteString("the edition boundary holds: nothing here needed ee\n")
+	}
+	return b.String()
+}

--- a/tools/editioncheck/main_test.go
+++ b/tools/editioncheck/main_test.go
@@ -1,0 +1,248 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Every case here drives the real `go` toolchain over a real module, because
+// the thing under test is what happens when a directory is taken away and a
+// suite is run twice. A table of strings would prove the classifier and not
+// the gate, and the defect this replaces was in the gate.
+
+// tree writes a community module with the packages named, plus an ee
+// directory to take away. Each package is a name and the body of its test.
+func tree(t *testing.T, packages map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "ee"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "ee", "marker.txt"),
+		[]byte("the enterprise edition lives here\n"), 0o644))
+
+	engine := filepath.Join(root, moduleDir)
+	require.NoError(t, os.MkdirAll(engine, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(engine, "go.mod"),
+		[]byte("module example/engine\n\ngo 1.26.0\n"), 0o644))
+
+	for name, body := range packages {
+		dir := filepath.Join(engine, "internal", name)
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "pkg.go"),
+			[]byte("package "+name+"\n"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "pkg_test.go"),
+			[]byte(body), 0o644))
+	}
+	return root
+}
+
+// passing is a package whose test does nothing and succeeds.
+func passing(name string) string {
+	return fmt.Sprintf("package %s\n\nimport \"testing\"\n\nfunc TestPasses(t *testing.T) {}\n", name)
+}
+
+// alwaysFails is the shape of the nine real failures: a stale generated file,
+// a schema drift, an emulator suite. It fails with ee and without it.
+func alwaysFails(name string) string {
+	return fmt.Sprintf("package %s\n\nimport \"testing\"\n\n"+
+		"func TestStaleGeneratedFile(t *testing.T) {\n\tt.Fatal(\"pages.gen.go is stale\")\n}\n", name)
+}
+
+// readsEE is the violation the gate exists for: no import, so the compiler
+// cannot see it, but the package cannot work without the enterprise tree on
+// disk.
+func readsEE(name string) string {
+	return fmt.Sprintf("package %s\n\nimport (\n\t\"os\"\n\t\"testing\"\n)\n\n"+
+		"func TestReadsTheEnterpriseTree(t *testing.T) {\n"+
+		"\tif _, err := os.Stat(\"../../../ee/marker.txt\"); err != nil {\n"+
+		"\t\tt.Fatalf(\"the enterprise tree is not there: %%v\", err)\n\t}\n}\n", name)
+}
+
+// flaky fails the first time it is run and passes every time after, by
+// consuming a marker its own package directory carries.
+func flaky(name string) string {
+	return fmt.Sprintf("package %s\n\nimport (\n\t\"os\"\n\t\"testing\"\n)\n\n"+
+		"func TestFlaky(t *testing.T) {\n"+
+		"\tif _, err := os.Stat(\"first-run\"); err == nil {\n"+
+		"\t\tos.Remove(\"first-run\")\n\t\tt.Fatal(\"failed once and will not fail again\")\n\t}\n}\n", name)
+}
+
+func TestACleanTreePassesWithEeTakenAway(t *testing.T) {
+	root := tree(t, map[string]string{"clean": passing("clean")})
+	rep, err := check(root, shell)
+	require.NoError(t, err)
+	require.True(t, rep.ok(), "a tree that needs nothing from ee must pass: %+v", rep)
+	require.Empty(t, rep.unrelated)
+	require.Contains(t, rep.render(), "builds and passes with ee taken away")
+}
+
+// The exact case that produced this tool. Thirteen pull requests were told
+// their edition boundary was broken by a stale generated file.
+func TestAPackageThatFailsWithEePresentIsNotAnEditionViolation(t *testing.T) {
+	root := tree(t, map[string]string{"stale": alwaysFails("stale")})
+	rep, err := check(root, shell)
+	require.NoError(t, err)
+	require.True(t, rep.ok(),
+		"a failure that reproduces with ee present is not this gate's finding")
+	require.Equal(t, []string{"example/engine/internal/stale"}, rep.unrelated)
+	require.Empty(t, rep.dependent, "it must not be named as needing ee")
+	require.Contains(t, rep.render(), "the engine job's finding")
+}
+
+// The proof it can still say no.
+func TestAPackageThatReachesIntoEeIsRefused(t *testing.T) {
+	root := tree(t, map[string]string{"reaches": readsEE("reaches")})
+	rep, err := check(root, shell)
+	require.NoError(t, err)
+	require.Equal(t, []string{"example/engine/internal/reaches"}, rep.dependent)
+	require.False(t, rep.ok(), "a package that needs ee must fail this gate")
+	require.Contains(t, rep.render(), "the community\nbuild needs the enterprise edition")
+}
+
+// The two must not cancel out. An unrelated failure alongside a real one is
+// how a loosened gate goes quietly green.
+func TestAnUnrelatedFailureDoesNotHideARealViolation(t *testing.T) {
+	root := tree(t, map[string]string{
+		"stale":   alwaysFails("stale"),
+		"reaches": readsEE("reaches"),
+		"clean":   passing("clean"),
+	})
+	rep, err := check(root, shell)
+	require.NoError(t, err)
+	require.False(t, rep.ok(), "the real violation must still refuse the tree")
+	require.Equal(t, []string{"example/engine/internal/reaches"}, rep.dependent)
+	require.Equal(t, []string{"example/engine/internal/stale"}, rep.unrelated)
+}
+
+func TestAFlakeIsReportedAsUndecidedRatherThanAsAViolation(t *testing.T) {
+	root := tree(t, map[string]string{"unsteady": flaky("unsteady")})
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, moduleDir, "internal", "unsteady", "first-run"), []byte("x"), 0o644))
+
+	rep, err := check(root, shell)
+	require.NoError(t, err)
+	require.Equal(t, []string{"example/engine/internal/unsteady"}, rep.unclear)
+	require.Empty(t, rep.dependent, "one failure and one pass is not evidence of a dependency")
+	require.False(t, rep.ok(), "an undecided answer is not a pass")
+	require.Contains(t, rep.render(), "COULD-NOT-LOOK")
+}
+
+// A community tree that does not compile without ee is the same violation
+// arriving one stage earlier, and it must be classified the same way.
+func TestATreeThatOnlyCompilesWithEeIsRefused(t *testing.T) {
+	root := tree(t, map[string]string{"clean": passing("clean")})
+	writeEEModule(t, root)
+	engine := filepath.Join(root, moduleDir)
+	require.NoError(t, os.WriteFile(filepath.Join(engine, "go.mod"),
+		[]byte("module example/engine\n\ngo 1.26.0\n\nrequire example/ee v0.0.0\n\nreplace example/ee => ../ee\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(engine, "internal", "clean", "uses.go"),
+		[]byte("package clean\n\nimport \"example/ee\"\n\nvar _ = ee.Name\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(engine, "go.sum"), nil, 0o644))
+
+	rep, err := check(root, shell)
+	require.NoError(t, err)
+	require.Equal(t, []string{buildPseudoPackage}, rep.dependent)
+	require.False(t, rep.ok())
+}
+
+// And a tree that was already broken must not be blamed on the boundary.
+func TestATreeThatDoesNotCompileEitherWayIsNotAnEditionViolation(t *testing.T) {
+	root := tree(t, map[string]string{"broken": passing("broken")})
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, moduleDir, "internal", "broken", "pkg.go"),
+		[]byte("package broken\n\nthis is not go\n"), 0o644))
+
+	rep, err := check(root, shell)
+	require.NoError(t, err)
+	require.Equal(t, []string{buildPseudoPackage}, rep.unrelated)
+	require.Empty(t, rep.dependent)
+	require.True(t, rep.ok(), "a tree that never compiled says nothing about ee")
+}
+
+// ee must be on disk again whatever happened, because this runs on a
+// contributor's checkout as well as on a runner that is thrown away.
+func TestEeIsPutBackAfterEveryVerdict(t *testing.T) {
+	for name, body := range map[string]string{
+		"clean":   passing("clean"),
+		"stale":   alwaysFails("stale"),
+		"reaches": readsEE("reaches"),
+	} {
+		root := tree(t, map[string]string{name: body})
+		_, err := check(root, shell)
+		require.NoError(t, err)
+		require.DirExists(t, filepath.Join(root, "ee"), "ee was not put back after %s", name)
+		require.NoDirExists(t, filepath.Join(root, hidden))
+	}
+}
+
+func TestARunWithNoEeDirectoryIsAnErrorRatherThanAPass(t *testing.T) {
+	root := tree(t, map[string]string{"clean": passing("clean")})
+	require.NoError(t, os.RemoveAll(filepath.Join(root, "ee")))
+	_, err := check(root, shell)
+	require.Error(t, err, "nothing was taken away, so nothing was proved")
+	require.Contains(t, err.Error(), "nothing was proved")
+}
+
+func TestFailedPackagesReadsTheSummaryLineAndNotTheFailingTest(t *testing.T) {
+	out := strings.Join([]string{
+		"--- FAIL: TestSomething (0.00s)",
+		"FAIL",
+		"FAIL\tgithub.com/a/b/internal/docs\t0.008s",
+		"ok  \tgithub.com/a/b/internal/fine\t0.100s",
+		"FAIL\tgithub.com/a/b/internal/cli [build failed]",
+		"FAIL\tgithub.com/a/b/internal/cli [build failed]",
+		"FAIL\tgithub.com/a/b/internal/db [setup failed]",
+	}, "\n")
+	require.Equal(t, []string{
+		"github.com/a/b/internal/cli",
+		"github.com/a/b/internal/db",
+		"github.com/a/b/internal/docs",
+	}, failedPackages(out),
+		"a package that could not build or set up fails on this line and on no other")
+}
+
+func TestASuiteThatFailsWithoutNamingAPackageIsUndecided(t *testing.T) {
+	rep, err := check(tree(t, map[string]string{"clean": passing("clean")}),
+		func(dir string, args ...string) (string, bool) {
+			if args[1] == "build" {
+				return "", true
+			}
+			return "signal: killed\n", false
+		})
+	require.NoError(t, err)
+	require.False(t, rep.ok(), "a suite that died is not a pass and is not a catch")
+	require.Contains(t, rep.render(), "COULD-NOT-LOOK")
+}
+
+func writeEEModule(t *testing.T, root string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "ee", "go.mod"),
+		[]byte("module example/ee\n\ngo 1.26.0\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "ee", "ee.go"),
+		[]byte("package ee\n\n// Name is what the community build must not need.\nconst Name = \"enterprise\"\n"), 0o644))
+}
+
+func TestATreeLeftAsideByAnInterruptedRunIsPutBack(t *testing.T) {
+	root := tree(t, map[string]string{"clean": passing("clean")})
+	require.NoError(t, os.Rename(filepath.Join(root, "ee"), filepath.Join(root, hidden)))
+
+	rep, err := check(root, shell)
+	require.NoError(t, err, "a tree left aside by a killed run must be recovered, not reported as missing")
+	require.True(t, rep.ok())
+	require.DirExists(t, filepath.Join(root, "ee"))
+	require.NoDirExists(t, filepath.Join(root, hidden))
+}
+
+func TestTwoTreesAreARefusalRatherThanAGuess(t *testing.T) {
+	root := tree(t, map[string]string{"clean": passing("clean")})
+	require.NoError(t, os.MkdirAll(filepath.Join(root, hidden), 0o755))
+
+	_, err := check(root, shell)
+	require.Error(t, err, "which of the two is the real ee is not something this may guess")
+	require.Contains(t, err.Error(), "cannot tell which tree is the real one")
+}


### PR DESCRIPTION
## The failure

`edition boundary` is a required context, and on the night of 2026-09-08 it was
red on 13 of the 25 open pull requests: 306, 309, 311, 312, 314, 315, 317, 318,
320, 321, 325, 326 and 327. Main was green.

None of the thirteen was an edition violation.

The job's first step was four lines of shell. Delete `ee`, build the community
module, run `go test ./internal/... -short`, and let the exit code be the
verdict. Every one of the thirteen failed inside that `go test`. The two steps
that actually test the rule, the grep for an `antifailure/antifailure/ee`
import and the `strings` pass over the community binary, never ran on any of
them, and pass on all thirteen when run by hand.

Nine distinct engine failures accounted for the thirteen red marks:

| signature | pull requests |
| --- | --- |
| stale `pages.gen.go`, `TestEmbeddedPagesAreTheDocumentationThatShips` | 306 309 312 314 317 318 320 326 |
| emulator and egress suites in `runtime/local` | 306 312 314 318 325 |
| stale `sources.gen.go`, `TestSources_MatchTheRealPackages` | 311 315 321 326 |
| manifest schema drift, `TestSchemaAndGoTypesDoNotDrift` and friends | 311 315 326 327 |
| fidelity benchmarks | 311 327 |
| command reference out of step with the tree | 315 |
| `TestLicense_StatusInJSONNamesTheEdition` | 320 |
| `TestEveryFieldTheSidecarRecordsSurvivesTheDecodeIntoADecision` | 326 |
| `TestEverySchemaConstraintIsEnforced` | 327 |

The `engine` job was red on all thirteen for the same reasons, so the gate was
telling nobody anything the job beside it had not said, under a name that sent
thirteen branches looking for an enterprise import that was never there.

Two were reproduced by hand at the branch head with `ee` fully present. PR309's
`internal/docs` and PR321's `internal/proxyimage` fail identically with the
enterprise tree in place.

## What changed

The experiment was right and the reporting had no control. `tools/editioncheck`
runs the packages it saw fail a second time with `ee` put back:

- fails both ways: the engine job's finding, named as such, and this gate
  passes because it did not observe anything about the boundary
- passes with `ee` and fails without it: the violation, refused
- fails once, passes with `ee`, then passes again without it: undecided, and
  said so rather than accused or waved through

`ee` is moved aside rather than deleted, restored on every exit including an
interrupt, and a tree left aside by a killed run is recovered on the next one.
The old `rm -rf ee` was survivable only because a runner is thrown away, and
`just edition` now runs this too.

## What it still refuses

Thirteen tests, each mutation tested with one break per assertion, 11 of 11
cells CAUGHT on the first matrix and 2 of 2 on the second. Beyond the fixture
suite, two experiments on the real repository:

- at PR309's head, narrowed to the package that was red, the tool reports
  `internal/docs` as the engine job's finding and exits 0. That is the exact
  case that produced the wrong answer.
- with a package added under `engine/internal` that stats `../../../ee` at test
  time and no import at all, the tool reports it as needing the enterprise
  edition and exits 1. `ee` was on disk after both.

## The boundary itself

Nothing in this branch loosens what MIT means. No engine or tools package
imports `ee` on any of the thirteen branches, and no candidate for moving a
containment package out of `ee` and into `engine` turned up: the gate never
flagged a placement, because it never reached the steps that would.
