### PR TITLE
gate: two checks reported a verdict about something they never examined

### DIFF
--- a/.changes/a-strict-package-nobody-measured-read-as-one-at-100.md
+++ b/.changes/a-strict-package-nobody-measured-read-as-one-at-100.md
@@ -1,0 +1,28 @@
+# fixed
+
+The coverage gate could not tell a package at 100 percent from one nobody
+measured.
+
+`tools/coverage` built its package list from the COVERAGE PROFILE and never
+from `thresholds.yaml`, and `thresholdFor` was called only inside that loop. So
+a package the thresholds NAME and the profile does not carry was never
+iterated, never compared to its floor, and never printed even under `-all`.
+Nothing compared the two lists.
+
+`internal/masking` sits in the strict tier at 100 percent, described in the
+thresholds file as a package where a missed line is a masking, isolation or
+redaction failure. Measured against a profile with that one package removed and
+everything else present, the old gate prints
+
+    coverage: 19 packages measured against C.5
+    coverage: every package meets its threshold
+
+and exits 0. The package with the strictest floor in the repository had not
+been measured at all, and the gate whose entire job is to stop a number being a
+claim rather than a measurement reported that as success.
+
+Any tier entry the profile does not carry is now refused by name and by tier,
+in the same terms `vulncheck` already uses for a suppression that suppresses
+nothing: it is either tests that stopped running, a package that moved, or dead
+policy that belongs deleted. The same profile with the package restored still
+passes, so the refusal cannot be satisfied by refusing everything.

--- a/.changes/a-test-command-that-ran-nothing-and-passed.md
+++ b/.changes/a-test-command-that-ran-nothing-and-passed.md
@@ -1,0 +1,21 @@
+# fixed
+
+Seven test commands reported success after running no tests.
+
+Every JavaScript suite in this repository is started by handing node a shell
+glob: `node --test test/*.test.ts` and six variations of it. When the glob
+matches nothing, `sh` passes the pattern through as a literal, node's own
+runner treats it as a pattern of its own, matches nothing, prints `pass 0` and
+exits 0. Rename `runner/test`, or rename the files inside it, and the `runner`
+required context goes green having executed nothing. The same shape covers
+`www`, `console`, `api`, and the three workspaces behind the `control plane`
+required context.
+
+Measured rather than reasoned about. With `runner/test` renamed away the old
+command exits 0 and reports `pass 0`; the same tree with the guard exits 1.
+
+Each script now requires its own files to exist before node is started. It
+closes the case where there is nothing to run. It does not close a file that
+exists and registers no test, and it does not close `npm run test
+--workspaces --if-present`, which silently skips a workspace whose `test`
+script has gone. Both are named here rather than left to be discovered.

--- a/.changes/the-credential-gate-could-not-say-it-had-not-looked.md
+++ b/.changes/the-credential-gate-could-not-say-it-had-not-looked.md
@@ -1,0 +1,25 @@
+# security
+
+The credential gate said a tree was clean when it had read no files.
+
+`no credentials in the tree` is a required context on every pull request, and
+`tools/scanrepo` printed one sentence for two different outcomes. Its walk
+swallowed the callback error, the stat error and the read error, each with a
+bare `return nil`, and nothing counted what had been examined, so a root that
+does not exist, a directory the scan could not enter, and a genuinely clean
+repository all produced "no live credentials in the tree" and exit 0. A
+credential inside a directory that would not open was not found, and not
+finding it was reported as its absence.
+
+Its own suite pinned the gap as correct. A case called
+`TestAMissingRootIsNotASilentPass` asserted the silent pass: it required a nil
+error and no findings from a root that is not there, and closed with a comment
+saying scanrepo trusts its argument. So the test list carried a green tick
+under a name promising the hole was closed.
+
+There are three answers now. A credential was found, the tree was read and is
+clean, or the scan could not look. The last one is refused and says which
+paths went unread, and the pass now reports how many files it read. The
+wording is the one fourteen other checks in this repository already use for
+this, which is the point: the idiom existed and the credential gate was the
+tool that did not use it.

--- a/api/package.json
+++ b/api/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "The managed functions behind antifailure.dev.",
   "scripts": {
-    "test": "node --test"
+    "test": "ls test/*.test.js > /dev/null && node --test"
   },
   "dependencies": {
     "@azure/data-tables": "^13.3.0"

--- a/console/package.json
+++ b/console/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "next dev -p 3100",
     "build": "next build",
-    "test": "node --test lib/*.test.ts",
+    "test": "ls lib/*.test.ts > /dev/null && node --test lib/*.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/runner/package.json
+++ b/runner/package.json
@@ -8,7 +8,7 @@
   "engines": { "node": ">=22.6" },
   "bin": { "af-runner": "./src/main.ts" },
   "scripts": {
-    "test": "node --experimental-strip-types --test test/*.test.ts",
+    "test": "ls test/*.test.ts > /dev/null && node --experimental-strip-types --test test/*.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/tools/coverage/main.go
+++ b/tools/coverage/main.go
@@ -76,6 +76,16 @@ func main() {
 		fail("%s covers no packages, so there is nothing to check. "+
 			"Produce it with `just coverage-profile` rather than by hand.", *profile)
 	}
+	if missing := unmeasured(cfg, byPkg); len(missing) > 0 {
+		fail("the thresholds name %d %s that %s does not carry:\n  %s\n\n"+
+			"A threshold on a package the profile never measured is not a package at 100 "+
+			"percent, it is a package nobody looked at, and this tool used to report the "+
+			"two identically. Either the tests stopped running, or the package moved, or "+
+			"the entry is dead policy and belongs deleted. Rerun with "+
+			"`just coverage-profile` before deciding which.",
+			len(missing), plural(len(missing), "package", "packages"), *profile,
+			strings.Join(missing, "\n  "))
+	}
 
 	report(cfg, byPkg, *all)
 }
@@ -209,6 +219,53 @@ func thresholdFor(cfg config, pkg string) (float64, string) {
 		}
 	}
 	return best, name
+}
+
+// unmeasured returns every package the thresholds NAME and the profile does not
+// carry, tier first so the report reads as a policy line.
+//
+// WHY THIS IS NOT A DETAIL. report() builds its list from the profile, so a
+// package named in thresholds.yaml and absent from the coverage profile was
+// never iterated, never compared to its floor and never printed, not even
+// under -all. internal/masking sits in the strict tier at 100 percent because
+// "a missed line is a masking, isolation, or redaction failure"; if its tests
+// stopped building, it left the profile and this gate went on printing a
+// package count and exiting 0. That is a check reporting a verdict about
+// something it never examined, which is the one failure this repository keeps
+// finding in its own instruments.
+//
+// The matching rule is thresholdFor's, deliberately: a tier entry may name a
+// tree rather than a package, so an entry matches when a measured package is
+// it or sits under it.
+func unmeasured(cfg config, byPkg map[string]counts) []string {
+	var out []string
+	for _, named := range []struct {
+		name string
+		rule tier
+	}{{"strict", cfg.Strict}, {"high", cfg.High}} {
+		for _, want := range named.rule.Packages {
+			matched := false
+			for pkg := range byPkg {
+				if pkg == want || strings.HasPrefix(pkg, want+"/") {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				out = append(out, named.name+"  "+want)
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// plural is the difference between "1 packages" and a sentence somebody reads.
+func plural(n int, one, many string) string {
+	if n == 1 {
+		return one
+	}
+	return many
 }
 
 func report(cfg config, byPkg map[string]counts, all bool) {

--- a/tools/coverage/main_test.go
+++ b/tools/coverage/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -141,5 +142,73 @@ func TestAThresholdsFileWithNoDefaultIsRefused(t *testing.T) {
 	}
 	if _, err := readConfig(p); err == nil {
 		t.Fatal("a file with no default was accepted, so every package would pass")
+	}
+}
+
+// The case the gate could not see. report() builds its package list from the
+// PROFILE, so a package the thresholds name and the profile does not carry was
+// never iterated, never compared to its floor, and never printed even under
+// -all. internal/masking is held at 100 percent because a missed line there is
+// a masking failure; if its tests stopped building, it left the profile and
+// this gate went on printing a count and exiting 0.
+func TestAStrictPackageMissingFromTheProfileIsNamed(t *testing.T) {
+	cfg, err := readConfig("thresholds.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Everything the thresholds name, except the one that fell out.
+	byPkg := map[string]counts{}
+	for _, tierPkgs := range [][]string{cfg.Strict.Packages, cfg.High.Packages} {
+		for _, p := range tierPkgs {
+			if p == "internal/masking" {
+				continue
+			}
+			byPkg[p] = counts{covered: 10, total: 10}
+		}
+	}
+	missing := unmeasured(cfg, byPkg)
+	if len(missing) != 1 {
+		t.Fatalf("unmeasured = %v, want exactly the one package that is not in the profile", missing)
+	}
+	if !strings.Contains(missing[0], "internal/masking") {
+		t.Errorf("the report does not name the missing package: %q", missing[0])
+	}
+	if !strings.Contains(missing[0], "strict") {
+		t.Errorf("the report does not say which tier was left unmeasured: %q", missing[0])
+	}
+}
+
+// The other direction, so the refusal cannot be satisfied by refusing
+// everything. A profile that carries every named package must be accepted.
+func TestAProfileCarryingEveryNamedPackageIsAccepted(t *testing.T) {
+	cfg, err := readConfig("thresholds.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	byPkg := map[string]counts{}
+	for _, tierPkgs := range [][]string{cfg.Strict.Packages, cfg.High.Packages} {
+		for _, p := range tierPkgs {
+			byPkg[p] = counts{covered: 10, total: 10}
+		}
+	}
+	if missing := unmeasured(cfg, byPkg); len(missing) != 0 {
+		t.Fatalf("a complete profile was reported as unmeasured: %v", missing)
+	}
+}
+
+// A tier entry may name a tree rather than a package, which is thresholdFor's
+// rule and has to be this one too. Naming only a subpackage must satisfy the
+// entry, or the refusal would fire on a correct profile.
+func TestASubpackageSatisfiesATreeEntry(t *testing.T) {
+	cfg := config{
+		Strict:  tier{Min: 100, Packages: []string{"internal/masking"}},
+		Default: tier{Min: 85},
+	}
+	byPkg := map[string]counts{"internal/masking/dialect": {covered: 1, total: 1}}
+	if missing := unmeasured(cfg, byPkg); len(missing) != 0 {
+		t.Fatalf("a subpackage did not satisfy the tree it sits under: %v", missing)
+	}
+	if missing := unmeasured(cfg, map[string]counts{"internal/maskingother": {covered: 1, total: 1}}); len(missing) != 1 {
+		t.Fatalf("a package that merely shares a prefix satisfied the entry: %v", missing)
 	}
 }

--- a/tools/scanrepo/main.go
+++ b/tools/scanrepo/main.go
@@ -5,6 +5,22 @@
 // disagree about what a credential looks like. That is also why the detector's
 // own tests assemble fake keys at runtime instead of writing them out: a test
 // fixture that looks like a key is a repository that fails this check.
+//
+// WHAT CHANGED AND WHY. This tool used to answer two questions with one
+// sentence. "No live credentials in the tree" was printed both when it had
+// read every file and found nothing, and when it had read NO FILES AT ALL.
+// The walk swallowed its callback error, the stat error and the read error,
+// each with a bare `return nil`, and nothing counted what was examined, so a
+// root that does not exist produced the same confident line as a clean
+// repository. Its own test suite pinned that: a case named
+// TestAMissingRootIsNotASilentPass asserted the silent pass, which put a green
+// tick under a name promising the hole was closed.
+//
+// So there are three answers here now rather than two, and the third is the
+// one that was missing. It found something, it read the tree and found
+// nothing, or it could not look. A scanner that skipped a file cannot say the
+// tree is clean, and a scanner that read nothing at all is pointed at the
+// wrong place.
 package main
 
 import (
@@ -12,6 +28,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 
 	"github.com/antifailure/antifailure/engine/pkg/livekey"
 )
@@ -36,38 +53,117 @@ type Finding struct {
 	Prefix   string
 }
 
+// Result is what the scan found AND what it managed to look at. The second
+// half is the point: len(Findings) == 0 means nothing was found, which is only
+// the same as "nothing is there" when Files is large and Unreadable is empty.
+type Result struct {
+	// Findings is every live credential in the tree.
+	Findings []Finding
+	// Files is how many regular files were read to completion.
+	Files int
+	// Unreadable is every path the scan could not look at, with the reason.
+	// A directory here takes its whole subtree with it.
+	Unreadable []string
+	// TooLarge is how many regular files were past maxFile and skipped by
+	// policy rather than by failure. Reported, not refused.
+	TooLarge int
+}
+
+// outcome is what this tool decides. Two exit codes, from four states: a
+// credential was found, no file was read at all, a path could not be read, or
+// the tree was read and is clean. The first three are refusals, and the middle
+// two used to print the fourth one's sentence.
+type outcome int
+
+const (
+	allowed outcome = iota
+	refused
+)
+
+func (o outcome) String() string {
+	if o == refused {
+		return "refused"
+	}
+	return "allowed"
+}
+
+// verdict is the decision, split out from the printing so that a test can
+// reach it. A check whose verdict lives inside main is a check whose verdict
+// nothing has ever asserted.
+func verdict(res Result) outcome {
+	if len(res.Findings) > 0 || res.Files == 0 || len(res.Unreadable) > 0 {
+		return refused
+	}
+	return allowed
+}
+
 func main() {
 	root := "."
 	if len(os.Args) > 1 {
 		root = os.Args[1]
 	}
 
-	found, err := scan(root)
+	res, err := scan(root)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "scanrepo:", err)
 		os.Exit(1)
 	}
-	for _, f := range found {
+	for _, f := range res.Findings {
 		fmt.Printf("%s: %s (%s)\n", f.Path, f.Provider, f.Prefix)
 	}
-	if len(found) > 0 {
+	if len(res.Findings) > 0 {
 		fmt.Fprintf(os.Stderr,
 			"\n%d live credentials are committed to this repository. Rotate each one, then "+
-				"remove it from the history.\n", len(found))
+				"remove it from the history.\n", len(res.Findings))
+	}
+
+	// The two ways of having looked at nothing, reported separately, because
+	// they send somebody to different places.
+	if res.Files == 0 {
+		fmt.Fprintf(os.Stderr,
+			"scanrepo: read 0 files under %s, so this check is looking in the wrong place "+
+				"rather than at a clean tree. A scan that examined nothing cannot say a "+
+				"repository carries no credential.\n", root)
+	}
+	if len(res.Unreadable) > 0 {
+		fmt.Fprintf(os.Stderr,
+			"scanrepo: read %d files and could not look at %d more:\n", res.Files, len(res.Unreadable))
+		for _, u := range res.Unreadable {
+			fmt.Fprintf(os.Stderr, "  %s\n", u)
+		}
+		fmt.Fprintf(os.Stderr,
+			"\nA credential in one of those would not have been found. Make them readable "+
+				"and run this again, or add the directory to skipDirs with a reason.\n")
+	}
+
+	if verdict(res) == refused {
 		os.Exit(1)
 	}
-	fmt.Println("scanrepo: no live credentials in the tree")
+
+	if res.TooLarge > 0 {
+		fmt.Printf("scanrepo: %d files read, %d past the %d MB bound and not read, "+
+			"no live credentials in the tree\n", res.Files, res.TooLarge, maxFile>>20)
+		return
+	}
+	fmt.Printf("scanrepo: %d files read, no live credentials in the tree\n", res.Files)
 }
 
-// scan walks a tree and reports every live credential in it.
+// scan walks a tree and reports every live credential in it, along with what it
+// was able to read.
 //
 // Split out from main so that it can be tested. A gate nobody has proved can
 // fail is a gate that passes everything the day it breaks, and this one is the
 // difference between a rotated key and a published one.
-func scan(root string) ([]Finding, error) {
-	var found []Finding
+//
+// The walk continues past a path it cannot read rather than stopping, so that
+// one unreadable directory produces a complete list of what was missed instead
+// of the first entry in it. Every one of those is recorded, and main refuses on
+// the list. Skipping quietly is what this tool used to do.
+func scan(root string) (Result, error) {
+	var res Result
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
+			res.Unreadable = append(res.Unreadable, fmt.Sprintf("%s (%v)", path, err))
 			return nil
 		}
 		if d.IsDir() {
@@ -77,17 +173,30 @@ func scan(root string) ([]Finding, error) {
 			return nil
 		}
 		info, statErr := d.Info()
-		if statErr != nil || info.Size() > maxFile || !info.Mode().IsRegular() {
+		if statErr != nil {
+			res.Unreadable = append(res.Unreadable, fmt.Sprintf("%s (%v)", path, statErr))
+			return nil
+		}
+		// Not a failure and not a hole worth refusing over: a socket, a
+		// device, a symlink. There is nothing in one to read.
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		if info.Size() > maxFile {
+			res.TooLarge++
 			return nil
 		}
 		body, readErr := os.ReadFile(path)
 		if readErr != nil {
+			res.Unreadable = append(res.Unreadable, fmt.Sprintf("%s (%v)", path, readErr))
 			return nil
 		}
+		res.Files++
 		for _, f := range livekey.Scan(string(body), path) {
-			found = append(found, Finding{Path: path, Provider: f.Provider, Prefix: f.Prefix})
+			res.Findings = append(res.Findings, Finding{Path: path, Provider: f.Provider, Prefix: f.Prefix})
 		}
 		return nil
 	})
-	return found, err
+	sort.Strings(res.Unreadable)
+	return res, err
 }

--- a/tools/scanrepo/main_test.go
+++ b/tools/scanrepo/main_test.go
@@ -37,10 +37,11 @@ func TestFindsACredentialInTheTree(t *testing.T) {
 	root := tree(t, map[string]string{
 		"config/settings.ts": "export const key = '" + fakeKey("sk_live_", 24) + "'\n",
 	})
-	found, err := scan(root)
+	res, err := scan(root)
 	if err != nil {
 		t.Fatal(err)
 	}
+	found := res.Findings
 	if len(found) != 1 {
 		t.Fatalf("found %d credentials, want 1: %+v", len(found), found)
 	}
@@ -61,10 +62,11 @@ func TestFindsSeveralKindsAtOnce(t *testing.T) {
 		"b/c.json":  `{"gh": "` + fakeKey("ghp_", 36) + `"}`,
 		"d/e/f.yml": "neon: " + fakeKey("napi_", 30),
 	})
-	found, err := scan(root)
+	res, err := scan(root)
 	if err != nil {
 		t.Fatal(err)
 	}
+	found := res.Findings
 	if len(found) != 3 {
 		t.Fatalf("found %d, want 3: %+v", len(found), found)
 	}
@@ -75,10 +77,11 @@ func TestNeverCarriesTheValue(t *testing.T) {
 	// credential there would publish it a second time.
 	secret := fakeKey("sk_live_", 24)
 	root := tree(t, map[string]string{"a.env": "K=" + secret})
-	found, err := scan(root)
+	res, err := scan(root)
 	if err != nil {
 		t.Fatal(err)
 	}
+	found := res.Findings
 	if len(found) != 1 {
 		t.Fatalf("found %d, want 1", len(found))
 	}
@@ -95,12 +98,21 @@ func TestIsQuietOnACleanTree(t *testing.T) {
 		"note.md":  "The key looks like sk_live_ followed by the rest.\n",
 		"urls.txt": "https://example.com/ac/path\n",
 	})
-	found, err := scan(root)
+	res, err := scan(root)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(found) != 0 {
-		t.Fatalf("a clean tree reported %d credentials: %+v", len(found), found)
+	if len(res.Findings) != 0 {
+		t.Fatalf("a clean tree reported %d credentials: %+v", len(res.Findings), res.Findings)
+	}
+	// The other half of a clean answer, and the half that used to be missing.
+	// "Nothing found" only means "nothing is there" when the scan says how
+	// much it read and that it could read all of it.
+	if res.Files != 3 {
+		t.Fatalf("read %d files, want 3", res.Files)
+	}
+	if len(res.Unreadable) != 0 {
+		t.Fatalf("a readable tree reported unreadable paths: %v", res.Unreadable)
 	}
 }
 
@@ -112,12 +124,12 @@ func TestSkipsTheDirectoriesItSaysItSkips(t *testing.T) {
 		"node_modules/pkg/fixture.js": "const k = '" + fakeKey("sk_live_", 24) + "'",
 		"dist/bundle.js":              "var k='" + fakeKey("ghp_", 36) + "'",
 	})
-	found, err := scan(root)
+	res, err := scan(root)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(found) != 0 {
-		t.Fatalf("a skipped directory was scanned: %+v", found)
+	if len(res.Findings) != 0 {
+		t.Fatalf("a skipped directory was scanned: %+v", res.Findings)
 	}
 }
 
@@ -132,27 +144,166 @@ func TestIgnoresAFileTooLargeToBeSource(t *testing.T) {
 	if err := os.WriteFile(big, body, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	found, err := scan(root)
+	res, err := scan(root)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(found) != 0 {
-		t.Fatalf("a file past the size bound was read: %+v", found)
+	if len(res.Findings) != 0 {
+		t.Fatalf("a file past the size bound was read: %+v", res.Findings)
+	}
+	// Counted as skipped by policy rather than as a failure to look, because
+	// the bound is a decision. main prints it rather than refusing on it.
+	if res.TooLarge != 1 {
+		t.Fatalf("TooLarge is %d, want 1", res.TooLarge)
+	}
+	if len(res.Unreadable) != 0 {
+		t.Fatalf("the size bound was reported as a path it could not read: %v", res.Unreadable)
 	}
 }
 
 func TestAMissingRootIsNotASilentPass(t *testing.T) {
-	// WalkDir on a path that is not there reports nothing to walk. A check
-	// pointed at the wrong tree must not be indistinguishable from a clean
-	// one, so this pins which of the two happens today.
-	found, err := scan(filepath.Join(t.TempDir(), "does-not-exist"))
+	// THIS TEST USED TO ASSERT THE OPPOSITE OF ITS NAME. It required err to be
+	// nil and the findings to be empty for a root that is not there, and its
+	// closing comment said "scanrepo trusts its argument". So the suite carried
+	// a green tick under a name promising the hole was closed, and the
+	// assertion held it open.
+	//
+	// WalkDir on a path that is not there calls the callback once with the
+	// error and nothing else, so the honest answer is neither a finding nor a
+	// clean tree: it is that nothing was read.
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	res, err := scan(missing)
 	if err != nil {
-		t.Fatalf("expected the walk to swallow the error, got %v", err)
+		t.Fatalf("the walk should record the error rather than return it, got %v", err)
 	}
-	if len(found) != 0 {
-		t.Fatalf("unexpected findings: %+v", found)
+	if res.Files != 0 {
+		t.Fatalf("read %d files under a root that does not exist", res.Files)
 	}
-	// Documented consequence: scanrepo trusts its argument. CI passes the
-	// repository root explicitly, and this test exists so that the day
-	// somebody changes that, they read this.
+	if len(res.Unreadable) != 1 {
+		t.Fatalf("a root that does not exist produced %d unreadable paths, want 1: %v",
+			len(res.Unreadable), res.Unreadable)
+	}
+	if !strings.Contains(res.Unreadable[0], "does-not-exist") {
+		t.Errorf("the unreadable path does not name the root: %q", res.Unreadable[0])
+	}
+}
+
+func TestReadingNothingIsRefusedRatherThanReportedClean(t *testing.T) {
+	// The verdict main reaches, rather than the shape scan returns. A tree
+	// with no files in it is not a tree with no credentials in it, and the
+	// difference is the whole reason this file was rewritten.
+	res, err := scan(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Findings) != 0 || res.Files != 0 {
+		t.Fatalf("an empty directory: %d findings, %d files", len(res.Findings), res.Files)
+	}
+	if verdict(res) != refused {
+		t.Fatalf("an empty tree reached verdict %v, want refused", verdict(res))
+	}
+}
+
+func TestADirectoryItCannotEnterIsNotACleanTree(t *testing.T) {
+	// The case that matters in a real repository: the walk reaches a directory
+	// it cannot open, and every file under it goes unscanned. Reporting that
+	// as clean is the failure this whole file is about.
+	if os.Geteuid() == 0 {
+		// Root reads a 0000 directory, so the case cannot be built here.
+		// Loudly, rather than as a quiet skip: this is the assertion that
+		// matters most and a run without it has not made it.
+		if os.Getenv("CI") != "" {
+			t.Fatal("running as root, so the unreadable directory case cannot be built and was NOT checked")
+		}
+		t.Skip("running as root: chmod 000 does not stop a read")
+	}
+	root := t.TempDir()
+	closed := filepath.Join(root, "closed")
+	if err := os.MkdirAll(closed, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(closed, "creds.env"),
+		[]byte("K="+fakeKey("sk_live_", 24)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "readme.md"), []byte("nothing here\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(closed, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(closed, 0o755) })
+
+	res, err := scan(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The credential inside is genuinely not found, which is exactly why the
+	// verdict must not be clean.
+	if len(res.Findings) != 0 {
+		t.Fatalf("the unreadable directory was read after all: %+v", res.Findings)
+	}
+	if res.Files != 1 {
+		t.Fatalf("read %d files, want the 1 readable one", res.Files)
+	}
+	if len(res.Unreadable) == 0 {
+		t.Fatal("a directory the scan could not enter was not recorded, so its contents " +
+			"went unscanned and the tree would be reported clean")
+	}
+	if verdict(res) != refused {
+		t.Fatalf("a tree with an unreadable directory reached verdict %v, want refused", verdict(res))
+	}
+}
+
+func TestAReadableTreeStillPasses(t *testing.T) {
+	// The other direction. A gate loosened until it stops complaining is the
+	// same defect wearing the opposite sign, so the clean case is pinned here
+	// against the same verdict function.
+	root := tree(t, map[string]string{
+		"main.go":  "package main\n\nfunc main() {}\n",
+		"doc/a.md": "The key looks like sk_live_ followed by the rest.\n",
+	})
+	res, err := scan(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if verdict(res) != allowed {
+		t.Fatalf("a clean readable tree reached verdict %v, want allowed: %+v", verdict(res), res)
+	}
+}
+
+func TestAFileItCannotOpenIsNotACleanTree(t *testing.T) {
+	// The directory case above is stopped by WalkDir, which reports the
+	// unreadable directory through the callback's error. A file that lists
+	// fine and will not open fails later, in the read, and that was a
+	// separate `return nil` with a separate silence.
+	if os.Geteuid() == 0 {
+		if os.Getenv("CI") != "" {
+			t.Fatal("running as root, so the unreadable file case cannot be built and was NOT checked")
+		}
+		t.Skip("running as root: chmod 000 does not stop a read")
+	}
+	root := tree(t, map[string]string{
+		"readme.md":  "nothing here\n",
+		"secret.env": "K=" + fakeKey("sk_live_", 24),
+	})
+	if err := os.Chmod(filepath.Join(root, "secret.env"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(filepath.Join(root, "secret.env"), 0o600) })
+
+	res, err := scan(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Findings) != 0 {
+		t.Fatalf("the unreadable file was read after all: %+v", res.Findings)
+	}
+	if len(res.Unreadable) != 1 {
+		t.Fatalf("a file that would not open produced %d unreadable paths, want 1: %v",
+			len(res.Unreadable), res.Unreadable)
+	}
+	if verdict(res) != refused {
+		t.Fatalf("a tree with a file that would not open reached verdict %v, want refused", verdict(res))
+	}
 }

--- a/web/apps/api/package.json
+++ b/web/apps/api/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "start": "node src/main.ts",
-    "test": "node --test --test-concurrency=1 test/*.test.ts",
+    "test": "ls test/*.test.ts > /dev/null && node --test --test-concurrency=1 test/*.test.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "openapi": "node scripts/openapi.ts ../../../www/public/openapi.json",
     "openapi:check": "node scripts/openapi.ts ../../../www/public/openapi.json --check"

--- a/web/packages/db/package.json
+++ b/web/packages/db/package.json
@@ -9,7 +9,7 @@
     "./schema": "./src/schema.ts"
   },
   "scripts": {
-    "test": "node --test --test-concurrency=1 test/*.test.ts",
+    "test": "ls test/*.test.ts > /dev/null && node --test --test-concurrency=1 test/*.test.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "seed": "node bin/seed-staging.ts"
   },

--- a/web/packages/policy/package.json
+++ b/web/packages/policy/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "exports": { ".": "./src/index.ts" },
   "scripts": {
-    "test": "node --test test/*.test.ts",
+    "test": "ls test/*.test.ts > /dev/null && node --test test/*.test.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "devDependencies": {

--- a/www/package.json
+++ b/www/package.json
@@ -10,7 +10,7 @@
     "build": "node scripts/optimize-images.mjs && next build && node scripts/markdown-twins.mjs",
     "start": "next start",
     "check:seo": "node scripts/check-seo.mjs",
-    "test": "node --import ./test/resolve.ts --test --test-concurrency=1 test/*.test.ts",
+    "test": "ls test/*.test.ts > /dev/null && node --import ./test/resolve.ts --test --test-concurrency=1 test/*.test.ts",
     "og": "node scripts/make-og.mjs"
   },
   "dependencies": {


### PR DESCRIPTION
Two checks that reported a verdict about something they had not examined.
Both were found by an audit of every required gate against three questions: can
it tell the thing it forbids from the thing it exists to permit, can it say "I
could not look" as an answer distinct from pass and from fail, and does its
NAME describe what it actually examined.

## The credential gate could not say it had not looked

`no credentials in the tree` is a required context on every pull request, and
`tools/scanrepo` printed one sentence for two different outcomes. Its walk
swallowed the callback error, the stat error and the read error, each with a
bare `return nil`, and nothing counted what had been examined. A root that does
not exist, a repository containing a directory the walk cannot enter, and a
genuinely clean tree all produced `scanrepo: no live credentials in the tree`
and exit 0.

Its own suite pinned the gap as correct behaviour. The last case was called
`TestAMissingRootIsNotASilentPass` and its body asserted the silent pass: a nil
error and no findings from a root that is not there, closing with a comment
saying scanrepo trusts its argument. A green tick under a name promising the
hole was closed, holding it open.

There are three answers now. A credential was found, the tree was read and is
clean, or the scan could not look. `scan` returns a `Result` carrying the file
count, the paths it could not read and the count skipped by the size bound, and
the decision moves into a `verdict` function so a test can reach it. Reading
zero files is refused separately from being unable to read a path, because the
two send somebody to different places. The wording is the one fourteen other
checks in this repository already use.

## Seven test commands reported success after running no tests

Every JavaScript suite here is started by handing node a shell glob. When the
glob matches nothing, `sh` passes the pattern through as a literal, node's own
runner treats it as a pattern of its own, matches nothing, prints `pass 0` and
exits 0.

Three required contexts rest on that. `runner` runs the command directly.
`control plane` reaches three of these scripts through `npm test --workspaces`.
`www` reaches the beacon, the console and the site API. Each script now
requires its own files to exist before node is started.

It does not close a file that exists and registers no test, and it does not
close `npm run test --workspaces --if-present`, which still skips a workspace
whose `test` script has gone. Both are named in the commit rather than left to
be discovered.

## What was proved, and what was not

The node guards are proved in both directions, measured rather than reasoned
about. With `runner/test` renamed away the old command exits 0 and reports
`pass 0`; the guarded command on the same tree exits 1; the tree restored, the
guard clears and node runs. All seven were driven in `sh`, the shell npm uses,
present and absent.

The scanrepo change was NOT proved locally before this was opened. The
machine's Go build lock was held continuously by other lanes for over forty
minutes with fifteen waiting, and the probe batch is still queued behind it. So
the only execution behind this half is this workflow's own `engine` job, which
runs `cd tools && go test ./... -count=1`. Said here rather than left implied,
because a claim of proof that was not made is the failure the whole pull
request is about. The mutation cells follow when the lock frees.

## A strict package nobody measured read as one at 100 percent

`tools/coverage` built its package list from the coverage profile and never
from `thresholds.yaml`, and `thresholdFor` was called only inside that loop. A
package the thresholds NAME and the profile does not carry was never iterated,
never compared to its floor, and never printed even under `-all`.

Measured end to end, through the real binary. Against a profile carrying every
named package except `internal/masking`, which is strict tier at 100 percent
because a missed line there is a masking, isolation or redaction failure, the
old gate prints `19 packages measured against C.5` and `every package meets its
threshold` and exits 0. This branch refuses and names the package and its tier.
The same profile with the package restored prints `20 packages measured` and
exits 0, so the refusal was not bought by refusing everything.

Three mutation cells, each aimed at one test that ran once and went red:
`unmeasured` reporting nothing, the tree rule narrowed to an exact match, and
the tree rule widened to a bare string prefix.

## The scanrepo proof, now that the build lock freed

    root that does not exist            BEFORE exit 0 clean   AFTER exit 1
    existing but empty root             BEFORE exit 0 clean   AFTER exit 1
    unreadable directory holding a key  BEFORE exit 0 clean   AFTER exit 1
    that directory made readable        BEFORE exit 1 found   AFTER exit 1 found

The third row is the one to read twice: a live Stripe key sat in a directory
the scan could not enter, and the old gate reported that repository clean. The
fourth is the legitimate case, unchanged, so the gate was not loosened to stop
it complaining. Four mutation cells, one break per assertion, each aimed with
`-run` at a single test confirmed to have run once and gone red.
