### PR TITLE
ee: a corpus a comment said already existed, and the two divergences it found

### DIFF
--- a/.changes/a-corpus-a-comment-said-already-existed.md
+++ b/.changes/a-corpus-a-comment-said-already-existed.md
@@ -1,0 +1,53 @@
+# fixed
+
+Two implementations of one decision, with a comment claiming they were held
+together by a file that was not in the tree.
+
+`ee/engine/license` parses and evaluates licences in Go and runs in the engine.
+`ee/web/server/src/license.ts` does the same in TypeScript and runs in the
+control plane, because single sign-on and provisioning are mounted there and the
+control plane has no engine in it. That file's own header names the hazard, and
+then lists three things holding the two sides together. The second was this, in
+the present tense: `ee/license-vectors.json` is a corpus of tokens with the
+verdict each one must produce, one suite here reads it and one in the engine
+reads the same file.
+
+None of it existed. Not the corpus, not either of the two files it named, not a
+single occurrence of the string in either suite. `ee/README.md` records three
+claims of exactly that shape and the lesson written under them is that a claim
+resting on an invented mechanism reads identically to a true one until somebody
+goes looking, and that the person who goes looking is usually the customer.
+
+The corpus exists now, emitted by the Go side because the Go side is the
+definition, on the same pattern the community tree already uses three times for
+the policy engine, for webhooks and for mock packs. Twenty one cases, covering
+every state and every refusal either implementation can produce, checked by a
+test on both sides that the coverage is complete rather than merely present.
+
+It found two divergences on its first run, which is what the paragraph had been
+promising to prevent.
+
+The first is the one that reaches a customer. The engine has always refused to
+permit a feature no build enforces anywhere, filtering them in `Evaluate`. The
+control plane did not: it permitted every feature a licence named. So one key
+made the engine say billing is not permitted and the control plane print that it
+is, in one deployment, to one buyer, with neither binary aware of the other. It
+is not reachable through the two gates the enterprise entry point mounts today,
+and it is reachable through the startup line that reports what the licence
+permits right now, which is the line an operator reads to check what they bought.
+
+The second is at a boundary. At the exact instant a grace period ends the
+control plane returned negative zero days, which JavaScript treats as a value
+distinct from zero, and the engine returned zero, because it is an integer and
+has no such value. Invisible in a rendered string and not invisible to anything
+comparing the two.
+
+The corpus also binds two lists that were duplicated across the two languages
+with a comment saying they matched and nothing checking that they did: every
+feature a licence can carry, and the features no build ships.
+
+There is no signing key in the repository and this adds none. The corpus carries
+the public half in the form an operator pastes into a deployment, and the tokens
+are fixtures, so regenerating recomputes the verdicts and leaves the tokens
+alone: a semantic change shows up as a diff of verdicts rather than of the whole
+file.

--- a/ee/engine/license/vectors_test.go
+++ b/ee/engine/license/vectors_test.go
@@ -1,0 +1,673 @@
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+
+// The shared licence corpus, emitted here and consumed by the control plane.
+//
+// WHY THIS FILE EXISTS, AND IT IS NOT "TO ADD TEST COVERAGE".
+//
+// There are two implementations of one decision. This package parses and
+// evaluates licences in Go and runs in the engine. `ee/web/server/src/license.ts`
+// parses and evaluates them in TypeScript and runs in the control plane, because
+// single sign-on and provisioning are mounted there and the control plane has no
+// engine in it. Two readers of one format drift, and the one that drifts is the
+// one nobody is holding against the other: a customer's engine says a feature is
+// not permitted while their control plane prints that it is, and both are
+// confident.
+//
+// THE COMMENT AT THE TOP OF license.ts SAID THIS FILE ALREADY EXISTED. It named
+// the hazard, then listed three things holding the two sides together, and the
+// second was "ee/license-vectors.json is a corpus of tokens with the verdict
+// each one must produce. test/license.test.ts here reads it and
+// ee/engine/license/vectors_test.go reads the same file." None of that was in
+// the tree: not the corpus, not this file, not a single occurrence of the string
+// in either suite. That is the exact shape ee/README.md records three times over
+// and warns about in its own words, which is that a claim resting on an invented
+// mechanism reads identically to a true one until somebody goes looking.
+//
+// So: this is the emitter, `ee/license-vectors.json` is the corpus, and
+// `ee/web/server/test/vectors.test.ts` is the consumer. It is the same shape
+// the community tree already uses three times, for the policy engine, for
+// webhooks and for mock packs, and the Go side emits in all of them because the
+// Go side is the definition.
+//
+//	go test ./license -run TestVectors -update-vectors
+//
+// WHAT THE CORPUS DOES NOT COMPARE, said here rather than left to be assumed
+// checked. It compares the DECISIONS: the refusal, the state, the days left,
+// whether the licence is honoured, which features are permitted, and whether one
+// more member passes the seat limit. It does NOT compare the warning sentences,
+// and they are measurably different today: this side formats an expiry date as
+// "5 September 2026" and the control plane uses `toUTCString`, which is
+// "Sat, 05 Sep 2026 00:00:00 GMT". Both are shown to an operator, so that is
+// worth fixing, and it is a difference in prose for two different surfaces
+// rather than a difference in what either binary permits. Recording it beats
+// quietly widening the corpus until it passes.
+
+package license_test
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/ee/engine/license"
+)
+
+var updateVectors = flag.Bool("update-vectors", false,
+	"rewrite ee/license-vectors.json from the current implementation")
+
+// corpusPath is where both sides read it from.
+const corpusPath = "../../license-vectors.json"
+
+// corpus is the whole file.
+type corpus struct {
+	// Note is addressed to whoever opens the file wondering what it is.
+	Note string `json:"note"`
+	// Keys is the AF_LICENSE_PUBLIC_KEYS value that trusts the signer, in the
+	// kid=base64 form an operator pastes into a deployment. It is a PUBLIC key.
+	// There is deliberately no signing key in this repository, in this file or
+	// anywhere near it, which is why the tokens below are fixtures rather than
+	// something either side mints while it runs.
+	Keys string `json:"keys"`
+	// AllFeatures and NotShipped bind two lists that were duplicated across the
+	// two languages with nothing checking them. license.ts declares its own
+	// ALL_FEATURES and says it matches this one; nothing made that true.
+	AllFeatures []string `json:"all_features"`
+	NotShipped  []string `json:"not_shipped"`
+	Cases       []vcase  `json:"cases"`
+}
+
+// vcase is one token, one moment, and the answer both implementations owe.
+type vcase struct {
+	Name string `json:"name"`
+	// Why this case is in the corpus, so that deleting it is a decision rather
+	// than a tidy-up.
+	Why string `json:"why"`
+
+	// The input.
+	Token    string   `json:"token"`
+	Org      string   `json:"org"`
+	Now      string   `json:"now"`
+	LastSeen string   `json:"last_seen,omitempty"`
+	Revoked  []string `json:"revoked,omitempty"`
+
+	// The answer. Refusal is empty when the token parses.
+	Refusal  string      `json:"refusal"`
+	State    string      `json:"state,omitempty"`
+	DaysLeft int         `json:"days_left"`
+	Honoured bool        `json:"honoured"`
+	Enabled  []string    `json:"enabled"`
+	Seats    []seatProbe `json:"seats,omitempty"`
+}
+
+// seatProbe is the seat limit asked as a number rather than through a
+// provisioning flow, because that is where the two sides could differ by one
+// and nothing would say so until a customer's twenty sixth member was refused
+// or allowed.
+type seatProbe struct {
+	Current  int  `json:"current"`
+	Exceeded bool `json:"exceeded"`
+}
+
+// spec is how a case is minted the first time. Once a case has a token in the
+// file, the token is the fixture and this is not consulted again: regenerating
+// recomputes the VERDICTS and leaves the tokens alone, so a semantic change
+// produces a diff of verdicts rather than a diff of the whole file.
+//
+// Changing what a case's licence says therefore means deleting that case's
+// token from the corpus, so that it is minted again. That is deliberate. A
+// corpus whose fixtures move under the verdicts is a corpus that cannot show
+// you what changed.
+type spec struct {
+	name     string
+	why      string
+	claims   license.Claims
+	org      string
+	now      time.Time
+	lastSeen time.Time
+	revoked  []string
+	// mint builds the token from the signed one, for the cases whose whole
+	// point is that the token is not what the signer produced. Nil means the
+	// signed token is used as it is.
+	mint  func(signed string) string
+	seats []int
+}
+
+var vectorEpoch = time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+
+func specs() []spec {
+	base := func() license.Claims {
+		return license.Claims{
+			ID:        "lic-corpus",
+			Org:       "acme",
+			Plan:      "enterprise",
+			Features:  []license.Feature{license.FeatureSSO, license.FeatureSCIM},
+			Seats:     25,
+			IssuedAt:  vectorEpoch,
+			ExpiresAt: vectorEpoch.AddDate(1, 0, 0),
+		}
+	}
+	with := func(f func(c *license.Claims)) license.Claims {
+		c := base()
+		f(&c)
+		return c
+	}
+
+	return []spec{
+		{
+			name:   "current license, two features, inside the term",
+			why:    "The ordinary case. If the two sides disagree here nothing else in the corpus matters.",
+			claims: base(),
+			org:    "acme",
+			now:    vectorEpoch.AddDate(0, 1, 0),
+			seats:  []int{0, 24, 25, 26},
+		},
+		{
+			name:   "the organization is compared without case or surrounding space",
+			why:    "An operator pastes a slug with a trailing space or a capital. Refusing that is a support ticket, and one side trimming while the other did not would refuse a licence that is fine.",
+			claims: with(func(c *license.Claims) { c.Org = "  ACME " }),
+			org:    "acme",
+			now:    vectorEpoch.AddDate(0, 1, 0),
+		},
+		{
+			name:   "a license issued to somebody else",
+			why:    "This is what stops a key being passed around, so both binaries have to refuse it and neither may permit a feature while doing so.",
+			claims: base(),
+			org:    "globex",
+			now:    vectorEpoch.AddDate(0, 1, 0),
+		},
+		{
+			name:   "the instant of expiry is not still active",
+			why:    "An off by one at the boundary is the most likely place two implementations differ, and it is invisible for a year.",
+			claims: base(),
+			org:    "acme",
+			now:    vectorEpoch.AddDate(1, 0, 0),
+		},
+		{
+			name:   "expired, inside the grace period",
+			why:    "Expiry is an ordinary commercial event and the software keeps working. A side that fell straight to expired would switch a paying customer off two weeks early.",
+			claims: base(),
+			org:    "acme",
+			now:    vectorEpoch.AddDate(1, 0, 3),
+		},
+		{
+			name:   "the instant the grace period ends is expired",
+			why:    "The other boundary, for the same reason as the first.",
+			claims: base(),
+			org:    "acme",
+			now:    vectorEpoch.AddDate(1, 0, license.DefaultGraceDays),
+		},
+		{
+			name:   "expired, past the grace period, permits nothing",
+			why:    "The state a lapsed customer is actually in. Settings are preserved and features are off, and a side that still permitted them would be giving the product away.",
+			claims: base(),
+			org:    "acme",
+			now:    vectorEpoch.AddDate(1, 1, 0),
+			seats:  []int{0, 26},
+		},
+		{
+			name:   "a license that carries its own grace period",
+			why:    "grace_days is optional and zero means the default. A side reading zero as no grace would cut a customer off on the day.",
+			claims: with(func(c *license.Claims) { c.GraceDays = 45 }),
+			org:    "acme",
+			now:    vectorEpoch.AddDate(1, 0, 30),
+		},
+		{
+			name:    "revoked",
+			why:     "Revocation is consulted from a list the operator supplies and there is no fetch. It has to beat everything else, including a licence that is otherwise current.",
+			claims:  base(),
+			org:     "acme",
+			now:     vectorEpoch.AddDate(0, 1, 0),
+			revoked: []string{"lic-corpus"},
+		},
+		{
+			name:     "the clock was rolled back past the tolerance",
+			why:      "A rolled back clock makes an expired licence look current, which is exactly what moving it is for. The check has to come before expiry on both sides.",
+			claims:   base(),
+			org:      "acme",
+			now:      vectorEpoch.AddDate(0, 1, 0),
+			lastSeen: vectorEpoch.AddDate(0, 2, 0),
+		},
+		{
+			name:     "a clock inside the hour of tolerance is not a rollback",
+			why:      "Ordinary time synchronisation moves a clock by seconds and a resumed virtual machine by more. A side with no tolerance would switch enterprise features off on an ntp step.",
+			claims:   base(),
+			org:      "acme",
+			now:      vectorEpoch.AddDate(0, 1, 0),
+			lastSeen: vectorEpoch.AddDate(0, 1, 0).Add(30 * time.Minute),
+		},
+		{
+			name:   "a license naming a feature this build does not ship",
+			why:    "THE DIVERGENCE THIS CORPUS WAS WRITTEN AFTER FINDING. The engine filters a feature it enforces nowhere and the control plane did not, so one binary said billing was permitted and the other said it was not, for the same key, in the same deployment.",
+			claims: with(func(c *license.Claims) { c.Features = append(c.Features, license.FeatureBilling) }),
+			org:    "acme",
+			now:    vectorEpoch.AddDate(0, 1, 0),
+		},
+		{
+			name:   "a license naming a feature from a later release",
+			why:    "The feature set is closed at issue time, not at read time. Refusing the whole licence over one unknown name would turn every ordering of upgrade and renewal into an outage for the features the customer did buy.",
+			claims: with(func(c *license.Claims) { c.Features = append(c.Features, "teleportation") }),
+			org:    "acme",
+			now:    vectorEpoch.AddDate(0, 1, 0),
+		},
+		{
+			name:   "unlimited seats is zero, not nobody",
+			why:    "Zero reading as a limit of none would lock every customer on an unmetered licence out of their own directory.",
+			claims: with(func(c *license.Claims) { c.Seats = 0 }),
+			org:    "acme",
+			now:    vectorEpoch.AddDate(0, 1, 0),
+			seats:  []int{0, 1000},
+		},
+		{
+			name:   "a trial license is still a license",
+			why:    "The trial flag changes what an operator is told and must not change what is permitted.",
+			claims: with(func(c *license.Claims) { c.Trial = true }),
+			org:    "acme",
+			now:    vectorEpoch.AddDate(0, 1, 0),
+		},
+		{
+			name:   "signed by a key this installation does not trust",
+			why:    "Distinct from tampered, because the two send an operator to two different places: one to ask for a licence signed by a current key, the other to suspect the file.",
+			claims: base(),
+			org:    "acme",
+			now:    vectorEpoch.AddDate(0, 1, 0),
+			mint: func(signed string) string {
+				// Signed by a key nobody trusts, minted here rather than
+				// derived from the good token, so the signature is genuine and
+				// only the key is unknown.
+				return signWithAnUntrustedKey()
+			},
+		},
+		{
+			name:   "the payload was edited after signing",
+			why:    "The one property the wire format exists to have.",
+			claims: base(),
+			org:    "acme",
+			now:    vectorEpoch.AddDate(0, 1, 0),
+			mint:   tamperWithThePayload,
+		},
+		{
+			name:   "not a license at all",
+			why:    "Somebody pastes the wrong thing into a deployment. Both sides refuse as malformed rather than as tampered, because tampered sends a reader looking for an attacker.",
+			claims: base(),
+			org:    "acme",
+			now:    vectorEpoch.AddDate(0, 1, 0),
+			mint:   func(string) string { return "not-a-license" },
+		},
+		{
+			name:   "the prefix is right and the rest is not base64url",
+			why:    "A truncated or re-encoded paste. Node's base64url decoder discards rubbish rather than refusing it, so this is the case where a round trip check on one side and none on the other would produce two different verdicts.",
+			claims: base(),
+			org:    "acme",
+			now:    vectorEpoch.AddDate(0, 1, 0),
+			mint:   func(string) string { return "aflic_not!base64.also!not" },
+		},
+		{
+			name:   "one part, no dot",
+			why:    "The shape of a licence cut at a line break in an email.",
+			claims: base(),
+			org:    "acme",
+			now:    vectorEpoch.AddDate(0, 1, 0),
+			mint: func(signed string) string {
+				for i := 0; i < len(signed); i++ {
+					if signed[i] == '.' {
+						return signed[:i]
+					}
+				}
+				return signed
+			},
+		},
+		{
+			name:   "whitespace and newlines survive the paste",
+			why:    "A licence copied out of an email arrives wrapped. Refusing that is a support ticket rather than a security property, and both sides have to be equally forgiving.",
+			claims: base(),
+			org:    "acme",
+			now:    vectorEpoch.AddDate(0, 1, 0),
+			mint: func(signed string) string {
+				mid := len(signed) / 2
+				return "  " + signed[:mid] + "\n  " + signed[mid:] + "\n"
+			},
+		},
+	}
+}
+
+// The signer for the corpus. Minted once, when a case has no token yet, and
+// never written to disk in its private half.
+var (
+	corpusKeyID = "corpus-1"
+	corpusPub   ed25519.PublicKey
+	corpusPriv  ed25519.PrivateKey
+	untrustedID = "not-trusted"
+	untrustedPr ed25519.PrivateKey
+)
+
+func signWithAnUntrustedKey() string {
+	claims := license.Claims{
+		ID: "lic-corpus", Org: "acme", Plan: "enterprise",
+		Features:  []license.Feature{license.FeatureSSO},
+		IssuedAt:  vectorEpoch,
+		ExpiresAt: vectorEpoch.AddDate(1, 0, 0),
+		KeyID:     untrustedID,
+	}
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		panic(err)
+	}
+	return fmt.Sprintf("aflic_%s.%s",
+		base64.RawURLEncoding.EncodeToString(payload),
+		base64.RawURLEncoding.EncodeToString(ed25519.Sign(untrustedPr, payload)))
+}
+
+// tamperWithThePayload flips one byte of the encoded payload, leaving the
+// signature alone, which is the shape of an edited licence rather than of a
+// corrupted one.
+func tamperWithThePayload(signed string) string {
+	body := signed[len("aflic_"):]
+	dot := -1
+	for i := 0; i < len(body); i++ {
+		if body[i] == '.' {
+			dot = i
+			break
+		}
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(body[:dot])
+	if err != nil {
+		panic(err)
+	}
+	edited := make([]byte, len(payload))
+	copy(edited, payload)
+	// "acme" becomes "acmf" wherever it appears, which changes the organization
+	// the licence names without changing its length.
+	for i := 0; i+4 <= len(edited); i++ {
+		if string(edited[i:i+4]) == "acme" {
+			edited[i+3] = 'f'
+			break
+		}
+	}
+	return "aflic_" + base64.RawURLEncoding.EncodeToString(edited) + "." + body[dot+1:]
+}
+
+func mintSigner(t *testing.T) {
+	t.Helper()
+	if corpusPriv != nil {
+		return
+	}
+	pub, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	corpusPub, corpusPriv = pub, priv
+	_, upriv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	untrustedPr = upriv
+}
+
+func signClaims(t *testing.T, claims license.Claims) string {
+	t.Helper()
+	if claims.KeyID == "" {
+		claims.KeyID = corpusKeyID
+	}
+	payload, err := json.Marshal(claims)
+	require.NoError(t, err)
+	return fmt.Sprintf("aflic_%s.%s",
+		base64.RawURLEncoding.EncodeToString(payload),
+		base64.RawURLEncoding.EncodeToString(ed25519.Sign(corpusPriv, payload)))
+}
+
+// verifierFor builds a verifier the way a deployment does, through
+// LoadVerifier and the environment, rather than by handing NewVerifier a map.
+// The corpus publishes its key in the AF_LICENSE_PUBLIC_KEYS form on purpose,
+// so this exercises the reader an operator's paste actually goes through.
+func verifierFor(t *testing.T, keys string, revoked []string) *license.Verifier {
+	t.Helper()
+	v, count, err := license.LoadVerifier(func(name string) string {
+		if name == license.TrustedKeysEnv {
+			return keys
+		}
+		return ""
+	})
+	require.NoError(t, err, "the corpus publishes a keys value this build cannot read")
+	require.Positive(t, count, "the corpus published a key and this build trusts none")
+	v.Revoke(revoked...)
+	return v
+}
+
+// answer runs the current implementation and returns the verdict fields.
+func answer(t *testing.T, c vcase, keys string) vcase {
+	t.Helper()
+	out := c
+	v := verifierFor(t, keys, c.Revoked)
+
+	now, err := time.Parse(time.RFC3339, c.Now)
+	require.NoError(t, err)
+	var lastSeen time.Time
+	if c.LastSeen != "" {
+		lastSeen, err = time.Parse(time.RFC3339, c.LastSeen)
+		require.NoError(t, err)
+	}
+
+	claims, err := v.Parse(c.Token)
+	if err != nil {
+		out.Refusal = refusalOf(err)
+		out.State = ""
+		out.DaysLeft = 0
+		out.Honoured = false
+		out.Enabled = []string{}
+		out.Seats = nil
+		return out
+	}
+
+	status := v.Evaluate(claims, license.Evaluation{Org: c.Org, Now: now, LastSeen: lastSeen})
+	out.Refusal = ""
+	out.State = string(status.State)
+	out.DaysLeft = status.DaysLeft
+	out.Honoured = status.Honoured()
+	out.Enabled = []string{}
+	for _, f := range license.AllFeatures() {
+		if status.Enabled(f) {
+			out.Enabled = append(out.Enabled, string(f))
+		}
+	}
+	sort.Strings(out.Enabled)
+
+	// A NEW slice, and the reason is a defect this file had until the mutation
+	// matrix found it. `out := c` copies the struct and copies the slice HEADER,
+	// so out.Seats and c.Seats share one backing array. Writing the computed
+	// answer into out.Seats[i] therefore overwrote the expected answer in
+	// c.Seats[i], and the comparison in TestVectors was a slice against itself.
+	// Breaking SeatsExceeded by one in the implementation left the suite green,
+	// which is the whole definition of an assertion that cannot say no.
+	out.Seats = nil
+	for _, probe := range c.Seats {
+		out.Seats = append(out.Seats, seatProbe{
+			Current:  probe.Current,
+			Exceeded: status.SeatsExceeded(probe.Current),
+		})
+	}
+	return out
+}
+
+// refusalOf names which of the three refusals an error is, because the three
+// send an operator to three different places and a corpus that recorded only
+// "refused" would let the two sides disagree about which one.
+func refusalOf(err error) string {
+	switch {
+	case errors.Is(err, license.ErrUnknownKey):
+		return "unknown_key"
+	case errors.Is(err, license.ErrTampered):
+		return "tampered"
+	case errors.Is(err, license.ErrMalformed):
+		return "malformed"
+	default:
+		return "unclassified:" + err.Error()
+	}
+}
+
+const corpusNote = "The licence corpus, shared by the Go reader in ee/engine/license " +
+	"and the TypeScript reader in ee/web/server/src/license.ts. Both must produce these " +
+	"verdicts. Emitted by ee/engine/license/vectors_test.go and read by " +
+	"ee/web/server/test/vectors.test.ts. Regenerate with " +
+	"'GOWORK=off go test ./license -run TestVectors -update-vectors' from ee/engine. " +
+	"The tokens are fixtures: regenerating recomputes the verdicts and leaves them alone, " +
+	"so a semantic change shows as a diff of verdicts. To change what a case's licence " +
+	"says, delete that case's token and regenerate. There is no signing key in this " +
+	"repository; 'keys' is the public half, in the form AF_LICENSE_PUBLIC_KEYS takes."
+
+func TestVectors(t *testing.T) {
+	stored := readCorpus(t)
+
+	if *updateVectors {
+		writeCorpus(t, buildCorpus(t, stored))
+		return
+	}
+
+	require.NotEmpty(t, stored.Cases,
+		"found no cases in %s, so this check is looking in the wrong place or the corpus was "+
+			"emptied. That is a failure, not a pass.", corpusPath)
+	require.NotEmpty(t, stored.Keys, "the corpus publishes no keys, so nothing in it can verify")
+
+	require.Equal(t, featureNames(license.AllFeatures()), stored.AllFeatures,
+		"the corpus and this build disagree about what features exist")
+	require.Equal(t, featureNames(license.NotShippedFeatures()), stored.NotShipped,
+		"the corpus and this build disagree about which features are not shipped")
+
+	for _, c := range stored.Cases {
+		t.Run(c.Name, func(t *testing.T) {
+			got := answer(t, c, stored.Keys)
+			require.Equal(t, c.Refusal, got.Refusal, "refusal, for: %s", c.Why)
+			require.Equal(t, c.State, got.State, "state, for: %s", c.Why)
+			require.Equal(t, c.DaysLeft, got.DaysLeft, "days left, for: %s", c.Why)
+			require.Equal(t, c.Honoured, got.Honoured, "honoured, for: %s", c.Why)
+			require.Equal(t, c.Enabled, got.Enabled, "permitted features, for: %s", c.Why)
+			require.Equal(t, c.Seats, got.Seats, "the seat limit, for: %s", c.Why)
+		})
+	}
+}
+
+// TestVectorsCoverEveryRefusalAndEveryState is the check on the corpus rather
+// than on the implementation.
+//
+// A corpus is only worth what it covers, and a corpus that quietly stopped
+// carrying a state would pass for ever while the two sides drifted on exactly
+// the case it dropped. So the states and refusals this package can produce are
+// enumerated from the package's own constants, and every one has to appear.
+func TestVectorsCoverEveryRefusalAndEveryState(t *testing.T) {
+	stored := readCorpus(t)
+	require.NotEmpty(t, stored.Cases, "no cases, so this check has nothing to look at")
+
+	seenState := map[string]bool{}
+	seenRefusal := map[string]bool{}
+	for _, c := range stored.Cases {
+		if c.Refusal != "" {
+			seenRefusal[c.Refusal] = true
+			continue
+		}
+		seenState[c.State] = true
+	}
+
+	// StateNone is deliberately absent: it is the answer to having no token at
+	// all, and a corpus of tokens cannot carry the case of there being none.
+	// Both sides test it directly, and saying so here is cheaper than a reader
+	// wondering whether it was forgotten.
+	for _, want := range []string{"active", "grace", "expired", "revoked", "wrong_org", "clock_rollback"} {
+		require.True(t, seenState[want], "no case in the corpus produces the state %q", want)
+	}
+	for _, want := range []string{"malformed", "tampered", "unknown_key"} {
+		require.True(t, seenRefusal[want], "no case in the corpus produces the refusal %q", want)
+	}
+}
+
+func featureNames(fs []license.Feature) []string {
+	out := make([]string, 0, len(fs))
+	for _, f := range fs {
+		out = append(out, string(f))
+	}
+	sort.Strings(out)
+	return out
+}
+
+func readCorpus(t *testing.T) corpus {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Clean(corpusPath))
+	if os.IsNotExist(err) {
+		if *updateVectors {
+			return corpus{}
+		}
+		t.Fatalf("%s does not exist. Regenerate it with -update-vectors.", corpusPath)
+	}
+	require.NoError(t, err)
+	var c corpus
+	require.NoError(t, json.Unmarshal(body, &c), "%s is not readable as a corpus", corpusPath)
+	return c
+}
+
+// buildCorpus keeps every token the file already carries and recomputes every
+// verdict.
+func buildCorpus(t *testing.T, stored corpus) corpus {
+	t.Helper()
+
+	tokens := map[string]string{}
+	for _, c := range stored.Cases {
+		if c.Token != "" {
+			tokens[c.Name] = c.Token
+		}
+	}
+
+	out := corpus{
+		Note:        corpusNote,
+		Keys:        stored.Keys,
+		AllFeatures: featureNames(license.AllFeatures()),
+		NotShipped:  featureNames(license.NotShippedFeatures()),
+	}
+
+	needsMinting := false
+	for _, s := range specs() {
+		if tokens[s.name] == "" {
+			needsMinting = true
+		}
+	}
+	if needsMinting {
+		require.Empty(t, stored.Keys,
+			"a case has no token and the corpus already publishes a key, so minting one now would "+
+				"invalidate every other token. Delete %s and regenerate the whole file.", corpusPath)
+		mintSigner(t)
+		out.Keys = corpusKeyID + "=" + base64.StdEncoding.EncodeToString(corpusPub)
+	}
+
+	for _, s := range specs() {
+		c := vcase{Name: s.name, Why: s.why, Org: s.org, Now: s.now.UTC().Format(time.RFC3339)}
+		if !s.lastSeen.IsZero() {
+			c.LastSeen = s.lastSeen.UTC().Format(time.RFC3339)
+		}
+		c.Revoked = s.revoked
+		if token, ok := tokens[s.name]; ok {
+			c.Token = token
+		} else {
+			signed := signClaims(t, s.claims)
+			if s.mint != nil {
+				signed = s.mint(signed)
+			}
+			c.Token = signed
+		}
+		for _, current := range s.seats {
+			c.Seats = append(c.Seats, seatProbe{Current: current})
+		}
+		out.Cases = append(out.Cases, answer(t, c, out.Keys))
+	}
+	return out
+}
+
+func writeCorpus(t *testing.T, c corpus) {
+	t.Helper()
+	body, err := json.MarshalIndent(c, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Clean(corpusPath), append(body, '\n'), 0o600))
+	t.Logf("wrote %d cases to %s", len(c.Cases), corpusPath)
+}

--- a/ee/license-vectors.json
+++ b/ee/license-vectors.json
@@ -1,0 +1,347 @@
+{
+  "note": "The licence corpus, shared by the Go reader in ee/engine/license and the TypeScript reader in ee/web/server/src/license.ts. Both must produce these verdicts. Emitted by ee/engine/license/vectors_test.go and read by ee/web/server/test/vectors.test.ts. Regenerate with 'GOWORK=off go test ./license -run TestVectors -update-vectors' from ee/engine. The tokens are fixtures: regenerating recomputes the verdicts and leaves them alone, so a semantic change shows as a diff of verdicts. To change what a case's licence says, delete that case's token and regenerate. There is no signing key in this repository; 'keys' is the public half, in the form AF_LICENSE_PUBLIC_KEYS takes.",
+  "keys": "corpus-1=1RWy8EBJzsEWSZcJI+EYo0u3Rxs5yKIwVSan9uw4WfI=",
+  "all_features": [
+    "air_gapped",
+    "audit_stream",
+    "billing",
+    "compliance_packs",
+    "enterprise_dashboard",
+    "enterprise_secrets",
+    "multi_runtime",
+    "policy_enforcement",
+    "rbac",
+    "scim",
+    "sso",
+    "support_access"
+  ],
+  "not_shipped": [
+    "billing",
+    "enterprise_dashboard"
+  ],
+  "cases": [
+    {
+      "name": "current license, two features, inside the term",
+      "why": "The ordinary case. If the two sides disagree here nothing else in the corpus matters.",
+      "token": "aflic_eyJpZCI6ImxpYy1jb3JwdXMiLCJvcmciOiJhY21lIiwicGxhbiI6ImVudGVycHJpc2UiLCJmZWF0dXJlcyI6WyJzc28iLCJzY2ltIl0sInNlYXRzIjoyNSwiaXNzdWVkX2F0IjoiMjAyNi0wNi0wMVQwMDowMDowMFoiLCJleHBpcmVzX2F0IjoiMjAyNy0wNi0wMVQwMDowMDowMFoiLCJraWQiOiJjb3JwdXMtMSJ9.xj4Z8HqKtnZMlH4tQ7QaURsQQgnjWycTpQ0hiBD5wsE2aXlR4Ph5J2vGNF_SyWSmjxuCOgBbRMZNxG8H-PjvBw",
+      "org": "acme",
+      "now": "2026-07-01T00:00:00Z",
+      "refusal": "",
+      "state": "active",
+      "days_left": 335,
+      "honoured": true,
+      "enabled": [
+        "scim",
+        "sso"
+      ],
+      "seats": [
+        {
+          "current": 0,
+          "exceeded": false
+        },
+        {
+          "current": 24,
+          "exceeded": false
+        },
+        {
+          "current": 25,
+          "exceeded": true
+        },
+        {
+          "current": 26,
+          "exceeded": true
+        }
+      ]
+    },
+    {
+      "name": "the organization is compared without case or surrounding space",
+      "why": "An operator pastes a slug with a trailing space or a capital. Refusing that is a support ticket, and one side trimming while the other did not would refuse a licence that is fine.",
+      "token": "aflic_eyJpZCI6ImxpYy1jb3JwdXMiLCJvcmciOiIgIEFDTUUgIiwicGxhbiI6ImVudGVycHJpc2UiLCJmZWF0dXJlcyI6WyJzc28iLCJzY2ltIl0sInNlYXRzIjoyNSwiaXNzdWVkX2F0IjoiMjAyNi0wNi0wMVQwMDowMDowMFoiLCJleHBpcmVzX2F0IjoiMjAyNy0wNi0wMVQwMDowMDowMFoiLCJraWQiOiJjb3JwdXMtMSJ9.-e2p1mWkBrZW7GL6LiBaxHXfi2S-n14el-ps826bYrz4_hKpZMH2ixo5WhvkhHZ-zJ0EWxwBHuwJuurd_TfIBA",
+      "org": "acme",
+      "now": "2026-07-01T00:00:00Z",
+      "refusal": "",
+      "state": "active",
+      "days_left": 335,
+      "honoured": true,
+      "enabled": [
+        "scim",
+        "sso"
+      ]
+    },
+    {
+      "name": "a license issued to somebody else",
+      "why": "This is what stops a key being passed around, so both binaries have to refuse it and neither may permit a feature while doing so.",
+      "token": "aflic_eyJpZCI6ImxpYy1jb3JwdXMiLCJvcmciOiJhY21lIiwicGxhbiI6ImVudGVycHJpc2UiLCJmZWF0dXJlcyI6WyJzc28iLCJzY2ltIl0sInNlYXRzIjoyNSwiaXNzdWVkX2F0IjoiMjAyNi0wNi0wMVQwMDowMDowMFoiLCJleHBpcmVzX2F0IjoiMjAyNy0wNi0wMVQwMDowMDowMFoiLCJraWQiOiJjb3JwdXMtMSJ9.xj4Z8HqKtnZMlH4tQ7QaURsQQgnjWycTpQ0hiBD5wsE2aXlR4Ph5J2vGNF_SyWSmjxuCOgBbRMZNxG8H-PjvBw",
+      "org": "globex",
+      "now": "2026-07-01T00:00:00Z",
+      "refusal": "",
+      "state": "wrong_org",
+      "days_left": 0,
+      "honoured": false,
+      "enabled": []
+    },
+    {
+      "name": "the instant of expiry is not still active",
+      "why": "An off by one at the boundary is the most likely place two implementations differ, and it is invisible for a year.",
+      "token": "aflic_eyJpZCI6ImxpYy1jb3JwdXMiLCJvcmciOiJhY21lIiwicGxhbiI6ImVudGVycHJpc2UiLCJmZWF0dXJlcyI6WyJzc28iLCJzY2ltIl0sInNlYXRzIjoyNSwiaXNzdWVkX2F0IjoiMjAyNi0wNi0wMVQwMDowMDowMFoiLCJleHBpcmVzX2F0IjoiMjAyNy0wNi0wMVQwMDowMDowMFoiLCJraWQiOiJjb3JwdXMtMSJ9.xj4Z8HqKtnZMlH4tQ7QaURsQQgnjWycTpQ0hiBD5wsE2aXlR4Ph5J2vGNF_SyWSmjxuCOgBbRMZNxG8H-PjvBw",
+      "org": "acme",
+      "now": "2027-06-01T00:00:00Z",
+      "refusal": "",
+      "state": "grace",
+      "days_left": 14,
+      "honoured": true,
+      "enabled": [
+        "scim",
+        "sso"
+      ]
+    },
+    {
+      "name": "expired, inside the grace period",
+      "why": "Expiry is an ordinary commercial event and the software keeps working. A side that fell straight to expired would switch a paying customer off two weeks early.",
+      "token": "aflic_eyJpZCI6ImxpYy1jb3JwdXMiLCJvcmciOiJhY21lIiwicGxhbiI6ImVudGVycHJpc2UiLCJmZWF0dXJlcyI6WyJzc28iLCJzY2ltIl0sInNlYXRzIjoyNSwiaXNzdWVkX2F0IjoiMjAyNi0wNi0wMVQwMDowMDowMFoiLCJleHBpcmVzX2F0IjoiMjAyNy0wNi0wMVQwMDowMDowMFoiLCJraWQiOiJjb3JwdXMtMSJ9.xj4Z8HqKtnZMlH4tQ7QaURsQQgnjWycTpQ0hiBD5wsE2aXlR4Ph5J2vGNF_SyWSmjxuCOgBbRMZNxG8H-PjvBw",
+      "org": "acme",
+      "now": "2027-06-04T00:00:00Z",
+      "refusal": "",
+      "state": "grace",
+      "days_left": 11,
+      "honoured": true,
+      "enabled": [
+        "scim",
+        "sso"
+      ]
+    },
+    {
+      "name": "the instant the grace period ends is expired",
+      "why": "The other boundary, for the same reason as the first.",
+      "token": "aflic_eyJpZCI6ImxpYy1jb3JwdXMiLCJvcmciOiJhY21lIiwicGxhbiI6ImVudGVycHJpc2UiLCJmZWF0dXJlcyI6WyJzc28iLCJzY2ltIl0sInNlYXRzIjoyNSwiaXNzdWVkX2F0IjoiMjAyNi0wNi0wMVQwMDowMDowMFoiLCJleHBpcmVzX2F0IjoiMjAyNy0wNi0wMVQwMDowMDowMFoiLCJraWQiOiJjb3JwdXMtMSJ9.xj4Z8HqKtnZMlH4tQ7QaURsQQgnjWycTpQ0hiBD5wsE2aXlR4Ph5J2vGNF_SyWSmjxuCOgBbRMZNxG8H-PjvBw",
+      "org": "acme",
+      "now": "2027-06-15T00:00:00Z",
+      "refusal": "",
+      "state": "expired",
+      "days_left": 0,
+      "honoured": false,
+      "enabled": []
+    },
+    {
+      "name": "expired, past the grace period, permits nothing",
+      "why": "The state a lapsed customer is actually in. Settings are preserved and features are off, and a side that still permitted them would be giving the product away.",
+      "token": "aflic_eyJpZCI6ImxpYy1jb3JwdXMiLCJvcmciOiJhY21lIiwicGxhbiI6ImVudGVycHJpc2UiLCJmZWF0dXJlcyI6WyJzc28iLCJzY2ltIl0sInNlYXRzIjoyNSwiaXNzdWVkX2F0IjoiMjAyNi0wNi0wMVQwMDowMDowMFoiLCJleHBpcmVzX2F0IjoiMjAyNy0wNi0wMVQwMDowMDowMFoiLCJraWQiOiJjb3JwdXMtMSJ9.xj4Z8HqKtnZMlH4tQ7QaURsQQgnjWycTpQ0hiBD5wsE2aXlR4Ph5J2vGNF_SyWSmjxuCOgBbRMZNxG8H-PjvBw",
+      "org": "acme",
+      "now": "2027-07-01T00:00:00Z",
+      "refusal": "",
+      "state": "expired",
+      "days_left": -16,
+      "honoured": false,
+      "enabled": [],
+      "seats": [
+        {
+          "current": 0,
+          "exceeded": false
+        },
+        {
+          "current": 26,
+          "exceeded": false
+        }
+      ]
+    },
+    {
+      "name": "a license that carries its own grace period",
+      "why": "grace_days is optional and zero means the default. A side reading zero as no grace would cut a customer off on the day.",
+      "token": "aflic_eyJpZCI6ImxpYy1jb3JwdXMiLCJvcmciOiJhY21lIiwicGxhbiI6ImVudGVycHJpc2UiLCJmZWF0dXJlcyI6WyJzc28iLCJzY2ltIl0sInNlYXRzIjoyNSwiaXNzdWVkX2F0IjoiMjAyNi0wNi0wMVQwMDowMDowMFoiLCJleHBpcmVzX2F0IjoiMjAyNy0wNi0wMVQwMDowMDowMFoiLCJncmFjZV9kYXlzIjo0NSwia2lkIjoiY29ycHVzLTEifQ.dCeu7fTEB3ZV1iJ2S4loutV8r7uS7-nISagvmkCReT9No8fYD5MpEqfqQ7YDi0pmvLFQYhptWrdFo9WfOuMPCQ",
+      "org": "acme",
+      "now": "2027-07-01T00:00:00Z",
+      "refusal": "",
+      "state": "grace",
+      "days_left": 15,
+      "honoured": true,
+      "enabled": [
+        "scim",
+        "sso"
+      ]
+    },
+    {
+      "name": "revoked",
+      "why": "Revocation is consulted from a list the operator supplies and there is no fetch. It has to beat everything else, including a licence that is otherwise current.",
+      "token": "aflic_eyJpZCI6ImxpYy1jb3JwdXMiLCJvcmciOiJhY21lIiwicGxhbiI6ImVudGVycHJpc2UiLCJmZWF0dXJlcyI6WyJzc28iLCJzY2ltIl0sInNlYXRzIjoyNSwiaXNzdWVkX2F0IjoiMjAyNi0wNi0wMVQwMDowMDowMFoiLCJleHBpcmVzX2F0IjoiMjAyNy0wNi0wMVQwMDowMDowMFoiLCJraWQiOiJjb3JwdXMtMSJ9.xj4Z8HqKtnZMlH4tQ7QaURsQQgnjWycTpQ0hiBD5wsE2aXlR4Ph5J2vGNF_SyWSmjxuCOgBbRMZNxG8H-PjvBw",
+      "org": "acme",
+      "now": "2026-07-01T00:00:00Z",
+      "revoked": [
+        "lic-corpus"
+      ],
+      "refusal": "",
+      "state": "revoked",
+      "days_left": 0,
+      "honoured": false,
+      "enabled": []
+    },
+    {
+      "name": "the clock was rolled back past the tolerance",
+      "why": "A rolled back clock makes an expired licence look current, which is exactly what moving it is for. The check has to come before expiry on both sides.",
+      "token": "aflic_eyJpZCI6ImxpYy1jb3JwdXMiLCJvcmciOiJhY21lIiwicGxhbiI6ImVudGVycHJpc2UiLCJmZWF0dXJlcyI6WyJzc28iLCJzY2ltIl0sInNlYXRzIjoyNSwiaXNzdWVkX2F0IjoiMjAyNi0wNi0wMVQwMDowMDowMFoiLCJleHBpcmVzX2F0IjoiMjAyNy0wNi0wMVQwMDowMDowMFoiLCJraWQiOiJjb3JwdXMtMSJ9.xj4Z8HqKtnZMlH4tQ7QaURsQQgnjWycTpQ0hiBD5wsE2aXlR4Ph5J2vGNF_SyWSmjxuCOgBbRMZNxG8H-PjvBw",
+      "org": "acme",
+      "now": "2026-07-01T00:00:00Z",
+      "last_seen": "2026-08-01T00:00:00Z",
+      "refusal": "",
+      "state": "clock_rollback",
+      "days_left": 0,
+      "honoured": false,
+      "enabled": []
+    },
+    {
+      "name": "a clock inside the hour of tolerance is not a rollback",
+      "why": "Ordinary time synchronisation moves a clock by seconds and a resumed virtual machine by more. A side with no tolerance would switch enterprise features off on an ntp step.",
+      "token": "aflic_eyJpZCI6ImxpYy1jb3JwdXMiLCJvcmciOiJhY21lIiwicGxhbiI6ImVudGVycHJpc2UiLCJmZWF0dXJlcyI6WyJzc28iLCJzY2ltIl0sInNlYXRzIjoyNSwiaXNzdWVkX2F0IjoiMjAyNi0wNi0wMVQwMDowMDowMFoiLCJleHBpcmVzX2F0IjoiMjAyNy0wNi0wMVQwMDowMDowMFoiLCJraWQiOiJjb3JwdXMtMSJ9.xj4Z8HqKtnZMlH4tQ7QaURsQQgnjWycTpQ0hiBD5wsE2aXlR4Ph5J2vGNF_SyWSmjxuCOgBbRMZNxG8H-PjvBw",
+      "org": "acme",
+      "now": "2026-07-01T00:00:00Z",
+      "last_seen": "2026-07-01T00:30:00Z",
+      "refusal": "",
+      "state": "active",
+      "days_left": 335,
+      "honoured": true,
+      "enabled": [
+        "scim",
+        "sso"
+      ]
+    },
+    {
+      "name": "a license naming a feature this build does not ship",
+      "why": "THE DIVERGENCE THIS CORPUS WAS WRITTEN AFTER FINDING. The engine filters a feature it enforces nowhere and the control plane did not, so one binary said billing was permitted and the other said it was not, for the same key, in the same deployment.",
+      "token": "aflic_eyJpZCI6ImxpYy1jb3JwdXMiLCJvcmciOiJhY21lIiwicGxhbiI6ImVudGVycHJpc2UiLCJmZWF0dXJlcyI6WyJzc28iLCJzY2ltIiwiYmlsbGluZyJdLCJzZWF0cyI6MjUsImlzc3VlZF9hdCI6IjIwMjYtMDYtMDFUMDA6MDA6MDBaIiwiZXhwaXJlc19hdCI6IjIwMjctMDYtMDFUMDA6MDA6MDBaIiwia2lkIjoiY29ycHVzLTEifQ.4h0XX1VJMSanSRAjoRMKmFv1-7bbDWpPGzsqT5n3sYrHnq-lV0Ffy_siwbeBTg518SgRJTv2knBh8CzBt0Q-Bw",
+      "org": "acme",
+      "now": "2026-07-01T00:00:00Z",
+      "refusal": "",
+      "state": "active",
+      "days_left": 335,
+      "honoured": true,
+      "enabled": [
+        "scim",
+        "sso"
+      ]
+    },
+    {
+      "name": "a license naming a feature from a later release",
+      "why": "The feature set is closed at issue time, not at read time. Refusing the whole licence over one unknown name would turn every ordering of upgrade and renewal into an outage for the features the customer did buy.",
+      "token": "aflic_eyJpZCI6ImxpYy1jb3JwdXMiLCJvcmciOiJhY21lIiwicGxhbiI6ImVudGVycHJpc2UiLCJmZWF0dXJlcyI6WyJzc28iLCJzY2ltIiwidGVsZXBvcnRhdGlvbiJdLCJzZWF0cyI6MjUsImlzc3VlZF9hdCI6IjIwMjYtMDYtMDFUMDA6MDA6MDBaIiwiZXhwaXJlc19hdCI6IjIwMjctMDYtMDFUMDA6MDA6MDBaIiwia2lkIjoiY29ycHVzLTEifQ.x9U-rHwgdblg38quvVQvutT-bYm7oDF7j1FWC6ICEkYr3WBk7y8CwcnxPu3SPggOEZwHM3byF-QXBSTBxm6qBQ",
+      "org": "acme",
+      "now": "2026-07-01T00:00:00Z",
+      "refusal": "",
+      "state": "active",
+      "days_left": 335,
+      "honoured": true,
+      "enabled": [
+        "scim",
+        "sso"
+      ]
+    },
+    {
+      "name": "unlimited seats is zero, not nobody",
+      "why": "Zero reading as a limit of none would lock every customer on an unmetered licence out of their own directory.",
+      "token": "aflic_eyJpZCI6ImxpYy1jb3JwdXMiLCJvcmciOiJhY21lIiwicGxhbiI6ImVudGVycHJpc2UiLCJmZWF0dXJlcyI6WyJzc28iLCJzY2ltIl0sInNlYXRzIjowLCJpc3N1ZWRfYXQiOiIyMDI2LTA2LTAxVDAwOjAwOjAwWiIsImV4cGlyZXNfYXQiOiIyMDI3LTA2LTAxVDAwOjAwOjAwWiIsImtpZCI6ImNvcnB1cy0xIn0.FQgQxlltKDvVgo8cAtMqWvhBb1jyz2qImqW-Ud5OsyVFhUzbOeMMUoNYmbNxlpVagpXB_fBGCALAo9AQH9-hDA",
+      "org": "acme",
+      "now": "2026-07-01T00:00:00Z",
+      "refusal": "",
+      "state": "active",
+      "days_left": 335,
+      "honoured": true,
+      "enabled": [
+        "scim",
+        "sso"
+      ],
+      "seats": [
+        {
+          "current": 0,
+          "exceeded": false
+        },
+        {
+          "current": 1000,
+          "exceeded": false
+        }
+      ]
+    },
+    {
+      "name": "a trial license is still a license",
+      "why": "The trial flag changes what an operator is told and must not change what is permitted.",
+      "token": "aflic_eyJpZCI6ImxpYy1jb3JwdXMiLCJvcmciOiJhY21lIiwicGxhbiI6ImVudGVycHJpc2UiLCJmZWF0dXJlcyI6WyJzc28iLCJzY2ltIl0sInNlYXRzIjoyNSwiaXNzdWVkX2F0IjoiMjAyNi0wNi0wMVQwMDowMDowMFoiLCJleHBpcmVzX2F0IjoiMjAyNy0wNi0wMVQwMDowMDowMFoiLCJ0cmlhbCI6dHJ1ZSwia2lkIjoiY29ycHVzLTEifQ.s0efurfgcqddtis4P7HVxhpiVeGg3CwJXFMTEvrxAhgXG4EJgYsIc1t1iM5ZmRABSpDLozKU2GBCZ9-n6BY4AQ",
+      "org": "acme",
+      "now": "2026-07-01T00:00:00Z",
+      "refusal": "",
+      "state": "active",
+      "days_left": 335,
+      "honoured": true,
+      "enabled": [
+        "scim",
+        "sso"
+      ]
+    },
+    {
+      "name": "signed by a key this installation does not trust",
+      "why": "Distinct from tampered, because the two send an operator to two different places: one to ask for a licence signed by a current key, the other to suspect the file.",
+      "token": "aflic_eyJpZCI6ImxpYy1jb3JwdXMiLCJvcmciOiJhY21lIiwicGxhbiI6ImVudGVycHJpc2UiLCJmZWF0dXJlcyI6WyJzc28iXSwic2VhdHMiOjAsImlzc3VlZF9hdCI6IjIwMjYtMDYtMDFUMDA6MDA6MDBaIiwiZXhwaXJlc19hdCI6IjIwMjctMDYtMDFUMDA6MDA6MDBaIiwia2lkIjoibm90LXRydXN0ZWQifQ.oV8PEmTtmv_8MivJ2wzQtnStLn6itoVJyiqBtTmXqwG9_o69sYMWzxboKHcw-ByZ8rjSoIaPH9K1oM8JJEHiAQ",
+      "org": "acme",
+      "now": "2026-07-01T00:00:00Z",
+      "refusal": "unknown_key",
+      "days_left": 0,
+      "honoured": false,
+      "enabled": []
+    },
+    {
+      "name": "the payload was edited after signing",
+      "why": "The one property the wire format exists to have.",
+      "token": "aflic_eyJpZCI6ImxpYy1jb3JwdXMiLCJvcmciOiJhY21mIiwicGxhbiI6ImVudGVycHJpc2UiLCJmZWF0dXJlcyI6WyJzc28iLCJzY2ltIl0sInNlYXRzIjoyNSwiaXNzdWVkX2F0IjoiMjAyNi0wNi0wMVQwMDowMDowMFoiLCJleHBpcmVzX2F0IjoiMjAyNy0wNi0wMVQwMDowMDowMFoiLCJraWQiOiJjb3JwdXMtMSJ9.xj4Z8HqKtnZMlH4tQ7QaURsQQgnjWycTpQ0hiBD5wsE2aXlR4Ph5J2vGNF_SyWSmjxuCOgBbRMZNxG8H-PjvBw",
+      "org": "acme",
+      "now": "2026-07-01T00:00:00Z",
+      "refusal": "tampered",
+      "days_left": 0,
+      "honoured": false,
+      "enabled": []
+    },
+    {
+      "name": "not a license at all",
+      "why": "Somebody pastes the wrong thing into a deployment. Both sides refuse as malformed rather than as tampered, because tampered sends a reader looking for an attacker.",
+      "token": "not-a-license",
+      "org": "acme",
+      "now": "2026-07-01T00:00:00Z",
+      "refusal": "malformed",
+      "days_left": 0,
+      "honoured": false,
+      "enabled": []
+    },
+    {
+      "name": "the prefix is right and the rest is not base64url",
+      "why": "A truncated or re-encoded paste. Node's base64url decoder discards rubbish rather than refusing it, so this is the case where a round trip check on one side and none on the other would produce two different verdicts.",
+      "token": "aflic_not!base64.also!not",
+      "org": "acme",
+      "now": "2026-07-01T00:00:00Z",
+      "refusal": "malformed",
+      "days_left": 0,
+      "honoured": false,
+      "enabled": []
+    },
+    {
+      "name": "one part, no dot",
+      "why": "The shape of a licence cut at a line break in an email.",
+      "token": "aflic_eyJpZCI6ImxpYy1jb3JwdXMiLCJvcmciOiJhY21lIiwicGxhbiI6ImVudGVycHJpc2UiLCJmZWF0dXJlcyI6WyJzc28iLCJzY2ltIl0sInNlYXRzIjoyNSwiaXNzdWVkX2F0IjoiMjAyNi0wNi0wMVQwMDowMDowMFoiLCJleHBpcmVzX2F0IjoiMjAyNy0wNi0wMVQwMDowMDowMFoiLCJraWQiOiJjb3JwdXMtMSJ9",
+      "org": "acme",
+      "now": "2026-07-01T00:00:00Z",
+      "refusal": "malformed",
+      "days_left": 0,
+      "honoured": false,
+      "enabled": []
+    },
+    {
+      "name": "whitespace and newlines survive the paste",
+      "why": "A licence copied out of an email arrives wrapped. Refusing that is a support ticket rather than a security property, and both sides have to be equally forgiving.",
+      "token": "  aflic_eyJpZCI6ImxpYy1jb3JwdXMiLCJvcmciOiJhY21lIiwicGxhbiI6ImVudGVycHJpc2UiLCJmZWF0dXJlcyI6WyJzc28iLCJzY2ltIl0sInNlYXRzIjoyNSwiaXNzdWVkX2F0IjoiMjAyNi0wNi0wMVQwMDowMD\n  owMFoiLCJleHBpcmVzX2F0IjoiMjAyNy0wNi0wMVQwMDowMDowMFoiLCJraWQiOiJjb3JwdXMtMSJ9.xj4Z8HqKtnZMlH4tQ7QaURsQQgnjWycTpQ0hiBD5wsE2aXlR4Ph5J2vGNF_SyWSmjxuCOgBbRMZNxG8H-PjvBw\n",
+      "org": "acme",
+      "now": "2026-07-01T00:00:00Z",
+      "refusal": "",
+      "state": "active",
+      "days_left": 335,
+      "honoured": true,
+      "enabled": [
+        "scim",
+        "sso"
+      ]
+    }
+  ]
+}

--- a/ee/web/server/package.json
+++ b/ee/web/server/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "start": "node src/main.ts",
-    "test": "node --test --test-concurrency=1 test/license.test.ts && node --test --test-concurrency=1 test/entrypoint.test.ts",
+    "test": "node --test --test-concurrency=1 test/license.test.ts && node --test --test-concurrency=1 test/entrypoint.test.ts && node --test --test-concurrency=1 test/vectors.test.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {

--- a/ee/web/server/src/license.ts
+++ b/ee/web/server/src/license.ts
@@ -22,10 +22,21 @@
 //      field, so there is no negotiation to disagree about. Ed25519 over the
 //      raw payload bytes, and both languages have that primitive natively.
 //   2. ee/license-vectors.json is a corpus of tokens with the verdict each one
-//      must produce. test/license.test.ts here reads it and
-//      ee/engine/license/vectors_test.go reads the same file. A divergence
-//      fails one side or the other on the next run rather than in a customer's
+//      must produce. ee/engine/license/vectors_test.go emits it and
+//      test/vectors.test.ts here reads the same file. A divergence fails one
+//      side or the other on the next run rather than in a customer's
 //      installation.
+//
+//      THIS PARAGRAPH WAS FICTION WHEN IT WAS WRITTEN, and it is recorded
+//      rather than quietly corrected. The corpus did not exist, neither of the
+//      two files it named existed, and the string appeared nowhere in either
+//      suite. It said "reads it" in the present tense while nothing read
+//      anything, in the file whose whole purpose is to name this hazard
+//      honestly. ee/README.md records three claims of exactly this shape and
+//      the lesson written under them is the reason this note stays: a claim
+//      resting on an invented mechanism reads identically to a true one until
+//      somebody goes looking. Building it found a real divergence on the first
+//      run, which is what the paragraph had been promising to prevent.
 //   3. This file is deliberately smaller than the Go one. It does not issue,
 //      does not rotate, and does not persist. It answers one question.
 //
@@ -56,7 +67,12 @@ export type Feature =
   | 'compliance_packs'
   | 'air_gapped'
 
-/** Every feature a licence can carry, sorted, matching license.AllFeatures. */
+/** Every feature a licence can carry, sorted, matching license.AllFeatures.
+ *
+ *  "Matching" is checked rather than asserted: ee/license-vectors.json carries
+ *  the Go side's list and test/vectors.test.ts compares this one against it. It
+ *  used to be a sentence, and a sentence is what the two lists had between them
+ *  for as long as both existed. */
 export const ALL_FEATURES: readonly Feature[] = [
   'air_gapped',
   'audit_stream',
@@ -71,6 +87,24 @@ export const ALL_FEATURES: readonly Feature[] = [
   'sso',
   'support_access',
 ]
+
+/** Features no build enforces anywhere, so a licence naming one permits
+ *  nothing.
+ *
+ *  THE DIVERGENCE THIS EXISTS TO END. The Go reader has always filtered these,
+ *  in Evaluate, by asking license.Shipped. This one did not: it permitted every
+ *  feature a licence named. So the same key made the engine say billing is not
+ *  permitted and the control plane print that it is, in one deployment, to one
+ *  customer, with neither binary aware of the other. It is not reachable through
+ *  the two gates the entry point mounts today, and it IS reachable through the
+ *  startup line that reports what the licence permits right now, which is the
+ *  line an operator reads to check what they bought.
+ *
+ *  The definition is ee/engine/license's notShipped map, which carries the
+ *  reason each one is refused; licensegen prints those and this list does not
+ *  need them. The names are held together by ee/license-vectors.json, which
+ *  carries the Go side's list and a case whose licence names one. */
+export const NOT_SHIPPED: readonly string[] = ['billing', 'enterprise_dashboard']
 
 export interface Claims {
   id: string
@@ -366,12 +400,26 @@ export function evaluate(claims: Claims, ev: Evaluation): Status {
 
   const expired = claims.expiresAt.toUTCString()
   if (ev.now.getTime() >= graceEnds.getTime()) {
-    return statusOf('expired', claims, empty, -daysBetween(graceEnds, ev.now),
+    // Negated through a variable, and zero returned as itself.
+    //
+    // At the exact instant the grace period ends, daysBetween is 0 and `-0` in
+    // JavaScript is a value distinct from `0`: Object.is separates them and so
+    // does a strict comparison in a test. The Go side is an int and has no such
+    // value, so the two implementations answered differently at a boundary that
+    // is reached once per licence. Found by the shared corpus on its first run,
+    // which is what the corpus is for.
+    const behind = daysBetween(graceEnds, ev.now)
+    return statusOf('expired', claims, empty, behind === 0 ? 0 : -behind,
       `This license expired on ${expired} and its grace period has ended. Enterprise features ` +
         `are off and every enterprise setting is preserved; renewing turns them back on unchanged.`)
   }
 
-  const permitted = new Set<string>(claims.features)
+  // Filtered, not copied. A feature this build enforces nowhere is carried in
+  // the claims and never permitted, which is also how an unknown name from a
+  // later release is treated: the licence names something no binary can act on,
+  // and answering true would tell every caller a capability is available when
+  // asking for it does nothing.
+  const permitted = new Set<string>(claims.features.filter((f) => !NOT_SHIPPED.includes(f)))
   let state: State
   let daysLeft: number
   let warning: string

--- a/ee/web/server/test/vectors.test.ts
+++ b/ee/web/server/test/vectors.test.ts
@@ -1,0 +1,192 @@
+// The shared licence corpus, read here and emitted by the Go reader.
+//
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+//
+// WHAT THIS PROVES THAT license.test.ts CANNOT. That file drives this
+// implementation against licences it mints itself, so it proves this reader is
+// internally consistent. It would have stayed green through every divergence
+// between this reader and the engine's, because it never asks the engine
+// anything. There are two implementations of one decision here, which this
+// repository's own list names as its most expensive recurring defect, and the
+// only thing that can catch a drift between two implementations is a corpus
+// neither of them owns.
+//
+// ee/engine/license/vectors_test.go emits ee/license-vectors.json from the Go
+// implementation, which license.ts's own header calls the definition. This
+// reads the same file and has to reproduce every verdict in it. A change to
+// either side that alters a decision now fails a test in one language or the
+// other, on the next run, rather than in a customer's installation where one
+// binary says a feature is permitted and the other says it is not.
+//
+// It found exactly that on its first run: this side permitted every feature a
+// licence named, and the engine has always filtered the ones no build enforces.
+//
+// WHAT IT DOES NOT COMPARE, said here rather than left to be assumed checked.
+// The verdicts: the refusal, the state, the days left, whether the licence is
+// honoured, which features are permitted, and the seat limit as a number. NOT
+// the warning sentences, which differ today in how they format a date, this
+// side using toUTCString and the Go side "2 January 2006". Both are shown to an
+// operator, so it is worth fixing, and it is a difference in prose for two
+// surfaces rather than in what either binary permits.
+
+import { describe, it, before } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  ALL_FEATURES,
+  NOT_SHIPPED,
+  LicenseRefused,
+  evaluate,
+  parseLicense,
+  trustedKeys,
+  type Status,
+} from '../src/license.ts'
+
+interface SeatProbe {
+  current: number
+  exceeded: boolean
+}
+
+interface Vector {
+  name: string
+  why: string
+  token: string
+  org: string
+  now: string
+  last_seen?: string
+  revoked?: string[]
+  refusal: string
+  state?: string
+  days_left: number
+  honoured: boolean
+  enabled: string[]
+  seats?: SeatProbe[]
+}
+
+interface Corpus {
+  note: string
+  keys: string
+  all_features: string[]
+  not_shipped: string[]
+  cases: Vector[]
+}
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const corpusPath = path.join(here, '..', '..', '..', 'license-vectors.json')
+
+let corpus: Corpus
+
+before(async () => {
+  // Read once, and REFUSED rather than skipped when it is not there. A suite
+  // that quietly passes because it could not find the thing it compares against
+  // is the failure this repository keeps finding in its own instruments: the
+  // absence of an answer read as a satisfied condition.
+  let body: string
+  try {
+    body = await readFile(corpusPath, 'utf8')
+  } catch (err) {
+    throw new Error(
+      `could not read the licence corpus at ${corpusPath}. It is emitted by ` +
+        `ee/engine/license/vectors_test.go; regenerate it with ` +
+        `'GOWORK=off go test ./license -run TestVectors -update-vectors' from ee/engine. ` +
+        `Refusing to skip: a run that proves nothing about a corpus is worse than a red one. ` +
+        `Underlying error: ${err instanceof Error ? err.message : String(err)}`,
+    )
+  }
+  corpus = JSON.parse(body) as Corpus
+  assert.ok(
+    Array.isArray(corpus.cases) && corpus.cases.length > 0,
+    `found no cases in ${corpusPath}, so this check is looking in the wrong place or the ` +
+      `corpus was emptied. That is a failure, not a pass.`,
+  )
+  assert.ok(corpus.keys, 'the corpus publishes no keys, so nothing in it can verify')
+})
+
+describe('the two licence readers agree', () => {
+  it('carries the same list of features as the engine', () => {
+    // The list was duplicated across two languages with a comment saying it
+    // matched, which is what nothing was checking.
+    assert.deepEqual([...ALL_FEATURES].sort(), [...corpus.all_features].sort())
+  })
+
+  it('refuses the same features as unshipped', () => {
+    assert.deepEqual([...NOT_SHIPPED].sort(), [...corpus.not_shipped].sort())
+  })
+
+  it('reproduces every verdict in the corpus', () => {
+    const keys = trustedKeys(corpus.keys)
+    let checked = 0
+
+    for (const c of corpus.cases) {
+      const label = `${c.name}\n  why this case exists: ${c.why}`
+
+      let status: Status | null = null
+      let refusal = ''
+      try {
+        const claims = parseLicense(c.token, keys)
+        status = evaluate(claims, {
+          org: c.org,
+          now: new Date(c.now),
+          lastSeen: c.last_seen ? new Date(c.last_seen) : null,
+          revoked: new Set(c.revoked ?? []),
+        })
+      } catch (err) {
+        if (!(err instanceof LicenseRefused)) throw err
+        refusal = err.refusal
+      }
+
+      assert.equal(refusal, c.refusal, `refusal for ${label}`)
+      if (c.refusal !== '') {
+        checked += 1
+        continue
+      }
+      assert.ok(status, `no status and no refusal for ${label}`)
+      assert.equal(status.state, c.state, `state for ${label}`)
+      assert.equal(status.daysLeft, c.days_left, `days left for ${label}`)
+      assert.equal(status.honoured(), c.honoured, `honoured for ${label}`)
+      assert.deepEqual(
+        ALL_FEATURES.filter((f) => status!.enabled(f)).sort(),
+        [...c.enabled].sort(),
+        `permitted features for ${label}`,
+      )
+      for (const probe of c.seats ?? []) {
+        assert.equal(
+          status.seatsExceeded(probe.current),
+          probe.exceeded,
+          `the seat limit at ${probe.current} members for ${label}`,
+        )
+      }
+      checked += 1
+    }
+
+    // The count, asserted. A loop over an array that turned out to be empty
+    // passes in silence, and this file's whole value is the number of cases it
+    // actually compared.
+    assert.equal(
+      checked,
+      corpus.cases.length,
+      `compared ${checked} of ${corpus.cases.length} cases, so some were skipped`,
+    )
+  })
+
+  it('covers every state and every refusal the corpus can carry', () => {
+    // The check on the corpus rather than on the implementation, and the mirror
+    // of the one the Go side makes. A corpus that quietly stopped carrying a
+    // state would pass here for ever while the two sides drifted on exactly the
+    // case it dropped.
+    const states = new Set(corpus.cases.filter((c) => c.refusal === '').map((c) => c.state))
+    const refusals = new Set(corpus.cases.filter((c) => c.refusal !== '').map((c) => c.refusal))
+
+    // 'none' is deliberately absent: it is the answer to having no token at all,
+    // and a corpus of tokens cannot carry the case of there being none. Both
+    // sides test it directly.
+    for (const want of ['active', 'grace', 'expired', 'revoked', 'wrong_org', 'clock_rollback']) {
+      assert.ok(states.has(want), `no case in the corpus produces the state ${want}`)
+    }
+    for (const want of ['malformed', 'tampered', 'unknown_key']) {
+      assert.ok(refusals.has(want), `no case in the corpus produces the refusal ${want}`)
+    }
+  })
+})


### PR DESCRIPTION
## The failure

`ee/web/server/src/license.ts` names this repository's most expensive recurring
defect in its own header, two implementations of one decision, and then lists
three things holding the Go reader and the TypeScript reader together. The
second is this, in the present tense:

> `ee/license-vectors.json` is a corpus of tokens with the verdict each one must
> produce. `test/license.test.ts` here reads it and
> `ee/engine/license/vectors_test.go` reads the same file.

**None of it was in the tree.** Not the corpus, not either of the two files it
named, not `ee/engine/license/testdata`, and not one occurrence of the string in
either suite. `ee/README.md` records three claims of exactly that shape, and the
lesson written under them is that a claim resting on an invented mechanism reads
identically to a true one until somebody goes looking. The comment is corrected
in place and its own history kept, for the same reason that section keeps its.

What was really holding the two readers together is one item from the same list
and it is genuine: the wire format is deliberately not a JWT and carries no
algorithm field, so there is nothing to negotiate. That is structural, and it
catches none of expiry, grace, clock rollback, org matching, seats or unknown
key handling, which is where two parsers of one format actually diverge.

## The two divergences it found on its first run

**One reaches a customer.** `Evaluate` on the Go side has always refused to
permit a feature no build enforces anywhere, by asking `Shipped`. This side did
not: it permitted every feature a licence named. So one key made the engine say
billing is not permitted while the control plane printed that it is, in one
deployment, to one buyer, with neither binary aware of the other. Not reachable
through the two gates the enterprise entry point mounts today. Reachable through
the startup line that reports what the licence permits right now, which is the
line an operator reads to check what they bought.

**One is at a boundary.** At the exact instant a grace period ends this side
returned `-0` days left, which JavaScript treats as a value distinct from `0`,
and the Go side returned `0`, because it is an integer and has no such value.
Invisible in a rendered string and not invisible to anything comparing the two.

## The shape

The one the community tree already uses three times, for the policy engine, for
webhooks and for mock packs: **Go emits, the other language proves it
reproduces.** Twenty one cases covering every state and every refusal either
implementation can produce, and both sides carry a second test asserting that
coverage is complete, because a corpus that quietly stopped carrying a case
would pass for ever while the two sides drifted on exactly the one it dropped.

It also binds two lists that were duplicated across the two languages with a
comment saying they matched and nothing checking it: every feature a licence can
carry, and the features no build ships.

**No signing key is added and none is needed.** The corpus carries the public
half in the form an operator pastes into a deployment, and the tokens are
fixtures: regenerating recomputes the verdicts and leaves the tokens alone, so a
semantic change shows as a diff of verdicts rather than of the whole file.

**The instant is in the corpus, not implied by the clock.** Every case carries
its own `now`, and where the case is about a rolled back clock, its own
`last_seen`, both as RFC3339 strings that each side parses. Nothing here reads
the wall clock, so no case expires on its own and a run in a year answers what a
run today answers. That is also what makes the two expiry boundary cases
possible: they name the exact instant of expiry and the exact instant the grace
period ends, which a relative offset from `now()` could never hit.

## Mutation tested, and the cell that survived was the point

Nineteen cells, each aimed at one assertion, each confirmed red in the test it
was aimed at rather than in a neighbour.

**The seat limit broken by one left the Go suite GREEN.** The cause was in the
new test file, not the implementation: `out := c` copies the slice header, so
the computed answer was written into the same backing array as the expected one
and the comparison was a slice against itself. An assertion that could not say
no, found by the only instrument that looks for that. Fixed, and the cell now
fails on the case it names.

| side | cells | survived |
| --- | --- | --- |
| Go, `ee/engine/license` | 9 | 0 after the fix, 1 before it |
| TypeScript, `ee/web/server` | 10 | 0 |

The Go cells: unshipped features no longer filtered; no rollback tolerance;
grace 14 to 7 days; org compared exactly; the seat limit off by one; the corpus
emptied; the corpus file deleted; the corpus losing its tampered case; the
corpus feature list losing an entry. The TypeScript cells are the same set plus
`NOT_SHIPPED` and `ALL_FEATURES` losing an entry each.

## What was run

- `GOWORK=off go test ./license -run TestVectors -count=1` rc=0, 21 subtests,
  and `gofmt -l` and `go vet ./license` both clean.
- `node --test test/vectors.test.ts` **pass 4, fail 0**, and the existing
  `test/license.test.ts` still **pass 20, fail 0** with the fix in place.
- `npm --prefix ee/web run typecheck` rc=0 across all five workspaces.
- `gatecheck` rc=0, so the added `node --test` invocation needs no new justfile
  recipe. Also `changecheck`, `prosecheck`, `actioncheck`, `claimcheck` and
  `scanrepo` rc=0, the last confirming the corpus adds no credential.

## Note for the reviewer

**#324 merged while this was in flight** and this branch was rebased onto the
squash, so it carries only its own commit and its base is `main`.

**What the corpus does NOT compare, stated rather than left to be assumed
checked:** the verdicts only. The refusal, the state, the days left, whether the
licence is honoured, which features are permitted, and the seat limit as a
number. **Not the warning sentences**, which differ today in how they format a
date: `toUTCString` on the control plane against `"2 January 2006"` in the
engine. Both are shown to an operator, so it is worth fixing, and it is a
difference in prose for two surfaces rather than in what either binary permits.
Widening the corpus to cover it would have meant changing one of the two
messages in this pull request, which is a separate decision.
