### PR TITLE
engine: the fidelity report claimed a substitution the sidecar refuses

### DIFF
--- a/.changes/a-report-that-claimed-a-substitution-the-sidecar-refuses.md
+++ b/.changes/a-report-that-claimed-a-substitution-the-sidecar-refuses.md
@@ -1,0 +1,37 @@
+# fixed
+
+The fidelity report said a wildcard capture was a faithful substitution, and
+for half the hosts such a rule matches the sidecar refuses it.
+
+`af fidelity` classified every capture rule the same way: `substituted,
+recorded into the inbox and answered with the provider's documented success
+shape`. That sentence is true for a host somebody named that this build has a
+handler for. It was also printed for a rule covering a domain rather than
+naming a host, which the sidecar answers with a 403 having recorded nothing
+whenever it has no handler for whichever host arrives. A delivery path written
+as `*.zapier.com` read in the report as captured into the inbox and posted
+nowhere at run time, and the one document that exists to say what a copy does
+not reproduce was the thing hiding it.
+
+Calling such a rule refused would have been the same mistake pointing the other
+way. The guard is `!known && !d.NamesHost()`, so a request under
+`*.resend.com` IS captured and one under `*.zapier.com` is not, and neither
+answer can be read off the rule. It is reported unmeasured with the reason,
+which leaves the score and is named in the exclusions rather than counted as an
+answer nobody checked. The mock branch of the same function already treats the
+same rule shape that way.
+
+Half of the same overstatement is left standing and named rather than papered
+over. Whether a host somebody DID name is answered with the provider's own body
+or with the generic empty object depends on the sidecar's handler list, which
+lives in `package main` and cannot be imported by the report. This build has no
+Zapier handler, so a named Zapier host is answered `{}` and a client checking
+`status` reads that as a failure. Four new tests in the sidecar pin its actual
+behaviour for a Zapier hook and a HubSpot contact write, including that one as
+a stated limit, so a registry both sides can read has something to be checked
+against when somebody builds it.
+
+`af net explain` has the same blind spot from the other side: it gives the
+identical CAPTURE verdict for both rules. Also not fixed here, for the same
+reason, because a fifth copy of a host matching list is how the four this
+repository already has drifted apart.

--- a/docs/plan/four-stacks/README.md
+++ b/docs/plan/four-stacks/README.md
@@ -1,0 +1,723 @@
+# The four stacks, rehearsed against their own published files
+
+This is the row that is judged by whether the product does the thing it is
+being built to do, on somebody else's repository, with no edits to their
+application. PostHog, ClickHouse and Supabase publish the file a twin would be
+built from. Goliath Data publishes nothing, so it gets a shape and a question
+list rather than a rehearsal, which is the ruling in `enterprise_plan.md` and is
+not reopened here.
+
+Everything below was measured on 2026-09-08 against `origin/main` at 53d62204.
+The findings that would change once L1.1, L3.1, L4.4 or L6.1 land are marked.
+
+## Where the files came from
+
+Nothing here was hand written to resemble a stack. Each manifest is a
+mechanical conversion of a file fetched from the project's own repository, by
+`compose2af.py` beside this README, which records every compose key it could
+not express rather than dropping it quietly.
+
+| Stack | File | Services |
+| --- | --- | --- |
+| ClickHouse | `ClickHouse/examples`, `docker-compose-recipes/recipes/ch-1S_1K/docker-compose.yaml` | 2 |
+| Supabase | `supabase/supabase`, `docker/docker-compose.yml` with `docker/.env.example` | 11 |
+| PostHog | `PostHog/posthog`, `docker-compose.hobby.yml` merged with `docker-compose.base.yml` | 37 |
+| Goliath Data | nothing is published | not rehearsable |
+
+All four were fetched on 2026-09-08 from:
+
+```
+https://raw.githubusercontent.com/ClickHouse/examples/main/docker-compose-recipes/recipes/ch-1S_1K/docker-compose.yaml
+https://raw.githubusercontent.com/supabase/supabase/master/docker/docker-compose.yml
+https://raw.githubusercontent.com/supabase/supabase/master/docker/.env.example
+https://raw.githubusercontent.com/PostHog/posthog/master/docker-compose.hobby.yml
+https://raw.githubusercontent.com/PostHog/posthog/master/docker-compose.base.yml
+https://raw.githubusercontent.com/PostHog/posthog/master/bin/deploy-hobby
+```
+
+The last one was read and not converted. It is the script that writes PostHog's
+`.env`, and reading it is how F16 below is stated as fact rather than guessed.
+PostHog's `.env.example` was deliberately NOT used: its own first line says it
+is for local development of the repository only, it is not what the hobby
+compose file reads, and it carries a private key that this report will not
+carry.
+
+Nothing was sent to any of those projects. No issue, discussion, pull request or
+support ticket was opened anywhere. The fetches above are the whole of the
+contact.
+
+## The number
+
+**Stacks that came up: 0 of 4. Services that reached ready: 0 of 50.**
+
+One fidelity report was captured all the same, for the Goliath shape, and it is
+where F0 below came from. `af fidelity` answers without a running environment
+and reports every unmeasurable component as unmeasured rather than as a pass,
+which is the behaviour the rest of this report leans on: it is why the zero
+above is a zero and not a small number somebody could mistake for progress.
+
+That number is about this machine and not about the three manifests, and the
+distinction is the whole of the reporting here. All four manifests validate and
+`af explain` renders every one of them. None reached a running environment,
+because `af up` cannot create an environment at all on this machine tonight,
+and none of the fifty services could have been started even if it could,
+because their images cannot be fetched.
+
+| Stack | Declared | Manifest valid | Reached ready | Why not |
+| --- | --- | --- | --- | --- |
+| ClickHouse ch-1S_1K | 2 | yes | 0 | `af up` killed at 25m32s on `building the egress proxy`, and neither of its two images is on this machine |
+| Supabase self hosting | 11 | yes | 0 | same sidecar prerequisite, and none of its 11 images is on this machine |
+| PostHog hobby | 37 | yes | 0 | same, and none of its images is on this machine |
+| Goliath shape | 4 | yes | 0 | same |
+
+Checked one at a time with `docker image inspect`, which answers in under a
+second where `docker images` does not answer at all: `clickhouse-server`,
+`clickhouse-keeper`, `supabase/postgres`, `postgrest`, `envoy`,
+`hashicorp/http-echo`, `alpine:3` and `nginx:alpine` are all absent. So the
+registry, not the sidecar, is the outer blocker: with the sidecar image seeded
+by hand the stacks still could not start, because there is nothing to start
+them from.
+
+`af down` afterwards was clean: six resources removed, three compensated by the
+journal, which is the half of the lifecycle that did work.
+
+### What the machine actually did, so the number is readable
+
+- The Docker daemon answers `docker info` and `docker version`, and runs a
+  cached image in under a second: `alpine`, `postgres:17`, `golang:1.25-alpine`
+  and `busybox` all ran with `--pull=never` and exited 0.
+- It cannot pull. `docker run hashicorp/http-echo:1.0` failed after 2m56s with
+  `TLS handshake timeout` against `registry-1.docker.io`.
+- It cannot enumerate. `docker ps` and `docker images` returned nothing inside
+  180 seconds, against 236 containers and 115 running, at load average 30.
+  Every container level observation in this report is therefore COULD-NOT-LOOK.
+- Load average sat between 19 and 39 for the whole session, and `af doctor`
+  reported `fail Docker daemon: the daemon did not respond` while the CLI was
+  answering, which is the same condition seen from a shorter timeout.
+
+## What the product got right, said before the findings
+
+Three things worked exactly as they are meant to, and they are why the rest of
+this report can be trusted at all.
+
+**It refused to print a number it could not defend.** The ClickHouse report,
+captured in full at `fidelity/clickhouse-1s-1k.txt`, ends with
+`Nothing in this environment could be measured, so there is no score`, and then
+names all eleven exclusions. A zero would have been readable as a bad result
+rather than as an absent one.
+
+**It noticed the stores the conversion could not declare.** F4 below says the
+`datastores` block can only name a ClickHouse, so the ClickHouse recipe's two
+services had to be written as ordinary services with an image. The report found
+them anyway:
+
+```
+datastores     unmeasured (2 unmeasured)
+  clickhouse   a clickhouse running clickhouse/clickhouse-server:latest that nothing in
+               the manifest's datastores list names, so nobody chose a stance for it,
+               nothing here copied anything into it, and nothing here can say whether it
+               holds production's data or came up empty
+```
+
+That is the conversion gap being caught by the product rather than by this
+report, which is the strongest form the finding could take. On PostHog it found
+nine stores across 37 services, from the images alone, and eight of them are
+right: ClickHouse, Postgres, Elasticsearch, Kafka, MinIO, Redis, SeaweedFS and
+Valkey, each named with the image it is running and each saying that nobody
+chose a stance for it. The full report is at `fidelity/posthog-hobby.txt`. F4
+below is the list of engines the `datastores` block cannot declare, and this is
+the same list arriving from the other direction with no help from the manifest.
+
+**It refused a literal credential.** 29 Supabase values and 13 PostHog values
+were rejected as credential shaped and had to move out of the committed
+manifest. That refusal produced F10 below, which is a gap in where they move to
+and not an argument against the refusal.
+
+## Findings, each with the lane that owes it
+
+The first one is the twin lying about itself, and it was found by running
+`af fidelity`, which is the one part of the exercise this machine could
+complete.
+
+### F0. The fidelity report claimed a faithful provider substitution for a rule the sidecar refuses
+
+This is the finding the row was told to hunt, and it turned out to live one
+level up from where it was expected. The fear was that a wildcard would answer
+200 and produce a twin that silently posts nowhere. The sidecar does not do
+that: a capture whose rule does not name the host is refused with a 403, mock
+with no fixture answers 404, and synth with no model key answers 403. Nothing
+fabricates a success for a host that was merely swept up by a domain.
+
+The REPORT does. `af fidelity` on a manifest carrying three capture rules gave
+all three the same verdict:
+
+```
+third_party    substituted (3 substituted)
+  *.zapier.com substituted  recorded into the inbox and answered with the provider's documented success shape
+  api.resend.… substituted  recorded into the inbox and answered with the provider's documented success shape
+  hooks.zapie… substituted  recorded into the inbox and answered with the provider's documented success shape
+```
+
+Three rules, three different run time behaviours, one sentence:
+
+| Rule | What the sidecar does | What the report said |
+| --- | --- | --- |
+| `*.zapier.com` capture | 403, nothing recorded | substituted, answered with the provider's shape |
+| `api.resend.com` capture | recorded, answered with Resend's own success body | substituted, answered with the provider's shape |
+| `hooks.zapier.com` capture | recorded, answered `{}` | substituted, answered with the provider's shape |
+
+Only the middle row is true. `hostComponent` in
+`engine/internal/fidelity/build.go` matched `schema.ModeCapture` and set
+`Substituted` with that sentence unconditionally, asking neither whether the
+rule names the host nor whether this build has a handler for it.
+
+What the correction is, and what it is not. The obvious repair is to call a
+wildcard capture refused, and that would be wrong for half the hosts such a rule
+matches. The sidecar's guard is `!known && !d.NamesHost()`, so a request under
+`*.resend.com` IS captured, because this build has a Resend handler, and one
+under `*.zapier.com` is refused, because it does not. Neither answer can be read
+off the rule, so the rule is now reported `Unmeasured` with the reason, which is
+the package's own word for a thing it could not determine and is exactly what
+the mock branch of the same function already does with the same rule shape
+through `PackReason`. It leaves the score and is named in the exclusions rather
+than being counted as an answer nobody checked.
+
+The predicate is a LEADING star and not any star, which is the same one the mock
+branch uses and the same one the policy uses to decide `NamesHost`. An interior
+star, as in `email.*.amazonaws.com`, pins the service label and the label count,
+so it can only ever reach SES, the policy counts it as naming the host, and the
+sidecar captures it. Widening to every pattern would trade one wrong answer for
+a quieter one, and a fourth test holds that line.
+
+For a company whose entire outbound path is a Zapier catch hook and two CRMs,
+every line of the third party dimension would have been overstated, and the
+document that exists to say what the twin does not reproduce would have been
+the thing hiding it.
+
+**Half of it is fixed in this branch.** Three tests pin it, and one of them
+asserts that the component leaves the score AND is named in the exclusions,
+because those are two separate claims: dropping out of the denominator is what
+stops a guess being counted, and appearing in `Excluded` with a reason is what
+stops it disappearing silently.
+
+**The other half is not fixed and the reason is stated.** Whether a NAMED host,
+or a host a wildcard happens to cover, is answered with the provider's own shape,
+with the generic empty object, or with a 403, depends on the sidecar's handler
+list, which lives in `package main` under
+`engine/cmd/af-proxy` and cannot be imported by the report. Copying it in would
+make a fifth copy of host matching beside the four this repository already
+carries, in the Go engine, in the console's TypeScript, in the generated sidecar
+sources and in the enterprise deny list, and those four drifting apart is the
+reason a fifth is the wrong answer. The fix is one registry both read. See F14,
+which is the same missing registry seen from the CLI.
+
+Owed by: the fidelity lane for the classification, L0.3 for the registry.
+
+
+### F1. There is no way to mount a file into a service, and all three stacks need one
+
+`container.HostConfig` in `engine/internal/runtime/local/container.go` sets
+neither `Binds` nor `Mounts`, and `schemas/manifest.v1.json` has no `volumes`
+key on a service. So this is a manifest surface gap and a runtime gap at once,
+and neither can be worked around from a manifest.
+
+The three published files ask for 36 bind mounts of a file or a directory, and
+13 named volumes:
+
+| Stack | Bind mounts | Named volumes |
+| --- | --- | --- |
+| ClickHouse ch-1S_1K | 3 | 0 |
+| Supabase | 18 | 2 |
+| PostHog hobby | 15 | 11 |
+
+What each one costs, concretely:
+
+- **ClickHouse.** Both services lose their entire configuration. The server
+  never receives the `<zookeeper>` block that points it at the keeper, and the
+  keeper never receives `keeper_config.xml`. The containers would start on
+  image defaults, which is a different topology from the recipe and would be
+  reported as the recipe.
+- **Supabase.** The `db` service loses all seven SQL files under
+  `/docker-entrypoint-initdb.d`, which is where `roles.sql` creates
+  `supabase_auth_admin`, `authenticator`, `anon` and `service_role`. Without
+  them `auth`, `rest`, `realtime`, `storage` and `supavisor` cannot connect at
+  all. `api-gw` loses `envoy.yaml`, so Envoy starts with no configuration.
+- **PostHog.** ClickHouse loses `config.xml`, `users.xml`, the protobuf IDL and
+  the init SQL; `web`, `plugins`, `livestream`, `feature-flags` and `cymbal`
+  lose their shared directories.
+
+Owed by: the runtime lane and whoever owns the manifest schema. This is the
+single blocker that stops all three stacks, and no other finding can be
+observed past it.
+
+### F2. A manifest cannot say the application has no Postgres
+
+`database` has no off switch. The ClickHouse recipe declares no database and
+`af explain` fills in `provider docker, Postgres 17` anyway, then `af up`
+spends its first minutes creating a golden for a store the twin does not have.
+The twin has one component production does not, and the fidelity report counts
+it.
+
+Owed by: L2.1.
+
+### F3. The engine's Postgres answers to `db`, and two of the three stacks have a service called `db`
+
+`DatabaseAlias` is the literal string `db` at
+`engine/internal/runtime/local/local.go:51`, and a service is attached to the
+same inner network with `Aliases: []string{s.Name}` at `container.go:343`.
+Nothing in `engine/internal/manifest/validate.go` refuses a service named `db`.
+Supabase and PostHog both name one, and both resolve `db` from several other
+services expecting their own Postgres.
+
+The fix cannot be to refuse the name, because renaming the application's
+service is an edit to their application and the whole claim is that there is
+none. It has to be on the engine's side.
+
+Owed by: the runtime lane with L2.1. NOT CONFIRMED BY EXPERIMENT: the alias
+collision is read from the code, and no environment reached the point where two
+containers claim one alias, because of F1 and the machine.
+
+### F4. Only one datastore engine has a provider, and PostHog declares eight it does not have
+
+`newDatastoreProvider` in `engine/internal/env/datastores.go` has a single case,
+`clickhouse`, and refuses everything else by name with AF-MAN-002 and the
+sentence `The engines it can provide are: clickhouse`. That refusal is the
+right shape and it is the correct behaviour. It is also the whole gap.
+
+PostHog's published file declares Postgres and ClickHouse, which this build
+provides, and Kafka, Zookeeper, Redis, Valkey, Elasticsearch, MinIO, SeaweedFS
+and Temporal, which it does not. Supabase declares no second store at all,
+because everything it keeps is in its own Postgres.
+
+Declaring any of those eight in the `datastores` block refuses the manifest, so
+the only way to express them today is as ordinary services with an image, which
+is what the converted PostHog manifest does. That works as far as starting a
+container and it means none of them is masked, branched, verified or reported
+on, which is the difference the `datastores` block exists to make.
+
+Owed by: L4.1 through L4.4. This finding changes when they land.
+
+### F5. `af explain` does not print `datastores` at all
+
+`af explain -o json` carries the datastores array, including the `primary` entry
+the database block normalizes into. The human output, which is the surface a
+person reads and whose own help says it shows the effective configuration with
+every default filled in, prints no line about them. A declared ClickHouse is
+invisible in the document that exists to say what an environment will be.
+
+Owed by: L4.4.
+
+### F6. `command` in a manifest replaces the entrypoint, and in compose it does not
+
+`engine/internal/runtime/local/container.go:300` sets `cfg.Cmd` to
+`/bin/sh -c <command>` and then `cfg.Entrypoint = []string{}`. Compose sets CMD
+and leaves ENTRYPOINT alone, so the image's entrypoint still runs and the
+command is its arguments.
+
+The difference is not cosmetic for these stacks. Supabase's `db` declares
+`command: ["postgres", "-c", "config_file=..."]` against `supabase/postgres`,
+whose entrypoint is the script that runs the init SQL. Converted faithfully,
+the manifest skips that script. The same applies to `rest`, `functions` and
+`supavisor` in Supabase and to `web`, `objectstorage`, `kafka-init` and
+`temporal-django-worker` in PostHog. An image built `FROM scratch` has no
+`/bin/sh` at all, so a command on one cannot run.
+
+Owed by: the runtime lane.
+
+### F7. There is no `entrypoint` key, and dropping it corrupts the command beside it
+
+Five services across the three files declare one: Supabase's `api-gw`, and
+PostHog's `proxy`, `objectstorage`, `seaweedfs` and `kafka-init`. There is no
+manifest key for any of them, so the conversion drops them and records that it
+did.
+
+Dropping an entrypoint is not a missing feature on its own. It is a missing
+feature that breaks the key next to it, and PostHog's `kafka-init` is the
+clearest case in the three files:
+
+```yaml
+entrypoint: /bin/sh
+command:
+    - -c
+    - |
+        set -x
+        until rpk topic list --brokers kafka:9092 2>/dev/null; do
+        ...
+```
+
+The entrypoint is the shell and the command is its arguments. Converted, the
+entrypoint is gone and the argv list is joined into one string, so the manifest
+carries a command beginning with a literal `-c`, which the engine then wraps as
+`/bin/sh -c "-c set -x ..."`. It parses, it validates, and it runs nothing. The
+same shape appears on `objectstorage`, `seaweedfs`, `proxy` and Supabase's
+`api-gw`.
+
+Owed by: whoever owns the manifest schema, with the runtime lane, because the
+key and the semantics in F6 are one decision.
+
+### F8. Two thirds of the declared readiness checks can be expressed, and the third that cannot is the one that matters
+
+The manifest offers `health_path` and `health_timeout`, and `waitReady` in
+`engine/internal/runtime/local/container.go:707` is more capable than the schema
+suggests. A service with a port and no `health_path` is ready when a TCP
+connect succeeds, so a bare TCP check IS expressible. A service with a port and
+a `health_path` is ready when an HTTP GET returns any status at all, 500
+included, which is deliberate and documented in the code.
+
+The three files declare 20 healthchecks between them:
+
+| What the check is | Count | Expressible |
+| --- | --- | --- |
+| an HTTP GET on a path | 9 | yes, as `health_path` |
+| a command inside the container | 8 | no |
+| a bare TCP connect | 2 | yes, as a port with no `health_path` |
+| an HTTP GET that needs an Authorization header | 1 | no |
+
+So nine of the twenty cannot be written down, and the eight commands are the
+ones the project chose deliberately: `pg_isready -U postgres` on Supabase's
+`db`, `postgrest --ready`, `imgproxy health`. Supabase's Postgres accepts a
+connection on 5432 while it is still running its init scripts, which is exactly
+what `pg_isready` exists to distinguish and exactly what a TCP connect cannot.
+
+Worse, and this is the number the row was told to count: a service with NO port
+is ready when its container is running.
+
+```go
+if s.Port <= 0 || hostPort == 0 {
+	// Nothing to poll from here. A worker is ready when it is running, and
+	// asking for more would mean inventing a protocol the application does
+	// not speak.
+	return r.confirmStillRunning(ctx, s, id)
+}
+```
+
+That reasoning is right for a worker and wrong for these stacks, because a
+compose file uses the absence of a published port to mean `only other services
+reach this`, not `this is a worker`. Of PostHog's 37 services, 32 publish no
+port; of Supabase's 11, nine do not. Under the current model, `ready` for 41 of
+the 50 declared services across the three stacks would mean `the container was
+created and has not exited yet`.
+
+Owed by: the runtime lane with whoever owns the manifest schema.
+
+### F9. A service may publish one port
+
+Supabase's `supavisor` publishes 5432 and 6543. PostHog's `proxy`,
+`objectstorage` and `seaweedfs` publish two or three each. Whichever port the
+conversion picks, the others are unreachable from outside the environment, and
+because readiness is measured on the published port, F8 above decides which of
+them the environment waits on.
+
+Owed by: whoever owns the manifest schema, with the runtime lane.
+
+### F10. Environment values are looked up by name in one flat namespace
+
+`secrets.Chain.Lookup` takes a name and asks each source in turn. There is no
+service scope. Supabase's compose gives `DATABASE_URL` one value in `storage`
+and a different one in `supavisor`, and both are credentials, so neither can be
+a literal in the manifest and both resolve through the same name. One of the
+two is wrong, and nothing says which.
+
+The refusal that forces this is correct and should stay: the manifest refuses a
+literal value shaped like a credential, which is what moved 29 Supabase values
+and 13 PostHog values out of the file. The gap is that the place they move to
+cannot tell two services apart.
+
+Owed by: the secrets lane.
+
+### F11. There is no `env_file`
+
+Four PostHog services read one. Every variable in it has to be enumerated in
+the manifest, which is what makes the converted PostHog manifest 799 lines for
+37 services.
+
+Owed by: whoever owns the manifest schema.
+
+### F12. The sidecar image has no pull path, and building it needs the network
+
+`ensureProxyImage` inspects for the image and, failing that, builds it: a
+`golang:1.25-alpine` stage running `go build` with `GOFLAGS=-mod=mod`, which
+fetches the module graph from inside the container. There is no pull, no
+prebuilt artifact and no way to seed it. The tag is content addressed off the
+sidecar sources, so every engine version pays this once per machine.
+
+Tonight it paid nothing and returned nothing: one progress line,
+`building the egress proxy (once per version)`, for 25 minutes and 32 seconds
+until the run was killed. There is no timeout on that step and no output from
+it, so a user has no way to tell a slow build from a hung one.
+
+The contrast is the measurement. The same sidecar, compiled on the host where
+the module cache is already warm and packaged into the same `FROM scratch`
+image under the engine's own content addressed tag, took 237.5 seconds
+end to end on this machine, of which the Go build was a few seconds and the
+rest was the daemon exporting and unpacking a 10.9 MB layer under load. The
+container build did not finish in 1532. The difference is entirely the module
+fetch, and it is a fetch of this repository's own dependency graph over a
+network that was refusing TLS handshakes.
+
+That image was seeded by hand for this session, which is disclosed here rather
+than left implicit: it is why the `db` alias experiment below could run at all,
+and it means nothing in this report is evidence about the build step.
+
+There is a second cold dependency behind the same door, and it is worse in one
+respect. `ensureIngressImage` builds `antifailure/ingress:socat-1` from
+`FROM alpine:3.20` and `RUN apk add --no-cache socat`, so it needs both a
+registry pull and a package fetch. It is skipped when no service publishes a
+port, which is the only reason the experiment below could run.
+
+Owed by: the runtime lane and whoever owns releases. This is the finding that
+turned a rehearsal into a refusal, so it is the one to fix first if the row is
+re-run.
+
+### F13. A domain wildcard with `mode: allow` is accepted, and would post to a real endpoint
+
+`host: "*"` is refused outside block mode, at
+`engine/internal/manifest/validate.go:752`. `host: "*.zapier.com"` with
+`mode: allow` is not refused, and `af net explain` renders it as a clean ALLOW
+with no other rule matching and no caution:
+
+```
+POST https://hooks.zapier.com/hooks/catch/1234/abcd
+
+  ALLOW
+
+  The rule for *.zapier.com decided allow because the host ends in .zapier.com.
+```
+
+For a delivery path that posts to a customer's CRM through a Zapier catch hook,
+that is a rehearsal firing somebody's real automation at real contacts. It is
+the opposite of the failure this row was told to look for and it is worse than
+it.
+
+Owed by: L0.3 with L6.1.
+
+### F14. `af net explain` cannot tell the two capture rules apart, and the sidecar can
+
+The same blind spot as F0, seen from the CLI rather than from the report, and
+this is the half that answers the question the row was actually sent to ask.
+
+**No wildcard answers 200.** The sidecar refuses a capture whose rule does not
+name the host. `Decision.NamesHost()` is false for a leading wildcard and for
+match all, and `capture` in `engine/cmd/af-proxy/capture.go` refuses on
+`!known && !d.NamesHost()` with a 403 and an explanation. Mock with no matching
+fixture answers 404. Synth with no model key answers 403. Nothing fabricates a
+success for a host that was merely swept up by a domain. Four tests in
+`engine/cmd/af-proxy/crm_capture_test.go` pin exactly this for
+`hooks.zapier.com` and `api.hubapi.com`, and they run through the real policy
+engine and the real capture handler with no fake between them.
+
+**But the instrument that is supposed to say so cannot.** `af net explain`
+gives the identical verdict for both rules:
+
+```
+  CAPTURE
+  The rule for *.zapier.com decided capture because the host ends in .zapier.com.
+
+  CAPTURE
+  The rule for hooks.zapier.com decided capture because the host matches exactly.
+```
+
+One of those is answered and recorded; the other is refused at run time. A
+person checking their egress policy before a demo reads the first and believes
+their Zapier deliveries are being captured into the inbox.
+
+This half cannot be fixed by looking at the rule alone, which is why F0 stopped
+at saying it did not know. The report can say a wildcard is undetermined; the
+CLI is being asked what will happen to one specific request, and answering that
+needs the handler list. `*.resend.com` covering `api.resend.com` is captured and
+`*.zapier.com` covering `hooks.zapier.com` is refused, and the difference is
+entirely in that list.
+
+The fix is not to duplicate the sidecar's handler list into the CLI. That list
+already exists in the Go engine, in the console's TypeScript, in the generated
+sidecar sources and in the enterprise deny list, and a fifth copy is how these
+four drift. It is to move the host to provider matching into one package both
+the sidecar and `af net explain` consult.
+
+Owed by: L0.3.
+
+### F15. There is no Zapier capture handler, so a named Zapier host is answered with the wrong shape
+
+`captureHandlerFor` has entries for Resend, SendGrid, Postmark, Mailgun,
+Twilio, SES and Slack. A host somebody named that is not in that list gets
+`genericCapture`, which records the whole body and answers 200 with `{}`.
+
+Zapier's catch hook answers
+`{"status": "success", "attempt": ..., "id": ..., "request_id": ...}`, and a
+client that checks `status` reads `{}` as a failure. The message is captured
+either way, so this is a wrong shape rather than a lost message, and the fourth
+test in `crm_capture_test.go` states it as a limit rather than leaving a reader
+to assume it was checked.
+
+Owed by: L0.3.
+
+### F15a. `af fidelity` printed its whole report and then did not exit
+
+Every one of the four runs printed the complete report, including the closing
+list of exclusions, and was then killed by a 400 second timeout with exit 124.
+The output is not truncated, so the hang is after the last line is written.
+
+COULD-NOT-LOOK as to the cause. The likely candidate is a Docker client call
+that does not return while the daemon is unresponsive, which is the same
+condition every other Docker observation in this report ran into, and it cannot
+be told apart from a real defect without a machine where the daemon answers. It
+is written down rather than left out because a command that prints its answer
+and then hangs is indistinguishable, in a script, from one that never answered.
+
+Owed by: nobody yet. Re-run it on a machine with a responsive daemon before
+attributing it.
+
+### F16. A published compose file is half a deployment, and the conversion gets the half that is published
+
+Two things a manifest needs are simply not in a compose file, and neither is a
+defect in anything. They decide what `convert and run` can mean, so they belong
+here rather than in a footnote.
+
+**The egress policy.** Compose says nothing about which hosts a service reaches,
+so all three converted manifests carry `egress.default: block` and no rules,
+which is the only honest default. The first run of any of them refuses every
+outbound call the application makes, and the loop is to read `af net log` and
+name what shows up. That loop compounds with F8: a service that never becomes
+ready because of a blocked call at startup publishes no port, so it is reported
+ready right up until it exits.
+
+**The environment.** PostHog's `docker-compose.hobby.yml` is not self contained.
+`bin/deploy-hobby` writes the `.env` beside it, generating `POSTHOG_SECRET`,
+`ENCRYPTION_SALT_KEYS` and `BROWSERLESS_SECRET` from `/dev/urandom` and
+`openssl rand` at install time, and taking `DOMAIN`, `TLS_BLOCK`,
+`REGISTRY_URL`, `CADDY_TLS_BLOCK`, `CADDY_HOST` and `POSTHOG_APP_TAG` from
+prompts or the environment. Converted from the compose file alone, every one of
+those resolves empty, which is why `SITE_URL` in the converted manifest reads
+`https://` and nothing else.
+
+That is not a gap to close. Those three are secrets, and the engine already
+refuses a literal credential in a committed manifest, so they were always going
+to come from outside it. What it means is that the conversion produces a
+manifest that is correct about the services and incomplete about the deployment,
+and a reader should know which half they are holding. The Supabase conversion is
+better off only because Supabase publishes a `.env.example` beside its compose
+file, and that is what was used.
+
+Owed by: nobody. It is a property of the input format, and it belongs in the
+onboarding documentation rather than in a lane.
+
+### F17. The datastore detector called PostgREST a Postgres, on Supabase's own file
+
+The Supabase report, captured in full at `fidelity/supabase-selfhost.txt`, says
+this:
+
+```
+datastores     unmeasured (3 unmeasured)
+  db           a postgres running supabase/postgres:17.6.1.136 that nothing in the
+               manifest's datastores list names ...
+  meta         a postgres running supabase/postgres-meta:v0.96.6 that nothing in the
+               manifest's datastores list names ...
+  rest         a postgres running postgrest/postgrest:v14.12 that nothing in the
+               manifest's datastores list names ...
+```
+
+One of those three is a Postgres. `postgres-meta` is a stateless HTTP API over
+somebody else's Postgres and `postgrest` is a stateless HTTP API over somebody
+else's Postgres. Neither holds anything, so neither can hold production's data
+and neither needs a stance.
+
+The mechanism is in `engineOfImage` at
+`engine/internal/fidelity/datastores.go:378`. The registry prefix is stripped,
+which is right, and the remaining base name is tested with
+`strings.Contains(base, token)`. The token is `postgres`, and `postgrest` is
+`postgres` with a `t` on the end, so it matches. `postgres-meta` matches for the
+same reason.
+
+Two things follow, and the second is the one that costs something.
+
+The false positives are noise in the one list a reader is supposed to take
+seriously. The exclusion list is where this report says what it could not
+measure, and three entries where there is one store is how a list like that
+stops being read.
+
+And the same substring rule will do this to other stacks. Anything named after
+the store it talks to is a candidate: a `redis-exporter`, a `kafka-ui`, a
+`mongo-express`. Each would be reported as an unmeasured store of the kind it
+merely monitors.
+
+PostHog's report carries the third variant of the same thing. It lists
+`kafka-init` as a Kafka, and `kafka-init` is a run once job that creates topics
+using the Redpanda image and exits. It is a client of the broker in the next
+row, not a second broker.
+
+Not fixed here, deliberately. A word boundary rule stops `postgrest` and does
+not stop `postgres-meta` or `kafka-init`, so the correct fix is a decision
+about how to tell a store from a client of a store, and that decision belongs
+to whoever owns this table rather than to a lane passing through. Two signals
+the table does not use are sitting in the same manifest: a service that other
+services `depends_on` is more likely to be the store, and a service that exits
+is not one. The token `supabase` in the same
+row is worth looking at in the same pass: the base name is taken after the last
+slash, so `supabase/postgres` reaches the table as `postgres` and the
+`supabase` token can only ever fire on an image actually named something like
+`supabase-postgres`.
+
+Owed by: L4.4.
+
+## How to re-run it
+
+`compose2af.py` and `report.py` beside this README are the whole conversion.
+They need PyYAML and nothing else.
+
+```
+python3 compose2af.py docker-compose.yml --env .env.example \
+    --name supabase-selfhost -o supabase-selfhost/antifailure.yaml
+python3 report.py
+```
+
+The converter is deliberately dull. It refuses to guess: every compose key it
+has no manifest home for is printed with the services that declare it, and a
+value shaped like a credential is moved to a `.env` beside the manifest rather
+than written into a file that gets committed, because the engine refuses that
+and is right to. The one place it makes a choice is `depends_on`, where compose
+allows a map with conditions and the manifest takes a list of names, so the
+conditions are dropped and the names kept.
+
+Where two services give one variable name two different values, it says so and
+keeps the last, because `.env` is one flat namespace and there is nothing else
+it could do. That happened once, for `DATABASE_URL` across Supabase's `storage`
+and `supavisor`, and it is F10 below.
+
+## What was proved and what was not
+
+Proved: the conversions, from the projects' own published files. The manifests
+validate and `af explain` renders them. The engine's refusals of a literal
+credential, of a datastore engine it has no provider for, and of a match all
+rule outside block mode. The sidecar's behaviour for a Zapier and a CRM
+hostname under a wildcard and under an exact rule, by test. The teardown.
+
+Not proved, and not to be reported as anything else: that any of these stacks
+runs. No container of any of them was created. The `db` alias collision is read
+from the code and was never observed, and so is the entrypoint difference in F6
+and the absence of bind mounts in F1.
+
+The fidelity reports that were captured are reports on an environment that does
+not exist. Every service, the database and the datastore come back `unmeasured`
+with the reason, which is the honest answer and is why F0 is about the third
+party dimension alone: that dimension is computed from the manifest and does not
+need anything running, so it is the one part of the report that said something
+substantive, and what it said was wrong.
+
+## The mutation table
+
+Every test in this branch was mutation tested: the production line it guards was
+broken, the suite re-run, and the cell classified on the `=== RUN` count rather
+than on the exit code, because a break that stops the package compiling exits
+non zero having run nothing and reads exactly like a catch. Restores were from a
+file snapshot rather than with `git checkout`, because the worktree is shared
+state.
+
+The full table is reported in this lane's handover. One cell is worth writing
+down here, because it is the defect the discipline exists to catch.
+
+The first attempt at the cell for `TestCapture_ANamedZapierHostIsRecordedAndAnswered`
+replaced the guard `if !known && !d.NamesHost() {` with `if true {`. That
+removed the last use of `known`, so the package stopped compiling: exit 1, zero
+tests run, and a summary that would read as a caught mutation to anything
+counting exit codes. It was redone as `if !known && !d.NamesHost() || true {`,
+which keeps `known` in use and actually runs the suite.

--- a/docs/plan/four-stacks/clickhouse-1s-1k/antifailure.yaml
+++ b/docs/plan/four-stacks/clickhouse-1s-1k/antifailure.yaml
@@ -1,0 +1,27 @@
+version: 1
+name: clickhouse-1s-1k
+
+# Converted from ClickHouse's own published recipe, fetched from
+# ClickHouse/examples at docker-compose-recipes/recipes/ch-1S_1K/docker-compose.yaml.
+# Nothing here was invented: every service, image, port and dependency below is
+# in that file.
+
+services:
+  - name: clickhouse-keeper
+    kind: worker
+    build:
+      strategy: image
+      image: clickhouse/clickhouse-keeper:latest-alpine
+
+  - name: clickhouse
+    kind: web
+    port: 8123
+    health_path: /ping
+    depends_on:
+      - clickhouse-keeper
+    build:
+      strategy: image
+      image: clickhouse/clickhouse-server:latest
+
+egress:
+  default: block

--- a/docs/plan/four-stacks/compose2af.py
+++ b/docs/plan/four-stacks/compose2af.py
@@ -1,0 +1,192 @@
+"""Convert a published docker compose file into an antifailure.yaml.
+
+Mechanical, and it refuses to be clever. Every service in the compose file
+becomes a service in the manifest. Every compose key the manifest has no home
+for is recorded in a dropped list rather than dropped quietly, because a
+conversion that silently loses a bind mount produces a twin that starts and is
+not the thing it is a twin of.
+"""
+import sys, os, re, json, collections
+sys.path.insert(0, os.path.dirname(__file__))
+import yaml
+
+# What a manifest service can carry, from schemas/manifest.v1.json.
+EXPRESSIBLE = {"image", "command", "ports", "environment", "depends_on", "build"}
+# Everything else in a compose service has no manifest key at all.
+
+CRED_HINT = re.compile(r"(KEY|SECRET|TOKEN|PASSWORD|PASSWD|CREDENTIAL)", re.I)
+
+def looks_like_a_credential(name, value):
+    """Approximates the engine's own refusal so the conversion does not have to
+    be run once per rejected line. The engine is the authority; this only keeps
+    the loop short."""
+    if not value:
+        return False
+    if re.match(r"^[a-z+]+://[^/\s]*:[^@/\s]+@", value):
+        return True          # a URI carrying a password
+    if value.count(".") == 2 and value.startswith("ey"):
+        return True          # a JWT
+    if CRED_HINT.search(name) and len(value) >= 16:
+        return True
+    return False
+
+# Compose escapes a literal dollar as $$, so a shell script embedded in a
+# command keeps its own variables. Resolving before unescaping turns $$ELAPSED
+# into a bare $ and silently breaks the script, which is what this placeholder
+# exists to stop.
+DOLLAR = "\x00AF-LITERAL-DOLLAR\x00"
+
+def resolve(v, env):
+    """Resolve ${VAR:-default} and $VAR the way compose does, no further."""
+    if not isinstance(v, str):
+        return v
+    v = v.replace("$$", DOLLAR)
+    def sub(m):
+        name = m.group("name")
+        default = m.group("default")
+        if name in env and env[name] != "":
+            return env[name]
+        return default if default is not None else ""
+    v = re.sub(r"\$\{(?P<name>[A-Za-z_][A-Za-z0-9_]*)(?::?-(?P<default>[^}]*))?\}", sub, v)
+    v = re.sub(r"\$(?P<name>[A-Za-z_][A-Za-z0-9_]*)", lambda m: env.get(m.group("name"), ""), v)
+    return v.replace(DOLLAR, "$")
+
+def load_env(path):
+    env = {}
+    if not path or not os.path.exists(path):
+        return env
+    for line in open(path):
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, _, val = line.partition("=")
+        env[k.strip()] = val.strip()
+    return env
+
+def flatten_extends(services, base_services):
+    """Compose `extends` merges the base service under the local one."""
+    out = {}
+    for name, svc in services.items():
+        svc = dict(svc or {})
+        ext = svc.pop("extends", None)
+        if ext:
+            base = dict((base_services or {}).get(ext.get("service", name)) or {})
+            merged = dict(base)
+            for k, v in svc.items():
+                if k == "environment" and isinstance(v, list) and isinstance(merged.get(k), list):
+                    merged[k] = list(merged[k]) + v
+                else:
+                    merged[k] = v
+            svc = merged
+        out[name] = svc
+    return out
+
+def env_pairs(node, env):
+    pairs = []
+    if isinstance(node, dict):
+        for k, v in node.items():
+            pairs.append((k, resolve("" if v is None else str(v), env)))
+    elif isinstance(node, list):
+        for item in node:
+            k, _, v = str(item).partition("=")
+            pairs.append((k, resolve(v, env)))
+    # Compose lets a later entry win for the same key, and the manifest refuses
+    # a name declared twice. Keeping the last is what compose would have run.
+    seen = {}
+    for k, v in pairs:
+        seen[k] = v
+    return list(seen.items())
+
+def first_port(svc, env):
+    """The container port a manifest can name. Compose publishes host:container."""
+    ports = svc.get("ports") or []
+    for p in ports:
+        p = resolve(str(p), env)
+        parts = p.split("/")[0].split(":")
+        try:
+            return int(parts[-1])
+        except ValueError:
+            continue
+    return None
+
+def convert(compose_path, env_path, base_path, name):
+    d = yaml.safe_load(open(compose_path))
+    base = yaml.safe_load(open(base_path)) if base_path else None
+    env = load_env(env_path)
+    services = flatten_extends(d.get("services") or {}, (base or {}).get("services"))
+
+    dropped = collections.defaultdict(list)
+    dotenv = {}
+    collisions = []
+    out_services = []
+    for sname, svc in services.items():
+        svc = svc or {}
+        for k in svc:
+            if k not in EXPRESSIBLE:
+                dropped[k].append(sname)
+        image = resolve(svc.get("image") or "", env)
+        entry = {"name": re.sub(r"[^a-z0-9-]", "-", sname.lower())}
+        port = first_port(svc, env)
+        if port:
+            entry["kind"] = "web"
+            entry["port"] = port
+        else:
+            entry["kind"] = "worker"
+        cmd = svc.get("command")
+        if isinstance(cmd, list):
+            entry["command"] = " ".join(resolve(str(c), env) for c in cmd)
+        elif isinstance(cmd, str):
+            entry["command"] = resolve(cmd, env)
+        dep = svc.get("depends_on")
+        if isinstance(dep, dict):
+            dep = list(dep.keys())
+        if dep:
+            entry["depends_on"] = [re.sub(r"[^a-z0-9-]", "-", x.lower()) for x in dep]
+        if image:
+            entry["build"] = {"strategy": "image", "image": image}
+        elif svc.get("build"):
+            entry["build"] = {"strategy": "dockerfile"}
+            dropped["build(local source, not published as an image)"].append(sname)
+        ev = env_pairs(svc.get("environment"), env)
+        if ev:
+            out_env = []
+            for k, v in ev:
+                if looks_like_a_credential(k, v):
+                    # The manifest refuses a literal credential, correctly: it is
+                    # a committed file. The value moves to .env, which is the
+                    # place the engine looks before the encrypted store.
+                    prev = dotenv.get(k)
+                    if prev is not None and prev != v:
+                        collisions.append((k, sname))
+                    dotenv[k] = v
+                    out_env.append({"name": k})
+                else:
+                    out_env.append({"name": k, "value": v})
+            entry["env"] = out_env
+        out_services.append(entry)
+
+    manifest = {"version": 1, "name": name, "services": out_services,
+                "egress": {"default": "block"}}
+    return manifest, dropped, services, dotenv, collisions
+
+if __name__ == "__main__":
+    import argparse
+    ap = argparse.ArgumentParser()
+    ap.add_argument("compose"); ap.add_argument("--env"); ap.add_argument("--base")
+    ap.add_argument("--name", required=True); ap.add_argument("-o", required=True)
+    a = ap.parse_args()
+    m, dropped, services, dotenv, collisions = convert(a.compose, a.env, a.base, a.name)
+    with open(os.path.join(os.path.dirname(a.o) or ".", ".env"), "w") as f:
+        for k, v in dotenv.items():
+            f.write(f"{k}={v}\n")
+    with open(a.o, "w") as f:
+        yaml.safe_dump(m, f, sort_keys=False, width=100)
+    print(f"{len(m['services'])} services written to {a.o}")
+    print(f"{len(dotenv)} credential shaped values moved out of the manifest into .env")
+    if collisions:
+        print("SAME NAME, DIFFERENT VALUE, and .env is one flat namespace:")
+        for k, s2 in collisions:
+            print(f"  {k} (redeclared by {s2})")
+    print("compose keys with no manifest home:")
+    for k, v in sorted(dropped.items(), key=lambda kv: -len(kv[1])):
+        print(f"  {k}: {len(v)} services -> {', '.join(v[:6])}{' ...' if len(v)>6 else ''}")

--- a/docs/plan/four-stacks/fidelity/clickhouse-1s-1k.txt
+++ b/docs/plan/four-stacks/fidelity/clickhouse-1s-1k.txt
@@ -1,0 +1,41 @@
+
+Fidelity of clickhouse-1-ch-1s-1k-307ef8
+services       unmeasured (2 unmeasured)
+  clickhouse-… unmeasured   nothing is running for this environment; bring it up with af up first
+  clickhouse   unmeasured   nothing is running for this environment; bring it up with af up first
+
+database       unmeasured (2 unmeasured)
+  data         unmeasured   the branch could not be read: db.docker: resolve the branch connection: Get "http://%2Fvar%2Frun%2Fdocker.sock/v1.51/containers/af-db-clickhouse-1-ch-1s-1k-307ef8/json": context canceled
+  provenance   unmeasured   the provider could not be asked which golden this branch came from: db.docker: list containers: Get "http://%2Fvar%2Frun%2Fdocker.sock/v1.51/containers/json?all=1&filters=%7B%22label%22%3A%7B%22dev.antifailure.managed%22%3Atrue…
+
+third_party    not measured: the manifest names no third party hosts, and everything else is in block mode
+
+auth           not measured: the manifest declares no personas
+
+runtime        not measured: the environment runs on the local runtime, which publishes an address this machine can reach, and nothing in the manifest says what production runs on, so there is nothing to compare it against
+
+traffic        not measured: the manifest does not ask for traffic, so there is none to reproduce
+
+datastores     unmeasured (2 unmeasured)
+  clickhouse   unmeasured   a clickhouse running clickhouse/clickhouse-server:latest that nothing in the manifest's datastores list names, so nobody chose a stance for it, nothing here copied anything into it, and nothing here can say whether it holds production's data or came up empty
+  clickhouse-… unmeasured   a clickhouse running clickhouse/clickhouse-keeper:latest-alpine that nothing in the manifest's datastores list names, so nobody chose a stance for it, nothing here copied anything into it, and nothing here can say whether it holds production's data or came up empty
+
+topology       not measured: no service says how many instances it runs, so this environment runs one of each and nothing in the manifest says whether production runs one
+
+Nothing in this environment could be measured, so there is no score.
+A component is production's own when the environment reaches the real thing.
+A substitution, a refusal and an absence are all counted and none of them
+counts as reproduced. Nothing unmeasured is counted either way.
+
+Not measured, and so not counted:
+  auth           the manifest declares no personas
+  database       data: the branch could not be read: db.docker: resolve the branch connection: Get "http://%2Fvar%2Frun%2Fdocker.sock/v1.51/containers/af-db-clickhouse-1-ch-1s-1k-307ef8/json": context canceled
+  database       provenance: the provider could not be asked which golden this branch came from: db.docker: list containers: Get "http://%2Fvar%2Frun%2Fdocker.sock/v1.51/containers/json?all=1&filters=%7B%22label%22%3A%7B%22dev.antifailure.managed%22%3Atrue…
+  datastores     clickhouse: a clickhouse running clickhouse/clickhouse-server:latest that nothing in the manifest's datastores list names, so nobody chose a stance for it, nothing here copied anything into it, and nothing here can say whether it holds production's data or came up empty
+  datastores     clickhouse-keeper: a clickhouse running clickhouse/clickhouse-keeper:latest-alpine that nothing in the manifest's datastores list names, so nobody chose a stance for it, nothing here copied anything into it, and nothing here can say whether it holds production's data or came up empty
+  runtime        the environment runs on the local runtime, which publishes an address this machine can reach, and nothing in the manifest says what production runs on, so there is nothing to compare it against
+  services       clickhouse: nothing is running for this environment; bring it up with af up first
+  services       clickhouse-keeper: nothing is running for this environment; bring it up with af up first
+  third_party    the manifest names no third party hosts, and everything else is in block mode
+  topology       no service says how many instances it runs, so this environment runs one of each and nothing in the manifest says whether production runs one
+  traffic        the manifest does not ask for traffic, so there is none to reproduce

--- a/docs/plan/four-stacks/fidelity/posthog-hobby.txt
+++ b/docs/plan/four-stacks/fidelity/posthog-hobby.txt
@@ -1,0 +1,125 @@
+
+Fidelity of posthog-hobb-posthog-hobby-c4220c
+services       unmeasured (37 unmeasured)
+  db           unmeasured   nothing is running for this environment; bring it up with af up first
+  redis7       unmeasured   nothing is running for this environment; bring it up with af up first
+  valkey       unmeasured   nothing is running for this environment; bring it up with af up first
+  clickhouse   unmeasured   nothing is running for this environment; bring it up with af up first
+  zookeeper    unmeasured   nothing is running for this environment; bring it up with af up first
+  kafka        unmeasured   nothing is running for this environment; bring it up with af up first
+  worker       unmeasured   nothing is running for this environment; bring it up with af up first
+  web          unmeasured   nothing is running for this environment; bring it up with af up first
+  plugins      unmeasured   nothing is running for this environment; bring it up with af up first
+  ingestion-g… unmeasured   nothing is running for this environment; bring it up with af up first
+  ingestion-s… unmeasured   nothing is running for this environment; bring it up with af up first
+  recording-a… unmeasured   nothing is running for this environment; bring it up with af up first
+  ingestion-e… unmeasured   nothing is running for this environment; bring it up with af up first
+  ingestion-l… unmeasured   nothing is running for this environment; bring it up with af up first
+  ingestion-t… unmeasured   nothing is running for this environment; bring it up with af up first
+  proxy        unmeasured   nothing is running for this environment; bring it up with af up first
+  objectstora… unmeasured   nothing is running for this environment; bring it up with af up first
+  seaweedfs    unmeasured   nothing is running for this environment; bring it up with af up first
+  browserless  unmeasured   nothing is running for this environment; bring it up with af up first
+  asyncmigrat… unmeasured   nothing is running for this environment; bring it up with af up first
+  temporal     unmeasured   nothing is running for this environment; bring it up with af up first
+  elasticsear… unmeasured   nothing is running for this environment; bring it up with af up first
+  temporal-ad… unmeasured   nothing is running for this environment; bring it up with af up first
+  temporal-ui  unmeasured   nothing is running for this environment; bring it up with af up first
+  temporal-dj… unmeasured   nothing is running for this environment; bring it up with af up first
+  capture      unmeasured   nothing is running for this environment; bring it up with af up first
+  capture-logs unmeasured   nothing is running for this environment; bring it up with af up first
+  replay-capt… unmeasured   nothing is running for this environment; bring it up with af up first
+  property-de… unmeasured   nothing is running for this environment; bring it up with af up first
+  livestream   unmeasured   nothing is running for this environment; bring it up with af up first
+  personhog-r… unmeasured   nothing is running for this environment; bring it up with af up first
+  personhog-r… unmeasured   nothing is running for this environment; bring it up with af up first
+  feature-fla… unmeasured   nothing is running for this environment; bring it up with af up first
+  hypercache-… unmeasured   nothing is running for this environment; bring it up with af up first
+  kafka-init   unmeasured   nothing is running for this environment; bring it up with af up first
+  cymbal       unmeasured   nothing is running for this environment; bring it up with af up first
+  cymbal-reso… unmeasured   nothing is running for this environment; bring it up with af up first
+
+database       unmeasured (2 unmeasured)
+  data         unmeasured   the branch could not be read: db.docker: resolve the branch connection: Get "http://%2Fvar%2Frun%2Fdocker.sock/v1.51/containers/af-db-posthog-hobb-posthog-hobby-c4220c/json": context cancel…
+  provenance   unmeasured   the provider could not be asked which golden this branch came from: db.docker: list golden images: Get "http://%2Fvar%2Frun%2Fdocker.sock/v1.51/images/json?filters=%7B%22reference%22%3A%7B%22antifailure%2Fgolden%3A%2A%22%3Atrue…
+
+third_party    not measured: the manifest names no third party hosts, and everything else is in block mode
+
+auth           not measured: the manifest declares no personas
+
+runtime        not measured: the environment runs on the local runtime, which publishes an address this machine can reach, and nothing in the manifest says what production runs on, so there is nothing to compare it against
+
+traffic        not measured: the manifest does not ask for traffic, so there is none to reproduce
+
+datastores     unmeasured (9 unmeasured)
+  clickhouse   unmeasured   a clickhouse running clickhouse/clickhouse-server:26.6.2.158 that nothing in the manifest's datastores list names, so nobody chose a stance for it, nothing here copied anything into it, and nothing here can say whether it holds production's data or came up empty
+  db           unmeasured   a postgres running postgres:15.12-alpine that nothing in the manifest's datastores list names, so nobody chose a stance for it, nothing here copied anything into it, and nothing here can say whether it holds production's data or came up empty
+  elasticsear… unmeasured   a elasticsearch running elasticsearch:7.17.28 that nothing in the manifest's datastores list names, so nobody chose a stance for it, nothing here copied anything into it, and nothing here can say whether it holds production's data or came up empty
+  kafka        unmeasured   a kafka running docker.io/redpandadata/redpanda:v25.1.9 that nothing in the manifest's datastores list names, so nobody chose a stance for it, nothing here copied anything into it, and nothing here can say whether it holds production's data or came up empty
+  kafka-init   unmeasured   a kafka running docker.io/redpandadata/redpanda:v25.1.9 that nothing in the manifest's datastores list names, so nobody chose a stance for it, nothing here copied anything into it, and nothing here can say whether it holds production's data or came up empty
+  objectstora… unmeasured   a object store running minio/minio:RELEASE.2025-04-22T22-12-26Z that nothing in the manifest's datastores list names, so nobody chose a stance for it, nothing here copied anything into it, and nothing here can say whether it holds production's data or came up empty
+  redis7       unmeasured   a redis running redis:7.2-alpine that nothing in the manifest's datastores list names, so nobody chose a stance for it, nothing here copied anything into it, and nothing here can say whether it holds production's data or came up empty
+  seaweedfs    unmeasured   a object store running chrislusf/seaweedfs:4.29 that nothing in the manifest's datastores list names, so nobody chose a stance for it, nothing here copied anything into it, and nothing here can say whether it holds production's data or came up empty
+  valkey       unmeasured   a redis running valkey/valkey:8.1-alpine that nothing in the manifest's datastores list names, so nobody chose a stance for it, nothing here copied anything into it, and nothing here can say whether it holds production's data or came up empty
+
+topology       not measured: no service says how many instances it runs, so this environment runs one of each and nothing in the manifest says whether production runs one
+
+Nothing in this environment could be measured, so there is no score.
+A component is production's own when the environment reaches the real thing.
+A substitution, a refusal and an absence are all counted and none of them
+counts as reproduced. Nothing unmeasured is counted either way.
+
+Not measured, and so not counted:
+  auth           the manifest declares no personas
+  database       data: the branch could not be read: db.docker: resolve the branch connection: Get "http://%2Fvar%2Frun%2Fdocker.sock/v1.51/containers/af-db-posthog-hobb-posthog-hobby-c4220c/json": context cancel…
+  database       provenance: the provider could not be asked which golden this branch came from: db.docker: list golden images: Get "http://%2Fvar%2Frun%2Fdocker.sock/v1.51/images/json?filters=%7B%22reference%22%3A%7B%22antifailure%2Fgolden%3A%2A%22%3Atrue…
+  datastores     clickhouse: a clickhouse running clickhouse/clickhouse-server:26.6.2.158 that nothing in the manifest's datastores list names, so nobody chose a stance for it, nothing here copied anything into it, and nothing here can say whether it holds production's data or came up empty
+  datastores     db: a postgres running postgres:15.12-alpine that nothing in the manifest's datastores list names, so nobody chose a stance for it, nothing here copied anything into it, and nothing here can say whether it holds production's data or came up empty
+  datastores     elasticsearch: a elasticsearch running elasticsearch:7.17.28 that nothing in the manifest's datastores list names, so nobody chose a stance for it, nothing here copied anything into it, and nothing here can say whether it holds production's data or came up empty
+  datastores     kafka: a kafka running docker.io/redpandadata/redpanda:v25.1.9 that nothing in the manifest's datastores list names, so nobody chose a stance for it, nothing here copied anything into it, and nothing here can say whether it holds production's data or came up empty
+  datastores     kafka-init: a kafka running docker.io/redpandadata/redpanda:v25.1.9 that nothing in the manifest's datastores list names, so nobody chose a stance for it, nothing here copied anything into it, and nothing here can say whether it holds production's data or came up empty
+  datastores     objectstorage: a object store running minio/minio:RELEASE.2025-04-22T22-12-26Z that nothing in the manifest's datastores list names, so nobody chose a stance for it, nothing here copied anything into it, and nothing here can say whether it holds production's data or came up empty
+  datastores     redis7: a redis running redis:7.2-alpine that nothing in the manifest's datastores list names, so nobody chose a stance for it, nothing here copied anything into it, and nothing here can say whether it holds production's data or came up empty
+  datastores     seaweedfs: a object store running chrislusf/seaweedfs:4.29 that nothing in the manifest's datastores list names, so nobody chose a stance for it, nothing here copied anything into it, and nothing here can say whether it holds production's data or came up empty
+  datastores     valkey: a redis running valkey/valkey:8.1-alpine that nothing in the manifest's datastores list names, so nobody chose a stance for it, nothing here copied anything into it, and nothing here can say whether it holds production's data or came up empty
+  runtime        the environment runs on the local runtime, which publishes an address this machine can reach, and nothing in the manifest says what production runs on, so there is nothing to compare it against
+  services       asyncmigrationscheck: nothing is running for this environment; bring it up with af up first
+  services       browserless: nothing is running for this environment; bring it up with af up first
+  services       capture: nothing is running for this environment; bring it up with af up first
+  services       capture-logs: nothing is running for this environment; bring it up with af up first
+  services       clickhouse: nothing is running for this environment; bring it up with af up first
+  services       cymbal: nothing is running for this environment; bring it up with af up first
+  services       cymbal-resolution: nothing is running for this environment; bring it up with af up first
+  services       db: nothing is running for this environment; bring it up with af up first
+  services       elasticsearch: nothing is running for this environment; bring it up with af up first
+  services       feature-flags: nothing is running for this environment; bring it up with af up first
+  services       hypercache-server: nothing is running for this environment; bring it up with af up first
+  services       ingestion-error-tracking: nothing is running for this environment; bring it up with af up first
+  services       ingestion-general: nothing is running for this environment; bring it up with af up first
+  services       ingestion-logs: nothing is running for this environment; bring it up with af up first
+  services       ingestion-sessionreplay: nothing is running for this environment; bring it up with af up first
+  services       ingestion-traces: nothing is running for this environment; bring it up with af up first
+  services       kafka: nothing is running for this environment; bring it up with af up first
+  services       kafka-init: nothing is running for this environment; bring it up with af up first
+  services       livestream: nothing is running for this environment; bring it up with af up first
+  services       objectstorage: nothing is running for this environment; bring it up with af up first
+  services       personhog-replica: nothing is running for this environment; bring it up with af up first
+  services       personhog-router: nothing is running for this environment; bring it up with af up first
+  services       plugins: nothing is running for this environment; bring it up with af up first
+  services       property-defs-rs: nothing is running for this environment; bring it up with af up first
+  services       proxy: nothing is running for this environment; bring it up with af up first
+  services       recording-api: nothing is running for this environment; bring it up with af up first
+  services       redis7: nothing is running for this environment; bring it up with af up first
+  services       replay-capture: nothing is running for this environment; bring it up with af up first
+  services       seaweedfs: nothing is running for this environment; bring it up with af up first
+  services       temporal: nothing is running for this environment; bring it up with af up first
+  services       temporal-admin-tools: nothing is running for this environment; bring it up with af up first
+  services       temporal-django-worker: nothing is running for this environment; bring it up with af up first
+  services       temporal-ui: nothing is running for this environment; bring it up with af up first
+  services       valkey: nothing is running for this environment; bring it up with af up first
+  services       web: nothing is running for this environment; bring it up with af up first
+  services       worker: nothing is running for this environment; bring it up with af up first
+  services       zookeeper: nothing is running for this environment; bring it up with af up first
+  third_party    the manifest names no third party hosts, and everything else is in block mode
+  topology       no service says how many instances it runs, so this environment runs one of each and nothing in the manifest says whether production runs one
+  traffic        the manifest does not ask for traffic, so there is none to reproduce

--- a/docs/plan/four-stacks/fidelity/supabase-selfhost.txt
+++ b/docs/plan/four-stacks/fidelity/supabase-selfhost.txt
@@ -1,0 +1,61 @@
+
+Fidelity of supabase-sel-supabase-selfhos-0d277b
+services       unmeasured (11 unmeasured)
+  studio       unmeasured   nothing is running for this environment; bring it up with af up first
+  api-gw       unmeasured   nothing is running for this environment; bring it up with af up first
+  auth         unmeasured   nothing is running for this environment; bring it up with af up first
+  rest         unmeasured   nothing is running for this environment; bring it up with af up first
+  realtime     unmeasured   nothing is running for this environment; bring it up with af up first
+  storage      unmeasured   nothing is running for this environment; bring it up with af up first
+  imgproxy     unmeasured   nothing is running for this environment; bring it up with af up first
+  meta         unmeasured   nothing is running for this environment; bring it up with af up first
+  functions    unmeasured   nothing is running for this environment; bring it up with af up first
+  db           unmeasured   nothing is running for this environment; bring it up with af up first
+  supavisor    unmeasured   nothing is running for this environment; bring it up with af up first
+
+database       unmeasured (2 unmeasured)
+  data         unmeasured   the branch could not be read: db.docker: resolve the branch connection: Get "http://%2Fvar%2Frun%2Fdocker.sock/v1.51/containers/af-db-supabase-sel-supabase-selfhos-0d277b/json": context can…
+  provenance   unmeasured   the provider could not be asked which golden this branch came from: db.docker: list golden images: Get "http://%2Fvar%2Frun%2Fdocker.sock/v1.51/images/json?filters=%7B%22reference%22%3A%7B%22antifailure%2Fgolden%3A%2A%22%3Atrue…
+
+third_party    not measured: the manifest names no third party hosts, and everything else is in block mode
+
+auth           not measured: the manifest declares no personas
+
+runtime        not measured: the environment runs on the local runtime, which publishes an address this machine can reach, and nothing in the manifest says what production runs on, so there is nothing to compare it against
+
+traffic        not measured: the manifest does not ask for traffic, so there is none to reproduce
+
+datastores     unmeasured (3 unmeasured)
+  db           unmeasured   a postgres running supabase/postgres:17.6.1.136 that nothing in the manifest's datastores list names, so nobody chose a stance for it, nothing here copied anything into it, and nothing here can say whether it holds production's data or came up empty
+  meta         unmeasured   a postgres running supabase/postgres-meta:v0.96.6 that nothing in the manifest's datastores list names, so nobody chose a stance for it, nothing here copied anything into it, and nothing here can say whether it holds production's data or came up empty
+  rest         unmeasured   a postgres running postgrest/postgrest:v14.12 that nothing in the manifest's datastores list names, so nobody chose a stance for it, nothing here copied anything into it, and nothing here can say whether it holds production's data or came up empty
+
+topology       not measured: no service says how many instances it runs, so this environment runs one of each and nothing in the manifest says whether production runs one
+
+Nothing in this environment could be measured, so there is no score.
+A component is production's own when the environment reaches the real thing.
+A substitution, a refusal and an absence are all counted and none of them
+counts as reproduced. Nothing unmeasured is counted either way.
+
+Not measured, and so not counted:
+  auth           the manifest declares no personas
+  database       data: the branch could not be read: db.docker: resolve the branch connection: Get "http://%2Fvar%2Frun%2Fdocker.sock/v1.51/containers/af-db-supabase-sel-supabase-selfhos-0d277b/json": context can…
+  database       provenance: the provider could not be asked which golden this branch came from: db.docker: list golden images: Get "http://%2Fvar%2Frun%2Fdocker.sock/v1.51/images/json?filters=%7B%22reference%22%3A%7B%22antifailure%2Fgolden%3A%2A%22%3Atrue…
+  datastores     db: a postgres running supabase/postgres:17.6.1.136 that nothing in the manifest's datastores list names, so nobody chose a stance for it, nothing here copied anything into it, and nothing here can say whether it holds production's data or came up empty
+  datastores     meta: a postgres running supabase/postgres-meta:v0.96.6 that nothing in the manifest's datastores list names, so nobody chose a stance for it, nothing here copied anything into it, and nothing here can say whether it holds production's data or came up empty
+  datastores     rest: a postgres running postgrest/postgrest:v14.12 that nothing in the manifest's datastores list names, so nobody chose a stance for it, nothing here copied anything into it, and nothing here can say whether it holds production's data or came up empty
+  runtime        the environment runs on the local runtime, which publishes an address this machine can reach, and nothing in the manifest says what production runs on, so there is nothing to compare it against
+  services       api-gw: nothing is running for this environment; bring it up with af up first
+  services       auth: nothing is running for this environment; bring it up with af up first
+  services       db: nothing is running for this environment; bring it up with af up first
+  services       functions: nothing is running for this environment; bring it up with af up first
+  services       imgproxy: nothing is running for this environment; bring it up with af up first
+  services       meta: nothing is running for this environment; bring it up with af up first
+  services       realtime: nothing is running for this environment; bring it up with af up first
+  services       rest: nothing is running for this environment; bring it up with af up first
+  services       storage: nothing is running for this environment; bring it up with af up first
+  services       studio: nothing is running for this environment; bring it up with af up first
+  services       supavisor: nothing is running for this environment; bring it up with af up first
+  third_party    the manifest names no third party hosts, and everything else is in block mode
+  topology       no service says how many instances it runs, so this environment runs one of each and nothing in the manifest says whether production runs one
+  traffic        the manifest does not ask for traffic, so there is none to reproduce

--- a/docs/plan/four-stacks/goliath-shape/QUESTIONS.md
+++ b/docs/plan/four-stacks/goliath-shape/QUESTIONS.md
@@ -1,0 +1,57 @@
+# Five questions for the Goliath Data call
+
+Goliath Data publishes no compose file, no chart and no self hosting guide.
+There is nothing to convert, so there is no rehearsal, and a twin built from a
+guessed stack would be a fabrication that happens to compile. The manifest
+beside this file is a SHAPE and not a twin: it is what everything readable
+about the company from the outside describes, and every field in it is one of
+the questions below waiting for an answer.
+
+Each question turns one block of that manifest into a real one in an afternoon.
+
+1. **What is the primary record store, and which major version?**
+   `database.provider` and `database.version`. If it is managed Postgres, which
+   service, because that decides whether branching is a native clone or a
+   snapshot restore, and those differ by minutes per branch rather than by
+   percentages.
+
+2. **What holds the event and scoring data, and is it a second store or the
+   same Postgres?**
+   `datastores[]`. If it is a second store, its engine decides whether this
+   build can provide it at all: today the engine provides `clickhouse` and
+   refuses every other name by name.
+
+3. **What is the queue between ingestion and inference?**
+   Kafka, SQS, Redis, Postgres itself. There is no manifest key for a queue
+   that is not a datastore, and no provider for one that is not ClickHouse, so
+   this answer decides whether the middle of their pipeline can be rehearsed or
+   has to be declared absent and said so in the fidelity report.
+
+4. **Where does the county feed enter, and is it a poll, a push or a file
+   drop?**
+   A poll is an `egress` rule and a schedule. A push is an inbound webhook and
+   needs `webhook_path` on the rule that names the sender. A file drop is
+   neither and is the case with no manifest key at all.
+
+5. **Which third party endpoints does the application call, by hostname, and
+   which of them does it call at startup?**
+   This is the one that decides whether a rehearsal is honest, and asking it
+   properly needs the hostname rather than the vendor. A rule has to NAME the
+   host. Under a rule written as `*.zapier.com` the sidecar answers a 403,
+   because this build has no Zapier handler, while both instruments a person
+   would check said the delivery was being captured: `af net explain` reported
+   CAPTURE and the fidelity report reported a substitution with the provider's
+   own success shape. F0 and F14 in the README beside this file are those two,
+   and one of them is fixed.
+
+   The startup half is a separate question with a separate cost. A call made
+   before the first request turns a policy gap into a service that never becomes
+   ready, and a service that publishes no port is reported ready as soon as its
+   container is running, so it reads as healthy until it exits.
+
+   Worth knowing before the call: even a NAMED Zapier host is answered with an
+   empty object rather than Zapier's `{"status": "success", ...}`, because there
+   is no Zapier handler in this build. If their delivery code checks `status`,
+   that is a real gap and it is a small one to close.
+
+Nobody has contacted Goliath Data about any of this. The call is Vir's.

--- a/docs/plan/four-stacks/goliath-shape/antifailure.yaml
+++ b/docs/plan/four-stacks/goliath-shape/antifailure.yaml
@@ -1,0 +1,88 @@
+version: 1
+name: goliath-shape
+
+# NOT A TWIN OF GOLIATH DATA'S APPLICATION.
+#
+# Goliath Data publishes no compose file, no Helm chart and no self hosting
+# guide, so there is nothing to convert and a manifest that pretended otherwise
+# would be a fabrication that happens to compile. What is written down below is
+# the SHAPE that everything readable about the company from the outside
+# describes: a Postgres record store, a continuously ingested external feed, an
+# inference step over it, and outbound delivery to third party CRMs through
+# Zapier. Every field is a question for the call, and the five that matter are
+# in QUESTIONS.md beside this file.
+#
+# The reason it is worth writing anyway is the egress block. The CRM and Zapier
+# endpoints are the case where a rule covering a domain rather than naming a
+# host makes the difference between a rehearsal that records a delivery and one
+# that is refused, and the answer turned out to depend on whether this build has
+# a handler for the provider. Every rule below therefore NAMES its host, and a
+# test in engine/internal/manifest keeps it that way. What the report said about
+# these three rules before this branch is F0 in the README beside this file.
+
+services:
+  - name: api
+    kind: web
+    port: 8080
+    health_path: /health
+    build:
+      strategy: image
+      image: hashicorp/http-echo:1.0
+
+  - name: feed-ingest
+    kind: worker
+    build:
+      strategy: image
+      image: hashicorp/http-echo:1.0
+
+  - name: scorer
+    kind: worker
+    depends_on:
+      - feed-ingest
+    build:
+      strategy: image
+      image: hashicorp/http-echo:1.0
+
+  - name: crm-delivery
+    kind: worker
+    depends_on:
+      - scorer
+    build:
+      strategy: image
+      image: hashicorp/http-echo:1.0
+
+database:
+  provider: docker
+  version: 17
+
+datastores:
+  - name: events
+    engine: clickhouse
+    stance: empty
+    because: >-
+      The shape of the second store is a question for the call and not an
+      answer. Declaring it empty says so in the fidelity report, which is the
+      only thing that tells an empty store somebody chose apart from an empty
+      store nobody noticed.
+
+egress:
+  default: block
+  rules:
+    # Each of these NAMES a host. F0 and F14 in the README are what happens
+    # when they do not, one seen from the fidelity report and one from
+    # af net explain, and neither instrument could tell the difference.
+    - host: hooks.zapier.com
+      mode: capture
+      note: >-
+        The outbound hook, recorded rather than fired at somebody's real
+        automation. Named rather than written as a pattern, because a pattern
+        is refused by the sidecar when no handler matches the host that
+        arrives. This build has no Zapier handler either, so the body it
+        answers with is the generic empty object and not Zapier's own success
+        shape, which is a stated limit rather than a thing to discover later.
+    - host: api.hubapi.com
+      mode: mock
+      note: "HubSpot's API, answered from a fixture or refused, never invented"
+    - host: api.salesforce.com
+      mode: block
+      note: "named and blocked, so a call to it reads as a refusal rather than as a timeout"

--- a/docs/plan/four-stacks/posthog-hobby/antifailure.yaml
+++ b/docs/plan/four-stacks/posthog-hobby/antifailure.yaml
@@ -1,0 +1,799 @@
+version: 1
+name: posthog-hobby
+services:
+- name: db
+  kind: worker
+  build:
+    strategy: image
+    image: postgres:15.12-alpine
+  env:
+  - name: POSTGRES_USER
+    value: posthog
+  - name: POSTGRES_DB
+    value: posthog
+  - name: POSTGRES_PASSWORD
+    value: posthog
+- name: redis7
+  kind: worker
+  command: redis-server --maxmemory-policy allkeys-lru --maxmemory 200mb
+  build:
+    strategy: image
+    image: redis:7.2-alpine
+- name: valkey
+  kind: worker
+  command: valkey-server --maxmemory-policy allkeys-lru --maxmemory 200mb
+  build:
+    strategy: image
+    image: valkey/valkey:8.1-alpine
+- name: clickhouse
+  kind: worker
+  depends_on:
+  - kafka
+  - zookeeper
+  build:
+    strategy: image
+    image: clickhouse/clickhouse-server:26.6.2.158
+  env:
+  - name: CLICKHOUSE_SKIP_USER_SETUP
+    value: '1'
+  - name: KAFKA_HOSTS
+    value: kafka:9092
+- name: zookeeper
+  kind: worker
+  build:
+    strategy: image
+    image: zookeeper:3.7.0
+  env:
+  - name: ZOO_AUTOPURGE_PURGEINTERVAL
+    value: '1'
+  - name: ZOO_AUTOPURGE_SNAPRETAINCOUNT
+    value: '3'
+- name: kafka
+  kind: worker
+  command: redpanda start --kafka-addr internal://0.0.0.0:9092,external://0.0.0.0:19092 --advertise-kafka-addr
+    internal://kafka:9092,external://localhost:19092 --pandaproxy-addr internal://0.0.0.0:8082,external://0.0.0.0:18082
+    --advertise-pandaproxy-addr internal://kafka:8082,external://localhost:18082 --schema-registry-addr
+    internal://0.0.0.0:8081,external://0.0.0.0:18081 --rpc-addr kafka:33145 --advertise-rpc-addr kafka:33145
+    --mode dev-container --smp 2 --memory 3G --reserve-memory 500M --overprovisioned --set redpanda.empty_seed_starts_cluster=false
+    --seeds kafka:33145 --set redpanda.auto_create_topics_enabled=true
+  depends_on:
+  - zookeeper
+  build:
+    strategy: image
+    image: docker.io/redpandadata/redpanda:v25.1.9
+  env:
+  - name: KAFKA_LOG_RETENTION_MS
+    value: '3600000'
+  - name: KAFKA_LOG_RETENTION_CHECK_INTERVAL_MS
+    value: '300000'
+  - name: KAFKA_LOG_RETENTION_HOURS
+    value: '1'
+- name: worker
+  kind: worker
+  command: ./bin/docker-worker-celery --with-scheduler
+  depends_on:
+  - db
+  - redis7
+  - clickhouse
+  - kafka
+  - web
+  - personhog-router
+  - browserless
+  build:
+    strategy: image
+    image: ':'
+  env:
+  - name: SITE_URL
+    value: https://
+  - name: SECRET_KEY
+    value: ''
+  - name: OBJECT_STORAGE_ACCESS_KEY_ID
+  - name: OBJECT_STORAGE_SECRET_ACCESS_KEY
+  - name: OBJECT_STORAGE_ENDPOINT
+    value: http://objectstorage:19000
+  - name: OBJECT_STORAGE_PUBLIC_ENDPOINT
+    value: https://
+  - name: SESSION_RECORDING_V2_S3_ENDPOINT
+    value: http://seaweedfs:8333
+  - name: SESSION_RECORDING_V2_S3_ACCESS_KEY_ID
+    value: any
+  - name: SESSION_RECORDING_V2_S3_SECRET_ACCESS_KEY
+    value: any
+  - name: OBJECT_STORAGE_ENABLED
+    value: 'True'
+  - name: RECORDING_API_URL
+    value: http://recording-api:6738
+  - name: INTERNAL_API_SECRET
+    value: ''
+  - name: ENCRYPTION_SALT_KEYS
+    value: ''
+  - name: POSTHOG_SKIP_MIGRATION_CHECKS
+    value: '1'
+  - name: PERSONHOG_ADDR
+    value: personhog-router:50052
+  - name: PERSONHOG_ENABLED
+    value: 'true'
+  - name: BROWSERLESS_CDP_URL
+    value: ws://browserless:3000
+  - name: BROWSERLESS_TOKEN
+    value: ''
+  - name: HEATMAP_BROWSERLESS_URL
+    value: http://browserless:3000
+  - name: HEATMAP_BROWSERLESS_TOKEN
+    value: ''
+  - name: FEATURE_FLAGS_SERVICE_URL
+    value: http://feature-flags:3001
+  - name: CLICKHOUSE_LOGS_CLUSTER_HOST
+    value: clickhouse
+  - name: CLICKHOUSE_LOGS_CLUSTER_SECURE
+    value: 'false'
+  - name: ANTHROPIC_API_KEY
+    value: ''
+  - name: OPENAI_API_KEY
+    value: ''
+- name: web
+  kind: worker
+  command: /compose/start
+  depends_on:
+  - db
+  - redis7
+  - clickhouse
+  - kafka
+  - objectstorage
+  - seaweedfs
+  - personhog-router
+  build:
+    strategy: image
+    image: ':'
+  env:
+  - name: SITE_URL
+    value: https://
+  - name: LIVESTREAM_HOST
+    value: https:///livestream
+  - name: SECRET_KEY
+    value: ''
+  - name: OBJECT_STORAGE_ACCESS_KEY_ID
+  - name: OBJECT_STORAGE_SECRET_ACCESS_KEY
+  - name: SESSION_RECORDING_V2_S3_ACCESS_KEY_ID
+    value: any
+  - name: SESSION_RECORDING_V2_S3_SECRET_ACCESS_KEY
+    value: any
+  - name: OBJECT_STORAGE_ENDPOINT
+    value: http://objectstorage:19000
+  - name: OBJECT_STORAGE_PUBLIC_ENDPOINT
+    value: https://
+  - name: SESSION_RECORDING_V2_S3_ENDPOINT
+    value: http://seaweedfs:8333
+  - name: OBJECT_STORAGE_ENABLED
+    value: 'True'
+  - name: RECORDING_API_URL
+    value: http://recording-api:6738
+  - name: INTERNAL_API_SECRET
+    value: ''
+  - name: ENCRYPTION_SALT_KEYS
+    value: ''
+  - name: OTEL_SERVICE_NAME
+    value: posthog
+  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+    value: ''
+  - name: OTEL_SDK_DISABLED
+    value: 'true'
+  - name: OPT_OUT_CAPTURE
+    value: 'false'
+  - name: CSP_REPORT_ENDPOINT
+    value: ''
+  - name: DEPLOYMENT
+    value: hobby
+  - name: PERSONHOG_ADDR
+    value: personhog-router:50052
+  - name: PERSONHOG_ENABLED
+    value: 'true'
+  - name: FEATURE_FLAGS_SERVICE_URL
+    value: http://feature-flags:3001
+  - name: CLICKHOUSE_LOGS_CLUSTER_HOST
+    value: clickhouse
+  - name: CLICKHOUSE_LOGS_CLUSTER_SECURE
+    value: 'false'
+  - name: ANTHROPIC_API_KEY
+    value: ''
+  - name: OPENAI_API_KEY
+    value: ''
+- name: plugins
+  kind: worker
+  command: node nodejs/dist/index.js
+  depends_on:
+  - db
+  - redis7
+  - valkey
+  - clickhouse
+  - kafka
+  - objectstorage
+  - seaweedfs
+  build:
+    strategy: image
+    image: -node:latest
+  env:
+  - name: SITE_URL
+    value: https://
+  - name: SECRET_KEY
+    value: ''
+  - name: OBJECT_STORAGE_ACCESS_KEY_ID
+  - name: OBJECT_STORAGE_SECRET_ACCESS_KEY
+  - name: OBJECT_STORAGE_ENDPOINT
+    value: http://objectstorage:19000
+  - name: OBJECT_STORAGE_PUBLIC_ENDPOINT
+    value: https://
+  - name: OBJECT_STORAGE_ENABLED
+    value: 'True'
+  - name: CDP_REDIS_HOST
+    value: redis7
+  - name: CDP_REDIS_PORT
+    value: '6379'
+  - name: LOGS_REDIS_HOST
+    value: redis7
+  - name: LOGS_REDIS_PORT
+    value: '6379'
+  - name: LOGS_REDIS_TLS
+    value: 'false'
+  - name: TRACES_REDIS_HOST
+    value: redis7
+  - name: TRACES_REDIS_PORT
+    value: '6379'
+  - name: TRACES_REDIS_TLS
+    value: 'false'
+  - name: CDP_VALKEY_HOST
+    value: valkey
+  - name: CDP_VALKEY_PORT
+    value: '6379'
+  - name: ENCRYPTION_SALT_KEYS
+    value: ''
+  - name: PERSONS_DATABASE_URL
+  - name: BEHAVIORAL_COHORTS_DATABASE_URL
+  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+    value: ''
+- name: ingestion-general
+  kind: worker
+  command: node nodejs/dist/index.js
+  depends_on:
+  - db
+  - redis7
+  - clickhouse
+  - kafka
+  - objectstorage
+  - personhog-router
+  build:
+    strategy: image
+    image: -node:latest
+  env:
+  - name: PERSONS_DATABASE_URL
+  - name: BEHAVIORAL_COHORTS_DATABASE_URL
+  - name: ENCRYPTION_SALT_KEYS
+    value: ''
+  - name: PERSONHOG_ADDR
+    value: personhog-router:50052
+  - name: PERSONHOG_ENABLED
+    value: 'true'
+- name: ingestion-sessionreplay
+  kind: worker
+  command: node nodejs/dist/index.js
+  depends_on:
+  - db
+  - redis7
+  - kafka
+  - seaweedfs
+  build:
+    strategy: image
+    image: -node:latest
+  env:
+  - name: SESSION_RECORDING_V2_S3_ACCESS_KEY_ID
+    value: any
+  - name: SESSION_RECORDING_V2_S3_SECRET_ACCESS_KEY
+    value: any
+  - name: SESSION_RECORDING_V2_S3_TIMEOUT_MS
+    value: '120000'
+  - name: SESSION_RECORDING_V2_S3_ENDPOINT
+    value: http://seaweedfs:8333
+  - name: ENCRYPTION_SALT_KEYS
+    value: ''
+- name: recording-api
+  kind: worker
+  command: node nodejs/dist/index.js
+  depends_on:
+  - db
+  - redis7
+  - clickhouse
+  - seaweedfs
+  build:
+    strategy: image
+    image: -node:latest
+  env:
+  - name: SESSION_RECORDING_V2_S3_ACCESS_KEY_ID
+    value: any
+  - name: SESSION_RECORDING_V2_S3_SECRET_ACCESS_KEY
+    value: any
+  - name: SESSION_RECORDING_V2_S3_ENDPOINT
+    value: http://seaweedfs:8333
+  - name: ENCRYPTION_SALT_KEYS
+    value: ''
+  - name: INTERNAL_API_SECRET
+    value: ''
+- name: ingestion-error-tracking
+  kind: worker
+  command: node nodejs/dist/index.js
+  depends_on:
+  - db
+  - redis7
+  - kafka
+  build:
+    strategy: image
+    image: -node:latest
+  env:
+  - name: ENCRYPTION_SALT_KEYS
+    value: ''
+  - name: ERROR_TRACKING_CYMBAL_BASE_URL
+    value: http://cymbal:3302
+- name: ingestion-logs
+  kind: worker
+  command: node nodejs/dist/index.js
+  depends_on:
+  - db
+  - redis7
+  - kafka
+  build:
+    strategy: image
+    image: -node:latest
+  env:
+  - name: LOGS_REDIS_TLS
+    value: 'false'
+- name: ingestion-traces
+  kind: worker
+  command: node nodejs/dist/index.js
+  depends_on:
+  - db
+  - redis7
+  - kafka
+  build:
+    strategy: image
+    image: -node:latest
+  env:
+  - name: TRACES_REDIS_TLS
+    value: 'false'
+- name: proxy
+  kind: web
+  port: 80
+  command: -c 'set -x && echo "$CADDYFILE" > /etc/caddy/Caddyfile && echo "$CADDY_EXTRA_CONFIG" >> /etc/caddy/Caddyfile
+    && exec caddy run -c /etc/caddy/Caddyfile'
+  depends_on:
+  - web
+  - livestream
+  build:
+    strategy: image
+    image: caddy
+  env:
+  - name: CADDY_TLS_BLOCK
+    value: ''
+  - name: CADDY_HOST
+    value: ', http://, https://'
+- name: objectstorage
+  kind: web
+  port: 19000
+  command: -c 'mkdir -p /data/posthog /data/ducklake-dev /data/ai-blobs && minio server --address ":19000"
+    --console-address ":19001" /data'
+  build:
+    strategy: image
+    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+  env:
+  - name: MINIO_ROOT_USER
+    value: object_storage_root_user
+  - name: MINIO_ROOT_PASSWORD
+- name: seaweedfs
+  kind: web
+  port: 8333
+  command: server -s3 -s3.port=8333 -dir=/data -volume.max=1000
+  build:
+    strategy: image
+    image: chrislusf/seaweedfs:4.29
+- name: browserless
+  kind: worker
+  build:
+    strategy: image
+    image: ghcr.io/browserless/chromium:v2.51.2
+  env:
+  - name: TOKEN
+    value: ''
+- name: asyncmigrationscheck
+  kind: worker
+  command: python manage.py run_async_migrations --check
+  build:
+    strategy: image
+    image: ':'
+  env:
+  - name: SITE_URL
+    value: https://
+  - name: SECRET_KEY
+    value: ''
+  - name: SKIP_ASYNC_MIGRATIONS_SETUP
+    value: '0'
+- name: temporal
+  kind: web
+  port: 7233
+  depends_on:
+  - db
+  - elasticsearch
+  build:
+    strategy: image
+    image: temporalio/auto-setup:1.26.2
+  env:
+  - name: DB
+    value: postgres12
+  - name: DB_PORT
+    value: '5432'
+  - name: POSTGRES_USER
+    value: posthog
+  - name: POSTGRES_PWD
+    value: posthog
+  - name: POSTGRES_SEEDS
+    value: db
+  - name: DYNAMIC_CONFIG_FILE_PATH
+    value: config/dynamicconfig/development-sql.yaml
+  - name: ENABLE_ES
+    value: 'false'
+  - name: ES_SEEDS
+    value: elasticsearch
+  - name: ES_VERSION
+    value: v7
+- name: elasticsearch
+  kind: worker
+  build:
+    strategy: image
+    image: elasticsearch:7.17.28
+  env:
+  - name: cluster.routing.allocation.disk.threshold_enabled
+    value: 'true'
+  - name: cluster.routing.allocation.disk.watermark.low
+    value: 512mb
+  - name: cluster.routing.allocation.disk.watermark.high
+    value: 256mb
+  - name: cluster.routing.allocation.disk.watermark.flood_stage
+    value: 128mb
+  - name: discovery.type
+    value: single-node
+  - name: ES_JAVA_OPTS
+    value: -Xms256m -Xmx256m
+  - name: xpack.security.enabled
+    value: 'false'
+- name: temporal-admin-tools
+  kind: worker
+  depends_on:
+  - temporal
+  build:
+    strategy: image
+    image: temporalio/admin-tools:1.26.2
+  env:
+  - name: TEMPORAL_CLI_ADDRESS
+    value: temporal:7233
+- name: temporal-ui
+  kind: web
+  port: 8080
+  depends_on:
+  - temporal
+  - db
+  build:
+    strategy: image
+    image: temporalio/ui:2.47.2
+  env:
+  - name: TEMPORAL_ADDRESS
+    value: temporal:7233
+  - name: TEMPORAL_CORS_ORIGINS
+    value: http://localhost:3000
+  - name: TEMPORAL_CSRF_COOKIE_INSECURE
+    value: 'true'
+  - name: TEMPORAL_CODEC_ENDPOINT
+    value: http://localhost:8000
+- name: temporal-django-worker
+  kind: worker
+  command: /compose/temporal-django-worker
+  depends_on:
+  - db
+  - redis7
+  - clickhouse
+  - kafka
+  - objectstorage
+  - seaweedfs
+  - temporal
+  - browserless
+  build:
+    strategy: image
+    image: ':'
+  env:
+  - name: SITE_URL
+    value: https://
+  - name: SECRET_KEY
+    value: ''
+  - name: BROWSERLESS_CDP_URL
+    value: ws://browserless:3000
+  - name: BROWSERLESS_TOKEN
+    value: ''
+  - name: HEATMAP_BROWSERLESS_URL
+    value: http://browserless:3000
+  - name: HEATMAP_BROWSERLESS_TOKEN
+    value: ''
+  - name: FEATURE_FLAGS_SERVICE_URL
+    value: http://feature-flags:3001
+  - name: CLICKHOUSE_LOGS_CLUSTER_HOST
+    value: clickhouse
+  - name: CLICKHOUSE_LOGS_CLUSTER_SECURE
+    value: 'false'
+  - name: ANTHROPIC_API_KEY
+    value: ''
+  - name: OPENAI_API_KEY
+    value: ''
+- name: capture
+  kind: worker
+  build:
+    strategy: image
+    image: ghcr.io/posthog/posthog/capture:master
+  env:
+  - name: ADDRESS
+    value: 0.0.0.0:3000
+  - name: KAFKA_TOPIC
+    value: events_plugin_ingestion
+  - name: KAFKA_ERROR_TRACKING_TOPIC
+    value: ingestion-errortracking-main
+  - name: KAFKA_HOSTS
+    value: kafka:9092
+  - name: REDIS_URL
+    value: redis://redis7:6379/
+  - name: CAPTURE_MODE
+    value: events
+  - name: RUST_LOG
+    value: info,rdkafka=warn
+  - name: CAPTURE_V1_SINKS
+    value: msk
+  - name: CAPTURE_V1_SINK_MSK_KAFKA_HOSTS
+    value: kafka:9092
+  - name: CAPTURE_V1_SINK_MSK_KAFKA_TOPIC_MAIN
+    value: events_plugin_ingestion
+  - name: CAPTURE_V1_SINK_MSK_KAFKA_TOPIC_HISTORICAL
+    value: events_plugin_ingestion_historical
+  - name: CAPTURE_V1_SINK_MSK_KAFKA_TOPIC_OVERFLOW
+    value: events_plugin_ingestion_overflow
+  - name: CAPTURE_V1_SINK_MSK_KAFKA_TOPIC_DLQ
+    value: events_plugin_ingestion_dlq
+  - name: CAPTURE_V1_SINK_MSK_KAFKA_TOPIC_EXCEPTION
+    value: ingestion-errortracking-main
+  - name: CAPTURE_V1_SINK_MSK_KAFKA_TOPIC_HEATMAP
+    value: heatmaps_ingestion
+  - name: CAPTURE_V1_SINK_MSK_KAFKA_TOPIC_CLIENT_INGESTION_WARNING
+    value: ingestion-clientwarnings-main-1
+- name: capture-logs
+  kind: worker
+  build:
+    strategy: image
+    image: ghcr.io/posthog/posthog/capture-logs:master
+  env:
+  - name: BIND_HOST
+    value: 0.0.0.0
+  - name: BIND_PORT
+    value: '4318'
+  - name: RUST_LOG
+    value: info,rdkafka=warn
+  - name: RUST_BACKTRACE
+    value: '1'
+  - name: KAFKA_HOSTS
+    value: kafka:9092
+  - name: JWT_SECRET
+  - name: KAFKA_TOPIC
+    value: logs_ingestion
+  - name: KAFKA_METRICS_TOPIC
+    value: metrics_ingestion
+- name: replay-capture
+  kind: worker
+  build:
+    strategy: image
+    image: ghcr.io/posthog/posthog/capture:master
+  env:
+  - name: ADDRESS
+    value: 0.0.0.0:3000
+  - name: KAFKA_TOPIC
+    value: session_recording_snapshot_item_events
+  - name: KAFKA_HOSTS
+    value: kafka:9092
+  - name: REDIS_URL
+    value: redis://redis7:6379/
+  - name: CAPTURE_MODE
+    value: recordings
+- name: property-defs-rs
+  kind: worker
+  depends_on:
+  - kafka-init
+  - db
+  build:
+    strategy: image
+    image: ghcr.io/posthog/posthog/property-defs-rs:master
+  env:
+  - name: DATABASE_URL
+  - name: KAFKA_HOSTS
+    value: kafka:9092
+  - name: SKIP_WRITES
+    value: 'false'
+  - name: SKIP_READS
+    value: 'false'
+  - name: FILTER_MODE
+    value: opt-out
+- name: livestream
+  kind: worker
+  depends_on:
+  - kafka
+  build:
+    strategy: image
+    image: ghcr.io/posthog/posthog/livestream:master
+  env:
+  - name: LIVESTREAM_JWT_SECRET
+    value: ''
+- name: personhog-replica
+  kind: worker
+  depends_on:
+  - db
+  build:
+    strategy: image
+    image: ghcr.io/posthog/posthog/personhog-replica:master
+  env:
+  - name: PRIMARY_DATABASE_URL
+- name: personhog-router
+  kind: worker
+  depends_on:
+  - personhog-replica
+  build:
+    strategy: image
+    image: ghcr.io/posthog/posthog/personhog-router:master
+  env:
+  - name: GRPC_ADDRESS
+    value: 0.0.0.0:50052
+  - name: REPLICA_URL
+    value: http://personhog-replica:50051
+  - name: BACKEND_TIMEOUT_MS
+    value: '5000'
+  - name: RUST_LOG
+    value: info
+  - name: METRICS_PORT
+    value: '9101'
+- name: feature-flags
+  kind: worker
+  depends_on:
+  - db
+  - redis7
+  build:
+    strategy: image
+    image: ghcr.io/posthog/posthog/feature-flags:master
+  env:
+  - name: WRITE_DATABASE_URL
+  - name: READ_DATABASE_URL
+  - name: PERSONS_WRITE_DATABASE_URL
+  - name: PERSONS_READ_DATABASE_URL
+  - name: MAXMIND_DB_PATH
+    value: /share/GeoLite2-City.mmdb
+  - name: REDIS_URL
+    value: redis://redis7:6379/
+  - name: ADDRESS
+    value: 0.0.0.0:3001
+  - name: RUST_LOG
+    value: info
+  - name: COOKIELESS_REDIS_HOST
+    value: redis7
+  - name: COOKIELESS_REDIS_PORT
+    value: '6379'
+- name: hypercache-server
+  kind: worker
+  depends_on:
+  - redis7
+  build:
+    strategy: image
+    image: ghcr.io/posthog/posthog/hypercache-server:master
+  env:
+  - name: REDIS_URL
+    value: redis://redis7:6379/
+  - name: ADDRESS
+    value: 0.0.0.0:3002
+  - name: RUST_LOG
+    value: info
+- name: kafka-init
+  kind: worker
+  command: "-c set -x\necho \"Waiting for Kafka broker to accept connections...\"\nTIMEOUT=60\nELAPSED=0\n\
+    # Use rpk topic list as the readiness check - it's a simple operation\n# that confirms the broker\
+    \ is accepting Kafka protocol requests\nuntil rpk topic list --brokers kafka:9092 2>/dev/null; do\n\
+    \    echo \"Kafka broker not ready yet (elapsed: ${ELAPSED}s)...\"\n    sleep 2\n    ELAPSED=$((ELAPSED\
+    \ + 2))\n    if [ $ELAPSED -ge $TIMEOUT ]; then\n        echo \"Timeout waiting for Kafka broker after\
+    \ ${TIMEOUT}s\"\n        echo \"Final attempt to list topics:\"\n        rpk topic list --brokers\
+    \ kafka:9092 || true\n        exit 1\n    fi\ndone\necho \"Kafka broker is accepting requests, creating\
+    \ topics...\"\n# Create topics needed by rust services and the combined analytics ingestion\n# consumer,\
+    \ which checks topic existence at startup for every output it produces\n# to (see analytics/outputs/registry.ts).\
+    \ Auto-create only fires on producer-first\n# writes, so pre-create them here.\n# Note: $ escapes\
+    \ $ for docker-compose variable substitution\nTOPICS=\"clickhouse_events_json \\\n    clickhouse_ai_events_json\
+    \ \\\n    clickhouse_heatmap_events \\\n    clickhouse_flag_evaluations \\\n    clickhouse_ingestion_warnings\
+    \ \\\n    events_plugin_ingestion_ai \\\n    events_plugin_ingestion_dlq \\\n    events_plugin_ingestion_overflow\
+    \ \\\n    events_plugin_ingestion_async \\\n    ingestion-clientwarnings-main-1 \\\n    heatmaps_ingestion\
+    \ \\\n    clickhouse_groups \\\n    clickhouse_person \\\n    clickhouse_person_distinct_id \\\n \
+    \   clickhouse_app_metrics2 \\\n    log_entries \\\n    clickhouse_tophog\"\nfor topic in $TOPICS;\
+    \ do\n    if rpk topic create \"$topic\" --brokers kafka:9092 -p 1 -r 1 2>&1; then\n        echo \"\
+    Topic $topic created successfully\"\n    else\n        if rpk topic list --brokers kafka:9092 | grep\
+    \ -q \"$topic\"; then\n            echo \"Topic $topic already exists, continuing\"\n        else\n\
+    \            echo \"Failed to create topic $topic\"\n            exit 1\n        fi\n    fi\ndone\n\
+    echo \"Final topic list:\"\nrpk topic list --brokers kafka:9092\necho \"Topics ready\"\n"
+  depends_on:
+  - kafka
+  build:
+    strategy: image
+    image: docker.io/redpandadata/redpanda:v25.1.9
+- name: cymbal
+  kind: worker
+  depends_on:
+  - kafka-init
+  - seaweedfs
+  - db
+  - redis7
+  - cymbal-resolution
+  build:
+    strategy: image
+    image: ghcr.io/posthog/posthog/cymbal:master
+  env:
+  - name: KAFKA_HOSTS
+    value: kafka:9092
+  - name: OBJECT_STORAGE_BUCKET
+    value: posthog
+  - name: OBJECT_STORAGE_ACCESS_KEY_ID
+    value: any
+  - name: OBJECT_STORAGE_SECRET_ACCESS_KEY
+    value: any
+  - name: OBJECT_STORAGE_ENDPOINT
+    value: http://seaweedfs:8333
+  - name: OBJECT_STORAGE_FORCE_PATH_STYLE
+    value: 'true'
+  - name: BIND_HOST
+    value: 0.0.0.0
+  - name: BIND_PORT
+    value: '3302'
+  - name: DATABASE_URL
+  - name: PERSONS_URL
+  - name: MAXMIND_DB_PATH
+    value: /share/GeoLite2-City.mmdb
+  - name: REDIS_URL
+    value: redis://redis7:6379/
+  - name: ISSUE_BUCKETS_REDIS_URL
+    value: redis://redis7:6379/
+  - name: RUST_LOG
+    value: info
+  - name: CYMBAL_REMOTE_RESOLUTION_HOST
+    value: cymbal-resolution
+  - name: INTERNAL_API_SECRET
+    value: ''
+- name: cymbal-resolution
+  kind: worker
+  depends_on:
+  - seaweedfs
+  - db
+  build:
+    strategy: image
+    image: ghcr.io/posthog/posthog/cymbal:master
+  env:
+  - name: CYMBAL_MODE
+    value: resolution
+  - name: GRPC_ADDRESS
+    value: 0.0.0.0:50061
+  - name: OBJECT_STORAGE_BUCKET
+    value: posthog
+  - name: OBJECT_STORAGE_ACCESS_KEY_ID
+    value: any
+  - name: OBJECT_STORAGE_SECRET_ACCESS_KEY
+    value: any
+  - name: OBJECT_STORAGE_ENDPOINT
+    value: http://seaweedfs:8333
+  - name: OBJECT_STORAGE_FORCE_PATH_STYLE
+    value: 'true'
+  - name: DATABASE_URL
+  - name: INTERNAL_API_SECRET
+    value: ''
+  - name: RUST_LOG
+    value: info
+egress:
+  default: block

--- a/docs/plan/four-stacks/report.py
+++ b/docs/plan/four-stacks/report.py
@@ -1,0 +1,72 @@
+"""What each published stack asks for that a manifest cannot say."""
+import sys, os, yaml, collections, json
+sys.path.insert(0, os.path.dirname(__file__))
+from compose2af import flatten_extends, load_env
+
+# Every key a manifest service can carry, from schemas/manifest.v1.json.
+MANIFEST_SERVICE_KEYS = {
+    "name","path","kind","build","command","port","health_path","health_timeout",
+    "env","replicas","resources","schedule","migrate","depends_on"}
+
+# The compose keys that DO map, and what they map to.
+MAPS = {
+    "image": "build.strategy: image, build.image",
+    "command": "command (see the entrypoint note)",
+    "environment": "env[]",
+    "depends_on": "depends_on",
+    "ports": "port, and only ONE of them",
+    "build": "build.strategy: dockerfile",
+}
+
+def hc_kind(hc):
+    if not hc: return None
+    test = hc.get("test")
+    if isinstance(test, str): test = ["CMD-SHELL", test]
+    if not test: return None
+    joined = " ".join(str(x) for x in test)
+    if "/dev/tcp/" in joined: return "a bare TCP connect"
+    if "http" in joined.lower():
+        if "-H " in joined or "Authorization" in joined: return "an HTTP GET that needs a header"
+        return "an HTTP GET on a path"
+    return "a command inside the container"
+
+def go(path, name, base=None, envfile=None):
+    d = yaml.safe_load(open(path))
+    b = yaml.safe_load(open(base)) if base else None
+    svcs = flatten_extends(d.get("services") or {}, (b or {}).get("services"))
+    env = load_env(envfile)
+    unmapped = collections.defaultdict(list)
+    binds, namedvols, multiport, hcs = [], [], [], collections.Counter()
+    hc_detail = []
+    for n, s in svcs.items():
+        s = s or {}
+        for k in s:
+            if k not in MAPS:
+                unmapped[k].append(n)
+        for v in (s.get("volumes") or []):
+            src = v.split(":")[0] if isinstance(v, str) else str(v)
+            (binds if (src.startswith("./") or src.startswith("/") or src.startswith("$")) else namedvols).append(f"{n}:{src}")
+        if len(s.get("ports") or []) > 1:
+            multiport.append(n)
+        k = hc_kind(s.get("healthcheck"))
+        if k:
+            hcs[k] += 1
+            hc_detail.append((n, k))
+    print(f"\n########## {name}: {len(svcs)} declared services")
+    print(f"  bind mounts of a file or directory from the repository: {len(binds)}")
+    for x in binds: print(f"      {x}")
+    print(f"  named docker volumes: {len(namedvols)}")
+    for x in namedvols: print(f"      {x}")
+    print(f"  services declaring more than one published port: {len(multiport)} {multiport}")
+    print(f"  readiness predicates, by what they actually are:")
+    for k, c in hcs.most_common(): print(f"      {c:2d}  {k}")
+    print(f"  compose keys with NO manifest key at all:")
+    for k, v in sorted(unmapped.items(), key=lambda kv: -len(kv[1])):
+        print(f"      {k:16s} {len(v):3d} services")
+    named_db = [n for n in svcs if n == "db"]
+    print(f"  services named 'db', which is the engine's own Postgres alias: {named_db}")
+
+U = "/private/tmp/af-stacks-l91/upstream"
+go(f"{U}/ch-1S_1K.yaml", "ClickHouse ch-1S_1K, from ClickHouse/examples")
+go(f"{U}/supabase.yml", "Supabase self hosting, from supabase/supabase docker/", envfile=f"{U}/supabase.env.example")
+go(f"{U}/posthog-hobby.yml", "PostHog hobby, from PostHog/posthog", base=f"{U}/posthog-base.yml")

--- a/docs/plan/four-stacks/supabase-selfhost/antifailure.yaml
+++ b/docs/plan/four-stacks/supabase-selfhost/antifailure.yaml
@@ -1,0 +1,368 @@
+version: 1
+name: supabase-selfhost
+services:
+- name: studio
+  kind: worker
+  build:
+    strategy: image
+    image: supabase/studio:2026.08.03-sha-022b374
+  env:
+  - name: HOSTNAME
+    value: 0.0.0.0
+  - name: STUDIO_PG_META_URL
+    value: http://meta:8080
+  - name: POSTGRES_PORT
+    value: '5432'
+  - name: POSTGRES_HOST
+    value: db
+  - name: POSTGRES_DB
+    value: postgres
+  - name: POSTGRES_PASSWORD
+  - name: POSTGRES_USER_READ_WRITE
+    value: postgres
+  - name: PG_META_CRYPTO_KEY
+  - name: PGRST_DB_SCHEMAS
+    value: public,graphql_public
+  - name: PGRST_DB_MAX_ROWS
+    value: '1000'
+  - name: PGRST_DB_EXTRA_SEARCH_PATH
+    value: public
+  - name: DEFAULT_ORGANIZATION_NAME
+    value: Default Organization
+  - name: DEFAULT_PROJECT_NAME
+    value: Default Project
+  - name: OPENAI_API_KEY
+  - name: SUPABASE_URL
+    value: http://api-gw:8000
+  - name: SUPABASE_PUBLIC_URL
+    value: http://localhost:8000
+  - name: SUPABASE_ANON_KEY
+  - name: SUPABASE_SERVICE_KEY
+  - name: AUTH_JWT_SECRET
+  - name: SUPABASE_PUBLISHABLE_KEY
+    value: ''
+  - name: SUPABASE_SECRET_KEY
+    value: ''
+  - name: ENABLED_FEATURES_LOGS_ALL
+    value: 'false'
+  - name: SNIPPETS_MANAGEMENT_FOLDER
+    value: /app/snippets
+  - name: EDGE_FUNCTIONS_MANAGEMENT_FOLDER
+    value: /app/edge-functions
+- name: api-gw
+  kind: web
+  port: 8000
+  depends_on:
+  - studio
+  build:
+    strategy: image
+    image: envoyproxy/envoy:v1.39.0
+  env:
+  - name: ANON_KEY
+  - name: SERVICE_ROLE_KEY
+  - name: SUPABASE_PUBLISHABLE_KEY
+    value: ''
+  - name: SUPABASE_SECRET_KEY
+    value: ''
+  - name: ANON_KEY_ASYMMETRIC
+    value: ''
+  - name: SERVICE_ROLE_KEY_ASYMMETRIC
+    value: ''
+  - name: SUPABASE_PUBLIC_URL
+    value: http://localhost:8000
+  - name: DASHBOARD_USERNAME
+    value: supabase
+  - name: DASHBOARD_PASSWORD
+- name: auth
+  kind: worker
+  depends_on:
+  - db
+  build:
+    strategy: image
+    image: supabase/gotrue:v2.189.0
+  env:
+  - name: GOTRUE_API_HOST
+    value: 0.0.0.0
+  - name: GOTRUE_API_PORT
+    value: '9999'
+  - name: API_EXTERNAL_URL
+    value: http://localhost:8000/auth/v1
+  - name: GOTRUE_DB_DRIVER
+    value: postgres
+  - name: GOTRUE_DB_DATABASE_URL
+  - name: GOTRUE_SITE_URL
+    value: http://localhost:3000
+  - name: GOTRUE_URI_ALLOW_LIST
+    value: ''
+  - name: GOTRUE_DISABLE_SIGNUP
+    value: 'false'
+  - name: GOTRUE_JWT_ADMIN_ROLES
+    value: service_role
+  - name: GOTRUE_JWT_AUD
+    value: authenticated
+  - name: GOTRUE_JWT_DEFAULT_GROUP_NAME
+    value: authenticated
+  - name: GOTRUE_JWT_EXP
+    value: '3600'
+  - name: GOTRUE_JWT_SECRET
+  - name: GOTRUE_JWT_ISSUER
+    value: http://localhost:8000/auth/v1
+  - name: GOTRUE_EXTERNAL_EMAIL_ENABLED
+    value: 'true'
+  - name: GOTRUE_EXTERNAL_ANONYMOUS_USERS_ENABLED
+    value: 'false'
+  - name: GOTRUE_MAILER_AUTOCONFIRM
+    value: 'false'
+  - name: GOTRUE_SMTP_ADMIN_EMAIL
+    value: admin@example.com
+  - name: GOTRUE_SMTP_HOST
+    value: supabase-mail
+  - name: GOTRUE_SMTP_PORT
+    value: '2500'
+  - name: GOTRUE_SMTP_USER
+    value: fake_mail_user
+  - name: GOTRUE_SMTP_PASS
+    value: fake_mail_password
+  - name: GOTRUE_SMTP_SENDER_NAME
+    value: fake_sender
+  - name: GOTRUE_MAILER_URLPATHS_INVITE
+    value: '"/auth/v1/verify"'
+  - name: GOTRUE_MAILER_URLPATHS_CONFIRMATION
+    value: '"/auth/v1/verify"'
+  - name: GOTRUE_MAILER_URLPATHS_RECOVERY
+    value: '"/auth/v1/verify"'
+  - name: GOTRUE_MAILER_URLPATHS_EMAIL_CHANGE
+    value: '"/auth/v1/verify"'
+  - name: GOTRUE_EXTERNAL_PHONE_ENABLED
+    value: 'true'
+  - name: GOTRUE_SMS_AUTOCONFIRM
+    value: 'true'
+- name: rest
+  kind: worker
+  command: postgrest
+  depends_on:
+  - db
+  build:
+    strategy: image
+    image: postgrest/postgrest:v14.12
+  env:
+  - name: PGRST_DB_URI
+  - name: PGRST_DB_SCHEMAS
+    value: public,graphql_public
+  - name: PGRST_DB_MAX_ROWS
+    value: '1000'
+  - name: PGRST_DB_EXTRA_SEARCH_PATH
+    value: public
+  - name: PGRST_DB_ANON_ROLE
+    value: anon
+  - name: PGRST_ADMIN_SERVER_PORT
+    value: '3001'
+  - name: PGRST_ADMIN_SERVER_HOST
+    value: localhost
+  - name: PGRST_JWT_SECRET
+    value: ${JWT_SECRET}
+  - name: PGRST_DB_USE_LEGACY_GUCS
+    value: 'false'
+  - name: PGRST_APP_SETTINGS_JWT_SECRET
+  - name: PGRST_APP_SETTINGS_JWT_EXP
+    value: '3600'
+- name: realtime
+  kind: worker
+  depends_on:
+  - db
+  build:
+    strategy: image
+    image: supabase/realtime:v2.102.3
+  env:
+  - name: PORT
+    value: '4000'
+  - name: DB_HOST
+    value: db
+  - name: DB_PORT
+    value: '5432'
+  - name: DB_USER
+    value: supabase_admin
+  - name: DB_PASSWORD
+  - name: DB_NAME
+    value: postgres
+  - name: DB_AFTER_CONNECT_QUERY
+    value: SET search_path TO _realtime
+  - name: DB_ENC_KEY
+  - name: API_JWT_SECRET
+  - name: SECRET_KEY_BASE
+  - name: METRICS_JWT_SECRET
+  - name: ERL_AFLAGS
+    value: -proto_dist inet_tcp
+  - name: DNS_NODES
+    value: ''''''
+  - name: RLIMIT_NOFILE
+    value: '10000'
+  - name: APP_NAME
+    value: realtime
+  - name: SEED_SELF_HOST
+    value: 'true'
+  - name: RUN_JANITOR
+    value: 'true'
+  - name: DISABLE_HEALTHCHECK_LOGGING
+    value: 'true'
+- name: storage
+  kind: worker
+  depends_on:
+  - db
+  - rest
+  - imgproxy
+  build:
+    strategy: image
+    image: supabase/storage-api:v1.60.4
+  env:
+  - name: ANON_KEY
+  - name: SERVICE_KEY
+  - name: POSTGREST_URL
+    value: http://rest:3000
+  - name: AUTH_JWT_SECRET
+  - name: DATABASE_URL
+  - name: STORAGE_PUBLIC_URL
+    value: http://localhost:8000
+  - name: REQUEST_ALLOW_X_FORWARDED_PATH
+    value: 'true'
+  - name: FILE_SIZE_LIMIT
+    value: '52428800'
+  - name: STORAGE_BACKEND
+    value: file
+  - name: GLOBAL_S3_BUCKET
+    value: stub
+  - name: FILE_STORAGE_BACKEND_PATH
+    value: /var/lib/storage
+  - name: TENANT_ID
+    value: stub
+  - name: REGION
+    value: stub
+  - name: ENABLE_IMAGE_TRANSFORMATION
+    value: 'true'
+  - name: IMGPROXY_URL
+    value: http://imgproxy:5001
+  - name: S3_PROTOCOL_ACCESS_KEY_ID
+  - name: S3_PROTOCOL_ACCESS_KEY_SECRET
+- name: imgproxy
+  kind: worker
+  build:
+    strategy: image
+    image: darthsim/imgproxy:v3.30.1
+  env:
+  - name: IMGPROXY_BIND
+    value: :5001
+  - name: IMGPROXY_LOCAL_FILESYSTEM_ROOT
+    value: /
+  - name: IMGPROXY_USE_ETAG
+    value: 'true'
+  - name: IMGPROXY_AUTO_WEBP
+    value: 'true'
+  - name: IMGPROXY_MAX_SRC_RESOLUTION
+    value: '16.8'
+- name: meta
+  kind: worker
+  depends_on:
+  - db
+  build:
+    strategy: image
+    image: supabase/postgres-meta:v0.96.6
+  env:
+  - name: PG_META_PORT
+    value: '8080'
+  - name: PG_META_DB_HOST
+    value: db
+  - name: PG_META_DB_PORT
+    value: '5432'
+  - name: PG_META_DB_NAME
+    value: postgres
+  - name: PG_META_DB_USER
+    value: postgres
+  - name: PG_META_DB_PASSWORD
+  - name: CRYPTO_KEY
+- name: functions
+  kind: worker
+  command: start --main-service /home/deno/functions/main
+  depends_on:
+  - api-gw
+  build:
+    strategy: image
+    image: supabase/edge-runtime:v1.74.0
+  env:
+  - name: JWT_SECRET
+  - name: SUPABASE_URL
+    value: http://api-gw:8000
+  - name: SUPABASE_PUBLIC_URL
+    value: http://localhost:8000
+  - name: SUPABASE_ANON_KEY
+  - name: SUPABASE_SERVICE_ROLE_KEY
+  - name: SUPABASE_PUBLISHABLE_KEYS
+    value: '{"default":""}'
+  - name: SUPABASE_SECRET_KEYS
+    value: '{"default":""}'
+  - name: SUPABASE_DB_URL
+  - name: VERIFY_JWT
+    value: 'false'
+- name: db
+  kind: worker
+  command: postgres -c config_file=/etc/postgresql/postgresql.conf -c log_min_messages=fatal
+  build:
+    strategy: image
+    image: supabase/postgres:17.6.1.136
+  env:
+  - name: POSTGRES_HOST
+    value: /var/run/postgresql
+  - name: PGPORT
+    value: '5432'
+  - name: POSTGRES_PORT
+    value: '5432'
+  - name: PGPASSWORD
+  - name: POSTGRES_PASSWORD
+  - name: PGDATABASE
+    value: postgres
+  - name: POSTGRES_DB
+    value: postgres
+  - name: JWT_SECRET
+  - name: JWT_EXP
+    value: '3600'
+- name: supavisor
+  kind: web
+  port: 5432
+  command: /bin/sh -c /app/bin/migrate && /app/bin/supavisor eval "$(cat /etc/pooler/pooler.exs)" && /app/bin/server
+  depends_on:
+  - db
+  build:
+    strategy: image
+    image: supabase/supavisor:2.9.5
+  env:
+  - name: PORT
+    value: '4000'
+  - name: POSTGRES_PORT
+    value: '5432'
+  - name: POSTGRES_HOST
+    value: db
+  - name: POSTGRES_DB
+    value: postgres
+  - name: POSTGRES_PASSWORD
+  - name: DATABASE_URL
+  - name: CLUSTER_POSTGRES
+    value: 'true'
+  - name: SECRET_KEY_BASE
+  - name: VAULT_ENC_KEY
+  - name: API_JWT_SECRET
+  - name: METRICS_JWT_SECRET
+  - name: REGION
+    value: local
+  - name: ERL_AFLAGS
+    value: -proto_dist inet_tcp
+  - name: POOLER_TENANT_ID
+    value: your-tenant-id
+  - name: POOLER_DEFAULT_POOL_SIZE
+    value: '20'
+  - name: POOLER_MAX_CLIENT_CONN
+    value: '100'
+  - name: POOLER_POOL_MODE
+    value: transaction
+  - name: DB_POOL_SIZE
+    value: '5'
+egress:
+  default: block

--- a/engine/cmd/af-proxy/crm_capture_test.go
+++ b/engine/cmd/af-proxy/crm_capture_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/internal/policy"
+	"github.com/antifailure/antifailure/engine/pkg/schema"
+)
+
+// The twin that posts nowhere, and the one that posts somewhere real.
+//
+// A prospect's application delivers to third party CRMs through a Zapier catch
+// hook. That is the case where the two failure modes of an egress rule are
+// both expensive and both silent. A rule that answers a plausible success for
+// a host nobody named produces a rehearsal in which every delivery reports
+// success and no record moves, which is a twin that lies. A rule that lets the
+// request out produces a rehearsal that fires somebody's real automation
+// against real contacts, which is worse.
+//
+// The tests below drive the real policy engine and the real capture handler,
+// with no fake in between, so they say what the sidecar does rather than what
+// the manifest was hoping for.
+
+// captureThrough runs one request through the capture path under a policy
+// built from the given rules, and returns the raw response.
+func captureThrough(t *testing.T, rules []schema.EgressRule, host, path, body string) string {
+	t.Helper()
+	engine, err := policy.New(&schema.Egress{Default: schema.ModeBlock, Rules: rules})
+	require.NoError(t, err)
+
+	preq := policy.Request{Host: host, Port: 443, Method: http.MethodPost, Path: path, TLS: true}
+	decision := engine.Evaluate(preq)
+	require.Equal(t, schema.ModeCapture, decision.Mode,
+		"the rule under test has to reach capture, or this proves nothing about capture")
+
+	req := httptest.NewRequest(http.MethodPost, "https://"+host+path, strings.NewReader(body))
+	var out bytes.Buffer
+	p := &proxy{out: json.NewEncoder(&bytes.Buffer{})}
+	rec := record{}
+	p.capture(&out, req, preq, decision, &rec)
+	return out.String()
+}
+
+// TestCapture_AWildcardOverAZapierHostIsRefusedRatherThanAnswered is the
+// commercially damaging case, stated as the sidecar decides it.
+func TestCapture_AWildcardOverAZapierHostIsRefusedRatherThanAnswered(t *testing.T) {
+	t.Parallel()
+	resp := captureThrough(t,
+		[]schema.EgressRule{{Host: "*.zapier.com", Mode: schema.ModeCapture}},
+		"hooks.zapier.com", "/hooks/catch/1234/abcd", `{"email":"lead@example.test"}`)
+
+	require.True(t, strings.HasPrefix(resp, "HTTP/1.1 403"),
+		"a rule that covers zapier.com rather than naming hooks.zapier.com must not "+
+			"answer as Zapier would; got %q", firstLineOf(resp))
+	require.NotContains(t, resp, "X-Antifailure-Captured: true",
+		"nothing was captured, so nothing may claim it was")
+}
+
+// TestCapture_AWildcardOverACRMHostIsRefusedRatherThanAnswered is the same
+// question asked of HubSpot, because a delivery path usually names more than
+// one third party and a reader should not have to assume the second behaves
+// like the first.
+func TestCapture_AWildcardOverACRMHostIsRefusedRatherThanAnswered(t *testing.T) {
+	t.Parallel()
+	resp := captureThrough(t,
+		[]schema.EgressRule{{Host: "*.hubapi.com", Mode: schema.ModeCapture}},
+		"api.hubapi.com", "/crm/v3/objects/contacts", `{"properties":{"email":"lead@example.test"}}`)
+
+	require.True(t, strings.HasPrefix(resp, "HTTP/1.1 403"),
+		"got %q", firstLineOf(resp))
+}
+
+// TestCapture_ANamedZapierHostIsRecordedAndAnswered is the other half, and it
+// is what makes the refusal above a boundary rather than a blanket no.
+func TestCapture_ANamedZapierHostIsRecordedAndAnswered(t *testing.T) {
+	t.Parallel()
+	resp := captureThrough(t,
+		[]schema.EgressRule{{Host: "hooks.zapier.com", Mode: schema.ModeCapture}},
+		"hooks.zapier.com", "/hooks/catch/1234/abcd", `{"email":"lead@example.test"}`)
+
+	require.True(t, strings.HasPrefix(resp, "HTTP/1.1 200"),
+		"a host somebody wrote down is consent to capture it; got %q", firstLineOf(resp))
+	require.Contains(t, resp, "X-Antifailure-Captured: true")
+}
+
+// TestCapture_ZapierHasNoHandlerSoTheBodyItAnswersIsNotZapiersShape is a
+// stated limit rather than a passing test dressed up as one.
+//
+// Zapier's catch hook answers {"status":"success","attempt":...,"id":...,
+// "request_id":...}, and a client that checks status carries on. This build
+// has no Zapier handler, so a NAMED zapier host is answered by the generic
+// shape, an empty object. The message is recorded either way, which is what
+// makes it the right guess for a host somebody wrote down, and it is not the
+// provider's own shape and no report should say it is.
+func TestCapture_ZapierHasNoHandlerSoTheBodyItAnswersIsNotZapiersShape(t *testing.T) {
+	t.Parallel()
+	h, known := captureHandlerFor("hooks.zapier.com", "/hooks/catch/1234/abcd")
+	require.False(t, known, "if a Zapier handler is added, this test is the one to update")
+	require.Equal(t, "unknown", h.name)
+
+	var out bytes.Buffer
+	h.respond(&out)
+	require.Contains(t, out.String(), "{}",
+		"the generic shape, which a client checking status does not read as success")
+}
+
+func firstLineOf(s string) string {
+	if i := strings.Index(s, "\r\n"); i >= 0 {
+		return s[:i]
+	}
+	return s
+}

--- a/engine/internal/fidelity/build.go
+++ b/engine/internal/fidelity/build.go
@@ -455,6 +455,39 @@ func hostComponent(h Host) Component {
 		c.State = Substituted
 		c.Detail = "the provider's own sandbox, with test credentials substituted at the sidecar"
 	case schema.ModeCapture:
+		if strings.HasPrefix(h.Name, "*") {
+			// A rule covering a domain rather than naming a host cannot be
+			// classified from the rule, and saying either thing would be
+			// wrong for half the hosts it matches.
+			//
+			// A LEADING star, which is the same predicate the mock branch
+			// below uses and the same one the policy uses to decide
+			// Decision.NamesHost. An interior star, as in
+			// email.*.amazonaws.com, pins the service label and the label
+			// count, so it can only ever reach one service, the policy counts
+			// it as naming the host, and the sidecar captures it. Widening
+			// this to every pattern would report those as unknown when they
+			// are not.
+			//
+			// The sidecar captures such a request only when this build has a
+			// handler for whatever host actually arrives, and refuses it with
+			// a 403 otherwise: *.resend.com is captured because there is a
+			// Resend handler, and *.zapier.com is refused because there is
+			// not. This ran as Substituted with the sentence about the
+			// provider's documented success shape, for both, so a delivery
+			// path written as *.zapier.com read here as recorded into the
+			// inbox and was refused at run time having recorded nothing.
+			//
+			// Unmeasured rather than a guess in either direction, which is
+			// what the mock branch below already does with the same rule shape
+			// through PackReason. It is excluded from the score and named,
+			// rather than counted as an answer nobody checked.
+			c.State = Unmeasured
+			c.Detail = "a rule covering a domain rather than naming a host, so whether the " +
+				"sidecar captures a request or refuses it depends on which host arrives and " +
+				"whether this build has a handler for that provider, which the rule does not say"
+			break
+		}
 		c.State = Substituted
 		c.Detail = "recorded into the inbox and answered with the provider's documented success shape"
 	case schema.ModeMock:

--- a/engine/internal/fidelity/thirdparty_capture_test.go
+++ b/engine/internal/fidelity/thirdparty_capture_test.go
@@ -1,0 +1,115 @@
+package fidelity_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/internal/fidelity"
+	"github.com/antifailure/antifailure/engine/pkg/schema"
+)
+
+// The report said a wildcard capture was a faithful substitution, and for half
+// the hosts such a rule matches the sidecar refuses it.
+//
+// The failure this exists to stop is the report lying about the one thing it
+// exists to be honest about. A prospect's delivery path posts to third party
+// CRMs through a Zapier catch hook. Written as *.zapier.com under capture,
+// af fidelity reported `substituted, recorded into the inbox and answered with
+// the provider's documented success shape`, and at run time the sidecar
+// answered 403 and recorded nothing. Somebody reading that report before a demo
+// would believe their deliveries were being captured.
+//
+// The correction is not the opposite claim. The sidecar captures a request
+// under such a rule when this build has a handler for the host that actually
+// arrives and refuses it otherwise, so *.resend.com IS captured and
+// *.zapier.com is not, and neither answer can be read off the rule. Unmeasured
+// is the package's own word for that, and the mock branch of the same function
+// already uses it for the same rule shape through PackReason.
+func TestThirdParty_AWildcardCaptureIsUnmeasuredRatherThanASubstitution(t *testing.T) {
+	t.Parallel()
+
+	obs := full()
+	obs.Manifest.Egress.Rules = append(obs.Manifest.Egress.Rules,
+		schema.EgressRule{Host: "*.zapier.com", Mode: schema.ModeCapture})
+	obs.Hosts = append(obs.Hosts,
+		fidelity.Host{Name: "*.zapier.com", Mode: schema.ModeCapture})
+
+	c := componentState(t, fidelity.Build(obs), schema.FidelityThirdParty, "*.zapier.com")
+
+	require.Equal(t, fidelity.Unmeasured, c.State,
+		"a rule that does not name a host says nothing about what the sidecar will do")
+	require.NotContains(t, c.Detail, "documented success shape",
+		"the report must not claim a provider's own shape for a rule that may never reach capture")
+	require.Contains(t, c.Detail, "naming a host",
+		"an unmeasured component is only useful when it says why")
+}
+
+// The other half, and it is what makes the rule above a boundary rather than a
+// blanket refusal to answer. A host somebody wrote down IS captured and
+// answered, and the report should keep saying so.
+func TestThirdParty_ANamedCaptureHostIsStillASubstitution(t *testing.T) {
+	t.Parallel()
+
+	c := componentState(t, fidelity.Build(full()), schema.FidelityThirdParty, "api.resend.com")
+
+	require.Equal(t, fidelity.Substituted, c.State)
+	require.Contains(t, c.Detail, "recorded into the inbox")
+}
+
+// An unmeasured component leaves the score and is named in Excluded, and this
+// asserts the second half of that rather than trusting it.
+//
+// The two halves are not the same claim. Dropping out of the denominator is
+// what stops a guess being counted; appearing in Excluded with a reason is what
+// stops it disappearing silently, and a percentage that quietly absorbs an
+// unknown is the thing this package exists to refuse.
+func TestThirdParty_AWildcardCaptureLeavesTheScoreAndIsNamed(t *testing.T) {
+	t.Parallel()
+
+	obs := full()
+	obs.Manifest.Egress.Rules = append(obs.Manifest.Egress.Rules,
+		schema.EgressRule{Host: "*.zapier.com", Mode: schema.ModeCapture})
+	obs.Hosts = append(obs.Hosts,
+		fidelity.Host{Name: "*.zapier.com", Mode: schema.ModeCapture})
+
+	before := fidelity.Build(full()).Score()
+	after := fidelity.Build(obs).Score()
+
+	require.Equal(t, before.Counted, after.Counted,
+		"an unmeasured component is in neither half of the fraction")
+
+	var named bool
+	for _, e := range after.Excluded {
+		if e.Component == "*.zapier.com" {
+			named = true
+			require.Contains(t, e.Because, "naming a host",
+				"the exclusion carries the reason or it is a silent absence")
+		}
+	}
+	require.True(t, named, "the excluded component has to appear in Excluded by name")
+}
+
+// An interior star is not the same rule shape and must not be swept up.
+//
+// email.*.amazonaws.com pins the service label and the label count, so it can
+// only ever reach SES and no other service under that domain. The policy counts
+// that as naming the host, `Decision.NamesHost` is true for it, and the sidecar
+// captures it. Reporting it as undetermined would trade one wrong answer for
+// another, quieter one, and this is what keeps the predicate a leading star
+// rather than any star at all.
+func TestThirdParty_AnInteriorStarNamesTheServiceAndIsStillASubstitution(t *testing.T) {
+	t.Parallel()
+
+	obs := full()
+	obs.Manifest.Egress.Rules = append(obs.Manifest.Egress.Rules,
+		schema.EgressRule{Host: "email.*.amazonaws.com", Mode: schema.ModeCapture})
+	obs.Hosts = append(obs.Hosts,
+		fidelity.Host{Name: "email.*.amazonaws.com", Mode: schema.ModeCapture})
+
+	c := componentState(t, fidelity.Build(obs), schema.FidelityThirdParty, "email.*.amazonaws.com")
+
+	require.Equal(t, fidelity.Substituted, c.State,
+		"a pattern whose stars are all interior can reach only one service, "+
+			"which is what the policy means by naming a host")
+}

--- a/engine/internal/manifest/fourstacks_test.go
+++ b/engine/internal/manifest/fourstacks_test.go
@@ -1,0 +1,87 @@
+package manifest_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/internal/manifest"
+)
+
+// The four stacks are a standing question put to the validator.
+//
+// docs/plan/four-stacks holds three manifests converted mechanically from
+// PostHog's, ClickHouse's and Supabase's own published compose files, and one
+// that is a shape rather than a twin. They are evidence rather than examples,
+// and the reason they are worth a test is that they are the only manifests in
+// this repository that somebody else's application asked for. Everything under
+// examples/ was written here and validates because it was written to.
+//
+// A schema change that refuses one of these is a schema change that refuses a
+// real published stack. That may still be the right change, and this test does
+// not argue against it: it makes the cost visible in the same commit rather
+// than in a customer's terminal.
+//
+// The counts are asserted because the point of the row was how many services
+// each published file declares. A conversion that silently lost a service
+// would still parse.
+func TestTheFourStacksStillParse(t *testing.T) {
+	t.Parallel()
+
+	root, err := filepath.Abs(filepath.Join("..", "..", ".."))
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		dir      string
+		services int
+		why      string
+	}{
+		{"clickhouse-1s-1k", 2,
+			"ClickHouse/examples, docker-compose-recipes/recipes/ch-1S_1K"},
+		{"supabase-selfhost", 11,
+			"supabase/supabase, docker/docker-compose.yml"},
+		{"posthog-hobby", 37,
+			"PostHog/posthog, docker-compose.hobby.yml over docker-compose.base.yml"},
+		{"goliath-shape", 4,
+			"a shape proved instead of a twin, because nothing is published"},
+	} {
+		t.Run(tc.dir, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(root, "docs", "plan", "four-stacks", tc.dir, "antifailure.yaml")
+			if _, statErr := os.Stat(path); statErr != nil {
+				t.Fatalf("%s is missing: %v", path, statErr)
+			}
+			m, loadErr := manifest.Load(path)
+			require.NoError(t, loadErr, "%s (%s) no longer validates", tc.dir, tc.why)
+			require.Len(t, m.Services, tc.services,
+				"%s declares %d services in its published file", tc.dir, tc.services)
+		})
+	}
+}
+
+// TestTheGoliathShapeNamesEveryThirdPartyHost is the assertion the shape exists
+// to carry.
+//
+// A rule that covers a domain rather than naming a host is refused by the
+// sidecar rather than answered, so a delivery path written as *.zapier.com gets
+// a 403 at run time while af net explain reports it as CAPTURE. The manifest
+// beside this test names each host, and this is what keeps it that way.
+func TestTheGoliathShapeNamesEveryThirdPartyHost(t *testing.T) {
+	t.Parallel()
+
+	root, err := filepath.Abs(filepath.Join("..", "..", ".."))
+	require.NoError(t, err)
+	m, err := manifest.Load(filepath.Join(root,
+		"docs", "plan", "four-stacks", "goliath-shape", "antifailure.yaml"))
+	require.NoError(t, err)
+	require.NotNil(t, m.Egress)
+	require.NotEmpty(t, m.Egress.Rules, "the shape is about the egress block")
+
+	for _, r := range m.Egress.Rules {
+		require.NotContains(t, r.Host, "*",
+			"the rule for %q covers a domain rather than naming a host, which is the "+
+				"case the sidecar refuses and af net explain cannot distinguish", r.Host)
+	}
+}


### PR DESCRIPTION
The row is L9.1: convert PostHog's, ClickHouse's and Supabase's own published
compose files into manifests, run them, and count what reached ready. Goliath
Data publishes nothing, so its deliverable is a shape and a question list rather
than a twin built from a guess, which is the ruling already in the plan and is
not reopened.

## The finding

The row was hunting one failure in particular: an egress rule answering 200 for
a Zapier or CRM hostname, producing a twin in which every delivery reports
success and no record moves. The sidecar does not do that. A capture whose rule
does not name the host is refused with a 403, mock with no fixture answers 404,
synth with no model key answers 403, and nothing fabricates a success for a host
a domain merely swept up. Four new tests pin that for a Zapier catch hook and a
HubSpot contact write, driven through the real policy engine and the real
capture handler with no fake between them.

**The report does.** `af fidelity` gave the same verdict to three capture rules
whose run time behaviour is three different things:

```
third_party    substituted (3 substituted)
  *.zapier.com substituted  recorded into the inbox and answered with the provider's documented success shape
  api.resend.… substituted  recorded into the inbox and answered with the provider's documented success shape
  hooks.zapie… substituted  recorded into the inbox and answered with the provider's documented success shape
```

| Rule | What the sidecar does | What the report said |
| --- | --- | --- |
| `*.zapier.com` capture | 403, nothing recorded, because there is no Zapier handler | substituted, the provider's own shape |
| `api.resend.com` capture | recorded, answered with Resend's own body | substituted, the provider's own shape |
| `hooks.zapier.com` capture | recorded, answered `{}` | substituted, the provider's own shape |

Only the middle row is true. The headline percentage does not move, because a
substitution and a refusal are both counted and neither is reproduced. What
moves is the sentence a person reads and the dimension's one word verdict,
which is where somebody looks to decide whether the third party surface can be
relied on. For a company whose whole outbound path is a catch hook and two
CRMs, every line of that dimension was the wrong word.

The wildcard half is fixed here, and the obvious repair would have been the same
mistake pointing the other way. Calling such a rule refused is wrong for half the
hosts it matches: `*.resend.com` IS captured, because there is a Resend handler,
and `*.zapier.com` is not. Neither answer can be read off the rule, so it is
reported unmeasured with the reason, which leaves the score and is named in the
exclusions rather than counted as an answer nobody checked. The mock branch of
the same function already treats the same rule shape that way.

The other half is not fixed and that is deliberate. Whether a host somebody DID
name is answered with the provider's own body or with an empty object depends on
the sidecar's handler list, which is in `package main` and cannot be imported by
the report. `af net explain` has the same blind spot from the other side, giving
the identical CAPTURE verdict for both rules. Both want one host to provider
registry that the sidecar, the report and the CLI read. That list already exists
in four places here, and a fifth copy is how those four drifted apart.

## The number, unflattered

**Stacks that came up: 0 of 4. Services that reached ready: 0 of 50.**

All four manifests validate and `af explain` renders every one. None reached a
running environment, and the reason is the machine rather than the manifests:

- `af up` on the smallest stack was killed at 25 minutes 32 seconds, still on
  the single progress line `building the egress proxy (once per version)`.
  `ensureProxyImage` has no pull path: it compiles the sidecar inside a
  `golang:1.25-alpine` container, fetching the module graph over the network,
  with no timeout and no output.
- The registry is unreachable. `docker pull` fails after 2m56s with
  `TLS handshake timeout`, and not one of the fifty services' images is cached
  here, so even with the sidecar seeded by hand there is nothing to start.
- `docker ps` and `docker images` return nothing inside 180 seconds against 236
  containers at load average 30. Every container level observation is therefore
  COULD-NOT-LOOK and is labelled as such.
- What did work: the daemon runs a cached image in under a second, `af down`
  removed six resources and compensated three through the journal, and
  `af fidelity` answered without a running environment, reporting every
  unmeasurable component as unmeasured rather than as a pass. That last one is
  why the zero above is a zero and not a small number that could be mistaken for
  progress, and it is where the finding above came from.

## The rest of the diff

`docs/plan/four-stacks` carries the four manifests, the converter that produced
three of them mechanically from the projects' own files, the per stack analysis,
the Goliath question list, and sixteen more findings each named with the lane
that owes it. The three that stop all three stacks before anything else can be
observed:

- **No way to mount a file into a service.** `HostConfig` sets neither `Binds`
  nor `Mounts` and the schema has no `volumes` key, against 36 bind mounts and
  13 named volumes in the three published files. Supabase's Postgres loses the
  seven SQL files that create `supabase_auth_admin`, `authenticator`, `anon` and
  `service_role`, so five other services cannot connect at all.
- **The engine's Postgres answers to the alias `db`,** and both Supabase and
  PostHog declare a service called `db`. Nothing refuses it. The fix cannot be
  to refuse the name, because renaming their service is an edit to their
  application and the whole claim is that there is none.
- **A service with no published port is ready when its container is running.**
  Of the fifty services, 41 publish no port, so `ready` would mean `created and
  has not exited yet` for most of a stack.

The four manifests get a test of their own. They are the only manifests here
that somebody else's application asked for, and a schema change that refuses one
is a schema change that refuses a real published stack, which may still be
right. The test makes that cost visible in the same commit rather than in a
customer's terminal.

## Contact

Nothing was sent to PostHog, ClickHouse, Supabase or Goliath Data. No issue,
discussion, pull request or support ticket was opened anywhere. Five files were
fetched and read, and that is the whole of it.
