### PR TITLE
infra: nothing refused a gate that resolves its own version at run time

### DIFF
--- a/.changes/a-gate-that-could-not-be-installed-reported-a-verdict.md
+++ b/.changes/a-gate-that-could-not-be-installed-reported-a-verdict.md
@@ -1,0 +1,27 @@
+# fixed
+
+A required context reported a verdict about a change it never read, and then healed itself.
+
+`npx --yes cspell` floated on the dist tag. On 2026-09-08 it resolved a version
+whose own sibling package had not finished publishing, and the spelling step of
+the `www` job died with "No matching version found for cspell-gitignore@10.3.0".
+Twenty minutes later the identical command passed on another pull request.
+Nothing was checked in between and nothing said so.
+
+That failure is the worst shaped one this repository has. In the summary view it
+is indistinguishable from a real spelling mistake, and then the registry catches
+up, so the next person re-runs the red job, sees green, and learns that
+re-running a red job is how you fix one.
+
+`cspell` was pinned in an earlier change. This adds the gate for the class.
+`TestEveryToolIsFetchedAtAPinnedVersion` refuses a workflow or a recipe that
+fetches a package with `npx --yes` and no version. It reads the justfile as well
+as the workflow, because an unpinned recipe beside a pinned CI step is exactly
+the disagreement `gatecheck` exists to stop: the developer's run and the gate's
+run would resolve different software.
+
+What it cannot see is written into it rather than implied. `apt-get install`
+resolves against Ubuntu's archive every run and is not practically pinnable. And
+a pin answers which thing, never whether it arrived: a tool pinned to a commit
+and to a version still failed the same day with exit 22 fetching its own
+tarball, which is a different failure with a different remedy.

--- a/tools/gatecheck/main_test.go
+++ b/tools/gatecheck/main_test.go
@@ -696,6 +696,84 @@ func TestEveryPinnedActionSaysWhichVersionItIs(t *testing.T) {
 	}
 }
 
+func TestEveryToolIsFetchedAtAPinnedVersion(t *testing.T) {
+	// A GATE FOR THE CLASS, WRITTEN THE DAY THE CLASS COST A REQUIRED CONTEXT.
+	//
+	// On 2026-09-08 the `www` job died with "No matching version found for
+	// cspell-gitignore@10.3.0". The step was `npx --yes cspell`, floating on
+	// the dist tag, and it had resolved a version whose own sibling package was
+	// not published yet. Twenty minutes later the same command passed on
+	// another pull request. Nothing was checked in between and nothing said so.
+	//
+	// That is the worst shaped false red this repository has: it is
+	// indistinguishable from a real spelling failure in the summary view, and
+	// then it HEALS ITSELF, so the next person re-runs the red job, sees green,
+	// and learns that re-running a red job is how you fix one. Every other rule
+	// here exists to teach the opposite.
+	//
+	// TestEveryActionIsPinnedToACommit above makes the same argument about
+	// actions and has held for months. Container images are the third such
+	// surface and are covered separately, by the tests that walk every file
+	// able to start a container rather than only the workflows, because this
+	// repository names an image in four spellings and only one of them is an
+	// `image:` key in a `services:` block.
+	//
+	// THE JUSTFILE AS WELL AS THE WORKFLOW, because `gatecheck` exists to stop
+	// those two disagreeing and an unpinned recipe beside a pinned CI step is
+	// exactly that disagreement, one where the developer's run and the gate's
+	// run resolve different software.
+	//
+	// WHAT THIS CANNOT SEE, said rather than implied. `apt-get install`
+	// resolves against Ubuntu's archive on every run and is not practically
+	// pinnable, so `postgresql-client-17`, `zsh` and `libsecret-tools` are
+	// outside this and always will be. `npx <tool>` WITHOUT `--yes` is not here
+	// either, and does not need to be: it resolves from the workspace's own
+	// node_modules, which a lockfile pins, which is why `npx playwright` and
+	// `npx tsc` are safe where `npx --yes` was not. And a pin answers WHICH
+	// thing, never whether it arrived: `lycheeverse/lychee-action` was pinned to
+	// a commit and to v0.24.2 and still failed on 2026-09-08 with exit 22
+	// fetching its own tarball. That is a different failure with a different
+	// remedy and this cannot help with it.
+	npxYes := regexp.MustCompile(`npx\s+(?:--yes|-y)\s+(\S+)`)
+
+	files, err := filepath.Glob(filepath.Join("..", "..", ".github", "workflows", "*.yml"))
+	if err != nil || len(files) == 0 {
+		t.Fatalf("no workflows found: %v", err)
+	}
+	files = append(files, filepath.Join("..", "..", "justfile"))
+
+	checked := 0
+	for _, file := range files {
+		body, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, m := range npxYes.FindAllStringSubmatch(string(body), -1) {
+			spec := m[1]
+			checked++
+			// A version is an `@` that is not the scope marker at the front,
+			// so `@scope/pkg` alone is unpinned and `@scope/pkg@1.2.3` is not.
+			if at := strings.LastIndex(spec, "@"); at <= 0 {
+				t.Errorf("%s: `npx --yes %s` resolves a version at run time.\n"+
+					"    Write it as %s@<version>. A gate that cannot be installed reports "+
+					"a verdict about a change it never read, and then heals itself, which "+
+					"teaches the next person that re-running a red job is how you fix one.",
+					filepath.Base(file), spec, spec)
+			}
+		}
+	}
+
+	// The floor is low because the tree is: there is one such command and it is
+	// written twice, once in the workflow and once in the recipe gatecheck
+	// holds equal to it. Zero would mean the pattern has stopped matching,
+	// which is this check reporting clean because it could not look.
+	if checked < 2 {
+		t.Fatalf("only %d `npx --yes` invocations were found, and there are two. "+
+			"The pattern has stopped matching, so this check proved nothing", checked)
+	}
+	t.Logf("%d run time package fetches checked, all pinned", checked)
+}
+
 func TestNoWorkflowGrantsWriteToEveryJob(t *testing.T) {
 	// A workflow level `contents: write` gives it to every job in the file,
 	// including the ones that only compile something. The release workflow had


### PR DESCRIPTION
## The failure

`npx --yes cspell` floated on the dist tag. On 2026-09-08 it resolved a version
whose own sibling package had not finished publishing, and the spelling step of
the `www` job died with:

```
npm error code ETARGET
npm error notarget No matching version found for cspell-gitignore@10.3.0.
```

`www` is a required context, so #322 read as failing its prose gate with clean
prose, and the identical command passed on #306 twenty minutes later. Between
those two runs the gate checked nothing and did not say so.

## Why this one is worse than a flake

CLAUDE.md names the things that render as a red check where only one means a
test failed. This is the worst shaped of the false ones. In the summary view it
is indistinguishable from a real spelling mistake, and then **it heals itself**,
so the next person re-runs the red job, sees green, and learns that re-running a
red job is how you fix one. That is the precise habit every other rule about
reading CI here exists to prevent.

## What this adds

`TestEveryToolIsFetchedAtAPinnedVersion`, beside `TestEveryActionIsPinnedToACommit`,
which makes the same argument about actions and has held for months. It refuses
a workflow or a recipe that fetches a package with `npx --yes` and no version.

It reads the **justfile as well as the workflows**. An unpinned recipe beside a
pinned CI step is exactly the disagreement `gatecheck` exists to stop, and a
worse one than it looks: the developer's run and the gate's run would resolve
different software while appearing to run the same command.

## What is deliberately not here

**Container images**, which are the third surface of this. They are a separate
change, already open, which walks every file able to start a container rather
than only the workflows. That is the right shape and mine was not: this
repository names an image in four spellings, and one of them is a shell
parameter default in a test harness, reaching neither an `image:` key nor a
`docker run` line. A scan written for workflows reads it as absent.

## What it cannot see, written into it rather than implied

- `apt-get install` resolves against Ubuntu's archive every run and is not
  practically pinnable.
- A pin answers **which** thing, never whether it arrived. On the same day, an
  action pinned to a commit and to `v0.24.2` still failed with exit 22 fetching
  its own tarball from GitHub releases. That is a different failure with a
  different remedy, and it is the one kind of red where re-running the job is
  correct.

## Verified

- The extraction was simulated over all twenty workflow files and the justfile
  before the test was written: two `npx --yes` invocations, both pinned.
- The floor is two rather than a round number for a stated reason. There is one
  such command in the tree and it is written twice, in the workflow and in the
  recipe `gatecheck` holds equal to it. Zero would mean the pattern had stopped
  matching, which is a check reporting clean because it could not look.
- Mutation cells are queued behind the build lock: the pinned version removed
  from `ci.yml`, which is the case that produced this gate, must go red; and the
  justfile copy unpinned so the count falls to one, which must fail saying the
  pattern has stopped matching. I will report both.
