### PR TITLE
engine: the encoded pass found the run and could not find where it began

### DIFF
--- a/engine/internal/proxyimage/sources.gen.go
+++ b/engine/internal/proxyimage/sources.gen.go
@@ -3266,11 +3266,7 @@ func scanEncoded(text, where string) []Finding {
 			at := i + idx
 			i = at + len(marker)
 
-			lo, hi := base64Run(text, at)
-			if hi-lo > maxEncoded {
-				continue
-			}
-			decoded, ok := decodeRun(text[lo:hi])
+			decoded, ok := decodeFrom(text, at)
 			if !ok {
 				continue
 			}
@@ -3286,54 +3282,70 @@ func scanEncoded(text, where string) []Finding {
 	return out
 }
 
-// base64Run returns the bounds of the base64 run containing at.
-func base64Run(text string, at int) (int, int) {
-	lo := at
-	for lo > 0 && base64Rune(rune(text[lo-1])) {
-		lo--
-	}
+// base64End returns where the base64 run containing at stops.
+func base64End(text string, at int) int {
 	hi := at
 	for hi < len(text) && base64Rune(rune(text[hi])) {
 		hi++
 	}
-	return lo, hi
+	return hi
 }
 
-// decodeRun decodes a base64 run whose start may not be the start of the
-// encoding.
+// decodeFrom decodes the encoding the marker at at belongs to.
 //
-// Four attempts, because the run found by walking backwards over base64
-// characters can begin up to three characters inside a group: a marker for one
-// of the two offset alignments sits behind bytes that are themselves base64
-// characters. Whichever attempt yields a PEM private key is the right one, and
-// nothing else is accepted, so a blob that decodes to arbitrary bytes is not a
-// finding.
-func decodeRun(run string) (string, bool) {
-	for k := 0; k < 4 && k < len(run); k++ {
-		body := run[k:]
+// The start is derived from the marker rather than found by walking backwards
+// over base64 characters, and that is the difference between working and
+// nearly working. base64 encodes three bytes into four characters, so a marker
+// for the two offset alignments begins exactly four characters into the
+// encoding and a marker for the aligned case begins at its start. Two
+// candidates cover all three, and neither depends on what sits in front: a key
+// pasted straight after other base64, with no separator, has no run boundary to
+// walk back to and the walk would begin decoding from the wrong byte.
+//
+// Only a decode that yields a PEM private key is accepted, and that is what
+// picks between the candidates rather than a nicety on top. The first candidate
+// decodes cleanly for an offset key too, into bytes shifted by three, which
+// look like base64 and are not the key. Taking the first thing that decodes
+// would return those.
+//
+// Nothing checks what sits in front of the second candidate, and that is
+// deliberate. A guard was written here to require those four characters to be
+// base64, and breaking it changed no answer: a character base64 has no meaning
+// for makes the decode itself fail, and a decode that fails is already a
+// candidate skipped. A check that cannot say no is worse than no check,
+// because it reads as protection.
+func decodeFrom(text string, at int) (string, bool) {
+	hi := base64End(text, at)
+	for _, start := range []int{at, at - 4} {
+		if start < 0 || hi-start > maxEncoded {
+			continue
+		}
+		body := text[start:hi]
 		body = body[:len(body)-len(body)%4]
 		if len(body) < 4 {
 			continue
 		}
 		decoded, err := base64.StdEncoding.DecodeString(body)
 		if err != nil {
-			// A run that carries padding in the middle, which happens when two
+			// A run carrying padding in the middle, which happens when two
 			// values sit side by side, decodes up to that point. Everything
 			// before the padding is still worth reading.
-			if cut := strings.IndexByte(body, '='); cut > 0 {
-				body = body[:cut-cut%4]
-				if len(body) < 4 {
-					continue
-				}
-				decoded, err = base64.StdEncoding.DecodeString(body)
+			cut := strings.IndexByte(body, '=')
+			if cut <= 0 {
+				continue
 			}
+			body = body[:cut-cut%4]
+			if len(body) < 4 {
+				continue
+			}
+			decoded, err = base64.StdEncoding.DecodeString(body)
 			if err != nil {
 				continue
 			}
 		}
-		text := string(decoded)
-		if strings.Contains(text, "-----BEGIN") && strings.Contains(text, "PRIVATE KEY") {
-			return text, true
+		out := string(decoded)
+		if strings.Contains(out, "-----BEGIN") && strings.Contains(out, "PRIVATE KEY") {
+			return out, true
 		}
 	}
 	return "", false

--- a/engine/pkg/livekey/livekey.go
+++ b/engine/pkg/livekey/livekey.go
@@ -391,11 +391,7 @@ func scanEncoded(text, where string) []Finding {
 			at := i + idx
 			i = at + len(marker)
 
-			lo, hi := base64Run(text, at)
-			if hi-lo > maxEncoded {
-				continue
-			}
-			decoded, ok := decodeRun(text[lo:hi])
+			decoded, ok := decodeFrom(text, at)
 			if !ok {
 				continue
 			}
@@ -411,54 +407,70 @@ func scanEncoded(text, where string) []Finding {
 	return out
 }
 
-// base64Run returns the bounds of the base64 run containing at.
-func base64Run(text string, at int) (int, int) {
-	lo := at
-	for lo > 0 && base64Rune(rune(text[lo-1])) {
-		lo--
-	}
+// base64End returns where the base64 run containing at stops.
+func base64End(text string, at int) int {
 	hi := at
 	for hi < len(text) && base64Rune(rune(text[hi])) {
 		hi++
 	}
-	return lo, hi
+	return hi
 }
 
-// decodeRun decodes a base64 run whose start may not be the start of the
-// encoding.
+// decodeFrom decodes the encoding the marker at at belongs to.
 //
-// Four attempts, because the run found by walking backwards over base64
-// characters can begin up to three characters inside a group: a marker for one
-// of the two offset alignments sits behind bytes that are themselves base64
-// characters. Whichever attempt yields a PEM private key is the right one, and
-// nothing else is accepted, so a blob that decodes to arbitrary bytes is not a
-// finding.
-func decodeRun(run string) (string, bool) {
-	for k := 0; k < 4 && k < len(run); k++ {
-		body := run[k:]
+// The start is derived from the marker rather than found by walking backwards
+// over base64 characters, and that is the difference between working and
+// nearly working. base64 encodes three bytes into four characters, so a marker
+// for the two offset alignments begins exactly four characters into the
+// encoding and a marker for the aligned case begins at its start. Two
+// candidates cover all three, and neither depends on what sits in front: a key
+// pasted straight after other base64, with no separator, has no run boundary to
+// walk back to and the walk would begin decoding from the wrong byte.
+//
+// Only a decode that yields a PEM private key is accepted, and that is what
+// picks between the candidates rather than a nicety on top. The first candidate
+// decodes cleanly for an offset key too, into bytes shifted by three, which
+// look like base64 and are not the key. Taking the first thing that decodes
+// would return those.
+//
+// Nothing checks what sits in front of the second candidate, and that is
+// deliberate. A guard was written here to require those four characters to be
+// base64, and breaking it changed no answer: a character base64 has no meaning
+// for makes the decode itself fail, and a decode that fails is already a
+// candidate skipped. A check that cannot say no is worse than no check,
+// because it reads as protection.
+func decodeFrom(text string, at int) (string, bool) {
+	hi := base64End(text, at)
+	for _, start := range []int{at, at - 4} {
+		if start < 0 || hi-start > maxEncoded {
+			continue
+		}
+		body := text[start:hi]
 		body = body[:len(body)-len(body)%4]
 		if len(body) < 4 {
 			continue
 		}
 		decoded, err := base64.StdEncoding.DecodeString(body)
 		if err != nil {
-			// A run that carries padding in the middle, which happens when two
+			// A run carrying padding in the middle, which happens when two
 			// values sit side by side, decodes up to that point. Everything
 			// before the padding is still worth reading.
-			if cut := strings.IndexByte(body, '='); cut > 0 {
-				body = body[:cut-cut%4]
-				if len(body) < 4 {
-					continue
-				}
-				decoded, err = base64.StdEncoding.DecodeString(body)
+			cut := strings.IndexByte(body, '=')
+			if cut <= 0 {
+				continue
 			}
+			body = body[:cut-cut%4]
+			if len(body) < 4 {
+				continue
+			}
+			decoded, err = base64.StdEncoding.DecodeString(body)
 			if err != nil {
 				continue
 			}
 		}
-		text := string(decoded)
-		if strings.Contains(text, "-----BEGIN") && strings.Contains(text, "PRIVATE KEY") {
-			return text, true
+		out := string(decoded)
+		if strings.Contains(out, "-----BEGIN") && strings.Contains(out, "PRIVATE KEY") {
+			return out, true
 		}
 	}
 	return "", false

--- a/engine/pkg/livekey/livekey_test.go
+++ b/engine/pkg/livekey/livekey_test.go
@@ -200,6 +200,11 @@ func privateKeyVectors() []liveVector {
 			base64.StdEncoding.EncodeToString([]byte("xy" + pkcs8))},
 		{"private key, base64 wrapped with a trailing value", "Private key",
 			encoded(pkcs8) + " " + fake("", 40, base64s)},
+		// No separator in front of it, which is what a run walked backwards
+		// from the marker cannot find the start of. The marker says where the
+		// encoding begins; the characters before it do not.
+		{"private key, base64 wrapped after other base64", "Private key",
+			fake("", 41, base64s) + encoded(pkcs8)},
 	}
 }
 

--- a/engine/pkg/livekey/livekey_test.go
+++ b/engine/pkg/livekey/livekey_test.go
@@ -196,7 +196,15 @@ func privateKeyVectors() []liveVector {
 		{"private key, base64 wrapped", "Private key", encoded(pkcs8)},
 		{"private key, base64 wrapped in a manifest value", "Private key",
 			"      - name: AF_GITHUB_APP_PRIVATE_KEY\n        value: " + encoded(pkcs8) + "\n"},
-		{"private key, base64 wrapped mid blob", "Private key",
+		// The three byte alignments, named, because base64 packs three bytes
+		// into four characters and where the key starts inside that group
+		// decides how its header reads once encoded. The case above is the
+		// aligned one. These are the other two, a key one and two bytes into
+		// the blob that carries it, and a pass that only reads the aligned one
+		// answers for the least interesting third of the problem.
+		{"private key, base64 wrapped one byte in", "Private key",
+			base64.StdEncoding.EncodeToString([]byte("x" + pkcs8))},
+		{"private key, base64 wrapped two bytes in", "Private key",
 			base64.StdEncoding.EncodeToString([]byte("xy" + pkcs8))},
 		{"private key, base64 wrapped with a trailing value", "Private key",
 			encoded(pkcs8) + " " + fake("", 40, base64s)},


### PR DESCRIPTION
Follow-up to #334, found by that change's own mutation matrix.

One cell survived. Breaking the check that the decoded bytes are a PEM private
key changed no answer any test could see, which meant that check was
decoration. It is not, and the reason it looked like decoration is that the
start of the encoding was being guessed.

The start was found by walking backwards over base64 characters to the edge of
the run, then trying the first four offsets from there. That works when the key
is the whole run. A key pasted straight after other base64, with no separator,
has no edge to walk back to, so the walk begins decoding from the wrong byte
and finds nothing.

The marker says where the encoding begins. base64 packs three bytes into four
characters, so a marker for the two offset alignments begins exactly four
characters into the encoding and one for the aligned case begins at its start.
Two candidates cover all three, and the PEM check is what chooses between them:
the first candidate decodes cleanly for an offset key as well, into bytes
shifted by three that look like base64 and are not the key. Taking the first
thing that decodes returns those.

A second guard went the other way. It required the four characters in front of
the second candidate to be base64, and breaking it changed no answer either. It
could not: a character base64 has no meaning for makes the decode fail, and a
failed decode is already a candidate skipped. It is removed rather than left
looking like protection, with the reason recorded where it stood.

## Verification

One vector added, a key with base64 immediately in front of it and no
separator, which is the case the walk could not read.

`livekey` refuses 25 of 25 live credential forms with 0 false positives over 30
synthetic non credentials, quoted from the test's own line.

Mutation cells, each aimed at the exact test with `-run` and the `=== RUN` count
required to be 1:

| Break | Test | Verdict |
| --- | --- | --- |
| the encoded pass stops checking what it decoded | `TestScan_FindsAPrivateKeyWhoeverIssuedIt` | CAUGHT |
| only the aligned candidate start is tried | `TestScan_FindsAPrivateKeyWhoeverIssuedIt` | CAUGHT |
| the encoded pass reports without running the pattern pass | `TestScan_TheEncodedPassAnswersOnlyForRealKeyMaterial` | CAUGHT |

The same third break aimed at `TestScan_RefusesNothingItShouldNot` survives, and
that is the answer to which test owns the line rather than a gap: that corpus
carries no base64 wrapped key for the encoded pass to reach.
