### PR TITLE
schema: a gate refused a runtime the engine would run

### DIFF
--- a/.changes/a-gate-that-said-no-for-a-reason-that-was-not-true.md
+++ b/.changes/a-gate-that-said-no-for-a-reason-that-was-not-true.md
@@ -1,0 +1,28 @@
+# fixed
+
+`schemas/manifest.v1.json` closed `runtime.provider` to `local` and
+`kubernetes`, so a documentation page could not show the one manifest line a
+registered cloud runtime exists to answer. `manifestcheck` refused the page,
+and the reason it gave was false:
+
+    runtime.provider is "ecs", which is not one the manifest accepts. The
+    engine refuses it with AF-MAN-002. It has to be one of: kubernetes, local
+
+The engine does not refuse it. Nothing validates a manifest against the JSON
+Schema at parse time, and the switch in `newRuntime` consults the runtime
+registry before it refuses anything, so a build that carries an `ecs` runtime
+accepts that manifest and runs the environment. The gate said no about the
+right field for a reason a reader would believe and that was not true, which is
+worse than saying nothing.
+
+`runtime.provider` now carries no list, the way `datastore.engine` carries
+none, and for the reason that field already records: a manifest naming a
+runtime this build has no provider for is refused by the provider lookup, by
+name, against the runtimes that build actually has, which says more than an
+unknown value would. A schema that enumerates providers is a schema somebody
+has to edit every time a build registers one, which is the opposite of an
+extension point.
+
+`manifestcheck`'s message now reports what the gate actually read, which is the
+schema, and stops asserting what a build will do. The enum half of that gate
+had no test of its own until now.

--- a/docs/src/content/docs/reference/manifest.md
+++ b/docs/src/content/docs/reference/manifest.md
@@ -484,7 +484,7 @@ name.
 
 | Key | Notes |
 | --- | --- |
-| `provider` | `local`. `kubernetes` is named in the schema and not built yet; asking for it is refused rather than substituted. |
+| `provider` | Which runtime places the environment. `local` and `kubernetes` are built in, and a build registers any others it carries. The schema keeps no list, the way `datastore.engine` keeps none: a name this build has no runtime for is refused by name, against the runtimes that build actually has, rather than substituted. |
 | `ttl` | How long an environment lives. |
 | `idle_sleep` | Suspend after this long with no traffic. |
 | `domain` | Wildcard domain for preview URLs. |

--- a/docs/src/content/docs/reference/schemas/manifest-v1.md
+++ b/docs/src/content/docs/reference/schemas/manifest-v1.md
@@ -407,7 +407,7 @@ Where and how long the environment runs. The provider decides the machinery; the
 | `kubeconfig_context` | string | no | Which kubeconfig context to use. Naming it prevents an environment landing on whatever cluster happened to be current. Max length 253. |
 | `max_ttl` | string | no | The furthest af env extend may push an environment's expiry, measured from when it was created. A lifetime that can be extended forever is not a lifetime, and this is the bound. Defaults to `168h`. Matches `^[0-9]+(h\|d)$`. |
 | `namespace_prefix` | string | no | Prefix for Kubernetes namespaces. Defaults to `af`. Max length 40. |
-| `provider` | `local`, `kubernetes` | no | Defaults to `local`. |
+| `provider` | string | no | Which runtime places the environment. local and kubernetes are built in. Open rather than a fixed list, for the reason datastore.engine is: a build registers the runtimes it carries, so a manifest naming one this build has no runtime for is refused by the provider lookup, by name, against the runtimes that build actually has, which says more than an unknown value would. Defaults to `local`. Max length 64. |
 | `ttl` | string | no | How long an environment lives before the reaper tears it down. Extend one you are still using with af env extend, up to max_ttl. Defaults to `24h`. Matches `^[0-9]+(h\|d)$`. |
 
 ## Service

--- a/engine/internal/docs/pages.gen.go
+++ b/engine/internal/docs/pages.gen.go
@@ -17512,7 +17512,7 @@ name.
 
 | Key | Notes |
 | --- | --- |
-| ` + "`" + `provider` + "`" + ` | ` + "`" + `local` + "`" + `. ` + "`" + `kubernetes` + "`" + ` is named in the schema and not built yet; asking for it is refused rather than substituted. |
+| ` + "`" + `provider` + "`" + ` | Which runtime places the environment. ` + "`" + `local` + "`" + ` and ` + "`" + `kubernetes` + "`" + ` are built in, and a build registers any others it carries. The schema keeps no list, the way ` + "`" + `datastore.engine` + "`" + ` keeps none: a name this build has no runtime for is refused by name, against the runtimes that build actually has, rather than substituted. |
 | ` + "`" + `ttl` + "`" + ` | How long an environment lives. |
 | ` + "`" + `idle_sleep` + "`" + ` | Suspend after this long with no traffic. |
 | ` + "`" + `domain` + "`" + ` | Wildcard domain for preview URLs. |
@@ -19010,7 +19010,7 @@ Where and how long the environment runs. The provider decides the machinery; the
 | ` + "`" + `kubeconfig_context` + "`" + ` | string | no | Which kubeconfig context to use. Naming it prevents an environment landing on whatever cluster happened to be current. Max length 253. |
 | ` + "`" + `max_ttl` + "`" + ` | string | no | The furthest af env extend may push an environment's expiry, measured from when it was created. A lifetime that can be extended forever is not a lifetime, and this is the bound. Defaults to ` + "`" + `168h` + "`" + `. Matches ` + "`" + `^[0-9]+(h\|d)$` + "`" + `. |
 | ` + "`" + `namespace_prefix` + "`" + ` | string | no | Prefix for Kubernetes namespaces. Defaults to ` + "`" + `af` + "`" + `. Max length 40. |
-| ` + "`" + `provider` + "`" + ` | ` + "`" + `local` + "`" + `, ` + "`" + `kubernetes` + "`" + ` | no | Defaults to ` + "`" + `local` + "`" + `. |
+| ` + "`" + `provider` + "`" + ` | string | no | Which runtime places the environment. local and kubernetes are built in. Open rather than a fixed list, for the reason datastore.engine is: a build registers the runtimes it carries, so a manifest naming one this build has no runtime for is refused by the provider lookup, by name, against the runtimes that build actually has, which says more than an unknown value would. Defaults to ` + "`" + `local` + "`" + `. Max length 64. |
 | ` + "`" + `ttl` + "`" + ` | string | no | How long an environment lives before the reaper tears it down. Extend one you are still using with af env extend, up to max_ttl. Defaults to ` + "`" + `24h` + "`" + `. Matches ` + "`" + `^[0-9]+(h\|d)$` + "`" + `. |
 
 ## Service

--- a/schemas/manifest.v1.json
+++ b/schemas/manifest.v1.json
@@ -1581,11 +1581,9 @@
       "properties": {
         "provider": {
           "type": "string",
-          "enum": [
-            "local",
-            "kubernetes"
-          ],
-          "default": "local"
+          "maxLength": 64,
+          "default": "local",
+          "description": "Which runtime places the environment. local and kubernetes are built in. Open rather than a fixed list, for the reason datastore.engine is: a build registers the runtimes it carries, so a manifest naming one this build has no runtime for is refused by the provider lookup, by name, against the runtimes that build actually has, which says more than an unknown value would."
         },
         "ttl": {
           "type": "string",

--- a/tools/manifestcheck/main.go
+++ b/tools/manifestcheck/main.go
@@ -386,6 +386,20 @@ func walk(value any, node, root map[string]any, path string, report func(string)
 // comparing a YAML integer to a JSON number invites a false positive over
 // nothing. And it stays quiet unless EVERY branch that has an enum refuses the
 // value, so a value permitted by one arm of a oneOf is permitted.
+//
+// WHAT THE MESSAGE MAY CLAIM, and why it no longer claims what it used to. It
+// said "the engine refuses it with AF-MAN-002. It has to be one of: ...", and
+// that is a statement about a program this gate has never read. It was false
+// where it mattered most. runtime.provider carried the enum local, kubernetes,
+// so a page showing runtime.provider: ecs was refused with a remediation
+// telling the reader the engine would refuse it too, while a build that has
+// registered an ecs runtime accepts it and runs the environment: nothing
+// validates a manifest against this schema at parse time, and the switch in
+// newRuntime consults the registry before it refuses. A gate that says no
+// about the right field for a reason that is not true is worse than one that
+// says nothing, because the reader believes it. So the message now reports
+// what was actually read, which is the schema, and names the shape a key takes
+// when a registration can answer it.
 func checkEnum(value string, node, root map[string]any, path string, report func(string)) {
 	var allowed []string
 	for _, alt := range branches(node, root) {
@@ -410,8 +424,11 @@ func checkEnum(value string, node, root map[string]any, path string, report func
 		return
 	}
 	sort.Strings(allowed)
-	report(fmt.Sprintf("%s is %q, which is not one the manifest accepts. The engine refuses it "+
-		"with AF-MAN-002. It has to be one of: %s", path, value, strings.Join(allowed, ", ")))
+	report(fmt.Sprintf("%s is %q, which schemas/manifest.v1.json does not list for that key. "+
+		"It lists: %s. This gate reads the schema and not the engine, so it reports what the "+
+		"manifest declares and not what a build will run: a key a provider registration can "+
+		"answer carries no list at all, the way datastore.engine and runtime.provider do.",
+		path, value, strings.Join(allowed, ", ")))
 }
 
 // propertyFor finds the schema for a key across a node's branches, and reports

--- a/tools/manifestcheck/main_test.go
+++ b/tools/manifestcheck/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -44,6 +45,7 @@ const schemaJSON = `{
         "additionalProperties": false,
         "properties": {
           "name": {"type": "string"},
+          "kind": {"type": "string", "enum": ["web", "worker", "cron"]},
           "port": {"type": "integer"},
           "health_path": {"type": "string"},
           "env": {"type": "array", "items": {"$ref": "#/$defs/envVar"}}
@@ -173,5 +175,114 @@ func TestCheckingNothingIsAnError(t *testing.T) {
 	_, err := check(t, root)
 	if err == nil || !strings.Contains(err.Error(), "no pages") {
 		t.Fatalf("err = %v, want a refusal to report green on nothing", err)
+	}
+}
+
+// A key that exists carrying a value the schema does not list is the second
+// half of this gate, and it had no test at all until this lane.
+func TestAValueOutsideAClosedEnumIsReported(t *testing.T) {
+	page := "```yaml\nname: x\nservices:\n  - name: web\n    kind: batch\n```\n"
+	root := tree(t, page, "")
+	out, err := check(t, root)
+	if err == nil {
+		t.Fatalf("a value outside a closed enum was accepted, output %q", out)
+	}
+}
+
+// A value the schema does list passes, so the test above is discriminating
+// rather than reporting every value it sees.
+func TestAValueTheEnumListsPasses(t *testing.T) {
+	page := "```yaml\nname: x\nservices:\n  - name: web\n    kind: worker\n```\n"
+	root := tree(t, page, "")
+	if _, err := check(t, root); err != nil {
+		t.Fatalf("a value the enum lists was reported: %v", err)
+	}
+}
+
+// enumNode is the schema for one key of the miniature manifest above.
+func enumNode(t *testing.T, path ...string) (map[string]any, map[string]any) {
+	t.Helper()
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(schemaJSON), &doc); err != nil {
+		t.Fatal(err)
+	}
+	node := doc
+	for _, step := range path {
+		next, ok := node[step].(map[string]any)
+		if !ok {
+			t.Fatalf("the miniature schema has no %q under %v", step, path)
+		}
+		node = next
+	}
+	return node, doc
+}
+
+// THE FAILURE THIS TEST IS FOR. The message used to say "The engine refuses it
+// with AF-MAN-002. It has to be one of: ...", which is a claim about a program
+// this gate never reads, and it was false for exactly the field that most
+// needed it: runtime.provider carried an enum, so a page showing a cloud
+// runtime was refused with a remediation saying the engine would refuse it
+// too, while a build carrying that runtime accepts it and runs.
+func TestTheEnumMessageReportsTheSchemaAndNotTheEngine(t *testing.T) {
+	node, doc := enumNode(t, "properties", "services", "items", "properties", "kind")
+	var got []string
+	checkEnum("batch", node, doc, "services[0].kind", func(m string) { got = append(got, m) })
+	if len(got) != 1 {
+		t.Fatalf("checkEnum reported %d findings, want 1: %v", len(got), got)
+	}
+	if !strings.Contains(got[0], "schemas/manifest.v1.json") {
+		t.Errorf("the message does not name what was read: %q", got[0])
+	}
+	if strings.Contains(got[0], "AF-MAN-002") {
+		t.Errorf("the message asserts an error code for a program this gate never read: %q", got[0])
+	}
+	if !strings.Contains(got[0], "cron") || !strings.Contains(got[0], "web") {
+		t.Errorf("the message does not say what the schema does list: %q", got[0])
+	}
+}
+
+// A key with no enum takes any value, which is what a provider registration
+// needs and is the shape datastore.engine and runtime.provider carry.
+func TestAKeyThatDeclaresNoEnumTakesAnyValue(t *testing.T) {
+	node, doc := enumNode(t, "properties", "name")
+	var got []string
+	checkEnum("anything at all", node, doc, "name", func(m string) { got = append(got, m) })
+	if len(got) != 0 {
+		t.Fatalf("a key with no enum reported %v", got)
+	}
+}
+
+// THE ORIGINATING CASE, against the real schema rather than the miniature.
+// A documentation page could not show the manifest line the cloud runtimes
+// exist to answer, because schemas/manifest.v1.json closed runtime.provider to
+// local and kubernetes. Re-adding that enum turns this red.
+func TestTheRealSchemaLetsAPageShowARegisteredRuntime(t *testing.T) {
+	body, err := os.ReadFile(filepath.Join("..", "..", "schemas", "manifest.v1.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "schemas", "manifest.v1.json"), string(body))
+	mustWrite(t, filepath.Join(root, "docs", "src", "content", "docs", "page.md"),
+		"```yaml\nversion: 1\nruntime:\n  provider: ecs\n```\n")
+	if out, err := check(t, root); err != nil {
+		t.Fatalf("the documentation cannot show a registered runtime: %v\n%s", err, out)
+	}
+}
+
+// The other direction, against the same real schema. A set that is genuinely
+// closed stays checked: no registration decides what a service kind is, so a
+// page showing one the schema does not list is still reported.
+func TestTheRealSchemaStillRefusesAValueOutsideAClosedSet(t *testing.T) {
+	body, err := os.ReadFile(filepath.Join("..", "..", "schemas", "manifest.v1.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "schemas", "manifest.v1.json"), string(body))
+	mustWrite(t, filepath.Join(root, "docs", "src", "content", "docs", "page.md"),
+		"```yaml\nversion: 1\nservices:\n  - name: web\n    kind: batch\n```\n")
+	if out, err := check(t, root); err == nil {
+		t.Fatalf("a value outside a closed set was accepted, output %q", out)
 	}
 }


### PR DESCRIPTION
`schemas/manifest.v1.json` closed `runtime.provider` to `local` and
`kubernetes`. A documentation page could therefore not show the one manifest
line a registered cloud runtime exists to answer, and the gate that refused it
gave a reason that is not true.

    runtime.provider is "ecs", which is not one the manifest accepts. The
    engine refuses it with AF-MAN-002. It has to be one of: kubernetes, local

The engine does not refuse it. Nothing validates a manifest against the JSON
Schema at parse time, which `engine/internal/manifest/validate.go` says twice in
its own comments, and the switch in `newRuntime` consults the runtime registry
before it refuses anything. A build that has registered an `ecs` runtime accepts
that manifest and runs the environment. So the gate said no about the right
field for a reason a reader believes and that is false, which is worse than
saying nothing.

## The decision, because this is a v1 contract surface

`runtime.provider` now carries no list, the way `datastore.engine` carries none,
and its description gives the same argument that field already records.

The editions question this entangles with is whether the community schema may
name a runtime only an enterprise build can serve. It does not have to, and that
is the point of the change: after it, the schema names no providers at all. It
declares the field OPEN, which is true in every edition, and the refusal of an
unknown name is left to the provider lookup, which is the only thing that knows
what a particular build carries. The alternative, a schema enumerating what the
current build serves, makes the schema differ between editions. That is wrong on
its own terms: this file has a `$id` and is published at one URL, so an editor
validating against it would refuse a manifest the customer's own binary runs.
Section 2.5 of the plan governs where CODE lives, not what the contract names.

`AddRuntimeProvider` and `RuntimeProviderNamed` were already an extension point.
A schema that enumerates providers is a schema somebody must edit every time a
build registers one, which is the opposite of one.

## What still says no, and what no longer does

An unknown runtime is still refused, by name, against the runtimes the build
actually has. That is `newRuntime`'s default arm and it is unchanged; the tests
that hold it are `TestARuntimeThisBuildDoesNotHaveIsRefusedRatherThanSubstituted`
and `TestARefusalNamesTheRegisteredProvidersAsWellAsTheBuiltInOnes`. A typo gets
a better message than the schema ever gave it, because the schema's list was
fixed and the engine's is the build's.

What is lost is named rather than left to be discovered. `tools/modecheck`'s
table rule checks a reference table cell that claims to list a closed set the
schema declares, and with the enum gone the `runtime.provider` row falls out of
its reach. The cell it was covering was wrong anyway: it said `kubernetes` "is
named in the schema and not built yet", and
`TestTheKubernetesRuntimeIsBuiltRatherThanRefused` has held since kubernetes was
built. That cell is rewritten here. Nothing gates its successor, and no gate in
this repository knows the runtime set, so this is a real reduction in coverage
in exchange for a field that stops lying.

## The same defect, one field away, not fixed here

`database.provider` carries a closed enum and its lookup consults the same
registry through `DatabaseProviderNamed`, so `database.provider: something` a
build has registered produces the identical false remediation. It is a different
v1 field with its own callers and it is not this row. Reported rather than
changed.

Three further copies of the runtime list are maintained by hand and are not fed
by this schema: `RuntimeProvider` in `engine/pkg/schema/manifest.go`, `PROVIDERS`
in `web/apps/api/src/routers/runtimes.ts`, which says in its own comment that it
is kept in step by hand, and the provider `select` in the console's environments
page. The control plane will refuse to register a runtime record named `ecs`.
Also reported rather than changed.

## Tests

The enum half of `manifestcheck` had no test at all. It has five now, including
the originating case against the real schema rather than the miniature: a page
showing `runtime.provider: ecs` must pass, and re-adding the enum turns it red.
