### PR TITLE
infra: a moving tag decided what every test suite ran against

### DIFF
--- a/.changes/a-moving-tag-decided-what-the-tests-ran-against.md
+++ b/.changes/a-moving-tag-decided-what-the-tests-ran-against.md
@@ -1,0 +1,30 @@
+# security
+
+Thirteen container images were named by a tag, so nothing in the repository
+recorded what the tests had run against.
+
+`postgres:17-alpine` appeared in eight places across four workflows, three more
+in the justfile, and once in the preview script, and `quay.io/keycloak/keycloak:26.0`
+in the single sign on conformance harness. A tag is a name the publisher can
+repoint. The Postgres tag resolved to 17.11 when this was written and will
+resolve to 17.12 with no commit here, which means the server that the row level
+security suites proved things about is whichever build carried the tag that
+morning. This repository already made the argument against itself, in
+`engine/pkg/emulator/aws.go`, where LocalStack is pinned by digest because a tag
+that moves changes what an environment was tested against without anything in
+this repository changing. A database is the harder case, not the softer one.
+
+All thirteen now name the multi architecture index digest, so a runner and a
+developer's Mac resolve one declaration to their own image. Dependabot does not
+and cannot refresh them: its docker file fetcher accepts a file only when the
+name matches a Dockerfile, or it is a Helm values file, or its first YAML
+document carries both `apiVersion` and `kind`, and a workflow carries `on` and
+`jobs`. So the refresh is a person's job and the procedure is written beside the
+pin. Three tests in `tools/gatecheck` hold it: one refuses a moving tag anywhere
+a container is started, one refuses a tree where two sites pin the same image to
+different digests, which is what a half finished bump looks like, and one proves
+the check still says no.
+
+The apt packages beside them, `postgresql-client-17`, `zsh` and
+`libsecret-tools`, are deliberately left unpinned, and the reason is recorded
+with the rest.

--- a/.github/workflows/antifailure.yml
+++ b/.github/workflows/antifailure.yml
@@ -94,9 +94,12 @@ jobs:
     # database into a public runner would be the single worst thing this
     # repository could do, and what the masking rules are about is the shape
     # rather than the rows.
+    # Pinned by digest, because the tag moves and nothing updates it. The
+    # reasoning and the refresh procedure are in .github/workflows/ci.yml,
+    # above the af-cp-test container.
     services:
       staging:
-        image: postgres:17-alpine
+        image: postgres:17-alpine@sha256:18cfe3ef5e6815560c98237d6216d1e5119702fb0f3894c8785dd58b8bbe5d73
         env:
           POSTGRES_PASSWORD: staging
           POSTGRES_DB: antifailure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -503,10 +503,72 @@ jobs:
         # extension can be created and records nothing, so the query
         # regression checks read a permanently empty table. It is the same
         # container `just db` starts, deliberately, so local and CI agree.
+        #
+        # PINNED BY DIGEST, AND THIS IS THE COMMENT THE OTHER ELEVEN SITES
+        # POINT AT. `postgres:17-alpine` is a tag, and a tag moves. It resolves
+        # to Postgres 17.11 today and it will resolve to 17.12 without a commit
+        # here, so the server these suites were read against and the server
+        # they run against are the same only by the publisher's schedule.
+        # engine/pkg/emulator/aws.go already makes this argument about
+        # LocalStack: a tag that moves changes what an environment was tested
+        # against without anything in this repository changing. The database is
+        # the harder case rather than the softer one, because every policy,
+        # grant and masking rule these suites assert is enforced by the server
+        # and not by us.
+        #
+        # THE DIGEST IS THE MULTI ARCHITECTURE INDEX, not one architecture's
+        # manifest, for the reason the LocalStack pin gives. The registry
+        # answers this tag with an `application/vnd.oci.image.index.v1+json`
+        # carrying sixteen entries, linux/amd64 for the runner and
+        # linux/arm64/v8 for a developer's Mac among them, so one declaration
+        # resolves to each machine's own image and neither is pinned to the
+        # other's architecture. The tag is kept in front of the digest because
+        # docker resolves by the digest and ignores the tag, so it costs
+        # nothing and it is the only half a person can read.
+        #
+        # NOTHING UPDATES THIS, and that is the cost, stated rather than left
+        # for the next person to assume away. `.github/dependabot.yml` declares
+        # the docker ecosystem, but Dependabot's docker file fetcher accepts a
+        # file only when its NAME matches /dockerfile|containerfile/i, or it is
+        # a `values*.yaml` Helm file, or its first YAML document is a mapping
+        # carrying both `apiVersion` and `kind`. A workflow carries `on` and
+        # `jobs`, so it is refused before anything looks for an image in it,
+        # and the github-actions ecosystem reads `uses:` declarations only and
+        # skips `docker://` with a TODO in the parser. dependabot-core issue
+        # 5819 has asked for this since 2022 and is still open. Adding
+        # `/.github/workflows` to the docker `directories` list does not fix it
+        # and makes it worse: the fetcher would find no acceptable file there
+        # and raise DependencyFileNotFound on every scheduled run.
+        #
+        # SO A PERSON REFRESHES IT, and no daemon is needed to do it. Get a
+        # pull token from
+        # https://auth.docker.io/token?service=registry.docker.io&scope=repository:library/postgres:pull
+        # then read the digest the tag points at now:
+        #
+        #     curl -sI -H "Authorization: Bearer $TOKEN" \
+        #       -H "Accept: application/vnd.oci.image.index.v1+json" \
+        #       https://registry-1.docker.io/v2/library/postgres/manifests/17-alpine
+        #
+        # and take the `docker-content-digest` header. A `content-type` of
+        # `...image.index.v1+json` on that response is the proof it is the
+        # index rather than one architecture. Change it in every place at once:
+        # TestEveryPinnedImageAgreesOnOneDigest in tools/gatecheck refuses a
+        # tree where two sites name the same image at different digests, which
+        # is what a half finished bump looks like.
+        #
+        # WHAT IS DELIBERATELY LEFT UNPINNED, so it is a decision rather than
+        # an oversight. `postgresql-client-17` above, and `zsh` and
+        # `libsecret-tools` installed by apt elsewhere in these workflows, name
+        # no version. Distribution point releases are withdrawn and replaced
+        # far more often than container digests are, so a pinned apt version
+        # fails the build on the day the mirror drops it, and the version that
+        # gets dropped is as often as not the one carrying the fix. The
+        # container is the surface where pinning is cheap and the apt package
+        # is the surface where it is not.
         run: |
           set -euo pipefail
           docker run -d --name af-cp-test -p 55432:5432 \
-            -e POSTGRES_PASSWORD=test -e POSTGRES_DB=antifailure postgres:17-alpine \
+            -e POSTGRES_PASSWORD=test -e POSTGRES_DB=antifailure postgres:17-alpine@sha256:18cfe3ef5e6815560c98237d6216d1e5119702fb0f3894c8785dd58b8bbe5d73 \
             -c shared_preload_libraries=pg_stat_statements \
             -c pg_stat_statements.track=all
           # A real query against the target database, not pg_isready. During
@@ -542,11 +604,14 @@ jobs:
       # exactly that path. The proof needs a target that has never heard of
       # the source's roles, which is a separate server, and this is it. Also
       # what `just db` starts, so local and CI agree.
+      # Pinned by digest, because the tag moves and nothing updates it. The
+      # reasoning and the refresh procedure are in this file, above the
+      # af-cp-test container.
       - name: Start a second Postgres, for the copy tests
         run: |
           set -euo pipefail
           docker run -d --name af-cp-target -p 55433:5432 \
-            -e POSTGRES_PASSWORD=test -e POSTGRES_DB=antifailure postgres:17-alpine
+            -e POSTGRES_PASSWORD=test -e POSTGRES_DB=antifailure postgres:17-alpine@sha256:18cfe3ef5e6815560c98237d6216d1e5119702fb0f3894c8785dd58b8bbe5d73
           ready=0
           for _ in $(seq 1 90); do
             if docker exec af-cp-target psql -U postgres -d antifailure -tAc 'select 1' \
@@ -987,9 +1052,12 @@ jobs:
     # Row-level security cannot be tested against a fake: the whole property is
     # that the database refuses what the application asks for, and a fake would
     # only prove the application asks nicely.
+    # Pinned by digest, because the tag moves and nothing updates it. The
+    # reasoning and the refresh procedure are in this file, above the
+    # af-cp-test container.
     services:
       postgres:
-        image: postgres:17-alpine
+        image: postgres:17-alpine@sha256:18cfe3ef5e6815560c98237d6216d1e5119702fb0f3894c8785dd58b8bbe5d73
         env:
           POSTGRES_PASSWORD: test
           POSTGRES_DB: antifailure
@@ -1154,9 +1222,12 @@ jobs:
     # and provisioning through the real server against the real row-level
     # security policies, and there is no version of that against a fake: the
     # property under test is what Postgres refuses.
+    # Pinned by digest, because the tag moves and nothing updates it. The
+    # reasoning and the refresh procedure are in this file, above the
+    # af-cp-test container.
     services:
       postgres:
-        image: postgres:17-alpine
+        image: postgres:17-alpine@sha256:18cfe3ef5e6815560c98237d6216d1e5119702fb0f3894c8785dd58b8bbe5d73
         env:
           POSTGRES_PASSWORD: test
           POSTGRES_DB: antifailure

--- a/.github/workflows/control-plane-image.yml
+++ b/.github/workflows/control-plane-image.yml
@@ -354,7 +354,10 @@ jobs:
               spec:
                 containers:
                   - name: pg
-                    image: postgres:17-alpine
+                    # Pinned by digest, because the tag moves and nothing updates it. The
+                    # reasoning and the refresh procedure are in .github/workflows/ci.yml,
+                    # above the af-cp-test container.
+                    image: postgres:17-alpine@sha256:18cfe3ef5e6815560c98237d6216d1e5119702fb0f3894c8785dd58b8bbe5d73
                     env:
                       - { name: POSTGRES_USER, value: af_migrator }
                       - { name: POSTGRES_DB, value: antifailure }

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -81,9 +81,12 @@ jobs:
     # everything under test is what Postgres enforces: row level security, the
     # policies the masking plan has to preserve, the partitions the rules have
     # to follow, and the roles pg_dump does not carry.
+    # Pinned by digest, because the tag moves and nothing updates it. The
+    # reasoning and the refresh procedure are in .github/workflows/ci.yml,
+    # above the af-cp-test container.
     services:
       staging:
-        image: postgres:17-alpine
+        image: postgres:17-alpine@sha256:18cfe3ef5e6815560c98237d6216d1e5119702fb0f3894c8785dd58b8bbe5d73
         env:
           POSTGRES_PASSWORD: staging
           POSTGRES_DB: antifailure
@@ -609,9 +612,12 @@ jobs:
     # TestEveryLegCanReachTheSourceItsManifestNames in tools/dogfood, which
     # reads the manifests rather than this list and so narrows or widens with
     # them.
+    # Pinned by digest, because the tag moves and nothing updates it. The
+    # reasoning and the refresh procedure are in .github/workflows/ci.yml,
+    # above the af-cp-test container.
     services:
       staging:
-        image: postgres:17-alpine
+        image: postgres:17-alpine@sha256:18cfe3ef5e6815560c98237d6216d1e5119702fb0f3894c8785dd58b8bbe5d73
         env:
           POSTGRES_PASSWORD: staging
           POSTGRES_DB: antifailure

--- a/ee/web/sso/test/keycloak-up.sh
+++ b/ee/web/sso/test/keycloak-up.sh
@@ -30,7 +30,14 @@ set -euo pipefail
 
 NAME="${AF_KEYCLOAK_CONTAINER:-af-keycloak}"
 PORT="${AF_KEYCLOAK_PORT:-8443}"
-IMAGE="${AF_KEYCLOAK_IMAGE:-quay.io/keycloak/keycloak:26.0}"
+# The image is pinned by digest. `26.0` is a tag and a tag moves, so a suite
+# that proves single sign on works against "Keycloak 26.0" proves it against
+# whichever build carried that tag on the day it ran. The digest is quay's
+# multi architecture index, linux/amd64 and linux/arm64, so a runner and a
+# developer's Mac resolve this one line to their own image. The reasoning in
+# full, and the refresh procedure, are in .github/workflows/ci.yml above the
+# af-cp-test container.
+IMAGE="${AF_KEYCLOAK_IMAGE:-quay.io/keycloak/keycloak:26.0@sha256:09a381c715ab0b111835b70f2905955274843a219c6f27efb348e4d9f4086858}"
 STATE="${TMPDIR:-/tmp}/af-keycloak-${NAME}"
 
 if [ "${1:-}" = "--down" ]; then

--- a/justfile
+++ b/justfile
@@ -284,10 +284,13 @@ merge pr *args:
 # one, so both `nc -z` and `pg_isready` answer yes during a window when the next
 # query fails with "the database system is shutting down". Getting this wrong is
 # how a suite ends up skipping and reporting ok.
+# Pinned by digest, because the tag moves and nothing updates it. The
+# reasoning and the refresh procedure are in .github/workflows/ci.yml,
+# above the af-cp-test container.
 db:
     @docker rm -f af-cp-test > /dev/null 2>&1 || true
     docker run -d --name af-cp-test -p 55432:5432 \
-      -e POSTGRES_PASSWORD=test -e POSTGRES_DB=antifailure postgres:17-alpine \
+      -e POSTGRES_PASSWORD=test -e POSTGRES_DB=antifailure postgres:17-alpine@sha256:18cfe3ef5e6815560c98237d6216d1e5119702fb0f3894c8785dd58b8bbe5d73 \
       -c shared_preload_libraries=pg_stat_statements \
       -c pg_stat_statements.track=all
     @echo "waiting for postgres"
@@ -300,7 +303,7 @@ db:
     @echo "up on 55432"
     @docker rm -f af-cp-target > /dev/null 2>&1 || true
     docker run -d --name af-cp-target -p 55433:5432 \
-      -e POSTGRES_PASSWORD=test -e POSTGRES_DB=antifailure postgres:17-alpine
+      -e POSTGRES_PASSWORD=test -e POSTGRES_DB=antifailure postgres:17-alpine@sha256:18cfe3ef5e6815560c98237d6216d1e5119702fb0f3894c8785dd58b8bbe5d73
     @for i in $(seq 1 90); do \
       docker exec af-cp-target psql -U postgres -d antifailure -tAc 'select 1' > /dev/null 2>&1 && break; \
       sleep 1; \
@@ -912,8 +915,11 @@ drill: _reports
     cleanup() { docker rm -f af-drill-test > /dev/null 2>&1 || true; }
     trap cleanup EXIT
     cleanup
+    # Pinned by digest, because the tag moves and nothing updates it. The
+    # reasoning and the refresh procedure are in .github/workflows/ci.yml,
+    # above the af-cp-test container.
     docker run -d --name af-drill-test -p 55434:5432 \
-      -e POSTGRES_PASSWORD=test -e POSTGRES_DB=antifailure postgres:17-alpine > /dev/null
+      -e POSTGRES_PASSWORD=test -e POSTGRES_DB=antifailure postgres:17-alpine@sha256:18cfe3ef5e6815560c98237d6216d1e5119702fb0f3894c8785dd58b8bbe5d73 > /dev/null
     # A real query against the target database rather than pg_isready. The
     # image runs initdb against a temporary server and pg_isready answers on
     # that one, before POSTGRES_DB exists.

--- a/tools/gatecheck/main_test.go
+++ b/tools/gatecheck/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1305,5 +1306,355 @@ func TestLibReachabilityCountsSiblingsButNotDeadCycles(t *testing.T) {
 		if alive[stem] {
 			t.Errorf("%s has no way in from outside lib/ and was reported alive", stem)
 		}
+	}
+}
+
+// Container images. The same supply chain argument as the action pins above,
+// one layer down. An action reference decides what CODE runs; a service
+// container image decides what the code was tested AGAINST, and this
+// repository's suites assert what a real Postgres refuses, which is a property
+// of the server rather than of us. `postgres:17-alpine` is a tag, a tag moves,
+// and the reasoning in full lives at the most authoritative of the twelve
+// sites: .github/workflows/ci.yml, above the af-cp-test container.
+
+// registryTagged matches a registry qualified image reference carrying a tag:
+// a host with at least one dot, an optional port, a path, and a tag. It has no
+// leading boundary on purpose, because the case it was written for is a shell
+// default, `${AF_KEYCLOAK_IMAGE:-quay.io/keycloak/keycloak:26.0}`, where every
+// plausible boundary character is already taken.
+var registryTagged = regexp.MustCompile(
+	`[a-z0-9][a-z0-9-]*(?:\.[a-z0-9-]+)+(?::[0-9]+)?/[a-z0-9._/-]+:[A-Za-z0-9_][A-Za-z0-9._-]*`)
+
+// imageKey matches a YAML `image:` field. Anchored on a boundary for the
+// reason the `uses:` pattern above is: without one, any word ending in the
+// five characters `image:` reads as the field.
+var imageKey = regexp.MustCompile(`(?:^|\s)image:\s*(\S+)`)
+
+// taggedImage reports whether tok, as it appears in a shell command, names a
+// container image by tag. It is deliberately narrow: the tokens that surround
+// a real `docker run` are ports, environment assignments and flags, and a
+// check that reads `-p 55432:5432` as an image called 55432 is a check that
+// gets ignored and then deleted.
+func taggedImage(tok string) bool {
+	tok = strings.Trim(tok, `"'`)
+	// A digest is the thing being asked for, a variable cannot be read here,
+	// and a URL is not an image.
+	if strings.ContainsAny(tok, "$@") || strings.Contains(tok, "://") {
+		return false
+	}
+	i := strings.LastIndex(tok, ":")
+	if i <= 0 || i == len(tok)-1 {
+		return false
+	}
+	name, tag := tok[:i], tok[i+1:]
+	// A colon with a path after it is not a tag separator.
+	if strings.Contains(tag, "/") {
+		return false
+	}
+	// `sha256:<hex>` is the digest itself written on its own, which turns up
+	// in checksum commands and in the prose of these very comments.
+	if name == "sha256" {
+		return false
+	}
+	letters := false
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z':
+			letters = true
+		case r >= '0' && r <= '9', r == '.', r == '_', r == '/', r == '-':
+		default:
+			return false
+		}
+	}
+	// The name half must carry a letter. This is the whole reason a port
+	// mapping does not read as an image.
+	if !letters {
+		return false
+	}
+	for i, r := range tag {
+		ok := r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '_'
+		if i > 0 {
+			ok = ok || r == '.' || r == '-'
+		}
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// imageFinding is one image reference that names a tag and no digest.
+type imageFinding struct {
+	line int
+	ref  string
+	why  string
+}
+
+// unpinnedImages reads a file this repository controls and reports every
+// container image in it that is named by something a publisher can move.
+//
+// Three shapes, because there are three ways this repository starts a
+// container and no single pattern sees all of them: a workflow `services:`
+// block and a Kubernetes Deployment both write a YAML `image:` field, a
+// justfile recipe and a shell script both write a `docker run` command, and
+// one script carries the reference as a shell default that neither shape
+// reaches.
+//
+// WHAT THIS CANNOT SEE, said rather than implied. An image named with no tag
+// at all, `docker run alpine sh`, is one bare word in a shell command and
+// indistinguishable from a subcommand, so the third rule below refuses a
+// `docker run` that names neither a digest nor a variable rather than trying
+// to find the word. And Go source that starts a container is not read here;
+// engine/pkg/emulator/aws.go carries its own pin and its own reasoning.
+func unpinnedImages(name, body string) []imageFinding {
+	var out []imageFinding
+	yaml := strings.HasSuffix(name, ".yml") || strings.HasSuffix(name, ".yaml")
+
+	// Shell continuations, so a `docker run` split over four lines is read as
+	// the one command it is. The line number stays that of the first line.
+	type logical struct {
+		line int
+		text string
+	}
+	var joined []logical
+	physical := strings.Split(body, "\n")
+	for i := 0; i < len(physical); i++ {
+		start, text := i+1, physical[i]
+		for strings.HasSuffix(text, "\\") && i+1 < len(physical) {
+			i++
+			text = strings.TrimSuffix(text, "\\") + " " + strings.TrimSpace(physical[i])
+		}
+		joined = append(joined, logical{start, text})
+	}
+
+	for _, l := range joined {
+		// 1. A YAML image field. The workflows write one in a `services:`
+		// block and control-plane-image.yml writes one inside a Deployment it
+		// pipes to kubectl, and both are the same field.
+		if yaml {
+			for _, m := range imageKey.FindAllStringSubmatch(l.text, -1) {
+				ref := m[1]
+				if strings.Contains(ref, "$") {
+					continue // An expression, resolved at run time.
+				}
+				if !strings.Contains(ref, "@sha256:") {
+					out = append(out, imageFinding{l.line, ref, "a YAML image: field names a tag"})
+				}
+			}
+		}
+
+		// 2. A registry qualified reference anywhere in the line, which is the
+		// only rule that reaches a reference held in a shell variable.
+		for _, idx := range registryTagged.FindAllStringIndex(l.text, -1) {
+			ref := l.text[idx[0]:idx[1]]
+			if idx[0] >= 2 && l.text[idx[0]-2:idx[0]] == "//" {
+				continue // Part of a URL.
+			}
+			if idx[1] < len(l.text) && l.text[idx[1]] == '@' {
+				continue // Pinned, the digest follows.
+			}
+			out = append(out, imageFinding{l.line, ref, "a registry reference names a tag"})
+		}
+
+		// 3. A docker command. Every argument is checked, and separately the
+		// command as a whole has to name its image by digest or by variable,
+		// which is what catches an image named with no tag at all.
+		if !strings.Contains(l.text, "docker run ") && !strings.Contains(l.text, "docker pull ") {
+			continue
+		}
+		fields := strings.Fields(l.text)
+		named := false
+		for _, tok := range fields {
+			if strings.Contains(tok, "@sha256:") || strings.Contains(tok, "$") {
+				named = true
+			}
+			if taggedImage(tok) {
+				out = append(out, imageFinding{l.line, tok, "a docker argument names a tag"})
+			}
+		}
+		if !named {
+			out = append(out, imageFinding{l.line, strings.TrimSpace(l.text),
+				"a docker command names neither a digest nor a variable"})
+		}
+	}
+	return out
+}
+
+// filesThatStartContainers is every file in this repository that can start
+// one. The workflows, the justfile, and every shell script, found by walking
+// rather than by a list, so a new script is covered on the day it is written
+// rather than on the day somebody remembers to add it here.
+func filesThatStartContainers(t *testing.T) []string {
+	t.Helper()
+	root := filepath.Join("..", "..")
+	files, err := filepath.Glob(filepath.Join(root, ".github", "workflows", "*.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	files = append(files, filepath.Join(root, "justfile"))
+	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case "node_modules", ".git", "testdata", "dist", "build":
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if strings.HasSuffix(d.Name(), ".sh") {
+			files = append(files, path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A glob or a walk that quietly stops matching reads exactly like a clean
+	// tree, which is the failure this repository keeps finding in its own
+	// instruments.
+	if len(files) < 25 {
+		t.Fatalf("only %d files were found to scan; the walk has probably stopped matching", len(files))
+	}
+	return files
+}
+
+func TestEveryContainerImageIsPinnedToADigest(t *testing.T) {
+	// A tag is a name the publisher can repoint. `postgres:17-alpine` resolved
+	// to 17.11 when this was written and will resolve to 17.12 with no commit
+	// here, so a suite that proved what Postgres refuses proved it against
+	// whatever was behind the tag that morning. A digest cannot move.
+	//
+	// Nothing else enforces this. Dependabot's docker file fetcher accepts a
+	// file only when its NAME matches /dockerfile|containerfile/i, or it is a
+	// `values*.yaml` Helm file, or its first YAML document carries both
+	// `apiVersion` and `kind`; a workflow carries `on` and `jobs` and is
+	// refused. The github-actions ecosystem reads `uses:` only. So this test
+	// is the whole of the enforcement, and the pin has to be refreshed by a
+	// person. .github/workflows/ci.yml says how.
+	checked := 0
+	for _, file := range filesThatStartContainers(t) {
+		body, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatal(err)
+		}
+		checked++
+		for _, f := range unpinnedImages(filepath.Base(file), string(body)) {
+			t.Errorf("%s:%d: %s: %s\n"+
+				"    Resolve the multi architecture index digest without a daemon:\n"+
+				"    TOKEN=$(curl -s 'https://auth.docker.io/token?service=registry.docker.io&scope=repository:library/<image>:pull' | jq -r .token)\n"+
+				"    curl -sI -H \"Authorization: Bearer $TOKEN\" -H 'Accept: application/vnd.oci.image.index.v1+json' \\\n"+
+				"      https://registry-1.docker.io/v2/library/<image>/manifests/<tag>\n"+
+				"    Then write it as <image>:<tag>@<digest>, in every site at once.",
+				filepath.ToSlash(file), f.line, f.why, f.ref)
+		}
+	}
+	if checked < 25 {
+		t.Fatalf("only %d files were read; the scan has probably stopped matching", checked)
+	}
+}
+
+func TestEveryPinnedImageAgreesOnOneDigest(t *testing.T) {
+	// Twelve sites name the same Postgres and no mechanism holds them equal.
+	// A bump that changes eleven of them leaves one job testing against a
+	// different server, and every job still passes, which is the shape of a
+	// defect nobody finds. This is the check that a partial bump fails on.
+	pinned := regexp.MustCompile(`([a-z0-9][a-z0-9._/:-]*)@(sha256:[0-9a-f]{64})`)
+	digests := map[string]map[string][]string{}
+	for _, file := range filesThatStartContainers(t) {
+		body, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, m := range pinned.FindAllStringSubmatch(string(body), -1) {
+			name := strings.SplitN(m[1], ":", 2)[0]
+			if digests[name] == nil {
+				digests[name] = map[string][]string{}
+			}
+			digests[name][m[2]] = append(digests[name][m[2]], filepath.ToSlash(file))
+		}
+	}
+	if len(digests) == 0 {
+		t.Fatal("no pinned image was found at all; the pattern has stopped matching")
+	}
+	for name, byDigest := range digests {
+		if len(byDigest) > 1 {
+			for digest, files := range byDigest {
+				t.Errorf("%s is pinned to %s in %v", name, digest, files)
+			}
+			t.Errorf("%s is pinned to %d different digests; a bump changed some sites and not others",
+				name, len(byDigest))
+		}
+	}
+}
+
+func TestTheImagePinCheckRefusesAMovingTag(t *testing.T) {
+	// The exact cases that produced this check, each in the shape it was
+	// found in. A check that has never been shown to say no is not a check.
+	refused := []struct {
+		name, body string
+	}{
+		{"ci.yml", "    services:\n      postgres:\n        image: postgres:17-alpine\n"},
+		{"cp.yml", "                  - name: pg\n                    image: postgres:17-alpine\n"},
+		{"ci.yml", "          docker run -d --name af-cp-test -p 55432:5432 \\\n" +
+			"            -e POSTGRES_PASSWORD=test -e POSTGRES_DB=antifailure postgres:17-alpine \\\n" +
+			"            -c shared_preload_libraries=pg_stat_statements\n"},
+		{"keycloak-up.sh", "IMAGE=\"${AF_KEYCLOAK_IMAGE:-quay.io/keycloak/keycloak:26.0}\"\n"},
+		{"up.sh", "docker run -d --name x alpine sh -c true\n"},
+	}
+	for _, c := range refused {
+		if got := unpinnedImages(c.name, c.body); len(got) == 0 {
+			t.Errorf("a moving tag passed: %q", c.body)
+		}
+	}
+
+	// And the same five, pinned, which is the direction that proves the check
+	// is not simply always saying no.
+	const pg = "postgres:17-alpine@sha256:18cfe3ef5e6815560c98237d6216d1e5119702fb0f3894c8785dd58b8bbe5d73"
+	const kc = "quay.io/keycloak/keycloak:26.0@sha256:09a381c715ab0b111835b70f2905955274843a219c6f27efb348e4d9f4086858"
+	accepted := []struct {
+		name, body string
+	}{
+		{"ci.yml", "    services:\n      postgres:\n        image: " + pg + "\n"},
+		{"cp.yml", "                  - name: pg\n                    image: " + pg + "\n"},
+		{"ci.yml", "          docker run -d --name af-cp-test -p 55432:5432 \\\n" +
+			"            -e POSTGRES_PASSWORD=test -e POSTGRES_DB=antifailure " + pg + " \\\n" +
+			"            -c shared_preload_libraries=pg_stat_statements\n"},
+		{"keycloak-up.sh", "IMAGE=\"${AF_KEYCLOAK_IMAGE:-" + kc + "}\"\n"},
+		{"up.sh", "docker run -d --name x " + pg + " sh -c true\n"},
+	}
+	for _, c := range accepted {
+		if got := unpinnedImages(c.name, c.body); len(got) != 0 {
+			t.Errorf("a pinned image was reported: %q gave %v", c.body, got)
+		}
+	}
+}
+
+func TestAPortMappingIsNotAContainerImage(t *testing.T) {
+	// The false positives this narrowed against, and each of them sits inside
+	// a real `docker run` in this repository. A port mapping has a colon and
+	// digits on both sides, an environment assignment has a colon nowhere but
+	// looks like a word, a database URL has a colon three times, and an image
+	// held in a variable cannot be read at all. A check that fires on any of
+	// these is a check that gets switched off.
+	body := "          docker run -d --name af-cp-target -p 55433:5432 \\\n" +
+		"            -e POSTGRES_PASSWORD=test -e POSTGRES_DB=antifailure \\\n" +
+		"            -e URL=postgres://postgres:test@127.0.0.1:5432/antifailure \\\n" +
+		"            \"$IMAGE\" -c pg_stat_statements.track=all\n"
+	if got := unpinnedImages("ci.yml", body); len(got) != 0 {
+		t.Errorf("a port mapping or an environment assignment was read as an image: %v", got)
+	}
+	// A URL to the registry, which these very comments contain.
+	if got := unpinnedImages("ci.yml", "        # https://registry-1.docker.io/v2/library/postgres/manifests/17-alpine\n"); len(got) != 0 {
+		t.Errorf("a registry URL was read as an image: %v", got)
+	}
+	// A workflow expression, which resolves to an image built in the same run.
+	if got := unpinnedImages("cd.yml", "        image: ${{ needs.build.outputs.image }}\n"); len(got) != 0 {
+		t.Errorf("a workflow expression was read as a moving tag: %v", got)
+	}
+	// And the boundary has not cost the pattern the thing it is for.
+	if got := unpinnedImages("ci.yml", "        image: postgres:17-alpine\n"); len(got) != 1 {
+		t.Errorf("a real moving tag stopped being found: %v", got)
 	}
 }

--- a/tools/preview/up.sh
+++ b/tools/preview/up.sh
@@ -85,13 +85,16 @@ else
   # from one somebody else is depending on, and refuse to remove the second.
   # The password reaches docker on stdin rather than on the command line, so it
   # is not in the process table for the life of the run.
+  # Pinned by digest, because the tag moves and nothing updates it. The
+  # reasoning and the refresh procedure are in .github/workflows/ci.yml,
+  # above the af-cp-test container.
   docker run -d \
     --name "$container" \
     --label af-preview=1 \
     -p "$db_port:5432" \
     --env-file /dev/stdin \
     -e POSTGRES_DB=antifailure \
-    postgres:17-alpine >/dev/null <<ENVFILE
+    postgres:17-alpine@sha256:18cfe3ef5e6815560c98237d6216d1e5119702fb0f3894c8785dd58b8bbe5d73 >/dev/null <<ENVFILE
 POSTGRES_PASSWORD=$(cat "$pgpass_file")
 ENVFILE
   say "  created $container on $db_port"


### PR DESCRIPTION
## The failure

Thirteen container images in this repository were named by a tag.
`postgres:17-alpine` in eight places across four workflows, three more in the
justfile, one in `tools/preview/up.sh`, and `quay.io/keycloak/keycloak:26.0` in
the single sign on conformance harness.

A tag is a name the publisher can repoint. That tag resolves to Postgres 17.11
today and will resolve to 17.12 with nothing here changing, so the server that
the row level security suites, the masking rules, the policy checks and the role
grants were proved against is whichever build carried the tag on the morning the
job ran. Nothing in the tree records which one. A green run says nothing about
which server produced it.

`engine/pkg/emulator/aws.go` already makes this argument, in its own words: a
tag that moves changes what an environment was tested against without anything
in this repository changing. A database is the harder case rather than the
softer one, because every property those suites assert is enforced by the server
and not by us.

## The eight sites, and the five more beside them

The count is complete rather than the ones a first grep found. Five are
`services:` blocks, two are `docker run` steps, and one is a `containers:` entry
inside a Kubernetes Deployment piped to `kubectl apply` from a heredoc, which no
pattern written for `services:` would ever have seen.

| file | line on main | shape |
| --- | --- | --- |
| `.github/workflows/antifailure.yml` | 99 | `services:` |
| `.github/workflows/ci.yml` | 509 | `docker run`, the af-cp-test container |
| `.github/workflows/ci.yml` | 549 | `docker run`, the af-cp-target container |
| `.github/workflows/ci.yml` | 992 | `services:` |
| `.github/workflows/ci.yml` | 1159 | `services:` |
| `.github/workflows/control-plane-image.yml` | 357 | a Deployment in a heredoc |
| `.github/workflows/dogfood.yml` | 86 | `services:` |
| `.github/workflows/dogfood.yml` | 614 | `services:` |

Four more outside the workflows, found by asking what else starts a container
rather than by grepping for the same string. `justfile` at 290, 303 and 916, and
`tools/preview/up.sh` at 94. The justfile is not a local convenience here:
`drill.yml` runs `just drill`, which starts a ninth Postgres in CI, and `ci.yml`
says twice that its container is "the same container `just db` starts,
deliberately, so local and CI agree". Pinning one side and not the other would
have made that sentence false.

And a thirteenth, which is not Postgres at all:
`ee/web/sso/test/keycloak-up.sh` carries `quay.io/keycloak/keycloak:26.0` as a
shell default, so the single sign on conformance suite proves what "Keycloak
26.0" does rather than what a known build does.

## Four spellings, and this is the part worth carrying forward

If you are auditing pins anywhere else in this repository, the count is not the
finding. **An image is named in four different shapes here and no single pattern
sees more than two of them.**

1. `image:` under a `services:` block. The tidy case, and the only one a scan
   written for workflows tends to look for.
2. An argument to `docker run`, which sits past a backslash continuation on the
   line AFTER the command, so a per line scan reads it as absent.
3. `image:` inside a Kubernetes Deployment in a heredoc piped to `kubectl
   apply`. It IS an `image:` key, so a pattern that anchors on `services:`
   misses it in the other direction.
4. A shell parameter default, `IMAGE="${AF_KEYCLOAK_IMAGE:-quay.io/keycloak/keycloak:26.0}"`.
   It reaches neither an `image:` key nor a `docker run` line, and no
   workflow shaped extraction finds it at all.

Two independent extractions were run against this tree tonight and the fourth
shape was found by neither until the search stopped being about workflows and
started being about what can start a container. That is why the gate below
walks the tree rather than reading a list of files, and why it carries three
separate rules instead of one clever pattern.

## The digests, and why they are the index

| image | digest | media type | entries |
| --- | --- | --- | --- |
| `postgres:17-alpine` | `sha256:18cfe3ef5e6815560c98237d6216d1e5119702fb0f3894c8785dd58b8bbe5d73` | `application/vnd.oci.image.index.v1+json` | 16, including linux/amd64 and linux/arm64/v8 |
| `quay.io/keycloak/keycloak:26.0` | `sha256:09a381c715ab0b111835b70f2905955274843a219c6f27efb348e4d9f4086858` | `application/vnd.oci.image.index.v1+json` | 4, including linux/amd64 and linux/arm64 |

Both are the multi architecture index, for the reason the LocalStack pin gives:
a runner on amd64 and a developer's Mac on arm64 resolve one declaration to
their own image, and neither is pinned to the other's architecture. The proof is
the `content-type` the registry answers with, which is the index media type
rather than a single manifest, and the platform list inside it.

Docker on this machine is not answering, so both were resolved over HTTP against
the registries rather than with a daemon: a pull token from `auth.docker.io` and
`quay.io/v2/auth`, then the `docker-content-digest` header on the tag, then a
second request BY that digest to confirm it resolves. The tag is kept in front
of the digest because docker resolves by the digest and ignores the tag, which
makes the readable half free.

**Unverified by execution until CI runs.** No container was started locally.

## Dependabot does not cover these, and cannot be configured to

This is the finding that decided the shape of the change, so here is how it was
established rather than a claim.

`.github/dependabot.yml` declares a `docker` ecosystem, which is why the
question is worth asking. Read from dependabot-core itself:

- `docker/lib/dependabot/docker/file_fetcher.rb` accepts a file when its NAME
  matches `/dockerfile|containerfile/i`.
- `docker/lib/dependabot/shared/shared_file_fetcher.rb` accepts a YAML file only
  when it is a `values*.yaml` Helm file, or when
  `likely_kubernetes_resource?` holds, which is `resource.is_a?(::Hash) &&
  resource.key?("apiVersion") && resource.key?("kind")` on the first document.
  A workflow's first document carries `on` and `jobs`, so it is refused before
  anything looks for an image inside it.
- `github_actions/lib/dependabot/github_actions/file_parser.rb` reads
  `uses_declarations` only, and returns early on `docker://` with the comment
  `TODO: Support Docker references and path references`.

dependabot-core issue 5819, "Update `container` image references in GitHub
Action workflows", has been open since 2022-09-30 and was still open as of this
writing, with a stalebot notice from 2026-06-03 and a reply holding it open.

**So no configuration change is made here, and adding one would be worse.**
Putting `/.github/workflows` in the docker `directories` list would fetch the
`.yml` files and then find none of them acceptable, and `fetch_files` raises
`DependencyFileNotFound` when nothing is accepted, so the result is a Dependabot
job that errors on every scheduled run rather than one that opens a pull
request. What WOULD update these is Renovate, whose `github-actions` manager
reads `services:` and `container:` images; adopting a second dependency bot is a
decision this pull request does not take on its own.

The cost is therefore stated rather than hidden: **these pins do not refresh
themselves.** The refresh procedure, including the two registry requests that
need no daemon, is written beside the pin in `ci.yml`.

## The gate, because a gate is worth more than a one time fix

`tools/gatecheck` already holds every action to a commit sha, in
`TestEveryActionIsPinnedToACommit`. That test could not be extended to images,
because an image is not a `uses:` reference and turns up in three different
shapes, so three tests were added beside it in the same file, which `just
test-tools` and `ci.yml` already run. No new CI gate and no new justfile recipe,
so `gatecheck` itself stays satisfied.

- `TestEveryContainerImageIsPinnedToADigest` refuses a moving tag in any file
  that can start a container. The file list is a WALK, not a list: the
  workflows, the justfile, and every `.sh` in the tree, so a script written next
  month is covered the day it is written. It fails when fewer than 25 files are
  found, because a walk that quietly stops matching reads exactly like a clean
  tree.
- `TestEveryPinnedImageAgreesOnOneDigest` refuses a tree where two sites pin the
  same image to different digests. That is what a half finished bump looks like,
  and it is invisible to everything else here: every job still passes while one
  of them tests against a different server.
- `TestTheImagePinCheckRefusesAMovingTag` and
  `TestAPortMappingIsNotAContainerImage` are the two directions. The first
  refuses all five shapes and accepts all five pinned. The second proves it does
  not fire on `-p 55432:5432`, on `-e POSTGRES_PASSWORD=test`, on a
  `postgres://` URL, on a registry URL in a comment, or on
  `image: ${{ needs.build.outputs.image }}`.

What the check cannot see is written into the code rather than left implied. An
image named with no tag at all, `docker run alpine sh`, is one bare word in a
shell command and indistinguishable from a subcommand, so instead of guessing
which word it is, the check refuses a `docker run` that names neither a digest
nor a variable. Go source that starts a container is not read; the LocalStack
pin carries its own reasoning.

## The apt packages, deliberately not pinned

`postgresql-client-17`, `zsh` and `libsecret-tools` are installed with no
version in eight places. They stay that way, and the reason is recorded next to
the container pin so the next person does not have to rediscover it: a
distribution point release is withdrawn and replaced far more often than a
container digest is, so a pinned apt version fails the build on the day the
mirror drops it, and the dropped version is as often as not the one carrying the
fix. The container is the surface where pinning is cheap. The apt package is not.
