### PR TITLE
ci: the step that said generated files were stale was wrong about three of the eleven it stopped

### DIFF
--- a/.changes/the-step-that-said-generated-files-were-stale-when-a-test-had-failed.md
+++ b/.changes/the-step-that-said-generated-files-were-stale-when-a-test-had-failed.md
@@ -1,0 +1,30 @@
+# fixed
+
+The check that said your generated files were stale was wrong about three of
+the eleven pull requests it stopped.
+
+One CI step ran thirteen generators and then compared, and it was named
+"Generated files are current". Four of those generators are
+`go test <package> -update-something`, which runs the whole package, so a test
+in the engine's cli package that has nothing to do with any committed artifact
+failed under that name. On one morning it said that about three branches whose
+generated files were fine.
+
+The other eight had really drifted, and there the step printed a diff and
+stopped. A diff names the file that moved. It does not name which of the
+thirteen generators owns it, so the only remedy a reader could infer was
+`just generate`, the whole set, several minutes of npm and Docker. Six of those
+eight needed `go run ./tools/docsembed` alone, which takes about a second.
+
+The generating and the comparing are two steps now, so the name asserts only
+what the step checked, and the comparison is `tools/gendrift`, which groups the
+drifted paths under the command that rewrites each one. It also refuses two
+things the old comparison could not see: a generated file that is new and
+therefore untracked, which `git diff` cannot report at all, and a ledger row
+pointing at a path no longer in the tree, which would otherwise go on printing
+a number about a file it had stopped comparing.
+
+The local gate compared a hand written list of paths in the justfile while CI
+compared the whole tree, so the two asked different questions. Both run this
+now, and only CI passes `-strict`, which additionally refuses a changed path no
+generator claims.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
         run: npx playwright install --with-deps chromium
         working-directory: runner
 
-      - name: Generated files are current
+      - name: The generators run, and so do the tests of the packages they live in
         # The error catalog and the sidecar's packaged source are generated and
         # checked in. A drift between the generator and what is committed is
         # invisible until somebody wonders why their change did nothing.
@@ -135,6 +135,16 @@ jobs:
         # A release published a fresh file while this repository carried a stale
         # one, and the stale one is what a legal review opens. No release job
         # can see that half of it, because it never reads the committed copy.
+        #
+        # Named for what it does rather than for what the next step checks.
+        # Four of these are `go test <pkg> -update-something`, which runs the
+        # WHOLE package, so a test in engine/internal/cli that has nothing to
+        # do with the committed reference fails here. Under the old name this
+        # step said "Generated files are current", and on 2026-09-08 it said
+        # that about three pull requests whose generated files were fine and
+        # whose cli tests were red. Three lanes went to look at the wrong
+        # thing, which is what a step name that asserts more than the step
+        # checked costs.
         run: |
           go run ./tools/errgen
           go run ./tools/lintgen
@@ -148,7 +158,24 @@ jobs:
           go run ./tools/eventcheck -freeze .
           (cd engine && go test ./internal/masking -update-transforms)
           (cd engine && go test ./internal/hud -update-frames)
-          git diff --exit-code
+
+      - name: Generated files are current
+        # Now this step fails for one reason and says which generator to run.
+        #
+        # It used to be `git diff --exit-code` on the end of the block above,
+        # which printed a diff and stopped. A diff names the file that moved.
+        # It does not name which of the thirteen generators owns it, and the
+        # only remedy a reader could infer was `just generate`, the entire set,
+        # several minutes of npm and Docker. Eight of the eleven pull requests
+        # that failed this on 2026-09-08 needed exactly one generator, and for
+        # six of them it was `go run ./tools/docsembed`, which takes a second.
+        #
+        # -strict because this is a clean checkout: anything at all that
+        # changed here was written by a generator, so a changed path the ledger
+        # does not claim means something writes an artifact that nothing
+        # compares. `just gate` runs the same tool without it, because a
+        # developer is always in the middle of an edit.
+        run: go run ./tools/gendrift -strict .
 
       - name: The engine's parsers survive arbitrary input
         # The manifest is a file from the repository under test, and the

--- a/.gitignore
+++ b/.gitignore
@@ -147,6 +147,7 @@ runner/artifacts/
 /fieldsweep
 /figurecheck
 /gatecheck
+/gendrift
 /installcheck
 /installsh
 /keycheck

--- a/justfile
+++ b/justfile
@@ -1443,11 +1443,13 @@ fuzz-engine seconds="60":
 
 # Regenerate everything that is generated, then prove nothing changed.
 #
-# Scoped to the generated files rather than the whole tree. CI can diff
-# everything because it runs on a clean checkout; you cannot, because you are
-# always in the middle of an edit, and a gate that fails whenever you have
-# uncommitted work is a gate you learn to skip. The property either way is the
-# same: what is generated matches what it is generated from.
+# The comparison is `tools/gendrift`, which knows which generator owns which
+# path and says so when one has drifted. Here it looks only at what it owns,
+# because you are always in the middle of an edit and a gate that fails on
+# uncommitted work is a gate you learn to skip. CI adds -strict, which also
+# refuses a changed path no generator claims, and can do that because it runs
+# on a clean checkout. The property either way is the same: what is generated
+# matches what it is generated from.
 _generated:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -1472,27 +1474,16 @@ _generated:
     # exists to catch.
     go run ./tools/installcheck . web || npm --prefix web ci --no-audit --no-fund
     npm --prefix web run openapi:check --workspace apps/api
-    git diff --exit-code -- \
-      THIRD_PARTY_NOTICES.md \
-      www/public/errors.v1.json \
-      engine/internal/errors/codes.gen.go \
-      docs/src/content/docs/reference/errors.md \
-      www/public/lint-findings.v1.json \
-      engine/internal/insights/findings.gen.go \
-      engine/internal/insights/findings.register.json \
-      docs/src/content/docs/reference/lint-findings.md \
-      engine/internal/proxyimage/sources.gen.go \
-      engine/internal/docs/pages.gen.go \
-      schemas/policy-vectors.json \
-      schemas/mockpack-vectors.json \
-      schemas/webhook-vectors.json \
-      schemas/events.v1.json \
-      engine/internal/events/stream.register.json \
-      docs/src/content/docs/reference/cli.md \
-      docs/src/content/docs/reference/transforms.md \
-      docs/src/content/docs/guides/dashboard.md \
-      engine/internal/hud/testdata \
-      docs/src/content/docs/reference/schemas
+    # Scoped to what the generators own, which is what `gendrift` is for.
+    # This used to be `git diff` against a literal list of paths spelled out
+    # here, and CI compared the whole tree instead, so the two gates asked
+    # different questions and only one of them could ever notice a generator
+    # that started writing somewhere new. Both ask this now, and the list lives
+    # beside the mapping from a path to the command that rewrites it.
+    #
+    # No -strict here, unlike CI. You are always in the middle of an edit, and
+    # a gate that fails on your uncommitted work is a gate you learn to skip.
+    go run ./tools/gendrift .
 
 # Every manifest field either does something or is refused.
 #

--- a/tools/gendrift/main.go
+++ b/tools/gendrift/main.go
@@ -155,9 +155,12 @@ func run(root string, strict bool, out io.Writer) error {
 	}
 
 	if len(owned) == 0 && (!strict || len(unowned) == 0) {
-		fmt.Fprintf(out, "gendrift: %d generated %s match their generators\n",
+		// The write is returned rather than discarded. A gate whose only
+		// output is a claim that it looked has to notice when that claim did
+		// not reach anybody.
+		_, err := fmt.Fprintf(out, "gendrift: %d generated %s match their generators\n",
 			countPaths(), plural(countPaths(), "path", "paths"))
-		return nil
+		return err
 	}
 
 	var b strings.Builder

--- a/tools/gendrift/main.go
+++ b/tools/gendrift/main.go
@@ -1,0 +1,274 @@
+// Command gendrift names the generated files that no longer match their
+// generator, and the command that regenerates each one.
+//
+// The failure it exists for, measured on 2026-09-08: eleven of the sixteen
+// open pull requests whose engine check was red failed one step, and the step
+// is named "Generated files are current". It was WRONG about three of them.
+// That step runs the generators and then compares, and four of the generators
+// are `go test <pkg> -update-something`, which runs the whole package. So a
+// test in engine/internal/cli that has nothing to do with the committed
+// reference fails, and the pull request is told its generated files are stale
+// when they are not. Three lanes were sent to look at the wrong thing.
+//
+// The other eight were real drift, and there the step printed a diff and
+// stopped. A diff says WHICH file moved. It does not say which of the thirteen
+// generators owns it, and `just generate` is the whole set, several minutes of
+// npm and Docker, for a lane that needed one of them. Every one of those eight
+// branches had edited documentation and never regenerated
+// engine/internal/docs/pages.gen.go, which `go run ./tools/docsembed` rewrites
+// in about a second.
+//
+// So the ledger below is the answer to "what do I run", and it is a table
+// rather than a sentence in a comment because a sentence cannot be checked.
+// Each row was read out of the generator that writes the path, not recalled:
+// engine/internal/events/stream.register.json is written by
+// `go run ./tools/eventcheck -freeze .` and NOT by the neighbouring
+// `go test ./internal/events -update-schema`, which is the pairing anybody
+// reading the justfile in order would guess wrong.
+//
+// This also replaces a hand maintained list. `just _generated` compared a
+// literal list of paths spelled out in the justfile, and CI compared the whole
+// tree, so the two gates asked different questions and only one of them could
+// notice a generator that started writing somewhere new. Now both ask this.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// generator is one command and everything it writes.
+//
+// A path is a repository relative path, and a directory stands for everything
+// under it: schemadoc renders a page per schema, so naming the directory is
+// what lets a new schema arrive without editing this file, and hud writes one
+// golden frame per case for the same reason.
+type generator struct {
+	command string
+	paths   []string
+}
+
+// ledger is every generated artifact this repository commits.
+//
+// The order is the order the generators run in, so that somebody reading this
+// beside the workflow or the justfile can follow both at once.
+var ledger = []generator{
+	{"go run ./tools/errgen", []string{
+		"www/public/errors.v1.json",
+		"engine/internal/errors/codes.gen.go",
+		"docs/src/content/docs/reference/errors.md",
+	}},
+	{"go run ./tools/lintgen", []string{
+		"www/public/lint-findings.v1.json",
+		"engine/internal/insights/findings.gen.go",
+		"engine/internal/insights/findings.register.json",
+		"docs/src/content/docs/reference/lint-findings.md",
+	}},
+	{"go run ./tools/proxysrc", []string{
+		"engine/internal/proxyimage/sources.gen.go",
+	}},
+	{"go run ./tools/docsembed", []string{
+		"engine/internal/docs/pages.gen.go",
+	}},
+	{"go run ./tools/schemadoc .", []string{
+		"docs/src/content/docs/reference/schemas",
+	}},
+	{"go run ./tools/notices -out THIRD_PARTY_NOTICES.md", []string{
+		"THIRD_PARTY_NOTICES.md",
+	}},
+	{"cd engine && go test ./internal/policy -update-vectors", []string{
+		"schemas/policy-vectors.json",
+	}},
+	{"cd engine && go test ./internal/mockpack -update-vectors", []string{
+		"schemas/mockpack-vectors.json",
+	}},
+	{"cd engine && go test ./internal/webhook -update-vectors", []string{
+		"schemas/webhook-vectors.json",
+	}},
+	{"cd engine && go test ./internal/cli -update-reference", []string{
+		"docs/src/content/docs/reference/cli.md",
+	}},
+	{"cd engine && go test ./internal/events -update-schema", []string{
+		"schemas/events.v1.json",
+	}},
+	{"go run ./tools/eventcheck -freeze .", []string{
+		"engine/internal/events/stream.register.json",
+	}},
+	{"cd engine && go test ./internal/masking -update-transforms", []string{
+		"docs/src/content/docs/reference/transforms.md",
+	}},
+	{"cd engine && go test ./internal/hud -update-frames", []string{
+		"engine/internal/hud/testdata",
+		"docs/src/content/docs/guides/dashboard.md",
+	}},
+}
+
+func main() {
+	strict := flag.Bool("strict", false,
+		"also fail on a changed path no generator owns, for a clean checkout")
+	flag.Parse()
+	root := "."
+	if args := flag.Args(); len(args) > 0 {
+		root = args[0]
+	}
+
+	if err := run(root, *strict, os.Stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "gendrift: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// run compares the working tree against HEAD and reports drift.
+//
+// strict is the difference between the two callers. CI runs on a clean
+// checkout, so anything at all that changed was written by a generator, and a
+// changed path this ledger does not claim means a generator has started
+// writing somewhere nothing is watching. A developer's `just gate` runs in the
+// middle of an edit, where unowned changes are the edit itself, so there it
+// looks only at what it owns. That difference is the reason the two gates
+// could previously ask different questions, and naming it is what keeps them
+// asking the same one.
+func run(root string, strict bool, out io.Writer) error {
+	if err := checkLedger(root); err != nil {
+		return err
+	}
+
+	changed, err := changedPaths(root)
+	if err != nil {
+		return err
+	}
+
+	owned := map[string][]string{}
+	var unowned []string
+	for _, p := range changed {
+		if g, ok := ownerOf(p); ok {
+			owned[g] = append(owned[g], p)
+			continue
+		}
+		unowned = append(unowned, p)
+	}
+
+	if len(owned) == 0 && (!strict || len(unowned) == 0) {
+		fmt.Fprintf(out, "gendrift: %d generated %s match their generators\n",
+			countPaths(), plural(countPaths(), "path", "paths"))
+		return nil
+	}
+
+	var b strings.Builder
+	if len(owned) > 0 {
+		b.WriteString("These committed files do not match what their generator just wrote.\n")
+		b.WriteString("Run the command beside each one, or `just generate` to run them all.\n\n")
+		for _, g := range ledger {
+			hits, ok := owned[g.command]
+			if !ok {
+				continue
+			}
+			sort.Strings(hits)
+			b.WriteString("  " + g.command + "\n")
+			for _, p := range hits {
+				b.WriteString("      " + p + "\n")
+			}
+		}
+	}
+	if strict && len(unowned) > 0 {
+		if len(owned) > 0 {
+			b.WriteString("\n")
+		}
+		sort.Strings(unowned)
+		b.WriteString("These changed on a clean checkout and no generator in tools/gendrift\n")
+		b.WriteString("claims them, so something writes them and nothing compares them:\n\n")
+		for _, p := range unowned {
+			b.WriteString("      " + p + "\n")
+		}
+		b.WriteString("\nAdd each one to the ledger beside the generator that writes it.\n")
+	}
+	return fmt.Errorf("%s", b.String())
+}
+
+// checkLedger refuses a ledger that has gone stale.
+//
+// A generated file that is renamed and not renamed here leaves a row pointing
+// at nothing, and a row pointing at nothing can never report drift. The check
+// would go on printing a number and would have stopped looking at that file,
+// which is the exact defect this repository keeps finding in its own
+// instruments. So a missing path is a failure and not a skip.
+func checkLedger(root string) error {
+	var missing []string
+	for _, g := range ledger {
+		for _, p := range g.paths {
+			if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(p))); err != nil {
+				missing = append(missing, p+" (from `"+g.command+"`)")
+			}
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	return fmt.Errorf("the ledger names %d %s that is not in the tree, so nothing compares it:\n      %s",
+		len(missing), plural(len(missing), "path", "paths"), strings.Join(missing, "\n      "))
+}
+
+// changedPaths is everything git reports as modified, added or untracked.
+//
+// Untracked is included because a generator that writes a NEW file is the case
+// a plain `git diff` cannot see at all: the file is not in the index, so the
+// comparison passes and the artifact is never committed.
+func changedPaths(root string) ([]string, error) {
+	cmd := exec.Command("git", "status", "--porcelain=v1", "--untracked-files=all")
+	cmd.Dir = root
+	stdout, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("reading the working tree: %w", err)
+	}
+	var paths []string
+	for _, line := range strings.Split(string(stdout), "\n") {
+		if len(line) < 4 {
+			continue
+		}
+		p := strings.TrimSpace(line[3:])
+		// A rename is reported as "old -> new" and the new name is the one
+		// a generator wrote.
+		if i := strings.Index(p, " -> "); i >= 0 {
+			p = p[i+4:]
+		}
+		paths = append(paths, strings.Trim(p, `"`))
+	}
+	return paths, nil
+}
+
+// ownerOf is the generator that writes a path, if any owns it.
+//
+// A ledger entry that names a directory owns everything beneath it, and the
+// separator is required so that `docs/reference/schemas` does not claim a
+// sibling called `docs/reference/schemas-old`.
+func ownerOf(path string) (string, bool) {
+	for _, g := range ledger {
+		for _, p := range g.paths {
+			if path == p || strings.HasPrefix(path, p+"/") {
+				return g.command, true
+			}
+		}
+	}
+	return "", false
+}
+
+func countPaths() int {
+	n := 0
+	for _, g := range ledger {
+		n += len(g.paths)
+	}
+	return n
+}
+
+func plural(n int, one, many string) string {
+	if n == 1 {
+		return one
+	}
+	return many
+}

--- a/tools/gendrift/main_test.go
+++ b/tools/gendrift/main_test.go
@@ -1,0 +1,214 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// repoWithLedger is a git repository carrying every path the ledger claims,
+// committed, so that a test can dirty exactly one of them and nothing else.
+//
+// The whole ledger has to exist because checkLedger refuses a tree missing one
+// of its paths, and that refusal is itself under test below. A fixture that
+// quietly satisfied it would make every other case here pass for the wrong
+// reason.
+func repoWithLedger(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+
+	run := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = root
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %s: %s", strings.Join(args, " "), out)
+	}
+	run("init", "-q")
+
+	for _, g := range ledger {
+		for _, p := range g.paths {
+			// A ledger entry is a file or a directory and the tool must
+			// accept either, so a path with no extension is made a directory
+			// with one file under it. That is what schemadoc and the hud
+			// golden frames actually are.
+			full := filepath.Join(root, filepath.FromSlash(p))
+			if filepath.Ext(p) == "" {
+				require.NoError(t, os.MkdirAll(full, 0o755))
+				require.NoError(t, os.WriteFile(filepath.Join(full, "one.txt"), []byte("one\n"), 0o644))
+				continue
+			}
+			require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+			require.NoError(t, os.WriteFile(full, []byte("generated\n"), 0o644))
+		}
+	}
+	run("add", "-A")
+	run("commit", "-qm", "the generated tree")
+	return root
+}
+
+func write(t *testing.T, root, rel, body string) {
+	t.Helper()
+	full := filepath.Join(root, filepath.FromSlash(rel))
+	require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+	require.NoError(t, os.WriteFile(full, []byte(body), 0o644))
+}
+
+// A clean tree passes, and says how much it looked at.
+//
+// The count is in the message on purpose: a gate that prints "ok" having
+// examined nothing reads the same as one that examined everything, and this
+// repository has shipped both.
+func TestACleanTreeReportsHowManyPathsItCompared(t *testing.T) {
+	root := repoWithLedger(t)
+	var out bytes.Buffer
+	require.NoError(t, run(root, true, &out))
+	require.Contains(t, out.String(), "generated paths match their generators")
+	require.Contains(t, out.String(), strconv.Itoa(countPaths()))
+}
+
+// The whole point: the message names the ONE command to run.
+//
+// pages.gen.go is the specific file eight pull requests drifted on, and
+// docsembed is the second of thirteen generators. A tool that answered
+// "run just generate" would send a lane to several minutes of npm and Docker
+// for a one second fix.
+func TestADriftedFileNamesTheGeneratorThatOwnsIt(t *testing.T) {
+	root := repoWithLedger(t)
+	write(t, root, "engine/internal/docs/pages.gen.go", "drifted\n")
+
+	var out bytes.Buffer
+	err := run(root, true, &out)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "engine/internal/docs/pages.gen.go")
+	require.Contains(t, err.Error(), "go run ./tools/docsembed")
+	require.NotContains(t, err.Error(), "go run ./tools/proxysrc")
+}
+
+// The pairing a reader of the justfile would get wrong.
+//
+// stream.register.json sits beside events.v1.json in every list in this
+// repository and a different command writes each. If this ever reports
+// -update-schema for the register, the table has been rewritten from memory
+// rather than from the generators.
+func TestTheEventRegisterAndTheEventSchemaHaveDifferentGenerators(t *testing.T) {
+	root := repoWithLedger(t)
+	write(t, root, "engine/internal/events/stream.register.json", "drifted\n")
+
+	var out bytes.Buffer
+	err := run(root, true, &out)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "go run ./tools/eventcheck -freeze .")
+	require.NotContains(t, err.Error(), "-update-schema")
+}
+
+// A generator writing a file that was never committed is drift too.
+//
+// `git diff` cannot see this case at all, because an untracked file is not in
+// the index, so a comparison built on diff alone passes and the artifact never
+// reaches the tree.
+func TestANewFileAGeneratorWroteIsDriftEvenThoughItIsUntracked(t *testing.T) {
+	root := repoWithLedger(t)
+	write(t, root, "docs/src/content/docs/reference/schemas/manifest-v2.md", "new\n")
+
+	var out bytes.Buffer
+	err := run(root, true, &out)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "manifest-v2.md")
+	require.Contains(t, err.Error(), "go run ./tools/schemadoc .")
+}
+
+// A directory entry owns what is under it and not what merely starts the same.
+//
+// Without the separator, `docs/.../reference/schemas` would claim a sibling
+// called `schemas-old`, and a real edit would be reported as generated drift
+// with a command that does not fix it.
+func TestADirectoryEntryDoesNotClaimASiblingWithTheSamePrefix(t *testing.T) {
+	root := repoWithLedger(t)
+	write(t, root, "docs/src/content/docs/reference/schemas-old/note.md", "mine\n")
+
+	var out bytes.Buffer
+	err := run(root, true, &out)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no generator in tools/gendrift")
+	require.NotContains(t, err.Error(), "go run ./tools/schemadoc .")
+}
+
+// strict is the difference between the two callers, and it has to be real.
+//
+// CI runs on a clean checkout, where an unowned change means a generator has
+// started writing somewhere nothing watches. A developer's gate runs in the
+// middle of an edit, where the same change is the edit. If strict did nothing,
+// `just gate` would fail on every uncommitted line and would be turned off.
+func TestAnUnownedChangeFailsOnlyInStrictMode(t *testing.T) {
+	root := repoWithLedger(t)
+	write(t, root, "engine/internal/env/env.go", "somebody is editing this\n")
+
+	var strictOut bytes.Buffer
+	require.Error(t, run(root, true, &strictOut))
+
+	var looseOut bytes.Buffer
+	require.NoError(t, run(root, false, &looseOut))
+	require.Contains(t, looseOut.String(), "match their generators")
+}
+
+// A ledger row pointing at nothing is a refusal, never a quiet pass.
+//
+// This is the failure mode of every check in this repository that went blind:
+// the artifact was renamed, the row was not, and the comparison went on
+// printing a number about a file it could no longer see.
+func TestALedgerPathMissingFromTheTreeIsARefusal(t *testing.T) {
+	root := repoWithLedger(t)
+	require.NoError(t, os.Remove(filepath.Join(root, "engine/internal/docs/pages.gen.go")))
+
+	var out bytes.Buffer
+	err := run(root, true, &out)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "nothing compares it")
+	require.Contains(t, err.Error(), "pages.gen.go")
+}
+
+// The ledger describes THIS repository, not a fixture.
+//
+// Everything above runs against a tree the test built, so all of it would keep
+// passing if the ledger drifted from the real one. This is the assertion that
+// notices, and it is the reason the tool is safe to put in front of the gate
+// that eleven pull requests failed.
+func TestEveryLedgerPathExistsInThisRepository(t *testing.T) {
+	root := "../.."
+	for _, g := range ledger {
+		for _, p := range g.paths {
+			_, err := os.Stat(filepath.Join(root, filepath.FromSlash(p)))
+			require.NoError(t, err, "%s, claimed by `%s`", p, g.command)
+		}
+	}
+	require.Greater(t, countPaths(), 15)
+}
+
+// The local gate reports the drifted artifact and stays quiet about your work.
+//
+// This is the case that makes the two guards on `strict` different. A
+// developer with a stale generated file AND uncommitted edits is the ordinary
+// state of `just gate`, and it must name the artifact and say nothing about
+// the edits. Reporting the edits is how a gate becomes noise and then becomes
+// skipped, which is the reason none of the eleven pull requests had run it.
+func TestTheLocalGateNamesTheDriftedArtifactAndNotYourEdits(t *testing.T) {
+	root := repoWithLedger(t)
+	write(t, root, "engine/internal/docs/pages.gen.go", "drifted\n")
+	write(t, root, "engine/internal/env/env.go", "somebody is editing this\n")
+
+	var out bytes.Buffer
+	err := run(root, false, &out)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "go run ./tools/docsembed")
+	require.NotContains(t, err.Error(), "engine/internal/env/env.go")
+	require.NotContains(t, err.Error(), "no generator in tools/gendrift")
+}


### PR DESCRIPTION
## The failure

On 2026-09-08 the `engine` required check was red on seventeen open pull
requests while main was green. Eleven of the seventeen failed the same step,
and that step is named **"Generated files are current"**. It had nothing to say
about three of them.

The step runs thirteen generators and then compares. Four of those generators
are `go test <package> -update-something`, which runs the **whole** package. So
a test in `engine/internal/cli` that has no relationship to any committed
artifact fails inside a step whose name asserts something about generated
files:

| PR | what the step name said | what actually failed |
| --- | --- | --- |
| 315 | generated files are stale | `TestEveryCommandTheEnginePrintsNamesAFlagThatExists` |
| 320 | generated files are stale | `TestLicense_StatusInJSONNamesTheEdition` |
| 326 | generated files are stale | `TestEveryFieldTheSidecarRecordsSurvivesTheDecodeIntoADecision` |

**Correction to an earlier draft of this body, which said "nothing was stale on
any of the three".** Nothing established that, and the true statement is
stronger. The comparison was the LAST line of the block and the shell is
`bash -e`, so all three died at the cli package, the eighth of twelve commands,
and the comparison never ran on any of them. The step did not find those trees
stale. It asserted staleness it had never reached, under a name that is the
only thing the checks list and the jobs API return, and three lanes went to
look at the wrong thing.

The other eight had really drifted, and there the step ended in
`git diff --exit-code`. A diff names the file that moved. It does not name
which of the thirteen generators owns it, and the only remedy a reader could
infer was `just generate`, the entire set, including an npm install and a
Docker dependent step, for a lane that needed one generator. Six of the eight
needed `go run ./tools/docsembed` and nothing else, roughly a second: they had
edited documentation and never regenerated `engine/internal/docs/pages.gen.go`.

## What changed

The generating and the comparing are two steps now, so the name asserts only
what the step checked.

The comparison is `tools/gendrift`. It carries the mapping from a generated
path to the command that rewrites it, and groups its findings under that
command. Against this repository, with `pages.gen.go` dirtied:

```
gendrift: These committed files do not match what their generator just wrote.
Run the command beside each one, or `just generate` to run them all.

  go run ./tools/docsembed
      engine/internal/docs/pages.gen.go
```

Every ledger row was read out of the generator that writes the path rather than
recalled. One of them is the pairing anybody reading the justfile in order
would get wrong: `engine/internal/events/stream.register.json` is written by
`go run ./tools/eventcheck -freeze .`, not by the `-update-schema` run sitting
beside it in every list in this repository. There is a test whose only job is
that distinction.

Two things the old comparison could not see, both now covered:

- **A generated file that is new is untracked**, so it is not in the index and
  `git diff` reports nothing about it at all. `gendrift` reads the working
  tree.
- **A ledger row pointing at a path no longer in the tree** can never report
  drift on it, and the check would go on printing a number having silently
  stopped looking at that file. That is a refusal here, not a skip.

## The two gates had stopped asking the same question

`just _generated` compared a literal list of twenty paths spelled out in the
justfile. CI compared the whole tree. Only one of them could ever notice a
generator that had started writing somewhere new, and the list was maintained
by hand beside generators that do not mention it. Both run `gendrift` now. CI
passes `-strict`, which additionally refuses a changed path no generator
claims, and can do that because it runs on a clean checkout. The local gate
does not, because you are always in the middle of an edit and a gate that fails
on uncommitted work is a gate you learn to skip, which is what all eleven had
done.

## Verification

`go run ./tools/gendrift -strict .` on the clean committed tree passes and says
how many paths it compared. On the same tree with `pages.gen.go` dirtied it
refuses and names `docsembed`, which is the output quoted above. It was then
restored and the tree confirmed clean, so the proof did not leave the state it
created.

Mutation tested, nine cells, eight red:

| cell | broken | caught by |
| --- | --- | --- |
| owner prefix without separator | `HasPrefix(path, p+"/")` to `HasPrefix(path, p)` | `TestADirectoryEntryDoesNotClaimASiblingWithTheSamePrefix` |
| ledger miss reported as a skip | drop the append | `TestALedgerPathMissingFromTheTreeIsARefusal` |
| untracked files not listed | `untracked-files=all` to `no` | `TestANewFileAGeneratorWroteIsDriftEvenThoughItIsUntracked` |
| wrong command printed | print `just generate` instead of the owner | `TestADriftedFileNamesTheGeneratorThatOwnsIt` |
| event register mispaired | move it to the `-update-schema` row | `TestTheEventRegisterAndTheEventSchemaHaveDifferentGenerators` |
| second strict guard removed | drop `strict &&` | `TestTheLocalGateNamesTheDriftedArtifactAndNotYourEdits` |
| count not reported | print bare `ok` | `TestACleanTreeReportsHowManyPathsItCompared` |
| ledger path typo | rename `pages.gen.go` in the ledger | `TestEveryLedgerPathExistsInThisRepository` |
| first strict guard removed | drop `strict &&` | **not caught, and it is equivalent** |

The ninth is an equivalent mutant for the input its test supplies. With no
owned drift the early return has already handled the case, so the mutated line
is never reached. The cell aimed at the input that does reach it, a drifted
artifact alongside uncommitted edits, is red. Both guards are load bearing, for
different inputs.

The harness lied twice before it worked, and both are the failure this
repository names most often. It first counted `=== RUN` lines from a `go test`
run with no `-v`, so all nine cells reported COULD-NOT-LOOK. It then matched
`^--- FAIL: <name>$` against a line that ends in a duration, so all nine
reported GREEN NOT CAUGHT while the package was exiting 1. Only the third run
is the table above.

`prosecheck` 926 files, 0 findings. `changecheck` passes. No attribution
trailer. Signed off.

## What this does not do

It turns no pull request green. The eight stale ones each need their own
generator run on their own branch, and those branches have live lanes in them,
so the routing went to the lead rather than into a push under somebody else's
feet. What this changes is that the next lane to hit this reads the command it
needs instead of a step name that was wrong about three of eleven.
