### PR TITLE
ci: the comment explaining the lying step name made a claim of its own that nothing had checked

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,12 +139,17 @@ jobs:
         # Named for what it does rather than for what the next step checks.
         # Four of these are `go test <pkg> -update-something`, which runs the
         # WHOLE package, so a test in engine/internal/cli that has nothing to
-        # do with the committed reference fails here. Under the old name this
-        # step said "Generated files are current", and on 2026-09-08 it said
-        # that about three pull requests whose generated files were fine and
-        # whose cli tests were red. Three lanes went to look at the wrong
-        # thing, which is what a step name that asserts more than the step
-        # checked costs.
+        # do with the committed reference fails here.
+        #
+        # Under the old name this step said "Generated files are current", and
+        # the comparison was the LAST line of it. The shell is `bash -e`, so on
+        # 2026-09-08 three pull requests died at the cli package, which is the
+        # eighth of twelve commands, and the comparison never ran on any of
+        # them. The step did not find those trees stale. It reported staleness
+        # it had not measured, under a name that is the only thing the checks
+        # list and the jobs API return, and three lanes went to look at the
+        # wrong thing. That is what a step name asserting more than the step
+        # reached costs.
         run: |
           go run ./tools/errgen
           go run ./tools/lintgen


### PR DESCRIPTION
Follow up to #333, which merged while this was being written.

#333 split the CI step whose name asserted more than it had reached, and the
comment it left in `ci.yml` then made the same kind of claim itself. It said the
old step reported stale generated files "about three pull requests whose
generated files were fine".

Nothing established that. The comparison, `git diff --exit-code`, was the LAST
line of the block, and the shell is `bash -e`. All three of those pull requests
(315, 320, 326) died at `(cd engine && go test ./internal/cli -update-reference)`,
which is the eighth of twelve commands. The comparison never ran on any of them,
so nobody knows whether those three trees were current.

The true statement is stronger and it is the one the comment carries now: the
step did not find those trees stale, it **asserted staleness it had never
reached**.

Writing "their files were fine" in a repository whose gates keep failing for
this exact reason, a check reporting a verdict about something it never looked
at, repeated the defect one level up, inside the comment explaining the defect.

Comment only. No behaviour from #333 changes. `changecheck` 1 changed path, none
of it behaviour anybody outside can see, and the commit carries a
`Changelog-None` with that reason. `prosecheck` 934 files, 0 findings.