### PR TITLE
engine: a private key sat in our own manifest and the credential gate passed over it

### DIFF
--- a/.changes/a-private-key-committed-to-a-public-repository.md
+++ b/.changes/a-private-key-committed-to-a-public-repository.md
@@ -1,0 +1,30 @@
+# security
+
+This repository's own manifest carried a private key, and the check named "no
+credentials in the tree" passed over it.
+
+`antifailure.yaml` declared `AF_GITHUB_APP_PRIVATE_KEY` with `value:` set to a
+2048 bit RSA key, base64 encoded rather than PEM. The comment beside it gave
+the reason for the encoding: the manifest validator refuses a literal beginning
+with BEGIN, and base64 does not begin with BEGIN. The published schema says
+what a manifest is in as many words, that it declares the name and where the
+value comes from and never the value itself, and the file held up as the
+example of that was the one breaking it.
+
+The detector behind the credential gate had a matching hole, and it was a
+deliberate decision taken one step too far. A bare PEM is not evidence of
+Google, so reporting one as a service account key would send somebody to rotate
+a credential they do not have. That was implemented as reporting nothing at
+all, so any private key with no cloud marker beside it was invisible to the
+gate, to the proxy tripwire and to the manifest validator. It now reports a
+private key under its own name, owning no provider, and Google's own marker
+still promotes the finding to the more specific one. A second pass decodes
+base64 before deciding, so the encoding that walked past the validator does not
+walk past this.
+
+The key itself is supplied rather than written down. A manifest declaring a
+webhook path for GitHub is rehearsing a GitHub App, so the engine now generates
+`GITHUB_APP_PRIVATE_KEY` for the life of the environment and offers it to the
+chain the way it already offers the webhook signing secrets. Nothing is
+configured outside the manifest and `af up` needs no setup it did not need
+before.

--- a/antifailure.yaml
+++ b/antifailure.yaml
@@ -169,16 +169,30 @@ services:
 
       # The GitHub App is configured for the same reason, so /webhooks/github
       # exists and an installation can be rehearsed. Nothing here can reach
-      # GitHub: api.github.com is blocked below, and the App id and key were
-      # never registered with GitHub. The key is a throwaway generated for
-      # this file with `openssl genpkey`, committed on purpose and useless
-      # anywhere else; it is base64 rather than PEM because the api accepts
-      # either and the validator refuses a literal beginning with BEGIN, again
-      # correctly. The webhook secret is a rename of the engine's, as above.
+      # GitHub: api.github.com is blocked below, and the App id was never
+      # registered with GitHub.
+      #
+      # The key is supplied rather than written down, and it used to be written
+      # down. This file carried a real 2048 bit RSA private key as a literal,
+      # 2272 characters of it, base64 encoded rather than PEM because the
+      # validator refuses a literal beginning with BEGIN and base64 walked past
+      # it. The comment beside it said the key was a throwaway and that was
+      # true; it was still a private key committed to a public repository, in
+      # the one file this product holds up as an ordinary manifest. The
+      # published schema says what a manifest is in as many words: it declares
+      # the name and where the value comes from, and never the value itself,
+      # which is why the file is safe to commit.
+      #
+      # So the engine makes one. A manifest declaring a webhook path for GitHub
+      # is rehearsing a GitHub App, and GITHUB_APP_PRIVATE_KEY is generated for
+      # the life of the environment and offered under the same condition as the
+      # signing secret below. Nothing is configured outside this file, nothing
+      # is committed, and af up on a laptop needs no setup it did not need
+      # before.
       - name: AF_GITHUB_APP_ID
         value: "1"
       - name: AF_GITHUB_APP_PRIVATE_KEY
-        value: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRRFpWNE1yTEpBN2YvUU8KSENBWHREeUNCc01wMzdiWlkzM2dlSnYvZjZ1aitMQWx1cTBGN2MwTDA5bW1OMDhpNVpMK29XWklJbEFZSFg2TwpvSmE2dDFHUnpZZUZudVRIcURLamdHZjh6YmJsZDVhdUZ5cENwZ0NJUlFRODIxbXFKYTZtbVJNQW5oZS9JbDZ2CmZOak5ONTlXd1JiQVM1eWFLZkJMWW05SG9nZ01hRVg4dkhxSWNWZUVnZWNaWlZQY2hrRFdMQXlxWnNEaEl5L1YKeFJET1dJVy80TUs0NzlMZkNxSjgrZU9aNHMxY0R4RU43L0dsL0JaRGdzMElhL3E5ZEtyV3N4TzZCUUlaNU5JbQoweVp5M0c3czF3WThzNDlIcVhnbW5wczVJRHpQUnBteDh4cnl3Q0NFV0JiOXhSbWk1dldNV0xGakpwUHc3Vk9VCjhXS0FBbGVMQWdNQkFBRUNnZ0VBSUZjWkhGc0dDVHgvRWRIQWtCWmwxelB2WlhNMXI1VDgzWTBhS3E0U0x4VFUKWW9EV1pIdjFRZzNLSktWZjZxdytMNzBrelpZQmYxMGdLdjZkVkhlWkNuamY4aE9VZ2xzTHAwV2c4NVAwRGsxawpYVStkYzdaazBqZHhnU2E0bEdJRllpS0Q3OWhydXlsVTdUTHhjRjZXOWZTY1plSmxFVHd0Vm96MVRGNUJhVldkCkRYVVppNHFYMHJvaHhEMkpTQnlHOTh0V3ZqcnZsZmxLUmJJMndEdHp0Z1BKQTJXM2RBQzJ0dXdIbEtjOUZDdjMKVTZqMG4vekhUN1ZHWFo4MHFlMkRvVVFLRkw0ZGg4VjhqQnNSMkFYRmdTOW9idnM2NkgzTzJkWDZLM1pIT29yagp0K2JWNjRYUko2dXIyN014WGZPRURjbnFMMFJ6L3VaTGtIWVBaQk9LWVFLQmdRRDlSSVp5cXQzTHk5c0xiaGszCkZ3Z3c0T2hZN1FPUnhUMlNCdldsbWdnWjQ3M1ZxTkpDS3JTRUhRd05iMk5DM1ZYaTgrSWRCbG9lS2ZmNy9mNDQKSDhvaWcySmJqcGtPdll5aXJDZ2Zwc041dkFSVUtqWnpHWldNV2FvbThEZ09pWm8rMzhuRDd4TktOSjZqL3FTUApDN0NSdkxEcVE4MFJvN0d3WWRPbTMzeGFhd0tCZ1FEYnI4Um4wTG9jM2JUNUNPWFNyRHdhZWZtZzB1UTE0VDNFClRUYy94Yy9lamJBNVRqbU5vYkttUHBIMDA4bzZwaTJhL0RZNVhwV0Z3TW5DNDdnVmNjeTB2Nnd0MzdMU2k0TjQKWEE1SHcwcWR1TkVUK0tQTWhMbFFXNE4vbFZGTysxa05UMmtFZk9GM2VWTU4rSjZxTVpRZHc2Ukx1enROM0FkcQpYeUw0TjF0L1lRS0JnQ0JQb3J0MFV4R1I4Mk1VNjhDY2ZwNEZ3MzY4MWl5OXRpb3dHeHpDZHZBZW52Um9NbExnCnNlRDg5N0dyR1VYSmlSQ0lQcnVuT000S1dxbmFjSmxtYk5wVVdyTUZrVDlSTFdUL2c2cnVFcGd3UlhrYlhaRDMKbloyblBzN3k3S1BtS0RpSFFtMXR6Yzgwd1Z4NHV6UElzUUVXeXBkSWlSd0wvenBhY0s4a2FlLzdBb0dBV3BqaQo0M2xWdDEvTEtVUjlHdU9DcWR5UmtMeEg5dHhiejUrVVlFMWdpMFJkWDFTZU1ZVjBtbENGZXJUNDJqVDc2OFdGClN5Vnhma1ppTG1nZzIxOGg3NHg0SWpiMWxSU0o5RkhxWmJmcEJxQllRT2N5RGI3U2VZd3o3NktSZElQOVZwcmcKRVVTNjZyMXkvZmtBM2VreVR4QUdxbUNkZFY5L0EyUVdsTXluaENFQ2dZRUF6cktDdjVXRWp2bHRBQ0tDRXBoQQp2bWMwNFUxZWFKSUQwQlBYeStGNnRDSlhmbXVTNjZKTlQxTDRFRWtmZkpKRytxc3drbjRIRHpSRUlkWDFlME5rCkkzMHY2WEdhdURKL1ZNbE1uQ3lOR2xyT3B1Ti9qK1d1b2RpUnc5VmNqYVNncEJ2OU94a1hodUtWSzlvSm4wM3MKdGVMUk8yZnhXWW1Eajc4VGI5M3R6M1k9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K
+        from: GITHUB_APP_PRIVATE_KEY
       - name: AF_GITHUB_APP_WEBHOOK_SECRET
         from: GITHUB_WEBHOOK_SECRET
 

--- a/docs/src/content/docs/guides/webhooks.md
+++ b/docs/src/content/docs/guides/webhooks.md
@@ -48,6 +48,42 @@ signing secrets. A value typed into the manifest instead would be the first
 thing to drift from the one the sender uses, and every event would then be
 refused as unsigned by the very verification this exists to exercise.
 
+## The GitHub App's own key
+
+A GitHub App is three credentials, and the webhook secret is only one of them.
+The other two are the numeric App id and the private key the App signs its JWT
+with, and an application that reads all three usually refuses to start with
+some of them: a webhook secret with no private key is an endpoint that verifies
+deliveries and can do nothing with them.
+
+So a manifest that declares a webhook path for GitHub is offered a private key
+as well, under `GITHUB_APP_PRIVATE_KEY`, generated for the life of the
+environment:
+
+```yaml
+services:
+  - name: api
+    env:
+      - name: AF_GITHUB_APP_ID
+        value: "1"
+      - name: AF_GITHUB_APP_PRIVATE_KEY
+        from: GITHUB_APP_PRIVATE_KEY
+      - name: AF_GITHUB_APP_WEBHOOK_SECRET
+        from: GITHUB_WEBHOOK_SECRET
+```
+
+It is a real RSA key in PKCS#8, because the applications that read one reject a
+placeholder, and it is a different key in every environment. It authenticates
+nothing: GitHub has never seen it, and `api.github.com` is reachable only if
+your own egress rules allow it.
+
+Exporting `GITHUB_APP_PRIVATE_KEY` yourself wins over the generated one, for
+the case where you are rehearsing against an App you really registered.
+
+Writing the key into the manifest instead is the thing this replaces. A
+manifest is committed, so a key written there is a key in the repository for as
+long as the file is there, and the engine refuses a value that carries one.
+
 ## Delivery failed
 
 ```

--- a/engine/internal/cli/commands.go
+++ b/engine/internal/cli/commands.go
@@ -10,9 +10,9 @@ import (
 	"github.com/spf13/cobra"
 
 	aferrors "github.com/antifailure/antifailure/engine/internal/errors"
+	"github.com/antifailure/antifailure/engine/internal/env"
 	"github.com/antifailure/antifailure/engine/internal/manifest"
 	"github.com/antifailure/antifailure/engine/internal/secrets"
-	"github.com/antifailure/antifailure/engine/internal/webhook"
 	"github.com/antifailure/antifailure/engine/pkg/extension"
 	"github.com/antifailure/antifailure/engine/pkg/schema"
 )
@@ -147,14 +147,15 @@ func explainSecrets(ctx context.Context, e *Env, m *schema.Manifest, root string
 	// happen, which is worse than not answering. Built by one constructor for
 	// exactly that reason.
 	chain := secrets.LocalChain(root, e.Getenv, extension.Default, e.Keyring())
-	// The signing secrets af up derives, in front, exactly as the orchestrator
-	// places them. Explain has no environment yet, so the values are derived
-	// for a placeholder identifier; what it reports is the source and never
-	// the value, and the source is the same one af up will name.
+	// The values af up makes for the environment, in front, exactly as the
+	// orchestrator places them. Explain has no environment yet, so they are
+	// made for a placeholder identifier; what it reports is the source and
+	// never the value, and the source is the same one af up will name. One
+	// constructor for both, because a list assembled twice is a list that
+	// drifts and the drift is invisible until somebody is debugging a variable
+	// explain said would resolve.
 	if m.Egress != nil {
-		if provided := webhook.Secrets(m.Egress.Rules, "explain", e.Getenv); len(provided) > 0 {
-			chain = chain.Prepended(secrets.NewProvidedSource(webhook.SecretsSourceName, provided))
-		}
+		chain = chain.Prepended(env.EnvironmentSources(m.Egress.Rules, "explain", e.Getenv)...)
 	}
 
 	resolved, err := secrets.Resolve(ctx, chain, secrets.Request{

--- a/engine/internal/cli/commands.go
+++ b/engine/internal/cli/commands.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	aferrors "github.com/antifailure/antifailure/engine/internal/errors"
 	"github.com/antifailure/antifailure/engine/internal/env"
+	aferrors "github.com/antifailure/antifailure/engine/internal/errors"
 	"github.com/antifailure/antifailure/engine/internal/manifest"
 	"github.com/antifailure/antifailure/engine/internal/secrets"
 	"github.com/antifailure/antifailure/engine/pkg/extension"

--- a/engine/internal/docs/pages.gen.go
+++ b/engine/internal/docs/pages.gen.go
@@ -9714,6 +9714,42 @@ signing secrets. A value typed into the manifest instead would be the first
 thing to drift from the one the sender uses, and every event would then be
 refused as unsigned by the very verification this exists to exercise.
 
+## The GitHub App's own key
+
+A GitHub App is three credentials, and the webhook secret is only one of them.
+The other two are the numeric App id and the private key the App signs its JWT
+with, and an application that reads all three usually refuses to start with
+some of them: a webhook secret with no private key is an endpoint that verifies
+deliveries and can do nothing with them.
+
+So a manifest that declares a webhook path for GitHub is offered a private key
+as well, under ` + "`" + `GITHUB_APP_PRIVATE_KEY` + "`" + `, generated for the life of the
+environment:
+
+` + "`" + "`" + "`" + `yaml
+services:
+  - name: api
+    env:
+      - name: AF_GITHUB_APP_ID
+        value: "1"
+      - name: AF_GITHUB_APP_PRIVATE_KEY
+        from: GITHUB_APP_PRIVATE_KEY
+      - name: AF_GITHUB_APP_WEBHOOK_SECRET
+        from: GITHUB_WEBHOOK_SECRET
+` + "`" + "`" + "`" + `
+
+It is a real RSA key in PKCS#8, because the applications that read one reject a
+placeholder, and it is a different key in every environment. It authenticates
+nothing: GitHub has never seen it, and ` + "`" + `api.github.com` + "`" + ` is reachable only if
+your own egress rules allow it.
+
+Exporting ` + "`" + `GITHUB_APP_PRIVATE_KEY` + "`" + ` yourself wins over the generated one, for
+the case where you are rehearsing against an App you really registered.
+
+Writing the key into the manifest instead is the thing this replaces. A
+manifest is committed, so a key written there is a key in the repository for as
+long as the file is there, and the engine refuses a value that carries one.
+
 ## Delivery failed
 
 ` + "`" + "`" + "`" + `

--- a/engine/internal/env/env.go
+++ b/engine/internal/env/env.go
@@ -535,7 +535,7 @@ func (o *Orchestrator) openReading(ctx context.Context) (*session, error) {
 // store is last because it is the long-lived default.
 func (o *Orchestrator) secretChain() *secrets.Chain {
 	if o.opts.Secrets != nil {
-		return o.withWebhookSecrets(o.opts.Secrets)
+		return o.withEnvironmentSources(o.opts.Secrets)
 	}
 	getenv := o.opts.Getenv
 	if getenv == nil {
@@ -546,12 +546,12 @@ func (o *Orchestrator) secretChain() *secrets.Chain {
 	// One constructor, shared with af explain and with model key resolution, so
 	// that a command whose job is to say where a value will come from cannot
 	// describe a different chain than the one that resolves it.
-	return o.withWebhookSecrets(
+	return o.withEnvironmentSources(
 		secrets.LocalChain(o.opts.Root, getenv, registry, secrets.NewSystemKeyring()))
 }
 
-// withWebhookSecrets puts the signing secrets this environment derives in
-// front of a chain, under the names the sender uses.
+// withEnvironmentSources puts the values this environment makes for itself in
+// front of a chain, under the names the manifest refers to them by.
 //
 // So that a service can declare `from: STRIPE_WEBHOOK_SECRET` on whatever
 // variable its application actually reads and receive the value the engine
@@ -560,12 +560,24 @@ func (o *Orchestrator) secretChain() *secrets.Chain {
 // that could not hold a value computed at af up, and the api in this
 // repository's own twin, which reads AF_STRIPE_WEBHOOK_SECRET, started with
 // billing off while every simulated event was refused before it was sent.
-func (o *Orchestrator) withWebhookSecrets(chain *secrets.Chain) *secrets.Chain {
-	provided := o.WebhookSecrets()
-	if len(provided) == 0 {
+//
+// The GitHub App identity joined it for the same reason read the other way
+// round. There was nowhere for a manifest to get one, so this repository's own
+// twin carried a real 2048 bit RSA key as a literal in a file committed to a
+// public repository, because a literal was the only thing that worked.
+func (o *Orchestrator) withEnvironmentSources(chain *secrets.Chain) *secrets.Chain {
+	if o.opts.Manifest == nil || o.opts.Manifest.Egress == nil {
 		return chain
 	}
-	return chain.Prepended(secrets.NewProvidedSource(webhook.SecretsSourceName, provided))
+	getenv := o.opts.Getenv
+	if getenv == nil {
+		getenv = os.Getenv
+	}
+	sources := EnvironmentSources(o.opts.Manifest.Egress.Rules, o.envID, getenv)
+	if len(sources) == 0 {
+		return chain
+	}
+	return chain.Prepended(sources...)
 }
 
 // resolveSecrets looks up everything the manifest declares.

--- a/engine/internal/env/sources.go
+++ b/engine/internal/env/sources.go
@@ -1,0 +1,76 @@
+package env
+
+// The sources the engine itself answers with, built in one place.
+//
+// af up resolves the manifest's variables against a chain, and af explain
+// reports what that chain will answer. They have to build the identical one:
+// a command whose job is to say where a value will come from is worse than
+// useless if it describes a different lookup than the one that happens. Two
+// call sites each assembling their own list is how they drift, and this file
+// exists so there is only one list.
+
+import (
+	"github.com/antifailure/antifailure/engine/internal/secrets"
+	"github.com/antifailure/antifailure/engine/internal/webhook"
+	"github.com/antifailure/antifailure/engine/pkg/schema"
+)
+
+// EnvironmentSources returns the sources that hold values the engine makes for
+// an environment, in the order they go in front of the chain.
+//
+// Two of them today. The webhook signing secrets, derived from the environment
+// identifier, so a service declaring `from: STRIPE_WEBHOOK_SECRET` receives the
+// value the sender will actually sign with. And the GitHub App identity,
+// generated on demand, so a service declaring `from: GITHUB_APP_PRIVATE_KEY`
+// receives a key that exists for the life of this environment and nowhere
+// else.
+//
+// The App identity is offered under the same condition as the github signing
+// secret: a webhook path declared against GitHub. That is what says the App is
+// being rehearsed here, and it is one rule rather than two so the two halves of
+// the same App cannot be configured apart.
+func EnvironmentSources(rules []schema.EgressRule, envID string, getenv func(string) string) []secrets.Source {
+	var out []secrets.Source
+	if provided := webhook.Secrets(rules, envID, getenv); len(provided) > 0 {
+		out = append(out, secrets.NewProvidedSource(webhook.SecretsSourceName, provided))
+	}
+	if recipes := gitHubAppIdentity(rules, getenv); len(recipes) > 0 {
+		out = append(out, secrets.NewGeneratedSource(secrets.GitHubAppIdentitySourceName, recipes))
+	}
+	return out
+}
+
+// gitHubAppIdentity is the recipe for the App key, when this environment
+// rehearses a GitHub App and nothing else can answer for it.
+//
+// A key already exported wins, and it wins by this source standing aside
+// rather than by copying the value. Somebody who exported one is rehearsing
+// against an App they really registered, and generating over the top of that
+// would hand their application an identity GitHub has never heard of. Standing
+// aside leaves the shell to answer, so af explain says the value came from this
+// shell's environment, which is where it came from. Copying it would have
+// af explain name this source for a value it did not make, and a report that
+// says a value was generated when it was read is the kind of small lie that
+// costs somebody an afternoon.
+func gitHubAppIdentity(rules []schema.EgressRule, getenv func(string) string) map[string]func() (string, error) {
+	if !rehearsesGitHubApp(rules) {
+		return nil
+	}
+	if getenv != nil && getenv(secrets.GitHubAppPrivateKeyEnv) != "" {
+		return nil
+	}
+	return map[string]func() (string, error){
+		secrets.GitHubAppPrivateKeyEnv: secrets.GenerateGitHubAppPrivateKey,
+	}
+}
+
+// rehearsesGitHubApp reports whether any egress rule sends GitHub's callbacks
+// into this environment.
+func rehearsesGitHubApp(rules []schema.EgressRule) bool {
+	for _, r := range rules {
+		if r.WebhookPath != "" && webhook.ForHost(r.Host) == "github" {
+			return true
+		}
+	}
+	return false
+}

--- a/engine/internal/env/sources_test.go
+++ b/engine/internal/env/sources_test.go
@@ -1,0 +1,166 @@
+package env_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/internal/env"
+	"github.com/antifailure/antifailure/engine/internal/manifest"
+	"github.com/antifailure/antifailure/engine/internal/secrets"
+	"github.com/antifailure/antifailure/engine/pkg/schema"
+)
+
+// noEnv is a shell with nothing exported, which is what a fresh checkout is.
+func noEnv(string) string { return "" }
+
+func githubRules() []schema.EgressRule {
+	return []schema.EgressRule{{Host: "api.github.com", Mode: "block", WebhookPath: "/webhooks/github"}}
+}
+
+func sourceNames(t *testing.T, sources []secrets.Source) []string {
+	t.Helper()
+	out := make([]string, 0, len(sources))
+	for _, s := range sources {
+		out = append(out, s.Name())
+	}
+	return out
+}
+
+func TestEnvironmentSources_OffersAnAppKeyToAManifestRehearsingAnApp(t *testing.T) {
+	t.Parallel()
+	// The condition is one rule rather than two, because the App id, the key
+	// and the webhook secret are three halves of one credential and an
+	// environment that has some of them is refused by the application.
+	sources := env.EnvironmentSources(githubRules(), "envid", noEnv)
+	require.Contains(t, sourceNames(t, sources), secrets.GitHubAppIdentitySourceName)
+
+	value, found, err := lookup(t, sources, secrets.GitHubAppPrivateKeyEnv)
+	require.NoError(t, err)
+	require.True(t, found, "a manifest rehearsing a GitHub App was offered no key")
+	require.Contains(t, value, "PRIVATE KEY", "the value is not a key")
+}
+
+func TestEnvironmentSources_OffersNothingToAManifestThatRehearsesNoApp(t *testing.T) {
+	t.Parallel()
+	// Generating a key for an environment that never asks is the cost this is
+	// shaped to avoid, and a source in the "Looked in" list that could never
+	// have answered sends somebody to configure a place that does not exist.
+	for _, rules := range [][]schema.EgressRule{
+		nil,
+		{{Host: "api.stripe.com", Mode: "block", WebhookPath: "/webhooks/stripe"}},
+		// A GitHub rule with no webhook path is not a rehearsal of the App: no
+		// delivery reaches the service, so there is nothing for the App to be.
+		{{Host: "api.github.com", Mode: "block"}},
+	} {
+		sources := env.EnvironmentSources(rules, "envid", noEnv)
+		require.NotContains(t, sourceNames(t, sources), secrets.GitHubAppIdentitySourceName)
+	}
+}
+
+func TestEnvironmentSources_StandsAsideForAKeySomebodyExported(t *testing.T) {
+	t.Parallel()
+	// Somebody who exported one is rehearsing against an App they really
+	// registered, and generating over the top of that would hand their
+	// application an identity GitHub has never heard of.
+	//
+	// It stands aside rather than copying the value, so the shell answers and
+	// af explain names the shell. A source that copied the value would be
+	// reported as having generated it, which is a small lie about where a
+	// credential came from.
+	getenv := func(name string) string {
+		if name == secrets.GitHubAppPrivateKeyEnv {
+			return "a key somebody exported"
+		}
+		return ""
+	}
+	sources := env.EnvironmentSources(githubRules(), "envid", getenv)
+	require.NotContains(t, sourceNames(t, sources), secrets.GitHubAppIdentitySourceName)
+
+	// And the signing secret is still offered, so standing aside for one value
+	// did not stand aside for the other.
+	require.Contains(t, sourceNames(t, sources), "the environment's webhook signing secrets")
+}
+
+func TestEnvironmentSources_StillCarriesTheSigningSecrets(t *testing.T) {
+	t.Parallel()
+	// The two halves of the same App come from the same call, and this is what
+	// says the identity did not arrive by displacing the secret.
+	sources := env.EnvironmentSources(githubRules(), "envid", noEnv)
+	value, found, err := lookup(t, sources, "GITHUB_WEBHOOK_SECRET")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.NotEmpty(t, value)
+}
+
+// TestEnvironmentSources_ThisRepositorysOwnManifestResolves is the end to end
+// half, against the file the failure was found in.
+//
+// antifailure.yaml declared AF_GITHUB_APP_PRIVATE_KEY with a literal value: a
+// 2048 bit RSA key, in a public repository, in the one file this product holds
+// up as an ordinary manifest. It now declares `from`, and nothing supplies that
+// name unless this path does. So the assertion is not that the manifest parses,
+// which it did before and would again with the variable resolving nowhere. It
+// is that the variable is answered, by this source, with a key.
+func TestEnvironmentSources_ThisRepositorysOwnManifestResolves(t *testing.T) {
+	t.Parallel()
+	root := repositoryRoot(t)
+	body, err := os.ReadFile(filepath.Join(root, "antifailure.yaml"))
+	require.NoError(t, err)
+	m, err := manifest.Parse(body, filepath.Join(root, "antifailure.yaml"), "")
+	require.NoError(t, err, "this repository's own manifest does not parse")
+
+	var declared *schema.EnvVar
+	for _, s := range m.Services {
+		for i, e := range s.Env {
+			if e.Name == "AF_GITHUB_APP_PRIVATE_KEY" {
+				declared = &s.Env[i]
+			}
+		}
+	}
+	require.NotNil(t, declared, "the manifest no longer declares the App key at all")
+	require.Empty(t, declared.Value, "the key is a literal in a committed file again")
+	require.Equal(t, secrets.GitHubAppPrivateKeyEnv, declared.From)
+
+	require.NotNil(t, m.Egress)
+	sources := env.EnvironmentSources(m.Egress.Rules, "envid", noEnv)
+	value, found, err := lookup(t, sources, declared.From)
+	require.NoError(t, err)
+	require.True(t, found, "nothing supplies %s, so af up would stop at AF-SEC-001", declared.From)
+	require.Contains(t, value, "PRIVATE KEY")
+}
+
+// lookup asks each source in order, the way the chain does.
+func lookup(t *testing.T, sources []secrets.Source, name string) (string, bool, error) {
+	t.Helper()
+	for _, s := range sources {
+		v, found, err := s.Lookup(context.Background(), name)
+		if err != nil {
+			return "", false, err
+		}
+		if found {
+			return v.Reveal(), true, nil
+		}
+	}
+	return "", false, nil
+}
+
+// repositoryRoot walks up to the directory holding the manifest.
+func repositoryRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "antifailure.yaml")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		require.NotEqual(t, parent, dir, "walked to the filesystem root without finding antifailure.yaml")
+		dir = parent
+	}
+	t.Fatal("antifailure.yaml is not within ten directories of this test file")
+	return ""
+}

--- a/engine/internal/manifest/manifest_test.go
+++ b/engine/internal/manifest/manifest_test.go
@@ -1,6 +1,7 @@
 package manifest_test
 
 import (
+	"encoding/base64"
 	"os"
 	"path/filepath"
 	"strings"
@@ -328,6 +329,30 @@ func TestParse_RejectsACredentialShapedLiteralValue(t *testing.T) {
 	body := "version: 1\nname: s\nservices:\n  - name: web\n    port: 3000\n    env:\n      - name: URL\n        value: " +
 		"postgres://user:supersecretpassword@db:5432/app\n"
 	require.Contains(t, messages(problems(t, mustFail(t, body))), "shaped like a credential")
+}
+
+// The evasion that got a real private key into this repository's own manifest.
+//
+// The prefix list reads the first characters of the value, so a literal
+// beginning with BEGIN is refused and the same key base64 encoded is not. That
+// is not a hypothesis about what somebody might do: antifailure.yaml carried a
+// 2048 bit RSA key encoded exactly that way, and the comment beside it named
+// the encoding as the way past this check.
+func TestParse_RejectsAPrivateKeyThatWasEncodedToGetPastTheCheck(t *testing.T) {
+	t.Parallel()
+	pem := "-----BEGIN " + "PRIVATE KEY-----\n" + strings.Repeat("MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC7VJTUt9Us8cKj", 4) +
+		"\n-----END " + "PRIVATE KEY-----\n"
+	encoded := base64.StdEncoding.EncodeToString([]byte(pem))
+	body := "version: 1\nname: s\nservices:\n  - name: web\n    port: 3000\n    env:\n" +
+		"      - name: AF_GITHUB_APP_PRIVATE_KEY\n        value: " + encoded + "\n"
+	require.Contains(t, messages(problems(t, mustFail(t, body))), "shaped like a credential")
+
+	// And the same key written plainly, which the prefix list already caught
+	// and which must keep being caught.
+	plain := "version: 1\nname: s\nservices:\n  - name: web\n    port: 3000\n    env:\n" +
+		"      - name: AF_GITHUB_APP_PRIVATE_KEY\n        value: |\n" +
+		"          " + strings.ReplaceAll(strings.TrimSuffix(pem, "\n"), "\n", "\n          ") + "\n"
+	require.Contains(t, messages(problems(t, mustFail(t, plain))), "shaped like a credential")
 }
 
 func TestParse_RejectsBothValueAndFrom(t *testing.T) {

--- a/engine/internal/manifest/validate.go
+++ b/engine/internal/manifest/validate.go
@@ -16,6 +16,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/antifailure/antifailure/engine/internal/oracle"
+	"github.com/antifailure/antifailure/engine/pkg/livekey"
 	"github.com/antifailure/antifailure/engine/pkg/schema"
 )
 
@@ -1714,6 +1715,17 @@ func looksLikeCredentialValue(v string) bool {
 		if strings.HasPrefix(v, p) {
 			return true
 		}
+	}
+	// The prefixes above read the first characters of the value, and that is
+	// exactly what an encoding moves out of the way. This repository's own
+	// manifest carried a 2048 bit RSA private key under `value:`, base64
+	// encoded, and the comment beside it named the reason: the list above
+	// refuses a literal beginning with BEGIN, and base64 does not begin with
+	// BEGIN. The detector the credential gate uses decodes before it decides,
+	// so asking it here is what makes the validator and the gate agree about
+	// what a committed credential is.
+	if len(livekey.Scan(v, "the value")) > 0 {
+		return true
 	}
 	// A connection string carrying a password.
 	if strings.Contains(v, "://") && strings.Contains(v, "@") {

--- a/engine/internal/proxyimage/sources.gen.go
+++ b/engine/internal/proxyimage/sources.gen.go
@@ -2900,6 +2900,7 @@ func (e *Engine) InspectsAnyHost() bool {
 package livekey
 
 import (
+	"encoding/base64"
 	"strings"
 )
 
@@ -3005,6 +3006,14 @@ func pemGap(r rune) bool {
 // one of these patterns would fail that check on the detector's own source.
 const pemPrivateKeyHeader = "-----BEGIN " + "PRIVATE KEY-----"
 
+// pemHeaderFor opens a private key of one algorithm. Assembled for the same
+// reason as the constant above, and separate from it because the algorithms
+// each get their own header line and a scanner that only knew PKCS#8 would
+// miss every key ssh-keygen and openssl ever wrote by default.
+func pemHeaderFor(algorithm string) string {
+	return "-----BEGIN " + algorithm + " PRIVATE KEY-----"
+}
+
 // patterns are live credentials only.
 //
 // Every entry here has a test mode counterpart that is deliberately absent:
@@ -3062,6 +3071,42 @@ var patterns = []pattern{
 	{provider: "GCP service account key", prefix: pemPrivateKeyHeader, minTail: 60,
 		tail: base64ish, skip: pemGap, also: []string{"gserviceaccount.com"}},
 
+	// A private key belonging to nobody the detector can name, which is the
+	// one shape this package used to answer nothing about.
+	//
+	// The rule above says a bare PEM is not evidence of Google, and that is
+	// still right: reporting one as a service account key sends somebody to
+	// rotate a credential their project does not have. What was wrong was the
+	// step after it. "This is not Google's" was implemented as "this is not a
+	// credential", so a 2048 bit RSA key sat in this repository's own
+	// antifailure.yaml while the required check that reads this package
+	// reported no credentials in the tree. A private key is a credential
+	// whoever issued it; the honest finding names the shape and declines to
+	// name an owner.
+	//
+	// These sit AFTER the service account entry and the first of them shares
+	// its prefix, which is what gives Google precedence: Scan records one
+	// finding per prefix, so where the corroborating marker is beside the key
+	// the finding says GCP service account key, and where it is not it says
+	// private key rather than nothing.
+	//
+	// minTail is 60 for the same reason it is 60 above. A PEM body wraps at 64
+	// characters, so one line of real key material clears it, and the redacted
+	// examples that fill documentation, REDACTED or an ellipsis where the body
+	// goes, do not.
+	{provider: "Private key", prefix: pemPrivateKeyHeader, minTail: 60,
+		tail: base64ish, skip: pemGap},
+	{provider: "Private key", prefix: pemHeaderFor("RSA"), minTail: 60,
+		tail: base64ish, skip: pemGap},
+	{provider: "Private key", prefix: pemHeaderFor("EC"), minTail: 60,
+		tail: base64ish, skip: pemGap},
+	{provider: "Private key", prefix: pemHeaderFor("DSA"), minTail: 60,
+		tail: base64ish, skip: pemGap},
+	{provider: "Private key", prefix: pemHeaderFor("OPENSSH"), minTail: 60,
+		tail: base64ish, skip: pemGap},
+	{provider: "Private key", prefix: pemHeaderFor("ENCRYPTED"), minTail: 60,
+		tail: base64ish, skip: pemGap},
+
 	// Azure. Three shapes and none of them has a prefix of its own, because
 	// Azure keys are plain base64 and are told apart by the field that carries
 	// them. The field name is the marker, and it is what the finding reports.
@@ -3105,7 +3150,31 @@ var patterns = []pattern{
 // Case sensitive on purpose. Every prefix here is emitted in a fixed case by
 // the provider that issues it, and folding case turns "AC" into a match for
 // the word "ac" in a URL.
+//
+// Two passes, because one of them reads what is written and the other reads
+// what was hidden. A base64 wrapped key is the same credential with the
+// markers this file matches on encoded away, and it is not a hypothetical: the
+// manifest in this repository carried one, in base64 rather than PEM, and the
+// comment beside it said the encoding was chosen because the validator refuses
+// a literal beginning with BEGIN.
 func Scan(text, where string) []Finding {
+	out := scanPatterns(text, where)
+	seen := map[string]bool{}
+	for _, f := range out {
+		seen[f.Prefix] = true
+	}
+	for _, f := range scanEncoded(text, where) {
+		if seen[f.Prefix] {
+			continue
+		}
+		seen[f.Prefix] = true
+		out = append(out, f)
+	}
+	return out
+}
+
+// scanPatterns is the literal pass, over the text exactly as it arrived.
+func scanPatterns(text, where string) []Finding {
 	var out []Finding
 	seen := map[string]bool{}
 	for _, p := range patterns {
@@ -3144,6 +3213,130 @@ func Scan(text, where string) []Finding {
 		}
 	}
 	return out
+}
+
+// encodedBeginMarkers are how the opening of a PEM block reads once the whole
+// block has been base64 encoded.
+//
+// Three of them, because base64 works on groups of three bytes and the reading
+// depends on where the block starts inside the group. A key encoded on its own,
+// which is the common case and the one this repository shipped, is the first.
+// The other two are the same header a few bytes into a larger blob.
+//
+// They are triggers rather than findings. What follows a hit is a decode and
+// then the ordinary pass over the result, so the length and corroboration
+// rules that keep prose out of the literal pass apply to the decoded text as
+// well, and nothing is reported on the strength of a prefix alone.
+var encodedBeginMarkers = []string{
+	"LS0tLS1CRUdJ",
+	"LS0tQkVHSU4g",
+	"LS0tLUJFR0lO",
+}
+
+// base64Rune reports whether a character can appear inside a base64 body.
+//
+// Padding is included, unlike base64ish above, because here the run is being
+// delimited rather than measured: the padding is part of the value that has to
+// be handed to the decoder.
+func base64Rune(r rune) bool { return base64ish(r) || r == '=' }
+
+// maxEncoded bounds the run that is decoded. A private key is under three
+// kilobytes encoded; this is generous and it stops a megabyte of base64 in a
+// fixture from being decoded because it happens to open with the marker.
+const maxEncoded = 1 << 16
+
+// scanEncoded finds a credential that was base64 encoded before it was written.
+//
+// The evasion this closes was not adversarial and it is worse for that. The
+// manifest in this repository held a real RSA private key as a single base64
+// literal, and the comment beside it explained the encoding as the way to get
+// past a validator that refuses a value beginning with BEGIN. Every instrument
+// that could have objected read the encoded form and saw an opaque string, and
+// the required check named "no credentials in the tree" passed over it for as
+// long as it was there.
+func scanEncoded(text, where string) []Finding {
+	var out []Finding
+	seen := map[string]bool{}
+	for _, marker := range encodedBeginMarkers {
+		for i := 0; ; {
+			idx := strings.Index(text[i:], marker)
+			if idx < 0 {
+				break
+			}
+			at := i + idx
+			i = at + len(marker)
+
+			lo, hi := base64Run(text, at)
+			if hi-lo > maxEncoded {
+				continue
+			}
+			decoded, ok := decodeRun(text[lo:hi])
+			if !ok {
+				continue
+			}
+			for _, f := range scanPatterns(decoded, where) {
+				if seen[f.Prefix] {
+					continue
+				}
+				seen[f.Prefix] = true
+				out = append(out, f)
+			}
+		}
+	}
+	return out
+}
+
+// base64Run returns the bounds of the base64 run containing at.
+func base64Run(text string, at int) (int, int) {
+	lo := at
+	for lo > 0 && base64Rune(rune(text[lo-1])) {
+		lo--
+	}
+	hi := at
+	for hi < len(text) && base64Rune(rune(text[hi])) {
+		hi++
+	}
+	return lo, hi
+}
+
+// decodeRun decodes a base64 run whose start may not be the start of the
+// encoding.
+//
+// Four attempts, because the run found by walking backwards over base64
+// characters can begin up to three characters inside a group: a marker for one
+// of the two offset alignments sits behind bytes that are themselves base64
+// characters. Whichever attempt yields a PEM private key is the right one, and
+// nothing else is accepted, so a blob that decodes to arbitrary bytes is not a
+// finding.
+func decodeRun(run string) (string, bool) {
+	for k := 0; k < 4 && k < len(run); k++ {
+		body := run[k:]
+		body = body[:len(body)-len(body)%4]
+		if len(body) < 4 {
+			continue
+		}
+		decoded, err := base64.StdEncoding.DecodeString(body)
+		if err != nil {
+			// A run that carries padding in the middle, which happens when two
+			// values sit side by side, decodes up to that point. Everything
+			// before the padding is still worth reading.
+			if cut := strings.IndexByte(body, '='); cut > 0 {
+				body = body[:cut-cut%4]
+				if len(body) < 4 {
+					continue
+				}
+				decoded, err = base64.StdEncoding.DecodeString(body)
+			}
+			if err != nil {
+				continue
+			}
+		}
+		text := string(decoded)
+		if strings.Contains(text, "-----BEGIN") && strings.Contains(text, "PRIVATE KEY") {
+			return text, true
+		}
+	}
+	return "", false
 }
 
 func hasTail(s string, min int, ok func(rune) bool, skip func(rune) bool) bool {

--- a/engine/internal/secrets/generated.go
+++ b/engine/internal/secrets/generated.go
@@ -1,0 +1,114 @@
+package secrets
+
+// Values the engine makes up for an environment, rather than looking up.
+//
+// The webhook signing secrets next door are derived from the environment
+// identifier and cost nothing to compute, so they are handed over as a plain
+// map. An identity is different: it is a keypair, generating one is expensive
+// enough to notice, and most environments never ask for it. So this source
+// holds the recipe rather than the value and runs it the first time somebody
+// looks the name up.
+//
+// The laziness is the point rather than an optimisation. A manifest with a
+// GitHub webhook path that declares no App variable would otherwise pay for a
+// 2048 bit key on every af up, af explain and af webhook trigger, to hand it to
+// nobody.
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"sync"
+)
+
+// GeneratedSource holds values the engine will compute on demand.
+//
+// One computation per name per source, cached, because a source consulted
+// twice must answer the same thing twice: a key that changed between af up
+// resolving it and af explain reporting it would be two identities where the
+// user was told there was one.
+type GeneratedSource struct {
+	Label   string
+	Recipes map[string]func() (string, error)
+
+	mu     sync.Mutex
+	cached map[string]string
+}
+
+// NewGeneratedSource wraps values the engine will make when asked.
+func NewGeneratedSource(label string, recipes map[string]func() (string, error)) *GeneratedSource {
+	return &GeneratedSource{Label: label, Recipes: recipes, cached: map[string]string{}}
+}
+
+func (g *GeneratedSource) Name() string { return g.Label }
+
+// Available is false when there is nothing to generate, so an environment that
+// needs none of this never sees the source in a "Looked in" list.
+func (g *GeneratedSource) Available(context.Context) (bool, string) {
+	return len(g.Recipes) > 0, ""
+}
+
+func (g *GeneratedSource) Lookup(_ context.Context, name string) (Value, bool, error) {
+	recipe, ok := g.Recipes[name]
+	if !ok {
+		return Value{}, false, nil
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.cached == nil {
+		g.cached = map[string]string{}
+	}
+	if v, done := g.cached[name]; done {
+		return NewFrom(v, g.Name()), true, nil
+	}
+	v, err := recipe()
+	if err != nil {
+		return Value{}, false, fmt.Errorf("generating %s: %w", name, err)
+	}
+	g.cached[name] = v
+	return NewFrom(v, g.Name()), true, nil
+}
+
+// GitHubAppPrivateKeyEnv is the name a manifest reads the generated App
+// identity under. It is GitHub's own conventional spelling with no prefix, the
+// same convention the webhook signing secrets use, so that an application
+// reading it under a name of its own says `from: GITHUB_APP_PRIVATE_KEY` and
+// the two sides cannot drift.
+const GitHubAppPrivateKeyEnv = "GITHUB_APP_PRIVATE_KEY"
+
+// GitHubAppIdentitySourceName is how the chain refers to this source in af
+// explain and in the "Looked in" list of AF-SEC-001.
+const GitHubAppIdentitySourceName = "the identity this environment generates for its GitHub App"
+
+// GenerateGitHubAppPrivateKey makes an App identity for one environment.
+//
+// RSA 2048 in PKCS#8, which is what GitHub issues and what Node's
+// createPrivateKey reads without argument. It is a real key because the half
+// configured case is refused by the applications that read it: an App id and a
+// webhook secret with no key is an endpoint that verifies deliveries and can
+// do nothing with them, so a placeholder string would either be rejected at
+// startup or fail later with a decoder error that names the wrong problem.
+//
+// It is generated rather than committed for the reason this whole path exists.
+// A key written into a manifest is a key in a public repository for as long as
+// the file is there, and this one was: 2048 bits of RSA sat in this
+// repository's own antifailure.yaml, under `value:`, base64 encoded so that
+// the validator's refusal of a literal beginning with BEGIN did not see it.
+//
+// Fresh per environment rather than derived from the environment identifier.
+// Nothing outside the environment ever needs to reproduce it, so there is
+// nothing to be gained by making it predictable and something to lose.
+func GenerateGitHubAppPrivateKey() (string, error) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return "", err
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		return "", err
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})), nil
+}

--- a/engine/internal/secrets/generated_test.go
+++ b/engine/internal/secrets/generated_test.go
@@ -1,0 +1,125 @@
+package secrets_test
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/internal/secrets"
+	"github.com/antifailure/antifailure/engine/pkg/livekey"
+)
+
+func TestGeneratedSource_RunsTheRecipeOnlyWhenSomebodyAsks(t *testing.T) {
+	t.Parallel()
+	// The laziness is the reason this type exists rather than a map. A 2048 bit
+	// key costs enough to notice and most environments never declare the
+	// variable, so an environment that does not ask must not pay.
+	runs := 0
+	src := secrets.NewGeneratedSource("a label", map[string]func() (string, error){
+		"A_NAME": func() (string, error) { runs++; return "a value", nil },
+	})
+	require.Zero(t, runs, "the recipe ran before anything looked the name up")
+
+	_, found, err := src.Lookup(context.Background(), "SOMETHING_ELSE")
+	require.NoError(t, err)
+	require.False(t, found)
+	require.Zero(t, runs, "a lookup of a different name ran the recipe")
+
+	v, found, err := src.Lookup(context.Background(), "A_NAME")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, "a value", v.Reveal())
+	require.Equal(t, 1, runs)
+}
+
+func TestGeneratedSource_AnswersTheSameThingTwice(t *testing.T) {
+	t.Parallel()
+	// A source consulted twice has to answer the same thing twice. A key that
+	// changed between af up resolving it and af explain reporting it would be
+	// two identities where the user was told there was one.
+	runs := 0
+	src := secrets.NewGeneratedSource("a label", map[string]func() (string, error){
+		"A_NAME": func() (string, error) { runs++; return string(rune('a' + runs)), nil },
+	})
+	first, _, err := src.Lookup(context.Background(), "A_NAME")
+	require.NoError(t, err)
+	second, _, err := src.Lookup(context.Background(), "A_NAME")
+	require.NoError(t, err)
+	require.Equal(t, first.Reveal(), second.Reveal())
+	require.Equal(t, 1, runs, "the recipe ran twice")
+}
+
+func TestGeneratedSource_ReportsAFailedRecipeRatherThanAnEmptyValue(t *testing.T) {
+	t.Parallel()
+	// An empty value handed to a service is a container that starts and fails
+	// ten seconds later in a log nobody is watching.
+	src := secrets.NewGeneratedSource("a label", map[string]func() (string, error){
+		"A_NAME": func() (string, error) { return "", errors.New("no entropy") },
+	})
+	_, found, err := src.Lookup(context.Background(), "A_NAME")
+	require.Error(t, err)
+	require.False(t, found)
+	require.Contains(t, err.Error(), "A_NAME")
+}
+
+func TestGeneratedSource_IsInvisibleWhenItHoldsNothing(t *testing.T) {
+	t.Parallel()
+	// A source with nothing to generate must not appear in the "Looked in"
+	// list of a missing variable. A list naming a source that could never have
+	// answered sends somebody to configure a place that does not exist.
+	empty := secrets.NewGeneratedSource("a label", nil)
+	ok, _ := empty.Available(context.Background())
+	require.False(t, ok)
+
+	full := secrets.NewGeneratedSource("a label", map[string]func() (string, error){
+		"A_NAME": func() (string, error) { return "a value", nil },
+	})
+	ok, _ = full.Available(context.Background())
+	require.True(t, ok)
+}
+
+func TestGenerateGitHubAppPrivateKey_IsAKeyTheApplicationsCanRead(t *testing.T) {
+	t.Parallel()
+	// The half configured case is refused by every application that reads
+	// these three variables together, so a placeholder string would either be
+	// rejected at startup or fail later with a decoder error naming the wrong
+	// problem. It has to be a real key.
+	value, err := secrets.GenerateGitHubAppPrivateKey()
+	require.NoError(t, err)
+
+	block, rest := pem.Decode([]byte(value))
+	require.NotNil(t, block, "the value is not PEM")
+	require.Equal(t, "PRIVATE KEY", block.Type, "GitHub issues PKCS#8 and Node reads it without argument")
+	require.Empty(t, rest)
+
+	key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	require.NoError(t, err)
+	require.NotNil(t, key)
+}
+
+func TestGenerateGitHubAppPrivateKey_IsDifferentEveryTime(t *testing.T) {
+	t.Parallel()
+	// Nothing outside the environment reproduces it, so there is nothing to be
+	// gained by making it predictable and something to lose.
+	first, err := secrets.GenerateGitHubAppPrivateKey()
+	require.NoError(t, err)
+	second, err := secrets.GenerateGitHubAppPrivateKey()
+	require.NoError(t, err)
+	require.NotEqual(t, first, second)
+}
+
+func TestGenerateGitHubAppPrivateKey_IsWhatTheCredentialGateRefuses(t *testing.T) {
+	t.Parallel()
+	// The point of generating it is that it never has to be written down, and
+	// the check that would object if it were is the one this asserts against.
+	// If this ever stops finding it, the key stopped being real.
+	value, err := secrets.GenerateGitHubAppPrivateKey()
+	require.NoError(t, err)
+	found := livekey.Scan(value, "the value")
+	require.Len(t, found, 1)
+	require.Equal(t, "Private key", found[0].Provider)
+}

--- a/engine/pkg/livekey/livekey.go
+++ b/engine/pkg/livekey/livekey.go
@@ -25,6 +25,7 @@
 package livekey
 
 import (
+	"encoding/base64"
 	"strings"
 )
 
@@ -130,6 +131,14 @@ func pemGap(r rune) bool {
 // one of these patterns would fail that check on the detector's own source.
 const pemPrivateKeyHeader = "-----BEGIN " + "PRIVATE KEY-----"
 
+// pemHeaderFor opens a private key of one algorithm. Assembled for the same
+// reason as the constant above, and separate from it because the algorithms
+// each get their own header line and a scanner that only knew PKCS#8 would
+// miss every key ssh-keygen and openssl ever wrote by default.
+func pemHeaderFor(algorithm string) string {
+	return "-----BEGIN " + algorithm + " PRIVATE KEY-----"
+}
+
 // patterns are live credentials only.
 //
 // Every entry here has a test mode counterpart that is deliberately absent:
@@ -187,6 +196,42 @@ var patterns = []pattern{
 	{provider: "GCP service account key", prefix: pemPrivateKeyHeader, minTail: 60,
 		tail: base64ish, skip: pemGap, also: []string{"gserviceaccount.com"}},
 
+	// A private key belonging to nobody the detector can name, which is the
+	// one shape this package used to answer nothing about.
+	//
+	// The rule above says a bare PEM is not evidence of Google, and that is
+	// still right: reporting one as a service account key sends somebody to
+	// rotate a credential their project does not have. What was wrong was the
+	// step after it. "This is not Google's" was implemented as "this is not a
+	// credential", so a 2048 bit RSA key sat in this repository's own
+	// antifailure.yaml while the required check that reads this package
+	// reported no credentials in the tree. A private key is a credential
+	// whoever issued it; the honest finding names the shape and declines to
+	// name an owner.
+	//
+	// These sit AFTER the service account entry and the first of them shares
+	// its prefix, which is what gives Google precedence: Scan records one
+	// finding per prefix, so where the corroborating marker is beside the key
+	// the finding says GCP service account key, and where it is not it says
+	// private key rather than nothing.
+	//
+	// minTail is 60 for the same reason it is 60 above. A PEM body wraps at 64
+	// characters, so one line of real key material clears it, and the redacted
+	// examples that fill documentation, REDACTED or an ellipsis where the body
+	// goes, do not.
+	{provider: "Private key", prefix: pemPrivateKeyHeader, minTail: 60,
+		tail: base64ish, skip: pemGap},
+	{provider: "Private key", prefix: pemHeaderFor("RSA"), minTail: 60,
+		tail: base64ish, skip: pemGap},
+	{provider: "Private key", prefix: pemHeaderFor("EC"), minTail: 60,
+		tail: base64ish, skip: pemGap},
+	{provider: "Private key", prefix: pemHeaderFor("DSA"), minTail: 60,
+		tail: base64ish, skip: pemGap},
+	{provider: "Private key", prefix: pemHeaderFor("OPENSSH"), minTail: 60,
+		tail: base64ish, skip: pemGap},
+	{provider: "Private key", prefix: pemHeaderFor("ENCRYPTED"), minTail: 60,
+		tail: base64ish, skip: pemGap},
+
 	// Azure. Three shapes and none of them has a prefix of its own, because
 	// Azure keys are plain base64 and are told apart by the field that carries
 	// them. The field name is the marker, and it is what the finding reports.
@@ -230,7 +275,31 @@ var patterns = []pattern{
 // Case sensitive on purpose. Every prefix here is emitted in a fixed case by
 // the provider that issues it, and folding case turns "AC" into a match for
 // the word "ac" in a URL.
+//
+// Two passes, because one of them reads what is written and the other reads
+// what was hidden. A base64 wrapped key is the same credential with the
+// markers this file matches on encoded away, and it is not a hypothetical: the
+// manifest in this repository carried one, in base64 rather than PEM, and the
+// comment beside it said the encoding was chosen because the validator refuses
+// a literal beginning with BEGIN.
 func Scan(text, where string) []Finding {
+	out := scanPatterns(text, where)
+	seen := map[string]bool{}
+	for _, f := range out {
+		seen[f.Prefix] = true
+	}
+	for _, f := range scanEncoded(text, where) {
+		if seen[f.Prefix] {
+			continue
+		}
+		seen[f.Prefix] = true
+		out = append(out, f)
+	}
+	return out
+}
+
+// scanPatterns is the literal pass, over the text exactly as it arrived.
+func scanPatterns(text, where string) []Finding {
 	var out []Finding
 	seen := map[string]bool{}
 	for _, p := range patterns {
@@ -269,6 +338,130 @@ func Scan(text, where string) []Finding {
 		}
 	}
 	return out
+}
+
+// encodedBeginMarkers are how the opening of a PEM block reads once the whole
+// block has been base64 encoded.
+//
+// Three of them, because base64 works on groups of three bytes and the reading
+// depends on where the block starts inside the group. A key encoded on its own,
+// which is the common case and the one this repository shipped, is the first.
+// The other two are the same header a few bytes into a larger blob.
+//
+// They are triggers rather than findings. What follows a hit is a decode and
+// then the ordinary pass over the result, so the length and corroboration
+// rules that keep prose out of the literal pass apply to the decoded text as
+// well, and nothing is reported on the strength of a prefix alone.
+var encodedBeginMarkers = []string{
+	"LS0tLS1CRUdJ",
+	"LS0tQkVHSU4g",
+	"LS0tLUJFR0lO",
+}
+
+// base64Rune reports whether a character can appear inside a base64 body.
+//
+// Padding is included, unlike base64ish above, because here the run is being
+// delimited rather than measured: the padding is part of the value that has to
+// be handed to the decoder.
+func base64Rune(r rune) bool { return base64ish(r) || r == '=' }
+
+// maxEncoded bounds the run that is decoded. A private key is under three
+// kilobytes encoded; this is generous and it stops a megabyte of base64 in a
+// fixture from being decoded because it happens to open with the marker.
+const maxEncoded = 1 << 16
+
+// scanEncoded finds a credential that was base64 encoded before it was written.
+//
+// The evasion this closes was not adversarial and it is worse for that. The
+// manifest in this repository held a real RSA private key as a single base64
+// literal, and the comment beside it explained the encoding as the way to get
+// past a validator that refuses a value beginning with BEGIN. Every instrument
+// that could have objected read the encoded form and saw an opaque string, and
+// the required check named "no credentials in the tree" passed over it for as
+// long as it was there.
+func scanEncoded(text, where string) []Finding {
+	var out []Finding
+	seen := map[string]bool{}
+	for _, marker := range encodedBeginMarkers {
+		for i := 0; ; {
+			idx := strings.Index(text[i:], marker)
+			if idx < 0 {
+				break
+			}
+			at := i + idx
+			i = at + len(marker)
+
+			lo, hi := base64Run(text, at)
+			if hi-lo > maxEncoded {
+				continue
+			}
+			decoded, ok := decodeRun(text[lo:hi])
+			if !ok {
+				continue
+			}
+			for _, f := range scanPatterns(decoded, where) {
+				if seen[f.Prefix] {
+					continue
+				}
+				seen[f.Prefix] = true
+				out = append(out, f)
+			}
+		}
+	}
+	return out
+}
+
+// base64Run returns the bounds of the base64 run containing at.
+func base64Run(text string, at int) (int, int) {
+	lo := at
+	for lo > 0 && base64Rune(rune(text[lo-1])) {
+		lo--
+	}
+	hi := at
+	for hi < len(text) && base64Rune(rune(text[hi])) {
+		hi++
+	}
+	return lo, hi
+}
+
+// decodeRun decodes a base64 run whose start may not be the start of the
+// encoding.
+//
+// Four attempts, because the run found by walking backwards over base64
+// characters can begin up to three characters inside a group: a marker for one
+// of the two offset alignments sits behind bytes that are themselves base64
+// characters. Whichever attempt yields a PEM private key is the right one, and
+// nothing else is accepted, so a blob that decodes to arbitrary bytes is not a
+// finding.
+func decodeRun(run string) (string, bool) {
+	for k := 0; k < 4 && k < len(run); k++ {
+		body := run[k:]
+		body = body[:len(body)-len(body)%4]
+		if len(body) < 4 {
+			continue
+		}
+		decoded, err := base64.StdEncoding.DecodeString(body)
+		if err != nil {
+			// A run that carries padding in the middle, which happens when two
+			// values sit side by side, decodes up to that point. Everything
+			// before the padding is still worth reading.
+			if cut := strings.IndexByte(body, '='); cut > 0 {
+				body = body[:cut-cut%4]
+				if len(body) < 4 {
+					continue
+				}
+				decoded, err = base64.StdEncoding.DecodeString(body)
+			}
+			if err != nil {
+				continue
+			}
+		}
+		text := string(decoded)
+		if strings.Contains(text, "-----BEGIN") && strings.Contains(text, "PRIVATE KEY") {
+			return text, true
+		}
+	}
+	return "", false
 }
 
 func hasTail(s string, min int, ok func(rune) bool, skip func(rune) bool) bool {

--- a/engine/pkg/livekey/livekey_test.go
+++ b/engine/pkg/livekey/livekey_test.go
@@ -1,6 +1,7 @@
 package livekey_test
 
 import (
+	"encoding/base64"
 	"strings"
 	"testing"
 
@@ -148,6 +149,60 @@ const (
 	pemFooter = "-----END " + "PRIVATE KEY-----"
 )
 
+// The certificate is the negative control for every private key vector below.
+// It is the public half of the same pair, it is committed on purpose in every
+// repository that terminates TLS, and it opens with the same dashes.
+const (
+	certHeader = "-----BEGIN " + "CERTIFICATE-----"
+	certFooter = "-----END " + "CERTIFICATE-----"
+)
+
+// algorithmHeader is what openssl and ssh-keygen write by default. PKCS#8 is
+// only one of the spellings and it is not the most common one on a laptop.
+func algorithmHeader(algorithm string) string {
+	return "-----BEGIN " + algorithm + " PRIVATE KEY-----"
+}
+
+// encoded is the shape this lane exists for: the whole block base64 encoded
+// into one line, which is how the key reached this repository's own manifest
+// and how it got past a validator that refuses a literal beginning with BEGIN.
+func encoded(pem string) string {
+	return base64.StdEncoding.EncodeToString([]byte(pem))
+}
+
+// privateKeyVector is one private key that must be refused whoever issued it.
+func privateKeyVectors() []liveVector {
+	body := fake("", 64, base64s)
+	pkcs8 := pemHeader + "\n" + body + "\n" + pemFooter
+	return []liveVector{
+		{"private key, bare pkcs8", "Private key", pkcs8},
+		{"private key, rsa header", "Private key",
+			algorithmHeader("RSA") + "\n" + body + "\n" + "-----END " + "RSA PRIVATE KEY-----"},
+		{"private key, ec header", "Private key",
+			algorithmHeader("EC") + "\n" + body + "\n" + "-----END " + "EC PRIVATE KEY-----"},
+		{"private key, openssh header", "Private key",
+			algorithmHeader("OPENSSH") + "\n" + body + "\n" + "-----END " + "OPENSSH PRIVATE KEY-----"},
+		{"private key, in a kubernetes secret", "Private key",
+			"tls.key: |\n  " + pemHeader + "\n  " + body + "\n  " + pemFooter},
+		// The reason a bare key is a finding at all. The marker that would
+		// make it Google's is five thousand characters away, so it does not
+		// corroborate, and the answer before this lane was silence rather than
+		// a finding that declined to name an owner.
+		{"private key, gcp marker too far away", "Private key",
+			pkcs8 + strings.Repeat(" ", 5000) + "af@af.iam.gserviceaccount.com"},
+
+		// The exact form this repository shipped: one base64 line, in a
+		// manifest, as the value of an environment variable.
+		{"private key, base64 wrapped", "Private key", encoded(pkcs8)},
+		{"private key, base64 wrapped in a manifest value", "Private key",
+			"      - name: AF_GITHUB_APP_PRIVATE_KEY\n        value: " + encoded(pkcs8) + "\n"},
+		{"private key, base64 wrapped mid blob", "Private key",
+			base64.StdEncoding.EncodeToString([]byte("xy" + pkcs8))},
+		{"private key, base64 wrapped with a trailing value", "Private key",
+			encoded(pkcs8) + " " + fake("", 40, base64s)},
+	}
+}
+
 // serviceAccountFile is the credential Google issues, in the form it is written
 // to disk: JSON, with the PEM line breaks escaped rather than literal. The
 // escaped break is the reason the pattern needed a skip at all, so the on disk
@@ -289,14 +344,12 @@ func benignVectors() []struct{ name, text string } {
 		{"azurite, account name after the key",
 			"AccountKey=" + fake("", 86, base64s) + "==;AccountName=devstoreaccount1"},
 
-		// A private key that is not Google's. Naming the wrong provider sends
-		// somebody to rotate a credential that has nothing to do with the
-		// finding, so a PEM with no marker beside it is not a GCP finding.
-		{"tls private key, no marker", pemHeader + "\n" + fake("", 64, base64s) + "\n" + pemFooter},
-		{"tls private key, in a kubernetes secret",
-			"tls.key: |\n  " + pemHeader + "\n  " + fake("", 64, base64s) + "\n  " + pemFooter},
-		{"gcp marker too far from the key", pemHeader + "\n" + fake("", 64, base64s) + "\n" + pemFooter +
-			strings.Repeat(" ", 5000) + "af@af.iam.gserviceaccount.com"},
+		// A certificate, which is the public half and is published on purpose.
+		// It opens with the same five dashes as the key beside it in the same
+		// file, and refusing it would refuse every TLS chain in every
+		// repository there is.
+		{"certificate, bare pem", certHeader + "\n" + fake("", 64, base64s) + "\n" + certFooter},
+		{"certificate, base64 wrapped", encoded(certHeader + "\n" + fake("", 64, base64s) + "\n" + certFooter)},
 
 		// Another provider's secret under another provider's name. Every OAuth
 		// service in existence spells it client_secret, and a finding that
@@ -360,12 +413,57 @@ func TestScan_WillNotNameGoogleForSomebodyElsesPrivateKey(t *testing.T) {
 	// A bare PEM is a private key and it is not evidence of a cloud. Reporting
 	// it as a GCP service account key would send somebody to rotate a
 	// credential their Google project does not have.
+	//
+	// What changed is the other half. Declining to name Google used to mean
+	// reporting nothing at all, and this test asserted the nothing. A private
+	// key is a credential whoever issued it, so the answer is now a finding
+	// that names the shape and no owner, and Google's marker still promotes it
+	// to the more specific one.
 	body := fake("", 64, base64s)
 	bare := pemHeader + "\n" + body + "\n" + pemFooter
-	require.Empty(t, livekey.Scan(bare, "the body"))
+
+	anonymous := livekey.Scan(bare, "the body")
+	require.Len(t, anonymous, 1, "a private key with no owner beside it is still a credential")
+	require.Equal(t, "Private key", anonymous[0].Provider)
+
 	found := livekey.Scan(bare+"\nclient_email: af@af.iam.gserviceaccount.com", "the body")
-	require.Len(t, found, 1, "the same key with Google's own marker beside it is a finding")
+	require.Len(t, found, 1, "the same key with Google's own marker beside it is one finding, not two")
 	require.Equal(t, "GCP service account key", found[0].Provider)
+}
+
+func TestScan_FindsAPrivateKeyWhoeverIssuedIt(t *testing.T) {
+	t.Parallel()
+	// The hole this closes, stated as the case that produced it: a 2048 bit
+	// RSA key sat in this repository's own antifailure.yaml, base64 encoded,
+	// and the required check that reads this package reported no credentials
+	// in the tree for as long as it was there.
+	for _, v := range privateKeyVectors() {
+		t.Run(v.name, func(t *testing.T) {
+			found := livekey.Scan(v.text, "the body")
+			require.Len(t, found, 1, "%s was not recognised, or was recognised twice", v.name)
+			require.Equal(t, v.provider, found[0].Provider)
+			require.Equal(t, "the body", found[0].Where)
+		})
+	}
+}
+
+func TestScan_TheEncodedPassAnswersOnlyForRealKeyMaterial(t *testing.T) {
+	t.Parallel()
+	// The encoded pass decodes before it decides, so everything the literal
+	// pass refuses to call a credential it refuses too. Each of these decodes
+	// cleanly and none of them is a private key.
+	body := fake("", 64, base64s)
+	for name, text := range map[string]string{
+		"a certificate":        encoded(certHeader + "\n" + body + "\n" + certFooter),
+		"a public key":         encoded("-----BEGIN " + "PUBLIC KEY-----\n" + body + "\n-----END " + "PUBLIC KEY-----"),
+		"a redacted key":       encoded(pemHeader + "\nREDACTED\n" + pemFooter),
+		"a header with no body": encoded(pemHeader),
+		"ordinary prose":       encoded("the file opens with " + pemHeader + " and we never log past it"),
+		"not base64 at all":    "LS0tLS1CRUdJ this is a sentence about the encoding",
+	} {
+		require.Empty(t, livekey.Scan(text, "the body"),
+			"%s decoded to something that is not a private key and was refused anyway", name)
+	}
 }
 
 func TestScan_MeasuresThePemBodyThroughTheLineBreak(t *testing.T) {
@@ -384,15 +482,24 @@ func TestScan_NeverEchoesACloudCredential(t *testing.T) {
 	// The Azure shapes have no prefix of their own, so the finding reports the
 	// field name that carried them. That is still a marker and it is still not
 	// the value, and this is the assertion that keeps it that way.
-	for _, v := range liveCloudVectors() {
+	for _, v := range append(liveCloudVectors(), privateKeyVectors()...) {
 		t.Run(v.name, func(t *testing.T) {
 			found := livekey.Scan(v.text, "the body")
 			require.Len(t, found, 1)
 			rendered := found[0].String() + " " + livekey.Describe(found)
 			// Every run of thirty characters in the vector, which is longer
 			// than any field name and shorter than any of these credentials.
+			//
+			// Except the marker itself, which the finding reports on purpose
+			// and which the private key headers push past thirty characters.
+			// A window that is part of the marker is the finding saying what
+			// it found, not the finding leaking what it found.
 			for i := 0; i+30 <= len(v.text); i++ {
-				require.NotContains(t, rendered, v.text[i:i+30],
+				window := v.text[i : i+30]
+				if strings.Contains(found[0].Prefix, window) {
+					continue
+				}
+				require.NotContains(t, rendered, window,
 					"the finding carried a piece of the credential")
 			}
 		})
@@ -407,7 +514,7 @@ func TestScan_NeverEchoesACloudCredential(t *testing.T) {
 // Run it with -v and the last line is the number.
 func TestScan_TheNumber(t *testing.T) {
 	t.Parallel()
-	live := liveCloudVectors()
+	live := append(liveCloudVectors(), privateKeyVectors()...)
 	benign := benignVectors()
 
 	detected := 0
@@ -424,7 +531,7 @@ func TestScan_TheNumber(t *testing.T) {
 		}
 	}
 
-	t.Logf("livekey: %d/%d live GCP and Azure credential forms refused, "+
+	t.Logf("livekey: %d/%d live credential forms refused, "+
 		"%d false positives over %d synthetic non credentials",
 		detected, len(live), positives, len(benign))
 	require.Equal(t, len(live), detected)

--- a/engine/pkg/livekey/livekey_test.go
+++ b/engine/pkg/livekey/livekey_test.go
@@ -454,12 +454,12 @@ func TestScan_TheEncodedPassAnswersOnlyForRealKeyMaterial(t *testing.T) {
 	// cleanly and none of them is a private key.
 	body := fake("", 64, base64s)
 	for name, text := range map[string]string{
-		"a certificate":        encoded(certHeader + "\n" + body + "\n" + certFooter),
-		"a public key":         encoded("-----BEGIN " + "PUBLIC KEY-----\n" + body + "\n-----END " + "PUBLIC KEY-----"),
-		"a redacted key":       encoded(pemHeader + "\nREDACTED\n" + pemFooter),
+		"a certificate":         encoded(certHeader + "\n" + body + "\n" + certFooter),
+		"a public key":          encoded("-----BEGIN " + "PUBLIC KEY-----\n" + body + "\n-----END " + "PUBLIC KEY-----"),
+		"a redacted key":        encoded(pemHeader + "\nREDACTED\n" + pemFooter),
 		"a header with no body": encoded(pemHeader),
-		"ordinary prose":       encoded("the file opens with " + pemHeader + " and we never log past it"),
-		"not base64 at all":    "LS0tLS1CRUdJ this is a sentence about the encoding",
+		"ordinary prose":        encoded("the file opens with " + pemHeader + " and we never log past it"),
+		"not base64 at all":     "LS0tLS1CRUdJ this is a sentence about the encoding",
 	} {
 		require.Empty(t, livekey.Scan(text, "the body"),
 			"%s decoded to something that is not a private key and was refused anyway", name)


### PR DESCRIPTION
## The failure

`antifailure.yaml` declared `AF_GITHUB_APP_PRIVATE_KEY` with `value:` set to a
2048 bit RSA private key, 2272 characters of it, base64 encoded rather than PEM.
The comment beside it gave the reason for the encoding: the manifest validator
refuses a literal beginning with BEGIN, and base64 does not begin with BEGIN.

The published schema says what a manifest is: it declares the name and where
the value comes from, and never the value itself, "which is why the file is safe
to commit". The file this product holds up as an ordinary manifest was the one
breaking that. This repository is public.

## Three instruments that could have objected

**`no credentials in the tree`** is one of the nine required contexts. It ran on
every commit, green, for as long as the key was there. It uses `pkg/livekey`,
and livekey carried a decision taken one step too far: a bare PEM is not
evidence of Google, which is right, implemented as reporting nothing at all,
which is not. Two benign vectors and a named test asserted the nothing. A
private key with no cloud marker beside it was invisible to the repository scan,
to the proxy tripwire and to the sandbox check, whoever issued it.

It is now a finding under its own name, owning no provider. Google's marker
still promotes it: the service account entry sits ahead of it and shares its
prefix, and `Scan` records one finding per prefix.

**The encoding** needed answering separately. A detector that reads the first
characters of a value is exactly what an encoding moves out of the way. A second
pass finds the three alignments a base64 encoded PEM header can have, decodes
the run, and puts the ordinary pass over the result, so nothing is reported on
the strength of a prefix and a certificate stays a certificate.

**The manifest validator** now asks livekey the same question, so the manifest
check and the credential gate cannot disagree about what a committed credential
is. Before this the two answered differently about the same file.

## The supply path

The key could not be supplied before. The engine derives a webhook signing
secret per provider so a manifest can say `from: GITHUB_WEBHOOK_SECRET`, and
there was nowhere at all for an App private key to come from, so a literal was
the only thing that worked.

A manifest declaring a webhook path for GitHub is rehearsing a GitHub App, and
the App id, the key and the webhook secret are refused by the applications that
read them unless all three are present. The same rule that offers the signing
secret now offers `GITHUB_APP_PRIVATE_KEY`, generated once per environment,
PKCS#8, real because a placeholder fails later with a decoder error that names
the wrong problem. It stands aside for a key somebody exported rather than
copying it, so `af explain` names the shell when the shell answered.

`af up` and `af explain` build that source list from one constructor. They
already had to build the identical chain and each was assembling its own.

## What does not change

Nothing outside a preview environment. Staging and production read the App key
from Key Vault, the Helm chart reads it from a Kubernetes secret, and neither
has ever read this file. **There is no manual step.**

## What deleting the value does not fix

The key is still in the history, in `b6a0ba39` and every commit since. The
manifest said it was generated for this file with `openssl genpkey` and never
registered with GitHub, the App id beside it is `1`, and it matches nothing this
repository deploys. Whether it is one of the four exposed credentials carrying a
prior decision not to rotate is not recorded anywhere in this repository, so
this branch changes no credential and creates none.
