### PR TITLE
engine: the suite had two answers and one of its claims could honestly be given neither

### DIFF
--- a/.changes/copy-on-write-had-two-answers-and-needed-three.md
+++ b/.changes/copy-on-write-had-two-answers-and-needed-three.md
@@ -1,0 +1,30 @@
+# changed
+
+The conformance suite had two answers, and the claim this whole database
+category is sold on could honestly be given neither of them.
+
+`CopyOnWrite_BranchTimeMatchesTheDeclaration` decides by stopwatch, and the
+stopwatch is only as good as the storage under the run. Over a single local
+Postgres the only way a fake cloud control plane can hand back a branch carrying
+the golden's data is `CREATE DATABASE ... TEMPLATE`, which copies files. The
+large arm is then slower by seconds per gibibyte whatever the provider would do
+against the real service, so a provider that really does clone in constant time,
+declaring so truthfully, FAILED. Declaring false would have been green and false
+about the product; skipping the behaviour would have turned off the one
+instrument the wave was held for.
+
+There is now a third verdict, `UNPROVEN`, distinct from pass and from fail. The
+measurement still runs in full and every number is still printed; what changes
+is what the readings are turned into. It is reachable only from a test fixture
+declaring, in prose, that the storage IT built copies every branch, it is
+refused unless the provider declares copy on write true, it is failed if the
+fixture's own readings contradict the declaration, and it is never rendered as a
+proved claim: `conformance.CopyOnWriteClaim` publishes the word `unproven`
+instead of the declared value.
+
+Three cells of the benchmark comparison table published `yes` for copy on write
+beside the words "not measured yet", which is the same unfalsifiable declaration
+one surface further out. They now say `unproven`, a ledger records the verdict
+for every provider that declares a value, and two sweeps check both directions:
+no declaration without a recorded verdict, and no published cell that disagrees
+with one.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -33,15 +33,35 @@ that is real for nothing.
 | Provider | Copy on write | First golden, per GB | Branch, 8 MB | Branch, 1.43 GB | Runs |
 | --- | --- | --- | --- | --- | --- |
 | `pgurl` | no | 55 s to 169 s | 0.2 s | 25 s to 110 s | `2026-09-07-0941`, `2026-09-07-1002` |
-| `aurora` | yes | not measured yet, L2.2 | | | |
-| `rds` | no | not measured yet, L2.3 | | | |
-| `cloudsql` | yes | not measured yet, L2.4 | | | |
-| `azure-pg` | no | not measured yet, L2.5 | | | |
-| `alloydb` | yes | not measured yet, L2.6 | | | |
+| `aurora` | unproven | not measured yet, L2.2 | | | |
+| `rds` | unproven | not measured yet, L2.3 | | | |
+| `cloudsql` | unproven | not measured yet, L2.4 | | | |
+| `azure-pg` | unproven | not measured yet, L2.5 | | | |
+| `alloydb` | unproven | not measured yet, L2.6 | | | |
 
 A row with no number is a row that has not been measured. It is left visible on
 purpose: a table that only listed the providers somebody had got around to
 timing would read as a claim about the ones it omitted.
+
+**`unproven` in the copy on write column is a third answer, and it is neither a
+yes nor a no.** Five of these six cells used to carry a verdict beside the words
+"not measured yet", which is the whole defect this column exists against: a
+capability declared and published with nothing able to refuse it. Three said
+`yes` and two said `no`, and the two were the same mistake in the direction that
+happens to cost the vendor rather than the buyer. The suite's own reasoning is
+that the false side matters as much as the true side, because a provider that
+understates a flat branch time puts the wrong row in the table somebody chooses
+from, so both now say `unproven`.
+
+The column says what the ledger in `engine/conformance/ledger.go` recorded, and
+a test checks every cell against it in both directions: no cell may claim more
+than the ledger, and no cell may claim less. Unproven means the conformance
+suite ran the measurement in full and the harness underneath it could not
+exhibit the behaviour either way. A fake cloud control plane over one local
+Postgres can only hand back a branch with `CREATE DATABASE ... TEMPLATE`, which
+copies files, so the stopwatch reads the harness rather than the provider.
+Settling one of these needs the real service with an account. Only `pgurl` has a
+recorded verdict, and it has one because the numbers beside it were measured.
 
 **A range rather than a figure, because that is what was measured.** The two
 `pgurl` runs are the same commit against the same server twenty one minutes

--- a/docs/src/content/docs/contributing/provider-authoring.md
+++ b/docs/src/content/docs/contributing/provider-authoring.md
@@ -216,6 +216,57 @@ Those two are complementary, so one of the two possible declarations is refused
 on every run. There is no reading of the stopwatch that lets both pass, which is
 the property a check needs before a green one means anything.
 
+### The third answer, for a harness that cannot exhibit the behaviour
+
+The stopwatch is only as good as the storage underneath the run, and there is a
+harness on which a truthful `CopyOnWrite: true` cannot pass. A fake cloud
+control plane over one local Postgres can only hand back a branch carrying the
+golden's data with `CREATE DATABASE ... TEMPLATE`, which copies files. The large
+arm is then slower by seconds per gibibyte whatever the provider would do
+against the real service, so the stopwatch is reading the harness.
+
+Declaring `false` to get a green is a lie about the product. Skipping the
+behaviour turns off the one instrument that can refuse this category's central
+commercial claim. Loosening the allowance leaves it running, printing a verdict,
+and unable to refuse anything.
+
+So the behaviour has a third answer, **unproven**, and it is not a pass.
+
+```
+NOT PROVED BY THIS RUN. This is not a pass.
+  UNPROVEN  aurora  CopyOnWrite_BranchTimeMatchesTheDeclaration
+```
+
+`Options.HarnessCopiesEveryBranch` is the only thing that reaches it. It is a
+sentence your TEST FIXTURE writes about the storage it built, naming the
+mechanism, and it is nothing a provider can reach: `Capabilities()` is the thing
+under examination, and a subject that could excuse itself from a check is the
+unfalsifiable declaration this whole behaviour exists to refuse.
+
+Four things make it a verdict rather than a way out.
+
+- **The measurement still runs, in full.** Both goldens are built, both arms are
+  timed, the ballast is weighed in the branch, and every number is printed.
+  Unproven changes what the readings are turned into, never whether they were
+  taken.
+- **It is refused unless you declare `CopyOnWrite: true`.** On the false side a
+  copying harness exhibits exactly what is being asserted, so there is nothing
+  it cannot reach.
+- **It is checked against your own readings.** A fixture that declares its
+  storage copies and then branches in constant time is failed for the
+  declaration. Setting the field on a harness that turns out to share storage
+  turns a pass into a failure, so it cannot be set defensively by somebody who
+  has not looked.
+- **It buys nothing you can publish.** `conformance.CopyOnWriteClaim` renders the
+  declaration as the word `unproven` wherever a customer would read it, the
+  ledger in `engine/conformance/ledger.go` records the verdict per provider, and
+  a test refuses a comparison table cell that says otherwise.
+
+What remains, and it is stated rather than papered over: a copying harness
+cannot tell an honest provider from a dishonest one, because the two produce the
+same readings on it. That is a property of the harness. Settling it needs the
+real service with an account, and nothing short of that does.
+
 The suite makes a golden large by writing ballast into it from inside the `Mask`
 callback, so a provider needs no extra method: hand `Mask` a connection string
 that works, which every other behaviour needs anyway, and the sizing takes care

--- a/engine/conformance/claim_test.go
+++ b/engine/conformance/claim_test.go
@@ -1,0 +1,425 @@
+package conformance_test
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/antifailure/antifailure/engine/conformance"
+)
+
+// The two sweeps that make the ledger's completeness a property of a check
+// rather than of the afternoon somebody grepped.
+//
+// The ruling that produced the third verdict has a second condition: an
+// unproven CopyOnWrite: true is not publishable as a proved claim anywhere a
+// customer reads it. A condition of that shape decays the moment somebody adds
+// a provider or a row, so it is kept the way claimcheck keeps its own rule.
+// Do not sweep by hand, because a sweep is only true on the day it is run.
+//
+// The two directions are different questions and neither implies the other.
+//
+// DECLARATIONS. Every provider.Caps literal in the repository that sets
+// CopyOnWrite has a ledger entry. This is the direction that catches a provider
+// arriving with a declaration nobody recorded a verdict for, which is the state
+// all five of the existing ones were in before the ledger existed.
+//
+// PUBLICATIONS. Every cell in the comparison table's copy on write column says
+// what the ledger says. This is the direction that catches the claim reaching a
+// buyer, and it is the one that was already broken: three rows of that table
+// published yes for providers that do not exist yet, beside the words "not
+// measured yet" in the next cell.
+
+// repoRoot is where the sweeps look, and it is asserted rather than assumed.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("resolve the repository root: %v", err)
+	}
+	// Named files rather than a directory, because a wrong root that happens
+	// to be a directory would make both sweeps find nothing and pass.
+	for _, marker := range []string{"go.work", "CONTRIBUTING.md"} {
+		if _, err := os.Stat(filepath.Join(root, marker)); err != nil {
+			t.Fatalf("%s does not look like the repository root: %s is not there (%v). "+
+				"Both sweeps below walk the tree from here, and a root that resolved to "+
+				"the wrong place would find nothing and report that as clean.",
+				root, marker, err)
+		}
+	}
+	return root
+}
+
+// TestEveryCopyOnWriteDeclarationHasARecordedVerdict is the declaration sweep.
+func TestEveryCopyOnWriteDeclarationHasARecordedVerdict(t *testing.T) {
+	root := repoRoot(t)
+	found := declaringDirs(t, root)
+	if len(found) == 0 {
+		t.Fatal("the sweep found no provider.Caps literal setting CopyOnWrite anywhere in " +
+			"the repository. There are several, so the sweep is broken rather than the " +
+			"tree being clean, and a sweep that cannot find what it is looking for reports " +
+			"every future provider as recorded too.")
+	}
+
+	// Each ledger entry claims a directory, through its Evidence path. That
+	// path is checked to exist for the reason claimcheck checks its own: an
+	// entry pointing at a file nobody wrote reads as a recorded verdict and is
+	// a dead link.
+	byDir := map[string]string{}
+	for name, e := range conformance.CopyOnWriteLedger {
+		if e.Evidence == "" {
+			t.Errorf("the ledger entry for %q names no evidence. The entry's whole job is "+
+				"to point at the instrument that would refuse the declaration, and one "+
+				"that points nowhere is the recorded verdict equivalent of a function "+
+				"with no callers.", name)
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(root, e.Evidence)); err != nil {
+			t.Errorf("the ledger entry for %q names %s as its evidence and that file is "+
+				"not there: %v", name, e.Evidence, err)
+			continue
+		}
+		dir := filepath.Dir(e.Evidence)
+		if other, dup := byDir[dir]; dup {
+			t.Errorf("%q and %q both name evidence in %s, so the sweep cannot tell which "+
+				"entry records the verdict for that provider", name, other, dir)
+			continue
+		}
+		byDir[dir] = name
+		if e.Verdict != conformance.Proved && e.Verdict != conformance.Unproven {
+			t.Errorf("the ledger entry for %q records the verdict %q. A ledger records what "+
+				"a run reached, and a run that refuted a declaration leaves a provider "+
+				"nobody should ship rather than a row in this table.", name, e.Verdict)
+		}
+		if len(strings.TrimSpace(e.Because)) < 40 {
+			t.Errorf("the ledger entry for %q gives %q as its reason. The reason is the only "+
+				"thing that tells a harness which cannot exhibit the property apart from "+
+				"an instrument nobody has fired, and both of those publish as unproven.",
+				name, e.Because)
+		}
+	}
+
+	for _, dir := range found {
+		if _, ok := byDir[dir]; !ok {
+			t.Errorf("%s declares a copy on write value in a provider.Caps literal and no "+
+				"ledger entry records a verdict for it. Add one to CopyOnWriteLedger in "+
+				"engine/conformance/ledger.go, with the verdict a run actually reached: "+
+				"unproven is the honest entry for an instrument nobody has fired, and it "+
+				"is not a defect to record, it is the state every provider starts in.", dir)
+		}
+	}
+	for dir, name := range byDir {
+		if !contains(found, dir) {
+			t.Errorf("the ledger records a verdict for %q with evidence in %s, and no "+
+				"provider.Caps literal there sets CopyOnWrite. A stale entry describes a "+
+				"decision about something that is no longer here and would silently cover "+
+				"a future declaration that landed in the same directory.", name, dir)
+		}
+	}
+
+	names := make([]string, 0, len(byDir))
+	for _, n := range byDir {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	t.Logf("%d directories declare a copy on write value, and the ledger records a verdict "+
+		"for each: %s", len(found), strings.Join(names, ", "))
+}
+
+// declaringDirs walks the tree and returns every directory holding a
+// provider.Caps composite literal that sets CopyOnWrite.
+//
+// The literal's TYPE is what is matched, not the field name, and that is the
+// whole reason this parses rather than greps. provider.DatastoreCaps carries a
+// field of the same name, checked by a different suite under different rules,
+// and a grep for "CopyOnWrite:" cannot tell the two apart. Test files are
+// skipped: a fake declaring a value to be caught by is the instrument, not a
+// claim about a product.
+func declaringDirs(t *testing.T, root string) []string {
+	t.Helper()
+	seen := map[string]bool{}
+	fset := token.NewFileSet()
+
+	for _, tree := range []string{"engine", "ee"} {
+		base := filepath.Join(root, tree)
+		if _, err := os.Stat(base); err != nil {
+			t.Fatalf("the sweep cannot read %s: %v. A tree it cannot walk is a tree it "+
+				"reports as clean.", base, err)
+		}
+		err := filepath.WalkDir(base, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				if d.Name() == "node_modules" || d.Name() == "testdata" {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			f, perr := parser.ParseFile(fset, path, nil, 0)
+			if perr != nil {
+				// Refused rather than skipped. A file the sweep could not read
+				// is a file it could not check, and counting it as clean is
+				// the shape of gap this whole package is against.
+				t.Errorf("the sweep could not parse %s: %v", path, perr)
+				return nil
+			}
+			ast.Inspect(f, func(n ast.Node) bool {
+				lit, ok := n.(*ast.CompositeLit)
+				if !ok {
+					return true
+				}
+				sel, ok := lit.Type.(*ast.SelectorExpr)
+				if !ok || sel.Sel == nil || sel.Sel.Name != "Caps" {
+					return true
+				}
+				pkg, ok := sel.X.(*ast.Ident)
+				if !ok || pkg.Name != "provider" {
+					return true
+				}
+				for _, elt := range lit.Elts {
+					kv, ok := elt.(*ast.KeyValueExpr)
+					if !ok {
+						continue
+					}
+					key, ok := kv.Key.(*ast.Ident)
+					if !ok || key.Name != "CopyOnWrite" {
+						continue
+					}
+					rel, rerr := filepath.Rel(root, filepath.Dir(path))
+					if rerr == nil {
+						seen[filepath.ToSlash(rel)] = true
+					}
+				}
+				return true
+			})
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walk %s: %v", base, err)
+		}
+	}
+
+	out := make([]string, 0, len(seen))
+	for d := range seen {
+		// The suite's own fakes declare values on purpose, one of them wrong
+		// on purpose, because that is how the behaviour is proved able to
+		// fail. They are the instrument rather than a product claim, and a
+		// ledger entry for a deliberately broken provider would be a verdict
+		// about a thing nobody ships.
+		if strings.Contains(d, "testutil/fakes") {
+			continue
+		}
+		out = append(out, d)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func contains(hay []string, needle string) bool {
+	for _, h := range hay {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// benchmarkTable is the comparison table the wave publishes into, and the sweep
+// below reads the real file rather than a copy of it.
+const benchmarkTable = "benchmarks/README.md"
+
+// copyOnWriteColumn is the column heading that makes a table one of these.
+const copyOnWriteColumn = "Copy on write"
+
+// TestThePublishedCopyOnWriteColumnSaysWhatTheLedgerSays is the publication
+// sweep.
+func TestThePublishedCopyOnWriteColumnSaysWhatTheLedgerSays(t *testing.T) {
+	root := repoRoot(t)
+	path := filepath.Join(root, benchmarkTable)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("the publication sweep cannot read %s: %v. This is the table the wave "+
+			"publishes its copy on write claim into, so a sweep that cannot find it has "+
+			"stopped checking the surface a buyer reads, and returning early here would "+
+			"look exactly like a clean tree.", benchmarkTable, err)
+	}
+
+	problems, rows := checkPublishedColumn(string(raw))
+	if rows == 0 {
+		t.Fatalf("%s has no %q column. Either the table moved and this sweep now checks "+
+			"nothing, or the column was removed; both need a person, because the sweep "+
+			"passing while checking nothing is the failure it exists to prevent.",
+			benchmarkTable, copyOnWriteColumn)
+	}
+	for _, p := range problems {
+		t.Error(p)
+	}
+	t.Logf("%d rows of the %q column in %s agree with the ledger",
+		rows, copyOnWriteColumn, benchmarkTable)
+}
+
+// checkPublishedColumn reads a Markdown document, finds the copy on write
+// column, and reports every cell that says something the ledger does not.
+//
+// Separated from the test so the negative control below can point it at a
+// document that is wrong on purpose. A gate whose refusing branch has never
+// been reached is a gate nobody has watched say no.
+func checkPublishedColumn(doc string) (problems []string, rows int) {
+	lines := strings.Split(doc, "\n")
+	col := -1
+	for _, line := range lines {
+		if !strings.HasPrefix(strings.TrimSpace(line), "|") {
+			col = -1
+			continue
+		}
+		cells := splitRow(line)
+		if col < 0 {
+			for i, c := range cells {
+				if strings.EqualFold(c, copyOnWriteColumn) {
+					col = i
+				}
+			}
+			continue
+		}
+		if col >= len(cells) {
+			continue
+		}
+		// The separator row under a Markdown heading.
+		if strings.Trim(cells[0], "-: ") == "" {
+			continue
+		}
+		name := strings.Trim(cells[0], "`* ")
+		got := strings.ToLower(strings.TrimSpace(cells[col]))
+		rows++
+		want := publishedWord(conformance.PublishableClaim(name))
+		if got != want {
+			problems = append(problems, fmt.Sprintf(
+				"the %q column publishes %q for %q and the ledger says %q. The table is "+
+					"where a buyer chooses a vendor, so the cell is the claim rather than a "+
+					"summary of it, and a value typed into it is exactly the unfalsifiable "+
+					"declaration this whole behaviour was built to refuse. Either record a "+
+					"verdict for %q in engine/conformance/ledger.go or publish %q.",
+				copyOnWriteColumn, got, name, want, name, want))
+		}
+	}
+	return problems, rows
+}
+
+// publishedWord maps the ledger's vocabulary onto the table's.
+//
+// The table answers a yes or no question for a reader, and the verdict type
+// answers a three valued one for a machine. The mapping is one place, here, so
+// that the third value keeps its own word in both: unproven does not become no,
+// which would be a claim, and it does not become blank, which would be an
+// omission a reader fills in themselves.
+func publishedWord(claim string) string {
+	switch claim {
+	case "true":
+		return "yes"
+	case "false":
+		return "no"
+	default:
+		return claim
+	}
+}
+
+func splitRow(line string) []string {
+	trimmed := strings.Trim(strings.TrimSpace(line), "|")
+	parts := strings.Split(trimmed, "|")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		out = append(out, strings.TrimSpace(p))
+	}
+	return out
+}
+
+// TestThePublicationSweepCanSayNo is the negative control.
+//
+// A check that has only ever been watched pass is a check nobody has seen work.
+// This points the sweep at the exact document shape that produced the ruling:
+// a comparison table publishing yes for a provider whose declaration nothing
+// has proved.
+func TestThePublicationSweepCanSayNo(t *testing.T) {
+	// The table as it stood before this lane, reduced to the rows that matter.
+	// aurora has no ledger entry, so the ledger says unproven, and the cell
+	// says yes beside the words "not measured yet" in the next column.
+	const wrong = `
+| Provider | Copy on write | First golden, per GB |
+| --- | --- | --- |
+| ` + "`pgurl`" + ` | no | 55 s to 169 s |
+| ` + "`aurora`" + ` | yes | not measured yet, L2.2 |
+`
+	problems, rows := checkPublishedColumn(wrong)
+	if rows != 2 {
+		t.Fatalf("the control table has two provider rows and the sweep read %d, so what "+
+			"follows says nothing about whether it can refuse a cell", rows)
+	}
+	if len(problems) != 1 {
+		t.Fatalf("the sweep found %d problems in a table publishing an unproved yes, and "+
+			"there is exactly one. It cannot refuse the case that produced the ruling, so "+
+			"a green from it means nothing.\n%s", len(problems), strings.Join(problems, "\n"))
+	}
+	if !strings.Contains(problems[0], "aurora") || !strings.Contains(problems[0], "unproven") {
+		t.Fatalf("the sweep refused a cell and its complaint names neither the provider nor "+
+			"the word it should have published: %s", problems[0])
+	}
+
+	// The other half of the control. The same sweep over the same shape with
+	// the cell corrected must find nothing, or the red above is attributable
+	// to the fixture rather than to the cell.
+	fixed := strings.Replace(wrong, "| yes |", "| unproven |", 1)
+	problems, rows = checkPublishedColumn(fixed)
+	if rows != 2 || len(problems) != 0 {
+		t.Fatalf("the same table with the cell corrected still has %d problems over %d "+
+			"rows, so the refusal above was about the fixture and not the claim.\n%s",
+			len(problems), rows, strings.Join(problems, "\n"))
+	}
+}
+
+// TestAnUnprovenDeclarationIsNotPublishableAsTheDeclaredValue is the rendering
+// rule itself, checked directly.
+func TestAnUnprovenDeclarationIsNotPublishableAsTheDeclaredValue(t *testing.T) {
+	for _, tc := range []struct {
+		declared bool
+		answer   conformance.Answer
+		want     string
+	}{
+		{true, conformance.Proved, "true"},
+		{false, conformance.Proved, "false"},
+		{true, conformance.Unproven, "unproven"},
+		{false, conformance.Unproven, "unproven"},
+		{true, conformance.Refuted, "refuted"},
+		// The zero value, which is what a Finding somebody forgot to fill in
+		// carries. It publishes as unproven rather than as the declaration.
+		{true, conformance.Answer(""), "unproven"},
+		{true, conformance.Answer("PASSED"), "unproven"},
+	} {
+		got := conformance.CopyOnWriteClaim(tc.declared, tc.answer)
+		if got != tc.want {
+			t.Errorf("CopyOnWriteClaim(%v, %q) = %q, want %q. There must be no argument "+
+				"pairing that gets the declared value out of an answer that did not prove "+
+				"it, because every customer facing surface renders through this.",
+				tc.declared, tc.answer, got, tc.want)
+		}
+	}
+	if conformance.Unproven.Publishable() {
+		t.Error("Unproven reports itself publishable, which makes the third verdict a pass " +
+			"with a longer name")
+	}
+	if conformance.Refuted.Publishable() {
+		t.Error("Refuted reports itself publishable")
+	}
+	if !conformance.Proved.Publishable() {
+		t.Error("Proved reports itself not publishable, which would leave nothing sayable")
+	}
+}

--- a/engine/conformance/cow.go
+++ b/engine/conformance/cow.go
@@ -257,9 +257,91 @@ func copyOnWriteAllowance(smallTimes []time.Duration) time.Duration {
 // that threshold and the behaviour would then be measuring an empty table.
 const ballastTable = "conformance_ballast"
 
+// minHarnessLimitReason is the shortest a fixture's declaration may be.
+//
+// Crude on purpose, and it is not the thing doing the work. The reason is
+// PRINTED, in the run's report and beside the verdict, so a reader judges it;
+// this only stops the field being set to a word. A fixture that has thought
+// about why its storage cannot exhibit the claim has a sentence about it, and
+// one that has not should notice that it is being asked for one.
+const minHarnessLimitReason = 24
+
+// harnessLimit reads the fixture's declaration and refuses the three ways it
+// could be a loophole rather than a verdict.
+//
+// WHY THIS IS ON Options AND NOT ON provider.Caps, which is the first
+// condition of the ruling and the whole design.
+//
+// Options is the argument the TEST FIXTURE passes to RunDatabase. Caps is what
+// the provider returns from Capabilities(), which is the thing under
+// examination. A field here is a claim about the storage the fixture built; a
+// field there would be a claim by the subject about itself, and the suite
+// exists because a declaration nothing can refuse is worth nothing. So
+// Capabilities() cannot reach this, no method of provider.Database is consulted
+// for it, and there is no route by which a provider asks to be excused.
+//
+// That placement is necessary and it is not sufficient, because a fixture and
+// the provider it exercises are often written by the same person. Three
+// refusals do the rest, and each one costs a fixture something real.
+//
+// ONE. It is refused unless the provider declares CopyOnWrite true. On the
+// false side the copying harness exhibits exactly the property being asserted,
+// so the check is fully armed and there is nothing to be unable to see. A lane
+// copying its fixture across the wave from a provider that clones to one that
+// restores from a snapshot is told, rather than quietly keeping a verdict that
+// no longer applies.
+//
+// TWO. It must be corroborated by the measurement, below. A fixture that
+// declares it copies and then branches in constant time has said something
+// false about itself, and the suite fails it for the declaration rather than
+// passing it on the reading. So the field cannot be set defensively by somebody
+// who has not looked: setting it on a fixture that is in fact flat turns a pass
+// into a failure. It is a falsifiable claim about the harness, not an
+// annotation on the provider.
+//
+// THREE. It buys nothing. It cannot produce a pass, the run prints a block
+// naming it, and CopyOnWriteClaim renders the declaration as "unproven"
+// wherever a customer would read it. A provider that copies and declares
+// otherwise reaches the same place by claiming this as it does by being caught:
+// a claim it cannot publish.
+//
+// What remains, stated rather than papered over, is that a copying harness
+// cannot tell an honest provider from a dishonest one, because the two produce
+// the same readings on it. That is a property of the harness and not a gap in
+// this code, and it is why the ruling keeps the other route open: proving the
+// provider against the real service with an account settles it, and nothing
+// short of that does.
+func (h *harness) harnessLimit(caps provider.Caps) string {
+	h.t.Helper()
+	limit := strings.TrimSpace(h.opts.HarnessCopiesEveryBranch)
+	if limit == "" {
+		return ""
+	}
+	if !caps.CopyOnWrite {
+		h.t.Fatalf("this fixture declares that its storage copies every branch, and the "+
+			"provider declares CopyOnWrite FALSE. A copying harness exhibits a copying "+
+			"provider exactly, so this behaviour can settle that declaration and has to. "+
+			"The declaration is for a provider whose claim the harness cannot reach, and "+
+			"there is nothing here it cannot reach. The fixture said: %q", limit)
+	}
+	if len(limit) < minHarnessLimitReason {
+		h.t.Fatalf("this fixture declares that its storage copies every branch and gives %q as "+
+			"the reason, which is %d characters. The reason is published beside the verdict "+
+			"and is the only thing a reader has to judge whether the limit is structural or "+
+			"an excuse, so it has to name the mechanism: what the harness does instead of "+
+			"sharing storage, and why it has no choice.", limit, len(limit))
+	}
+	return limit
+}
+
 // copyOnWriteMatchesTheDeclaration is the behaviour.
 func (h *harness) copyOnWriteMatchesTheDeclaration(ctx context.Context) {
 	caps := h.p.Capabilities()
+	// Read and refused FIRST, before two goldens are built and six branches are
+	// timed. A configuration this behaviour is going to refuse should be
+	// refused in a second rather than after half an hour of measuring, and a
+	// fixture whose declaration is wrong finds out on the run that made it.
+	limit := h.harnessLimit(caps)
 	small, large, samples := h.copyOnWriteSettings()
 
 	smallV, smallBytes := h.refreshWithBallast(ctx, small)
@@ -351,6 +433,15 @@ func (h *harness) copyOnWriteMatchesTheDeclaration(ctx context.Context) {
 
 	if caps.CopyOnWrite {
 		if grown > allowance {
+			// The third verdict, and the only place in the suite that reaches
+			// it. A copy was measured, and the fixture said before the run
+			// that its own storage copies whatever the provider does. Neither
+			// PROVED nor REFUTED is a statement these readings support: the
+			// stopwatch is reading the harness.
+			if limit != "" {
+				h.unprovenBecauseTheHarnessCopies(limit, delta, grown, allowance, marginal)
+				return
+			}
 			h.t.Fatalf("this provider declares CopyOnWrite, and branching the golden with %s "+
 				"more data in it took %s longer, which is past the %s this machine's noise "+
 				"can account for. Copy on write means a branch shares storage with its golden, "+
@@ -361,6 +452,26 @@ func (h *harness) copyOnWriteMatchesTheDeclaration(ctx context.Context) {
 				bytesText(delta), grown.Round(time.Millisecond),
 				allowance.Round(time.Millisecond), marginal)
 		}
+		// The fixture's declaration, falsified. It said its storage copies
+		// every branch and the stopwatch says this one did not, so the thing
+		// that is wrong is the declaration rather than the provider. Refused
+		// rather than ignored, because a fixture allowed to claim a limit it
+		// does not have could set the field on every run in the wave and never
+		// be contradicted, and the third verdict would then be an annotation
+		// instead of a measurement nobody could fake.
+		if limit != "" {
+			h.t.Fatalf("this fixture declares that its storage copies every branch, and "+
+				"branching the golden with %s more data in it took only %s longer, inside "+
+				"the %s this machine's noise can account for. The harness exhibited shared "+
+				"storage, so it was able to settle this claim after all and the verdict is "+
+				"the pass it just measured. The declaration is what is wrong here: it is a "+
+				"statement about the fixture, it is checked against the fixture's own "+
+				"readings on every run, and it cannot be carried from one harness to "+
+				"another as a property of the provider. The fixture said: %q",
+				bytesText(delta), grown.Round(time.Millisecond),
+				allowance.Round(time.Millisecond), limit)
+		}
+
 		// A pass here is a bounded claim and it says so. The bound is the
 		// number printed above: this run refused every copy slower than
 		// `refusable` seconds per GiB and could not have refused a faster one,
@@ -404,6 +515,50 @@ func (h *harness) copyOnWriteMatchesTheDeclaration(ctx context.Context) {
 			allowance.Round(time.Millisecond), ts.Round(time.Millisecond),
 			neededSizeAdvice(grown, allowance, delta))
 	}
+}
+
+// unprovenBecauseTheHarnessCopies records and prints the third verdict.
+//
+// It prints the same numbers a pass or a failure would, because the reading is
+// not in doubt and is not what the verdict turns on: a copy was measured, at a
+// rate the run states, and the only open question is whose copy it was. A
+// verdict that withheld the measurement would be asking to be believed, which
+// is the posture this whole file was written against.
+//
+// The declared latency assertion that follows a pass is deliberately NOT made
+// here, and saying so is part of the verdict. That assertion asks whether a
+// provider whose branch time does not grow with the data is still inside the
+// latency it declared, and its premise is the thing this run could not
+// establish. Making it anyway would be reporting the harness's copy time as
+// the provider's branch latency, which is a number nobody should publish.
+func (h *harness) unprovenBecauseTheHarnessCopies(
+	limit string, delta int64, grown, allowance time.Duration, marginal float64,
+) {
+	h.t.Helper()
+	because := fmt.Sprintf(
+		"branching the golden with %s more data in it took %s longer, past the %s this "+
+			"machine's noise accounts for, which is %.2f seconds per GiB of copying.\n"+
+			"The provider declares CopyOnWrite true and the fixture declared, before the "+
+			"run, that its own storage copies every branch: %s\n"+
+			"So the stopwatch measured the harness and not the provider, and neither PROVED "+
+			"nor REFUTED is a thing these readings can say. The declared branch latency was "+
+			"NOT checked at the large size either, because that assertion's premise is the "+
+			"one this run could not reach.\n"+
+			"Settling it needs a harness that can share storage, which for this claim means "+
+			"the real service with an account.",
+		bytesText(delta), grown.Round(time.Millisecond),
+		allowance.Round(time.Millisecond), marginal, limit)
+
+	h.found.add(Finding{
+		Provider: h.p.Name(),
+		Behavior: "CopyOnWrite_BranchTimeMatchesTheDeclaration",
+		Answer:   Unproven,
+		Because:  because,
+	})
+	// Logged here as well as reported at the end of the run, because a reader
+	// who ran this one behaviour with -run sees the subtest's own output and
+	// should not have to know that the summary comes from somewhere else.
+	h.t.Logf("\nUNPROVEN. This is not a pass.\n%s\n", because)
 }
 
 // branchIsWithinTheDeclaredLatency is the assertion Caps.ExpectedBranchLatency

--- a/engine/conformance/db.go
+++ b/engine/conformance/db.go
@@ -40,6 +40,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -78,6 +79,16 @@ type Options struct {
 	// CopyOnWriteSamples is how many branches are timed per size. Zero uses
 	// the default.
 	CopyOnWriteSamples int
+	// HarnessCopiesEveryBranch is how a TEST FIXTURE declares that the storage
+	// it built copies the golden's bytes on every branch, whatever the
+	// provider would do against the real service. It is the only thing in the
+	// suite that can raise the third verdict, and cow.go carries the reasoning
+	// for why it sits here and not on provider.Caps.
+	//
+	// The value is the mechanism, in prose, and it is printed in the run's
+	// report. Empty means the fixture makes no such claim, which is the
+	// default and the state every existing run is in.
+	HarnessCopiesEveryBranch string
 	// CopyOnWriteTimeout bounds CopyOnWrite_BranchTimeMatchesTheDeclaration
 	// alone. Zero uses DefaultCopyOnWriteTimeout.
 	//
@@ -189,6 +200,7 @@ func RunDatabase(t *testing.T, factory Factory, opts Options) {
 	// would make the check something people learn to ignore.
 	before := inventorySnapshot(t, factory)
 	created := newCreatedSet()
+	found := newFindings()
 
 	for _, b := range databaseBehaviors {
 		b := b
@@ -211,9 +223,19 @@ func RunDatabase(t *testing.T, factory Factory, opts Options) {
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), limit)
 			defer cancel()
-			runBehavior(ctx, t, b.Name, factory, opts, created)
+			runBehavior(ctx, t, b.Name, factory, opts, created, found)
 		})
 	}
+
+	// What the run did NOT settle, printed before anything else it might say
+	// about leaks, and printed whether the run passed or failed.
+	//
+	// To os.Stderr rather than through t, because t.Logf on a subtest that did
+	// not fail is invisible without -v, and a third verdict nobody sees is a
+	// skip. Written from RunDatabase rather than from the behaviour so that it
+	// appears once, at the end, where a reader looking at the last few lines of
+	// a green run finds it.
+	found.reportUnproven(os.Stderr)
 
 	// A conformance suite for a product whose whole promise is that nothing
 	// outlives its environment must not itself leak. This has caught a
@@ -308,6 +330,11 @@ type harness struct {
 	// at the end can tell the suite's own leftovers from anything another test
 	// package happened to create while it was running.
 	created *createdSet
+	// found records the answers this run reached, so that RunDatabase can say
+	// at the end which behaviours it did not settle. A behaviour that reaches
+	// the third verdict writes here and the run prints it; nothing else in the
+	// suite reads it, because pass and fail are already carried by t.
+	found *findings
 	// masked and verified record what the refresh callbacks were asked to do,
 	// which is how the suite proves a provider actually called them rather
 	// than publishing a version it never checked.
@@ -359,8 +386,8 @@ func (c *createdSet) matches(inventoryID string) bool {
 	return false
 }
 
-func runBehavior(ctx context.Context, t *testing.T, name string, factory Factory, opts Options, created *createdSet) {
-	h := &harness{t: t, p: factory(t), opts: opts, created: created}
+func runBehavior(ctx context.Context, t *testing.T, name string, factory Factory, opts Options, created *createdSet, found *findings) {
+	h := &harness{t: t, p: factory(t), opts: opts, created: created, found: found}
 	t.Cleanup(func() { _ = h.p.Close() })
 
 	switch name {

--- a/engine/conformance/db_selftest_test.go
+++ b/engine/conformance/db_selftest_test.go
@@ -49,6 +49,7 @@ const (
 	urlEnv        = "AF_DB_SELFTEST_URL"
 	unverifiedEnv = "AF_DB_SELFTEST_PUBLISH_UNVERIFIED"
 	flatEnv       = "AF_DB_SELFTEST_FLAT_BRANCH"
+	copiesEnv     = "AF_DB_SELFTEST_HARNESS_COPIES"
 )
 
 // The two providers, named so a table can say which one proved a row.
@@ -148,6 +149,11 @@ func TestDatabaseSuiteChild(t *testing.T) {
 		// The timeout is the suite's shared one and it does not bound the copy
 		// on write behaviour, which has its own and much longer.
 		Timeout: 10 * time.Minute,
+		// The fixture's declaration about its own storage, which is the only
+		// thing that can raise the third verdict. Empty on every child except
+		// the four that exist to prove it, so every other row in the table
+		// above runs against a suite that still has two answers.
+		HarnessCopiesEveryBranch: os.Getenv(copiesEnv),
 	})
 }
 
@@ -164,6 +170,12 @@ type child struct {
 	// which is what a copy on write provider has and Postgres does not. It is
 	// not a fault either, and it has its own control below.
 	flatBranch bool
+	// harnessCopies is the fixture's declaration that its own storage copies
+	// every branch. It is not a fault and it is not an affordance on the
+	// provider at all: it is a statement the FIXTURE makes about the storage
+	// it built, which is the whole reason the third verdict cannot be reached
+	// from a provider.
+	harnessCopies string
 }
 
 // runChild executes one behaviour in a subprocess and reports whether it
@@ -190,6 +202,9 @@ func runChild(t *testing.T, c child) (bool, string) {
 	}
 	if c.flatBranch {
 		cmd.Env = append(cmd.Env, flatEnv+"=1")
+	}
+	if c.harnessCopies != "" {
+		cmd.Env = append(cmd.Env, copiesEnv+"="+c.harnessCopies)
 	}
 	if c.backend == onPG {
 		cmd.Env = append(cmd.Env, urlEnv+"="+postgresURL(), prefixEnv+"="+newPostgresPrefix(t))

--- a/engine/conformance/ledger.go
+++ b/engine/conformance/ledger.go
@@ -1,0 +1,119 @@
+package conformance
+
+// The ledger, which is the second half of the ruling that produced the third
+// verdict and the half that faces a customer.
+//
+// A three valued answer inside a test binary settles nothing on its own. The
+// wave publishes one shared table of branch time per provider, a buyer chooses
+// a vendor from it, and a cell in that table saying yes because somebody typed
+// yes is the same defect as a capability nothing can refuse, one surface
+// further out. So the rule is that the publishable value comes from a recorded
+// verdict, and the recorded verdicts live here where a sweep can check both
+// directions at once: no declaration without an entry, and no published claim
+// without a proved entry.
+//
+// WHY AN ENTRY THAT SAYS UNPROVEN IS THE HONEST ENTRY FOR MOST OF THESE.
+//
+// Unproven is not only "the harness copies". sitesmoke's rule is that an empty
+// set of findings is Undecided rather than Allowed, because a run that checked
+// nothing has proved nothing, and the same rule applies to a provider whose
+// instrument is armed and has never been fired. Both reach the same place: the
+// declaration is not evidence a customer facing surface may print. The Because
+// line is what tells the two apart, and it is why the ledger records prose
+// rather than a boolean.
+//
+// This is deliberately uncomfortable reading. Four of the six providers that
+// declare copy on write in this repository have no recorded verdict, and
+// writing that down is the point: before this file the same four looked
+// exactly like a provider that had been measured, because nothing anywhere
+// distinguished them.
+
+// LedgerEntry is what this repository can say about one provider's copy on
+// write declaration.
+type LedgerEntry struct {
+	// Declared is the value the provider returns from Capabilities().
+	Declared bool
+	// Verdict is what a run of CopyOnWrite_BranchTimeMatchesTheDeclaration
+	// recorded about that declaration. Only Proved is publishable.
+	Verdict Answer
+	// Because says why, and it is the only thing distinguishing a harness that
+	// cannot exhibit the property from an instrument nobody has fired.
+	Because string
+	// Evidence is the repository path to the instrument, so that a reader can
+	// go and look at what would have refused the declaration rather than
+	// taking this table's word for it.
+	Evidence string
+}
+
+// CopyOnWriteLedger is the recorded verdict for every provider in this
+// repository that declares a copy on write value.
+//
+// Keyed by the provider's Name(), which is what a manifest refers to and what
+// the comparison table's rows are labelled with.
+var CopyOnWriteLedger = map[string]LedgerEntry{
+	"pgurl": {
+		Declared: false,
+		Verdict:  Proved,
+		Because: "a branch is a server side file copy and the suite measures it as one. " +
+			"The false side of the assertion requires branch time to GROW with the data, " +
+			"which is the side a copying provider on a copying harness can settle, and " +
+			"the published benchmark shows 0.2 seconds at 8 MB against 25 to 110 seconds " +
+			"at 1.43 GB.",
+		Evidence: "engine/internal/db/pgurl/conformance_test.go",
+	},
+	"docker": {
+		Declared: true,
+		Verdict:  Unproven,
+		Because: "no run in this repository records a verdict for this provider. The " +
+			"declaration is about the daemon's storage driver rather than about anything " +
+			"the provider does, the suite's own conformance test needs a live Docker " +
+			"daemon, and the behaviour that would settle it builds two goldens as " +
+			"committed images. An instrument that exists and has not been fired has " +
+			"proved nothing.",
+		Evidence: "engine/internal/db/docker/conformance_test.go",
+	},
+	"neon": {
+		Declared: true,
+		Verdict:  Unproven,
+		Because: "no run in this repository records a verdict for this provider. Its " +
+			"conformance test runs against the real Neon API, which is a harness that CAN " +
+			"exhibit shared storage, so this is not the copying harness case and it is " +
+			"settleable: it needs AF_NEON_API_KEY and AF_NEON_PROJECT_ID and somebody to " +
+			"run it. Until then the declaration is Neon's claim rather than our finding.",
+		Evidence: "engine/internal/db/neon/conformance_test.go",
+	},
+	"dblab": {
+		Declared: true,
+		Verdict:  Unproven,
+		Because: "no run in this repository records a verdict for this provider. Its " +
+			"conformance test runs against a real Database Lab Engine, which is a harness " +
+			"that CAN exhibit shared storage, so it is settleable by anybody who stands " +
+			"one up: it needs AF_DBLAB_URL and AF_DBLAB_TOKEN. The engine is self hosted " +
+			"and costs nothing but disk, which makes this the cheapest of these to close.",
+		Evidence: "engine/internal/db/dblab/conformance_test.go",
+	},
+	"supabase": {
+		Declared: false,
+		Verdict:  Unproven,
+		Because: "no run in this repository records a verdict for this provider. A " +
+			"Supabase branch is created empty and then loaded, so the declaration is " +
+			"expected to hold, and expecting is what this ledger exists to stop being " +
+			"mistaken for measuring. It needs a project on a paid plan.",
+		Evidence: "engine/internal/db/supabase/conformance_test.go",
+	},
+}
+
+// PublishableClaim renders a provider's copy on write declaration for a
+// customer facing surface, from the ledger.
+//
+// A provider with no entry publishes as unproven rather than falling back to
+// its declaration, for the reason every default in this package takes the
+// cautious side: the failure mode of the missing case is a claim nobody
+// checked appearing beside claims somebody did.
+func PublishableClaim(providerName string) string {
+	e, ok := CopyOnWriteLedger[providerName]
+	if !ok {
+		return notProved
+	}
+	return CopyOnWriteClaim(e.Declared, e.Verdict)
+}

--- a/engine/conformance/unproven_selftest_test.go
+++ b/engine/conformance/unproven_selftest_test.go
@@ -1,0 +1,296 @@
+package conformance_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/antifailure/antifailure/engine/internal/testutil/fakes"
+)
+
+// The third verdict, proved in every direction it can go.
+//
+// A verdict with three answers needs three proofs and one of them is new. The
+// two old ones are not assumed to have survived: the whole risk of adding an
+// answer to an instrument is that the answer becomes the one it always gives,
+// and a suite that could no longer refuse a false copy on write claim would be
+// worse than the one that existed before this lane, because it would look like
+// the one that existed after it.
+//
+// So all four cells are here, side by side, against the same provider on the
+// same harness, differing only in the two bits that decide the verdict: whether
+// the storage under the run copies, and whether the fixture said so.
+//
+//	harness copies   fixture declared it   verdict
+//	yes              no                    REFUTED, and it must stay refuted
+//	yes              yes                   UNPROVEN, which is the new one
+//	no               no                    PROVED
+//	no               yes                   REFUTED, for the DECLARATION
+//
+// The fourth row is the lock. A fixture whose storage turns out to share after
+// all has said something false about itself, and the suite fails it for that
+// rather than passing it on the reading, which is what stops the declaration
+// being an annotation somebody sets on every run in the wave.
+//
+// WHAT THESE RUN AT, said out loud because it is not the shipped configuration.
+//
+// Each child builds two goldens and branches each of them several times, and
+// the shipped large size is half a gibibyte. Four children of that on a machine
+// with a load average of twenty four is hours, so these run at the floor the
+// behaviour will accept, which is 64 MiB against 4 MiB. That is a weaker
+// sentence than the same proof at the defaults and the suite says so itself:
+// every child prints the sizes it ran at, and prints the copy rate the
+// configuration was able to refuse. What is proved here is that the four cells
+// are reachable and distinguishable, which does not depend on the size.
+
+// The sizes these children run at, and the floors they sit on.
+//
+// 64 MiB is exactly MinCopyOnWriteLargeBytes, and 4 MiB is exactly a sixteenth
+// of it, which is MinCopyOnWriteRatio. A child configured any smaller is
+// refused by copyOnWriteSettings, which is the behaviour's own answer to a run
+// trying to buy a cheap pass, so these sit on the boundary rather than under it.
+const (
+	selftestSmallBytes = "4194304"
+	selftestLargeBytes = "67108864"
+)
+
+// theHarnessLimit is the sentence a Wave 2 fixture would write.
+//
+// It is the real one rather than a placeholder, because the reason is published
+// beside the verdict and a test that proved the machinery with the word "x"
+// would prove nothing about whether a reader can act on the output.
+const theHarnessLimit = "this fixture is a fake cloud control plane over one local Postgres, " +
+	"and the only way it can hand back a branch carrying the golden's data is " +
+	"CREATE DATABASE ... TEMPLATE, which copies files"
+
+const cowBehavior = "CopyOnWrite_BranchTimeMatchesTheDeclaration"
+
+// affordableCopyOnWrite points the children at the floor rather than the
+// shipped sizes, and at whichever Postgres the run was given.
+func affordableCopyOnWrite(t *testing.T) {
+	t.Helper()
+	t.Setenv("AF_CONFORMANCE_COW_SMALL_BYTES", selftestSmallBytes)
+	t.Setenv("AF_CONFORMANCE_COW_LARGE_BYTES", selftestLargeBytes)
+}
+
+func requireCopyOnWritePostgres(t *testing.T) {
+	t.Helper()
+	if !postgresReachable(t) {
+		t.Skipf("skipped: the third verdict is a claim about moving bytes and needs a "+
+			"Postgres at %s", postgresURL())
+	}
+}
+
+// TestACopyingProviderIsStillRefusedWhenNothingDeclaredTheHarness is the first
+// direction, and it is the one that must not have been disarmed.
+//
+// A provider that declares CopyOnWrite and copies every byte still fails, on a
+// harness that copies, when the fixture makes no claim about its storage. If
+// this direction broke, the third verdict would have turned the instrument the
+// whole database wave was held for into one that cannot say no.
+func TestACopyingProviderIsStillRefusedWhenNothingDeclaredTheHarness(t *testing.T) {
+	requireCopyOnWritePostgres(t)
+	affordableCopyOnWrite(t)
+
+	passed, out := runChild(t, child{
+		backend: onPG, behavior: cowBehavior, fault: copyOnWriteThatCopies(),
+	})
+	if passed {
+		t.Fatalf("the suite PASSED a provider that declares CopyOnWrite and copies every "+
+			"byte, with no declaration from the fixture. The third verdict has disarmed "+
+			"the two sided assertion, and every provider in the wave could now declare "+
+			"copy on write untested.\n%s", out)
+	}
+	requireFailedIn(t, out, cowBehavior)
+	if strings.Contains(out, "UNPROVEN") {
+		t.Fatalf("the child failed and reached the third verdict on the way, so the red is "+
+			"not attributable to the assertion. UNPROVEN must be unreachable when the "+
+			"fixture declared nothing.\n%s", out)
+	}
+}
+
+// TestAnHonestFlatProviderStillPasses is the second direction.
+//
+// The provider that really does branch in constant time, declaring so, on a
+// harness that can exhibit it, still passes and does not touch the third
+// verdict. Without this the red above would be attributable to the addition
+// rather than to the fault.
+func TestAnHonestFlatProviderStillPasses(t *testing.T) {
+	requireCopyOnWritePostgres(t)
+	affordableCopyOnWrite(t)
+
+	passed, out := runChild(t, child{backend: onPG, behavior: cowBehavior, flatBranch: true})
+	if !passed {
+		t.Fatalf("the suite FAILED a provider whose branch time really is constant and "+
+			"which declares so. The pass side of the assertion is gone.\n%s", out)
+	}
+	if strings.Contains(out, "UNPROVEN") || strings.Contains(out, "NOT PROVED BY THIS RUN") {
+		t.Fatalf("a run with nothing declared about the harness reached the third verdict, "+
+			"so the verdict is not gated on the declaration at all.\n%s", out)
+	}
+}
+
+// TestTheTemplateCopyHarnessReportsUnproven is the third direction, and it is
+// the one this lane exists for.
+//
+// A provider declaring CopyOnWrite truthfully, on a harness whose storage
+// copies, with the fixture declaring that limit before the run. The child must
+// not fail, must not read as a plain pass, and must print the verdict where
+// somebody sees it.
+func TestTheTemplateCopyHarnessReportsUnproven(t *testing.T) {
+	requireCopyOnWritePostgres(t)
+	affordableCopyOnWrite(t)
+
+	passed, out := runChild(t, child{
+		backend: onPG, behavior: cowBehavior,
+		fault:         copyOnWriteThatCopies(),
+		harnessCopies: theHarnessLimit,
+	})
+	if !passed {
+		t.Fatalf("the suite FAILED a truthful CopyOnWrite declaration on a harness that "+
+			"declared it cannot exhibit copy on write. That is the case the ruling exists "+
+			"to answer, and failing it is what blocks Aurora, Cloud SQL and AlloyDB.\n%s", out)
+	}
+	// Every one of these is a separate way the verdict could be invisible, and
+	// invisible is the failure mode that matters: a skip that reads as a pass
+	// is what this whole design is against.
+	for _, want := range []string{
+		"UNPROVEN",
+		"NOT PROVED BY THIS RUN. This is not a pass.",
+		theHarnessLimit,
+		"unproven",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("the run reached the third verdict and its output does not contain %q, "+
+				"so a reader of this run cannot tell it from a pass.\n%s", want, out)
+		}
+	}
+	// The measurement ran in full. An unproven verdict that skipped the work
+	// would be a skip with a longer name, and the readings are what make the
+	// verdict readable rather than asserted.
+	for _, want := range []string{"copy on write, measured", "marginal cost", "extra branch time"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("the unproven run did not print %q, so it did not take the measurement "+
+				"and the verdict is a skip wearing a longer word.\n%s", want, out)
+		}
+	}
+	// The subtest itself did not fail, which is what "not a pass" has to be
+	// reconciled with: Go has two states and the third one lives in the output.
+	if !strings.Contains(out, "--- PASS: TestDatabaseSuiteChild/"+cowBehavior) &&
+		!strings.Contains(out, "PASS") {
+		t.Errorf("the child neither failed nor passed the behaviour, so something other "+
+			"than the verdict decided this run.\n%s", out)
+	}
+	t.Logf("the report the run printed, which is the thing a reader sees:\n%s",
+		unprovenBlock(out))
+}
+
+// TestAFixtureThatDeclaresALimitItDoesNotHaveIsRefused is the fourth cell, and
+// it is the lock that stops the declaration being a free annotation.
+//
+// The fixture says its storage copies every branch. The provider branches in
+// constant time and the stopwatch says so. The suite fails, for the
+// DECLARATION rather than for the provider, because a fixture allowed to claim
+// a limit it does not have could set the field on every run in the wave and
+// never be contradicted.
+func TestAFixtureThatDeclaresALimitItDoesNotHaveIsRefused(t *testing.T) {
+	requireCopyOnWritePostgres(t)
+	affordableCopyOnWrite(t)
+
+	passed, out := runChild(t, child{
+		backend: onPG, behavior: cowBehavior,
+		flatBranch: true, harnessCopies: theHarnessLimit,
+	})
+	if passed {
+		t.Fatalf("a fixture declared that its storage copies every branch, the storage "+
+			"shared instead, and the suite said nothing. The declaration is then an "+
+			"annotation rather than a claim about the harness, and anybody could set it "+
+			"on every run in the wave.\n%s", out)
+	}
+	requireFailedIn(t, out, cowBehavior)
+	if !strings.Contains(out, "The declaration is what is wrong here") {
+		t.Errorf("the child failed and did not name the declaration as the thing that is "+
+			"wrong, so a reader would go looking at the provider.\n%s", out)
+	}
+}
+
+// TestTheHarnessLimitIsRefusedOnAProviderThatDeclaresCopyOnWriteFalse is the
+// first of the three refusals, checked on its own.
+//
+// On the false side a copying harness exhibits exactly what is being asserted,
+// so there is nothing the harness cannot reach and the declaration has no
+// subject. Refusing it is what tells a lane copying a fixture across the wave
+// from a provider that clones to one that restores from a snapshot.
+func TestTheHarnessLimitIsRefusedOnAProviderThatDeclaresCopyOnWriteFalse(t *testing.T) {
+	requireCopyOnWritePostgres(t)
+	affordableCopyOnWrite(t)
+
+	// The plain Postgres backed provider declares CopyOnWrite false, honestly,
+	// because it copies.
+	passed, out := runChild(t, child{
+		backend: onPG, behavior: cowBehavior, harnessCopies: theHarnessLimit,
+	})
+	if passed {
+		t.Fatalf("a fixture declared a harness limit against a provider that declares "+
+			"CopyOnWrite FALSE and the suite accepted it. The false side is settleable on "+
+			"a copying harness, so the declaration there is a misconfiguration that would "+
+			"otherwise sit unnoticed in a lane's fixture.\n%s", out)
+	}
+	requireFailedIn(t, out, cowBehavior)
+	if !strings.Contains(out, "there is nothing here it cannot reach") {
+		t.Errorf("the refusal did not say why the declaration has no subject on the false "+
+			"side.\n%s", out)
+	}
+	// Refused BEFORE the measurement, which is the difference between a
+	// configuration error found in a second and one found after half an hour
+	// of building goldens.
+	if strings.Contains(out, "copy on write, measured") {
+		t.Errorf("the misconfiguration was refused only after the measurement ran. A "+
+			"fixture whose declaration cannot apply should learn that before it builds "+
+			"two goldens.\n%s", out)
+	}
+}
+
+// TestAShortHarnessReasonIsRefused is the second refusal.
+func TestAShortHarnessReasonIsRefused(t *testing.T) {
+	requireCopyOnWritePostgres(t)
+	affordableCopyOnWrite(t)
+
+	passed, out := runChild(t, child{
+		backend: onPG, behavior: cowBehavior,
+		fault: copyOnWriteThatCopies(), harnessCopies: "it copies",
+	})
+	if passed {
+		t.Fatalf("a fixture reached the third verdict with %q as its whole reason. The "+
+			"reason is the only thing a reader has to judge the limit by, and one that "+
+			"says nothing turns the verdict back into a skip.\n%s", "it copies", out)
+	}
+	requireFailedIn(t, out, cowBehavior)
+}
+
+// requireFailedIn insists the child failed in the named behaviour rather than
+// anywhere at all, which is what makes a red mean one thing.
+func requireFailedIn(t *testing.T, out, behavior string) {
+	t.Helper()
+	marker := "--- FAIL: TestDatabaseSuiteChild/" + behavior
+	if !strings.Contains(out, marker) {
+		t.Fatalf("the child failed, and not in %s, so this proves nothing about that "+
+			"behaviour.\n%s", behavior, out)
+	}
+}
+
+// unprovenBlock pulls the report out of a child's output for the log.
+func unprovenBlock(out string) string {
+	i := strings.Index(out, "NOT PROVED BY THIS RUN")
+	if i < 0 {
+		return "(the run printed no report)"
+	}
+	rest := out[i:]
+	if j := strings.Index(rest, "\n\n"); j > 0 {
+		return rest[:j]
+	}
+	return rest
+}
+
+// copyOnWriteThatCopies names the fault rather than importing the constant into
+// four call sites, so that a rename in fakes reaches one line here.
+func copyOnWriteThatCopies() fakes.Fault { return fakes.CopyOnWriteThatCopies }

--- a/engine/conformance/unproven_selftest_test.go
+++ b/engine/conformance/unproven_selftest_test.go
@@ -26,32 +26,42 @@ import (
 //	no               no                    PROVED
 //	no               yes                   REFUTED, for the DECLARATION
 //
+// The third row is not repeated here. db_selftest_test.go already carries it as
+// TestTheFlatBranchAffordanceIsHonestWhenItDeclaresCopyOnWrite, against the same
+// provider on the same harness, and a second child of half a gibibyte proving
+// the same sentence is cost with no evidence in it.
+//
 // The fourth row is the lock. A fixture whose storage turns out to share after
 // all has said something false about itself, and the suite fails it for that
 // rather than passing it on the reading, which is what stops the declaration
 // being an annotation somebody sets on every run in the wave.
 //
-// WHAT THESE RUN AT, said out loud because it is not the shipped configuration.
+// WHAT THESE RUN AT, and why the first answer to that was wrong.
 //
 // Each child builds two goldens and branches each of them several times, and
-// the shipped large size is half a gibibyte. Four children of that on a machine
-// with a load average of twenty four is hours, so these run at the floor the
-// behaviour will accept, which is 64 MiB against 4 MiB. That is a weaker
-// sentence than the same proof at the defaults and the suite says so itself:
-// every child prints the sizes it ran at, and prints the copy rate the
-// configuration was able to refuse. What is proved here is that the four cells
-// are reachable and distinguishable, which does not depend on the size.
-
-// The sizes these children run at, and the floors they sit on.
+// the shipped large size is half a gibibyte, so the obvious economy is to run
+// these at the floor the behaviour will accept, 64 MiB against 4 MiB. That was
+// done, it passed on the machine it was written on, and CI refused it.
 //
-// 64 MiB is exactly MinCopyOnWriteLargeBytes, and 4 MiB is exactly a sixteenth
-// of it, which is MinCopyOnWriteRatio. A child configured any smaller is
-// refused by copyOnWriteSettings, which is the behaviour's own answer to a run
-// trying to buy a cheap pass, so these sit on the boundary rather than under it.
-const (
-	selftestSmallBytes = "4194304"
-	selftestLargeBytes = "67108864"
-)
+// CI's storage copied the 60 MiB of extra data in 163ms, inside the 250ms the
+// allowance gives to noise. So nothing was distinguishable: the copying
+// provider was not refused, because its copy was invisible, and the fixture
+// that declared its storage copies was refused, because on that hardware at
+// that size the storage did not measurably copy. Both reds were the instrument
+// working. cow.go says this in advance, about the size rather than about these
+// tests: smaller lets a real copy pass as shared storage on a fast disk, and
+// the default is the smallest size at which a copy running at the speed of the
+// fastest storage that exists is still refused.
+//
+// So these run at the SHIPPED sizes and set no override. That is the same
+// argument db_selftest_test.go already makes for the fault table beside it: a
+// self test run at sizes the suite does not ship proves the faults are
+// catchable at SOME configuration, which is a weaker sentence than anybody
+// reading a green would assume it to be. The economy was buying exactly that
+// weaker sentence, and paying for it with a proof that did not hold on the one
+// machine whose verdict blocks a merge.
+//
+// It costs three children of half a gibibyte. That is the price of the claim.
 
 // theHarnessLimit is the sentence a Wave 2 fixture would write.
 //
@@ -63,14 +73,6 @@ const theHarnessLimit = "this fixture is a fake cloud control plane over one loc
 	"CREATE DATABASE ... TEMPLATE, which copies files"
 
 const cowBehavior = "CopyOnWrite_BranchTimeMatchesTheDeclaration"
-
-// affordableCopyOnWrite points the children at the floor rather than the
-// shipped sizes, and at whichever Postgres the run was given.
-func affordableCopyOnWrite(t *testing.T) {
-	t.Helper()
-	t.Setenv("AF_CONFORMANCE_COW_SMALL_BYTES", selftestSmallBytes)
-	t.Setenv("AF_CONFORMANCE_COW_LARGE_BYTES", selftestLargeBytes)
-}
 
 func requireCopyOnWritePostgres(t *testing.T) {
 	t.Helper()
@@ -89,7 +91,6 @@ func requireCopyOnWritePostgres(t *testing.T) {
 // whole database wave was held for into one that cannot say no.
 func TestACopyingProviderIsStillRefusedWhenNothingDeclaredTheHarness(t *testing.T) {
 	requireCopyOnWritePostgres(t)
-	affordableCopyOnWrite(t)
 
 	passed, out := runChild(t, child{
 		backend: onPG, behavior: cowBehavior, fault: copyOnWriteThatCopies(),
@@ -108,27 +109,6 @@ func TestACopyingProviderIsStillRefusedWhenNothingDeclaredTheHarness(t *testing.
 	}
 }
 
-// TestAnHonestFlatProviderStillPasses is the second direction.
-//
-// The provider that really does branch in constant time, declaring so, on a
-// harness that can exhibit it, still passes and does not touch the third
-// verdict. Without this the red above would be attributable to the addition
-// rather than to the fault.
-func TestAnHonestFlatProviderStillPasses(t *testing.T) {
-	requireCopyOnWritePostgres(t)
-	affordableCopyOnWrite(t)
-
-	passed, out := runChild(t, child{backend: onPG, behavior: cowBehavior, flatBranch: true})
-	if !passed {
-		t.Fatalf("the suite FAILED a provider whose branch time really is constant and "+
-			"which declares so. The pass side of the assertion is gone.\n%s", out)
-	}
-	if strings.Contains(out, "UNPROVEN") || strings.Contains(out, "NOT PROVED BY THIS RUN") {
-		t.Fatalf("a run with nothing declared about the harness reached the third verdict, "+
-			"so the verdict is not gated on the declaration at all.\n%s", out)
-	}
-}
-
 // TestTheTemplateCopyHarnessReportsUnproven is the third direction, and it is
 // the one this lane exists for.
 //
@@ -138,7 +118,6 @@ func TestAnHonestFlatProviderStillPasses(t *testing.T) {
 // somebody sees it.
 func TestTheTemplateCopyHarnessReportsUnproven(t *testing.T) {
 	requireCopyOnWritePostgres(t)
-	affordableCopyOnWrite(t)
 
 	passed, out := runChild(t, child{
 		backend: onPG, behavior: cowBehavior,
@@ -194,7 +173,6 @@ func TestTheTemplateCopyHarnessReportsUnproven(t *testing.T) {
 // never be contradicted.
 func TestAFixtureThatDeclaresALimitItDoesNotHaveIsRefused(t *testing.T) {
 	requireCopyOnWritePostgres(t)
-	affordableCopyOnWrite(t)
 
 	passed, out := runChild(t, child{
 		backend: onPG, behavior: cowBehavior,
@@ -222,7 +200,6 @@ func TestAFixtureThatDeclaresALimitItDoesNotHaveIsRefused(t *testing.T) {
 // from a provider that clones to one that restores from a snapshot.
 func TestTheHarnessLimitIsRefusedOnAProviderThatDeclaresCopyOnWriteFalse(t *testing.T) {
 	requireCopyOnWritePostgres(t)
-	affordableCopyOnWrite(t)
 
 	// The plain Postgres backed provider declares CopyOnWrite false, honestly,
 	// because it copies.
@@ -253,7 +230,6 @@ func TestTheHarnessLimitIsRefusedOnAProviderThatDeclaresCopyOnWriteFalse(t *test
 // TestAShortHarnessReasonIsRefused is the second refusal.
 func TestAShortHarnessReasonIsRefused(t *testing.T) {
 	requireCopyOnWritePostgres(t)
-	affordableCopyOnWrite(t)
 
 	passed, out := runChild(t, child{
 		backend: onPG, behavior: cowBehavior,

--- a/engine/conformance/verdict.go
+++ b/engine/conformance/verdict.go
@@ -1,0 +1,206 @@
+package conformance
+
+// The suite had two answers, and one of the claims it checks can honestly be
+// given neither of them.
+//
+// CopyOnWrite_BranchTimeMatchesTheDeclaration decides by stopwatch: a branch of
+// a large golden that is no slower than a branch of a small one is shared
+// storage, and one that is slower is a copy. That reading is only as good as
+// the storage underneath the run. Over a single local Postgres the only way a
+// fake control plane can hand back a branch carrying the golden's data is
+// CREATE DATABASE ... TEMPLATE, which copies files, so the stopwatch reports a
+// copy no matter what the provider would do against the real service. A
+// provider that really does clone in constant time, declaring so truthfully,
+// FAILS on that harness.
+//
+// Three of the four ways out are worse than the problem.
+//
+// Declare CopyOnWrite false. Green, and false about the product.
+//
+// Skip the behaviour in the provider's own conformance test. That turns off the
+// one instrument that can refuse this category's central commercial claim, on
+// exactly the runs where somebody wanted a green.
+//
+// Loosen the allowance until a copy fits inside it. That leaves the behaviour
+// in the output, running, printing a verdict, and unable to refuse anything,
+// which is the defect this repository keeps finding in its own instruments.
+//
+// The fourth is what the rest of the repository already does. tools/sitesmoke
+// prints COULD NOT TELL and says in its own output that this is not a pass.
+// Mutation cells are classified on the "=== RUN" count, so a break that stopped
+// the package compiling is reported as the instrument being unable to look
+// rather than as a catch. The egress report is closed, open or unproven, and
+// unproven is never counted as closed. Verdicts here are three valued too.
+//
+// WHAT UNPROVEN IS NOT.
+//
+// It is not a skip. The measurement runs in full: two goldens are built, both
+// arms are timed, the sizes are checked, the ballast is weighed in the branch,
+// and every number is printed. Unproven changes the VERDICT the readings are
+// turned into, never whether they were taken.
+//
+// It is not a pass. Answer.Publishable is false for it, RunDatabase prints a
+// block at the end of the run naming every behaviour that reached it, and
+// CopyOnWriteClaim renders the provider's declaration as the word "unproven"
+// rather than as the value the provider declared.
+//
+// It is not something a provider can ask for. The only thing that raises it is
+// Options.HarnessCopiesEveryBranch, which is a claim by the TEST FIXTURE about
+// the storage it built, and the suite refuses that claim in three ways rather
+// than accepting the sentence. Options.HarnessCopiesEveryBranch says why.
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// Answer is the verdict a behaviour reached, and there are three of them.
+//
+// Proved and Refuted are the two the suite has always had, spelled with a
+// passing subtest and with t.Fatalf. They are named here so that the third one
+// is a member of a set rather than a special case bolted onto a boolean, which
+// is the difference between a three valued verdict and a pass with an excuse.
+type Answer string
+
+const (
+	// Proved means the behaviour ran and the declaration survived it.
+	Proved Answer = "PROVED"
+	// Refuted means the behaviour ran and the declaration did not survive it.
+	Refuted Answer = "REFUTED"
+	// Unproven means the behaviour ran, in full, and the harness underneath it
+	// structurally cannot exhibit the property either way, so both of the
+	// other answers would be a statement the readings do not support.
+	Unproven Answer = "UNPROVEN"
+)
+
+// Publishable reports whether a customer facing surface may print the
+// declaration this answer was checking as the value the provider declared.
+//
+// Only Proved. Refuted is a declaration the suite refused and Unproven is one
+// it could not reach, and the two of them are different from each other and
+// identical in this one respect: neither is evidence for the sentence a buyer
+// would read.
+func (a Answer) Publishable() bool { return a == Proved }
+
+// Finding is one behaviour's answer together with the reason for it.
+type Finding struct {
+	// Provider is the provider the behaviour ran against.
+	Provider string
+	// Behavior is the subtest name.
+	Behavior string
+	// Answer is the verdict.
+	Answer Answer
+	// Because is why, in prose, and it is printed rather than stored. An
+	// unproven verdict whose reason nobody can read is a skip wearing a
+	// longer word.
+	Because string
+}
+
+// findings collects what one run of the suite settled and what it did not.
+//
+// Behaviours run under subtests that may run in parallel, so this is written
+// from several goroutines and read once at the end.
+type findings struct {
+	mu   sync.Mutex
+	rows []Finding
+}
+
+func newFindings() *findings { return &findings{} }
+
+func (f *findings) add(row Finding) {
+	if f == nil {
+		return
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.rows = append(f.rows, row)
+}
+
+// unproven returns the findings that reached the third answer, sorted.
+func (f *findings) unproven() []Finding {
+	if f == nil {
+		return nil
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]Finding, 0, len(f.rows))
+	for _, r := range f.rows {
+		if r.Answer == Unproven {
+			out = append(out, r)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Behavior < out[j].Behavior })
+	return out
+}
+
+// reportUnproven writes the block a reader has to see, and reports whether it
+// wrote anything.
+//
+// Written to a plain io.Writer, and RunDatabase passes it os.Stderr rather than
+// t.Logf alone, because t.Logf on a subtest that did not fail is invisible
+// without -v. An unproven verdict that only appears under a flag is a skip that
+// reads as a pass, which is the exact failure this file exists to avoid, and
+// the whole point of the third answer is that somebody sees it.
+func (f *findings) reportUnproven(w io.Writer) bool {
+	rows := f.unproven()
+	if len(rows) == 0 {
+		return false
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "\nNOT PROVED BY THIS RUN. This is not a pass.\n")
+	for _, r := range rows {
+		fmt.Fprintf(&b, "  %-9s %s  %s\n", string(r.Answer), r.Provider, r.Behavior)
+		for _, line := range strings.Split(strings.TrimSpace(r.Because), "\n") {
+			fmt.Fprintf(&b, "            %s\n", strings.TrimSpace(line))
+		}
+	}
+	fmt.Fprintf(&b, "            The declaration stays as the provider wrote it and stays\n"+
+		"            unpublishable: a surface printing this provider's copy on write\n"+
+		"            value prints %q, never the declared value. conformance.CopyOnWriteClaim\n"+
+		"            is the only rendering of it a customer facing page may use.\n\n",
+		notProved)
+	_, _ = io.WriteString(w, b.String())
+	return true
+}
+
+// notProved is the word every surface prints in place of a declaration the
+// suite did not reach.
+const notProved = "unproven"
+
+// CopyOnWriteClaim renders a provider's copy on write declaration for
+// publication, and it is the only shape a customer facing surface may print it
+// in.
+//
+// The second condition of the ruling that produced the third answer is that an
+// unproven CopyOnWrite: true is not publishable as a proved claim anywhere a
+// customer reads it. A condition of that shape is kept by a function every
+// emission site calls, not by a sentence in a plan: the wave publishes one
+// shared table of branch time per provider, a buyer chooses a vendor from it,
+// and a cell that says true because somebody typed true is the same defect as a
+// capability nothing can refuse, one surface further out.
+//
+// So the value and the verdict are rendered together and cannot be separated by
+// the caller. There is no argument order that gets "true" out of an unproven
+// run.
+func CopyOnWriteClaim(declared bool, a Answer) string {
+	switch a {
+	case Unproven:
+		return notProved
+	case Refuted:
+		return "refuted"
+	case Proved:
+		if declared {
+			return "true"
+		}
+		return "false"
+	default:
+		// An answer this function does not know is not a pass, for the reason
+		// sitesmoke gives about a verdict word it cannot read. The zero value
+		// of Answer lands here, so a Finding somebody forgot to fill in
+		// publishes as unproven rather than as the declared value.
+		return notProved
+	}
+}

--- a/engine/internal/docs/pages.gen.go
+++ b/engine/internal/docs/pages.gen.go
@@ -3996,6 +3996,57 @@ Those two are complementary, so one of the two possible declarations is refused
 on every run. There is no reading of the stopwatch that lets both pass, which is
 the property a check needs before a green one means anything.
 
+### The third answer, for a harness that cannot exhibit the behaviour
+
+The stopwatch is only as good as the storage underneath the run, and there is a
+harness on which a truthful ` + "`" + `CopyOnWrite: true` + "`" + ` cannot pass. A fake cloud
+control plane over one local Postgres can only hand back a branch carrying the
+golden's data with ` + "`" + `CREATE DATABASE ... TEMPLATE` + "`" + `, which copies files. The large
+arm is then slower by seconds per gibibyte whatever the provider would do
+against the real service, so the stopwatch is reading the harness.
+
+Declaring ` + "`" + `false` + "`" + ` to get a green is a lie about the product. Skipping the
+behaviour turns off the one instrument that can refuse this category's central
+commercial claim. Loosening the allowance leaves it running, printing a verdict,
+and unable to refuse anything.
+
+So the behaviour has a third answer, **unproven**, and it is not a pass.
+
+` + "`" + "`" + "`" + `
+NOT PROVED BY THIS RUN. This is not a pass.
+  UNPROVEN  aurora  CopyOnWrite_BranchTimeMatchesTheDeclaration
+` + "`" + "`" + "`" + `
+
+` + "`" + `Options.HarnessCopiesEveryBranch` + "`" + ` is the only thing that reaches it. It is a
+sentence your TEST FIXTURE writes about the storage it built, naming the
+mechanism, and it is nothing a provider can reach: ` + "`" + `Capabilities()` + "`" + ` is the thing
+under examination, and a subject that could excuse itself from a check is the
+unfalsifiable declaration this whole behaviour exists to refuse.
+
+Four things make it a verdict rather than a way out.
+
+- **The measurement still runs, in full.** Both goldens are built, both arms are
+  timed, the ballast is weighed in the branch, and every number is printed.
+  Unproven changes what the readings are turned into, never whether they were
+  taken.
+- **It is refused unless you declare ` + "`" + `CopyOnWrite: true` + "`" + `.** On the false side a
+  copying harness exhibits exactly what is being asserted, so there is nothing
+  it cannot reach.
+- **It is checked against your own readings.** A fixture that declares its
+  storage copies and then branches in constant time is failed for the
+  declaration. Setting the field on a harness that turns out to share storage
+  turns a pass into a failure, so it cannot be set defensively by somebody who
+  has not looked.
+- **It buys nothing you can publish.** ` + "`" + `conformance.CopyOnWriteClaim` + "`" + ` renders the
+  declaration as the word ` + "`" + `unproven` + "`" + ` wherever a customer would read it, the
+  ledger in ` + "`" + `engine/conformance/ledger.go` + "`" + ` records the verdict per provider, and
+  a test refuses a comparison table cell that says otherwise.
+
+What remains, and it is stated rather than papered over: a copying harness
+cannot tell an honest provider from a dishonest one, because the two produce the
+same readings on it. That is a property of the harness. Settling it needs the
+real service with an account, and nothing short of that does.
+
 The suite makes a golden large by writing ballast into it from inside the ` + "`" + `Mask` + "`" + `
 callback, so a provider needs no extra method: hand ` + "`" + `Mask` + "`" + ` a connection string
 that works, which every other behaviour needs anyway, and the sizing takes care


### PR DESCRIPTION
## The problem, verified against the source

`CopyOnWrite_BranchTimeMatchesTheDeclaration` decides by stopwatch, and the
stopwatch is only as good as the storage under the run.

    CopyOnWrite true   requires  grown <= allowance
    CopyOnWrite false  requires  grown >  allowance

The wave's prescribed harness is a fake cloud control plane over one real local
Postgres. Over a single Postgres the only way a fake control plane can hand back
a branch carrying the golden's data is `CREATE DATABASE ... TEMPLATE`, which
copies files. The large arm is therefore slower by seconds per gibibyte whatever
the provider would do against the real service, so **a truthful
`CopyOnWrite: true` fails**. That blocks Aurora, Cloud SQL and AlloyDB, and it is
why the managed lane is withholding a provider for Xata rather than publish a
declaration it knows is false.

## The third verdict

`UNPROVEN`, distinct from pass and from fail, matching what the rest of the
repository already does: `sitesmoke` prints `COULD NOT TELL` and says in its own
output that this is not a pass, mutation cells are classified on the `=== RUN`
count, and the egress report is closed, open or unproven.

**It is not a skip.** The measurement runs in full. Both goldens are built, both
arms are timed, the sizes are checked, the ballast is weighed in the branch, and
every number is printed. Unproven changes what the readings are turned into,
never whether they were taken.

**Only a test fixture can raise it**, through `Options.HarnessCopiesEveryBranch`,
a sentence about the storage the fixture built. `Capabilities()` cannot reach it,
because a subject that can excuse itself from a check is the unfalsifiable
declaration this behaviour exists to refuse. Placement is necessary and not
sufficient, since a fixture and its provider are often written by one person, so
three refusals do the rest:

- Refused unless the provider declares `CopyOnWrite: true`. On the false side a
  copying harness exhibits exactly what is asserted, so there is nothing it
  cannot reach.
- Failed if the fixture's own readings contradict it. Setting the field on a
  harness that turns out to share storage turns a pass into a failure, so it
  cannot be set defensively by somebody who has not looked.
- It buys nothing publishable.

What remains, stated rather than papered over: a copying harness cannot tell an
honest provider from a dishonest one, because both produce the same readings on
it. That is a property of the harness. Settling it needs the real service with an
account.

## The emission side, which was already broken

Five of the six cells in the benchmark comparison table's copy on write column
carried a verdict beside the words "not measured yet". Three said `yes` and two
said `no`, and the two were the same mistake in the direction that costs the
vendor rather than the buyer. `cow.go` already argues that the false side matters
as much as the true side, so all five now say `unproven`.

`engine/conformance/ledger.go` records the verdict per provider, and two sweeps
check both directions.

- **Declarations.** Every `provider.Caps` literal setting `CopyOnWrite` has a
  recorded verdict. It parses the literal's TYPE rather than grepping the field
  name, because `provider.DatastoreCaps` carries a field of the same name checked
  by a different suite under different rules.
- **Publications.** Every cell of the copy on write column says what the ledger
  says, in both directions: no cell may claim more than the ledger and none may
  claim less. It refused two of my own cells while I was writing it.

Recording the verdicts honestly is uncomfortable reading. Four of the five
providers that declare a value have no recorded verdict, because their
conformance tests need credentials nobody has run them with. Before this they
looked exactly like a provider that had been measured.

## Proved in four directions

On a private Postgres 17 at load 24, at the SHIPPED sizes, about a minute per
measured child.

The first push ran them at the behaviour's floor of 64 MiB against 4 MiB, to save
time, and **CI refused it**. CI's storage copied the 60 MiB of extra data in
163ms, inside the 250ms the allowance gives to noise, so nothing was
distinguishable: the copying provider was not refused because its copy was
invisible, and the fixture declaring that its storage copies was refused because
the storage did not measurably copy. Both reds were the instrument working.
`cow.go` says this in advance about the size, and `db_selftest_test.go` already
warns that a self test run at sizes the suite does not ship proves the faults are
catchable at SOME configuration. The second commit sets no override.

| Direction | Result |
| --- | --- |
| A copying provider declaring copy on write, nothing declared about the harness | still REFUSED |
| An honest flat provider on a harness that can exhibit it | still PASSES |
| A truthful declaration on the template copy harness | UNPROVEN, printed |
| A fixture declaring a limit it does not have | REFUSED, for the declaration |

The rendered report, which is the thing a reader sees:

```
NOT PROVED BY THIS RUN. This is not a pass.
  UNPROVEN  postgres-template  CopyOnWrite_BranchTimeMatchesTheDeclaration
            branching the golden with 60.0 MiB more data in it took 293ms longer,
            past the 250ms this machine's noise accounts for, which is 4.99
            seconds per GiB of copying.
            ...
            The declaration stays as the provider wrote it and stays
            unpublishable: a surface printing this provider's copy on write
            value prints "unproven", never the declared value.
```

## Mutation table

Thirteen cells, classified on the `=== RUN` count rather than the exit code, each
run against the single test it was aimed at. All thirteen caught. The seven that
touch the measurement were re-run at the shipped sizes after the size correction
and all seven are still caught.

| Cell | The break | Aimed at | Verdict |
| --- | --- | --- | --- |
| 1 | the false side refusal is disabled | `TestTheHarnessLimitIsRefusedOnAProviderThatDeclaresCopyOnWriteFalse` | CAUGHT |
| 2 | the reason length refusal is disabled | `TestAShortHarnessReasonIsRefused` | CAUGHT |
| 3 | the corroboration refusal is disabled | `TestAFixtureThatDeclaresALimitItDoesNotHaveIsRefused` | CAUGHT |
| 4 | unproven no longer gated on the declaration | `TestACopyingProviderIsStillRefusedWhenNothingDeclaredTheHarness` | CAUGHT |
| 5 | the unproven path fatals instead | `TestTheTemplateCopyHarnessReportsUnproven` | CAUGHT |
| 6 | the report banner writes nothing | `TestTheTemplateCopyHarnessReportsUnproven` | CAUGHT |
| 7 | `CopyOnWriteClaim` renders unproven as true | `TestAnUnprovenDeclarationIsNotPublishableAsTheDeclaredValue` | CAUGHT |
| 8 | `Publishable` returns true for unproven | `TestAnUnprovenDeclarationIsNotPublishableAsTheDeclaredValue` | CAUGHT |
| 9 | a missing ledger entry falls back to true | `TestThePublicationSweepCanSayNo` | CAUGHT |
| 10 | a new provider directory declares with no entry | `TestEveryCopyOnWriteDeclarationHasARecordedVerdict` | CAUGHT |
| 11 | the table republishes an unproved `yes` | `TestThePublishedCopyOnWriteColumnSaysWhatTheLedgerSays` | CAUGHT |
| 12 | the ledger downgrades a proved cell | `TestThePublishedCopyOnWriteColumnSaysWhatTheLedgerSays` | CAUGHT |
| 13 | the refusal moves after the measurement | `TestTheHarnessLimitIsRefusedOnAProviderThatDeclaresCopyOnWriteFalse` | CAUGHT |

No non discriminating cell. Cell 13 also shows in the clock: the refusal runs in
0.15s pristine and 19.47s broken, which is the measurement it should have
preceded.

Sources were restored between cells from a file snapshot, never `git checkout`,
and no cell ran against a tree that was being mutated.

## Also checked

`go build ./...` in `engine` clean, `go vet ./conformance` clean, `prosecheck`
932 files and 0 findings, `claimcheck` clean, `changecheck` clean,
`engine/internal/docs/pages.gen.go` regenerated by `docsembed`. `docscheck`
needs `docs/dist`, which this machine has not built; that is environmental and
unrelated to this change.

One finding this lane did not act on, reported rather than fixed: the `docker`
provider declares `CopyOnWrite: true` and `docs/providers/overview.md` publishes
"Grows with the database" for it. Those cannot both be right, and the ledger now
records that nothing has measured it.
