### PR TITLE
ee: two pull requests built the same ECS package and merging both would have registered it twice

### DIFF
--- a/.changes/a-dns-rule-group-that-blocked-nothing.md
+++ b/.changes/a-dns-rule-group-that-blocked-nothing.md
@@ -20,13 +20,14 @@ holding it has not decided whether a query the firewall cannot evaluate is
 permitted, and a bool rounded that to whichever answer the zero value gave. It
 is the AWS value now, and that case reports unproven rather than either answer.
 
-The ECS runtime's egress report went from eight of thirteen paths closed to ten.
-The two that moved were open because a Fargate task must reach the registry to
-start, which answers the weaker half of the question: reaching ECR cannot be
-closed and reaching any repository, any log group and any bucket in the region
-can, by a VPC endpoint policy, and only the second is an exfiltration path. The
-generated ECR policy would also have denied the login, because
-ecr:GetAuthorizationToken takes no resource and was named against a repository.
+Two paths the first draft of the enumeration counted as open are closed, which is
+why the report says ten of thirteen and not eight. Both were called open because
+a Fargate task must reach the registry to start, and that answers the weaker half
+of the question: reaching ECR cannot be closed and reaching any repository, any
+log group and any bucket in the region can, by a VPC endpoint policy, and only
+the second is an exfiltration path. The generated ECR policy would also have
+denied the login, because ecr:GetAuthorizationToken takes no resource and was
+named against a repository.
 
 The generated firewall would have broken the environment it protects. Its allow
 list held four hardcoded AWS names, so a manifest declaring a host the sidecar

--- a/.changes/a-dns-rule-group-that-blocked-nothing.md
+++ b/.changes/a-dns-rule-group-that-blocked-nothing.md
@@ -1,0 +1,41 @@
+# security
+
+A Route 53 Resolver DNS Firewall rule group that let every query through was
+reported as closing the resolver.
+
+AWS processes a rule group by order of priority starting from the lowest, and
+defines ALLOW as permitting the request to go through and ALERT as permitting it
+and sending metrics and logs. So a group holding ALLOW on every domain at
+priority 5 and BLOCK on every domain at priority 1000 blocks nothing at all, and
+the check called it closed because every assertion it made about the terminal
+rule was true. It reads as configured in a console screenshot. The check now
+refuses that shape, a terminal rule moved off the end by priority, two rules
+sharing the last priority, which AWS refuses to create, and a domain with a star
+anywhere but the front, which a DNS Firewall domain list cannot hold. Each has a
+mutation aimed at it.
+
+The failure mode of that association was a bool and the AWS field takes three
+values. The third takes the answer from a setting no plan carries, so a plan
+holding it has not decided whether a query the firewall cannot evaluate is
+permitted, and a bool rounded that to whichever answer the zero value gave. It
+is the AWS value now, and that case reports unproven rather than either answer.
+
+The ECS runtime's egress report went from eight of thirteen paths closed to ten.
+The two that moved were open because a Fargate task must reach the registry to
+start, which answers the weaker half of the question: reaching ECR cannot be
+closed and reaching any repository, any log group and any bucket in the region
+can, by a VPC endpoint policy, and only the second is an exfiltration path. The
+generated ECR policy would also have denied the login, because
+ecr:GetAuthorizationToken takes no resource and was named against a repository.
+
+The generated firewall would have broken the environment it protects. Its allow
+list held four hardcoded AWS names, so a manifest declaring a host the sidecar
+forwards to would have had that host fail to resolve. It reads the manifest's
+egress catalogue now, and a declared host it cannot express as a rule is named
+in the refusal rather than dropped or widened.
+
+Instance metadata still cannot be closed on Fargate, and it can now be answered.
+A verdict carries the grade of evidence behind it, so a closure computed from a
+JSON document is counted apart from one recorded by an attempt made inside a
+task in the customer's own account. No recorded attempt leaves the path
+unproven, and nothing moves it on an absence.

--- a/.changes/ecs-runtime-containment-report.md
+++ b/.changes/ecs-runtime-containment-report.md
@@ -1,0 +1,30 @@
+# added
+
+`runtime.provider: ecs` is now answered by a containment report instead of by a
+list of the two runtimes that exist. It still refuses to start an environment,
+and the refusal is the feature: it enumerates thirteen distinct ways out of an
+ECS task on Fargate, names the ten the generated configuration closes, the one
+that is open and the two that neither the configuration nor AWS's documentation
+decides, and says which verdicts are computed from a configuration nobody has
+applied to an AWS account.
+
+An unproven verdict is not a weaker closed one and is never counted as one. The
+instance metadata service and the local time sync service are the two, both on
+link local addresses that no route table or security group reaches, and settling
+either takes one request from one running task in somebody's own account.
+
+Three things the enumeration found are worth knowing even if you never run on
+ECS. A security group cannot deny egress on Fargate, because the image pull runs
+over the task's own interface under that same security group, so denying egress
+produces a task that never starts. On AWS a security group cannot filter a DNS
+query at all: the Amazon provided resolver answers recursive lookups for public
+names from anywhere in the VPC and the VPC user guide states plainly that neither
+security groups nor network ACLs can filter traffic to it, so closing that path
+takes a Route 53 Resolver DNS Firewall rule group. And reaching ECR is a
+different question from reaching every repository, log group and bucket in the
+region: the first cannot be closed without giving up the ability to start an
+environment, the second can, by a VPC endpoint policy, and only the second is an
+exfiltration path.
+
+The honest summary is unchanged and is now written down: Antifailure runs on EKS
+and not on raw ECS.

--- a/docs/src/content/docs/enterprise/runtimes.md
+++ b/docs/src/content/docs/enterprise/runtimes.md
@@ -50,4 +50,114 @@ What the enterprise edition adds here is not a third runtime. It is placement
 across several of them at once: the requirements, the tags and the scheduling
 described above.
 
+## Why there is no ECS runtime
+
+`runtime.provider: ecs` is registered in the enterprise binary and it refuses,
+every time, with a report rather than an error. The reason is worth reading
+before assuming it is a gap somebody will close next release.
+
+A runtime is allowed to exist here only if it can prove an environment has no
+way out, and the Kubernetes runtime proves it the only way a proof works: it
+creates the `NetworkPolicy` objects itself, then runs one pod under exactly the
+rules a service runs under and has it try to escape before any application image
+starts. If any attempt gets out the environment does not start and you get
+**AF-RUN-043**. That is not caution. Several container network plugins accept a
+`NetworkPolicy` object and enforce nothing, every status reads green, and the
+only thing that can tell the two apart is a packet.
+
+ECS on Fargate cannot be given the same treatment, for two reasons that are
+properties of the platform rather than of this implementation.
+
+**The image pull runs inside the boundary.** A kubelet pulls on the node, so a
+pod can be denied every egress rule and still start. On Fargate platform version
+1.4.0 the ECR login, the image pull and the log push all flow over the task's own
+network interface, under the task's own security group, and AWS states that a
+Fargate task must have a route to the registry to pull an image. So a security
+group that denies egress does not produce a contained environment. It produces a
+task that never starts, and the endpoints that let it start are themselves
+reachable addresses.
+
+**The enforcement cannot be observed without an account.** Whether a cluster
+enforces a `NetworkPolicy` is answerable on a laptop in ninety seconds. Whether
+AWS enforces a route table is a fact about an account, and no test in this
+repository is permitted to need one.
+
+So what ships is the enumeration and the predicate over it, and the refusal
+carries both. Thirteen distinct egress paths out of a Fargate task, of which
+**ten are closed by the configuration this runtime would generate, one is open,
+and two are not decided by either the configuration or AWS's own
+documentation**. Every closed verdict carries the grade of evidence behind it,
+and the report separates the closures computed from a JSON document from any
+recorded by an attempt made inside a running task, because those are different
+claims.
+
+The one that is open is the task metadata endpoint, which is on by default for
+every Fargate task on platform version 1.4.0 or later with no documented way to
+turn it off.
+
+The two that are unproven are named rather than rounded up, because an unproven
+verdict is not a weaker closed one. The instance metadata service at
+`169.254.169.254` is the sharper of them: the Fargate launch type removes the
+documented credential source, because EC2 instance profiles are not available to
+containers in Fargate tasks, but AWS does not state that the address stops
+answering, and those are different claims. The local Amazon Time Sync Service at
+`169.254.169.123` is the other. Settling either needs one request from one
+running task, which is a request from a task in somebody's AWS account, so
+nothing here moves them on an absence of evidence.
+
+Two paths that a reader of an earlier draft of this page would have found in the
+open column are closed, and how they closed is the reusable part. The interface
+endpoints the image pull needs and the S3 gateway endpoint the layers come from
+cannot be disconnected without giving up the ability to start an environment at
+all. But reaching ECR is not the same question as reaching **any** repository,
+any log group and any bucket in the region, and only the second is an
+exfiltration path. A VPC endpoint policy naming this environment's own
+repository, log group and bucket closes the second while leaving the first, so
+the weaker half of the question was the one being answered.
+
+One finding is worth carrying away even if you never run on ECS. **On AWS the
+security group is irrelevant to a DNS query.** The VPC user guide states that
+traffic to and from the Amazon DNS server cannot be filtered with network ACLs
+or security groups, and that resolver answers recursive queries for public names
+from anywhere in the VPC. A DNS question is chosen by whoever asks it, so that
+is a data channel out that no security group audit will ever show you. Closing
+it takes a Route 53 Resolver DNS Firewall rule group whose last rule blocks every
+domain and which does not fail open. A containment argument carried over from
+Kubernetes gets this one wrong, because there the same attempt is closed by the
+policy that closes everything else.
+
+**A DNS Firewall rule group is read by priority from the lowest number up, and
+that is where the second finding is.** A group holding `ALLOW` on every domain
+at priority 5 and `BLOCK` on every domain at priority 1000 blocks nothing at all,
+because `ALLOW` permits the request to go through and the lower priority is
+consulted first. It reads as configured in a console screenshot. The check
+refuses that shape, along with a terminal rule moved off the end by priority, two
+rules sharing the last priority, which AWS refuses to create anyway, and a domain
+with a star anywhere but the front, which a DNS Firewall domain list cannot hold.
+
+The rule group's allow list is generated from the manifest's own egress
+catalogue rather than from a list of AWS names kept beside it. A host the
+manifest declares `allow` or `sandbox` is one the sidecar forwards to for real
+and therefore has to resolve; a host declared `block`, `mock`, `capture` or
+`synth` is answered locally and must not resolve, because a name the sidecar
+answers resolving publicly is a route around the decision the manifest made
+about it. A declared host that cannot be expressed as a DNS Firewall domain is
+named in the refusal rather than dropped or widened.
+
+**The honest summary is that Antifailure runs on EKS and not on raw ECS.** Use
+`runtime.provider: kubernetes` against an EKS cluster, where the probe runs.
+
+The report is generated for a real network rather than for a made up one, so
+that the security group rules and route table entries it judges are the ones
+your account would get. Six variables describe that network, and they are
+variables rather than manifest fields because a VPC identifier is a property of
+one company's account and does not belong in a file that gets forked:
+`AF_ECS_REGION`, `AF_ECS_CLUSTER`, `AF_ECS_VPC_ID`, `AF_ECS_VPC_CIDR`,
+`AF_ECS_SUBNET_IDS` and `AF_ECS_SUBNET_CIDRS`, the last two comma separated and
+in matching order. Setting them changes the report and does not change the
+answer, and the refusal you get without them says so before you go and build a
+VPC to find out. A seventh, `AF_ECS_PROBE_IMAGE`, is optional and names the
+image the containment probe container would run; with it unset the plan carries
+no probe container and the instance metadata path says so.
+
 Related: [scheduling](/docs/concepts/scheduling), [licensing](/docs/enterprise/licensing).

--- a/ee/engine/cmd/af/main.go
+++ b/ee/engine/cmd/af/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/antifailure/antifailure/ee/engine/feature"
 	"github.com/antifailure/antifailure/ee/engine/license"
 	"github.com/antifailure/antifailure/ee/engine/policyenforce"
+	"github.com/antifailure/antifailure/ee/engine/runtime/ecs"
 	"github.com/antifailure/antifailure/ee/engine/secrets"
 	"github.com/antifailure/antifailure/engine/pkg/afcli"
 	"github.com/antifailure/antifailure/engine/pkg/edition"
@@ -117,6 +118,18 @@ func main() {
 	for _, rule := range policyenforce.Rules(policy) {
 		fmt.Fprintf(os.Stderr, "af: organization policy: %s\n", rule)
 	}
+	// The ECS runtime, registered so that a manifest naming it is answered by
+	// the package that knows why it cannot have one, rather than by the
+	// engine's generic "this build has local and kubernetes" message.
+	//
+	// Registered even though it refuses every Open, and the refusal is the
+	// point. A person who writes runtime.provider: ecs has a question, and the
+	// two possible answers are a list of the runtimes that exist, which tells
+	// them nothing, or thirteen enumerated egress paths with the five that are
+	// not closed named individually. The second is the deliverable. See
+	// ee/engine/runtime/ecs/runtime.go for why there is no runtime behind it.
+	extension.Default.AddRuntimeProvider(ecs.NewProvider())
+
 	if warning := status.Warning; warning != "" {
 		fmt.Fprintf(os.Stderr, "af: %s\n", warning)
 	}

--- a/ee/engine/runtime/ecs/egress.go
+++ b/ee/engine/runtime/ecs/egress.go
@@ -1,6 +1,7 @@
 package ecs
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/netip"
 	"sort"
@@ -31,6 +32,34 @@ const (
 	Unproven Verdict = "unproven"
 )
 
+// Grade is what KIND of evidence produced a verdict, and it is in the type
+// rather than only in the caveat on purpose.
+//
+// Report.Caveat says in prose that a closed verdict is a statement about a JSON
+// document. That was true of every verdict this package could produce when the
+// caveat was written, and it stopped being true the moment a probe inside a
+// running task could record what it saw. Two closed verdicts of different
+// grades are different claims, and a sentence at the bottom of a report is the
+// wrong place to keep a distinction that a caller might want to act on: a
+// person deciding whether to trust an environment should be able to ask which
+// of the closures were observed, not read for it.
+type Grade string
+
+const (
+	// FromDocument means a predicate read the generated configuration. It is a
+	// statement about a JSON document and nothing has applied it to an account.
+	FromDocument Grade = "document"
+	// FromObservation means a probe inside a running task in the customer's own
+	// account made the attempt and this is what it saw. It is a statement about
+	// a packet.
+	FromObservation Grade = "observation"
+	// NotEstablished is the grade of every unproven verdict. Nothing looked, so
+	// there is no evidence of either kind, and it is a value rather than an
+	// empty string so that a report cannot carry a verdict whose grade nobody
+	// filled in.
+	NotEstablished Grade = "none"
+)
+
 // Path is one distinct way out of an ECS task on Fargate.
 //
 // Distinct means a different route, not a different phrasing of one route. Two
@@ -48,6 +77,20 @@ type Path struct {
 	Why string
 	// ClosedBy names the mechanism, or says plainly that nothing closes it.
 	ClosedBy string
+	// Observe interprets a recorded probe result for this path, and it is nil
+	// for every path the configuration decides.
+	//
+	// It is nil for those on purpose rather than for want of writing: a path a
+	// route table already answers does not need a second instrument, and a
+	// second instrument that could disagree with the first about the same fact
+	// is a way to be confidently wrong rather than a way to be more sure. Only
+	// the two link local addresses have one, because they are the two the
+	// configuration cannot decide at all.
+	//
+	// It is consulted ONLY when an observation for this path exists. With none,
+	// Check decides, and Check returns Unproven for both of them, which is the
+	// absence rule: no probe result means unproven, forever.
+	Observe func(Observation) (Verdict, string)
 	// Check evaluates the path against a plan and returns the verdict with the
 	// detail that justifies it. The detail is never empty, because a verdict
 	// with no reason is a verdict nobody can check.
@@ -85,7 +128,7 @@ func Paths() []Path {
 				"outbound IPv6.",
 			ClosedBy: "no IPv6 range on the VPC or its subnets, no egress only gateway route, " +
 				"and no IPv6 egress rule",
-			Check:    checkPublicIPv6,
+			Check: checkPublicIPv6,
 		},
 		{
 			ID:   "public-resolver-over-udp",
@@ -122,8 +165,11 @@ func Paths() []Path {
 			ClosedBy: "nothing a task definition can say. The Fargate launch type removes the " +
 				"documented credential source, because EC2 instance profiles are not " +
 				"available to containers in Fargate tasks, but AWS does not document " +
-				"whether the address answers, so the configuration does not settle it",
-			Check: checkInstanceMetadata,
+				"whether the address answers, so the configuration does not settle it. " +
+				"One attempt from one running task does, and the generated task definition " +
+				"carries the probe container that makes it",
+			Check:   checkInstanceMetadata,
+			Observe: observeLinkLocal,
 		},
 		{
 			ID:   "the-task-role-credentials-endpoint",
@@ -148,26 +194,32 @@ func Paths() []Path {
 		},
 		{
 			ID:   "the-interface-endpoints-the-image-pull-needs",
-			Name: "the ECR and CloudWatch Logs interface endpoints, which the task must reach in order to start",
+			Name: "any ECR repository or log group in the region, through the endpoints the image pull must reach",
 			Why: "On Fargate platform version 1.4.0 the ECR login, the image pull and the log " +
 				"push all flow over the TASK ENI, under this security group, and the " +
 				"documentation says plainly that a Fargate task must have a route to the " +
 				"registry to pull an image. There is no equivalent of a kubelet pulling the " +
 				"image outside the pod's policy, so a task whose security group denies " +
 				"everything never starts.",
-			ClosedBy: "nothing, without giving up the ability to run an environment at all. " +
-				"It is narrowed by an endpoint policy per endpoint and by egress rules " +
-				"naming the endpoints' own security group rather than an address range",
+			ClosedBy: "a VPC endpoint policy per endpoint, naming this environment's own " +
+				"repository and log group and no wildcard resource or action, plus egress " +
+				"rules naming the endpoints' own security group rather than an address " +
+				"range. The connection to the endpoint cannot be closed without giving up " +
+				"the ability to start an environment, and the route to any other " +
+				"repository, log group or service through it can be, which is the half " +
+				"that is an exfiltration path",
 			Check: checkInterfaceEndpoints,
 		},
 		{
 			ID:   "the-s3-gateway-endpoint-the-layers-come-from",
-			Name: "the S3 gateway endpoint, reached through a route table prefix list rather than an ENI",
+			Name: "any S3 bucket in the region, through the gateway endpoint the image layers come from",
 			Why: "ECR stores image layers in S3, so the pull needs S3 as well as ECR. A " +
 				"gateway endpoint is a route, and an unrestricted one is a path to every " +
 				"bucket in the region, including the ones that accept anonymous writes.",
-			ClosedBy: "nothing, for the same reason as the interface endpoints. It is narrowed " +
-				"by an endpoint policy",
+			ClosedBy: "a gateway endpoint policy naming the layer bucket with a read only " +
+				"action. The route itself stays, for the same reason as the interface " +
+				"endpoints, and an endpoint policy is the only narrowing a gateway " +
+				"endpoint has",
 			Check: checkS3Gateway,
 		},
 		{
@@ -210,10 +262,13 @@ func Paths() []Path {
 				"requests and Amazon Time Service NTP requests against one 1024 packet per " +
 				"second link local budget, which is documentary evidence that a link local " +
 				"NTP service is reachable from inside the network.",
-			ClosedBy: "not established. The EC2 page for the local Amazon Time Sync Service " +
-				"does not state the link local address and does not say whether security " +
-				"groups filter it, so this lane could not settle the path and does not " +
-				"assert either answer",
+			ClosedBy: "not established by any configuration. The EC2 page for the local " +
+				"Amazon Time Sync Service gives the IPv4 endpoint as 169.254.169.123 and " +
+				"says a link local address restricts the traffic to within the VPC, and it " +
+				"nowhere says whether a security group filters it. So the address is known " +
+				"and the filtering is not. An attempt would settle it and this lane " +
+				"could not build one: the attempt is NTP over UDP and no tool in a " +
+				"minimal container image makes it",
 			Check: checkTimeSync,
 		},
 	}
@@ -223,7 +278,11 @@ func Paths() []Path {
 type PathVerdict struct {
 	Path    Path
 	Verdict Verdict
-	Detail  string
+	// Grade says what kind of evidence produced Verdict. Unproven is always
+	// NotEstablished and NotEstablished is always Unproven, which is asserted
+	// rather than assumed.
+	Grade  Grade
+	Detail string
 }
 
 // Report is the whole predicate applied to one plan.
@@ -237,6 +296,17 @@ type Report struct {
 	Closed   int
 	Open     int
 	Unproven int
+	// ClosedByDocument and ClosedByObservation split Closed by grade, and they
+	// sum to it.
+	//
+	// They are published separately because the two are not the same claim and
+	// a single Closed count invites them to be read as though they were. One
+	// says the configuration this runtime generates removes the path. The other
+	// says a task in an account tried it and got nowhere. The second is the
+	// stronger evidence and the harder to get, and a report that hid which was
+	// which would let the easy one borrow the credibility of the hard one.
+	ClosedByDocument    int
+	ClosedByObservation int
 	// Total is len(Verdicts).
 	Total int
 }
@@ -249,21 +319,58 @@ type Report struct {
 // Closed verdict is a statement about a JSON document. Whether AWS enforces
 // that document is a statement about an account, and nothing in this repository
 // has ever observed it.
-const Caveat = "Every verdict here is computed from the configuration this runtime would " +
-	"generate. None of it has been applied to an AWS account and no packet has been " +
-	"observed failing to leave a task. A closed verdict means the generated " +
-	"configuration removes the path, not that AWS was seen enforcing it."
+const Caveat = "A verdict marked [document] is computed from the configuration this runtime " +
+	"would generate. It says the generated configuration removes the path, not that AWS was " +
+	"seen enforcing it, and nothing here has been applied to an AWS account. A verdict marked " +
+	"[observation] is a recorded attempt from a task inside the account that ran the " +
+	"environment, which is a statement about a packet rather than about a JSON document. Those " +
+	"are different grades of evidence and this report counts them separately. A path with " +
+	"neither stays unproven: no absence of evidence closes anything here."
 
-// Evaluate applies every path's check to a plan.
-func Evaluate(plan Plan) Report {
+// Evaluate applies every path's check to a plan, with no observed evidence.
+//
+// It is EvaluateWith against an empty set rather than a separate code path, so
+// that the no evidence case cannot drift away from the case the tests exercise.
+func Evaluate(plan Plan) Report { return EvaluateWith(plan, nil) }
+
+// EvaluateWith applies every path's check to a plan and lets recorded
+// observations answer the paths the plan cannot.
+//
+// The order is deliberate and it is the whole safety property. Check runs
+// FIRST and always, so the configuration's own answer is the floor. An
+// observation can only speak for a path that declared an Observe, and only when
+// one was actually recorded for it. There is no branch in which a missing
+// observation improves a verdict, which is what makes "it must never flip to
+// closed on absence of evidence" a property of the shape rather than a rule
+// somebody has to remember.
+func EvaluateWith(plan Plan, observed Observations) Report {
 	paths := Paths()
 	report := Report{Verdicts: make([]PathVerdict, 0, len(paths)), Total: len(paths)}
 	for _, path := range paths {
 		verdict, detail := path.Check(plan)
-		report.Verdicts = append(report.Verdicts, PathVerdict{Path: path, Verdict: verdict, Detail: detail})
+		grade := FromDocument
+		if verdict == Unproven {
+			grade = NotEstablished
+		}
+		if path.Observe != nil {
+			if obs, ok := observed.For(path.ID); ok {
+				verdict, detail = path.Observe(obs)
+				grade = FromObservation
+				if verdict == Unproven {
+					grade = NotEstablished
+				}
+			}
+		}
+		report.Verdicts = append(report.Verdicts,
+			PathVerdict{Path: path, Verdict: verdict, Grade: grade, Detail: detail})
 		switch verdict {
 		case Closed:
 			report.Closed++
+			if grade == FromObservation {
+				report.ClosedByObservation++
+			} else {
+				report.ClosedByDocument++
+			}
 		case Open:
 			report.Open++
 		default:
@@ -296,10 +403,14 @@ func (r Report) NotClosed() []PathVerdict {
 // String renders the report the way the refusal prints it.
 func (r Report) String() string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "%d of %d egress paths out of an ECS task on Fargate are closed by the "+
-		"generated configuration (%d open, %d unproven).\n", r.Closed, r.Total, r.Open, r.Unproven)
+	fmt.Fprintf(&b, "%d of %d egress paths out of an ECS task on Fargate are closed "+
+		"(%d open, %d unproven).\n", r.Closed, r.Total, r.Open, r.Unproven)
+	fmt.Fprintf(&b, "Of those %d, %d are closed by the generated configuration and %d by an "+
+		"attempt observed from a running task.\n",
+		r.Closed, r.ClosedByDocument, r.ClosedByObservation)
 	for _, v := range r.Verdicts {
-		fmt.Fprintf(&b, "  %-9s %s\n             %s\n", v.Verdict, v.Path.ID, v.Detail)
+		fmt.Fprintf(&b, "  %-9s %-12s %s\n                            %s\n",
+			v.Verdict, "["+string(v.Grade)+"]", v.Path.ID, v.Detail)
 	}
 	b.WriteString("\n" + Caveat + "\n")
 	return b.String()
@@ -403,6 +514,17 @@ func checkPublicResolver(p Plan) (Verdict, string) {
 
 // checkAmazonResolver is the one check where the security group is irrelevant,
 // and saying so is the useful part.
+//
+// It is also the check this lane found could not say no to the two shapes that
+// matter most. A rule group is evaluated in priority order starting from the
+// lowest, so "the last rule blocks everything" is necessary and nowhere near
+// sufficient: an ALLOW or ALERT rule matching every domain at a lower priority
+// answers every query before the terminal rule is ever reached, and the old
+// predicate called that group closed. AWS defines ALLOW as "permit the request
+// to go through" and ALERT as "permit the request and send metrics and logs to
+// Cloud Watch", so both of them let the query out and only BLOCK disallows it.
+// A rule group with ALLOW on * at priority 5 and BLOCK on * at priority 1000
+// blocks nothing at all, and it reads as configured in a console screenshot.
 func checkAmazonResolver(p Plan) (Verdict, string) {
 	const irrelevant = "security groups and network ACLs cannot filter this path, so nothing in " +
 		"the security group above is evidence about it: "
@@ -422,21 +544,103 @@ func checkAmazonResolver(p Plan) (Verdict, string) {
 		missing = append(missing, fmt.Sprintf("the rule group is associated with %q and this "+
 			"plan's VPC is %q", fw.AssociatedVPCID, p.Network.VPC.ID))
 	}
-	if fw.FailOpen {
-		missing = append(missing, "the association fails open, so a rule the firewall cannot "+
-			"reach permits the query")
+	deferred := false
+	switch fw.FailOpen {
+	case FailClosed:
+	case FailOpenEnabled:
+		missing = append(missing, "FirewallFailOpen is ENABLED, so a query DNS Firewall cannot "+
+			"evaluate is permitted rather than refused and the containment is best effort")
+	case FailOpenDeferred:
+		deferred = true
+	default:
+		missing = append(missing, fmt.Sprintf("FirewallFailOpen is %q, which is not one of the "+
+			"three values AWS accepts, so the failure mode of this association is not described "+
+			"by this plan", fw.FailOpen))
 	}
-	if last, ok := lastRule(fw.Rules); !ok {
-		missing = append(missing, "the rule group has no rules")
-	} else if !isBlockEverything(last) {
-		missing = append(missing, fmt.Sprintf("the last rule by priority is %s on %s and must "+
-			"be BLOCK on *", last.Action, strings.Join(last.Domains, ", ")))
-	}
+	missing = append(missing, ruleGroupFaults(fw.Rules)...)
+
+	// A definite fault outranks an undecided failure mode. Knowing the path is
+	// open is a stronger statement than not knowing what happens when the
+	// firewall breaks, and reporting unproven here would hide a fault behind an
+	// uncertainty.
 	if len(missing) > 0 {
 		return Open, irrelevant + strings.Join(missing, "; ")
 	}
+	if deferred {
+		return Unproven, irrelevant + "the rule group's rules are correct, and its " +
+			"FirewallFailOpen is USE_LOCAL_RESOURCE_SETTING, which takes the failure mode from a " +
+			"setting this plan does not carry. So whether a query DNS Firewall cannot evaluate is " +
+			"permitted is not decided here, and a two valued reading of that field would round " +
+			"the unknown case to whichever answer suited"
+	}
 	return Closed, irrelevant + "a DNS Firewall rule group associated with this VPC blocks every " +
-		"domain in its last rule and does not fail open"
+		"domain in its last rule by priority, no earlier rule permits every domain, every " +
+		"priority is unique, and FirewallFailOpen is DISABLED"
+}
+
+// ruleGroupFaults lists everything wrong with a rule group's rules.
+//
+// It returns every fault rather than the first, because the report is read by
+// somebody fixing the group and a check that stops at the first problem makes
+// them run it once per problem.
+func ruleGroupFaults(rules []DNSFirewallRule) []string {
+	if len(rules) == 0 {
+		return []string{"the rule group has no rules"}
+	}
+	var faults []string
+
+	// Unique priorities, because AWS requires them and because two rules
+	// sharing one leave the order the group is evaluated in undefined by
+	// anything in this plan. A rule group AWS refuses to create is not a
+	// containment either.
+	counts := map[int]int{}
+	for _, r := range rules {
+		counts[r.Priority]++
+	}
+	var dups []int
+	for priority, n := range counts {
+		if n > 1 {
+			dups = append(dups, priority)
+		}
+	}
+	sort.Ints(dups)
+	for _, priority := range dups {
+		faults = append(faults, fmt.Sprintf("%d rules share priority %d, and AWS requires a "+
+			"unique priority for each rule in a rule group", counts[priority], priority))
+	}
+
+	ordered := append([]DNSFirewallRule(nil), rules...)
+	sort.SliceStable(ordered, func(i, j int) bool { return ordered[i].Priority < ordered[j].Priority })
+
+	for _, r := range ordered {
+		switch strings.ToUpper(strings.TrimSpace(r.Action)) {
+		case "ALLOW", "BLOCK", "ALERT":
+		default:
+			faults = append(faults, fmt.Sprintf("the rule at priority %d has action %q, which is "+
+				"not one of ALLOW, BLOCK or ALERT", r.Priority, r.Action))
+		}
+		for _, d := range r.Domains {
+			if !expressibleDomain(d) {
+				faults = append(faults, fmt.Sprintf("the rule at priority %d matches %q, and a "+
+					"DNS Firewall domain specification may only start with a star, so this rule "+
+					"group cannot be created", r.Priority, d))
+			}
+		}
+	}
+
+	last := ordered[len(ordered)-1]
+	if !isBlockEverything(last) {
+		faults = append(faults, fmt.Sprintf("the last rule by priority is %s on %s and must be "+
+			"BLOCK on *", last.Action, strings.Join(last.Domains, ", ")))
+	}
+	for _, r := range ordered[:len(ordered)-1] {
+		if matchesEveryDomain(r) && permitsTheQuery(r) {
+			faults = append(faults, fmt.Sprintf("the rule at priority %d is %s on * and is "+
+				"evaluated before the terminal rule, so every query is permitted and the "+
+				"terminal BLOCK is never reached", r.Priority, strings.ToUpper(r.Action)))
+		}
+	}
+	return faults
 }
 
 // checkInstanceMetadata is the path the lane was warned about by name, and the
@@ -459,10 +663,21 @@ func checkInstanceMetadata(p Plan) (Verdict, string) {
 			"the instance and which no task definition can set, so this plan cannot close it",
 			p.LaunchType)
 	}
-	return Unproven, "the launch type is FARGATE, so no EC2 instance profile exists for the " +
-		"endpoint to vend, but AWS does not document whether 169.254.169.254 answers inside a " +
-		"Fargate task and a link local address is not filtered by the security group. Settling " +
-		"this needs one request from one running task, which needs an account"
+	base := "the launch type is FARGATE, so no EC2 instance profile exists for the endpoint to " +
+		"vend, but AWS does not document whether 169.254.169.254 answers inside a Fargate task " +
+		"and a link local address is not filtered by the security group. Settling this needs " +
+		"one request from one running task, and no probe result has been recorded for this " +
+		"environment. "
+	for _, c := range p.TaskDefinition.Containers {
+		if c.Name == "af-containment-probe" {
+			return Unproven, base + fmt.Sprintf("The task definition carries the probe container "+
+				"%q on image %q, which makes the request on the first run in an account and "+
+				"records what it saw", c.Name, c.Image)
+		}
+	}
+	return Unproven, base + "The task definition carries no probe container either, because this " +
+		"installation named no probe image, so as generated this plan has no way to answer the " +
+		"question even once it runs"
 }
 
 // checkTaskRoleCredentials is closed by an absence, which is the cheapest and
@@ -491,54 +706,246 @@ func checkTaskMetadata(p Plan) (Verdict, string) {
 		"statistics. With no task role it vends no credentials", p.PlatformVersion)
 }
 
-// checkInterfaceEndpoints reports the endpoints the design is obliged to open,
-// and reports how narrow they are, which is the only thing that can change.
+// checkInterfaceEndpoints answers the question the path is actually about,
+// which is not the one the first version of it answered.
+//
+// "The task can reach ECR" and "the task can reach ANY ECR repository and ANY
+// log group in the region" are very different claims, and only the second is an
+// exfiltration path. The first cannot be closed: on Fargate 1.4.0 the ECR
+// login, the image pull and the log push all run over the task ENI under this
+// security group, and AWS states that a Fargate task must have a route to the
+// registry to pull an image, so a plan that closes the connectivity closes the
+// product. The second can be closed, by an endpoint policy, and calling the
+// whole path open because the first half cannot be shut was reporting the
+// weaker fact and hiding the stronger one.
+//
+// So this returns Closed when the reachable set is exactly the endpoints the
+// pull and the log push need and every one of them carries a policy naming
+// concrete resources, and Open otherwise, naming which endpoint and why.
 func checkInterfaceEndpoints(p Plan) (Verdict, string) {
-	var reachable, unrestricted []string
+	needed := map[string]bool{
+		fmt.Sprintf("com.amazonaws.%s.ecr.api", p.Region): true,
+		fmt.Sprintf("com.amazonaws.%s.ecr.dkr", p.Region): true,
+		fmt.Sprintf("com.amazonaws.%s.logs", p.Region):    true,
+	}
+	var reachable, faults []string
 	for _, e := range p.Network.Endpoints {
 		if !strings.EqualFold(e.Type, "Interface") {
 			continue
 		}
 		reachable = append(reachable, e.Service)
-		if strings.TrimSpace(e.PolicyDocument) == "" {
-			unrestricted = append(unrestricted, e.Service)
+		if !needed[e.Service] {
+			faults = append(faults, fmt.Sprintf("%s is an interface endpoint the image pull and "+
+				"the log push do not need, and every endpoint in the VPC is a service the task "+
+				"can open a connection to", e.Service))
+			continue
+		}
+		if why, ok := policyNamesConcreteResources(e.PolicyDocument, p.TaskDefinition.Family); !ok {
+			faults = append(faults, fmt.Sprintf("%s: %s", e.Service, why))
 		}
 	}
 	if len(reachable) == 0 {
 		return Closed, "the plan holds no interface endpoints. Note that a Fargate task in a " +
 			"subnet with no route out and no ECR endpoint cannot pull an image, so a plan that " +
-			"closes this path cannot start an environment"
+			"closes this path this way cannot start an environment"
 	}
 	sort.Strings(reachable)
-	detail := fmt.Sprintf("the task can reach %s, because on Fargate 1.4.0 the image pull runs "+
-		"over the task ENI under this security group", strings.Join(reachable, ", "))
-	if len(unrestricted) > 0 {
-		sort.Strings(unrestricted)
-		return Open, detail + fmt.Sprintf("; and %s carry no endpoint policy, so the "+
-			"narrowing is absent as well", strings.Join(unrestricted, ", "))
+	if len(faults) > 0 {
+		sort.Strings(faults)
+		return Open, fmt.Sprintf("the task can reach %s, and %s", strings.Join(reachable, ", "),
+			strings.Join(faults, "; "))
 	}
-	return Open, detail + "; each carries an endpoint policy and is reached through an egress " +
-		"rule naming the endpoints' security group rather than an address range"
+	return Closed, fmt.Sprintf("the task can open TCP 443 to %s and to nothing else, because on "+
+		"Fargate 1.4.0 the image pull runs over the task ENI and that connectivity is the price "+
+		"of an environment starting at all. Each endpoint carries a policy naming this "+
+		"environment's own repository and log group, so no other repository, log group or "+
+		"service in the region is reachable through them, and the egress rule names the "+
+		"endpoints' security group rather than an address range. What is closed is the route to "+
+		"an arbitrary destination, not the connection itself", strings.Join(reachable, ", "))
+}
+
+// policyNamesConcreteResources reports whether a VPC endpoint policy narrows the
+// endpoint to named resources rather than to everything the service holds.
+//
+// An endpoint with no policy permits every action in that service that the
+// caller has credentials for. A policy naming Resource "*" is the same thing
+// written down. The bar here is that every Allow statement names at least one
+// resource with a literal prefix belonging to this environment, and no
+// statement grants every action, because an endpoint scoped to one repository
+// with ecr:* on it is still a place to push a layer.
+//
+// It fails towards open, the way reachesPublicIPv4 does. A policy this function
+// cannot parse is reported as unnarrowed, because the alternative is that a
+// malformed document silently counts as containment.
+func policyNamesConcreteResources(document, envName string) (string, bool) {
+	body := strings.TrimSpace(document)
+	if body == "" {
+		return "it carries no endpoint policy, so it permits every action in that service that " +
+			"the caller has credentials for", false
+	}
+	var doc iamPolicy
+	if err := json.Unmarshal([]byte(body), &doc); err != nil {
+		return fmt.Sprintf("its endpoint policy could not be read as a policy document (%v), and "+
+			"a document nobody could parse is not a narrowing", err), false
+	}
+	if len(doc.Statement) == 0 {
+		return "its endpoint policy holds no statements, which permits nothing and narrows " +
+			"nothing", false
+	}
+	for _, st := range doc.Statement {
+		if !strings.EqualFold(strings.TrimSpace(st.Effect), "Allow") {
+			continue
+		}
+		if len(st.Resource) == 0 {
+			return "its endpoint policy allows an action with no Resource at all", false
+		}
+		for _, action := range st.Action {
+			a := strings.TrimSpace(action)
+			if a == "*" || strings.HasSuffix(a, ":*") {
+				return fmt.Sprintf("its endpoint policy allows %q, which is every action in the "+
+					"service on whatever it names", action), false
+			}
+		}
+		if onlyResourcelessActions(st.Action) {
+			// The one carve out, and it is narrow on purpose. A handful of AWS
+			// actions take no resource at all, so IAM requires Resource "*" for
+			// them and a policy that named a repository instead would deny the
+			// call. ecr:GetAuthorizationToken is the one this plan needs, and
+			// without it the login fails and no image is pulled. It is not a
+			// destination: it returns a token scoped to the caller's own
+			// account rather than reaching anything. So a statement whose
+			// actions are ALL in that set may name a wildcard resource, and one
+			// that slips any other action into the same statement may not.
+			continue
+		}
+		named := false
+		for _, resource := range st.Resource {
+			section, ok := arnResourceSection(resource)
+			if !ok || section == "*" || strings.HasPrefix(section, "*") {
+				return fmt.Sprintf("its endpoint policy allows %q, which reaches every resource "+
+					"the service holds", resource), false
+			}
+			if envName != "" && strings.Contains(resource, envName) {
+				named = true
+			}
+		}
+		if envName != "" && !named {
+			return fmt.Sprintf("its endpoint policy names %s, and none of them belongs to %s, so "+
+				"it narrows the endpoint to somebody else's resources rather than to this "+
+				"environment's", strings.Join(st.Resource, ", "), envName), false
+		}
+	}
+	return "", true
+}
+
+// resourcelessActions are the actions that take no resource, so that a policy
+// naming them has to name a wildcard resource and naming one is not a widening.
+//
+// It is a fixed set rather than a pattern, and it holds exactly what this
+// runtime's own plan needs. A pattern here would be a way for the next action
+// somebody adds to inherit the exception without anybody deciding it should.
+var resourcelessActions = map[string]bool{
+	"ecr:GetAuthorizationToken": true,
+}
+
+// onlyResourcelessActions reports whether every action in a statement is one.
+//
+// Empty is false: a statement with no actions at all has not earned the
+// exception, it has just failed to say anything.
+func onlyResourcelessActions(actions []string) bool {
+	if len(actions) == 0 {
+		return false
+	}
+	for _, a := range actions {
+		if !resourcelessActions[strings.TrimSpace(a)] {
+			return false
+		}
+	}
+	return true
+}
+
+// arnResourceSection returns the part of an ARN after the account field, which
+// is the part that says WHICH repository, bucket or log group.
+//
+// An ARN is arn:partition:service:region:account:resource and the resource
+// section is everything after the fifth colon, so a bare "*" is not an ARN at
+// all and is reported as such rather than treated as a resource name that
+// happens to be a star.
+func arnResourceSection(arn string) (string, bool) {
+	parts := strings.SplitN(strings.TrimSpace(arn), ":", 6)
+	if len(parts) < 6 || parts[0] != "arn" {
+		return "", false
+	}
+	return parts[5], true
+}
+
+// iamPolicy is the part of a policy document this predicate reads.
+type iamPolicy struct {
+	Statement []iamStatement `json:"Statement"`
+}
+
+// iamStatement is one statement.
+type iamStatement struct {
+	Effect   string     `json:"Effect"`
+	Action   stringList `json:"Action"`
+	Resource stringList `json:"Resource"`
+}
+
+// stringList decodes an IAM field that is a string OR an array of strings.
+//
+// It exists because getting that cardinality wrong is a whole class of bug in
+// this repository's history: a to one field decoded as a list throws, and a
+// throw while decoding a list discards the entire list. Here the consequence
+// would be quieter and worse, because a policy that failed to parse is reported
+// as unnarrowed, so a decoder that could not read AWS's own single string form
+// would report every correctly scoped endpoint as open and nobody would look
+// twice at a containment check being pessimistic.
+type stringList []string
+
+// UnmarshalJSON accepts both shapes.
+func (l *stringList) UnmarshalJSON(raw []byte) error {
+	var one string
+	if err := json.Unmarshal(raw, &one); err == nil {
+		*l = stringList{one}
+		return nil
+	}
+	var many []string
+	if err := json.Unmarshal(raw, &many); err != nil {
+		return err
+	}
+	*l = many
+	return nil
 }
 
 // checkS3Gateway is separate from the interface endpoints because a gateway
 // endpoint is a route table entry rather than an ENI, so it is not governed by
 // the same rules and is not found by the same audit.
+//
+// It closes on the same argument: ECR serves image layers from S3 and the pull
+// needs both, so the connectivity stays, and what an endpoint policy can remove
+// is the route to every OTHER bucket in the region, including the ones that
+// accept anonymous writes. That removal is the difference between a read of one
+// AWS owned layer bucket and an upload target.
 func checkS3Gateway(p Plan) (Verdict, string) {
 	for _, e := range p.Network.Endpoints {
 		if !strings.EqualFold(e.Type, "Gateway") {
 			continue
 		}
-		if strings.TrimSpace(e.PolicyDocument) == "" {
-			return Open, fmt.Sprintf("%s is a gateway endpoint with no endpoint policy, which "+
-				"is a route to every bucket in the region", e.Service)
+		// The layer bucket is AWS's own and carries no environment name, so
+		// the concrete resource check runs with no name to require. What it
+		// still refuses is a wildcard bucket and a wildcard action, which are
+		// the two ways this endpoint becomes a route to every bucket.
+		if why, ok := policyNamesConcreteResources(e.PolicyDocument, ""); !ok {
+			return Open, fmt.Sprintf("%s is a gateway endpoint and %s", e.Service, why)
 		}
-		return Open, fmt.Sprintf("%s is reachable, because ECR stores image layers in S3 and "+
-			"the pull needs both. It carries an endpoint policy, which is the only narrowing "+
-			"available to a gateway endpoint", e.Service)
+		return Closed, fmt.Sprintf("%s is reachable, because ECR serves image layers from S3 and "+
+			"the pull needs both, and its endpoint policy names a concrete bucket with a read "+
+			"only action, so the route does not reach any other bucket in the region. An "+
+			"endpoint policy is the only narrowing available to a gateway endpoint and this one "+
+			"carries it", e.Service)
 	}
 	return Closed, "the plan holds no gateway endpoint. An ECR pull needs one, so a plan that " +
-		"closes this path cannot start an environment"
+		"closes this path this way cannot start an environment"
 }
 
 // checkExecuteCommand looks at the task definition and at the endpoints,
@@ -623,16 +1030,65 @@ func checkNeighbouringEnvironment(p Plan) (Verdict, string) {
 //
 // The VPC DNS quota page counts NTP requests against the same link local packet
 // budget as the resolver and instance metadata, which is documentary evidence
-// that a link local NTP service exists inside the network. The EC2 page for the
-// local Amazon Time Sync Service does not give the address and says nothing
-// about filtering. One page implies the path and no page decides it, so the
-// verdict says so and the path stays in the denominator.
+// that a link local NTP service exists inside the network, and the EC2 page for
+// the local Amazon Time Sync Service gives that service's IPv4 endpoint as
+// 169.254.169.123. What no page says is whether a security group filters it,
+// and a security group does not filter the resolver at all, so the one nearby
+// answer does not transfer.
+//
+// This lane corrected the earlier text on one point. The address IS documented,
+// on the page the time page links to rather than on the time page itself, and
+// the correction matters because an unproven path with no address can never be
+// answered at all.
+//
+// It still has no probe, and that is the honest end of it rather than an
+// unfinished one. The attempt is an NTP exchange over UDP and nothing in a
+// minimal container image makes one, so a probe target here could only ever
+// record that it could not try. This path went from unanswerable to answerable
+// in principle and no further, and it is reported that way rather than counted
+// as progress.
 func checkTimeSync(Plan) (Verdict, string) {
 	return Unproven, "the VPC DNS quota page counts Amazon Time Service NTP requests against " +
 		"the same 1024 packet per second link local budget as the resolver and instance " +
-		"metadata, so a link local NTP service is reachable from inside the VPC. No AWS page " +
-		"this lane read states whether a security group filters it, and this lane does not " +
-		"assert an answer it could not source"
+		"metadata, and the EC2 page gives the IPv4 endpoint as 169.254.169.123. No AWS page " +
+		"this lane read states whether a security group filters it, and no plan field decides " +
+		"it. A probe from one running task settles it and none has been recorded for this " +
+		"environment"
+}
+
+// observeLinkLocal turns one recorded attempt into a verdict.
+//
+// It is the only function in this package that can produce a Closed verdict
+// about a packet rather than about a document, and every branch of it is
+// written so that the absence of information stays absent.
+//
+// Reachable is the only outcome that is positive evidence, and it opens the
+// path. Refused and TimedOut close it, because a link local address with
+// nothing behind it is the shape of both. Errored does NOT close it: a probe
+// that could not run has not looked, and reading a broken instrument as a pass
+// is the single failure this repository keeps finding in its own checks.
+func observeLinkLocal(obs Observation) (Verdict, string) {
+	where := fmt.Sprintf("a probe inside a running task in environment %q dialled %s over %s",
+		obs.EnvironmentID, obs.Address, obs.Network)
+	if obs.ProbeVersion != ProbeVersion {
+		return Unproven, fmt.Sprintf("%s, and recorded the result as %q, which this build does "+
+			"not know how to read. A result from a probe whose behaviour is not this one is not "+
+			"evidence about this one", where, obs.ProbeVersion)
+	}
+	when := obs.ObservedAt.UTC().Format("2006-01-02T15:04:05Z")
+	switch obs.Outcome {
+	case Reachable:
+		return Open, fmt.Sprintf("%s at %s and something answered. This is an observed packet "+
+			"rather than a reading of a document: %s", where, when, obs.Detail)
+	case NoAnswer:
+		return Closed, fmt.Sprintf("%s at %s and nothing answered within %s. This is an "+
+			"observed packet rather than a reading of a document, and it is the only verdict "+
+			"in this report that is about one: %s", where, when, obs.Timeout, obs.Detail)
+	default:
+		return Unproven, fmt.Sprintf("%s at %s and could not make the attempt at all (%s). A "+
+			"probe that did not run says nothing about the path, and this is deliberately not "+
+			"read as a refusal", where, when, obs.Detail)
+	}
 }
 
 // gatewayKind names an AWS target by its id prefix, because in AWS the prefix
@@ -738,31 +1194,63 @@ func describePorts(rule Rule) string {
 	return fmt.Sprintf("%s/%d to %d", rule.Protocol, rule.FromPort, rule.ToPort)
 }
 
-// lastRule returns the rule with the highest priority number, which is the one
-// DNS Firewall evaluates last and therefore the one that decides a query no
-// earlier rule matched.
-func lastRule(rules []DNSFirewallRule) (DNSFirewallRule, bool) {
-	if len(rules) == 0 {
-		return DNSFirewallRule{}, false
-	}
-	last := rules[0]
-	for _, r := range rules[1:] {
-		if r.Priority > last.Priority {
-			last = r
-		}
-	}
-	return last, true
-}
-
-// isBlockEverything reports whether a rule blocks every domain.
-func isBlockEverything(rule DNSFirewallRule) bool {
-	if !strings.EqualFold(rule.Action, "BLOCK") {
-		return false
-	}
+// matchesEveryDomain reports whether a rule matches every query.
+func matchesEveryDomain(rule DNSFirewallRule) bool {
 	for _, d := range rule.Domains {
 		if strings.TrimSpace(d) == "*" {
 			return true
 		}
 	}
 	return false
+}
+
+// permitsTheQuery reports whether a rule's action lets the query out.
+//
+// ALERT is in here with ALLOW rather than with BLOCK, and that is the point of
+// the function existing at all. AWS defines ALERT as "permit the request and
+// send metrics and logs to Cloud Watch". It is the value somebody sets while
+// tuning a rule group and leaves, and read as a block it turns an open resolver
+// into a closed verdict with a graph to look at.
+func permitsTheQuery(rule DNSFirewallRule) bool {
+	switch strings.ToUpper(strings.TrimSpace(rule.Action)) {
+	case "ALLOW", "ALERT":
+		return true
+	default:
+		return false
+	}
+}
+
+// isBlockEverything reports whether a rule blocks every domain.
+func isBlockEverything(rule DNSFirewallRule) bool {
+	if !strings.EqualFold(strings.TrimSpace(rule.Action), "BLOCK") {
+		return false
+	}
+	return matchesEveryDomain(rule)
+}
+
+// expressibleDomain reports whether AWS would accept a domain specification.
+//
+// A specification "can optionally start with * (asterisk)" and may otherwise
+// hold only letters, digits, hyphens and the period that separates labels. So a
+// star in the middle, which the manifest's own host syntax allows and uses, is
+// not a pattern a DNS Firewall domain list can hold. The predicate refuses such
+// a rule group rather than assuming AWS would take it, because the alternative
+// is a plan that reads as containment and cannot be created.
+func expressibleDomain(domain string) bool {
+	d := strings.TrimSpace(domain)
+	if d == "" || len(d) > 255 {
+		return false
+	}
+	if d == "*" {
+		return true
+	}
+	d = strings.TrimPrefix(d, "*")
+	for _, r := range d {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '.':
+		default:
+			return false
+		}
+	}
+	return true
 }

--- a/ee/engine/runtime/ecs/egress.go
+++ b/ee/engine/runtime/ecs/egress.go
@@ -669,8 +669,8 @@ func checkInstanceMetadata(p Plan) (Verdict, string) {
 	base := "the launch type is FARGATE, so no EC2 instance profile exists for the endpoint to " +
 		"vend, but AWS does not document whether 169.254.169.254 answers inside a Fargate task " +
 		"and a link local address is not filtered by the security group. Settling this needs " +
-		"one request from one running task, and no probe result has been recorded for this " +
-		"environment. "
+		"one request from one running task, which needs an account, and no probe result has " +
+		"been recorded for this environment. "
 	for _, c := range p.TaskDefinition.Containers {
 		if c.Name == "af-containment-probe" {
 			return Unproven, base + fmt.Sprintf("The task definition carries the probe container "+

--- a/ee/engine/runtime/ecs/egress.go
+++ b/ee/engine/runtime/ecs/egress.go
@@ -299,7 +299,7 @@ func (r Report) String() string {
 	fmt.Fprintf(&b, "%d of %d egress paths out of an ECS task on Fargate are closed by the "+
 		"generated configuration (%d open, %d unproven).\n", r.Closed, r.Total, r.Open, r.Unproven)
 	for _, v := range r.Verdicts {
-		fmt.Fprintf(&b, "  %-8s %s\n           %s\n", v.Verdict, v.Path.ID, v.Detail)
+		fmt.Fprintf(&b, "  %-9s %s\n             %s\n", v.Verdict, v.Path.ID, v.Detail)
 	}
 	b.WriteString("\n" + Caveat + "\n")
 	return b.String()

--- a/ee/engine/runtime/ecs/egress.go
+++ b/ee/engine/runtime/ecs/egress.go
@@ -1,5 +1,8 @@
 package ecs
 
+// Not MIT. This directory is covered by the Antifailure Enterprise License; see
+// ee/LICENSE.md.
+
 import (
 	"encoding/json"
 	"fmt"

--- a/ee/engine/runtime/ecs/egress.go
+++ b/ee/engine/runtime/ecs/egress.go
@@ -1055,8 +1055,12 @@ func checkTimeSync(Plan) (Verdict, string) {
 		"the same 1024 packet per second link local budget as the resolver and instance " +
 		"metadata, and the EC2 page gives the IPv4 endpoint as 169.254.169.123. No AWS page " +
 		"this lane read states whether a security group filters it, and no plan field decides " +
-		"it. A probe from one running task settles it and none has been recorded for this " +
-		"environment"
+		"it. No probe here can record it either, and this path carries no probe target for " +
+		"that reason: the attempt is NTP over UDP, nothing in a minimal container image " +
+		"speaks it, and a probe whose only possible outcome is errored would fill this " +
+		"report with the word probe while learning nothing. So nothing about this path is " +
+		"outstanding. There is nowhere to put an answer until something in the task can " +
+		"make that exchange"
 }
 
 // observeLinkLocal turns one recorded attempt into a verdict.

--- a/ee/engine/runtime/ecs/egress.go
+++ b/ee/engine/runtime/ecs/egress.go
@@ -1,0 +1,768 @@
+package ecs
+
+import (
+	"fmt"
+	"net/netip"
+	"sort"
+	"strings"
+)
+
+// Verdict is what the predicate can say about one egress path.
+//
+// Three values rather than two, and the third is the point of the file. A
+// containment claim written with a boolean has nowhere to put "I looked and the
+// configuration does not decide this", so it rounds that case to whichever
+// answer the author was hoping for. Every instrument in this repository that
+// turned out to be lying had exactly that shape: a check that could not say "I
+// could not look" reported a pass instead.
+type Verdict string
+
+const (
+	// Closed means the generated configuration removes this path. It does NOT
+	// mean a packet was observed failing to get out. See Report.Caveat.
+	Closed Verdict = "closed"
+	// Open means the path exists in the generated configuration, either
+	// because AWS provides no way to remove it or because removing it would
+	// stop the environment from starting.
+	Open Verdict = "open"
+	// Unproven means the configuration does not decide it and neither does the
+	// documentation. It is not a weaker Closed and it must never be counted as
+	// one.
+	Unproven Verdict = "unproven"
+)
+
+// Path is one distinct way out of an ECS task on Fargate.
+//
+// Distinct means a different route, not a different phrasing of one route. Two
+// entries that the same single change would close are one path, because a
+// count of paths is only worth publishing if closing one of them is real work.
+type Path struct {
+	// ID is stable and appears in the refusal message and in the report.
+	ID string
+	// Name is one line a person can read.
+	Name string
+	// Why records that this is a route somebody has actually used, which is
+	// the bar for being in this list at all. A theoretical path inflates the
+	// denominator and makes the ratio look worse than the product is, which is
+	// its own kind of dishonesty.
+	Why string
+	// ClosedBy names the mechanism, or says plainly that nothing closes it.
+	ClosedBy string
+	// Check evaluates the path against a plan and returns the verdict with the
+	// detail that justifies it. The detail is never empty, because a verdict
+	// with no reason is a verdict nobody can check.
+	Check func(Plan) (Verdict, string)
+}
+
+// Paths is every egress path out of an ECS task on Fargate that this lane
+// could enumerate, in a stable order.
+//
+// The order is the order a person should read them: the three that look like
+// the internet, then the resolver, then the two link local endpoints, then the
+// routes the design itself has to open, then the ones somebody turns on.
+//
+// Every AWS behaviour asserted below was read from AWS documentation on
+// 2026-09-07 and the page is named in the text. None of it is from memory,
+// because the whole lane is a containment claim and a containment claim built
+// on a recollection of a cloud provider's defaults is worth nothing.
+func Paths() []Path {
+	return []Path{
+		{
+			ID:   "public-ipv4-through-a-gateway",
+			Name: "a TCP connection to a public IPv4 address, with no name lookup at all",
+			Why: "It is the obvious answer to interception by DNS, and it is what every " +
+				"exfiltration tool does first. It needs no resolver and it leaves no query.",
+			ClosedBy: "no route to an internet gateway or a NAT gateway, no public address " +
+				"on the task ENI, and no security group egress rule naming a public range",
+			Check: checkPublicIPv4,
+		},
+		{
+			ID:   "public-ipv6-through-an-egress-only-gateway",
+			Name: "the same connection over IPv6, which IPv4 security group rules do not cover",
+			Why: "A security group carries IPv4 and IPv6 rules separately, so a group audited " +
+				"in IPv4 and read as contained can be wide open over IPv6 through an egress " +
+				"only internet gateway, which exists precisely to give private subnets " +
+				"outbound IPv6.",
+			ClosedBy: "no IPv6 range on the VPC or its subnets, no egress only gateway route, " +
+				"and no IPv6 egress rule",
+			Check:    checkPublicIPv6,
+		},
+		{
+			ID:   "public-resolver-over-udp",
+			Name: "a DNS query straight to a public resolver, whose payload is whatever the client puts in it",
+			Why: "A name lookup is a data channel. The question in a DNS query is chosen by " +
+				"the sender, so a resolver that answers recursively is an unlogged upload " +
+				"with a 1024 packet per second budget, and a firewall that allows port 53 " +
+				"because it is only DNS is allowing exactly that.",
+			ClosedBy: "no route out and no egress rule reaching port 53 on a public range",
+			Check:    checkPublicResolver,
+		},
+		{
+			ID:   "the-amazon-provided-resolver",
+			Name: "the same query to the Route 53 Resolver at 169.254.169.253 or the VPC range plus two",
+			Why: "This is the sharpest one on AWS and it is the one a Kubernetes intuition " +
+				"gets wrong. The Amazon DNS server resolves public names recursively for " +
+				"anything in the VPC, and the VPC user guide states that you cannot filter " +
+				"traffic to or from it using network ACLs or security groups. So the whole " +
+				"security group is irrelevant to this path.",
+			ClosedBy: "a Route 53 Resolver DNS Firewall rule group associated with this VPC " +
+				"whose last rule blocks every domain and which does not fail open, or " +
+				"enableDnsSupport turned off on the VPC",
+			Check: checkAmazonResolver,
+		},
+		{
+			ID:   "the-ec2-instance-metadata-service",
+			Name: "169.254.169.254, which on an EC2 container instance hands out the instance role's credentials",
+			Why: "It is not on the internet and it is the highest value target in the list, " +
+				"because it turns any request forgery in the application into cloud " +
+				"credentials. The ECS documentation says containers on EC2 container " +
+				"instances can reach instance metadata and IAM role credentials, and names " +
+				"the defence as ECS_AWSVPC_BLOCK_IMDS, which is an ECS container agent " +
+				"variable set on the instance.",
+			ClosedBy: "nothing a task definition can say. The Fargate launch type removes the " +
+				"documented credential source, because EC2 instance profiles are not " +
+				"available to containers in Fargate tasks, but AWS does not document " +
+				"whether the address answers, so the configuration does not settle it",
+			Check: checkInstanceMetadata,
+		},
+		{
+			ID:   "the-task-role-credentials-endpoint",
+			Name: "169.254.170.2, which vends the task role's credentials to anything in the container",
+			Why: "It is the Fargate equivalent of the instance metadata service and it is " +
+				"always there. Any code in the container reads AWS_CONTAINER_CREDENTIALS_" +
+				"RELATIVE_URI and gets a signing key for whatever the task role permits.",
+			ClosedBy: "no taskRoleArn in the task definition, so the endpoint has nothing to " +
+				"vend. The endpoint itself cannot be turned off",
+			Check: checkTaskRoleCredentials,
+		},
+		{
+			ID:   "the-task-metadata-endpoint",
+			Name: "169.254.170.2/v4, on by default and with no documented way to turn it off",
+			Why: "It discloses the task ARN, the cluster name, the ENI address and container " +
+				"statistics to anything in the container. It is not a route to the internet " +
+				"and it vends no credentials once the task role is gone, but it is an " +
+				"endpoint the environment did not ask for and cannot remove.",
+			ClosedBy: "nothing. The ECS documentation states the task metadata endpoint is on " +
+				"by default for every Fargate task on platform version 1.4.0 or later",
+			Check: checkTaskMetadata,
+		},
+		{
+			ID:   "the-interface-endpoints-the-image-pull-needs",
+			Name: "the ECR and CloudWatch Logs interface endpoints, which the task must reach in order to start",
+			Why: "On Fargate platform version 1.4.0 the ECR login, the image pull and the log " +
+				"push all flow over the TASK ENI, under this security group, and the " +
+				"documentation says plainly that a Fargate task must have a route to the " +
+				"registry to pull an image. There is no equivalent of a kubelet pulling the " +
+				"image outside the pod's policy, so a task whose security group denies " +
+				"everything never starts.",
+			ClosedBy: "nothing, without giving up the ability to run an environment at all. " +
+				"It is narrowed by an endpoint policy per endpoint and by egress rules " +
+				"naming the endpoints' own security group rather than an address range",
+			Check: checkInterfaceEndpoints,
+		},
+		{
+			ID:   "the-s3-gateway-endpoint-the-layers-come-from",
+			Name: "the S3 gateway endpoint, reached through a route table prefix list rather than an ENI",
+			Why: "ECR stores image layers in S3, so the pull needs S3 as well as ECR. A " +
+				"gateway endpoint is a route, and an unrestricted one is a path to every " +
+				"bucket in the region, including the ones that accept anonymous writes.",
+			ClosedBy: "nothing, for the same reason as the interface endpoints. It is narrowed " +
+				"by an endpoint policy",
+			Check: checkS3Gateway,
+		},
+		{
+			ID:   "the-ecs-exec-channel",
+			Name: "ECS Exec, which is an interactive shell inbound and an unmetered channel outbound",
+			Why: "It is the one path on this list that a person opens deliberately, while " +
+				"debugging, and then leaves open. It runs over AWS Systems Manager rather " +
+				"than over anything the egress policy describes.",
+			ClosedBy: "enableExecuteCommand false and no ssmmessages endpoint in the plan",
+			Check:    checkExecuteCommand,
+		},
+		{
+			ID:   "a-peering-transit-or-private-gateway-route",
+			Name: "a route to the corporate network, which never touches the internet and is not covered by an internet check",
+			Why: "A containment check written as no internet gateway and no NAT gateway passes " +
+				"a VPC that is peered with the production VPC. That is worse than reaching " +
+				"the internet, because the thing on the other side is the database this " +
+				"environment is a twin of.",
+			ClosedBy: "a route table holding only the local route and the gateway endpoint " +
+				"prefix lists",
+			Check: checkPrivateGatewayRoutes,
+		},
+		{
+			ID:   "a-neighbouring-environment",
+			Name: "another environment's tasks in the same VPC",
+			Why: "Every environment in this design shares a VPC, and a security group written " +
+				"once and reused is how an environment reaches a peer environment's " +
+				"datastore while every rule in it still reads as correct. The Kubernetes " +
+				"suite has a behaviour for exactly this and it is the slowest and most " +
+				"important one it has.",
+			ClosedBy: "one security group per environment, egress rules naming only that group " +
+				"or an endpoint's group, and no rule naming a range wider than this " +
+				"environment's own subnets",
+			Check: checkNeighbouringEnvironment,
+		},
+		{
+			ID:   "the-local-amazon-time-sync-service",
+			Name: "the link local NTP service, which shares the link local packet budget with the resolver and metadata",
+			Why: "The VPC DNS quota page counts Route 53 Resolver queries, instance metadata " +
+				"requests and Amazon Time Service NTP requests against one 1024 packet per " +
+				"second link local budget, which is documentary evidence that a link local " +
+				"NTP service is reachable from inside the network.",
+			ClosedBy: "not established. The EC2 page for the local Amazon Time Sync Service " +
+				"does not state the link local address and does not say whether security " +
+				"groups filter it, so this lane could not settle the path and does not " +
+				"assert either answer",
+			Check: checkTimeSync,
+		},
+	}
+}
+
+// PathVerdict is one path with what the predicate decided about one plan.
+type PathVerdict struct {
+	Path    Path
+	Verdict Verdict
+	Detail  string
+}
+
+// Report is the whole predicate applied to one plan.
+type Report struct {
+	// Verdicts are in Paths order.
+	Verdicts []PathVerdict
+	// Closed, Open and Unproven count the verdicts. They are separate fields
+	// rather than one ratio because the ratio that matters is closed over
+	// total, and burying an unproven inside a numerator is the exact arithmetic
+	// this repository already caught its own fidelity instrument doing.
+	Closed   int
+	Open     int
+	Unproven int
+	// Total is len(Verdicts).
+	Total int
+}
+
+// Caveat is the sentence that has to travel with every number this package
+// produces, and it is a constant so that it cannot be paraphrased away.
+//
+// It is here because the difference between what this package proves and what
+// it would need an AWS account to prove is the whole honesty of the runtime. A
+// Closed verdict is a statement about a JSON document. Whether AWS enforces
+// that document is a statement about an account, and nothing in this repository
+// has ever observed it.
+const Caveat = "Every verdict here is computed from the configuration this runtime would " +
+	"generate. None of it has been applied to an AWS account and no packet has been " +
+	"observed failing to leave a task. A closed verdict means the generated " +
+	"configuration removes the path, not that AWS was seen enforcing it."
+
+// Evaluate applies every path's check to a plan.
+func Evaluate(plan Plan) Report {
+	paths := Paths()
+	report := Report{Verdicts: make([]PathVerdict, 0, len(paths)), Total: len(paths)}
+	for _, path := range paths {
+		verdict, detail := path.Check(plan)
+		report.Verdicts = append(report.Verdicts, PathVerdict{Path: path, Verdict: verdict, Detail: detail})
+		switch verdict {
+		case Closed:
+			report.Closed++
+		case Open:
+			report.Open++
+		default:
+			report.Unproven++
+		}
+	}
+	return report
+}
+
+// Contained reports whether every enumerated path is closed.
+//
+// It is false for the plans this package generates, and that is not a bug to be
+// fixed later. Three of the paths cannot be closed on ECS at all and two cannot
+// be decided without an account, so a true here would mean the enumeration had
+// been shortened rather than that the containment had improved.
+func (r Report) Contained() bool { return r.Closed == r.Total }
+
+// NotClosed lists the paths that are not closed, in Paths order, for the
+// refusal message.
+func (r Report) NotClosed() []PathVerdict {
+	var out []PathVerdict
+	for _, v := range r.Verdicts {
+		if v.Verdict != Closed {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// String renders the report the way the refusal prints it.
+func (r Report) String() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d of %d egress paths out of an ECS task on Fargate are closed by the "+
+		"generated configuration (%d open, %d unproven).\n", r.Closed, r.Total, r.Open, r.Unproven)
+	for _, v := range r.Verdicts {
+		fmt.Fprintf(&b, "  %-8s %s\n           %s\n", v.Verdict, v.Path.ID, v.Detail)
+	}
+	b.WriteString("\n" + Caveat + "\n")
+	return b.String()
+}
+
+// checkPublicIPv4 requires that all three of the mechanisms the plan relies on
+// are present.
+//
+// All three rather than any one of them, and that choice needs defending
+// because a single one of them is sufficient on its own. The predicate is a
+// statement about the configuration this runtime generates, not about the
+// minimum configuration that would happen to work: a plan that has lost one of
+// its three closures is no longer the plan the proof covers, and reporting it
+// closed would mean the check cannot fail when the generator regresses. A check
+// that cannot say no is worse than no check.
+func checkPublicIPv4(p Plan) (Verdict, string) {
+	var missing []string
+	for _, r := range p.Network.RouteTable.Routes {
+		if kind := gatewayKind(r.Target); kind == "an internet gateway" || kind == "a NAT gateway" {
+			missing = append(missing, fmt.Sprintf("the route table sends %s to %s (%s)",
+				r.Destination, r.Target, kind))
+		}
+	}
+	if p.Network.RouteTable.AssignPublicIP != AssignPublicIPDisabled {
+		missing = append(missing, fmt.Sprintf("assignPublicIp is %q and must be %q",
+			p.Network.RouteTable.AssignPublicIP, AssignPublicIPDisabled))
+	}
+	for _, rule := range p.Network.SecurityGroup.Egress {
+		if rule.CIDRv4 != "" && reachesPublicIPv4(rule.CIDRv4) {
+			missing = append(missing, fmt.Sprintf("a security group egress rule permits %s to %s",
+				describePorts(rule), rule.CIDRv4))
+		}
+	}
+	if len(missing) > 0 {
+		return Open, strings.Join(missing, "; ")
+	}
+	return Closed, "no internet gateway or NAT gateway route, assignPublicIp DISABLED, and no " +
+		"egress rule naming a range outside RFC 1918, RFC 6598 and the link local block"
+}
+
+// checkPublicIPv6 is separate from checkPublicIPv4 because a security group
+// holds the two rule sets separately and an audit written in one does not see
+// the other.
+func checkPublicIPv6(p Plan) (Verdict, string) {
+	var missing []string
+	if p.Network.VPC.IPv6CIDR != "" {
+		missing = append(missing, fmt.Sprintf("the VPC carries the IPv6 range %s", p.Network.VPC.IPv6CIDR))
+	}
+	for _, s := range p.Network.Subnets {
+		if s.IPv6CIDR != "" {
+			missing = append(missing, fmt.Sprintf("subnet %s carries the IPv6 range %s", s.ID, s.IPv6CIDR))
+		}
+	}
+	for _, r := range p.Network.RouteTable.Routes {
+		if gatewayKind(r.Target) == "an egress only internet gateway" || strings.Contains(r.Destination, "::/0") {
+			missing = append(missing, fmt.Sprintf("the route table sends %s to %s", r.Destination, r.Target))
+		}
+	}
+	for _, rule := range p.Network.SecurityGroup.Egress {
+		if rule.CIDRv6 != "" {
+			missing = append(missing, fmt.Sprintf("a security group egress rule permits %s to %s",
+				describePorts(rule), rule.CIDRv6))
+		}
+	}
+	if len(missing) > 0 {
+		return Open, strings.Join(missing, "; ")
+	}
+	return Closed, "no IPv6 range on the VPC or its subnets, no egress only internet gateway " +
+		"route, and no IPv6 egress rule"
+}
+
+// checkPublicResolver looks for port 53 reaching a public range specifically,
+// as well as for the route, because allowing DNS out is the exception people
+// grant without thinking of it as egress.
+func checkPublicResolver(p Plan) (Verdict, string) {
+	var missing []string
+	for _, r := range p.Network.RouteTable.Routes {
+		if kind := gatewayKind(r.Target); kind == "an internet gateway" || kind == "a NAT gateway" {
+			missing = append(missing, fmt.Sprintf("the route table sends %s to %s, which a "+
+				"query to a public resolver would take", r.Destination, r.Target))
+		}
+	}
+	for _, rule := range p.Network.SecurityGroup.Egress {
+		if !ruleCoversPort(rule, 53) {
+			continue
+		}
+		if rule.CIDRv4 != "" && reachesPublicIPv4(rule.CIDRv4) {
+			missing = append(missing, fmt.Sprintf("a security group egress rule permits %s to %s, "+
+				"which reaches a public resolver", describePorts(rule), rule.CIDRv4))
+		}
+		if rule.CIDRv6 != "" {
+			missing = append(missing, fmt.Sprintf("a security group egress rule permits %s to %s",
+				describePorts(rule), rule.CIDRv6))
+		}
+	}
+	if len(missing) > 0 {
+		return Open, strings.Join(missing, "; ")
+	}
+	return Closed, "no route out and no egress rule that reaches port 53 on a range outside the VPC"
+}
+
+// checkAmazonResolver is the one check where the security group is irrelevant,
+// and saying so is the useful part.
+func checkAmazonResolver(p Plan) (Verdict, string) {
+	const irrelevant = "security groups and network ACLs cannot filter this path, so nothing in " +
+		"the security group above is evidence about it: "
+
+	if !p.Network.VPC.EnableDNSSupport {
+		return Closed, irrelevant + "enableDnsSupport is off on the VPC, so queries to the " +
+			"Amazon provided DNS server do not succeed"
+	}
+	fw := p.Network.DNSFirewall
+	if fw == nil {
+		return Open, irrelevant + "enableDnsSupport is on and no Route 53 Resolver DNS Firewall " +
+			"rule group is associated with this VPC, so the resolver answers recursive queries " +
+			"for any public name"
+	}
+	var missing []string
+	if fw.AssociatedVPCID != p.Network.VPC.ID {
+		missing = append(missing, fmt.Sprintf("the rule group is associated with %q and this "+
+			"plan's VPC is %q", fw.AssociatedVPCID, p.Network.VPC.ID))
+	}
+	if fw.FailOpen {
+		missing = append(missing, "the association fails open, so a rule the firewall cannot "+
+			"reach permits the query")
+	}
+	if last, ok := lastRule(fw.Rules); !ok {
+		missing = append(missing, "the rule group has no rules")
+	} else if !isBlockEverything(last) {
+		missing = append(missing, fmt.Sprintf("the last rule by priority is %s on %s and must "+
+			"be BLOCK on *", last.Action, strings.Join(last.Domains, ", ")))
+	}
+	if len(missing) > 0 {
+		return Open, irrelevant + strings.Join(missing, "; ")
+	}
+	return Closed, irrelevant + "a DNS Firewall rule group associated with this VPC blocks every " +
+		"domain in its last rule and does not fail open"
+}
+
+// checkInstanceMetadata is the path the lane was warned about by name, and the
+// answer it produces is deliberately not Closed.
+//
+// The Fargate launch type removes the documented credential source: the ECS
+// task IAM role page states that EC2 instance profiles are not available to
+// containers in Fargate tasks. What it does not state, anywhere this lane could
+// find, is that 169.254.169.254 does not answer inside a Fargate task. Those
+// are different claims. The first is about what credentials exist and the
+// second is about what the address does, and rounding the second up to the
+// first is precisely how a containment claim softens into a plausible sentence.
+//
+// So Fargate is Unproven and EC2 is Open, and neither is Closed, because no
+// field of a task definition or a security group closes a link local address.
+func checkInstanceMetadata(p Plan) (Verdict, string) {
+	if !strings.EqualFold(p.LaunchType, "FARGATE") {
+		return Open, fmt.Sprintf("the launch type is %q. On a container instance the "+
+			"documented defence is the ECS_AWSVPC_BLOCK_IMDS agent variable, which is set on "+
+			"the instance and which no task definition can set, so this plan cannot close it",
+			p.LaunchType)
+	}
+	return Unproven, "the launch type is FARGATE, so no EC2 instance profile exists for the " +
+		"endpoint to vend, but AWS does not document whether 169.254.169.254 answers inside a " +
+		"Fargate task and a link local address is not filtered by the security group. Settling " +
+		"this needs one request from one running task, which needs an account"
+}
+
+// checkTaskRoleCredentials is closed by an absence, which is the cheapest and
+// most durable kind of closure in this file.
+func checkTaskRoleCredentials(p Plan) (Verdict, string) {
+	if arn := strings.TrimSpace(p.TaskDefinition.TaskRoleARN); arn != "" {
+		return Open, fmt.Sprintf("the task definition sets taskRoleArn to %q, and 169.254.170.2 "+
+			"vends that role's credentials to anything in the container that reads "+
+			"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", arn)
+	}
+	return Closed, "the task definition sets no taskRoleArn, so the credentials endpoint has " +
+		"nothing to vend. The execution role is not reachable from the container: ECS documents " +
+		"that execution role permissions are not accessed by the application"
+}
+
+// checkTaskMetadata can only ever return Open, and a check with one possible
+// answer is usually a bug. This one is a finding.
+//
+// It is written as a check rather than as a comment so that it appears in the
+// report, is counted in the denominator, and is printed in the refusal. A path
+// nothing can close is exactly the path a summary leaves out.
+func checkTaskMetadata(p Plan) (Verdict, string) {
+	return Open, fmt.Sprintf("platform version %q. The task metadata endpoint is on by default "+
+		"for every Fargate task on platform version 1.4.0 or later and AWS documents no way to "+
+		"turn it off. It discloses the task ARN, the cluster, the ENI address and container "+
+		"statistics. With no task role it vends no credentials", p.PlatformVersion)
+}
+
+// checkInterfaceEndpoints reports the endpoints the design is obliged to open,
+// and reports how narrow they are, which is the only thing that can change.
+func checkInterfaceEndpoints(p Plan) (Verdict, string) {
+	var reachable, unrestricted []string
+	for _, e := range p.Network.Endpoints {
+		if !strings.EqualFold(e.Type, "Interface") {
+			continue
+		}
+		reachable = append(reachable, e.Service)
+		if strings.TrimSpace(e.PolicyDocument) == "" {
+			unrestricted = append(unrestricted, e.Service)
+		}
+	}
+	if len(reachable) == 0 {
+		return Closed, "the plan holds no interface endpoints. Note that a Fargate task in a " +
+			"subnet with no route out and no ECR endpoint cannot pull an image, so a plan that " +
+			"closes this path cannot start an environment"
+	}
+	sort.Strings(reachable)
+	detail := fmt.Sprintf("the task can reach %s, because on Fargate 1.4.0 the image pull runs "+
+		"over the task ENI under this security group", strings.Join(reachable, ", "))
+	if len(unrestricted) > 0 {
+		sort.Strings(unrestricted)
+		return Open, detail + fmt.Sprintf("; and %s carry no endpoint policy, so the "+
+			"narrowing is absent as well", strings.Join(unrestricted, ", "))
+	}
+	return Open, detail + "; each carries an endpoint policy and is reached through an egress " +
+		"rule naming the endpoints' security group rather than an address range"
+}
+
+// checkS3Gateway is separate from the interface endpoints because a gateway
+// endpoint is a route table entry rather than an ENI, so it is not governed by
+// the same rules and is not found by the same audit.
+func checkS3Gateway(p Plan) (Verdict, string) {
+	for _, e := range p.Network.Endpoints {
+		if !strings.EqualFold(e.Type, "Gateway") {
+			continue
+		}
+		if strings.TrimSpace(e.PolicyDocument) == "" {
+			return Open, fmt.Sprintf("%s is a gateway endpoint with no endpoint policy, which "+
+				"is a route to every bucket in the region", e.Service)
+		}
+		return Open, fmt.Sprintf("%s is reachable, because ECR stores image layers in S3 and "+
+			"the pull needs both. It carries an endpoint policy, which is the only narrowing "+
+			"available to a gateway endpoint", e.Service)
+	}
+	return Closed, "the plan holds no gateway endpoint. An ECR pull needs one, so a plan that " +
+		"closes this path cannot start an environment"
+}
+
+// checkExecuteCommand looks at the task definition and at the endpoints,
+// because the flag alone is not the path: an ssmmessages endpoint left in the
+// VPC is the route the flag would use, and it outlives the flag.
+func checkExecuteCommand(p Plan) (Verdict, string) {
+	var missing []string
+	if p.TaskDefinition.EnableExecuteCommand {
+		missing = append(missing, "enableExecuteCommand is true")
+	}
+	for _, e := range p.Network.Endpoints {
+		if strings.Contains(e.Service, "ssmmessages") || strings.Contains(e.Service, ".ssm") {
+			missing = append(missing, fmt.Sprintf("%s is reachable, which is the channel ECS "+
+				"Exec runs over", e.Service))
+		}
+	}
+	if len(missing) > 0 {
+		return Open, strings.Join(missing, "; ")
+	}
+	return Closed, "enableExecuteCommand is false and no Systems Manager endpoint is reachable"
+}
+
+// checkPrivateGatewayRoutes is the path a naive internet check misses entirely.
+func checkPrivateGatewayRoutes(p Plan) (Verdict, string) {
+	var found []string
+	for _, r := range p.Network.RouteTable.Routes {
+		switch gatewayKind(r.Target) {
+		case "a VPC peering connection", "a transit gateway", "a virtual private gateway",
+			"a local gateway", "a carrier gateway":
+			found = append(found, fmt.Sprintf("%s to %s (%s)", r.Destination, r.Target,
+				gatewayKind(r.Target)))
+		}
+	}
+	if len(found) > 0 {
+		return Open, "the route table reaches a network that is not the internet and not this " +
+			"VPC: " + strings.Join(found, "; ")
+	}
+	return Closed, "the route table holds only the local route and gateway endpoint prefix lists"
+}
+
+// checkNeighbouringEnvironment is the isolation promise, and it is written
+// against the security group rather than against the subnet because every
+// environment in this design shares a VPC and therefore shares a range.
+func checkNeighbouringEnvironment(p Plan) (Verdict, string) {
+	own := map[string]bool{p.Network.SecurityGroup.ID: true}
+	for _, e := range p.Network.Endpoints {
+		if e.SecurityGroupID != "" {
+			own[e.SecurityGroupID] = true
+		}
+	}
+	var missing []string
+	for _, rule := range p.Network.SecurityGroup.Egress {
+		if rule.PeerSecurityGroupID != "" && !own[rule.PeerSecurityGroupID] {
+			missing = append(missing, fmt.Sprintf("an egress rule names security group %s, "+
+				"which is neither this environment's group nor an endpoint's",
+				rule.PeerSecurityGroupID))
+		}
+		if rule.CIDRv4 == "" {
+			continue
+		}
+		if !withinSubnets(rule.CIDRv4, p.Network.Subnets) {
+			missing = append(missing, fmt.Sprintf("an egress rule permits %s to %s, which is "+
+				"wider than this environment's own subnets", describePorts(rule), rule.CIDRv4))
+		}
+	}
+	for _, rule := range p.Network.SecurityGroup.Ingress {
+		if rule.PeerSecurityGroupID != "" && !own[rule.PeerSecurityGroupID] {
+			missing = append(missing, fmt.Sprintf("an ingress rule admits security group %s, "+
+				"which is neither this environment's group nor an endpoint's",
+				rule.PeerSecurityGroupID))
+		}
+	}
+	if len(missing) > 0 {
+		return Open, strings.Join(missing, "; ")
+	}
+	return Closed, "every rule names this environment's own security group or an endpoint's, " +
+		"and no rule names a range wider than this environment's subnets"
+}
+
+// checkTimeSync returns Unproven whatever the plan says, and that is the
+// honest answer rather than a placeholder.
+//
+// The VPC DNS quota page counts NTP requests against the same link local packet
+// budget as the resolver and instance metadata, which is documentary evidence
+// that a link local NTP service exists inside the network. The EC2 page for the
+// local Amazon Time Sync Service does not give the address and says nothing
+// about filtering. One page implies the path and no page decides it, so the
+// verdict says so and the path stays in the denominator.
+func checkTimeSync(Plan) (Verdict, string) {
+	return Unproven, "the VPC DNS quota page counts Amazon Time Service NTP requests against " +
+		"the same 1024 packet per second link local budget as the resolver and instance " +
+		"metadata, so a link local NTP service is reachable from inside the VPC. No AWS page " +
+		"this lane read states whether a security group filters it, and this lane does not " +
+		"assert an answer it could not source"
+}
+
+// gatewayKind names an AWS target by its id prefix, because in AWS the prefix
+// is the type and reading it is not a heuristic.
+func gatewayKind(target string) string {
+	switch {
+	case strings.HasPrefix(target, "igw-"):
+		return "an internet gateway"
+	case strings.HasPrefix(target, "nat-"):
+		return "a NAT gateway"
+	case strings.HasPrefix(target, "eigw-"):
+		return "an egress only internet gateway"
+	case strings.HasPrefix(target, "pcx-"):
+		return "a VPC peering connection"
+	case strings.HasPrefix(target, "tgw-"):
+		return "a transit gateway"
+	case strings.HasPrefix(target, "vgw-"):
+		return "a virtual private gateway"
+	case strings.HasPrefix(target, "lgw-"):
+		return "a local gateway"
+	case strings.HasPrefix(target, "cagw-"):
+		return "a carrier gateway"
+	case strings.HasPrefix(target, "vpce-"):
+		return "a VPC endpoint"
+	case target == "local":
+		return "the VPC itself"
+	default:
+		return "an unrecognised target"
+	}
+}
+
+// privateRanges are the ranges a rule may name without reaching the internet.
+//
+// Link local is in the list because a rule naming it does not reach a public
+// address, NOT because link local is safe. The two link local endpoints have
+// their own paths above, and they are not filtered by security groups at all,
+// so a security group check has nothing to say about them either way.
+var privateRanges = []netip.Prefix{
+	netip.MustParsePrefix("10.0.0.0/8"),
+	netip.MustParsePrefix("172.16.0.0/12"),
+	netip.MustParsePrefix("192.168.0.0/16"),
+	netip.MustParsePrefix("100.64.0.0/10"),
+	netip.MustParsePrefix("169.254.0.0/16"),
+	netip.MustParsePrefix("127.0.0.0/8"),
+}
+
+// reachesPublicIPv4 reports whether a CIDR contains any address outside the
+// private ranges.
+//
+// It fails towards public on purpose. A CIDR this function cannot parse is
+// reported as reaching the internet, because the alternative is that a
+// malformed rule silently counts as containment, and the whole file exists to
+// stop a containment claim resting on something nobody looked at.
+func reachesPublicIPv4(cidr string) bool {
+	prefix, err := netip.ParsePrefix(strings.TrimSpace(cidr))
+	if err != nil || !prefix.Addr().Is4() {
+		return true
+	}
+	for _, private := range privateRanges {
+		if private.Overlaps(prefix) && private.Bits() <= prefix.Bits() &&
+			private.Contains(prefix.Addr()) {
+			return false
+		}
+	}
+	return true
+}
+
+// withinSubnets reports whether a CIDR is inside one of the plan's own subnets.
+func withinSubnets(cidr string, subnets []Subnet) bool {
+	prefix, err := netip.ParsePrefix(strings.TrimSpace(cidr))
+	if err != nil {
+		return false
+	}
+	for _, s := range subnets {
+		sub, err := netip.ParsePrefix(strings.TrimSpace(s.IPv4CIDR))
+		if err != nil {
+			continue
+		}
+		if sub.Contains(prefix.Addr()) && sub.Bits() <= prefix.Bits() {
+			return true
+		}
+	}
+	return false
+}
+
+// ruleCoversPort reports whether a rule permits a port. Protocol "-1" is every
+// protocol and every port, which AWS represents with a port range of zero.
+func ruleCoversPort(rule Rule, port int) bool {
+	if rule.Protocol == "-1" {
+		return true
+	}
+	return rule.FromPort <= port && port <= rule.ToPort
+}
+
+// describePorts renders a rule's protocol and ports for a message.
+func describePorts(rule Rule) string {
+	if rule.Protocol == "-1" {
+		return "every protocol and port"
+	}
+	if rule.FromPort == rule.ToPort {
+		return fmt.Sprintf("%s/%d", rule.Protocol, rule.FromPort)
+	}
+	return fmt.Sprintf("%s/%d to %d", rule.Protocol, rule.FromPort, rule.ToPort)
+}
+
+// lastRule returns the rule with the highest priority number, which is the one
+// DNS Firewall evaluates last and therefore the one that decides a query no
+// earlier rule matched.
+func lastRule(rules []DNSFirewallRule) (DNSFirewallRule, bool) {
+	if len(rules) == 0 {
+		return DNSFirewallRule{}, false
+	}
+	last := rules[0]
+	for _, r := range rules[1:] {
+		if r.Priority > last.Priority {
+			last = r
+		}
+	}
+	return last, true
+}
+
+// isBlockEverything reports whether a rule blocks every domain.
+func isBlockEverything(rule DNSFirewallRule) bool {
+	if !strings.EqualFold(rule.Action, "BLOCK") {
+		return false
+	}
+	for _, d := range rule.Domains {
+		if strings.TrimSpace(d) == "*" {
+			return true
+		}
+	}
+	return false
+}

--- a/ee/engine/runtime/ecs/egress_test.go
+++ b/ee/engine/runtime/ecs/egress_test.go
@@ -783,6 +783,53 @@ func TestTheInstanceMetadataVerdictIsNotRoundedUp(t *testing.T) {
 	require.Contains(t, strings.ToLower(detail), "needs an account")
 }
 
+// TestTheTimeSyncVerdictDoesNotImplyAPendingMeasurement pairs a sentence with
+// the structure it describes, because those two drift apart silently.
+//
+// This path is unproven and it is unproven PERMANENTLY as this package stands.
+// It declares no Observe hook and Targets names no probe for it, so
+// EvaluateWith's nil check means an observation recorded against it is accepted
+// by the type and then discarded without a word.
+//
+// That design is deliberate and it is right. The attempt is NTP over UDP,
+// nothing in a minimal container image speaks it, and a probe whose only
+// possible outcome is errored fills a report with the word probe while learning
+// nothing. The defect was the SENTENCE. A detail reading "none has been recorded
+// for this environment" describes a measurement that is pending, a reader has no
+// way to see Targets from the report, and so the report invited somebody to wait
+// for a number that no run will ever supply. Nothing is outstanding. There is
+// nowhere to put an answer.
+//
+// The four assertions hold each other in both directions. Give this path an
+// Observe hook or a probe target and the first two go red, so the wording has to
+// be revisited; put the pending phrasing back and the last two go red.
+func TestTheTimeSyncVerdictDoesNotImplyAPendingMeasurement(t *testing.T) {
+	const id = "the-local-amazon-time-sync-service"
+
+	var path ecs.Path
+	for _, p := range ecs.Paths() {
+		if p.ID == id {
+			path = p
+		}
+	}
+	require.Equal(t, id, path.ID, "the path is gone, so the rest of this proves nothing")
+
+	require.Nil(t, path.Observe,
+		"with no Observe hook EvaluateWith discards an observation about this path, so a "+
+			"hook arriving without a detail rewrite leaves the report describing the old shape")
+	for _, target := range ecs.Targets() {
+		require.NotEqual(t, id, target.PathID,
+			"a probe target for a path with no Observe hook records a result nothing reads")
+	}
+
+	detail := detailByID(ecs.Evaluate(referencePlan()))[id]
+	require.NotContains(t, detail, "none has been recorded",
+		"nothing is pending here, and a detail saying nothing has been recorded YET is a "+
+			"measurement a reader waits for that no run will ever supply")
+	require.Contains(t, detail, "No probe here can record it",
+		"the detail has to say the absence is structural rather than a gap in the data")
+}
+
 func verdictsByID(r ecs.Report) map[string]ecs.Verdict {
 	out := map[string]ecs.Verdict{}
 	for _, v := range r.Verdicts {

--- a/ee/engine/runtime/ecs/egress_test.go
+++ b/ee/engine/runtime/ecs/egress_test.go
@@ -1,0 +1,437 @@
+package ecs_test
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/ee/engine/runtime/ecs"
+	"github.com/antifailure/antifailure/engine/pkg/extension"
+)
+
+// reference is the account description the generated plan is built from
+// throughout these tests. One value, so that a test that changes the plan is
+// visibly changing it rather than quietly using a different account.
+func reference() ecs.Inputs {
+	return ecs.Inputs{
+		Region:      "us-east-1",
+		Cluster:     "antifailure",
+		VPCID:       "vpc-0af1",
+		VPCCIDR:     "10.20.0.0/16",
+		SubnetIDs:   []string{"subnet-0a", "subnet-0b"},
+		SubnetCIDRs: []string{"10.20.1.0/24", "10.20.2.0/24"},
+	}
+}
+
+func referencePlan() ecs.Plan { return ecs.Generate(reference(), "af-example") }
+
+// expected is the verdict every path gets on the generated plan.
+//
+// It is written out in full rather than computed, because the point of the
+// table is to be a thing a person disagrees with. A test that asserted "the
+// report matches Evaluate" would pass for any predicate at all.
+var expected = map[string]ecs.Verdict{
+	"public-ipv4-through-a-gateway":              ecs.Closed,
+	"public-ipv6-through-an-egress-only-gateway": ecs.Closed,
+	"public-resolver-over-udp":                   ecs.Closed,
+	"the-amazon-provided-resolver":               ecs.Closed,
+	"the-ec2-instance-metadata-service":          ecs.Unproven,
+	"the-task-role-credentials-endpoint":         ecs.Closed,
+	"the-task-metadata-endpoint":                 ecs.Open,
+	"the-interface-endpoints-the-image-pull-needs": ecs.Open,
+	"the-s3-gateway-endpoint-the-layers-come-from": ecs.Open,
+	"the-ecs-exec-channel":                         ecs.Closed,
+	"a-peering-transit-or-private-gateway-route":   ecs.Closed,
+	"a-neighbouring-environment":                   ecs.Closed,
+	"the-local-amazon-time-sync-service":           ecs.Unproven,
+}
+
+// TestTheGeneratedPlanGetsTheVerdictItShould is the baseline every mutation
+// below is measured against.
+func TestTheGeneratedPlanGetsTheVerdictItShould(t *testing.T) {
+	report := ecs.Evaluate(referencePlan())
+	require.Equal(t, len(expected), report.Total,
+		"the enumeration and this table have drifted apart")
+	for _, v := range report.Verdicts {
+		want, ok := expected[v.Path.ID]
+		require.True(t, ok, "path %q is not in the table", v.Path.ID)
+		require.Equal(t, want, v.Verdict, "path %q said %q because: %s",
+			v.Path.ID, v.Verdict, v.Detail)
+		require.NotEmpty(t, v.Detail, "path %q gave a verdict with no reason", v.Path.ID)
+	}
+}
+
+// TestTheNumber is the figure this lane owes, asserted rather than described.
+//
+// It is deliberately not 13 of 13. Three of the paths cannot be closed on ECS
+// at all and two cannot be decided without an AWS account, so a green here at
+// 13 would mean somebody had shortened the enumeration.
+func TestTheNumber(t *testing.T) {
+	report := ecs.Evaluate(referencePlan())
+	require.Equal(t, 13, report.Total, "egress paths enumerated")
+	require.Equal(t, 8, report.Closed, "closed by the generated configuration")
+	require.Equal(t, 3, report.Open, "open, and named")
+	require.Equal(t, 2, report.Unproven, "not decided by the configuration or the documentation")
+	require.False(t, report.Contained(), "this plan must not report itself contained")
+	require.Len(t, report.NotClosed(), 5)
+}
+
+// mutation is one break in the generated plan and the paths it should move.
+type mutation struct {
+	// path is the path whose check the break is aimed at.
+	path string
+	// what describes the break, for the failure message.
+	what string
+	// apply breaks the plan.
+	apply func(*ecs.Plan)
+	// alsoOpens are paths that legitimately move as well, named so that a
+	// break which moves everything cannot pass by moving its target too.
+	alsoOpens []string
+}
+
+// mutations is the mutation test, run rather than reported.
+//
+// Every path this package calls Closed has one entry, because a verdict that
+// cannot become Open is not a check. The repository's rule is one break per
+// assertion, and that is what the alsoOpens field enforces: a break has to move
+// its own path and the named ones and nothing else, so a predicate that
+// returned Open for everything fails on the first row.
+func mutations() []mutation {
+	return []mutation{
+		{
+			path: "public-ipv4-through-a-gateway",
+			what: "a default route to an internet gateway",
+			apply: func(p *ecs.Plan) {
+				p.Network.RouteTable.Routes = append(p.Network.RouteTable.Routes,
+					ecs.Route{Destination: "0.0.0.0/0", Target: "igw-0bad"})
+			},
+			alsoOpens: []string{"public-resolver-over-udp"},
+		},
+		{
+			path: "public-ipv4-through-a-gateway",
+			what: "a public address on the task ENI",
+			apply: func(p *ecs.Plan) {
+				p.Network.RouteTable.AssignPublicIP = ecs.AssignPublicIPEnabled
+			},
+		},
+		{
+			path: "public-ipv4-through-a-gateway",
+			what: "an egress rule naming a public range",
+			apply: func(p *ecs.Plan) {
+				p.Network.SecurityGroup.Egress = append(p.Network.SecurityGroup.Egress,
+					ecs.Rule{Protocol: "tcp", FromPort: 443, ToPort: 443, CIDRv4: "0.0.0.0/0"})
+			},
+			// It also opens the resolver path, because a rule covering every
+			// address on port 443 covers port 53 only if the range does; this
+			// one does not, so the resolver path is untouched. It opens the
+			// neighbour path, because 0.0.0.0/0 is wider than the subnets.
+			alsoOpens: []string{"a-neighbouring-environment"},
+		},
+		{
+			path: "public-ipv6-through-an-egress-only-gateway",
+			what: "an IPv6 range on the VPC",
+			apply: func(p *ecs.Plan) { p.Network.VPC.IPv6CIDR = "2600:1f18::/56" },
+		},
+		{
+			path: "public-ipv6-through-an-egress-only-gateway",
+			what: "an egress only internet gateway route",
+			apply: func(p *ecs.Plan) {
+				p.Network.RouteTable.Routes = append(p.Network.RouteTable.Routes,
+					ecs.Route{Destination: "::/0", Target: "eigw-0bad"})
+			},
+		},
+		{
+			path: "public-resolver-over-udp",
+			what: "an egress rule reaching port 53 on a public resolver",
+			apply: func(p *ecs.Plan) {
+				p.Network.SecurityGroup.Egress = append(p.Network.SecurityGroup.Egress,
+					ecs.Rule{Protocol: "udp", FromPort: 53, ToPort: 53, CIDRv4: "1.1.1.1/32"})
+			},
+			// A public range in an egress rule is also exactly what the first
+			// path checks for, and it should be found by both.
+			alsoOpens: []string{"public-ipv4-through-a-gateway", "a-neighbouring-environment"},
+		},
+		{
+			path:  "the-amazon-provided-resolver",
+			what:  "a DNS firewall association that fails open",
+			apply: func(p *ecs.Plan) { p.Network.DNSFirewall.FailOpen = true },
+		},
+		{
+			path: "the-amazon-provided-resolver",
+			what: "a last rule that alerts instead of blocking",
+			apply: func(p *ecs.Plan) {
+				rules := p.Network.DNSFirewall.Rules
+				rules[len(rules)-1].Action = "ALERT"
+			},
+		},
+		{
+			path: "the-amazon-provided-resolver",
+			what: "a rule group associated with a different VPC",
+			apply: func(p *ecs.Plan) {
+				p.Network.DNSFirewall.AssociatedVPCID = "vpc-somebody-else"
+			},
+		},
+		{
+			path:  "the-amazon-provided-resolver",
+			what:  "no DNS firewall at all",
+			apply: func(p *ecs.Plan) { p.Network.DNSFirewall = nil },
+		},
+		{
+			path: "the-task-role-credentials-endpoint",
+			what: "a task role, which 169.254.170.2 then vends",
+			apply: func(p *ecs.Plan) {
+				p.TaskDefinition.TaskRoleARN = "arn:aws:iam::111122223333:role/app"
+			},
+		},
+		{
+			path:  "the-ecs-exec-channel",
+			what:  "ECS Exec turned on",
+			apply: func(p *ecs.Plan) { p.TaskDefinition.EnableExecuteCommand = true },
+		},
+		{
+			path: "the-ecs-exec-channel",
+			what: "a Systems Manager endpoint left in the VPC",
+			apply: func(p *ecs.Plan) {
+				p.Network.Endpoints = append(p.Network.Endpoints, ecs.VPCEndpoint{
+					Service: "com.amazonaws.us-east-1.ssmmessages", Type: "Interface",
+					SecurityGroupID: "sg-af-example-endpoints", PolicyDocument: "{}",
+				})
+			},
+		},
+		{
+			path: "a-peering-transit-or-private-gateway-route",
+			what: "a route to a peered VPC, which reaches production without touching the internet",
+			apply: func(p *ecs.Plan) {
+				p.Network.RouteTable.Routes = append(p.Network.RouteTable.Routes,
+					ecs.Route{Destination: "10.90.0.0/16", Target: "pcx-0prod"})
+			},
+		},
+		{
+			path: "a-peering-transit-or-private-gateway-route",
+			what: "a transit gateway route",
+			apply: func(p *ecs.Plan) {
+				p.Network.RouteTable.Routes = append(p.Network.RouteTable.Routes,
+					ecs.Route{Destination: "10.0.0.0/8", Target: "tgw-0corp"})
+			},
+		},
+		{
+			path: "a-neighbouring-environment",
+			what: "an egress rule naming another environment's security group",
+			apply: func(p *ecs.Plan) {
+				p.Network.SecurityGroup.Egress = append(p.Network.SecurityGroup.Egress,
+					ecs.Rule{Protocol: "tcp", FromPort: 5432, ToPort: 5432,
+						PeerSecurityGroupID: "sg-af-other-environment"})
+			},
+		},
+		{
+			path: "a-neighbouring-environment",
+			what: "an egress rule covering the whole VPC rather than this environment's subnets",
+			apply: func(p *ecs.Plan) {
+				p.Network.SecurityGroup.Egress = append(p.Network.SecurityGroup.Egress,
+					ecs.Rule{Protocol: "-1", CIDRv4: "10.20.0.0/16"})
+			},
+		},
+	}
+}
+
+// TestEveryClosureCanSayNo breaks the thing each closed path depends on and
+// requires the verdict to change.
+//
+// This is the mutation test, run in continuous integration rather than
+// performed once by hand and written up. A predicate whose Closed verdicts
+// survive their own mutation is a check that cannot say no, which this
+// repository has repeatedly found to be worse than no check at all.
+func TestEveryClosureCanSayNo(t *testing.T) {
+	for _, m := range mutations() {
+		t.Run(m.path+"/"+m.what, func(t *testing.T) {
+			require.Equal(t, ecs.Closed, expected[m.path],
+				"a mutation is only meaningful against a path the plan closes")
+
+			broken := referencePlan()
+			m.apply(&broken)
+			after := verdictsByID(ecs.Evaluate(broken))
+
+			require.Equal(t, ecs.Open, after[m.path],
+				"breaking %s left %s reporting %q, so that check cannot fail",
+				m.what, m.path, after[m.path])
+
+			moved := map[string]bool{m.path: true}
+			for _, id := range m.alsoOpens {
+				moved[id] = true
+				require.Equal(t, ecs.Open, after[id],
+					"%s was declared to move as well and did not", id)
+			}
+			for id, want := range expected {
+				if moved[id] {
+					continue
+				}
+				require.Equal(t, want, after[id],
+					"breaking %s also moved %s, which it was not declared to", m.what, id)
+			}
+		})
+	}
+}
+
+// TestEveryClosedPathHasAMutation stops a path from being added with a check
+// nothing ever breaks.
+//
+// Without it, the suite above measures whatever it happens to cover, and the
+// way a check that cannot say no gets into a repository is by arriving after
+// the test that would have caught it.
+func TestEveryClosedPathHasAMutation(t *testing.T) {
+	covered := map[string]bool{}
+	for _, m := range mutations() {
+		covered[m.path] = true
+	}
+	for id, want := range expected {
+		if want != ecs.Closed {
+			continue
+		}
+		require.True(t, covered[id],
+			"%s is reported closed and no mutation proves that check can fail", id)
+	}
+}
+
+// TestEveryPathIsDescribed requires the prose, because the enumeration is the
+// deliverable and an id with no reason attached is not evidence of anything.
+func TestEveryPathIsDescribed(t *testing.T) {
+	seen := map[string]bool{}
+	for _, p := range ecs.Paths() {
+		require.NotEmpty(t, p.ID)
+		require.False(t, seen[p.ID], "duplicate path id %q", p.ID)
+		seen[p.ID] = true
+		require.NotEmpty(t, p.Name, "%s has no name", p.ID)
+		require.NotEmpty(t, p.Why, "%s does not say why it is a real route", p.ID)
+		require.NotEmpty(t, p.ClosedBy, "%s does not say what closes it", p.ID)
+		require.NotNil(t, p.Check, "%s has no check", p.ID)
+	}
+}
+
+// TestTheReportCarriesItsCaveat is the one assertion that guards the honesty of
+// every number this package produces.
+func TestTheReportCarriesItsCaveat(t *testing.T) {
+	out := ecs.Evaluate(referencePlan()).String()
+	require.Contains(t, out, "8 of 13 egress paths")
+	require.Contains(t, out, ecs.Caveat)
+	require.Contains(t, out, "not that AWS was seen enforcing it")
+}
+
+// TestNoEmDashInTheProse holds the repository's writing rule on the strings
+// themselves rather than on the source, the way the engine's own four
+// assertions do, because this package is prose as much as it is code and a file
+// scanner does not read a composed report.
+func TestNoEmDashInTheProse(t *testing.T) {
+	report := ecs.Evaluate(referencePlan())
+	require.NotContains(t, report.String(), "—")
+	for _, p := range ecs.Paths() {
+		for _, s := range []string{p.Name, p.Why, p.ClosedBy} {
+			require.NotContains(t, s, "—", "%s", p.ID)
+			require.NotContains(t, s, "--", "%s", p.ID)
+		}
+	}
+}
+
+// TestTheProviderRefusesAndSaysWhy is the end to end assertion: a manifest
+// naming this runtime reaches Open and gets a refusal carrying the report.
+func TestTheProviderRefusesAndSaysWhy(t *testing.T) {
+	env := map[string]string{
+		ecs.EnvRegion: "us-east-1", ecs.EnvCluster: "antifailure",
+		ecs.EnvVPC: "vpc-0af1", ecs.EnvVPCCIDR: "10.20.0.0/16",
+		ecs.EnvSubnets: "subnet-0a,subnet-0b", ecs.EnvSubnetCIDR: "10.20.1.0/24,10.20.2.0/24",
+	}
+	p := &ecs.Provider{Getenv: func(k string) string { return env[k] }}
+	require.Equal(t, "ecs", p.Name())
+
+	rt, err := p.Open(context.Background(), extension.RuntimeConfig{})
+	require.Nil(t, rt, "a refusing provider must return no runtime at all")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "refuses to start an environment, on purpose")
+	require.Contains(t, err.Error(), "8 of 13 egress paths")
+	require.Contains(t, err.Error(), "the-ec2-instance-metadata-service")
+	require.Contains(t, err.Error(), "runtime.provider kubernetes")
+}
+
+// TestTheProviderSaysWhichVariablesAreMissing keeps the two refusals apart. An
+// installation that has described no network should be told that, not handed a
+// containment report about an empty plan.
+func TestTheProviderSaysWhichVariablesAreMissing(t *testing.T) {
+	p := &ecs.Provider{Getenv: func(string) string { return "" }}
+	rt, err := p.Open(context.Background(), extension.RuntimeConfig{})
+	require.Nil(t, rt)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), ecs.EnvVPC)
+	require.Contains(t, err.Error(), "Even fully described it would refuse")
+}
+
+// TestTheGeneratedPlanStartsSomething guards the direction the score could be
+// gamed in.
+//
+// Two of the three open paths close instantly if the plan simply stops emitting
+// the endpoints, and the resulting environment would pull no image and run
+// nothing. So the score going up must not be achievable by deleting the reason
+// it is down.
+func TestTheGeneratedPlanStartsSomething(t *testing.T) {
+	plan := referencePlan()
+	var services []string
+	for _, e := range plan.Network.Endpoints {
+		services = append(services, e.Service)
+	}
+	sort.Strings(services)
+	require.Contains(t, services, "com.amazonaws.us-east-1.ecr.api")
+	require.Contains(t, services, "com.amazonaws.us-east-1.ecr.dkr")
+	require.Contains(t, services, "com.amazonaws.us-east-1.s3",
+		"ECR serves image layers from S3 and a pull needs both")
+	require.NotEmpty(t, plan.TaskDefinition.ExecutionRoleARN,
+		"without an execution role nothing can pull an image")
+	require.Empty(t, plan.TaskDefinition.TaskRoleARN,
+		"the execution role is required and the task role must not be")
+}
+
+// TestThePlatformVersionIsPinned guards the one field whose default would make
+// the security group a claim about traffic it cannot see.
+func TestThePlatformVersionIsPinned(t *testing.T) {
+	plan := referencePlan()
+	require.Equal(t, "1.4.0", plan.PlatformVersion,
+		"below 1.4.0 a task carries a second Fargate owned ENI for image pulls that no rule "+
+			"in this plan describes and that VPC flow logs do not show")
+	require.Equal(t, "FARGATE", plan.LaunchType)
+	require.Equal(t, "awsvpc", plan.TaskDefinition.NetworkMode)
+}
+
+// TestTheInstanceMetadataVerdictIsNotRoundedUp is its own test because it is
+// the path the lane was warned about by name and the failure mode is a
+// plausible sentence rather than a wrong boolean.
+func TestTheInstanceMetadataVerdictIsNotRoundedUp(t *testing.T) {
+	plan := referencePlan()
+	byID := verdictsByID(ecs.Evaluate(plan))
+	require.Equal(t, ecs.Unproven, byID["the-ec2-instance-metadata-service"],
+		"Fargate removes the documented credential source and does not document that the "+
+			"address stops answering. Those are different claims")
+
+	plan.LaunchType = "EC2"
+	byID = verdictsByID(ecs.Evaluate(plan))
+	require.Equal(t, ecs.Open, byID["the-ec2-instance-metadata-service"],
+		"on a container instance the defence is an agent variable no task definition can set")
+
+	detail := detailByID(ecs.Evaluate(referencePlan()))["the-ec2-instance-metadata-service"]
+	require.Contains(t, strings.ToLower(detail), "needs an account")
+}
+
+func verdictsByID(r ecs.Report) map[string]ecs.Verdict {
+	out := map[string]ecs.Verdict{}
+	for _, v := range r.Verdicts {
+		out[v.Path.ID] = v.Verdict
+	}
+	return out
+}
+
+func detailByID(r ecs.Report) map[string]string {
+	out := map[string]string{}
+	for _, v := range r.Verdicts {
+		out[v.Path.ID] = v.Detail
+	}
+	return out
+}

--- a/ee/engine/runtime/ecs/egress_test.go
+++ b/ee/engine/runtime/ecs/egress_test.go
@@ -258,7 +258,16 @@ func mutations() []mutation {
 			apply: func(p *ecs.Plan) {
 				p.Network.Endpoints = append(p.Network.Endpoints, ecs.VPCEndpoint{
 					Service: "com.amazonaws.us-east-1.ssmmessages", Type: "Interface",
-					SecurityGroupID: "sg-af-example-endpoints", PolicyDocument: "{}",
+					SecurityGroupID: "sg-af-example-endpoints",
+					// Scoped as tightly as any endpoint in the plan, on
+					// purpose. An endpoint the image pull does not need is a
+					// service the task can open a connection to however good
+					// its policy is, and a mutation whose endpoint carried an
+					// empty policy would have been caught by the policy check
+					// instead and proved nothing about that.
+					PolicyDocument: `{"Statement":[{"Effect":"Allow","Principal":"*",` +
+						`"Action":["ssmmessages:CreateControlChannel"],` +
+						`"Resource":"arn:aws:ssmmessages:*:*:af-example"}]}`,
 				})
 			},
 			// It opens the interface endpoint path too, and that is not a
@@ -342,6 +351,25 @@ func mutations() []mutation {
 				p.Network.DNSFirewall.Rules = append([]ecs.DNSFirewallRule{
 					{Priority: 5, Action: "ALERT", Domains: []string{"*"}},
 				}, p.Network.DNSFirewall.Rules...)
+			},
+		},
+		{
+			path: "the-amazon-provided-resolver",
+			what: "two rules sharing a priority, with the terminal rule still last",
+			apply: func(p *ecs.Plan) {
+				// The isolated version of the row below. That one shares the
+				// LAST priority, so the terminal rule check catches it too and
+				// it proves nothing about whether the uniqueness rule works.
+				// This one leaves BLOCK on * alone at the highest priority and
+				// duplicates an earlier one, so the only thing that can refuse
+				// it is the uniqueness rule, and AWS refuses to create such a
+				// group at all: a plan that cannot be applied is not a
+				// containment either.
+				rules := p.Network.DNSFirewall.Rules
+				p.Network.DNSFirewall.Rules = append([]ecs.DNSFirewallRule{
+					{Priority: rules[0].Priority, Action: "ALLOW",
+						Domains: []string{"example.internal"}},
+				}, rules...)
 			},
 		},
 		{
@@ -565,6 +593,13 @@ func TestEveryPathIsDescribed(t *testing.T) {
 // every number this package produces.
 func TestTheReportCarriesItsCaveat(t *testing.T) {
 	out := ecs.Evaluate(referencePlan()).String()
+
+	// Logged rather than only asserted on, because the report IS the
+	// deliverable of this package and a number quoted in a message somewhere is
+	// worth less than the same number printed by the run that produced it. With
+	// -v this is the evidence, in continuous integration as well as here.
+	t.Log("\n" + out)
+
 	require.Contains(t, out, "10 of 13 egress paths")
 	require.Contains(t, out, "10 are closed by the generated configuration and 0 by an attempt")
 	require.Contains(t, out, ecs.Caveat)

--- a/ee/engine/runtime/ecs/egress_test.go
+++ b/ee/engine/runtime/ecs/egress_test.go
@@ -5,11 +5,13 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/antifailure/antifailure/ee/engine/runtime/ecs"
 	"github.com/antifailure/antifailure/engine/pkg/extension"
+	"github.com/antifailure/antifailure/engine/pkg/schema"
 )
 
 // reference is the account description the generated plan is built from
@@ -34,15 +36,15 @@ func referencePlan() ecs.Plan { return ecs.Generate(reference(), "af-example") }
 // table is to be a thing a person disagrees with. A test that asserted "the
 // report matches Evaluate" would pass for any predicate at all.
 var expected = map[string]ecs.Verdict{
-	"public-ipv4-through-a-gateway":              ecs.Closed,
-	"public-ipv6-through-an-egress-only-gateway": ecs.Closed,
-	"public-resolver-over-udp":                   ecs.Closed,
-	"the-amazon-provided-resolver":               ecs.Closed,
-	"the-ec2-instance-metadata-service":          ecs.Unproven,
-	"the-task-role-credentials-endpoint":         ecs.Closed,
-	"the-task-metadata-endpoint":                 ecs.Open,
-	"the-interface-endpoints-the-image-pull-needs": ecs.Open,
-	"the-s3-gateway-endpoint-the-layers-come-from": ecs.Open,
+	"public-ipv4-through-a-gateway":                ecs.Closed,
+	"public-ipv6-through-an-egress-only-gateway":   ecs.Closed,
+	"public-resolver-over-udp":                     ecs.Closed,
+	"the-amazon-provided-resolver":                 ecs.Closed,
+	"the-ec2-instance-metadata-service":            ecs.Unproven,
+	"the-task-role-credentials-endpoint":           ecs.Closed,
+	"the-task-metadata-endpoint":                   ecs.Open,
+	"the-interface-endpoints-the-image-pull-needs": ecs.Closed,
+	"the-s3-gateway-endpoint-the-layers-come-from": ecs.Closed,
 	"the-ecs-exec-channel":                         ecs.Closed,
 	"a-peering-transit-or-private-gateway-route":   ecs.Closed,
 	"a-neighbouring-environment":                   ecs.Closed,
@@ -66,17 +68,52 @@ func TestTheGeneratedPlanGetsTheVerdictItShould(t *testing.T) {
 
 // TestTheNumber is the figure this lane owes, asserted rather than described.
 //
-// It is deliberately not 13 of 13. Three of the paths cannot be closed on ECS
-// at all and two cannot be decided without an AWS account, so a green here at
-// 13 would mean somebody had shortened the enumeration.
+// It is deliberately not 13 of 13. One path cannot be closed on ECS at all and
+// two cannot be decided without a request from a running task, so a green here
+// at 13 would mean somebody had shortened the enumeration.
+//
+// It moved from 8 to 10 and the two that moved are named, because a count that
+// goes up without saying which paths moved is the kind of number this
+// repository does not publish. The interface endpoints and the S3 gateway were
+// reported open on the ground that a Fargate task must reach the registry to
+// start. That is true and it is the weaker half of the question: reaching ECR
+// cannot be closed and reaching ANY repository or ANY bucket can, by an
+// endpoint policy, and only the second is an exfiltration path.
 func TestTheNumber(t *testing.T) {
 	report := ecs.Evaluate(referencePlan())
 	require.Equal(t, 13, report.Total, "egress paths enumerated")
-	require.Equal(t, 8, report.Closed, "closed by the generated configuration")
-	require.Equal(t, 3, report.Open, "open, and named")
+	require.Equal(t, 10, report.Closed, "closed")
+	require.Equal(t, 1, report.Open, "open, and named")
 	require.Equal(t, 2, report.Unproven, "not decided by the configuration or the documentation")
 	require.False(t, report.Contained(), "this plan must not report itself contained")
-	require.Len(t, report.NotClosed(), 5)
+	require.Len(t, report.NotClosed(), 3)
+
+	require.Equal(t, 10, report.ClosedByDocument,
+		"with no probe result recorded, every closure is a statement about a document")
+	require.Equal(t, 0, report.ClosedByObservation,
+		"no packet has been observed, and the count that says so must not be borrowed")
+	require.Equal(t, report.Closed, report.ClosedByDocument+report.ClosedByObservation,
+		"the two grades must sum to the closed count or one of them is being hidden")
+}
+
+// TestTheGradesAndTheVerdictsAgree holds the invariant that makes the grade
+// worth having.
+//
+// A verdict of unproven with a grade of document would be a claim that a
+// document decided something it did not, and a closed verdict with no grade at
+// all would be a closure nobody has to say the provenance of. Both are ways for
+// the distinction the caveat draws to stop being enforced anywhere.
+func TestTheGradesAndTheVerdictsAgree(t *testing.T) {
+	for _, v := range ecs.Evaluate(referencePlan()).Verdicts {
+		if v.Verdict == ecs.Unproven {
+			require.Equal(t, ecs.NotEstablished, v.Grade, "%s", v.Path.ID)
+			continue
+		}
+		require.NotEqual(t, ecs.NotEstablished, v.Grade,
+			"%s has a verdict and no evidence grade", v.Path.ID)
+		require.Equal(t, ecs.FromDocument, v.Grade,
+			"%s was graded as observed and no observation was supplied", v.Path.ID)
+	}
 }
 
 // mutation is one break in the generated plan and the paths it should move.
@@ -90,6 +127,25 @@ type mutation struct {
 	// alsoOpens are paths that legitimately move as well, named so that a
 	// break which moves everything cannot pass by moving its target too.
 	alsoOpens []string
+	// wants is the verdict the target path must reach, and it defaults to
+	// Open.
+	//
+	// It exists for one break, and the break is worth the field. AWS's
+	// FirewallFailOpen is three valued and its third value takes the failure
+	// mode from a setting no plan carries, so a plan holding it has not decided
+	// whether the resolver path is closed. The honest verdict there is
+	// unproven, and a harness that could only express "this break makes it
+	// open" would have forced that break to be described in prose instead of
+	// run, which is how a case stops being tested.
+	wants ecs.Verdict
+}
+
+// want returns the verdict this mutation's target must reach.
+func (m mutation) want() ecs.Verdict {
+	if m.wants == "" {
+		return ecs.Open
+	}
+	return m.wants
 }
 
 // mutations is the mutation test, run rather than reported.
@@ -131,8 +187,8 @@ func mutations() []mutation {
 			alsoOpens: []string{"a-neighbouring-environment"},
 		},
 		{
-			path: "public-ipv6-through-an-egress-only-gateway",
-			what: "an IPv6 range on the VPC",
+			path:  "public-ipv6-through-an-egress-only-gateway",
+			what:  "an IPv6 range on the VPC",
 			apply: func(p *ecs.Plan) { p.Network.VPC.IPv6CIDR = "2600:1f18::/56" },
 		},
 		{
@@ -200,6 +256,12 @@ func mutations() []mutation {
 					SecurityGroupID: "sg-af-example-endpoints", PolicyDocument: "{}",
 				})
 			},
+			// It opens the interface endpoint path too, and that is not a
+			// leaky check. An endpoint in the VPC is a service the task can
+			// open a connection to whatever the flag says, so a reader asking
+			// "what can this task reach" should be told about it in the answer
+			// to that question as well as in the answer about ECS Exec.
+			alsoOpens: []string{"the-interface-endpoints-the-image-pull-needs"},
 		},
 		{
 			path: "a-peering-transit-or-private-gateway-route",
@@ -234,7 +296,191 @@ func mutations() []mutation {
 					ecs.Rule{Protocol: "-1", CIDRv4: "10.20.0.0/16"})
 			},
 		},
+
+		// The DNS firewall breaks this lane added, each aimed at a way the old
+		// predicate said closed about a rule group that blocks nothing.
+		{
+			path: "the-amazon-provided-resolver",
+			what: "the terminal block rule moved off the end by priority",
+			apply: func(p *ecs.Plan) {
+				// The allow rule is at 10 and the block at 1000. Moving the
+				// block to 5 does not delete it, does not change its action
+				// and does not change its domains: the group still contains
+				// BLOCK on * and reads as configured. It is simply evaluated
+				// first, so the allow rule at 10 is what decides every query
+				// the block did not match, and AWS processes a rule group
+				// "by order of priority, starting from the lowest setting".
+				rules := p.Network.DNSFirewall.Rules
+				rules[len(rules)-1].Priority = 5
+			},
+		},
+		{
+			path: "the-amazon-provided-resolver",
+			what: "an allow rule matching every domain ahead of the terminal block",
+			apply: func(p *ecs.Plan) {
+				// The shape the old predicate could not see. The last rule by
+				// priority is still BLOCK on *, so every assertion about the
+				// terminal rule passes, and no query ever reaches it because
+				// AWS defines ALLOW as permit the request to go through.
+				p.Network.DNSFirewall.Rules = append([]ecs.DNSFirewallRule{
+					{Priority: 5, Action: "ALLOW", Domains: []string{"*"}},
+				}, p.Network.DNSFirewall.Rules...)
+			},
+		},
+		{
+			path: "the-amazon-provided-resolver",
+			what: "an alert rule matching every domain, which permits rather than blocks",
+			apply: func(p *ecs.Plan) {
+				// ALERT is the value somebody sets while tuning and leaves.
+				// AWS defines it as permit the request and send metrics and
+				// logs, so it is ALLOW with a graph attached.
+				p.Network.DNSFirewall.Rules = append([]ecs.DNSFirewallRule{
+					{Priority: 5, Action: "ALERT", Domains: []string{"*"}},
+				}, p.Network.DNSFirewall.Rules...)
+			},
+		},
+		{
+			path: "the-amazon-provided-resolver",
+			what: "two rules sharing the last priority, which AWS refuses and this plan did not",
+			apply: func(p *ecs.Plan) {
+				p.Network.DNSFirewall.Rules = append(p.Network.DNSFirewall.Rules,
+					ecs.DNSFirewallRule{Priority: 1000, Action: "ALLOW", Domains: []string{"*"}})
+			},
+		},
+		{
+			path: "the-amazon-provided-resolver",
+			what: "an allow domain with a star in the middle, which AWS will not accept",
+			apply: func(p *ecs.Plan) {
+				rules := p.Network.DNSFirewall.Rules
+				rules[0].Domains = append(rules[0].Domains, "email.*.amazonaws.com")
+			},
+		},
+		{
+			path:  "the-amazon-provided-resolver",
+			what:  "a failure mode taken from a setting this plan does not carry",
+			wants: ecs.Unproven,
+			apply: func(p *ecs.Plan) {
+				p.Network.DNSFirewall.FailOpen = ecs.FailOpenDeferred
+			},
+		},
+
+		// The endpoint policy breaks, which are what the two new closures rest
+		// on. Each leaves the endpoint exactly where it was and widens only
+		// what may be reached through it, because that is the half of those
+		// paths that can be closed at all.
+		{
+			path: "the-interface-endpoints-the-image-pull-needs",
+			what: "an ECR endpoint policy naming a wildcard resource",
+			apply: func(p *ecs.Plan) {
+				setEndpointPolicy(p, "com.amazonaws.us-east-1.ecr.dkr",
+					`{"Statement":[{"Effect":"Allow","Principal":"*",`+
+						`"Action":["ecr:BatchGetImage"],"Resource":"*"}]}`)
+			},
+		},
+		{
+			path: "the-interface-endpoints-the-image-pull-needs",
+			what: "an ECR endpoint policy naming every repository by ARN",
+			apply: func(p *ecs.Plan) {
+				setEndpointPolicy(p, "com.amazonaws.us-east-1.ecr.dkr",
+					`{"Statement":[{"Effect":"Allow","Principal":"*",`+
+						`"Action":["ecr:BatchGetImage"],`+
+						`"Resource":"arn:aws:ecr:*:*:repository/*"}]}`)
+			},
+		},
+		{
+			path: "the-interface-endpoints-the-image-pull-needs",
+			what: "every ECR action on this environment's own repository",
+			apply: func(p *ecs.Plan) {
+				// Scoped to one repository and still a place to push a layer,
+				// which is why the action list is checked and not only the
+				// resource list.
+				setEndpointPolicy(p, "com.amazonaws.us-east-1.ecr.dkr",
+					`{"Statement":[{"Effect":"Allow","Principal":"*","Action":["ecr:*"],`+
+						`"Resource":"arn:aws:ecr:*:*:repository/af-example*"}]}`)
+			},
+		},
+		{
+			path: "the-interface-endpoints-the-image-pull-needs",
+			what: "a writing action smuggled into the statement that may name a wildcard resource",
+			apply: func(p *ecs.Plan) {
+				// The carve out for ecr:GetAuthorizationToken exists because
+				// that action takes no resource. This proves the carve out can
+				// say no when something else rides along in the same statement.
+				setEndpointPolicy(p, "com.amazonaws.us-east-1.ecr.api",
+					`{"Statement":[{"Effect":"Allow","Principal":"*",`+
+						`"Action":["ecr:GetAuthorizationToken","ecr:PutImage"],`+
+						`"Resource":"*"}]}`)
+			},
+		},
+		{
+			path: "the-interface-endpoints-the-image-pull-needs",
+			what: "a logs endpoint policy naming somebody else's log group",
+			apply: func(p *ecs.Plan) {
+				setEndpointPolicy(p, "com.amazonaws.us-east-1.logs",
+					`{"Statement":[{"Effect":"Allow","Principal":"*",`+
+						`"Action":["logs:PutLogEvents"],`+
+						`"Resource":"arn:aws:logs:*:*:log-group:/antifailure/af-other:*"}]}`)
+			},
+		},
+		{
+			path: "the-interface-endpoints-the-image-pull-needs",
+			what: "an endpoint policy stripped off entirely",
+			apply: func(p *ecs.Plan) {
+				setEndpointPolicy(p, "com.amazonaws.us-east-1.logs", "")
+			},
+		},
+		{
+			path: "the-interface-endpoints-the-image-pull-needs",
+			what: "an endpoint policy that is not a policy document",
+			apply: func(p *ecs.Plan) {
+				// Unparseable must fail towards open. A document nobody could
+				// read is not a narrowing, and the alternative is that a
+				// malformed policy silently counts as containment.
+				setEndpointPolicy(p, "com.amazonaws.us-east-1.logs", "{not json")
+			},
+		},
+		{
+			path: "the-s3-gateway-endpoint-the-layers-come-from",
+			what: "a gateway endpoint policy naming every bucket",
+			apply: func(p *ecs.Plan) {
+				setEndpointPolicy(p, "com.amazonaws.us-east-1.s3",
+					`{"Statement":[{"Effect":"Allow","Principal":"*","Action":["s3:GetObject"],`+
+						`"Resource":"arn:aws:s3:::*"}]}`)
+			},
+		},
+		{
+			path: "the-s3-gateway-endpoint-the-layers-come-from",
+			what: "a gateway endpoint policy that also permits writing",
+			apply: func(p *ecs.Plan) {
+				setEndpointPolicy(p, "com.amazonaws.us-east-1.s3",
+					`{"Statement":[{"Effect":"Allow","Principal":"*","Action":["s3:*"],`+
+						`"Resource":"arn:aws:s3:::prod-us-east-1-starport-layer-bucket/*"}]}`)
+			},
+		},
+		{
+			path: "the-s3-gateway-endpoint-the-layers-come-from",
+			what: "the gateway endpoint policy removed",
+			apply: func(p *ecs.Plan) {
+				setEndpointPolicy(p, "com.amazonaws.us-east-1.s3", "")
+			},
+		},
 	}
+}
+
+// setEndpointPolicy replaces one endpoint's policy in place, and fails loudly
+// if the endpoint is not there.
+//
+// The loud failure is the point: a mutation that silently changed nothing would
+// leave the verdict where it was, and the harness would report that the check
+// cannot fail when what actually happened is that the break never landed.
+func setEndpointPolicy(p *ecs.Plan, service, document string) {
+	for i := range p.Network.Endpoints {
+		if p.Network.Endpoints[i].Service == service {
+			p.Network.Endpoints[i].PolicyDocument = document
+			return
+		}
+	}
+	panic("no endpoint named " + service + " in the generated plan, so this mutation broke nothing")
 }
 
 // TestEveryClosureCanSayNo breaks the thing each closed path depends on and
@@ -254,7 +500,7 @@ func TestEveryClosureCanSayNo(t *testing.T) {
 			m.apply(&broken)
 			after := verdictsByID(ecs.Evaluate(broken))
 
-			require.Equal(t, ecs.Open, after[m.path],
+			require.Equal(t, m.want(), after[m.path],
 				"breaking %s left %s reporting %q, so that check cannot fail",
 				m.what, m.path, after[m.path])
 
@@ -314,9 +560,11 @@ func TestEveryPathIsDescribed(t *testing.T) {
 // every number this package produces.
 func TestTheReportCarriesItsCaveat(t *testing.T) {
 	out := ecs.Evaluate(referencePlan()).String()
-	require.Contains(t, out, "8 of 13 egress paths")
+	require.Contains(t, out, "10 of 13 egress paths")
+	require.Contains(t, out, "10 are closed by the generated configuration and 0 by an attempt")
 	require.Contains(t, out, ecs.Caveat)
 	require.Contains(t, out, "not that AWS was seen enforcing it")
+	require.Contains(t, out, "no absence of evidence closes anything here")
 }
 
 // TestNoEmDashInTheProse holds the repository's writing rule on the strings
@@ -349,9 +597,67 @@ func TestTheProviderRefusesAndSaysWhy(t *testing.T) {
 	require.Nil(t, rt, "a refusing provider must return no runtime at all")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "refuses to start an environment, on purpose")
-	require.Contains(t, err.Error(), "8 of 13 egress paths")
+	require.Contains(t, err.Error(), "10 of 13 egress paths")
 	require.Contains(t, err.Error(), "the-ec2-instance-metadata-service")
 	require.Contains(t, err.Error(), "runtime.provider kubernetes")
+}
+
+// TestTheProviderNamesTheHostsItsFirewallCannotResolve is the end to end
+// assertion for the composition with the egress catalogue.
+//
+// It is here rather than in the generator's own test because the failure it
+// guards is a silence: a host the manifest declares, that the firewall cannot
+// express, and that nobody is told about. The environment would then fail to
+// reach something it was told it could, for a reason printed nowhere, and the
+// obvious fix from the outside is to take the firewall off.
+func TestTheProviderNamesTheHostsItsFirewallCannotResolve(t *testing.T) {
+	env := map[string]string{
+		ecs.EnvRegion: "us-east-1", ecs.EnvCluster: "antifailure",
+		ecs.EnvVPC: "vpc-0af1", ecs.EnvVPCCIDR: "10.20.0.0/16",
+		ecs.EnvSubnets: "subnet-0a,subnet-0b", ecs.EnvSubnetCIDR: "10.20.1.0/24,10.20.2.0/24",
+	}
+	p := &ecs.Provider{Getenv: func(k string) string { return env[k] }}
+
+	_, err := p.Open(context.Background(), extension.RuntimeConfig{
+		Egress: schema.Egress{Rules: []schema.EgressRule{
+			{Host: "api.stripe.com", Mode: schema.ModeAllow},
+			{Host: "email.*.amazonaws.com", Mode: schema.ModeAllow},
+		}},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does NOT resolve email.*.amazonaws.com")
+	require.NotContains(t, err.Error(), "does NOT resolve api.stripe.com",
+		"a host the firewall CAN express must not be reported as one it cannot")
+}
+
+// TestTheProviderReadsEvidenceRecordedForThisInstallation proves the reader has
+// a live call site.
+//
+// A probe format with nothing consulting it would be a feature that exists and
+// does nothing, which is the shape this repository keeps finding. The writer's
+// live call site is a task this runtime refuses to create, and that is said in
+// the report rather than hidden; the reader's is here.
+func TestTheProviderReadsEvidenceRecordedForThisInstallation(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, ecs.Record(dir, "af-example", ecs.Observations{{
+		PathID: "the-ec2-instance-metadata-service", EnvironmentID: "af-example",
+		Address: "169.254.169.254:80", Network: "tcp", Timeout: ecs.ProbeTimeout,
+		Outcome: ecs.NoAnswer, Detail: "nothing answered within 3s",
+		ObservedAt: time.Date(2026, 9, 8, 4, 5, 6, 0, time.UTC), ProbeVersion: ecs.ProbeVersion,
+	}}))
+
+	env := map[string]string{
+		ecs.EnvRegion: "us-east-1", ecs.EnvCluster: "antifailure",
+		ecs.EnvVPC: "vpc-0af1", ecs.EnvVPCCIDR: "10.20.0.0/16",
+		ecs.EnvSubnets: "subnet-0a,subnet-0b", ecs.EnvSubnetCIDR: "10.20.1.0/24,10.20.2.0/24",
+	}
+	p := &ecs.Provider{Getenv: func(k string) string { return env[k] }}
+
+	_, err := p.Open(context.Background(), extension.RuntimeConfig{StateDir: dir})
+	require.Error(t, err, "the runtime refuses whatever the evidence says")
+	require.Contains(t, err.Error(), "11 of 13 egress paths",
+		"a recorded attempt has to reach the report, or the format is decoration")
+	require.Contains(t, err.Error(), "10 are closed by the generated configuration and 1 by an attempt")
 }
 
 // TestTheProviderSaysWhichVariablesAreMissing keeps the two refusals apart. An

--- a/ee/engine/runtime/ecs/egress_test.go
+++ b/ee/engine/runtime/ecs/egress_test.go
@@ -214,9 +214,11 @@ func mutations() []mutation {
 			alsoOpens: []string{"public-ipv4-through-a-gateway", "a-neighbouring-environment"},
 		},
 		{
-			path:  "the-amazon-provided-resolver",
-			what:  "a DNS firewall association that fails open",
-			apply: func(p *ecs.Plan) { p.Network.DNSFirewall.FailOpen = true },
+			path: "the-amazon-provided-resolver",
+			what: "a DNS firewall association that fails open",
+			apply: func(p *ecs.Plan) {
+				p.Network.DNSFirewall.FailOpen = ecs.FailOpenEnabled
+			},
 		},
 		{
 			path: "the-amazon-provided-resolver",

--- a/ee/engine/runtime/ecs/egress_test.go
+++ b/ee/engine/runtime/ecs/egress_test.go
@@ -591,6 +591,16 @@ func TestEveryPathIsDescribed(t *testing.T) {
 
 // TestTheReportCarriesItsCaveat is the one assertion that guards the honesty of
 // every number this package produces.
+//
+// The first three assertions are on the FIRST LINE rather than anywhere in the
+// output, and that is the load bearing part. A reader must not be able to see
+// "10 closed" without also seeing "1 open" and "2 unproven" in the same breath,
+// because the open and unproven counts are what stop the ten from reading as a
+// containment guarantee. A summary that quotes the numerator alone is how a
+// figure stops being true while every word in it stays accurate, and quoting
+// the headline is exactly what a person does. Asserting on the whole output
+// would pass a report that moved the caveat counts to the bottom, which is the
+// same report with the honesty removed.
 func TestTheReportCarriesItsCaveat(t *testing.T) {
 	out := ecs.Evaluate(referencePlan()).String()
 
@@ -600,7 +610,14 @@ func TestTheReportCarriesItsCaveat(t *testing.T) {
 	// -v this is the evidence, in continuous integration as well as here.
 	t.Log("\n" + out)
 
-	require.Contains(t, out, "10 of 13 egress paths")
+	first, _, _ := strings.Cut(strings.TrimSpace(out), "\n")
+	require.Contains(t, first, "10 of 13 egress paths",
+		"the headline must carry the ratio")
+	require.Contains(t, first, "2 unproven",
+		"the headline must carry the unproven count beside the closed count, so that "+
+			"neither can be quoted without the other")
+	require.Contains(t, first, "1 open",
+		"the headline must carry the open count beside the closed count")
 	require.Contains(t, out, "10 are closed by the generated configuration and 0 by an attempt")
 	require.Contains(t, out, ecs.Caveat)
 	require.Contains(t, out, "not that AWS was seen enforcing it")

--- a/ee/engine/runtime/ecs/egress_test.go
+++ b/ee/engine/runtime/ecs/egress_test.go
@@ -1,5 +1,8 @@
 package ecs_test
 
+// Not MIT. This directory is covered by the Antifailure Enterprise License; see
+// ee/LICENSE.md.
+
 import (
 	"context"
 	"sort"

--- a/ee/engine/runtime/ecs/evidence.go
+++ b/ee/engine/runtime/ecs/evidence.go
@@ -1,5 +1,8 @@
 package ecs
 
+// Not MIT. This directory is covered by the Antifailure Enterprise License; see
+// ee/LICENSE.md.
+
 import (
 	"bufio"
 	"encoding/json"

--- a/ee/engine/runtime/ecs/evidence.go
+++ b/ee/engine/runtime/ecs/evidence.go
@@ -1,0 +1,371 @@
+package ecs
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Evidence is the half of this package that is not a document.
+//
+// Everything in egress.go is a predicate over a plan, and the caveat that
+// travels with it says exactly what that is worth: a closed verdict there is a
+// statement about a JSON document. Two of the thirteen paths are link local
+// addresses, and no field of any AWS request decides them. AWS documents that
+// Fargate removes the EC2 instance profile, which is a claim about what
+// credentials exist; it does not say that 169.254.169.254 stops answering,
+// which is a claim about what the address does. Reading the first as the second
+// is how a containment claim turns into a plausible sentence.
+//
+// So this file settles them the only way they can be settled, which is by
+// trying. The attempt runs inside a task in the customer's own account, and
+// what it saw is recorded beside the environment and read back by the
+// predicate. That converts unproven from a permanent hole into a value that is
+// unproven until an environment has actually run and decided afterwards.
+//
+// The rule that keeps it honest is the absence rule: NO OBSERVATION MEANS
+// UNPROVEN, forever. A missing probe result is not a quiet pass, a probe that
+// could not run is not a refusal, and nothing in this file can move a path to
+// closed except a recorded attempt that got nowhere.
+
+// Outcome is what one attempt saw.
+//
+// Three values rather than four, and the missing one is the point. An earlier
+// draft of this file had Refused and TimedOut as separate outcomes, which reads
+// as more precise and is not: the probe is a shell command inside a container
+// image, it distinguishes those two cases nowhere, and every recorded Refused
+// would have been a guess dressed as a measurement. A vocabulary wider than the
+// instrument is the same defect as a check that cannot say no, pointed the
+// other way.
+type Outcome string
+
+const (
+	// Reachable means something answered. It is the one outcome that is
+	// positive evidence rather than the absence of it, and it opens the path.
+	Reachable Outcome = "reachable"
+	// NoAnswer means the attempt was made and got nowhere within its deadline,
+	// whether it was refused outright or hung until it was cut off.
+	NoAnswer Outcome = "no_answer"
+	// Errored means the probe could not make the attempt at all. It is NOT a
+	// refusal and must never be read as one: a probe that did not run tells you
+	// nothing about the path, which is the same distinction the three valued
+	// verdict exists for.
+	Errored Outcome = "errored"
+)
+
+// Observation is one recorded attempt from one running task.
+//
+// It carries the address and the deadline as well as the outcome, because a
+// timeout is only evidence if you know what was dialled and for how long. An
+// observation that says "timed out" and does not say against what is the same
+// kind of unfalsifiable claim as a check that cannot say no.
+type Observation struct {
+	// PathID is the egress path this attempt was about, and it must match an
+	// id in Paths.
+	PathID string `json:"path_id"`
+	// EnvironmentID names the environment whose task made the attempt.
+	EnvironmentID string `json:"environment_id"`
+	// Address is exactly what was dialled.
+	Address string `json:"address"`
+	// Network is the dial network, tcp or udp.
+	Network string `json:"network"`
+	// Timeout is how long the attempt was given before it was called a
+	// timeout.
+	Timeout time.Duration `json:"timeout"`
+	// Outcome is what happened.
+	Outcome Outcome `json:"outcome"`
+	// Detail is the error string or the answer, kept verbatim.
+	Detail string `json:"detail"`
+	// ObservedAt is when the attempt was made.
+	ObservedAt time.Time `json:"observed_at"`
+	// ProbeVersion identifies the probe that made it, so a result recorded by
+	// an older probe is not silently read as one this code would produce.
+	ProbeVersion string `json:"probe_version"`
+}
+
+// ProbeVersion is stamped into every observation this build records.
+const ProbeVersion = "af-ecs-probe/1"
+
+// Observations is a set of recorded attempts.
+type Observations []Observation
+
+// For returns the observation for a path, and whether there is one.
+//
+// When several were recorded for one path it returns the most recent, because
+// the question the predicate asks is what the environment saw last, not what
+// it saw first. An observation with a zero timestamp loses to any dated one.
+func (o Observations) For(pathID string) (Observation, bool) {
+	var best Observation
+	found := false
+	for _, obs := range o {
+		if obs.PathID != pathID {
+			continue
+		}
+		if !found || obs.ObservedAt.After(best.ObservedAt) {
+			best, found = obs, true
+		}
+	}
+	return best, found
+}
+
+// Target is one link local address the probe attempts.
+//
+// The list is short on purpose. A probe is only allowed to exist here for a
+// path the configuration cannot decide, because a probe for a path a route
+// table already answers would be a second instrument disagreeing with the
+// first about the same fact.
+type Target struct {
+	// PathID is the path in Paths this attempt settles.
+	PathID string
+	// Network and Address are what to dial.
+	Network string
+	Address string
+	// Why records where the address came from, because an address asserted
+	// from memory is exactly the kind of thing that makes a probe report
+	// confidently about the wrong endpoint.
+	Why string
+}
+
+// Targets are the link local addresses the probe attempts.
+//
+// One, not two, and the omission is deliberate rather than unfinished. The
+// instance metadata address is the one the ECS documentation names when it
+// describes containers on container instances reaching instance metadata and
+// IAM role credentials, and an HTTP GET against it is something any image with
+// wget can make.
+//
+// The local Amazon Time Sync Service is NOT here even though its address is now
+// known, because the attempt is an NTP exchange over UDP and nothing in a
+// minimal container image makes one. A target whose only possible recorded
+// outcome is Errored is not a way to answer a question, it is a way to fill a
+// report with the word "probe" while learning nothing, so that path keeps its
+// unproven verdict and this file says why instead.
+func Targets() []Target {
+	return []Target{
+		{
+			PathID:  "the-ec2-instance-metadata-service",
+			Network: "tcp",
+			Address: "169.254.169.254:80",
+			Why: "the ECS documentation names this address when it describes containers on " +
+				"container instances reaching instance metadata and IAM role credentials",
+		},
+	}
+}
+
+// Marker is the prefix of every line the probe emits.
+//
+// It exists for the reason the Kubernetes probe's marker exists: a container
+// that failed for some other reason must never be read as a result. A line
+// without it is not a probe result, and a run that produced no marked lines at
+// all produced no evidence, which is different from producing evidence of
+// containment.
+const Marker = "AF-ECS-PROBE"
+
+// ProbeScript is what the probe container runs.
+//
+// It is a shell script rather than a Go program because it runs inside the
+// customer's task on the customer's image, where there is no Antifailure
+// binary. The Kubernetes runtime's containment probe has exactly this shape and
+// for exactly this reason.
+//
+// Every branch prints a marked line, including the branch where there is no
+// tool to make the attempt with. A probe that stayed silent when it could not
+// run would be indistinguishable from one that found nothing, and the reader
+// would take the silence for an unrecorded path rather than for a broken
+// instrument.
+func ProbeScript(envID string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "#!/bin/sh\nenv_id=%q\n", envID)
+	for _, t := range Targets() {
+		fmt.Fprintf(&b, `
+if command -v wget >/dev/null 2>&1; then
+  if wget -T %d -q -O /dev/null http://%s/ >/dev/null 2>&1; then
+    echo "%s %s $env_id %s reachable something answered within %ds"
+  else
+    echo "%s %s $env_id %s no_answer nothing answered within %ds"
+  fi
+else
+  echo "%s %s $env_id %s errored no wget in this image, so no attempt was made"
+fi
+`,
+			int(ProbeTimeout.Seconds()), t.Address,
+			Marker, ProbeVersion, t.Address, int(ProbeTimeout.Seconds()),
+			Marker, ProbeVersion, t.Address, int(ProbeTimeout.Seconds()),
+			Marker, ProbeVersion, t.Address)
+	}
+	return b.String()
+}
+
+// ParseProbeOutput reads a probe container's log and returns what it recorded.
+//
+// It ignores every line that is not a marked one, so an image that prints its
+// own startup noise cannot be mistaken for a probe, and it refuses a marked
+// line it cannot read rather than skipping it, because a result this build
+// cannot parse is a malfunction and not an absence.
+//
+// It also refuses to invent the paths it did not see. A target with no line in
+// the output produces no observation, which leaves the path unproven, which is
+// the correct answer for a probe that did not report about it.
+func ParseProbeOutput(output string, now func() time.Time) (Observations, error) {
+	if now == nil {
+		now = time.Now
+	}
+	byAddress := map[string]Target{}
+	for _, t := range Targets() {
+		byAddress[t.Address] = t
+	}
+	var out Observations
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if !strings.HasPrefix(line, Marker+" ") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 5 {
+			return nil, fmt.Errorf("a %s line has %d fields and needs at least 5: %q",
+				Marker, len(fields), line)
+		}
+		version, envID, address, outcome := fields[1], fields[2], fields[3], Outcome(fields[4])
+		target, known := byAddress[address]
+		if !known {
+			return nil, fmt.Errorf("a %s line reports about %q, which is not one of this "+
+				"build's probe targets, so which path it settles is unknown: %q",
+				Marker, address, line)
+		}
+		switch outcome {
+		case Reachable, NoAnswer, Errored:
+		default:
+			return nil, fmt.Errorf("a %s line reports the outcome %q, which is not one this "+
+				"build knows: %q", Marker, outcome, line)
+		}
+		out = append(out, Observation{
+			PathID:        target.PathID,
+			EnvironmentID: envID,
+			Address:       address,
+			Network:       target.Network,
+			Timeout:       ProbeTimeout,
+			Outcome:       outcome,
+			Detail:        strings.Join(fields[5:], " "),
+			ObservedAt:    now(),
+			ProbeVersion:  version,
+		})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// ProbeTimeout is how long one attempt is given.
+//
+// Short, because the expected outcome of every attempt in Targets is that it
+// hangs until it is cut off, and a probe that takes a minute per path is a
+// probe somebody removes from the startup path.
+const ProbeTimeout = 3 * time.Second
+
+// EvidenceFile is the name the observations are recorded under, inside the
+// runtime's state directory.
+const EvidenceFile = "ecs-containment-evidence.json"
+
+// Record writes observations for one environment into the state directory.
+//
+// It merges rather than replaces, keyed by environment and path, so a second
+// run of one environment updates its own answer and leaves every other
+// environment's alone. A file that only ever held the last run would answer
+// the question for one environment and silently un answer it for the rest.
+func Record(stateDir, envID string, obs Observations) error {
+	if strings.TrimSpace(stateDir) == "" {
+		return errors.New("recording containment evidence needs a state directory, and an " +
+			"empty one would write beside whatever process was running")
+	}
+	existing, err := Load(stateDir)
+	if err != nil {
+		return err
+	}
+	keep := make(Observations, 0, len(existing)+len(obs))
+	replaced := map[string]bool{}
+	for _, o := range obs {
+		replaced[o.EnvironmentID+"\x00"+o.PathID] = true
+	}
+	for _, o := range existing {
+		if o.EnvironmentID == envID && replaced[o.EnvironmentID+"\x00"+o.PathID] {
+			continue
+		}
+		keep = append(keep, o)
+	}
+	keep = append(keep, obs...)
+	sort.SliceStable(keep, func(i, j int) bool {
+		if keep[i].EnvironmentID != keep[j].EnvironmentID {
+			return keep[i].EnvironmentID < keep[j].EnvironmentID
+		}
+		return keep[i].PathID < keep[j].PathID
+	})
+
+	body, err := json.MarshalIndent(keep, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(stateDir, EvidenceFile), append(body, '\n'), 0o644)
+}
+
+// Load reads recorded observations.
+//
+// A missing file is not an error and yields nothing, which is the absence rule
+// again: an installation that has never run a probe is in exactly the state
+// this package describes as unproven, and turning that into a failure would
+// push somebody towards writing a file by hand to make the message go away.
+//
+// A file that exists and cannot be parsed IS an error, because that is a
+// different thing: something wrote evidence and this build cannot read it, and
+// answering unproven there would be reporting an absence that is really a
+// malfunction.
+func Load(stateDir string) (Observations, error) {
+	// An empty state directory is not the current directory. Joining nothing
+	// with the file name yields a bare relative path, which would read
+	// whatever happens to be beside the process, and a containment verdict
+	// taken from a file in somebody's working directory is worse than no
+	// verdict at all.
+	if strings.TrimSpace(stateDir) == "" {
+		return nil, nil
+	}
+	body, err := os.ReadFile(filepath.Join(stateDir, EvidenceFile))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var out Observations
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("%s exists and could not be read as containment evidence, "+
+			"which is not the same as there being none: %w",
+			filepath.Join(stateDir, EvidenceFile), err)
+	}
+	return out, nil
+}
+
+// ForEnvironment narrows a set to one environment.
+//
+// It exists because evidence from another environment is evidence about
+// another task in another subnet, and reading it here would be the same defect
+// as a security group shared between environments: every rule still reads as
+// correct and the conclusion is about somewhere else.
+func (o Observations) ForEnvironment(envID string) Observations {
+	var out Observations
+	for _, obs := range o {
+		if obs.EnvironmentID == envID {
+			out = append(out, obs)
+		}
+	}
+	return out
+}

--- a/ee/engine/runtime/ecs/evidence_test.go
+++ b/ee/engine/runtime/ecs/evidence_test.go
@@ -408,10 +408,40 @@ func TestTheProbeContainerIsEmittedOnlyWithAnImage(t *testing.T) {
 	probe := withProbe.TaskDefinition.Containers[0]
 	require.Equal(t, ecs.ProbeContainerName, probe.Name)
 	require.Equal(t, in.ProbeImage, probe.Image)
-	require.True(t, probe.Essential,
-		"a probe whose failure does not stop the task is a bystander")
+	require.False(t, probe.Essential,
+		"on ECS the exit of an essential container stops the whole task, and a probe is a "+
+			"thing that runs and finishes, so marking it essential would kill every "+
+			"environment the moment the probe succeeded")
 	require.Equal(t, []string{"/bin/sh", "-c", ecs.ProbeScript("af-example")}, probe.Command)
 	require.Contains(t, detailByID(ecs.Evaluate(withProbe))[imds], ecs.ProbeContainerName)
+}
+
+// TestEveryProbeTargetPointsAtARealPath stops a target from settling a path
+// that is not in the enumeration.
+//
+// Without it a renamed path id would leave the probe recording results nobody
+// reads, and the verdict would stay unproven forever while a file full of
+// answers sat beside it. That is the quietest possible failure: the report is
+// still honest, the probe still runs, and the two never meet.
+func TestEveryProbeTargetPointsAtARealPath(t *testing.T) {
+	observable := map[string]bool{}
+	for _, p := range ecs.Paths() {
+		if p.Observe != nil {
+			observable[p.ID] = true
+		}
+	}
+	require.NotEmpty(t, ecs.Targets())
+	for _, target := range ecs.Targets() {
+		require.True(t, observable[target.PathID],
+			"the probe attempts %s for path %q, and no path with that id reads an observation",
+			target.Address, target.PathID)
+		require.NotEmpty(t, target.Why,
+			"%s is dialled and no source is recorded for the address, and an address asserted "+
+				"from memory makes a probe report confidently about the wrong endpoint",
+			target.Address)
+		require.NotContains(t, target.Why, "--")
+		require.NotContains(t, target.Why, "\u2014")
+	}
 }
 
 // mustFind returns one environment's observation or fails the test.

--- a/ee/engine/runtime/ecs/evidence_test.go
+++ b/ee/engine/runtime/ecs/evidence_test.go
@@ -1,5 +1,8 @@
 package ecs_test
 
+// Not MIT. This directory is covered by the Antifailure Enterprise License; see
+// ee/LICENSE.md.
+
 import (
 	"os"
 	"path/filepath"

--- a/ee/engine/runtime/ecs/evidence_test.go
+++ b/ee/engine/runtime/ecs/evidence_test.go
@@ -1,0 +1,427 @@
+package ecs_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/ee/engine/runtime/ecs"
+	"github.com/antifailure/antifailure/engine/pkg/schema"
+)
+
+// observedAt is a fixed clock, so that a test asserting on a rendered detail
+// line is asserting on the code rather than on the minute it ran in.
+func observedAt() time.Time { return time.Date(2026, 9, 8, 4, 5, 6, 0, time.UTC) }
+
+// imds is the path the probe exists for.
+const imds = "the-ec2-instance-metadata-service"
+
+// observation builds one recorded attempt for the reference environment.
+func observation(outcome ecs.Outcome) ecs.Observation {
+	return ecs.Observation{
+		PathID:        imds,
+		EnvironmentID: "af-example",
+		Address:       "169.254.169.254:80",
+		Network:       "tcp",
+		Timeout:       ecs.ProbeTimeout,
+		Outcome:       outcome,
+		Detail:        "nothing answered within 3s",
+		ObservedAt:    observedAt(),
+		ProbeVersion:  ecs.ProbeVersion,
+	}
+}
+
+// TestNoEvidenceLeavesTheLinkLocalPathUnproven is the assertion the whole
+// evidence mechanism exists to be safe under.
+//
+// It is written as its own test rather than folded into the verdict table
+// because the failure it guards is not a wrong verdict, it is a mechanism that
+// only ever moves in one direction. Every other path in this package is decided
+// by a plan, so its check answers whatever the plan says. This one is decided by
+// something that might not have happened, and the way that goes wrong is that
+// "we have no result" quietly becomes "we found nothing", which reads the same
+// in a report and means the opposite.
+func TestNoEvidenceLeavesTheLinkLocalPathUnproven(t *testing.T) {
+	for _, empty := range []ecs.Observations{nil, {}} {
+		report := ecs.EvaluateWith(referencePlan(), empty)
+		byID := verdictsByID(report)
+		require.Equal(t, ecs.Unproven, byID[imds],
+			"with no probe result the instance metadata path must stay unproven")
+
+		for _, v := range report.Verdicts {
+			if v.Path.ID != imds {
+				continue
+			}
+			require.Equal(t, ecs.NotEstablished, v.Grade)
+			require.Contains(t, v.Detail, "no probe result has been recorded")
+		}
+		require.Equal(t, 0, report.ClosedByObservation,
+			"nothing was observed, so nothing may be counted as observed")
+	}
+}
+
+// TestNoPathClosesOnAbsentEvidence is the same rule stated over the whole
+// enumeration rather than over one path.
+//
+// The one above would keep passing if somebody added a second observable path
+// and got its default wrong. This one cannot, because it asks the question of
+// every path that declares an Observe, and the set it asks about is read from
+// the enumeration rather than written down here.
+func TestNoPathClosesOnAbsentEvidence(t *testing.T) {
+	observable := 0
+	for _, p := range ecs.Paths() {
+		if p.Observe == nil {
+			continue
+		}
+		observable++
+		verdict, detail := p.Check(referencePlan())
+		require.Equal(t, ecs.Unproven, verdict,
+			"%s can be answered by a probe, and with no probe result its own check returned "+
+				"%q. A path whose evidence is optional must be unproven without it, or the "+
+				"absence of a probe is a pass: %s", p.ID, verdict, detail)
+	}
+	require.Equal(t, 1, observable,
+		"exactly one path has a probe today, and a change to that number should be a decision")
+}
+
+// TestAProbeResultDecidesTheLinkLocalPath walks the three outcomes.
+//
+// One test per outcome would read better and would test less: the value of
+// running them together is that the same plan and the same environment produce
+// three different verdicts, so a mechanism that ignored the observation
+// entirely could not pass any of them by accident.
+func TestAProbeResultDecidesTheLinkLocalPath(t *testing.T) {
+	for _, tc := range []struct {
+		outcome ecs.Outcome
+		want    ecs.Verdict
+		grade   ecs.Grade
+		says    string
+	}{
+		{ecs.Reachable, ecs.Open, ecs.FromObservation, "something answered"},
+		{ecs.NoAnswer, ecs.Closed, ecs.FromObservation, "nothing answered within"},
+		{ecs.Errored, ecs.Unproven, ecs.NotEstablished, "could not make the attempt at all"},
+	} {
+		t.Run(string(tc.outcome), func(t *testing.T) {
+			report := ecs.EvaluateWith(referencePlan(),
+				ecs.Observations{observation(tc.outcome)})
+			for _, v := range report.Verdicts {
+				if v.Path.ID != imds {
+					continue
+				}
+				require.Equal(t, tc.want, v.Verdict)
+				require.Equal(t, tc.grade, v.Grade)
+				require.Contains(t, v.Detail, tc.says)
+			}
+		})
+	}
+}
+
+// TestAnObservedClosureIsCountedApartFromADocumentedOne is the arithmetic the
+// grade was introduced for.
+func TestAnObservedClosureIsCountedApartFromADocumentedOne(t *testing.T) {
+	report := ecs.EvaluateWith(referencePlan(), ecs.Observations{observation(ecs.NoAnswer)})
+	require.Equal(t, 11, report.Closed, "the probe settles one more path")
+	require.Equal(t, 10, report.ClosedByDocument)
+	require.Equal(t, 1, report.ClosedByObservation)
+	require.Equal(t, 1, report.Unproven, "the time sync path has no probe and stays unproven")
+	require.False(t, report.Contained(),
+		"one open path remains and no evidence closes it, so this is still not contained")
+
+	out := report.String()
+	require.Contains(t, out, "11 of 13 egress paths")
+	require.Contains(t, out, "10 are closed by the generated configuration and 1 by an attempt")
+	require.Contains(t, out, "[observation]")
+	require.Contains(t, out, "[document]")
+}
+
+// TestEvidenceFromAnotherEnvironmentDoesNotAnswerForThisOne holds the boundary
+// that makes the evidence about this task rather than about some task.
+//
+// Every environment in this design shares a VPC, so evidence from a neighbour
+// is evidence about a different ENI in a different subnet under a different
+// security group. Reading it here would be the same defect as a security group
+// shared between environments: every field still reads as correct and the
+// conclusion is about somewhere else.
+func TestEvidenceFromAnotherEnvironmentDoesNotAnswerForThisOne(t *testing.T) {
+	neighbour := observation(ecs.NoAnswer)
+	neighbour.EnvironmentID = "af-somebody-else"
+
+	all := ecs.Observations{neighbour}
+	require.Empty(t, all.ForEnvironment("af-example"),
+		"a neighbour's result must not be visible to this environment")
+
+	report := ecs.EvaluateWith(referencePlan(), all.ForEnvironment("af-example"))
+	require.Equal(t, ecs.Unproven, verdictsByID(report)[imds])
+}
+
+// TestAResultFromAProbeThisBuildDoesNotKnowIsNotEvidence guards the version
+// stamp, which is the only thing standing between this reader and a file
+// written by something whose behaviour it is guessing at.
+func TestAResultFromAProbeThisBuildDoesNotKnowIsNotEvidence(t *testing.T) {
+	stale := observation(ecs.NoAnswer)
+	stale.ProbeVersion = "af-ecs-probe/0"
+
+	report := ecs.EvaluateWith(referencePlan(), ecs.Observations{stale})
+	byID := verdictsByID(report)
+	require.Equal(t, ecs.Unproven, byID[imds],
+		"a result recorded by a probe with different behaviour is not evidence about this one")
+	require.Equal(t, 0, report.ClosedByObservation)
+}
+
+// TestTheMostRecentResultWins is the ordering rule, and it is asserted in both
+// directions because a comparison written the wrong way round passes one of
+// them.
+func TestTheMostRecentResultWins(t *testing.T) {
+	older := observation(ecs.Reachable)
+	newer := observation(ecs.NoAnswer)
+	newer.ObservedAt = older.ObservedAt.Add(time.Hour)
+
+	forwards := ecs.EvaluateWith(referencePlan(), ecs.Observations{older, newer})
+	require.Equal(t, ecs.Closed, verdictsByID(forwards)[imds])
+
+	backwards := ecs.EvaluateWith(referencePlan(), ecs.Observations{newer, older})
+	require.Equal(t, ecs.Closed, verdictsByID(backwards)[imds],
+		"the answer must depend on the timestamps and not on the order of the slice")
+}
+
+// TestTheProbeScriptAttemptsWhatItSaysItDoes reads the generated script.
+//
+// A script is code that nothing in this repository executes, so the only thing
+// that can check it is an assertion about its text. That is weaker than running
+// it and it is said plainly rather than dressed up: what this proves is that the
+// script names the address the enumeration names and prints a marked line on
+// every branch, not that a container running it behaves as described.
+func TestTheProbeScriptAttemptsWhatItSaysItDoes(t *testing.T) {
+	script := ecs.ProbeScript("af-example")
+	require.Contains(t, script, "169.254.169.254")
+	require.Contains(t, script, "af-example")
+
+	require.Equal(t, 3, strings.Count(script, ecs.Marker+" "),
+		"reachable, no_answer and errored must each print a marked line, because a probe that "+
+			"stays silent when it cannot run is indistinguishable from one that found nothing")
+	require.Contains(t, script, "reachable")
+	require.Contains(t, script, "no_answer")
+	require.Contains(t, script, "errored no wget")
+}
+
+// TestTheProbeScriptOutputParsesBackIntoObservations closes the loop between
+// the two halves that have to agree.
+//
+// The script writes lines and the parser reads them, and nothing else checks
+// that they agree about the format. Feeding the parser a line shaped exactly
+// like the one the script prints is the closest this can get to running it.
+func TestTheProbeScriptOutputParsesBackIntoObservations(t *testing.T) {
+	out := "starting up\n" +
+		ecs.Marker + " " + ecs.ProbeVersion +
+		" af-example 169.254.169.254:80 no_answer nothing answered within 3s\n" +
+		"done\n"
+
+	obs, err := ecs.ParseProbeOutput(out, observedAt)
+	require.NoError(t, err)
+	require.Len(t, obs, 1, "the unmarked lines are not results and must not become any")
+	require.Equal(t, imds, obs[0].PathID)
+	require.Equal(t, "af-example", obs[0].EnvironmentID)
+	require.Equal(t, ecs.NoAnswer, obs[0].Outcome)
+	require.Equal(t, "nothing answered within 3s", obs[0].Detail)
+	require.Equal(t, observedAt(), obs[0].ObservedAt)
+
+	report := ecs.EvaluateWith(referencePlan(), obs)
+	require.Equal(t, ecs.Closed, verdictsByID(report)[imds],
+		"a result the probe could have printed must reach the predicate")
+}
+
+// TestTheParserRefusesWhatItCannotRead is the parser's own ability to say no.
+//
+// Each row is a line that is marked, so it claims to be a result, and that this
+// build cannot turn into one. Skipping such a line would leave the path
+// unproven, which is the answer for a probe that did not report and the wrong
+// answer for a probe that reported something unreadable.
+func TestTheParserRefusesWhatItCannotRead(t *testing.T) {
+	for _, tc := range []struct{ name, line, says string }{
+		{
+			name: "too few fields",
+			line: ecs.Marker + " " + ecs.ProbeVersion + " af-example",
+			says: "needs at least 5",
+		},
+		{
+			name: "an address this build does not probe",
+			line: ecs.Marker + " " + ecs.ProbeVersion +
+				" af-example 169.254.170.2:80 no_answer x",
+			says: "which path it settles is unknown",
+		},
+		{
+			name: "an outcome this build does not know",
+			line: ecs.Marker + " " + ecs.ProbeVersion +
+				" af-example 169.254.169.254:80 probably_fine x",
+			says: "not one this build knows",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			obs, err := ecs.ParseProbeOutput(tc.line+"\n", observedAt)
+			require.Error(t, err, "a marked line this build cannot read is a malfunction")
+			require.Contains(t, err.Error(), tc.says)
+			require.Nil(t, obs)
+		})
+	}
+}
+
+// TestUnmarkedOutputProducesNothing is the other half of the marker rule.
+func TestUnmarkedOutputProducesNothing(t *testing.T) {
+	obs, err := ecs.ParseProbeOutput("standard_init_linux.go: exec format error\n", observedAt)
+	require.NoError(t, err)
+	require.Empty(t, obs, "a container that failed for some other reason is not a result")
+}
+
+// TestRecordAndLoadKeepEveryEnvironmentsAnswer is the merge rule.
+func TestRecordAndLoadKeepEveryEnvironmentsAnswer(t *testing.T) {
+	dir := t.TempDir()
+
+	mine := observation(ecs.NoAnswer)
+	theirs := observation(ecs.Reachable)
+	theirs.EnvironmentID = "af-other"
+
+	require.NoError(t, ecs.Record(dir, "af-other", ecs.Observations{theirs}))
+	require.NoError(t, ecs.Record(dir, "af-example", ecs.Observations{mine}))
+
+	back, err := ecs.Load(dir)
+	require.NoError(t, err)
+	require.Len(t, back, 2, "recording one environment's answer must not erase another's")
+
+	got, ok := back.For(imds)
+	require.True(t, ok)
+	require.NotEmpty(t, got.EnvironmentID)
+
+	// And a second run of one environment replaces its own answer rather than
+	// accumulating beside it, because two answers for one path from one
+	// environment is a question about which is current that nobody wants.
+	again := observation(ecs.Reachable)
+	again.ObservedAt = observedAt().Add(time.Hour)
+	require.NoError(t, ecs.Record(dir, "af-example", ecs.Observations{again}))
+
+	back, err = ecs.Load(dir)
+	require.NoError(t, err)
+	require.Len(t, back, 2)
+	require.Equal(t, ecs.Reachable, mustFind(t, back, "af-example").Outcome)
+	require.Equal(t, ecs.Reachable, mustFind(t, back, "af-other").Outcome)
+}
+
+// TestLoadTellsAbsenceApartFromMalfunction is the distinction that decides
+// whether an unproven verdict means what it says.
+func TestLoadTellsAbsenceApartFromMalfunction(t *testing.T) {
+	dir := t.TempDir()
+
+	obs, err := ecs.Load(dir)
+	require.NoError(t, err, "an installation that has never run a probe is not an error")
+	require.Empty(t, obs)
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ecs.EvidenceFile),
+		[]byte("{not json"), 0o644))
+	obs, err = ecs.Load(dir)
+	require.Error(t, err,
+		"a file that exists and cannot be read is a malfunction, and reporting it as no "+
+			"evidence would answer unproven for a reason that is not the reason unproven means")
+	require.Contains(t, err.Error(), "which is not the same as there being none")
+	require.Nil(t, obs)
+}
+
+// TestResolvableHostsReadsTheManifestsOwnAnswer is the composition with the
+// egress catalogue.
+//
+// The modes are not split by taste. A host the sidecar forwards to for real has
+// to resolve or the environment does not work; a host the sidecar answers out of
+// a fixture, an inbox or a model must NOT resolve, because a name the sidecar
+// answers resolving publicly is a route around the decision the manifest made.
+func TestResolvableHostsReadsTheManifestsOwnAnswer(t *testing.T) {
+	allowed, unexpressible := ecs.ResolvableHosts(schema.Egress{Rules: []schema.EgressRule{
+		{Host: "api.stripe.com", Mode: schema.ModeAllow},
+		{Host: "api.twilio.com", Mode: schema.ModeSandbox},
+		{Host: "hooks.slack.com", Mode: schema.ModeCapture},
+		{Host: "api.openai.com", Mode: schema.ModeMock},
+		{Host: "evil.example.com", Mode: schema.ModeBlock},
+		{Host: "guess.example.com", Mode: schema.ModeSynth},
+		{Host: "*.googleapis.com", Mode: schema.ModeAllow},
+		{Host: "email.*.amazonaws.com", Mode: schema.ModeAllow},
+	}})
+
+	require.Equal(t, []string{"*.googleapis.com", "api.stripe.com", "api.twilio.com"}, allowed,
+		"allow and sandbox reach the real host and must resolve; block, mock, capture and "+
+			"synth are answered by the sidecar and must not")
+	require.Equal(t, []string{"email.*.amazonaws.com"}, unexpressible,
+		"a DNS Firewall domain specification may only start with a star, and a host that "+
+			"cannot be written as one must be named rather than dropped or widened")
+}
+
+// TestTheDeclaredHostsReachTheFirewall proves the composition is wired rather
+// than merely available.
+//
+// ResolvableHosts having the right answer proves nothing on its own: a reducer
+// nobody calls is a dead function that looks like a feature, which is the exact
+// shape this repository keeps finding. So this asserts the host is in the rule
+// group the generator emits, and that the terminal rule is still last.
+func TestTheDeclaredHostsReachTheFirewall(t *testing.T) {
+	in := reference()
+	in.ResolvableHosts = []string{"api.stripe.com"}
+	plan := ecs.Generate(in, "af-example")
+
+	rules := plan.Network.DNSFirewall.Rules
+	require.Len(t, rules, 2)
+	require.Equal(t, "ALLOW", rules[0].Action)
+	require.Contains(t, rules[0].Domains, "api.stripe.com",
+		"a host the manifest says the environment may reach has to resolve, or the firewall "+
+			"breaks the environment it is protecting and somebody removes it")
+	require.Contains(t, rules[0].Domains, "api.ecr.us-east-1.amazonaws.com",
+		"and the image pull still has to resolve, or nothing starts")
+
+	require.Equal(t, "BLOCK", rules[1].Action)
+	require.Equal(t, []string{"*"}, rules[1].Domains)
+	require.Greater(t, rules[1].Priority, rules[0].Priority,
+		"AWS processes a rule group by order of priority starting from the lowest, so the "+
+			"terminal rule has to carry the highest number")
+	require.Equal(t, ecs.FailClosed, plan.Network.DNSFirewall.FailOpen)
+
+	require.Equal(t, ecs.Closed, verdictsByID(ecs.Evaluate(plan))["the-amazon-provided-resolver"])
+}
+
+// TestTheProbeContainerIsEmittedOnlyWithAnImage guards the direction this could
+// have been faked in.
+//
+// A container naming a command that does not exist would be a plan that cannot
+// be applied wearing the shape of a control, which is what this package's own
+// DNS firewall check was taught to refuse. So the absence of an image produces
+// the absence of a container and a report that says so, not a container that
+// would fail.
+func TestTheProbeContainerIsEmittedOnlyWithAnImage(t *testing.T) {
+	bare := ecs.Generate(reference(), "af-example")
+	require.Empty(t, bare.TaskDefinition.Containers,
+		"with no probe image named, no probe container")
+	require.Contains(t, detailByID(ecs.Evaluate(bare))[imds], "no probe container either")
+
+	in := reference()
+	in.ProbeImage = "public.ecr.aws/docker/library/busybox:1.36"
+	withProbe := ecs.Generate(in, "af-example")
+	require.Len(t, withProbe.TaskDefinition.Containers, 1)
+
+	probe := withProbe.TaskDefinition.Containers[0]
+	require.Equal(t, ecs.ProbeContainerName, probe.Name)
+	require.Equal(t, in.ProbeImage, probe.Image)
+	require.True(t, probe.Essential,
+		"a probe whose failure does not stop the task is a bystander")
+	require.Equal(t, []string{"/bin/sh", "-c", ecs.ProbeScript("af-example")}, probe.Command)
+	require.Contains(t, detailByID(ecs.Evaluate(withProbe))[imds], ecs.ProbeContainerName)
+}
+
+// mustFind returns one environment's observation or fails the test.
+func mustFind(t *testing.T, all ecs.Observations, envID string) ecs.Observation {
+	t.Helper()
+	for _, o := range all {
+		if o.EnvironmentID == envID {
+			return o
+		}
+	}
+	t.Fatalf("no observation recorded for %s", envID)
+	return ecs.Observation{}
+}

--- a/ee/engine/runtime/ecs/plan.go
+++ b/ee/engine/runtime/ecs/plan.go
@@ -101,24 +101,9 @@ type Container struct {
 	// Essential marks a container whose exit stops the task.
 	Essential bool
 	// Command is the entrypoint override, which is how the containment probe
-	// is expressed in a task definition: ECS has no field for "run this first
-	// and stop if it fails", so the probe is a container whose command is the
-	// attempt and whose dependency ordering makes everything else wait.
+	// is expressed in a task definition: there is no field for "try this
+	// first", so the probe is a container whose command is the attempt.
 	Command []string
-	// DependsOn orders this container after others. It is what makes the
-	// probe run BEFORE any application image rather than beside it, which is
-	// the whole difference between a check and a bystander.
-	DependsOn []ContainerDependency
-}
-
-// ContainerDependency is one entry of a container's dependsOn list.
-type ContainerDependency struct {
-	// ContainerName is the container waited on.
-	ContainerName string
-	// Condition is START, COMPLETE, SUCCESS or HEALTHY. SUCCESS is the only
-	// one that means the waited on container exited zero, so it is the only
-	// one under which a failing probe stops the thing it was probing for.
-	Condition string
 }
 
 // NetworkPlan is the VPC, the subnets, the security group, the route table,

--- a/ee/engine/runtime/ecs/plan.go
+++ b/ee/engine/runtime/ecs/plan.go
@@ -100,6 +100,25 @@ type Container struct {
 	Image string
 	// Essential marks a container whose exit stops the task.
 	Essential bool
+	// Command is the entrypoint override, which is how the containment probe
+	// is expressed in a task definition: ECS has no field for "run this first
+	// and stop if it fails", so the probe is a container whose command is the
+	// attempt and whose dependency ordering makes everything else wait.
+	Command []string
+	// DependsOn orders this container after others. It is what makes the
+	// probe run BEFORE any application image rather than beside it, which is
+	// the whole difference between a check and a bystander.
+	DependsOn []ContainerDependency
+}
+
+// ContainerDependency is one entry of a container's dependsOn list.
+type ContainerDependency struct {
+	// ContainerName is the container waited on.
+	ContainerName string
+	// Condition is START, COMPLETE, SUCCESS or HEALTHY. SUCCESS is the only
+	// one that means the waited on container exited zero, so it is the only
+	// one under which a failing probe stops the thing it was probing for.
+	Condition string
 }
 
 // NetworkPlan is the VPC, the subnets, the security group, the route table,
@@ -256,22 +275,69 @@ type DNSFirewall struct {
 	// associated with a different VPC filters nothing here, and it is exactly
 	// the sort of thing that reads as configured in a console screenshot.
 	AssociatedVPCID string
-	// FailOpen is the association's failure mode. True means that when DNS
-	// Firewall cannot reach a rule, the query is allowed through, which turns
-	// the containment into a best effort.
-	FailOpen bool
+	// FailOpen is the VPC's DNS Firewall failure mode, and it is a string
+	// rather than a bool because AWS's own field is three valued and a bool
+	// cannot say the third thing.
+	//
+	// FirewallConfig.FirewallFailOpen takes ENABLED, DISABLED or
+	// USE_LOCAL_RESOURCE_SETTING. AWS documents that "by default, fail open is
+	// disabled, which means the failure mode is closed", and that with it
+	// enabled "DNS Firewall allows queries to proceed if it is unable to
+	// properly evaluate them". The third value defers the decision to a
+	// setting that is not in this plan, so a plan carrying it has not decided
+	// the failure mode and the predicate must not read it as either answer.
+	// That is the shape mismatch this field was found in: a two valued Go type
+	// standing in for a three valued AWS one rounds the unknown case to
+	// whichever answer the author was hoping for.
+	FailOpen FailOpenSetting
 	// Rules are the rule group's rules, and the predicate requires that the
 	// last one by priority blocks every domain.
 	Rules []DNSFirewallRule
 }
 
+// FailOpenSetting is the FirewallConfig.FirewallFailOpen value.
+type FailOpenSetting string
+
+// The three values AWS accepts.
+const (
+	// FailClosed is DISABLED, which AWS documents as the default and describes
+	// as favouring security over availability: DNS Firewall returns a failure
+	// error when it cannot properly evaluate a query.
+	FailClosed FailOpenSetting = "DISABLED"
+	// FailOpenEnabled is ENABLED, which allows queries to proceed when DNS
+	// Firewall cannot evaluate them. It is the value that turns this
+	// containment into a best effort.
+	FailOpenEnabled FailOpenSetting = "ENABLED"
+	// FailOpenDeferred is USE_LOCAL_RESOURCE_SETTING, which takes the answer
+	// from somewhere this plan does not describe. A plan holding it has not
+	// decided the failure mode, and the predicate says so rather than guessing.
+	FailOpenDeferred FailOpenSetting = "USE_LOCAL_RESOURCE_SETTING"
+)
+
 // DNSFirewallRule is one rule in the group.
 type DNSFirewallRule struct {
-	// Priority orders the rules. Lower is evaluated first.
+	// Priority orders the rules. AWS states that DNS Firewall "processes the
+	// rules in a rule group by order of priority, starting from the lowest
+	// setting", and that "you must specify a unique priority for each rule in
+	// a rule group". Both halves are checked: the order decides which rule
+	// answers, and a duplicate is a plan AWS refuses to apply, which is not a
+	// containment either.
 	Priority int
 	// Domains are the domain patterns the rule matches. "*" is every domain.
+	//
+	// A domain specification "can optionally start with * (asterisk)" and may
+	// otherwise hold only letters, digits, hyphens and the label separator, so
+	// a star anywhere but the front is not a pattern AWS will accept. That is
+	// why the generator refuses to translate a manifest host with a star in
+	// the middle rather than dropping it or widening it.
 	Domains []string
-	// Action is ALLOW, BLOCK, or ALERT. ALERT logs and permits, which is worth
-	// naming because it is the value somebody sets while tuning and leaves.
+	// Action is ALLOW, BLOCK, or ALERT.
+	//
+	// ALERT is not a weaker BLOCK. AWS defines ALLOW as "permit the request to
+	// go through" and ALERT as "permit the request and send metrics and logs
+	// to Cloud Watch", so both of them let the query out and only BLOCK
+	// disallows it. An ALERT rule matching every domain ahead of the terminal
+	// BLOCK is therefore a rule group that blocks nothing at all, which is the
+	// shape this file's predicate was found unable to see.
 	Action string
 }

--- a/ee/engine/runtime/ecs/plan.go
+++ b/ee/engine/runtime/ecs/plan.go
@@ -1,0 +1,277 @@
+// Package ecs is the AWS ECS on Fargate runtime, and it is mostly a proof
+// about containment rather than a placer of containers.
+//
+// The Kubernetes runtime earns its existence by creating NetworkPolicy objects
+// and then running a pod that tries to escape four ways before any application
+// image starts, refusing the environment with AF-RUN-043 when any attempt
+// succeeds. That order matters: the policy is a request to whatever CNI the
+// cluster runs, several CNIs accept the object and enforce nothing, and the
+// only thing that can tell those apart is a packet.
+//
+// ECS has the same gap in a worse place. A task definition, a security group
+// and a route table are all objects AWS accepts, and whether they contain
+// anything is a fact about the account they were applied to. So this package is
+// built around a predicate over the configuration an environment would be given
+// rather than around an API client, because the predicate is the part that can
+// be proved in continuous integration on a machine with no AWS account, and the
+// enforcement is the part that cannot.
+//
+// What this package deliberately does NOT do is start an environment. See
+// runtime.go for why, and read egress.go first: the enumeration there is the
+// deliverable, and the runtime's refusal is a consequence of it.
+package ecs
+
+// Plan is the whole AWS configuration one environment would be given.
+//
+// It is one flat value rather than a client talking to AWS, and that is the
+// design decision the rest of the package rests on. A predicate over a value
+// can be evaluated by a test, printed in an error message, checked into a
+// golden file and mutated one field at a time. A predicate over an account can
+// be evaluated in exactly one place, which is an account somebody is paying
+// for, and a repository whose containment proof lives there has no containment
+// proof at all on the day the credentials expire.
+//
+// Every field here is a field of a real AWS request or resource. Nothing is a
+// summary or a boolean standing in for a shape, because a summary is where the
+// thing being asserted stops being the thing being applied.
+type Plan struct {
+	// Region is the AWS region, which appears in the endpoint service names
+	// the plan has to match against.
+	Region string
+	// Cluster is the ECS cluster the tasks are placed in.
+	Cluster string
+	// LaunchType must be FARGATE. It is checked rather than assumed because
+	// the EC2 launch type puts the task on a container instance whose instance
+	// profile credentials are reachable from inside the container, and the
+	// only documented defence there is an agent variable on the instance
+	// (ECS_AWSVPC_BLOCK_IMDS) that no task definition can set.
+	LaunchType string
+	// PlatformVersion is the Fargate platform version. Below 1.4.0 a task gets
+	// a second, Fargate owned ENI carrying image pulls and secret retrieval
+	// which does not appear in VPC flow logs and which no security group in
+	// this plan describes, so a plan that does not pin 1.4.0 or later is
+	// making a claim about traffic it cannot see.
+	PlatformVersion string
+	// TaskDefinition is what runs.
+	TaskDefinition TaskDefinition
+	// Network is everything the packets can and cannot do.
+	Network NetworkPlan
+}
+
+// TaskDefinition is the ECS task definition, cut down to the fields that decide
+// whether anything can get out.
+type TaskDefinition struct {
+	// Family names the definition.
+	Family string
+	// NetworkMode must be awsvpc, which is the only mode Fargate supports and
+	// the only one that gives the task its own ENI and therefore its own
+	// security group.
+	NetworkMode string
+	// TaskRoleARN is the role whose credentials 169.254.170.2 vends to
+	// anything inside the container that asks.
+	//
+	// It must be EMPTY. That endpoint cannot be turned off on Fargate, so the
+	// only way to make it vend nothing is to give it nothing, and an
+	// environment that is a twin of production has no business holding
+	// production's IAM permissions in the first place.
+	TaskRoleARN string
+	// ExecutionRoleARN is the role Fargate itself uses to pull the image and
+	// push logs. It is NOT vended to the container: the credentials endpoint
+	// serves the task role, and the ECS documentation states plainly that
+	// execution role permissions "aren't accessed by" the application. It is
+	// therefore allowed to be set, and it has to be, because without it no
+	// image can be pulled at all.
+	ExecutionRoleARN string
+	// EnableExecuteCommand is ECS Exec. It must be false. It opens a channel to
+	// AWS Systems Manager that is an interactive shell inbound and an
+	// unmetered data channel outbound, and it is the one egress path in this
+	// list that a person turns on deliberately while debugging and forgets.
+	EnableExecuteCommand bool
+	// Containers are the images and their environments, in the order they
+	// appear in the definition.
+	Containers []Container
+}
+
+// Container is one container in the task definition.
+type Container struct {
+	// Name is the container name.
+	Name string
+	// Image is the image reference.
+	Image string
+	// Essential marks a container whose exit stops the task.
+	Essential bool
+}
+
+// NetworkPlan is the VPC, the subnets, the security group, the route table,
+// the endpoints and the DNS firewall, which together are the containment.
+type NetworkPlan struct {
+	// VPC is the network the task's ENI lives in.
+	VPC VPC
+	// Subnets are the subnets awsVpcConfiguration names.
+	Subnets []Subnet
+	// SecurityGroup is the single security group on the task ENI. One per
+	// environment, because a security group shared between environments is
+	// how one environment reaches another's database while every rule in it
+	// still reads as correct.
+	SecurityGroup SecurityGroup
+	// RouteTable is the table associated with every subnet above.
+	RouteTable RouteTable
+	// Endpoints are the VPC endpoints the task can reach. They exist because
+	// on Fargate 1.4.0 the image pull runs over the task ENI, so a task in a
+	// subnet with no route out cannot start without them.
+	Endpoints []VPCEndpoint
+	// DNSFirewall is the Route 53 Resolver DNS Firewall association, which is
+	// the ONLY thing in this struct that can close the resolver path. AWS
+	// states that traffic to the Amazon DNS server cannot be filtered with
+	// security groups or network ACLs, so without this the resolver at
+	// 169.254.169.253 answers recursive queries for any public name and the
+	// query itself carries whatever the client put in it.
+	DNSFirewall *DNSFirewall
+}
+
+// VPC is the network's own attributes.
+type VPC struct {
+	// ID is the VPC id.
+	ID string
+	// IPv4CIDR is the primary IPv4 range. The Route 53 Resolver also answers
+	// at this range's base address plus two, which is why the predicate reads
+	// it rather than only checking 169.254.169.253.
+	IPv4CIDR string
+	// IPv6CIDR is the IPv6 range, and it must be empty. Every security group
+	// rule in this plan is written in IPv4, and an IPv6 range with an egress
+	// only internet gateway is a full route to the internet that an IPv4
+	// reading of the same security group calls contained.
+	IPv6CIDR string
+	// EnableDNSSupport is whether the Amazon provided resolver answers at all.
+	EnableDNSSupport bool
+}
+
+// Subnet is one subnet the task may be placed in.
+type Subnet struct {
+	// ID is the subnet id.
+	ID string
+	// IPv4CIDR is its range.
+	IPv4CIDR string
+	// IPv6CIDR must be empty, for the reason on VPC.IPv6CIDR.
+	IPv6CIDR string
+	// MapPublicIPOnLaunch must be false.
+	MapPublicIPOnLaunch bool
+}
+
+// AssignPublicIP is the awsVpcConfiguration field of the same name. A task with
+// a public address in a subnet routed to an internet gateway is on the internet
+// whatever else the plan says, so it is a field of its own rather than a
+// property of the subnet.
+type AssignPublicIP string
+
+// The two values ECS accepts.
+const (
+	AssignPublicIPEnabled  AssignPublicIP = "ENABLED"
+	AssignPublicIPDisabled AssignPublicIP = "DISABLED"
+)
+
+// RouteTable is the route table associated with every subnet in the plan.
+type RouteTable struct {
+	// ID is the table id.
+	ID string
+	// Routes are its entries.
+	Routes []Route
+	// AssignPublicIP is what awsVpcConfiguration asks for. It sits here rather
+	// than on Subnet because it is a property of the task placement and not of
+	// the subnet, and because putting it beside the routes is where a reader
+	// checking "can this reach the internet" will look.
+	AssignPublicIP AssignPublicIP
+}
+
+// Route is one route table entry.
+type Route struct {
+	// Destination is a CIDR or a prefix list id.
+	Destination string
+	// Target is what the traffic is handed to: "local", a VPC endpoint, a
+	// gateway. The predicate reads its prefix, because AWS resource id
+	// prefixes are the type: igw for an internet gateway, nat for a NAT
+	// gateway, eigw for an egress only internet gateway, pcx for a peering
+	// connection, tgw for a transit gateway, vgw for a virtual private
+	// gateway, vpce for a VPC endpoint.
+	Target string
+}
+
+// SecurityGroup is the group on the task ENI.
+type SecurityGroup struct {
+	// ID is the group id.
+	ID string
+	// Egress are the outbound rules. A security group permits only what its
+	// rules name, so an empty list permits nothing outbound. It cannot be
+	// empty here, because the image pull runs over this ENI.
+	Egress []Rule
+	// Ingress are the inbound rules.
+	Ingress []Rule
+}
+
+// Rule is one security group rule.
+type Rule struct {
+	// Protocol is tcp, udp, icmp, or "-1" for every protocol.
+	Protocol string
+	// FromPort and ToPort bound the port range.
+	FromPort int
+	ToPort   int
+	// CIDRv4 is an IPv4 destination, empty when the rule names something else.
+	CIDRv4 string
+	// CIDRv6 is an IPv6 destination.
+	CIDRv6 string
+	// PrefixListID is an AWS managed prefix list, which is how a gateway
+	// endpoint's address ranges are named in a rule.
+	PrefixListID string
+	// PeerSecurityGroupID is another security group as the destination, which
+	// is how the task is allowed to reach the interface endpoints without
+	// naming an address range that will change.
+	PeerSecurityGroupID string
+}
+
+// VPCEndpoint is one endpoint the environment can reach.
+type VPCEndpoint struct {
+	// Service is the full service name, such as
+	// com.amazonaws.us-east-1.ecr.dkr.
+	Service string
+	// Type is Interface or Gateway.
+	Type string
+	// SecurityGroupID is the group on an interface endpoint's own ENIs.
+	SecurityGroupID string
+	// PolicyDocument is the endpoint policy. An endpoint with no policy allows
+	// every action on every resource in that service that the caller has
+	// credentials for, which for an anonymous caller is not much and for a
+	// caller who found any credentials at all is the whole service.
+	PolicyDocument string
+	// PrivateDNSEnabled is whether the service's public name resolves to the
+	// endpoint inside this VPC.
+	PrivateDNSEnabled bool
+}
+
+// DNSFirewall is a Route 53 Resolver DNS Firewall rule group associated with
+// the VPC.
+type DNSFirewall struct {
+	// RuleGroupID is the rule group.
+	RuleGroupID string
+	// AssociatedVPCID must be the plan's VPC. A rule group that exists and is
+	// associated with a different VPC filters nothing here, and it is exactly
+	// the sort of thing that reads as configured in a console screenshot.
+	AssociatedVPCID string
+	// FailOpen is the association's failure mode. True means that when DNS
+	// Firewall cannot reach a rule, the query is allowed through, which turns
+	// the containment into a best effort.
+	FailOpen bool
+	// Rules are the rule group's rules, and the predicate requires that the
+	// last one by priority blocks every domain.
+	Rules []DNSFirewallRule
+}
+
+// DNSFirewallRule is one rule in the group.
+type DNSFirewallRule struct {
+	// Priority orders the rules. Lower is evaluated first.
+	Priority int
+	// Domains are the domain patterns the rule matches. "*" is every domain.
+	Domains []string
+	// Action is ALLOW, BLOCK, or ALERT. ALERT logs and permits, which is worth
+	// naming because it is the value somebody sets while tuning and leaves.
+	Action string
+}

--- a/ee/engine/runtime/ecs/plan.go
+++ b/ee/engine/runtime/ecs/plan.go
@@ -1,6 +1,9 @@
 // Package ecs is the AWS ECS on Fargate runtime, and it is mostly a proof
 // about containment rather than a placer of containers.
 //
+// Not MIT. This directory is covered by the Antifailure Enterprise License; see
+// ee/LICENSE.md.
+//
 // The Kubernetes runtime earns its existence by creating NetworkPolicy objects
 // and then running a pod that tries to escape four ways before any application
 // image starts, refusing the environment with AF-RUN-043 when any attempt

--- a/ee/engine/runtime/ecs/runtime.go
+++ b/ee/engine/runtime/ecs/runtime.go
@@ -401,10 +401,21 @@ const ProbeContainerName = "af-containment-probe"
 // with.
 //
 // The Kubernetes runtime earns its existence by running a pod that tries to
-// escape before any application image starts. ECS has no field for "run this
-// first and stop if it fails", so it is a container whose command is the
-// attempt and which everything else depends on with the SUCCESS condition, the
-// only condition that means the waited on container exited zero.
+// escape before any application image starts. This container is the ECS
+// equivalent of the attempt and NOT of the ordering, and the difference is a
+// gap rather than a detail.
+//
+// It is not essential, because on ECS the exit of an essential container stops
+// the whole task and a probe is a thing that runs and finishes. Making it
+// essential would have killed every environment the moment the probe succeeded,
+// which is the sort of mistake that looks like rigour. The shape that makes a
+// probe run BEFORE an application image on ECS is the application container
+// carrying dependsOn with the SUCCESS condition, the only condition that means
+// the waited on container exited zero, and this plan cannot carry it because it
+// places no application containers at all. So the probe as generated runs
+// BESIDE what it is probing for rather than ahead of it. A runtime that placed
+// application containers would owe that ordering, and this one does not place
+// them because it refuses to start.
 //
 // It is conditional on an image because the alternative was worse. An earlier
 // draft of this function emitted the container unconditionally with a command
@@ -425,7 +436,7 @@ func probeContainer(image, envID string) []Container {
 	return []Container{{
 		Name:      ProbeContainerName,
 		Image:     image,
-		Essential: true,
+		Essential: false,
 		Command:   []string{"/bin/sh", "-c", ProbeScript(envID)},
 	}}
 }

--- a/ee/engine/runtime/ecs/runtime.go
+++ b/ee/engine/runtime/ecs/runtime.go
@@ -1,5 +1,8 @@
 package ecs
 
+// Not MIT. This directory is covered by the Antifailure Enterprise License; see
+// ee/LICENSE.md.
+
 import (
 	"context"
 	"fmt"
@@ -228,9 +231,9 @@ type Inputs struct {
 // Everything in an Antifailure environment leaves through the sidecar, so the
 // application never resolves anything and the sidecar resolves only what it is
 // going to connect to. A host declared block, mock, capture or synth is
-// answered by the sidecar out of a fixture, an inbox or a model, and letting it
-// resolve publicly would hand the application a way around the very decision
-// the manifest made about it. A host declared allow or sandbox is one the
+// answered by the sidecar out of a fixture, an inbox or a model, and a name the
+// sidecar answers resolving publicly is a route around the decision the
+// manifest made about it. A host declared allow or sandbox is one the
 // sidecar forwards to for real, so it has to resolve or the environment does
 // not work.
 //

--- a/ee/engine/runtime/ecs/runtime.go
+++ b/ee/engine/runtime/ecs/runtime.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/antifailure/antifailure/engine/pkg/extension"
 	"github.com/antifailure/antifailure/engine/pkg/provider"
+	"github.com/antifailure/antifailure/engine/pkg/schema"
 )
 
 // Name is the value runtime.provider takes in a manifest to reach this
@@ -41,6 +42,10 @@ const (
 	EnvVPCCIDR    = "AF_ECS_VPC_CIDR"
 	EnvSubnets    = "AF_ECS_SUBNET_IDS"
 	EnvSubnetCIDR = "AF_ECS_SUBNET_CIDRS"
+	// EnvProbeImage is optional, unlike every other variable here. It names
+	// the image the containment probe container runs. With it unset the plan
+	// carries no probe container and the instance metadata path says so.
+	EnvProbeImage = "AF_ECS_PROBE_IMAGE"
 )
 
 // NewProvider builds the provider with the process environment.
@@ -92,11 +97,33 @@ func (p *Provider) Open(_ context.Context, cfg extension.RuntimeConfig) (provide
 			"kubernetes against EKS, which is proved contained by a probe that runs before "+
 			"any application image", strings.Join(missing, ", "))
 	}
-	report := Evaluate(Generate(in, environmentID(cfg)))
+	envID := environmentID(cfg)
+	in.ResolvableHosts, in.UnexpressibleHosts = ResolvableHosts(cfg.Egress)
+
+	// Evidence recorded by a probe inside a task in this installation's own
+	// account, if any has ever been recorded. A read failure is reported rather
+	// than swallowed: a file that exists and cannot be read is a malfunction,
+	// and treating it as "no evidence" would answer unproven for a reason that
+	// is not the reason unproven means.
+	observed, err := Load(cfg.StateDir)
+	if err != nil {
+		return nil, fmt.Errorf("the ecs runtime could not read the containment evidence "+
+			"recorded for this installation, and an unreadable record is not the same as no "+
+			"record: %w", err)
+	}
+	report := EvaluateWith(Generate(in, envID), observed.ForEnvironment(envID))
 
 	var b strings.Builder
 	b.WriteString("the ecs runtime refuses to start an environment, on purpose.\n\n")
 	b.WriteString(report.String())
+	if len(in.UnexpressibleHosts) > 0 {
+		fmt.Fprintf(&b, "\nThe DNS firewall in this plan does NOT resolve %s, which the manifest "+
+			"declares the environment may reach. A DNS Firewall domain specification may only "+
+			"start with a star, so a host with one in the middle cannot be written as a rule. "+
+			"They are named here rather than dropped, because a firewall that silently breaks "+
+			"the environment it protects is a firewall somebody removes.\n",
+			strings.Join(in.UnexpressibleHosts, ", "))
+	}
 	b.WriteString("\nThe Kubernetes runtime is allowed to exist because it creates its own " +
 		"NetworkPolicy objects and then runs a pod under them that tries to escape before any " +
 		"application image starts. On Fargate the image pull runs over the task ENI under the " +
@@ -119,6 +146,7 @@ func (p *Provider) inputs() (Inputs, []string) {
 		VPCCIDR:     strings.TrimSpace(get(EnvVPCCIDR)),
 		SubnetIDs:   splitList(get(EnvSubnets)),
 		SubnetCIDRs: splitList(get(EnvSubnetCIDR)),
+		ProbeImage:  strings.TrimSpace(get(EnvProbeImage)),
 	}
 	var missing []string
 	for _, pair := range []struct {
@@ -171,6 +199,78 @@ type Inputs struct {
 	VPCCIDR     string
 	SubnetIDs   []string
 	SubnetCIDRs []string
+	// ResolvableHosts are the manifest's own hosts that something in this
+	// environment has to look up, already reduced from the egress catalogue.
+	//
+	// It is here rather than being derived inside Generate because Generate is
+	// a pure function of its inputs and reading a manifest is not, and because
+	// the reduction is the interesting part and belongs where it can be tested
+	// on its own.
+	ResolvableHosts []string
+	// ProbeImage is the image the containment probe container runs, and it is
+	// optional. With none, no probe container is emitted and the instance
+	// metadata path stays unproven with the absence named.
+	ProbeImage string
+	// UnexpressibleHosts are declared hosts that need to resolve and cannot be
+	// written as a DNS Firewall domain specification.
+	//
+	// They are carried so that the refusal can NAME them. A generator that
+	// quietly dropped them would produce a firewall that breaks the very
+	// environment it is protecting, which is how a containment control gets
+	// switched off; one that quietly widened them to a bare star would produce
+	// a firewall that protects nothing. Naming them is the only third option.
+	UnexpressibleHosts []string
+}
+
+// ResolvableHosts reduces a manifest's egress catalogue to the names something
+// in the environment actually has to look up.
+//
+// Everything in an Antifailure environment leaves through the sidecar, so the
+// application never resolves anything and the sidecar resolves only what it is
+// going to connect to. A host declared block, mock, capture or synth is
+// answered by the sidecar out of a fixture, an inbox or a model, and letting it
+// resolve publicly would hand the application a way around the very decision
+// the manifest made about it. A host declared allow or sandbox is one the
+// sidecar forwards to for real, so it has to resolve or the environment does
+// not work.
+//
+// That is why this composes with the egress catalogue rather than duplicating
+// it: the manifest already says what may be reached, and this reads that answer
+// instead of inventing a second list that could disagree with it.
+func ResolvableHosts(e schema.Egress) (allowed, unexpressible []string) {
+	for _, rule := range e.Rules {
+		switch rule.Mode {
+		case schema.ModeAllow, schema.ModeSandbox:
+		default:
+			continue
+		}
+		host := strings.TrimSpace(rule.Host)
+		if host == "" {
+			continue
+		}
+		if !expressibleDomain(host) {
+			unexpressible = append(unexpressible, host)
+			continue
+		}
+		allowed = append(allowed, host)
+	}
+	sort.Strings(allowed)
+	sort.Strings(unexpressible)
+	return dedupe(allowed), dedupe(unexpressible)
+}
+
+// dedupe removes repeats from a sorted list.
+func dedupe(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := in[:1]
+	for _, v := range in[1:] {
+		if v != out[len(out)-1] {
+			out = append(out, v)
+		}
+	}
+	return out
 }
 
 // Generate builds the configuration one environment would be given.
@@ -245,6 +345,7 @@ func Generate(in Inputs, envID string) Plan {
 			TaskRoleARN:          "",
 			ExecutionRoleARN:     fmt.Sprintf("arn:aws:iam::*:role/%s-execution", envID),
 			EnableExecuteCommand: false,
+			Containers:           probeContainer(in.ProbeImage, envID),
 		},
 		Network: NetworkPlan{
 			VPC: VPC{
@@ -271,13 +372,19 @@ func Generate(in Inputs, envID string) Plan {
 			DNSFirewall: &DNSFirewall{
 				RuleGroupID:     "rslvr-frg-" + envID,
 				AssociatedVPCID: in.VPCID,
-				FailOpen:        false,
+				// DISABLED rather than the zero value of a bool, because the
+				// AWS field is three valued and the third value defers the
+				// failure mode to a setting this plan does not carry. Written
+				// out so that the plan says what it means rather than
+				// inheriting it.
+				FailOpen: FailClosed,
 				Rules: []DNSFirewallRule{
 					// The allow rules come first by priority and name only what
 					// the environment is obliged to resolve. The block rule is
 					// last, so a name that matched nothing above is refused
 					// rather than resolved.
-					{Priority: 10, Action: "ALLOW", Domains: allowedDomains(in.Region)},
+					{Priority: 10, Action: "ALLOW",
+						Domains: allowedDomains(in.Region, in.ResolvableHosts)},
 					{Priority: 1000, Action: "BLOCK", Domains: []string{"*"}},
 				},
 			},
@@ -285,7 +392,45 @@ func Generate(in Inputs, envID string) Plan {
 	}
 }
 
-// interfaceEndpoint builds one interface endpoint with a policy.
+// ProbeContainerName is the container that attempts the link local address this
+// package cannot decide from a document.
+const ProbeContainerName = "af-containment-probe"
+
+// probeContainer is how the runtime probe is expressed in a task definition,
+// and it is emitted only when the installation has said what image to run it
+// with.
+//
+// The Kubernetes runtime earns its existence by running a pod that tries to
+// escape before any application image starts. ECS has no field for "run this
+// first and stop if it fails", so it is a container whose command is the
+// attempt and which everything else depends on with the SUCCESS condition, the
+// only condition that means the waited on container exited zero.
+//
+// It is conditional on an image because the alternative was worse. An earlier
+// draft of this function emitted the container unconditionally with a command
+// naming an af subcommand that does not exist, which is a plan that cannot be
+// applied wearing the shape of a control: exactly the thing the DNS firewall
+// check in this package was just taught to refuse. With no image named, no
+// container is emitted, and the report says the probe is absent, which is a
+// true statement about a plan somebody can then fix.
+//
+// What none of this claims is that the probe has ever run. This runtime refuses
+// to start an environment, so there is no task to run it in, and the evidence
+// reader in Open is wired to a writer whose live call site is a task this
+// repository does not create. That is written here rather than left to be found.
+func probeContainer(image, envID string) []Container {
+	if strings.TrimSpace(image) == "" {
+		return nil
+	}
+	return []Container{{
+		Name:      ProbeContainerName,
+		Image:     image,
+		Essential: true,
+		Command:   []string{"/bin/sh", "-c", ProbeScript(envID)},
+	}}
+}
+
+// interfaceEndpoint builds one interface endpoint with a policy.// interfaceEndpoint builds one interface endpoint with a policy.
 func interfaceEndpoint(region, service, sg, envID string) VPCEndpoint {
 	return VPCEndpoint{
 		Service:           fmt.Sprintf("com.amazonaws.%s.%s", region, service),
@@ -307,8 +452,17 @@ func interfaceEndpoint(region, service, sg, envID string) VPCEndpoint {
 func endpointPolicy(service, envID string) string {
 	switch service {
 	case "ecr.api", "ecr.dkr":
-		return fmt.Sprintf(`{"Statement":[{"Effect":"Allow","Principal":"*","Action":`+
-			`["ecr:GetAuthorizationToken","ecr:BatchGetImage","ecr:GetDownloadUrlForLayer"],`+
+		// Two statements rather than one, because ecr:GetAuthorizationToken
+		// takes no resource. Named against a repository ARN it denies the
+		// login, and a plan whose endpoint policy stops the image pull is not
+		// a narrower plan, it is a broken one. Every action that DOES take a
+		// resource is in the second statement, against this environment's own
+		// repository.
+		return fmt.Sprintf(`{"Statement":[`+
+			`{"Effect":"Allow","Principal":"*","Action":["ecr:GetAuthorizationToken"],`+
+			`"Resource":"*"},`+
+			`{"Effect":"Allow","Principal":"*","Action":`+
+			`["ecr:BatchGetImage","ecr:GetDownloadUrlForLayer"],`+
 			`"Resource":"arn:aws:ecr:*:*:repository/%s*"}]}`, envID)
 	case "logs":
 		return fmt.Sprintf(`{"Statement":[{"Effect":"Allow","Principal":"*","Action":`+
@@ -326,15 +480,23 @@ func s3EndpointPolicy(region string) string {
 		`["s3:GetObject"],"Resource":"arn:aws:s3:::prod-%s-starport-layer-bucket/*"}]}`, region)
 }
 
-// allowedDomains is what the DNS firewall lets through, which is only what the
-// image pull and the log push have to resolve.
-func allowedDomains(region string) []string {
+// allowedDomains is what the DNS firewall lets through: what the image pull and
+// the log push have to resolve, plus what the manifest declared.
+//
+// Both halves are needed and neither is optional. Without the first the task
+// never starts. Without the second the sidecar cannot resolve a host the
+// manifest said the environment may reach, so the environment is broken in a
+// way whose obvious fix is to remove the firewall, and a control people remove
+// is not a control. Nothing else is in the list, and the terminal rule refuses
+// the rest.
+func allowedDomains(region string, declared []string) []string {
 	out := []string{
 		fmt.Sprintf("api.ecr.%s.amazonaws.com", region),
 		fmt.Sprintf("dkr.ecr.%s.amazonaws.com", region),
 		fmt.Sprintf("logs.%s.amazonaws.com", region),
 		fmt.Sprintf("prod-%s-starport-layer-bucket.s3.%s.amazonaws.com", region, region),
 	}
+	out = append(out, declared...)
 	sort.Strings(out)
-	return out
+	return dedupe(out)
 }

--- a/ee/engine/runtime/ecs/runtime.go
+++ b/ee/engine/runtime/ecs/runtime.go
@@ -1,0 +1,340 @@
+package ecs
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/antifailure/antifailure/engine/pkg/extension"
+	"github.com/antifailure/antifailure/engine/pkg/provider"
+)
+
+// Name is the value runtime.provider takes in a manifest to reach this
+// package.
+const Name = "ecs"
+
+// Provider is the registered runtime provider for AWS ECS on Fargate.
+//
+// It never returns a runtime, and that is the deliverable rather than a stage
+// on the way to one. Read Open.
+type Provider struct {
+	// Getenv reads the network the environment would be placed in. It is a
+	// field rather than a call to os.Getenv so that a test can drive the
+	// generator without setting process wide state, which is the mistake that
+	// makes one test's environment leak into another's.
+	Getenv func(string) string
+}
+
+// The environment variables that describe the account's network.
+//
+// They are environment variables rather than manifest fields deliberately. A
+// VPC id, a subnet id and a security group id are properties of an
+// organisation's AWS account, they differ per installation, and putting them in
+// antifailure.yaml would mean a repository's manifest carried one company's
+// network layout into every fork of it.
+const (
+	EnvRegion     = "AF_ECS_REGION"
+	EnvCluster    = "AF_ECS_CLUSTER"
+	EnvVPC        = "AF_ECS_VPC_ID"
+	EnvVPCCIDR    = "AF_ECS_VPC_CIDR"
+	EnvSubnets    = "AF_ECS_SUBNET_IDS"
+	EnvSubnetCIDR = "AF_ECS_SUBNET_CIDRS"
+)
+
+// NewProvider builds the provider with the process environment.
+func NewProvider() *Provider { return &Provider{Getenv: os.Getenv} }
+
+// Name is the manifest value.
+func (p *Provider) Name() string { return Name }
+
+// Open refuses, every time, and returns the containment report as the reason.
+//
+// This is the whole lane and it needs the argument written where somebody
+// deleting it will read it.
+//
+// The plan this repository works from carries a standing risk in section 10:
+// the containment claim must not soften to make a cloud runtime possible, and
+// if ECS cannot be proved contained then the honest answer is that Antifailure
+// runs on EKS and not on raw ECS. The Kubernetes runtime is allowed to exist
+// because it creates the NetworkPolicy objects itself and then runs a pod under
+// them that tries to escape four ways before any application image starts. Two
+// properties make that possible and ECS on Fargate has neither.
+//
+// The first is that the image pull happens outside the policy. A kubelet pulls
+// on the node, so a pod can be denied every egress rule and still start. On
+// Fargate platform version 1.4.0 the ECR login, the image pull and the log push
+// all run over the task ENI under the task's own security group, and AWS states
+// that a Fargate task must have a route to the registry to pull an image. So a
+// security group that denies egress is not a configuration that runs an
+// environment, it is a configuration that runs nothing, and the row of the plan
+// that describes this lane as "a security group that denies egress" describes
+// something that cannot exist.
+//
+// The second is that the enforcement can be observed cheaply. A kind cluster on
+// this machine will tell you in ninety seconds whether its CNI enforces a
+// NetworkPolicy. Whether AWS enforces a route table is a fact about an account,
+// and the plan's own standing risk says no test may need a cloud account. So
+// the escape probe that earns a runtime its existence has never run here.
+//
+// What this package therefore does is publish the enumeration, generate the
+// configuration, prove the predicate over that configuration in continuous
+// integration, and refuse. A runtime that came up and could not prove it had no
+// egress would be worse than no runtime at all, because from the outside it
+// looks exactly like one that can.
+func (p *Provider) Open(_ context.Context, cfg extension.RuntimeConfig) (provider.Runtime, error) {
+	in, missing := p.inputs()
+	if len(missing) > 0 {
+		return nil, fmt.Errorf("the ecs runtime is not available, and this installation has not "+
+			"described a network for it either: %s are unset. Even fully described it would "+
+			"refuse, for the reason af prints when they are set. Use runtime.provider "+
+			"kubernetes against EKS, which is proved contained by a probe that runs before "+
+			"any application image", strings.Join(missing, ", "))
+	}
+	report := Evaluate(Generate(in, environmentID(cfg)))
+
+	var b strings.Builder
+	b.WriteString("the ecs runtime refuses to start an environment, on purpose.\n\n")
+	b.WriteString(report.String())
+	b.WriteString("\nThe Kubernetes runtime is allowed to exist because it creates its own " +
+		"NetworkPolicy objects and then runs a pod under them that tries to escape before any " +
+		"application image starts. On Fargate the image pull runs over the task ENI under the " +
+		"task's own security group, so a security group that denies egress starts nothing, and " +
+		"whether AWS enforces the rest is a fact about an account that no test in this " +
+		"repository is allowed to need. Use runtime.provider kubernetes against EKS.\n")
+	return nil, fmt.Errorf("%s", b.String())
+}
+
+// inputs reads the network description and reports what is missing.
+func (p *Provider) inputs() (Inputs, []string) {
+	get := p.Getenv
+	if get == nil {
+		get = os.Getenv
+	}
+	in := Inputs{
+		Region:      strings.TrimSpace(get(EnvRegion)),
+		Cluster:     strings.TrimSpace(get(EnvCluster)),
+		VPCID:       strings.TrimSpace(get(EnvVPC)),
+		VPCCIDR:     strings.TrimSpace(get(EnvVPCCIDR)),
+		SubnetIDs:   splitList(get(EnvSubnets)),
+		SubnetCIDRs: splitList(get(EnvSubnetCIDR)),
+	}
+	var missing []string
+	for _, pair := range []struct {
+		name  string
+		empty bool
+	}{
+		{EnvRegion, in.Region == ""},
+		{EnvCluster, in.Cluster == ""},
+		{EnvVPC, in.VPCID == ""},
+		{EnvVPCCIDR, in.VPCCIDR == ""},
+		{EnvSubnets, len(in.SubnetIDs) == 0},
+		{EnvSubnetCIDR, len(in.SubnetCIDRs) == 0},
+	} {
+		if pair.empty {
+			missing = append(missing, pair.name)
+		}
+	}
+	return in, missing
+}
+
+// environmentID is a stable name for the environment the plan is generated for.
+//
+// The runtime config carries no environment id, because a runtime is opened
+// once and creates many environments. The generated plan is therefore for a
+// named example rather than for a specific environment, and calling it that in
+// the identifier is better than picking one and implying the plan is about it.
+func environmentID(cfg extension.RuntimeConfig) string {
+	if ns := strings.TrimSpace(cfg.Runtime.NamespacePrefix); ns != "" {
+		return ns + "example"
+	}
+	return "af-example"
+}
+
+// splitList parses a comma separated environment variable.
+func splitList(v string) []string {
+	var out []string
+	for _, part := range strings.Split(v, ",") {
+		if part = strings.TrimSpace(part); part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+// Inputs are the account facts a plan is generated from.
+type Inputs struct {
+	Region      string
+	Cluster     string
+	VPCID       string
+	VPCCIDR     string
+	SubnetIDs   []string
+	SubnetCIDRs []string
+}
+
+// Generate builds the configuration one environment would be given.
+//
+// This is the function the predicate is a predicate about. It is deterministic
+// and it takes no clock and no randomness, so the plan for a given account and
+// environment is the same every time and a golden file over it is a real
+// regression test rather than a snapshot of one run.
+//
+// Everything it emits is the tightest shape the paths in egress.go allow. Where
+// a path cannot be closed, this function does not pretend: it still emits the
+// endpoints the image pull needs, because a plan that omitted them would score
+// better and start nothing.
+func Generate(in Inputs, envID string) Plan {
+	sg := "sg-" + envID
+	endpointSG := "sg-" + envID + "-endpoints"
+
+	subnets := make([]Subnet, 0, len(in.SubnetIDs))
+	for i, id := range in.SubnetIDs {
+		cidr := ""
+		if i < len(in.SubnetCIDRs) {
+			cidr = in.SubnetCIDRs[i]
+		}
+		subnets = append(subnets, Subnet{ID: id, IPv4CIDR: cidr})
+	}
+
+	endpoints := []VPCEndpoint{
+		interfaceEndpoint(in.Region, "ecr.api", endpointSG, envID),
+		interfaceEndpoint(in.Region, "ecr.dkr", endpointSG, envID),
+		interfaceEndpoint(in.Region, "logs", endpointSG, envID),
+		{
+			Service:         fmt.Sprintf("com.amazonaws.%s.s3", in.Region),
+			Type:            "Gateway",
+			PolicyDocument:  s3EndpointPolicy(in.Region),
+			SecurityGroupID: "",
+		},
+	}
+
+	// Egress names the endpoints' security group rather than an address range,
+	// because an interface endpoint's ENI addresses are assigned by AWS and a
+	// rule written against them is wrong the first time one is replaced.
+	egress := []Rule{
+		{Protocol: "tcp", FromPort: 443, ToPort: 443, PeerSecurityGroupID: endpointSG},
+		{Protocol: "tcp", FromPort: 443, ToPort: 443, PrefixListID: "pl-" + in.Region + "-s3"},
+	}
+	// And one rule per subnet for traffic inside the environment, which is not
+	// egress: a service reaching another service, the sidecar or the database
+	// alias never leaves this environment and is not decided against the
+	// egress policy.
+	for _, s := range subnets {
+		if s.IPv4CIDR != "" {
+			egress = append(egress, Rule{Protocol: "-1", CIDRv4: s.IPv4CIDR})
+		}
+	}
+
+	return Plan{
+		Region:  in.Region,
+		Cluster: in.Cluster,
+		// Pinned rather than left to LATEST. Below 1.4.0 a task carries a
+		// second Fargate owned ENI for image pulls and secret retrieval that
+		// no security group in this plan describes and that does not appear in
+		// VPC flow logs, so a plan on an older platform version is making a
+		// claim about traffic it cannot see.
+		LaunchType:      "FARGATE",
+		PlatformVersion: "1.4.0",
+		TaskDefinition: TaskDefinition{
+			Family:      envID,
+			NetworkMode: "awsvpc",
+			// Empty, and it is the single most important field in the file.
+			// 169.254.170.2 cannot be turned off, so the only way it vends
+			// nothing is for there to be nothing to vend.
+			TaskRoleARN:          "",
+			ExecutionRoleARN:     fmt.Sprintf("arn:aws:iam::*:role/%s-execution", envID),
+			EnableExecuteCommand: false,
+		},
+		Network: NetworkPlan{
+			VPC: VPC{
+				ID:       in.VPCID,
+				IPv4CIDR: in.VPCCIDR,
+				IPv6CIDR: "",
+				// Left ON, and the DNS firewall closes the resolver path
+				// instead. Turning it off would also close it, and it would
+				// break the private DNS names of the very interface endpoints
+				// the image pull needs, so the environment would stop starting.
+				EnableDNSSupport: true,
+			},
+			Subnets:       subnets,
+			SecurityGroup: SecurityGroup{ID: sg, Egress: egress},
+			RouteTable: RouteTable{
+				ID:             "rtb-" + envID,
+				AssignPublicIP: AssignPublicIPDisabled,
+				Routes: []Route{
+					{Destination: in.VPCCIDR, Target: "local"},
+					{Destination: "pl-" + in.Region + "-s3", Target: "vpce-" + envID + "-s3"},
+				},
+			},
+			Endpoints: endpoints,
+			DNSFirewall: &DNSFirewall{
+				RuleGroupID:     "rslvr-frg-" + envID,
+				AssociatedVPCID: in.VPCID,
+				FailOpen:        false,
+				Rules: []DNSFirewallRule{
+					// The allow rules come first by priority and name only what
+					// the environment is obliged to resolve. The block rule is
+					// last, so a name that matched nothing above is refused
+					// rather than resolved.
+					{Priority: 10, Action: "ALLOW", Domains: allowedDomains(in.Region)},
+					{Priority: 1000, Action: "BLOCK", Domains: []string{"*"}},
+				},
+			},
+		},
+	}
+}
+
+// interfaceEndpoint builds one interface endpoint with a policy.
+func interfaceEndpoint(region, service, sg, envID string) VPCEndpoint {
+	return VPCEndpoint{
+		Service:           fmt.Sprintf("com.amazonaws.%s.%s", region, service),
+		Type:              "Interface",
+		SecurityGroupID:   sg,
+		PrivateDNSEnabled: true,
+		PolicyDocument:    endpointPolicy(service, envID),
+	}
+}
+
+// endpointPolicy narrows an interface endpoint to the environment's own
+// repository or log group.
+//
+// An endpoint with no policy permits every action in that service that the
+// caller has credentials for. The container has no credentials while the task
+// role is absent, so today this narrows very little, and it is written anyway
+// because the day somebody adds a task role is the day it is the only thing
+// standing between this environment and the whole service.
+func endpointPolicy(service, envID string) string {
+	switch service {
+	case "ecr.api", "ecr.dkr":
+		return fmt.Sprintf(`{"Statement":[{"Effect":"Allow","Principal":"*","Action":`+
+			`["ecr:GetAuthorizationToken","ecr:BatchGetImage","ecr:GetDownloadUrlForLayer"],`+
+			`"Resource":"arn:aws:ecr:*:*:repository/%s*"}]}`, envID)
+	case "logs":
+		return fmt.Sprintf(`{"Statement":[{"Effect":"Allow","Principal":"*","Action":`+
+			`["logs:CreateLogStream","logs:PutLogEvents"],`+
+			`"Resource":"arn:aws:logs:*:*:log-group:/antifailure/%s:*"}]}`, envID)
+	default:
+		return `{"Statement":[{"Effect":"Deny","Principal":"*","Action":"*","Resource":"*"}]}`
+	}
+}
+
+// s3EndpointPolicy narrows the gateway endpoint to the buckets ECR serves
+// layers from in this region.
+func s3EndpointPolicy(region string) string {
+	return fmt.Sprintf(`{"Statement":[{"Effect":"Allow","Principal":"*","Action":`+
+		`["s3:GetObject"],"Resource":"arn:aws:s3:::prod-%s-starport-layer-bucket/*"}]}`, region)
+}
+
+// allowedDomains is what the DNS firewall lets through, which is only what the
+// image pull and the log push have to resolve.
+func allowedDomains(region string) []string {
+	out := []string{
+		fmt.Sprintf("api.ecr.%s.amazonaws.com", region),
+		fmt.Sprintf("dkr.ecr.%s.amazonaws.com", region),
+		fmt.Sprintf("logs.%s.amazonaws.com", region),
+		fmt.Sprintf("prod-%s-starport-layer-bucket.s3.%s.amazonaws.com", region, region),
+	}
+	sort.Strings(out)
+	return out
+}

--- a/engine/api/packages.txt
+++ b/engine/api/packages.txt
@@ -39,4 +39,5 @@ unstable github.com/antifailure/antifailure/ee/engine/compliance     Enterprise.
 unstable github.com/antifailure/antifailure/ee/engine/feature        Enterprise. Feature gating for the licensed build, which moves with the licence terms rather than with semantic versioning.
 unstable github.com/antifailure/antifailure/ee/engine/license        Enterprise. Licence parsing and verification, which changes whenever the licence format does.
 unstable github.com/antifailure/antifailure/ee/engine/policyenforce  Enterprise. Policy enforcement for the licensed build, tied to rules that are added and sharpened in minor releases.
+unstable github.com/antifailure/antifailure/ee/engine/runtime/ecs    Enterprise. The AWS ECS on Fargate containment predicate, which is an enumeration of egress paths and a check over the configuration one would be given. It changes whenever AWS changes what a task definition, a security group or a DNS Firewall rule group can say, which is not on this repository's release schedule.
 unstable github.com/antifailure/antifailure/ee/engine/secrets        Enterprise. The licensed secret backends, which follow whatever each vendor's API does.

--- a/engine/internal/docs/pages.gen.go
+++ b/engine/internal/docs/pages.gen.go
@@ -4803,6 +4803,116 @@ What the enterprise edition adds here is not a third runtime. It is placement
 across several of them at once: the requirements, the tags and the scheduling
 described above.
 
+## Why there is no ECS runtime
+
+` + "`" + `runtime.provider: ecs` + "`" + ` is registered in the enterprise binary and it refuses,
+every time, with a report rather than an error. The reason is worth reading
+before assuming it is a gap somebody will close next release.
+
+A runtime is allowed to exist here only if it can prove an environment has no
+way out, and the Kubernetes runtime proves it the only way a proof works: it
+creates the ` + "`" + `NetworkPolicy` + "`" + ` objects itself, then runs one pod under exactly the
+rules a service runs under and has it try to escape before any application image
+starts. If any attempt gets out the environment does not start and you get
+**AF-RUN-043**. That is not caution. Several container network plugins accept a
+` + "`" + `NetworkPolicy` + "`" + ` object and enforce nothing, every status reads green, and the
+only thing that can tell the two apart is a packet.
+
+ECS on Fargate cannot be given the same treatment, for two reasons that are
+properties of the platform rather than of this implementation.
+
+**The image pull runs inside the boundary.** A kubelet pulls on the node, so a
+pod can be denied every egress rule and still start. On Fargate platform version
+1.4.0 the ECR login, the image pull and the log push all flow over the task's own
+network interface, under the task's own security group, and AWS states that a
+Fargate task must have a route to the registry to pull an image. So a security
+group that denies egress does not produce a contained environment. It produces a
+task that never starts, and the endpoints that let it start are themselves
+reachable addresses.
+
+**The enforcement cannot be observed without an account.** Whether a cluster
+enforces a ` + "`" + `NetworkPolicy` + "`" + ` is answerable on a laptop in ninety seconds. Whether
+AWS enforces a route table is a fact about an account, and no test in this
+repository is permitted to need one.
+
+So what ships is the enumeration and the predicate over it, and the refusal
+carries both. Thirteen distinct egress paths out of a Fargate task, of which
+**ten are closed by the configuration this runtime would generate, one is open,
+and two are not decided by either the configuration or AWS's own
+documentation**. Every closed verdict carries the grade of evidence behind it,
+and the report separates the closures computed from a JSON document from any
+recorded by an attempt made inside a running task, because those are different
+claims.
+
+The one that is open is the task metadata endpoint, which is on by default for
+every Fargate task on platform version 1.4.0 or later with no documented way to
+turn it off.
+
+The two that are unproven are named rather than rounded up, because an unproven
+verdict is not a weaker closed one. The instance metadata service at
+` + "`" + `169.254.169.254` + "`" + ` is the sharper of them: the Fargate launch type removes the
+documented credential source, because EC2 instance profiles are not available to
+containers in Fargate tasks, but AWS does not state that the address stops
+answering, and those are different claims. The local Amazon Time Sync Service at
+` + "`" + `169.254.169.123` + "`" + ` is the other. Settling either needs one request from one
+running task, which is a request from a task in somebody's AWS account, so
+nothing here moves them on an absence of evidence.
+
+Two paths that a reader of an earlier draft of this page would have found in the
+open column are closed, and how they closed is the reusable part. The interface
+endpoints the image pull needs and the S3 gateway endpoint the layers come from
+cannot be disconnected without giving up the ability to start an environment at
+all. But reaching ECR is not the same question as reaching **any** repository,
+any log group and any bucket in the region, and only the second is an
+exfiltration path. A VPC endpoint policy naming this environment's own
+repository, log group and bucket closes the second while leaving the first, so
+the weaker half of the question was the one being answered.
+
+One finding is worth carrying away even if you never run on ECS. **On AWS the
+security group is irrelevant to a DNS query.** The VPC user guide states that
+traffic to and from the Amazon DNS server cannot be filtered with network ACLs
+or security groups, and that resolver answers recursive queries for public names
+from anywhere in the VPC. A DNS question is chosen by whoever asks it, so that
+is a data channel out that no security group audit will ever show you. Closing
+it takes a Route 53 Resolver DNS Firewall rule group whose last rule blocks every
+domain and which does not fail open. A containment argument carried over from
+Kubernetes gets this one wrong, because there the same attempt is closed by the
+policy that closes everything else.
+
+**A DNS Firewall rule group is read by priority from the lowest number up, and
+that is where the second finding is.** A group holding ` + "`" + `ALLOW` + "`" + ` on every domain
+at priority 5 and ` + "`" + `BLOCK` + "`" + ` on every domain at priority 1000 blocks nothing at all,
+because ` + "`" + `ALLOW` + "`" + ` permits the request to go through and the lower priority is
+consulted first. It reads as configured in a console screenshot. The check
+refuses that shape, along with a terminal rule moved off the end by priority, two
+rules sharing the last priority, which AWS refuses to create anyway, and a domain
+with a star anywhere but the front, which a DNS Firewall domain list cannot hold.
+
+The rule group's allow list is generated from the manifest's own egress
+catalogue rather than from a list of AWS names kept beside it. A host the
+manifest declares ` + "`" + `allow` + "`" + ` or ` + "`" + `sandbox` + "`" + ` is one the sidecar forwards to for real
+and therefore has to resolve; a host declared ` + "`" + `block` + "`" + `, ` + "`" + `mock` + "`" + `, ` + "`" + `capture` + "`" + ` or
+` + "`" + `synth` + "`" + ` is answered locally and must not resolve, because a name the sidecar
+answers resolving publicly is a route around the decision the manifest made
+about it. A declared host that cannot be expressed as a DNS Firewall domain is
+named in the refusal rather than dropped or widened.
+
+**The honest summary is that Antifailure runs on EKS and not on raw ECS.** Use
+` + "`" + `runtime.provider: kubernetes` + "`" + ` against an EKS cluster, where the probe runs.
+
+The report is generated for a real network rather than for a made up one, so
+that the security group rules and route table entries it judges are the ones
+your account would get. Six variables describe that network, and they are
+variables rather than manifest fields because a VPC identifier is a property of
+one company's account and does not belong in a file that gets forked:
+` + "`" + `AF_ECS_REGION` + "`" + `, ` + "`" + `AF_ECS_CLUSTER` + "`" + `, ` + "`" + `AF_ECS_VPC_ID` + "`" + `, ` + "`" + `AF_ECS_VPC_CIDR` + "`" + `,
+` + "`" + `AF_ECS_SUBNET_IDS` + "`" + ` and ` + "`" + `AF_ECS_SUBNET_CIDRS` + "`" + `, the last two comma separated and
+in matching order. Setting them changes the report and does not change the
+answer, and the refusal you get without them says so before you go and build a
+VPC to find out. A seventh, ` + "`" + `AF_ECS_PROBE_IMAGE` + "`" + `, is optional and names the
+image the containment probe container would run; with it unset the plan carries
+no probe container and the instance metadata path says so.
+
 Related: [scheduling](/docs/concepts/scheduling), [licensing](/docs/enterprise/licensing).
 `,
 	"enterprise/scim.md": `---

--- a/engine/internal/env/env.go
+++ b/engine/internal/env/env.go
@@ -849,6 +849,7 @@ func (o *Orchestrator) newRuntime(ctx context.Context) (provider.Runtime, error)
 			rt, err := p.Open(ctx, extension.RuntimeConfig{
 				Root:              o.opts.Root,
 				Runtime:           runtimeConfigOf(cfg),
+				Egress:            egressConfigOf(o.opts.Manifest),
 				TTL:               o.ttl(),
 				StateDir:          filepath.Join(o.opts.Root, StateDir),
 				Now:               o.opts.Clock.Now,
@@ -896,6 +897,18 @@ func runtimeConfigOf(cfg *schema.Runtime) schema.Runtime {
 		return schema.Runtime{}
 	}
 	return *cfg
+}
+
+// egressConfigOf copies the manifest's egress catalogue for a registration.
+//
+// A copy rather than the pointer, for the reason runtimeConfigOf gives: a
+// registration must not be able to edit the manifest the engine goes on
+// reading after it has been built.
+func egressConfigOf(m *schema.Manifest) schema.Egress {
+	if m == nil || m.Egress == nil {
+		return schema.Egress{}
+	}
+	return *m.Egress
 }
 
 // listNames renders a list of names for a sentence a person reads.

--- a/engine/pkg/extension/extension.go
+++ b/engine/pkg/extension/extension.go
@@ -332,6 +332,25 @@ type RuntimeConfig struct {
 	Root string
 	// Runtime is the manifest's runtime block, as a copy.
 	Runtime schema.Runtime
+	// Egress is the manifest's egress catalogue, as a copy.
+	//
+	// A runtime that places containers somewhere other than this machine has
+	// to build the network the sidecar runs in, and the shape of that network
+	// depends on what the environment is allowed to reach: a host declared
+	// allow or sandbox is one the sidecar forwards to for real and therefore
+	// has to resolve, and a host declared block, mock, capture or synth is
+	// answered locally and must NOT resolve, because a name the sidecar
+	// answers resolving publicly is a way around the decision the manifest
+	// made about it.
+	//
+	// It is here so a runtime composes with that catalogue rather than
+	// carrying a second list of hosts that can disagree with it. The ECS
+	// runtime is the first to need it, for the Route 53 Resolver DNS Firewall
+	// rule group that is the only thing on AWS able to close the resolver
+	// path: security groups and network ACLs cannot filter the Amazon DNS
+	// server, so the allow list in that rule group is where the manifest's
+	// answer has to end up.
+	Egress schema.Egress
 	// TTL is how long an environment this runtime creates may live, already
 	// parsed from the manifest. Zero means no expiry.
 	TTL time.Duration

--- a/engine/pkg/extension/extension_test.go
+++ b/engine/pkg/extension/extension_test.go
@@ -439,6 +439,43 @@ func TestTwoProvidersUnderOneNameAreRefused(t *testing.T) {
 	require.Contains(t, err.Error(), "aurora")
 }
 
+// TestTwoRuntimesUnderOneNameAreRefused covers the RUNTIME socket specifically,
+// and it is not a duplicate of the database test above.
+//
+// Validate loops over five sockets and the loop body is shared, so the database
+// test proves the body refuses a repeat. It proves nothing about which sockets
+// are IN the list. Dropping the runtime entry from that list leaves the
+// database test green and leaves a second registration of a runtime name
+// unrefused, and the two assertions after Validate are what that costs: the
+// first registration answers every lookup, so the second is dead code that
+// looks registered, and the name appears twice in the list a refusal prints.
+// That list reading "local, kubernetes, ecs, ecs" is the same defect the ecs
+// runtime exists to fix, arriving from the other direction.
+//
+// Two pull requests each adding the same registration is not hypothetical. It
+// is what merging both of them in sequence would have produced.
+func TestTwoRuntimesUnderOneNameAreRefused(t *testing.T) {
+	t.Parallel()
+	r := extension.NewRegistry()
+	first := &fakeRuntimeProvider{name: "ecs"}
+	second := &fakeRuntimeProvider{name: "ecs"}
+	r.AddRuntimeProvider(first)
+	r.AddRuntimeProvider(second)
+
+	err := r.Validate(nil)
+	require.Error(t, err, "a repeated runtime name must be refused")
+	require.Contains(t, err.Error(), "ecs")
+	require.Contains(t, err.Error(), "whichever was registered first")
+
+	// What the refusal is protecting against, asserted rather than described.
+	got, ok := r.RuntimeProviderNamed("ecs")
+	require.True(t, ok)
+	require.Same(t, first, got,
+		"the first registration answers, so a second one is silently dead")
+	require.Equal(t, []string{"ecs", "ecs"}, r.RuntimeProviderNames(),
+		"a refusal built from this list would name the runtime twice")
+}
+
 func TestAProviderWithNoNameIsRefused(t *testing.T) {
 	t.Parallel()
 	// Nothing in a manifest could ask for it, so it is a registration that can

--- a/tools/docs/dictionary.txt
+++ b/tools/docs/dictionary.txt
@@ -32,6 +32,7 @@ goleak
 gosec
 govulncheck
 kubeconfig
+kubelet
 llms
 lockfile
 lockfiles


### PR DESCRIPTION
## Why this branch exists

Two open pull requests built `ee/engine/runtime/ecs/` from a base where it did
not exist, and the board had them queued to merge as a pair.

They are not a pair. **#310's branch is #313's work carried forward under
different shas and then continued.** Both start with the same two commits, `ee:
the ECS containment claim was a sentence nobody had checked against AWS` and
`ee: a manifest naming the ecs runtime was answered by a list of two names`, and
the ECS package is byte identical at that point:

```
for f in egress.go egress_test.go plan.go runtime.go; do
  diff <(git show ddb3fc3b:ee/engine/runtime/ecs/$f) \
       <(git show 0ae1a1d0:ee/engine/runtime/ecs/$f)
done          # no output
```

From there #313 added documentation and two gate inputs, and #310 rewrote the
package over six more commits. Merging both in sequence would have added the
package twice.

## What a sequential merge would actually have produced

Not a compile error. Three things that all build:

1. **Two `extension.Default.AddRuntimeProvider(ecs.NewProvider())` calls** in
   `ee/engine/cmd/af/main.go`. See the section below, because the answer to what
   that does turned out to be worth its own commit.
2. **Two `engine/api/packages.txt` lines** for the same import path with two
   different reasons, in a file that is a gate's input.
3. **A documentation page describing a report the binary no longer prints.**
   #313's page publishes eight of thirteen egress paths closed, three open and
   two unproven. #310 closes two more. The shipped report says **ten closed, one
   open, two unproven**.

## What is in this branch

`#310's ECS package as the base, unchanged`, plus everything #313 had that #310
lacked. The eight commits of #310 are cherry picked onto current `main` and the
resulting `ee/engine/runtime/ecs/` is byte identical to `origin/w-ecs-close-egress`:

```
git diff origin/w-ecs-close-egress HEAD -- ee/engine/runtime/ecs/   # empty
```

### The per file decisions

| File | Decision | Why |
| --- | --- | --- |
| `egress.go`, `plan.go`, `runtime.go`, `evidence.go` | #310 | #310 is a strict continuation, not a fork. There is no #313 code to rescue. |
| `egress_test.go` | #310, plus one assertion ported from #313 | See the honesty commit below. |
| `enterprise/runtimes.md` | #313's page, **rewritten** | It described the branch that lost. |
| `pages.gen.go` | regenerated | `go run ./tools/docsembed`, never hand edited. |
| `packages.txt` | #310's reason | It names the three AWS objects the predicate tracks, which is what the package now reads. |
| `dictionary.txt` | #313's entry | `kubelet`, needed by the page. |
| `.changes/` | both, one reframed | #310's entry said the report "went from eight of thirteen to ten". True of the branch, false of the release: no version carried eight. |

`plan.go` and `runtime.go` were read on both sides rather than taken by date.
#313's version marks the containment probe container `Essential` and gives it a
`DependsOn`. On ECS the exit of an essential container stops the whole task, so
that would have **killed every environment the moment the probe succeeded**.
#310 is right, and the newer branch happens to be the correct one here for a
reason rather than by recency.

## The duplicate symbol hunt

```
grep -hE "^(func|type|var|const) " ee/engine/runtime/ecs/*.go | ... | sort | uniq -d
grep -c "runtime/ecs" engine/api/packages.txt          # 1
grep -c "AddRuntimeProvider" ee/engine/cmd/af/main.go  # 1
sort tools/docs/dictionary.txt | uniq -d               # empty
```

No duplicate declaration in the ECS package, in `env.go`, in `extension.go` or
in `main.go`.

## What a double runtime registration actually does, which is a finding

`AddRuntimeProvider` appends and returns nothing, so registration itself cannot
refuse. `RuntimeProviderNamed` returns the **first** match, so a second
registration under one name **silently loses** and is dead code that reads as
wired. `RuntimeProviderNames` returns the name **twice**, so the refusal a
manifest gets for an unknown runtime would have read `local, kubernetes, ecs,
ecs`, which is the same defect the ECS registration exists to fix arriving from
the other direction.

What saves it is `Registry.Validate`, which does refuse a repeated name and has
two real call sites, at the top of `openLocking` and `openReading`, before
anything is created. **So it refuses. That is the good answer and it was not the
tested one.**

`Validate` loops over five sockets with a shared body.
`TestTwoProvidersUnderOneNameAreRefused` registers two DATABASE providers, so it
proves the body refuses a repeat and proves nothing about which sockets are in
the list. Deleting `{SocketRuntimeProvider, r.runtimeNames()}` leaves that test
green and leaves a doubled runtime registration unrefused. There is a test for
the runtime socket now, with that deletion as its mutation and the database test
run against the same break as a control.

## The time sync verdict, fixed here because this branch now owns the package

Exactly one path declares an `Observe` hook, the instance metadata one, and
`EvaluateWith` gates the whole observation branch on `path.Observe != nil`. So an
observation recorded against the time sync path is accepted by the type and then
discarded. Measured on this branch with the metadata path as a paired control
through the same call:

```
the-local-amazon-time-sync-service   verdict=unproven  grade=none         closedByObservation=0
the-ec2-instance-metadata-service    verdict=closed    grade=observation  closedByObservation=1
```

**The design is right and is unchanged.** An NTP exchange is UDP, nothing in a
minimal container image makes one, and a probe whose only possible outcome is
`errored` fills a report with the word probe while learning nothing.

**The defect was the sentence.** The detail ended "A probe from one running task
settles it and none has been recorded for this environment", which describes a
measurement that is outstanding. A reader sees the detail and never sees
`Targets()`. Nothing is outstanding; there is nowhere to put an answer. Saying
"none has been recorded" about a question nothing can ask is the rounding the
`Unproven` verdict exists to prevent, one level up in the prose.

## Reachability, proved rather than compiled

Not "it compiles" and not "the provider is registered". The two binaries, built
from this tree, against one manifest naming `runtime.provider: ecs`.

**`af env list` is the path used** because it reaches `Orchestrator.Runtime` and
therefore the registry WITHOUT opening a session, so it needs no database
provider and no Docker daemon, which is the honest route on a machine whose
daemon is unreliable.

The community binary reproduces the exact failure both pull requests exist to
fix:

```
AF-MAN-002 The manifest at .../antifailure.yaml is not valid:
           runtime.provider is "ecs", and this build has local and kubernetes.
           Remove the field or set it to one of those
```

The enterprise binary is answered by the package instead. With no `AF_ECS_*` set:

```
Error: the ecs runtime is not available, and this installation has not described
       a network for it either: AF_ECS_REGION, AF_ECS_CLUSTER, AF_ECS_VPC_ID,
       AF_ECS_VPC_CIDR, AF_ECS_SUBNET_IDS, AF_ECS_SUBNET_CIDRS are unset.
```

With the network described, the full report, whose headline is the figure this
branch rewrote the documentation page to match:

```
Error: the ecs runtime refuses to start an environment, on purpose.

       10 of 13 egress paths out of an ECS task on Fargate are closed (1 open, 2
       unproven).
       Of those 10, 10 are closed by the generated configuration and 0 by an
       attempt observed from a running task.
```

**One correction worth recording**, because it is the shape this repository keeps
finding. The first end to end manifest was invalid, `egress` takes `default` and
`rules` rather than a bare sequence, and `af env list` **silently fell back to
the local runtime** rather than failing. A run that proved nothing looked exactly
like a run that passed. `af explain` is what said so, by name and line.

## Mutation table

Nine cells. Every one ran exactly one test, classified on the `=== RUN` count and
not on the exit code, clean tree green before and after each matrix.

| Cell | What was broken | Test | Verdict |
| --- | --- | --- | --- |
| A1 | ratio moved off the report headline | `TestTheReportCarriesItsCaveat` | CAUGHT |
| A2 | unproven count moved off the headline | `TestTheReportCarriesItsCaveat` | CAUGHT |
| A3 | open count moved off the headline | `TestTheReportCarriesItsCaveat` | CAUGHT |
| B1 | runtime socket deleted from `Validate`'s list | `TestTwoRuntimesUnderOneNameAreRefused` | CAUGHT |
| B2 | **control**: the same break as B1 | `TestTwoProvidersUnderOneNameAreRefused` | **SURVIVED** |
| C1 | an `Observe` hook added to the NTP path | `TestTheTimeSyncVerdictDoesNotImplyAPendingMeasurement` | CAUGHT |
| C2 | an NTP probe target added to `Targets()` | same | CAUGHT |
| C3 | the pending phrasing restored | same | CAUGHT |
| C4 | the structural clause removed | same | CAUGHT |

**B2 is the cell that earns the new test its existence.** It is the same break as
B1 measured against the pre-existing database duplicate test, and it stays green.
Without it, the new test would be indistinguishable from a duplicate.

## Gates

**Run locally, all green**: `prosecheck` (928 files), `claimcheck`, `varcheck`,
`sidebarcheck`, `changecheck`, `figurecheck`, `manifestcheck` (53 manifests),
`licensecheck`, `surfacecheck`, `modecheck`, `forbidden` (99 documents), `spell`
(98 files), `fieldsweep`, `socketcheck`, `constcheck`, `attribution`,
`conflictcheck`, `statuscheck`, `contactcheck`, `keycheck`, `execcheck`,
`docexamples`, plus both grep halves of `edition boundary`. Under the build lock:
`go build` and `go vet` on both modules, the whole `ee/engine/runtime/ecs`
package (72 tests) and `engine/pkg/extension`.

**NOT run locally, and named rather than left to be assumed**: the full
`just gate`. Docker was unresponsive on this machine for the whole of this lane,
so every Docker backed gate, the web, console and runner suites, the fuzzers and
`reproducible` could not be run here. CI runs them on a clean machine and that is
the instrument for them, reported by conclusion below rather than claimed.

## A finding NOT closed here, and why

`schemas/manifest.v1.json` constrains `runtime.provider` to
`enum: ["local", "kubernetes"]`, so **the documentation cannot show the manifest
line this runtime exists to answer**. Measured: a docs page carrying
`runtime.provider: ecs` in a yaml block fails `manifestcheck` with

```
runtime.provider is "ecs", which is not one the manifest accepts.
The engine refuses it with AF-MAN-002. It has to be one of: kubernetes, local
```

**That remediation is false for the enterprise binary.** Nothing validates a
manifest against the JSON Schema at parse time, the switch in `newRuntime` falls
through to the registry, and the provider answers with the report shown above. So
the gate says no about the right field for a wrong reason. It is why the page in
this branch describes the manifest line in prose instead of showing it.

The precedent for the fix is one field away in the same schema:
`datastore.provider` deliberately carries no enum, described as "Open rather than
a fixed list: a manifest naming an engine this build has no provider for is
refused by the provider lookup, by name, which says more than an unknown value
would."

It is not folded in here. It changes a v1 contract surface and it entangles with
the section 2.5 editions question, since it decides whether the community schema
advertises a name only the enterprise build answers. That is not a decision to
make inside a reconciliation whose job is to unblock two merges, so it has been
handed to central as its own lane.

## Supersedes

**#313 and #310 are both superseded by this branch** and are closed as such.
#310's package is the base; #313's contribution was documentation that had to be
rewritten rather than copied.
