### PR TITLE
ci: two commits reached main with no verdict, and the file promised they could not

### DIFF
--- a/.changes/ci-verdict-per-main-commit.md
+++ b/.changes/ci-verdict-per-main-commit.md
@@ -1,0 +1,41 @@
+# fixed
+
+Two commits reached main on 2026-09-08 with no CI verdict at all, and nothing
+said so. Four pull requests merged inside four minutes, and the API records the
+rest: the run on `09078be0` was in progress and survived; the runs on
+`39a771ff` and `f5e2ef68` were cancelled 36 and 33 seconds after they were
+created, one second after the next run was created in each case, and both carry
+an empty job list. Not one check ran on either commit.
+
+`cancel-in-progress: false` protects a run that has STARTED and nothing else.
+GitHub holds one PENDING run per concurrency group, so each merge took the place
+of the one queued behind the run in progress. The comment in `ci.yml` opened by
+saying a run on main is never cancelled and closed, thirty lines later, by
+saying a pending one still is and that fixing it would need a merge queue. Both
+halves were in the file, the first is what people read, and the second was
+wrong: `ci.yml` now keys its concurrency group on the commit for a push to main,
+which gives each one a group of one, so no main run can supersede another.
+`security.yml` had already used the same technique for its daily scan three days
+earlier and nobody carried it back. The cost is runner minutes, because a burst
+of six merges now runs six full CI runs where two ran before, and past the
+account's concurrency limit they queue. A queue is a delay. A cancelled pending
+run was a permanent hole, and a hole cannot be re-run into existence once the
+next merge has landed on top of it.
+
+The configuration change removes the cause this had. It cannot remove the
+condition, because a run can still be cancelled by hand, a job can still hit its
+own `timeout-minutes`, and the expression can be edited back. So
+`tools/mainverdict` reads what CI concluded on each of main's recent commits and
+refuses a branch carrying one that was never judged, running in
+`.github/workflows/ci-watch.yml` on every completed CI run on main and daily,
+and leaving one issue open until main is whole again. It passes `failure` along
+with `success`, because a red main is already the loudest thing in the
+repository; what it catches is the silent case, where `cancelled` and `skipped`
+render in a list exactly as a pass does. It has a third answer for the case
+where the run history it read does not reach the commits it was asked about,
+because reporting a branch clean on having read the top of it is the defect this
+repository keeps finding in its own instruments.
+
+`tools/cigate` already refused a cancelled run, and still does. Its explanation
+of what `cancelled` means on main was written against the old setting and now
+says what is true.

--- a/.github/workflows/ci-watch.yml
+++ b/.github/workflows/ci-watch.yml
@@ -1,0 +1,140 @@
+# A commit on main that CI never judged, noticed by something other than a
+# person scrolling the Actions tab.
+#
+# WHAT WENT WRONG. On 2026-09-08 four pull requests merged inside four minutes
+# and two of the resulting commits ended with no CI verdict at all. Nothing said
+# so. `cancelled` is not red, it renders in a list exactly as a pass does, and
+# the two runs in question carried an empty job list, so not one check ran on
+# either commit. It was found the next morning by reading the API by hand.
+#
+# ci.yml now keys its concurrency group on the commit, so a push to main is a
+# group of one and no main run can supersede another. That removes the cause
+# this incident had. It does not remove the condition: a run can be cancelled by
+# hand, a job can hit its own timeout-minutes, GitHub can report `stale`, and
+# the concurrency expression can be edited back by somebody who reads it as
+# noise. The fix and the watchdog answer different questions, and shipping only
+# the fix would leave the next instance of this as silent as the last.
+#
+# WHY IT IS NOT A JOB INSIDE ci.yml. A job there judging main's earlier commits
+# would turn a hole behind this commit into a red CI run on this commit, and
+# cd.yml gates on CI, so a commit whose own tests passed would stop deploying
+# because of somebody else's cancelled run. That punishes the wrong commit. Here
+# the answer is loud, assignable and blocks nothing that was ever green.
+#
+# WHY IT LEAVES AN ISSUE. Same reasoning as security-watch.yml, which watches
+# the daily scan: an issue is assignable and cannot be filtered into a folder
+# nobody opens, and one issue reopened beats one issue a day, which is a
+# watchdog people mute on the third day.
+#
+# WHAT IT WILL SAY ON THE DAY IT LANDS, so nobody reads the first red as a bug
+# in the watchdog: it will refuse, and it will name `39a771ff` and `f5e2ef68`,
+# because those two commits really do carry no verdict and no longer can. It
+# goes quiet when they leave the window.
+name: ci-watch
+
+on:
+  # The immediate half. A completed CI run on main triggers this with its
+  # conclusion already recorded, so a cancelled run is reported within a minute
+  # rather than at tomorrow's check.
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+  # The dead man's switch, for the states no CI completion announces: a run that
+  # never started at all, and a commit whose run is still queued hours later.
+  schedule:
+    - cron: "0 10 * * *"
+  workflow_dispatch:
+
+# CANCELLING A SUPERSEDED RUN IS RIGHT HERE, and saying why is the point of
+# writing it down in this file of all files. Everything ci.yml's group avoids is
+# about a run that is the only answer about ONE COMMIT, which nothing else can
+# provide once the commit is behind you. This run's answer is about main's
+# current state, so a newer run answers the same question better and the older
+# one is obsolete rather than lost.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  verdicts:
+    name: every commit on main was judged
+    # A CI run on a pull request also completes, and this asks nothing about
+    # pull requests. Without this the watchdog runs on every branch's CI and
+    # says the same thing about main every time.
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      # Reading workflow runs other than this one, and leaving the issue.
+      actions: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: tools/go.mod
+          cache-dependency-path: tools/go.sum
+
+      - name: Every recent commit on main carries a CI verdict
+        id: check
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: go run ./tools/mainverdict -branch main -window 20
+
+      - name: Leave one issue open until main is whole again
+        if: steps.check.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          title="A commit on main carries no CI verdict"
+          existing=$(gh issue list --state open --search "\"${title}\" in:title" \
+            --json number --jq '.[0].number // empty')
+
+          body=$(printf '%s\n\n%s\n\n%s\n' \
+            "mainverdict refused. The commits and the reason for each are in the run below." \
+            "Run: ${RUN_URL}" \
+            "A commit with no verdict cannot be released from, was never deployed, and makes a red on any later commit ambiguous across every commit behind it. Re-run CI on the named commits, or accept them by letting them leave the window.")
+
+          if [ -n "${existing}" ]; then
+            gh issue comment "${existing}" --body "${body}"
+          else
+            gh issue create --title "${title}" --body "${body}"
+          fi
+
+      # The job goes red as well as leaving the issue. A red check is visible
+      # without opening a notification. It blocks nothing: this workflow is not
+      # a required context and cd.yml does not read it.
+      - name: Fail loudly
+        if: steps.check.outcome == 'failure'
+        run: |
+          echo "::error title=A commit on main carries no CI verdict::mainverdict refused. See the step above for which commits and why."
+          exit 1
+
+      # THE CLOSING HALF, WITHOUT WHICH THE ISSUE IS A PERMANENT SCAR. An alert
+      # that never clears is one people stop believing.
+      - name: Close the issue once main is whole again
+        if: steps.check.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          title="A commit on main carries no CI verdict"
+          existing=$(gh issue list --state open --search "\"${title}\" in:title" \
+            --json number --jq '.[0].number // empty')
+          if [ -n "${existing}" ]; then
+            gh issue close "${existing}" \
+              --comment "Every commit in the window now carries a CI verdict. Closed by ci-watch."
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,38 +8,59 @@ on:
   pull_request:
 
 # A second push cancels the first run on a BRANCH, because the answer about the
-# older commit stopped mattering the moment the newer one arrived. On main it
-# does not, and the reason is directly below.
+# older commit stopped mattering the moment the newer one arrived. On main
+# nothing supersedes anything, and the reason is directly below.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  # A run on main is the verdict a tag and a deploy are read against, so it
-  # is never cancelled. On a branch the saving is real and nothing depends
-  # on the superseded answer, so cancelling stays.
+  # EVERY COMMIT ON MAIN GETS ITS OWN GROUP. On a branch the group is the ref,
+  # unchanged, and cancelling the superseded run stays.
   #
-  # Six merges landed inside one run's length on 2026-09-02 and each cancelled
-  # the one before it, so main went from 09:07 to past 12:30 with no COMPLETED
-  # run at all. Cancelled is not red, but it is not a verdict either, and at
-  # the time `release.yml` had no gate of its own, so the only thing standing
-  # between an unverified commit and published binaries was somebody holding
-  # merges by hand.
+  # This was the ref alone, with `cancel-in-progress: false` doing the
+  # protecting on main and a comment here saying a run on main is never
+  # cancelled. That sentence was wrong, its own last paragraph said so thirty
+  # lines further down, and between the two of them the file both promised the
+  # protection and withdrew it.
   #
-  # `release.yml` has a gate now and it reads THIS workflow's conclusion, which
-  # makes this line matter more rather than less: the gate refuses a cancelled
-  # run, so a main run that never finished is a release that cannot be cut.
+  # `cancel-in-progress: false` protects a run that has STARTED and nothing
+  # else. GitHub holds exactly ONE pending run per concurrency group, so every
+  # new merge cancels the run queued behind the one in progress. On 2026-09-08
+  # four pull requests merged inside four minutes and the API recorded this:
   #
-  # There is no clause for tags here because this workflow does not run on
-  # one. The `on:` block above is a push to main and a pull request, and
-  # nothing else, so `refs/tags/` is a ref this expression is never evaluated
-  # against. The first version of this line excluded tags anyway, which read
-  # as protection and was a condition that could not be true.
+  #   09078be0  created 13:09:53  jobs started 13:12:57  in_progress
+  #   39a771ff  created 13:13:15  NO JOBS AT ALL         cancelled 13:13:51
+  #   f5e2ef68  created 13:13:50  NO JOBS AT ALL         cancelled 13:14:23
+  #   822584fa  created 13:14:22  no jobs yet            pending
   #
-  # What this does NOT buy, so nobody reads more into it than it does: a run
-  # that has already STARTED is never cancelled, and that is the whole of it.
-  # GitHub still cancels a run that is merely PENDING when a newer one queues
-  # behind the same in progress run. So the newest commit always reaches a
-  # verdict, which is what a tag and a deploy are read against, and commits in
-  # between a burst of merges still get skipped. Every commit reaching a
-  # verdict needs a merge queue, not a bigger timeout.
+  # Each cancellation lands one second after the NEXT run is created, and both
+  # cancelled runs carry an empty job list, so neither ran a single check. The
+  # same shape emptied main from 09:07 to past 12:30 on 2026-09-02, which is
+  # the incident the old comment was written about.
+  #
+  # The old comment concluded that every commit reaching a verdict "needs a
+  # merge queue". It does not. Keying the group on the commit gives each push to
+  # main a group of one, so no run supersedes another and no pending run is ever
+  # taken. security.yml reached this answer for its daily scan on 2026-09-05 by
+  # keying its group on the event, and nobody carried the idea back to the runs
+  # it was learned from. This is that.
+  #
+  # WHAT IT COSTS, stated here rather than discovered later: runner minutes. Six
+  # merges in a burst now run six full CI runs where two ran before, and past
+  # the account's concurrency limit they QUEUE. A queue is a delay. A cancelled
+  # pending run was a permanent hole in main's history, and a hole cannot be
+  # re-run into existence once the next merge has landed on top of it.
+  #
+  # There is no clause for tags because this workflow does not run on one. The
+  # `on:` block above is a push to main and a pull request and nothing else, so
+  # `refs/tags/` is a ref this expression is never evaluated against.
+  #
+  # `tools/mainverdict` is what notices when this stops working, and it is not
+  # decoration: a run can still be cancelled by hand, a job can still hit its
+  # own timeout-minutes, and this expression can be edited back by somebody who
+  # reads the group as noise.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || 'branch' }}
+  # Kept, and now the belt to the group's braces. On main the group holds one
+  # run, so there is nothing left to supersede and this decides nothing; it
+  # stays false to say what must happen if the group is ever narrowed back. On a
+  # branch it is the whole of the saving.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 # Read, and only read. No job in this workflow writes anything back, and a

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,9 +32,17 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Same reasoning as `security.yml`: a run on main is the verdict the security
-  # tab is read against, so it is never cancelled. On a branch nothing depends
-  # on the superseded answer, so cancelling stays.
+  # Same reasoning as `security.yml`: a run that has already STARTED on main is
+  # never cancelled, because the security tab is read against it. On a branch
+  # nothing depends on the superseded answer, so cancelling stays.
+  #
+  # GitHub still cancels a merely PENDING run when a newer one queues behind the
+  # one in progress, so a burst of merges to main skips the analyses in the
+  # middle of it. That is accepted here and it is not accepted in ci.yml, which
+  # keys its group on the commit for exactly this reason. The difference is what
+  # the missing answer costs: a skipped CI run leaves a commit that can never be
+  # released from, while a skipped analysis leaves the security tab reporting
+  # the commit before it, and the next push to main brings it forward again.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 # Read at the top level. The one job that needs to write does so below, which

--- a/.github/workflows/crosslint.yml
+++ b/.github/workflows/crosslint.yml
@@ -34,30 +34,35 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # A run on main is the verdict a tag and a deploy are read against, so it
-  # is never cancelled. On a branch the saving is real and nothing depends
-  # on the superseded answer, so cancelling stays.
+  # A run that has already STARTED on main is never cancelled, and that is the
+  # whole of what this line buys. On a branch the saving is real and nothing
+  # depends on the superseded answer, so cancelling stays.
   #
   # Six merges landed inside one run's length on 2026-09-02 and each cancelled
   # the one before it, so main went from 09:07 to past 12:30 with no COMPLETED
-  # run at all. Cancelled is not red, but it is not a verdict either, and
-  # `release.yml` had no gate of its own, so the only thing standing between
-  # an unverified commit and published binaries was somebody holding merges
-  # by hand.
+  # run at all. Cancelled is not red, but it is not a verdict either.
+  #
+  # GitHub still cancels a run that is merely PENDING when a newer one queues
+  # behind the same in progress run, so a burst of merges still costs the push
+  # runs in the middle of it. This comment used to close by saying that every
+  # commit reaching a verdict needs a merge queue. That was wrong, and ci.yml
+  # says what it costs instead: keying the group on the commit gives each push
+  # to main a group of one, and the four merges on 2026-09-08 recorded there
+  # are the measurement.
+  #
+  # THIS WORKFLOW DELIBERATELY DOES NOT DO THE SAME, and the difference is
+  # whether anything reads a per commit conclusion from it. Nothing reads one
+  # from this: `tools/cigate` and `cd.yml` both gate on ci.yml, and
+  # `tools/mainverdict` watches ci.yml alone. A push run skipped here is an
+  # answer nobody was going to ask for, and the next push covers the same tree
+  # plus a change. A CI run skipped there was the only verdict that commit
+  # could ever have had.
   #
   # There is no clause for tags here because this workflow does not run on
   # one. The `on:` block above is a push to main and a pull request, and
   # nothing else, so `refs/tags/` is a ref this expression is never evaluated
   # against. The first version of this line excluded tags anyway, which read
   # as protection and was a condition that could not be true.
-  #
-  # What this does NOT buy, so nobody reads more into it than it does: a run
-  # that has already STARTED is never cancelled, and that is the whole of it.
-  # GitHub still cancels a run that is merely PENDING when a newer one queues
-  # behind the same in progress run. So the newest commit always reaches a
-  # verdict, which is what a tag and a deploy are read against, and commits in
-  # between a burst of merges still get skipped. Every commit reaching a
-  # verdict needs a merge queue, not a bigger timeout.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/.github/workflows/keyring.yml
+++ b/.github/workflows/keyring.yml
@@ -28,30 +28,35 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # A run on main is the verdict a tag and a deploy are read against, so it
-  # is never cancelled. On a branch the saving is real and nothing depends
-  # on the superseded answer, so cancelling stays.
+  # A run that has already STARTED on main is never cancelled, and that is the
+  # whole of what this line buys. On a branch the saving is real and nothing
+  # depends on the superseded answer, so cancelling stays.
   #
   # Six merges landed inside one run's length on 2026-09-02 and each cancelled
   # the one before it, so main went from 09:07 to past 12:30 with no COMPLETED
-  # run at all. Cancelled is not red, but it is not a verdict either, and
-  # `release.yml` had no gate of its own, so the only thing standing between
-  # an unverified commit and published binaries was somebody holding merges
-  # by hand.
+  # run at all. Cancelled is not red, but it is not a verdict either.
+  #
+  # GitHub still cancels a run that is merely PENDING when a newer one queues
+  # behind the same in progress run, so a burst of merges still costs the push
+  # runs in the middle of it. This comment used to close by saying that every
+  # commit reaching a verdict needs a merge queue. That was wrong, and ci.yml
+  # says what it costs instead: keying the group on the commit gives each push
+  # to main a group of one, and the four merges on 2026-09-08 recorded there
+  # are the measurement.
+  #
+  # THIS WORKFLOW DELIBERATELY DOES NOT DO THE SAME, and the difference is
+  # whether anything reads a per commit conclusion from it. Nothing reads one
+  # from this: `tools/cigate` and `cd.yml` both gate on ci.yml, and
+  # `tools/mainverdict` watches ci.yml alone. A push run skipped here is an
+  # answer nobody was going to ask for, and the next push covers the same tree
+  # plus a change. A CI run skipped there was the only verdict that commit
+  # could ever have had.
   #
   # There is no clause for tags here because this workflow does not run on
   # one. The `on:` block above is a push to main and a pull request, and
   # nothing else, so `refs/tags/` is a ref this expression is never evaluated
   # against. The first version of this line excluded tags anyway, which read
   # as protection and was a condition that could not be true.
-  #
-  # What this does NOT buy, so nobody reads more into it than it does: a run
-  # that has already STARTED is never cancelled, and that is the whole of it.
-  # GitHub still cancels a run that is merely PENDING when a newer one queues
-  # behind the same in progress run. So the newest commit always reaches a
-  # verdict, which is what a tag and a deploy are read against, and commits in
-  # between a burst of merges still get skipped. Every commit reaching a
-  # verdict needs a merge queue, not a bigger timeout.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 # Read, and only read. Every action is pinned to a commit rather than a tag,

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -38,30 +38,34 @@ concurrency:
   # skip a pending push run, which is the accepted trade below, and it can no
   # longer touch the daily one.
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'schedule' && 'schedule' || 'change' }}
-  # A run on main is the verdict a tag and a deploy are read against, so it
-  # is never cancelled. On a branch the saving is real and nothing depends
-  # on the superseded answer, so cancelling stays.
+  # A run that has already STARTED on main is never cancelled, and that is the
+  # whole of what this line buys. On a branch the saving is real and nothing
+  # depends on the superseded answer, so cancelling stays.
   #
   # Six merges landed inside one run's length on 2026-09-02 and each cancelled
   # the one before it, so main went from 09:07 to past 12:30 with no COMPLETED
-  # run at all. Cancelled is not red, but it is not a verdict either, and
-  # `release.yml` had no gate of its own, so the only thing standing between
-  # an unverified commit and published binaries was somebody holding merges
-  # by hand.
+  # run at all. Cancelled is not red, but it is not a verdict either.
+  #
+  # GitHub still cancels a run that is merely PENDING when a newer one queues
+  # behind the same in progress run, so a burst of merges still costs the push
+  # runs in the middle of it. ci.yml no longer accepts that cost: it keys its
+  # group on the commit, which gives each push to main a group of one, and a
+  # comment there records the four merges on 2026-09-08 that measured it.
+  #
+  # THIS WORKFLOW DELIBERATELY DOES NOT DO THE SAME, and the difference is what
+  # reads the run rather than what produces it. `security-watch` measures the
+  # SCHEDULED scan and refuses to accept a push run as a substitute, so a push
+  # run skipped here is an answer nobody was going to read, while a CI run
+  # skipped there was the only verdict that commit could ever have had. The
+  # scheduled scan is protected by its own group above, which is the half that
+  # mattered. Widening this to a group per commit would multiply the daily
+  # runner cost of a vulnerability scan for an answer with no reader.
   #
   # There is no clause for tags here because this workflow does not run on
   # one. The `on:` block above is a push to main and a pull request, and
   # nothing else, so `refs/tags/` is a ref this expression is never evaluated
   # against. The first version of this line excluded tags anyway, which read
   # as protection and was a condition that could not be true.
-  #
-  # What this does NOT buy, so nobody reads more into it than it does: a run
-  # that has already STARTED is never cancelled, and that is the whole of it.
-  # GitHub still cancels a run that is merely PENDING when a newer one queues
-  # behind the same in progress run. So the newest commit always reaches a
-  # verdict, which is what a tag and a deploy are read against, and commits in
-  # between a burst of merges still get skipped. Every commit reaching a
-  # verdict needs a merge queue, not a bigger timeout.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 # Read, and only read. Same reasoning as CI: nothing here writes back, and every

--- a/.gitignore
+++ b/.gitignore
@@ -157,6 +157,7 @@ runner/artifacts/
 /licensegen
 /lintcheck
 /lintgen
+/mainverdict
 /manifestcheck
 /modecheck
 /motioncheck

--- a/justfile
+++ b/justfile
@@ -858,6 +858,32 @@ check-tls:
 check-origins:
     go run ./tools/origincheck all --api https://app.antifailure.dev
 
+# Every recent commit on main carries a CI verdict, meaning a run that
+# COMPLETED and concluded something about it.
+#
+# Not in `just gate`, for the same reason as `check-tls` and `check-origins`.
+# Its answer is not a function of the tree: it asks the GitHub API what CI
+# concluded on each of main's last commits, so the same commit is clean this
+# hour and not clean the next time somebody cancels a run. It needs the network,
+# which `just gate` must not, and a token, which a contributor may not have.
+#
+# It exits 2, not 0, when the run history it read does not reach as far back as
+# the commits it was asked about. A check that reports success for a question it
+# never asked is the defect this repository keeps finding in its own
+# instruments, and here it would report a whole branch clean on having read the
+# top of it.
+#
+# `success` and `failure` both PASS. A red main is already the loudest thing in
+# the repository and a second instrument shouting about it teaches people to
+# silence both. What this catches is the silent one: `cancelled` and `skipped`
+# render in a list exactly as a pass does, and on 2026-09-08 two commits landed
+# on main with cancelled runs that had started no jobs at all.
+#
+# It runs unattended in .github/workflows/ci-watch.yml, on every completed CI
+# run on main and daily. Look further back with -window.
+mainverdict:
+    go run ./tools/mainverdict -repo antifailure/antifailure -branch main
+
 # The getting started path, run in order and timed.
 #
 # Not in `just gate`. It needs a Docker daemon and it takes minutes, because it

--- a/tools/cigate/main.go
+++ b/tools/cigate/main.go
@@ -33,12 +33,20 @@
 // of them is a verdict about the commit, and a thing that is not a verdict is
 // not a pass.
 //
-// ci.yml no longer cancels a superseded run on main or on a tag, and the reason
-// it was changed is this one: six merges landed inside one run's length on
-// 2026-09-02 and each cancelled the one before it, so main went hours with no
-// completed run and no commit a release could have been cut from. Superseding
-// is still why the word appears on a branch. On main it now means something
-// else, and something worth reading before re-running anything.
+// SUPERSEDING IS NOW THE ONE CAUSE THIS CANNOT BE, and that took two goes to
+// arrange. ci.yml stopped cancelling a RUNNING run on main after 2026-09-02,
+// when six merges landed inside one run's length and each cancelled the one
+// before it, leaving main with no commit a release could have been cut from.
+// That was only half of it: GitHub holds exactly one PENDING run per
+// concurrency group, so on 2026-09-08 four merges inside four minutes still
+// left two commits with runs that were cancelled before a single job started.
+// ci.yml now keys its group on the commit for a push to main, so no main run
+// can supersede another at all.
+//
+// So a cancelled run on main is worth reading rather than assuming: what is
+// left is a run somebody stopped by hand, a job that hit its own
+// timeout-minutes, and the concurrency expression having been edited back.
+// Superseding is still why the word appears on a branch.
 //
 // `skipped` refuses for the same reason and is easier to get wrong, because a
 // skipped run and a passing run render as the same absence of red in a list. A
@@ -148,8 +156,10 @@ var refusals = map[string]string{
 	"cancelled": "CI on this commit was cancelled, so it never reached a verdict. Several " +
 		"unrelated things are spelled that way: a job that hit its own timeout-minutes, a run " +
 		"somebody stopped by hand, and a run superseded by a newer push on the same branch. " +
-		"None of them says the commit is good. ci.yml no longer cancels a superseded run on " +
-		"main or on a tag, so a cancelled run here is worth reading rather than assuming. " +
+		"None of them says the commit is good. ci.yml gives each push to main its own " +
+		"concurrency group, so superseding is the one cause this cannot be on main, and a " +
+		"cancelled run here is worth reading rather than assuming. Check whether the " +
+		"concurrency group in ci.yml still carries the commit. " +
 		"Re-run CI on this commit, and re-run this release once it is green.",
 	"timed_out":       "CI on this commit ran out of time and never reached a verdict.",
 	"startup_failure": "CI on this commit never started, so nothing was checked.",

--- a/tools/gatecheck/main.go
+++ b/tools/gatecheck/main.go
@@ -557,6 +557,23 @@ func uncalledByGate(recipes []recipe, reachable map[string]bool) []string {
 		// is the moment a lapsed certificate is worth knowing about. Run it by
 		// hand with `just check-tls`.
 		"check-tls": true,
+		// Whether every recent commit on main carries a CI verdict. Out for
+		// the same reason as check-tls: its answer is not a function of the
+		// tree. It asks the GitHub API what CI concluded on each of main's
+		// last commits, so the same commit is clean this hour and not clean
+		// the next time somebody cancels a run, and it needs both the network
+		// and a token. It runs in ci-watch.yml on every completed CI run on
+		// main and daily, which is where a watchdog over a branch's history
+		// belongs. It gets no exemptFromGate entry because ci-watch.yml does
+		// not run on pull requests, so it is not a gate this comparison sees
+		// on the CI side at all, and an exemption naming it would be reported
+		// stale. What IS a function of the tree is every decision the command
+		// makes, and `go test ./tools/mainverdict` covers that inside
+		// `just test-tools`, which `gate` runs: every conclusion GitHub can
+		// report, the two that are verdicts and the eight that are not, a
+		// running commit inside and outside the grace, and a commit past the
+		// edge of the page reported as unread rather than as clean.
+		"mainverdict": true,
 		// The deployed route contract. The same shape as check-tls and out for
 		// the same reason: its answer is not a function of the tree. It asks
 		// the control plane that is running right now whether it serves the

--- a/tools/mainverdict/main.go
+++ b/tools/mainverdict/main.go
@@ -82,9 +82,16 @@ const (
 	// than adding one. When it does not reach, the answer is `could not look`
 	// rather than a quiet pass.
 	runsPerPage = 100
+	// The commit list is fetched wider than the window and then walked down the
+	// first parents, so this is the ceiling on that widening rather than the
+	// number of commits judged.
+	commitsPerPage = 100
 )
 
 // commit is the part of a commit this reasons about.
+//
+// Parents is here for one reason, and it is a correctness one rather than a
+// completeness one. See firstParents.
 type commit struct {
 	SHA    string `json:"sha"`
 	Commit struct {
@@ -92,6 +99,53 @@ type commit struct {
 			Date time.Time `json:"date"`
 		} `json:"committer"`
 	} `json:"commit"`
+	Parents []struct {
+		SHA string `json:"sha"`
+	} `json:"parents"`
+}
+
+// firstParents reduces a commit list to the branch's own line of descent,
+// newest first, and stops at `window` or at the edge of what was fetched.
+//
+// WHY THIS IS NOT TIDYING. `/repos/{repo}/commits?sha=main` is `git log`, not
+// `git log --first-parent`: it returns every commit REACHABLE from the branch,
+// in date order, so a real merge commit on main drags the whole merged
+// branch's history into the window. Those commits were never pushed to main,
+// so no push run on main ever judged them, and this command would report each
+// one as a commit nothing ever checked. Every one of those refusals would be
+// false, and a watchdog that cries wolf is the one thing worse here than no
+// watchdog: it gets muted, and then the real hole is silent again.
+//
+// This repository squash merges through `just merge`, so main's top is linear
+// today and this changes nothing about it. It is not linear further down: the
+// first 200 commits reachable from main differ from its first 200 first
+// parents, so the shape this guards against is already in this history rather
+// than hypothetical.
+func firstParents(commits []commit, window int) []commit {
+	if len(commits) == 0 {
+		return nil
+	}
+	bySHA := make(map[string]commit, len(commits))
+	for _, c := range commits {
+		bySHA[c.SHA] = c
+	}
+	out := make([]commit, 0, window)
+	// The API returns the branch head first, and that is the only commit this
+	// takes on trust from the ordering. Everything after it is reached by
+	// following the first parent, which is a link in the data rather than a
+	// position in a list.
+	cur, ok := bySHA[commits[0].SHA]
+	for ok && len(out) < window {
+		out = append(out, cur)
+		if len(cur.Parents) == 0 {
+			break
+		}
+		// Past the edge of what was fetched, this stops rather than guessing.
+		// Judging fewer commits than asked for is a smaller lie than judging a
+		// commit that is not on this branch's line at all.
+		cur, ok = bySHA[cur.Parents[0].SHA]
+	}
+	return out
 }
 
 // run is the part of a workflow run this reasons about.
@@ -387,8 +441,16 @@ func (a *api) get(path string, into any) error {
 // refusing, and a gate that has never been seen to pass is not a gate anybody
 // should trust.
 func (a *api) commits(from string, window int) ([]commit, error) {
+	// More than the window, because the list is date ordered and firstParents
+	// then walks it. A merge commit on the line puts commits in this response
+	// that are not on it, so asking for exactly `window` would leave the walk
+	// short by however many of them there were.
+	fetch := window * 4
+	if fetch > commitsPerPage {
+		fetch = commitsPerPage
+	}
 	var out []commit
-	err := a.get(fmt.Sprintf("/repos/%s/commits?sha=%s&per_page=%d", a.repo, from, window), &out)
+	err := a.get(fmt.Sprintf("/repos/%s/commits?sha=%s&per_page=%d", a.repo, from, fetch), &out)
 	return out, err
 }
 
@@ -457,10 +519,11 @@ func main() {
 	if start == "" {
 		start = *branch
 	}
-	commits, err := c.commits(start, *window)
+	fetched, err := c.commits(start, *window)
 	if err != nil {
 		fail("reading the commits at %s: %v", start, err)
 	}
+	commits := firstParents(fetched, *window)
 	runs, truncated, err := c.runs(*branch, *workflow)
 	if err != nil {
 		fail("reading the runs on %s: %v", *branch, err)

--- a/tools/mainverdict/main.go
+++ b/tools/mainverdict/main.go
@@ -1,0 +1,523 @@
+// Command mainverdict refuses a main branch carrying commits CI never judged.
+//
+// WHY THIS EXISTS. On 2026-09-08 four pull requests merged inside four minutes
+// and two of the four commits ended with no CI verdict at all. `822584fa` and
+// `09078be0` ran. `39a771ff` and `f5e2ef68` were cancelled before a single job
+// started, and the API confirms it: both runs carry an empty job list and both
+// were cancelled within one second of the NEXT run being created.
+//
+//	09078be0  created 13:09:53  jobs started 13:12:57  in_progress
+//	39a771ff  created 13:13:15  no jobs             cancelled 13:13:51
+//	f5e2ef68  created 13:13:50  no jobs             cancelled 13:14:23
+//	822584fa  created 13:14:22  no jobs yet         pending
+//
+// `cancel-in-progress: false` protects a run that has STARTED and nothing else.
+// GitHub holds exactly one pending run per concurrency group, so each merge
+// cancelled the one queued behind the in progress run. ci.yml now keys its
+// group on the commit for a push to main, so no main run can supersede another
+// and this shape cannot recur from the concurrency group. It can still happen
+// three other ways: somebody cancels a run by hand, a job hits its own
+// timeout-minutes, and the concurrency expression gets edited back.
+//
+// WHAT IT REFUSES, AND WHAT IT DELIBERATELY DOES NOT. This asks one question:
+// does every recent commit on main carry a COMPLETED CI verdict? A commit whose
+// run concluded `failure` HAS one, and this says so and passes it, because a red
+// main is already the loudest thing in the repository and a second instrument
+// shouting about it teaches people to silence both. The gap this closes is the
+// silent one: `cancelled` and `skipped` render in a list as an absence of red,
+// which is what a pass renders as too.
+//
+// THE THREE ANSWERS, and the exit code each leaves.
+//
+//	0  pass            every commit in the window carries a verdict
+//	1  refuse          at least one does not, and it is named
+//	2  could not look  the run list does not reach as far back as the window
+//
+// The third is not a pass wearing a different word. This reads the branch's
+// runs in one page and joins them to the commit list; when the page does not
+// reach the oldest commit asked about, the commits past its edge are unjudged
+// by this command rather than clean, and reporting them clean would be the
+// exact defect this repository keeps finding in its own instruments. Widen the
+// page or narrow the window, and it will answer.
+//
+// WHY IT READS PUSH RUNS ON THE BRANCH. A squash merge creates a commit that
+// existed nowhere before, so the pull request's own runs are about a different
+// sha and cannot stand in for it. The run that judges a main commit is the push
+// run on main, and this filters to exactly that: event `push`, branch `main`,
+// workflow path `.github/workflows/ci.yml`. Filtering by the workflow's `name:`
+// instead would follow a string anybody can change in the pull request that
+// changes what CI does; the path is the field that does not move.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"sort"
+	"strings"
+	"time"
+)
+
+// The workflow whose conclusion decides this, named by the file that produced
+// the run. Same constant and same reasoning as tools/cigate.
+const ciWorkflow = ".github/workflows/ci.yml"
+
+const (
+	defaultWindow = 20
+	// Sized against how long CI actually takes on this repository rather than
+	// against how long it ought to. The engine job alone runs about fourteen
+	// minutes, twelve jobs queue behind every other branch in flight, and a
+	// main run measured on 2026-09-08 took fifty five minutes end to end. A
+	// grace shorter than the slowest real run turns a busy night into a false
+	// alarm, and a watchdog that cries on a busy night is one people learn to
+	// ignore.
+	defaultGrace = 90 * time.Minute
+	// One page. Twenty commits of window against a hundred runs of history is
+	// four runs per commit before the page can fail to reach, and a commit
+	// carries one push run plus its re-runs, which keep the same object rather
+	// than adding one. When it does not reach, the answer is `could not look`
+	// rather than a quiet pass.
+	runsPerPage = 100
+)
+
+// commit is the part of a commit this reasons about.
+type commit struct {
+	SHA    string `json:"sha"`
+	Commit struct {
+		Committer struct {
+			Date time.Time `json:"date"`
+		} `json:"committer"`
+	} `json:"commit"`
+}
+
+// run is the part of a workflow run this reasons about.
+type run struct {
+	ID         int64     `json:"id"`
+	Path       string    `json:"path"`
+	HeadSHA    string    `json:"head_sha"`
+	Status     string    `json:"status"`
+	Conclusion string    `json:"conclusion"`
+	HTMLURL    string    `json:"html_url"`
+	CreatedAt  time.Time `json:"created_at"`
+	Event      string    `json:"event"`
+	HeadBranch string    `json:"head_branch"`
+}
+
+type runList struct {
+	// TotalCount is what says whether the page reached the end of the history
+	// or stopped at the edge of one page.
+	TotalCount int   `json:"total_count"`
+	Runs       []run `json:"workflow_runs"`
+}
+
+// answer is what this command knows about one commit, and about the branch.
+type answer int
+
+const (
+	pass answer = iota
+	waiting
+	refuse
+	couldNotLook
+)
+
+func (a answer) String() string {
+	switch a {
+	case pass:
+		return "pass"
+	case waiting:
+		return "waiting"
+	case refuse:
+		return "refuse"
+	default:
+		return "could not look"
+	}
+}
+
+// finding is one commit and what CI said about it.
+type finding struct {
+	SHA    string
+	Answer answer
+	Why    string
+	URL    string
+}
+
+// verdicts are the conclusions that ARE an answer about the commit. Both of
+// them: a red commit was judged, and the judgement was no.
+//
+// Every other conclusion GitHub can report is the absence of a judgement, and
+// listing the two rather than the eight is deliberate. A conclusion GitHub has
+// not invented yet arrives here as a word this map does not carry and is
+// treated as no verdict, which is the safe direction: the alternative is a new
+// word being read as a pass by a command that has never seen it.
+var verdicts = map[string]string{
+	"success": "CI passed",
+	"failure": "CI failed, which is a verdict and is not this command's business",
+}
+
+// noVerdict maps each conclusion that leaves a commit unjudged to the sentence
+// that points at its actual cause.
+var noVerdict = map[string]string{
+	"cancelled": "CI was cancelled, so this commit was never judged. On this repository " +
+		"that has meant a run cancelled while merely PENDING, because GitHub holds one " +
+		"pending run per concurrency group and the next merge takes its place. It also " +
+		"means a run somebody stopped by hand.",
+	"timed_out":       "CI ran out of time on this commit and reached no conclusion about it.",
+	"startup_failure": "CI never started on this commit, so nothing was checked.",
+	"stale":           "CI on this commit is stale: GitHub discarded the result without a verdict.",
+	"action_required": "CI on this commit is waiting on a human and has not passed.",
+	"neutral":         "CI on this commit concluded neutral, which is not a verdict.",
+	"skipped": "CI on this commit was skipped. A skipped run and a passing run look the same " +
+		"in a list and mean opposite things: nothing ran, so nothing was checked.",
+	"": "CI reports this commit as completed with no conclusion at all.",
+}
+
+// decide is the whole of the judgement, kept away from the network so a test
+// can hand it a branch in any state without arranging a repository.
+//
+// It returns the overall answer and a finding per commit, newest first, in the
+// order the commits were given.
+func decide(commits []commit, runs []run, workflow string, grace time.Duration, now time.Time, truncated bool) (answer, []finding, string) {
+	if len(commits) == 0 {
+		return couldNotLook, nil, "no commits came back for this branch, so there was nothing to judge. " +
+			"That is not a clean branch, it is an unread one."
+	}
+
+	// Newest first per commit, and sorted here rather than trusted from the
+	// response. The endpoint does return runs newest first today, and a check
+	// whose correctness rests on an ordering nobody promised in writing is a
+	// check that breaks on the day the answer matters. Same reasoning as
+	// tools/cigate, and the same shape.
+	byCommit := map[string][]run{}
+	oldestRun := time.Time{}
+	for _, r := range runs {
+		if r.Path != workflow {
+			continue
+		}
+		byCommit[r.HeadSHA] = append(byCommit[r.HeadSHA], r)
+		if oldestRun.IsZero() || r.CreatedAt.Before(oldestRun) {
+			oldestRun = r.CreatedAt
+		}
+	}
+	for sha := range byCommit {
+		rs := byCommit[sha]
+		sort.SliceStable(rs, func(i, j int) bool {
+			if !rs[i].CreatedAt.Equal(rs[j].CreatedAt) {
+				return rs[i].CreatedAt.After(rs[j].CreatedAt)
+			}
+			return rs[i].ID > rs[j].ID
+		})
+	}
+
+	// THE EDGE OF THE PAGE, and the reason this command has a third answer.
+	// A commit older than the oldest run on the page is a commit whose run may
+	// simply be on the next page. Reporting it as having no run would be this
+	// command inventing a hole; reporting it as fine would be it inventing a
+	// verdict. Neither is available, so it says it could not look.
+	unreachable := func(c commit) bool {
+		if !truncated || oldestRun.IsZero() {
+			return false
+		}
+		return c.Commit.Committer.Date.Before(oldestRun)
+	}
+
+	var findings []finding
+	worst := pass
+	for _, c := range commits {
+		f := finding{SHA: c.SHA}
+		rs := byCommit[c.SHA]
+		age := now.Sub(c.Commit.Committer.Date)
+		switch {
+		case len(rs) == 0 && unreachable(c):
+			f.Answer, f.Why = couldNotLook, fmt.Sprintf(
+				"no run for this commit on the page that was read, and the page does not "+
+					"reach back this far. Ask for more runs or a shorter window.")
+		case len(rs) == 0 && age < grace:
+			f.Answer, f.Why = waiting, fmt.Sprintf(
+				"no CI run yet, and this commit is only %s old, which is inside the %s grace.",
+				short(age), short(grace))
+		case len(rs) == 0:
+			f.Answer, f.Why = refuse, fmt.Sprintf(
+				"no CI run on this commit at all, %s after it landed. A commit on this branch "+
+					"with no run is a commit nothing ever checked.", short(age))
+		default:
+			latest := rs[0]
+			f.URL = latest.HTMLURL
+			switch {
+			case latest.Status != "completed" && age < grace:
+				f.Answer, f.Why = waiting, fmt.Sprintf("CI is %s, %s after the commit landed.",
+					statusWords(latest.Status), short(age))
+			case latest.Status != "completed":
+				f.Answer, f.Why = refuse, fmt.Sprintf(
+					"CI is still %s %s after the commit landed, past the %s grace. It has "+
+						"reached no verdict and at this age it is not going to.",
+					statusWords(latest.Status), short(age), short(grace))
+			default:
+				if why, isVerdict := verdicts[latest.Conclusion]; isVerdict {
+					f.Answer, f.Why = pass, why+"."
+				} else if why, known := noVerdict[latest.Conclusion]; known {
+					f.Answer, f.Why = refuse, why
+				} else {
+					f.Answer, f.Why = refuse, fmt.Sprintf(
+						"CI concluded %q on this commit, which is not a word this command "+
+							"recognises, and an unfamiliar answer is not a verdict.", latest.Conclusion)
+				}
+			}
+		}
+		findings = append(findings, f)
+		if rank(f.Answer) > rank(worst) {
+			worst = f.Answer
+		}
+	}
+
+	return worst, findings, summary(worst, findings)
+}
+
+// rank orders the answers by how badly this command wants to stop. `waiting` is
+// below `pass` on purpose: a branch whose newest commit is still running is not
+// worse than a clean one, it is a clean one with the newest answer outstanding,
+// and the overall exit code must not move for it.
+func rank(a answer) int {
+	switch a {
+	case refuse:
+		return 3
+	case couldNotLook:
+		return 2
+	case pass:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func summary(worst answer, findings []finding) string {
+	var refused, unread, held int
+	for _, f := range findings {
+		switch f.Answer {
+		case refuse:
+			refused++
+		case couldNotLook:
+			unread++
+		case waiting:
+			held++
+		}
+	}
+	switch worst {
+	case refuse:
+		return fmt.Sprintf("%d of %d commits on this branch carry no CI verdict. A commit with "+
+			"no verdict cannot be released from, was never deployed, and makes a red on a later "+
+			"commit ambiguous across every commit behind it.", refused, len(findings))
+	case couldNotLook:
+		return fmt.Sprintf("%d of %d commits could not be judged, because the run history read "+
+			"does not reach them. This is not a pass.", unread, len(findings))
+	default:
+		if held > 0 {
+			return fmt.Sprintf("every commit on this branch carries a CI verdict, or is new "+
+				"enough to still be earning one (%d of %d).", held, len(findings))
+		}
+		return fmt.Sprintf("every one of the %d commits read on this branch carries a CI verdict.", len(findings))
+	}
+}
+
+// statusWords turns the API's own status into something readable without
+// pretending to know statuses it does not.
+func statusWords(status string) string {
+	switch status {
+	case "queued", "pending", "waiting", "requested":
+		return status + " and has not started"
+	case "in_progress":
+		return "still running"
+	default:
+		return status
+	}
+}
+
+// short prints a duration in the units a person reads at three in the morning.
+func short(d time.Duration) string {
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	default:
+		return fmt.Sprintf("%dh%02dm", int(d.Hours()), int(d.Minutes())%60)
+	}
+}
+
+type api struct {
+	base  string
+	repo  string
+	token string
+	http  *http.Client
+}
+
+func (a *api) get(path string, into any) error {
+	req, err := http.NewRequest(http.MethodGet, a.base+path, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if a.token != "" {
+		req.Header.Set("Authorization", "Bearer "+a.token)
+	}
+	resp, err := a.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("the API answered %d for %s: %s", resp.StatusCode, path, strings.TrimSpace(string(body)))
+	}
+	return json.Unmarshal(body, into)
+}
+
+// commits reads the window, starting at `from`. That is the branch in every
+// unattended run and a commit when somebody is pointing this at a stretch of
+// history on purpose, which is the only way to express a POSITIVE control
+// against a branch that currently carries a hole: a window from the head always
+// includes the hole, so without this the command could only ever be watched
+// refusing, and a gate that has never been seen to pass is not a gate anybody
+// should trust.
+func (a *api) commits(from string, window int) ([]commit, error) {
+	var out []commit
+	err := a.get(fmt.Sprintf("/repos/%s/commits?sha=%s&per_page=%d", a.repo, from, window), &out)
+	return out, err
+}
+
+// runs reads one page of this workflow's push runs on the branch, newest first,
+// and reports whether the history is longer than the page.
+//
+// ASKING THE WORKFLOW'S OWN ENDPOINT IS NOT A TIDYING UP, it is the difference
+// between reading twenty commits of history and reading eight. The repository
+// wide `/actions/runs` returns every workflow's runs interleaved, and this
+// repository runs nine of them on a push to main: one page of a hundred carried
+// thirteen CI runs and reached back seven hours. The same page from
+// `/actions/workflows/ci.yml/runs` carries a hundred CI runs and reaches back
+// three days. Against the wide endpoint the default window of twenty commits
+// would have fallen off the edge of the page and answered `could not look`
+// every time, which is honest and useless.
+//
+// The endpoint takes the workflow's FILE NAME, and the path is filtered again
+// in decide. Two checks of the same thing on purpose: the file name is what the
+// route accepts, the path is the field on the run, and if either ever names
+// something else the mismatch is an empty result rather than another
+// workflow's verdict standing in for CI's.
+func (a *api) runs(branch, workflow string) ([]run, bool, error) {
+	var list runList
+	err := a.get(fmt.Sprintf("/repos/%s/actions/workflows/%s/runs?branch=%s&event=push&per_page=%d",
+		a.repo, path.Base(workflow), branch, runsPerPage), &list)
+	if err != nil {
+		return nil, false, err
+	}
+	return list.Runs, list.TotalCount > len(list.Runs), nil
+}
+
+func main() {
+	repo := flag.String("repo", os.Getenv("GITHUB_REPOSITORY"), "owner/name")
+	branch := flag.String("branch", "main", "the branch whose commits must each carry a verdict")
+	from := flag.String("from", "", "the commit to start the window at, defaulting to the branch head")
+	workflow := flag.String("workflow", ciWorkflow, "the workflow whose conclusion decides this")
+	window := flag.Int("window", defaultWindow, "how many commits back to read")
+	grace := flag.Duration("grace", defaultGrace, "how long a commit may go without a verdict before that is a refusal")
+	base := flag.String("api", "https://api.github.com", "the API root")
+	flag.Parse()
+
+	if *repo == "" {
+		fail("mainverdict needs a repository. Pass -repo or set GITHUB_REPOSITORY.")
+	}
+	if *window < 1 {
+		fail("a window of %d commits asks about nothing at all.", *window)
+	}
+
+	token := os.Getenv("GH_TOKEN")
+	if token == "" {
+		token = os.Getenv("GITHUB_TOKEN")
+	}
+	if token == "" {
+		// Refused rather than attempted, for the reason tools/cigate refuses:
+		// unauthenticated the API hides runs and rate limits hard, so the likely
+		// result is an empty list, which would read here as a branch of commits
+		// nothing ever ran. That is a false alarm, and a watchdog that cries
+		// wolf about its own token is one people turn off.
+		fail("mainverdict has no token. Set GH_TOKEN or GITHUB_TOKEN to a token that can " +
+			"read actions on this repository, which in a workflow means permissions: actions: read.")
+	}
+
+	c := &api{base: *base, repo: *repo, token: token, http: &http.Client{Timeout: 30 * time.Second}}
+
+	start := *from
+	if start == "" {
+		start = *branch
+	}
+	commits, err := c.commits(start, *window)
+	if err != nil {
+		fail("reading the commits at %s: %v", start, err)
+	}
+	runs, truncated, err := c.runs(*branch, *workflow)
+	if err != nil {
+		fail("reading the runs on %s: %v", *branch, err)
+	}
+
+	worst, findings, why := decide(commits, runs, *workflow, *grace, time.Now().UTC(), truncated)
+	report(os.Stdout, *repo, *branch, worst, findings, why)
+
+	switch worst {
+	case refuse:
+		fmt.Fprintf(os.Stderr, "::error title=A commit on %s carries no CI verdict::%s\n", *branch, why)
+		summarise(*branch, worst, findings, why)
+		os.Exit(1)
+	case couldNotLook:
+		fmt.Fprintf(os.Stderr, "::error title=mainverdict could not read far enough to answer::%s\n", why)
+		summarise(*branch, worst, findings, why)
+		os.Exit(2)
+	}
+	summarise(*branch, worst, findings, why)
+}
+
+func report(w io.Writer, repo, branch string, worst answer, findings []finding, why string) {
+	fmt.Fprintf(w, "mainverdict: %s on %s, %d commits read\n\n", repo, branch, len(findings))
+	for _, f := range findings {
+		mark := map[answer]string{pass: "ok    ", waiting: "wait  ", refuse: "NO    ", couldNotLook: "UNREAD"}[f.Answer]
+		fmt.Fprintf(w, "  %s %s  %s", mark, f.SHA[:min(8, len(f.SHA))], f.Why)
+		if f.URL != "" {
+			fmt.Fprintf(w, " %s", f.URL)
+		}
+		fmt.Fprintln(w)
+	}
+	fmt.Fprintf(w, "\nmainverdict: %s. %s\n", worst, why)
+}
+
+// summarise writes to the job summary when there is one. Best effort on
+// purpose: the verdict is the exit code, and a summary that could not be
+// written must never change it.
+func summarise(branch string, worst answer, findings []finding, why string) {
+	path := os.Getenv("GITHUB_STEP_SUMMARY")
+	if path == "" {
+		return
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0o644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	fmt.Fprintf(f, "### `%s`: %s\n\n%s\n\n", branch, worst, why)
+	for _, x := range findings {
+		if x.Answer == pass {
+			continue
+		}
+		fmt.Fprintf(f, "- `%s` %s %s\n", x.SHA[:min(8, len(x.SHA))], x.Why, x.URL)
+	}
+}
+
+func fail(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "mainverdict: "+format+"\n", args...)
+	os.Exit(2)
+}

--- a/tools/mainverdict/main.go
+++ b/tools/mainverdict/main.go
@@ -546,16 +546,16 @@ func main() {
 }
 
 func report(w io.Writer, repo, branch string, worst answer, findings []finding, why string) {
-	fmt.Fprintf(w, "mainverdict: %s on %s, %d commits read\n\n", repo, branch, len(findings))
+	_, _ = fmt.Fprintf(w, "mainverdict: %s on %s, %d commits read\n\n", repo, branch, len(findings))
 	for _, f := range findings {
 		mark := map[answer]string{pass: "ok    ", waiting: "wait  ", refuse: "NO    ", couldNotLook: "UNREAD"}[f.Answer]
-		fmt.Fprintf(w, "  %s %s  %s", mark, f.SHA[:min(8, len(f.SHA))], f.Why)
+		_, _ = fmt.Fprintf(w, "  %s %s  %s", mark, f.SHA[:min(8, len(f.SHA))], f.Why)
 		if f.URL != "" {
-			fmt.Fprintf(w, " %s", f.URL)
+			_, _ = fmt.Fprintf(w, " %s", f.URL)
 		}
-		fmt.Fprintln(w)
+		_, _ = fmt.Fprintln(w)
 	}
-	fmt.Fprintf(w, "\nmainverdict: %s. %s\n", worst, why)
+	_, _ = fmt.Fprintf(w, "\nmainverdict: %s. %s\n", worst, why)
 }
 
 // summarise writes to the job summary when there is one. Best effort on
@@ -570,13 +570,13 @@ func summarise(branch string, worst answer, findings []finding, why string) {
 	if err != nil {
 		return
 	}
-	defer f.Close()
-	fmt.Fprintf(f, "### `%s`: %s\n\n%s\n\n", branch, worst, why)
+	defer func() { _ = f.Close() }()
+	_, _ = fmt.Fprintf(f, "### `%s`: %s\n\n%s\n\n", branch, worst, why)
 	for _, x := range findings {
 		if x.Answer == pass {
 			continue
 		}
-		fmt.Fprintf(f, "- `%s` %s %s\n", x.SHA[:min(8, len(x.SHA))], x.Why, x.URL)
+		_, _ = fmt.Fprintf(f, "- `%s` %s %s\n", x.SHA[:min(8, len(x.SHA))], x.Why, x.URL)
 	}
 }
 

--- a/tools/mainverdict/main_test.go
+++ b/tools/mainverdict/main_test.go
@@ -315,7 +315,8 @@ func TestTheCommitsRequestStartsAtTheCommitItWasGiven(t *testing.T) {
 	if _, err := c.commits("09078be0", 4); err != nil {
 		t.Fatalf("reading commits: %v", err)
 	}
-	for _, want := range []string{"sha=09078be0", "per_page=4"} {
+	// per_page is the window widened for the first parent walk, not the window.
+	for _, want := range []string{"sha=09078be0", "per_page=16"} {
 		if !strings.Contains(asked[0], want) {
 			t.Errorf("the commits request does not carry %q: %s", want, asked[0])
 		}
@@ -333,5 +334,118 @@ func TestTheCancelledRefusalNamesThePendingCause(t *testing.T) {
 	if !strings.Contains(findings[0].Why, "PENDING") {
 		t.Errorf("a cancelled run refuses without naming the cause this repository has actually "+
 			"met, so the reader goes looking for a person who pressed a button: %q", findings[0].Why)
+	}
+}
+
+// A MERGE COMMIT ON MAIN MUST NOT DRAG THE MERGED BRANCH INTO THE WINDOW.
+// `/commits?sha=main` is `git log`, not `git log --first-parent`, so it returns
+// every commit reachable from the branch in date order. The branch's own
+// commits were never pushed to main, so no push run on main ever judged them,
+// and without this walk each one is reported as a commit nothing ever checked.
+// Every one of those refusals is false, and a watchdog that cries wolf gets
+// muted, which puts the real hole back in the dark.
+//
+// This is not hypothetical here: main's first 200 reachable commits already
+// differ from its first 200 first parents.
+func TestAMergedBranchesCommitsAreNotOnMainsLine(t *testing.T) {
+	merge := commitAt("mmmmmmmm", 1*time.Hour)
+	merge.Parents = []struct {
+		SHA string `json:"sha"`
+	}{{SHA: "pppppppp"}, {SHA: "bbbbbbbb"}}
+
+	onMain := commitAt("pppppppp", 3*time.Hour)
+	onMain.Parents = []struct {
+		SHA string `json:"sha"`
+	}{{SHA: "oooooooo"}}
+
+	// The merged branch's own commit. Newer than `pppppppp`, so a date ordered
+	// list puts it between the two and a walk that trusted the order would take
+	// it. Nothing on main ever ran CI on it.
+	onBranch := commitAt("bbbbbbbb", 2*time.Hour)
+
+	older := commitAt("oooooooo", 4*time.Hour)
+
+	fetched := []commit{merge, onBranch, onMain, older}
+	got := firstParents(fetched, 3)
+
+	var shas []string
+	for _, c := range got {
+		shas = append(shas, c.SHA)
+	}
+	want := []string{"mmmmmmmm", "pppppppp", "oooooooo"}
+	if len(shas) != len(want) {
+		t.Fatalf("the first parent walk returned %v, want %v", shas, want)
+	}
+	for i := range want {
+		if shas[i] != want[i] {
+			t.Fatalf("the first parent walk returned %v, want %v", shas, want)
+		}
+	}
+	for _, s := range shas {
+		if s == "bbbbbbbb" {
+			t.Error("a merged branch's own commit is in the window, so this would refuse main " +
+				"over a commit that was never pushed to it")
+		}
+	}
+}
+
+// The walk stops at the edge of what was fetched rather than guessing. Judging
+// fewer commits than asked for is a smaller lie than judging a commit that is
+// not on this branch's line.
+func TestTheWalkStopsAtTheEdgeOfWhatWasFetched(t *testing.T) {
+	head := commitAt("aaaaaaaa", 1*time.Hour)
+	head.Parents = []struct {
+		SHA string `json:"sha"`
+	}{{SHA: "not_in_this_page"}}
+
+	got := firstParents([]commit{head}, 20)
+	if len(got) != 1 {
+		t.Fatalf("the walk returned %d commits from a page holding one reachable commit", len(got))
+	}
+}
+
+// The whole window is judged when the line is linear, which is what main looks
+// like today. Without this the test above is satisfied by a walk that returns
+// one commit and stops.
+func TestALinearBranchYieldsTheWholeWindow(t *testing.T) {
+	link := func(sha, parent string, ago time.Duration) commit {
+		c := commitAt(sha, ago)
+		c.Parents = []struct {
+			SHA string `json:"sha"`
+		}{{SHA: parent}}
+		return c
+	}
+	fetched := []commit{
+		link("aaaaaaaa", "bbbbbbbb", 1*time.Hour),
+		link("bbbbbbbb", "cccccccc", 2*time.Hour),
+		link("cccccccc", "dddddddd", 3*time.Hour),
+		link("dddddddd", "eeeeeeee", 4*time.Hour),
+	}
+	if got := firstParents(fetched, 4); len(got) != 4 {
+		t.Fatalf("a linear branch of four yielded %d commits", len(got))
+	}
+}
+
+// The commits request asks for more than the window, because the list is date
+// ordered and the walk then reduces it. Asking for exactly the window would
+// leave the walk short by however many off line commits the response carried.
+func TestTheCommitsRequestFetchesWiderThanTheWindow(t *testing.T) {
+	var asked []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		asked = append(asked, r.URL.RequestURI())
+		fmt.Fprint(w, `[]`)
+	}))
+	defer server.Close()
+
+	c := &api{base: server.URL, repo: "antifailure/antifailure", token: "t", http: server.Client()}
+	if _, err := c.commits("main", 20); err != nil {
+		t.Fatalf("reading commits: %v", err)
+	}
+	if strings.Contains(asked[0], "per_page=20") {
+		t.Errorf("the commits request asks for exactly the window, so a merge commit in the "+
+			"response leaves the first parent walk short: %s", asked[0])
+	}
+	if !strings.Contains(asked[0], "per_page=80") {
+		t.Errorf("the commits request does not fetch wider than the window: %s", asked[0])
 	}
 }

--- a/tools/mainverdict/main_test.go
+++ b/tools/mainverdict/main_test.go
@@ -1,0 +1,337 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+var now = time.Date(2026, 9, 8, 15, 0, 0, 0, time.UTC)
+
+// fresh is a commit inside the grace, stale is one well past it.
+func commitAt(sha string, ago time.Duration) commit {
+	var c commit
+	c.SHA = sha
+	c.Commit.Committer.Date = now.Add(-ago)
+	return c
+}
+
+func runFor(sha, status, conclusion string) run {
+	return run{
+		ID:         1,
+		Path:       ciWorkflow,
+		HeadSHA:    sha,
+		Status:     status,
+		Conclusion: conclusion,
+		CreatedAt:  now.Add(-3 * time.Hour),
+		Event:      "push",
+		HeadBranch: "main",
+	}
+}
+
+// THE STATE TABLE THIS GATE EXISTS FOR. Every conclusion GitHub documents for a
+// workflow run appears here, plus the two ways of having no conclusion, and the
+// split is the whole design: `success` and `failure` are verdicts and pass,
+// because a red main is already the loudest thing in the repository. Everything
+// else is the absence of a verdict and refuses, because an absence renders in a
+// list exactly as a pass does.
+//
+// The positive controls are the first two rows and they are load bearing: a
+// command that refused everything would satisfy every other row in this file
+// and would be a watchdog nobody could ever leave switched on.
+func TestEveryStateGitHubCanReport(t *testing.T) {
+	cases := []struct {
+		status     string
+		conclusion string
+		want       answer
+	}{
+		{"completed", "success", pass},
+		{"completed", "failure", pass},
+
+		{"completed", "cancelled", refuse},
+		{"completed", "timed_out", refuse},
+		{"completed", "startup_failure", refuse},
+		{"completed", "stale", refuse},
+		{"completed", "action_required", refuse},
+		{"completed", "neutral", refuse},
+		{"completed", "skipped", refuse},
+		{"completed", "", refuse},
+		{"completed", "something_github_has_not_invented_yet", refuse},
+	}
+	for _, c := range cases {
+		name := c.status + "/" + c.conclusion
+		t.Run(name, func(t *testing.T) {
+			commits := []commit{commitAt("aaaaaaaa", 4*time.Hour)}
+			got, findings, why := decide(commits, []run{runFor("aaaaaaaa", c.status, c.conclusion)},
+				ciWorkflow, defaultGrace, now, false)
+			if got != c.want {
+				t.Fatalf("conclusion %q: got %s, want %s (%s)", c.conclusion, got, c.want, why)
+			}
+			if findings[0].Why == "" {
+				t.Error("the answer came with no reason, so nobody reading the log learns anything")
+			}
+		})
+	}
+}
+
+// THE CASE THAT PRODUCED THIS COMMAND. Two of four commits merged inside four
+// minutes on 2026-09-08 were cancelled before a job started. This is that
+// branch, in the API's own words, and the command must refuse it and must name
+// the two commits rather than only the count.
+func TestTheNightOfTheFourMerges(t *testing.T) {
+	commits := []commit{
+		commitAt("822584fa", 100*time.Minute),
+		commitAt("f5e2ef68", 101*time.Minute),
+		commitAt("39a771ff", 102*time.Minute),
+		commitAt("09078be0", 105*time.Minute),
+	}
+	runs := []run{
+		runFor("822584fa", "completed", "success"),
+		runFor("f5e2ef68", "completed", "cancelled"),
+		runFor("39a771ff", "completed", "cancelled"),
+		runFor("09078be0", "completed", "success"),
+	}
+	got, findings, why := decide(commits, runs, ciWorkflow, defaultGrace, now, false)
+	if got != refuse {
+		t.Fatalf("the night two commits lost their verdict answered %s, not refuse: %s", got, why)
+	}
+	var out bytes.Buffer
+	report(&out, "antifailure/antifailure", "main", got, findings, why)
+	for _, sha := range []string{"f5e2ef68", "39a771ff"} {
+		if !strings.Contains(out.String(), sha) {
+			t.Errorf("the report refuses without naming %s, so nobody knows which commit to re-run", sha)
+		}
+	}
+	if !strings.Contains(out.String(), "2 of 4") {
+		t.Errorf("the summary does not count the commits it refused:\n%s", out.String())
+	}
+}
+
+// THE NEGATIVE CONTROL, and it is the half that makes the other half mean
+// something. The same four commits with the verdicts they should have had must
+// pass, so a refusal is evidence about the branch rather than about the command.
+func TestTheSameFourCommitsWithVerdictsPass(t *testing.T) {
+	commits := []commit{
+		commitAt("822584fa", 100*time.Minute),
+		commitAt("f5e2ef68", 101*time.Minute),
+		commitAt("39a771ff", 102*time.Minute),
+		commitAt("09078be0", 105*time.Minute),
+	}
+	runs := []run{
+		runFor("822584fa", "completed", "success"),
+		runFor("f5e2ef68", "completed", "success"),
+		runFor("39a771ff", "completed", "failure"),
+		runFor("09078be0", "completed", "success"),
+	}
+	got, _, why := decide(commits, runs, ciWorkflow, defaultGrace, now, false)
+	if got != pass {
+		t.Fatalf("a branch where every commit was judged answered %s: %s", got, why)
+	}
+}
+
+// A commit still running inside the grace is not a hole, and the exit code must
+// not move for it. A watchdog that reds because CI is merely slow is one people
+// switch off, and this repository's main run takes about an hour under load.
+func TestARunningCommitInsideTheGraceIsNotAHole(t *testing.T) {
+	commits := []commit{commitAt("aaaaaaaa", 10*time.Minute)}
+	got, findings, why := decide(commits, []run{runFor("aaaaaaaa", "in_progress", "")},
+		ciWorkflow, defaultGrace, now, false)
+	if got != pass {
+		t.Fatalf("a ten minute old commit still running answered %s: %s", got, why)
+	}
+	if findings[0].Answer != waiting {
+		t.Fatalf("the commit itself should be waiting, got %s", findings[0].Answer)
+	}
+}
+
+// Past the grace it IS a hole. A run that has been queued for three hours has
+// reached no verdict and is not going to.
+func TestARunningCommitPastTheGraceIsAHole(t *testing.T) {
+	commits := []commit{commitAt("aaaaaaaa", 4*time.Hour)}
+	got, _, why := decide(commits, []run{runFor("aaaaaaaa", "queued", "")},
+		ciWorkflow, defaultGrace, now, false)
+	if got != refuse {
+		t.Fatalf("a four hour old commit still queued answered %s: %s", got, why)
+	}
+}
+
+// A commit with no run at all, past the grace, is the loudest version of the
+// same hole: nothing ever checked it.
+func TestACommitWithNoRunAtAllPastTheGraceIsAHole(t *testing.T) {
+	commits := []commit{commitAt("aaaaaaaa", 4*time.Hour)}
+	got, _, why := decide(commits, nil, ciWorkflow, defaultGrace, now, false)
+	if got != refuse {
+		t.Fatalf("a four hour old commit with no run answered %s: %s", got, why)
+	}
+}
+
+// COULD NOT LOOK IS A DISTINCT ANSWER AND NOT A PASS. When the run page is
+// truncated and does not reach back as far as the commit, the run may simply be
+// on the next page. Reporting a hole would be inventing one; reporting a pass
+// would be inventing a verdict.
+func TestACommitPastTheEdgeOfThePageIsUnreadRatherThanClean(t *testing.T) {
+	commits := []commit{
+		commitAt("aaaaaaaa", 1*time.Hour),
+		commitAt("bbbbbbbb", 9*time.Hour),
+	}
+	runs := []run{runFor("aaaaaaaa", "completed", "success")}
+	got, findings, why := decide(commits, runs, ciWorkflow, defaultGrace, now, true)
+	if got != couldNotLook {
+		t.Fatalf("a commit past the edge of the page answered %s, which claims to know: %s", got, why)
+	}
+	if findings[1].Answer != couldNotLook {
+		t.Fatalf("the unreachable commit answered %s", findings[1].Answer)
+	}
+	if strings.Contains(why, "carry no CI verdict") {
+		t.Error("could not look is being reported as a refusal, which sends somebody to re-run a run that may be fine")
+	}
+}
+
+// The same branch with an UNtruncated page is a real refusal, not an unread
+// one: the page reached the end of the history, so a missing run is missing.
+func TestAnUntruncatedPageTurnsTheSameGapIntoARefusal(t *testing.T) {
+	commits := []commit{
+		commitAt("aaaaaaaa", 1*time.Hour),
+		commitAt("bbbbbbbb", 9*time.Hour),
+	}
+	runs := []run{runFor("aaaaaaaa", "completed", "success")}
+	got, _, why := decide(commits, runs, ciWorkflow, defaultGrace, now, false)
+	if got != refuse {
+		t.Fatalf("a complete page with a commit missing its run answered %s: %s", got, why)
+	}
+}
+
+// An empty commit list is the shape that would otherwise let this pass on
+// having read nothing, which is how a check starts reporting ok about a
+// question it never asked.
+func TestNoCommitsIsNotACleanBranch(t *testing.T) {
+	got, _, why := decide(nil, nil, ciWorkflow, defaultGrace, now, false)
+	if got != couldNotLook {
+		t.Fatalf("an empty branch answered %s, which is a pass on having read nothing: %s", got, why)
+	}
+}
+
+// A run for another workflow on the same commit is not this workflow's verdict.
+// Without the path filter, security.yml passing would read as CI passing.
+func TestAnotherWorkflowsRunIsNotCIsVerdict(t *testing.T) {
+	commits := []commit{commitAt("aaaaaaaa", 4*time.Hour)}
+	other := runFor("aaaaaaaa", "completed", "success")
+	other.Path = ".github/workflows/security.yml"
+	got, _, why := decide(commits, []run{other}, ciWorkflow, defaultGrace, now, false)
+	if got != refuse {
+		t.Fatalf("another workflow's success answered %s for CI: %s", got, why)
+	}
+}
+
+// A re-run is the current answer about a commit. The newest run wins, and the
+// order is imposed here rather than trusted from the response.
+func TestTheNewestRunOnACommitIsTheAnswer(t *testing.T) {
+	commits := []commit{commitAt("aaaaaaaa", 4*time.Hour)}
+	old := runFor("aaaaaaaa", "completed", "cancelled")
+	old.ID, old.CreatedAt = 1, now.Add(-5*time.Hour)
+	newer := runFor("aaaaaaaa", "completed", "success")
+	newer.ID, newer.CreatedAt = 2, now.Add(-1*time.Hour)
+	// Given oldest first on purpose, so a command that trusted the response's
+	// order would read the cancelled one.
+	got, _, why := decide(commits, []run{old, newer}, ciWorkflow, defaultGrace, now, false)
+	if got != pass {
+		t.Fatalf("a commit re-run to green answered %s: %s", got, why)
+	}
+}
+
+// Every conclusion this command knows must carry a sentence. A refusal with no
+// reason sends somebody to the wrong file at three in the morning.
+func TestEveryKnownConclusionCarriesAReason(t *testing.T) {
+	for conclusion, why := range noVerdict {
+		if strings.TrimSpace(why) == "" {
+			t.Errorf("conclusion %q refuses with no reason", conclusion)
+		}
+	}
+	for conclusion, why := range verdicts {
+		if strings.TrimSpace(why) == "" {
+			t.Errorf("conclusion %q passes with no reason", conclusion)
+		}
+	}
+	for conclusion := range verdicts {
+		if _, both := noVerdict[conclusion]; both {
+			t.Errorf("conclusion %q is both a verdict and not one", conclusion)
+		}
+	}
+}
+
+// THE REQUEST, NOT ONLY THE DECISION. Every test above answers from a slice
+// this file wrote, so all of them stayed green while the command asked the
+// wrong endpoint: the repository wide `/actions/runs` interleaves nine
+// workflows on a push to main, so one page of a hundred carried thirteen CI
+// runs and reached back seven hours, and the default window of twenty commits
+// fell off the edge of it and answered `could not look` every time. The
+// decision was right and the question was wrong, which is the shape
+// `tools/prmerge` was caught in with twenty five green tests behind it.
+func TestTheRunsRequestAsksTheWorkflowsOwnEndpoint(t *testing.T) {
+	var asked []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		asked = append(asked, r.URL.RequestURI())
+		fmt.Fprint(w, `{"total_count":0,"workflow_runs":[]}`)
+	}))
+	defer server.Close()
+
+	c := &api{base: server.URL, repo: "antifailure/antifailure", token: "t", http: server.Client()}
+	if _, _, err := c.runs("main", ciWorkflow); err != nil {
+		t.Fatalf("reading runs: %v", err)
+	}
+	got := asked[0]
+	for _, want := range []string{
+		"/actions/workflows/ci.yml/runs",
+		"branch=main",
+		"event=push",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("the runs request does not carry %q, so it is not asking for this\n"+
+				"workflow's runs on this branch: %s", want, got)
+		}
+	}
+	if strings.Contains(got, "/actions/runs?") {
+		t.Errorf("the runs request asks the repository wide endpoint, which interleaves every "+
+			"workflow and reaches back a fraction as far: %s", got)
+	}
+}
+
+// The commit window starts where it was told to. Without this, `-from` could be
+// accepted, ignored, and the positive control would silently be the same
+// negative one.
+func TestTheCommitsRequestStartsAtTheCommitItWasGiven(t *testing.T) {
+	var asked []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		asked = append(asked, r.URL.RequestURI())
+		fmt.Fprint(w, `[]`)
+	}))
+	defer server.Close()
+
+	c := &api{base: server.URL, repo: "antifailure/antifailure", token: "t", http: server.Client()}
+	if _, err := c.commits("09078be0", 4); err != nil {
+		t.Fatalf("reading commits: %v", err)
+	}
+	for _, want := range []string{"sha=09078be0", "per_page=4"} {
+		if !strings.Contains(asked[0], want) {
+			t.Errorf("the commits request does not carry %q: %s", want, asked[0])
+		}
+	}
+}
+
+// A refusal must say what a cancelled run on main actually means, because the
+// sentence is the whole of what somebody gets at three in the morning. GitHub
+// spells several unrelated things `cancelled`, and the one this repository has
+// met is a run cancelled while merely PENDING.
+func TestTheCancelledRefusalNamesThePendingCause(t *testing.T) {
+	commits := []commit{commitAt("39a771ff", 4*time.Hour)}
+	_, findings, _ := decide(commits, []run{runFor("39a771ff", "completed", "cancelled")},
+		ciWorkflow, defaultGrace, now, false)
+	if !strings.Contains(findings[0].Why, "PENDING") {
+		t.Errorf("a cancelled run refuses without naming the cause this repository has actually "+
+			"met, so the reader goes looking for a person who pressed a button: %q", findings[0].Why)
+	}
+}


### PR DESCRIPTION
Four pull requests merged inside four minutes on 2026-09-08 and two of the
resulting commits carry no CI verdict at all. Nothing said so.

    09078be0  created 13:09:53  jobs started 13:12:57  in_progress
    39a771ff  created 13:13:15  NO JOBS AT ALL         cancelled 13:13:51
    f5e2ef68  created 13:13:50  NO JOBS AT ALL         cancelled 13:14:23
    822584fa  created 13:14:22  no jobs yet            pending

Each cancellation lands one second after the NEXT run is created, and the jobs
endpoint returns an EMPTY LIST for both cancelled runs, so neither ran a single
check. `cancel-in-progress: false` protects a run that has STARTED and nothing
else: GitHub holds exactly one PENDING run per concurrency group, so every merge
took the place of the run queued behind the one in progress.

## The comment was both right and wrong, thirty lines apart

`ci.yml` opened by saying a run on main is never cancelled, which is the half
that gets read and quoted, and closed by saying a pending one still is and that
fixing it "needs a merge queue". The second half, added on 2026-09-02 in
`bd155e7c`, is an accurate description of the mechanism and a false conclusion.
Keying the group on the commit gives each push to main a group of one, so no
main run can supersede another, and no merge queue is involved. `security.yml`
had already used exactly this technique for its daily scan on 2026-09-05, three
days earlier, after a merge burst cancelled that scan, and nobody carried it
back to the runs it was learned from.

The same contradictory comment was copied into `crosslint.yml`, `keyring.yml`
and `codeql.yml`. Their prose is corrected and their grouping is not, because
the difference is whether anything reads a per commit conclusion from them:
`cigate` and `cd.yml` both gate on `ci.yml`, and a skipped lint or analysis is
an answer nobody was going to ask for.

## The asymmetry with the other three workflows, considered rather than missed

`crosslint.yml`, `keyring.yml` and `codeql.yml` carry the same copied comment.
Their prose is corrected and their grouping is deliberately not, because nothing
reads a per commit conclusion from any of them. `cigate` and `cd.yml` both gate
on `ci.yml`, and `tools/mainverdict` watches `ci.yml` alone. A push run skipped
in a lint is an answer nobody was going to ask for, and the next push covers the
same tree plus a change. A CI run skipped on main was the only verdict that
commit could ever have had. `security.yml` is the same case for a different
reason, written in that file: `security-watch` measures the SCHEDULED scan and
refuses to accept a push run as a substitute, and the scheduled scan already has
its own group.

## What it costs

Runner minutes, and the file says so rather than leaving it to be discovered.
Six merges in a burst now run six full CI runs where two ran before, and past
the account's concurrency limit they queue. A queue is a delay. A cancelled
pending run was a permanent hole, and a hole cannot be re-run into existence
once the next merge has landed on top of it.

## The gate, because configuration cannot be the whole answer

A run can still be cancelled by hand, a job can still hit its own
`timeout-minutes`, GitHub can still report `stale`, and the expression can be
edited back by somebody who reads the group as noise. `tools/mainverdict` asks
what CI concluded on each of main's recent commits and refuses a branch carrying
one that was never judged. It runs in `.github/workflows/ci-watch.yml` on every
completed CI run on main and daily, and leaves one issue open until main is
whole again, which is `security-watch.yml`'s shape and its reason.

It passes `failure` alongside `success`. A red main is already the loudest thing
in the repository and a second instrument shouting about it teaches people to
silence both. What this catches is the silent case, where `cancelled` and
`skipped` render in a list exactly as a pass does.

It has a third answer and an exit code of its own for a run history that does
not reach the commits it was asked about. That answer earned itself before this
shipped: the first version asked `/actions/runs`, which interleaves every
workflow, so one page of a hundred carried thirteen CI runs and reached back
seven hours, and the default window of twenty commits fell off the edge of it.
Every test was green, because every one of them answered from a slice the test
file had written. It asks `/actions/workflows/ci.yml/runs` now, which reaches
back three days, and two tests assert the request rather than only the decision.

## Where it does not run, and why

Not in `just gate`: its answer is not a function of the tree and it needs the
network, which is `check-tls`'s exemption and now its own. Not a job inside
`ci.yml`: a job there judging main's earlier commits would turn somebody else's
cancelled run into a red on this commit, and `cd.yml` gates on CI, so the commit
that did nothing wrong would stop deploying.

`tools/cigate` already refused a cancelled run and still does. Its explanation
of what `cancelled` means on main was written against the old setting and now
says what is true.
