### PR TITLE
engine: the third verdict defaulted to trusting a harness that had said nothing

### DIFF
--- a/.changes/copy-on-write-had-two-answers-and-needed-three.md
+++ b/.changes/copy-on-write-had-two-answers-and-needed-three.md
@@ -1,30 +1,35 @@
 # changed
 
-The conformance suite had two answers, and the claim this whole database
-category is sold on could honestly be given neither of them.
+The conformance suite had two answers, and the claim this database category is
+sold on could honestly be given neither of them.
 
-`CopyOnWrite_BranchTimeMatchesTheDeclaration` decides by stopwatch, and the
-stopwatch is only as good as the storage under the run. Over a single local
-Postgres the only way a fake cloud control plane can hand back a branch carrying
-the golden's data is `CREATE DATABASE ... TEMPLATE`, which copies files. The
-large arm is then slower by seconds per gibibyte whatever the provider would do
-against the real service, so a provider that really does clone in constant time,
-declaring so truthfully, FAILED. Declaring false would have been green and false
-about the product; skipping the behaviour would have turned off the one
-instrument the wave was held for.
+`CopyOnWrite_BranchTimeMatchesTheDeclaration` decides by stopwatch, and over a
+fake cloud control plane on one local Postgres the stopwatch measures the
+harness. The only way such a fixture can hand back a branch carrying the
+golden's data is `CREATE DATABASE ... TEMPLATE`, which copies files, so a
+truthful `CopyOnWrite: true` failed and a `CopyOnWrite: false` passed
+comfortably. Both answers were about the harness.
 
-There is now a third verdict, `UNPROVEN`, distinct from pass and from fail. The
-measurement still runs in full and every number is still printed; what changes
-is what the readings are turned into. It is reachable only from a test fixture
-declaring, in prose, that the storage IT built copies every branch, it is
-refused unless the provider declares copy on write true, it is failed if the
-fixture's own readings contradict the declaration, and it is never rendered as a
-proved claim: `conformance.CopyOnWriteClaim` publishes the word `unproven`
-instead of the declared value.
+There is now a third verdict, `UNPROVEN`, distinct from pass and from fail and
+never called a skip. `Options.RealService` names the actual service a run
+drives, and LEAVING IT EMPTY is what produces the unproven verdict. It is an
+assertion of reality rather than an admission of simulation, because a field a
+fake sets to excuse itself is a field a fake can simply never set. Forgetting
+this one produces the safe answer.
 
-Three cells of the benchmark comparison table published `yes` for copy on write
-beside the words "not measured yet", which is the same unfalsifiable declaration
-one surface further out. They now say `unproven`, a ledger records the verdict
-for every provider that declares a value, and two sweeps check both directions:
-no declaration without a recorded verdict, and no published cell that disagrees
-with one.
+It is symmetric. An unasserted run is unproven whether the provider declares
+true or false, because the false side is the one that would otherwise ship: a
+snapshot restore provider passing comfortably against a copying fake publishes a
+certified claim about its service, and nobody rereads a green check.
+
+Six cells of the published comparison table carried a verdict beside the words
+"not measured yet". A ledger now records the verdict per provider, two sweeps
+check that no declaration lacks one and no published cell disagrees with one,
+and `conformance.CopyOnWriteClaim` renders an unproven declaration as the word
+`unproven` rather than as the declared value.
+
+Two providers were measured rather than assumed while proving this, both
+needing no account. `pgurl` declares false against a real Postgres and holds.
+`docker` declares true against a real daemon and holds, so the provider
+overview, which said its branch time grows with the database, was wrong and now
+says what the measurement says.

--- a/.changes/copy-on-write-had-two-answers-and-needed-three.md
+++ b/.changes/copy-on-write-had-two-answers-and-needed-three.md
@@ -17,7 +17,7 @@ assertion of reality rather than an admission of simulation, because a field a
 fake sets to excuse itself is a field a fake can simply never set. Forgetting
 this one produces the safe answer.
 
-It is symmetric. An unasserted run is unproven whether the provider declares
+It is symmetric. A run that asserts nothing is unproven whether the provider declares
 true or false, because the false side is the one that would otherwise ship: a
 snapshot restore provider passing comfortably against a copying fake publishes a
 certified claim about its service, and nobody rereads a green check.

--- a/docs/src/content/docs/contributing/provider-authoring.md
+++ b/docs/src/content/docs/contributing/provider-authoring.md
@@ -248,8 +248,8 @@ capability is being decided: a fake control plane over a real local Postgres doe
 **not** qualify, however real the Postgres is, because what the stopwatch timed
 was Postgres.
 
-**It is symmetric.** An unasserted run is unproven whether you declare `true` or
-`false`. The false side is the one worth spelling out, because it is the one that
+**It is symmetric.** A run that asserts nothing is unproven whether you declare
+`true` or `false`. The false side is the one worth spelling out, because it is the one that
 would otherwise ship: a snapshot restore provider declaring `false` against a
 copying fake passes comfortably, publishes a certified claim that its service is
 not copy on write, and nobody rereads a green check.

--- a/docs/src/content/docs/contributing/provider-authoring.md
+++ b/docs/src/content/docs/contributing/provider-authoring.md
@@ -216,56 +216,55 @@ Those two are complementary, so one of the two possible declarations is refused
 on every run. There is no reading of the stopwatch that lets both pass, which is
 the property a check needs before a green one means anything.
 
-### The third answer, for a harness that cannot exhibit the behaviour
+### The third answer, and why the default is unproven
 
-The stopwatch is only as good as the storage underneath the run, and there is a
-harness on which a truthful `CopyOnWrite: true` cannot pass. A fake cloud
+The stopwatch is only as good as the storage under the run, and a fake cloud
 control plane over one local Postgres can only hand back a branch carrying the
-golden's data with `CREATE DATABASE ... TEMPLATE`, which copies files. The large
-arm is then slower by seconds per gibibyte whatever the provider would do
-against the real service, so the stopwatch is reading the harness.
-
-Declaring `false` to get a green is a lie about the product. Skipping the
-behaviour turns off the one instrument that can refuse this category's central
-commercial claim. Loosening the allowance leaves it running, printing a verdict,
-and unable to refuse anything.
-
-So the behaviour has a third answer, **unproven**, and it is not a pass.
+golden's data with `CREATE DATABASE ... TEMPLATE`, which copies files. On that
+harness a truthful `CopyOnWrite: true` fails, and a `CopyOnWrite: false` passes
+comfortably. **Both answers are about the harness and neither is about your
+product**, so the behaviour has a third one.
 
 ```
 NOT PROVED BY THIS RUN. This is not a pass.
   UNPROVEN  aurora  CopyOnWrite_BranchTimeMatchesTheDeclaration
 ```
 
-`Options.HarnessCopiesEveryBranch` is the only thing that reaches it. It is a
-sentence your TEST FIXTURE writes about the storage it built, naming the
-mechanism, and it is nothing a provider can reach: `Capabilities()` is the thing
-under examination, and a subject that could excuse itself from a check is the
-unfalsifiable declaration this whole behaviour exists to refuse.
+**`Options.RealService` decides it, and leaving it empty is what produces the
+unproven verdict.** It is an assertion of reality, not an admission of
+simulation:
 
-Four things make it a verdict rather than a way out.
+```go
+conformance.RunDatabase(t, factory, conformance.Options{
+    RealService: "the real Neon API, against a real project",
+})
+```
 
-- **The measurement still runs, in full.** Both goldens are built, both arms are
-  timed, the ballast is weighed in the branch, and every number is printed.
-  Unproven changes what the readings are turned into, never whether they were
-  taken.
-- **It is refused unless you declare `CopyOnWrite: true`.** On the false side a
-  copying harness exhibits exactly what is being asserted, so there is nothing
-  it cannot reach.
-- **It is checked against your own readings.** A fixture that declares its
-  storage copies and then branches in constant time is failed for the
-  declaration. Setting the field on a harness that turns out to share storage
-  turns a pass into a failure, so it cannot be set defensively by somebody who
-  has not looked.
-- **It buys nothing you can publish.** `conformance.CopyOnWriteClaim` renders the
-  declaration as the word `unproven` wherever a customer would read it, the
-  ledger in `engine/conformance/ledger.go` records the verdict per provider, and
-  a test refuses a comparison table cell that says otherwise.
+A field you set to excuse a fake is a field a fake can simply never set, and the
+next author writes a control plane, never learns the field exists, and collects a
+measured verdict from a run that measured nothing. Forgetting this one produces
+the safe answer instead. Set it only when the run really drives the service whose
+capability is being decided: a fake control plane over a real local Postgres does
+**not** qualify, however real the Postgres is, because what the stopwatch timed
+was Postgres.
 
-What remains, and it is stated rather than papered over: a copying harness
-cannot tell an honest provider from a dishonest one, because the two produce the
-same readings on it. That is a property of the harness. Settling it needs the
-real service with an account, and nothing short of that does.
+**It is symmetric.** An unasserted run is unproven whether you declare `true` or
+`false`. The false side is the one worth spelling out, because it is the one that
+would otherwise ship: a snapshot restore provider declaring `false` against a
+copying fake passes comfortably, publishes a certified claim that its service is
+not copy on write, and nobody rereads a green check.
+
+**The measurement is not taken.** The verdict is decided before the behaviour
+runs, so two goldens and six branches could not change it, and publishing what a
+simulator timed invites somebody to quote it as though it were about the product.
+
+**It is not a skip, and it never uses the word.** A skip says this provider makes
+no such claim. An unproven says the provider does make the claim and this run
+could not reach it. The verdict is reprinted at the end of the run, the ledger in
+`engine/conformance/ledger.go` records it per provider, and
+`conformance.CopyOnWriteClaim` renders it, so the cell in the published
+comparison table reads `unproven` rather than blank. A blank cell is taken for a
+pass by every reader in a hurry.
 
 The suite makes a golden large by writing ballast into it from inside the `Mask`
 callback, so a provider needs no extra method: hand `Mask` a connection string
@@ -297,9 +296,12 @@ stronger statement than the one your run printed.
 the cost for a provider that bills by the gibibyte, and
 `AF_CONFORMANCE_COW_LARGE_BYTES` and its two siblings do the same from the
 environment for a machine that cannot afford the default. Both have floors, and
-both make the run say it was tuned. There is deliberately no way to skip the
-behaviour: a run that shrank says how far it shrank and what it could still
-refuse, and that can be read, where a run that skipped cannot.
+both make the run say it was tuned. Against a real service there is deliberately
+no way to skip the behaviour: a run that shrank says how far it shrank and what
+it could still refuse, and that can be read, where a run that skipped cannot.
+The one case that is neither a pass nor a shrunken run is the third verdict
+above, and it is not a skip either: it is a verdict, it prints, and it makes the
+claim unpublishable.
 
 `ExpectedBranchLatency` is checked the same way.
 `Branch_IsWithinTheDeclaredLatency` times the fastest of three branches of the

--- a/docs/src/content/docs/providers/overview.md
+++ b/docs/src/content/docs/providers/overview.md
@@ -19,14 +19,18 @@ database:
 
 | Provider | Where the data lives | Branch time | Needs |
 | --- | --- | --- | --- |
-| `docker` | A container on the machine running `af` | Grows with the database | A Docker daemon |
+| `docker` | A container on the machine running `af` | Flat, because the daemon's storage driver shares layers | A Docker daemon |
 | [`neon`](/docs/providers/neon) | A Neon project | Flat, because branches share storage | A Neon project and an API key |
 | [`dblab`](/docs/providers/dblab) | A Database Lab Engine you run | Flat, because clones are copy on write | A Database Lab Engine, ZFS, and its verification token |
 | [`supabase`](/docs/providers/supabase) | A Supabase branch, which is a whole separate project | Grows with the database, because a Supabase branch is created empty | A Supabase project on a paid plan and an access token |
 | [`pgurl`](/docs/providers/pgurl) | A database on any Postgres server you name | Grows with the database, because a branch is a server side file copy | A reachable Postgres and a role that may create databases |
 
-`docker` is the default and needs nothing. It is the right choice for a
-repository whose database is small enough that copying it is not the slow part.
+`docker` is the default and needs nothing. Its branch time is flat, measured
+rather than assumed: the conformance suite branches an 8 MiB golden and a 512 MiB
+one and the daemon's storage driver shares the layers, so the two cost the same.
+What is not flat is building the golden, because that commits an image. This row
+said "Grows with the database" until somebody ran the measurement, which is the
+whole argument for having one.
 
 `neon` is the right choice when it is. Neon branches are copy on write, so
 creating one takes about as long for a hundred gigabytes as for a hundred rows.

--- a/engine/conformance/cow.go
+++ b/engine/conformance/cow.go
@@ -257,91 +257,9 @@ func copyOnWriteAllowance(smallTimes []time.Duration) time.Duration {
 // that threshold and the behaviour would then be measuring an empty table.
 const ballastTable = "conformance_ballast"
 
-// minHarnessLimitReason is the shortest a fixture's declaration may be.
-//
-// Crude on purpose, and it is not the thing doing the work. The reason is
-// PRINTED, in the run's report and beside the verdict, so a reader judges it;
-// this only stops the field being set to a word. A fixture that has thought
-// about why its storage cannot exhibit the claim has a sentence about it, and
-// one that has not should notice that it is being asked for one.
-const minHarnessLimitReason = 24
-
-// harnessLimit reads the fixture's declaration and refuses the three ways it
-// could be a loophole rather than a verdict.
-//
-// WHY THIS IS ON Options AND NOT ON provider.Caps, which is the first
-// condition of the ruling and the whole design.
-//
-// Options is the argument the TEST FIXTURE passes to RunDatabase. Caps is what
-// the provider returns from Capabilities(), which is the thing under
-// examination. A field here is a claim about the storage the fixture built; a
-// field there would be a claim by the subject about itself, and the suite
-// exists because a declaration nothing can refuse is worth nothing. So
-// Capabilities() cannot reach this, no method of provider.Database is consulted
-// for it, and there is no route by which a provider asks to be excused.
-//
-// That placement is necessary and it is not sufficient, because a fixture and
-// the provider it exercises are often written by the same person. Three
-// refusals do the rest, and each one costs a fixture something real.
-//
-// ONE. It is refused unless the provider declares CopyOnWrite true. On the
-// false side the copying harness exhibits exactly the property being asserted,
-// so the check is fully armed and there is nothing to be unable to see. A lane
-// copying its fixture across the wave from a provider that clones to one that
-// restores from a snapshot is told, rather than quietly keeping a verdict that
-// no longer applies.
-//
-// TWO. It must be corroborated by the measurement, below. A fixture that
-// declares it copies and then branches in constant time has said something
-// false about itself, and the suite fails it for the declaration rather than
-// passing it on the reading. So the field cannot be set defensively by somebody
-// who has not looked: setting it on a fixture that is in fact flat turns a pass
-// into a failure. It is a falsifiable claim about the harness, not an
-// annotation on the provider.
-//
-// THREE. It buys nothing. It cannot produce a pass, the run prints a block
-// naming it, and CopyOnWriteClaim renders the declaration as "unproven"
-// wherever a customer would read it. A provider that copies and declares
-// otherwise reaches the same place by claiming this as it does by being caught:
-// a claim it cannot publish.
-//
-// What remains, stated rather than papered over, is that a copying harness
-// cannot tell an honest provider from a dishonest one, because the two produce
-// the same readings on it. That is a property of the harness and not a gap in
-// this code, and it is why the ruling keeps the other route open: proving the
-// provider against the real service with an account settles it, and nothing
-// short of that does.
-func (h *harness) harnessLimit(caps provider.Caps) string {
-	h.t.Helper()
-	limit := strings.TrimSpace(h.opts.HarnessCopiesEveryBranch)
-	if limit == "" {
-		return ""
-	}
-	if !caps.CopyOnWrite {
-		h.t.Fatalf("this fixture declares that its storage copies every branch, and the "+
-			"provider declares CopyOnWrite FALSE. A copying harness exhibits a copying "+
-			"provider exactly, so this behaviour can settle that declaration and has to. "+
-			"The declaration is for a provider whose claim the harness cannot reach, and "+
-			"there is nothing here it cannot reach. The fixture said: %q", limit)
-	}
-	if len(limit) < minHarnessLimitReason {
-		h.t.Fatalf("this fixture declares that its storage copies every branch and gives %q as "+
-			"the reason, which is %d characters. The reason is published beside the verdict "+
-			"and is the only thing a reader has to judge whether the limit is structural or "+
-			"an excuse, so it has to name the mechanism: what the harness does instead of "+
-			"sharing storage, and why it has no choice.", limit, len(limit))
-	}
-	return limit
-}
-
 // copyOnWriteMatchesTheDeclaration is the behaviour.
 func (h *harness) copyOnWriteMatchesTheDeclaration(ctx context.Context) {
 	caps := h.p.Capabilities()
-	// Read and refused FIRST, before two goldens are built and six branches are
-	// timed. A configuration this behaviour is going to refuse should be
-	// refused in a second rather than after half an hour of measuring, and a
-	// fixture whose declaration is wrong finds out on the run that made it.
-	limit := h.harnessLimit(caps)
 	small, large, samples := h.copyOnWriteSettings()
 
 	smallV, smallBytes := h.refreshWithBallast(ctx, small)
@@ -433,15 +351,6 @@ func (h *harness) copyOnWriteMatchesTheDeclaration(ctx context.Context) {
 
 	if caps.CopyOnWrite {
 		if grown > allowance {
-			// The third verdict, and the only place in the suite that reaches
-			// it. A copy was measured, and the fixture said before the run
-			// that its own storage copies whatever the provider does. Neither
-			// PROVED nor REFUTED is a statement these readings support: the
-			// stopwatch is reading the harness.
-			if limit != "" {
-				h.unprovenBecauseTheHarnessCopies(limit, delta, grown, allowance, marginal)
-				return
-			}
 			h.t.Fatalf("this provider declares CopyOnWrite, and branching the golden with %s "+
 				"more data in it took %s longer, which is past the %s this machine's noise "+
 				"can account for. Copy on write means a branch shares storage with its golden, "+
@@ -452,26 +361,6 @@ func (h *harness) copyOnWriteMatchesTheDeclaration(ctx context.Context) {
 				bytesText(delta), grown.Round(time.Millisecond),
 				allowance.Round(time.Millisecond), marginal)
 		}
-		// The fixture's declaration, falsified. It said its storage copies
-		// every branch and the stopwatch says this one did not, so the thing
-		// that is wrong is the declaration rather than the provider. Refused
-		// rather than ignored, because a fixture allowed to claim a limit it
-		// does not have could set the field on every run in the wave and never
-		// be contradicted, and the third verdict would then be an annotation
-		// instead of a measurement nobody could fake.
-		if limit != "" {
-			h.t.Fatalf("this fixture declares that its storage copies every branch, and "+
-				"branching the golden with %s more data in it took only %s longer, inside "+
-				"the %s this machine's noise can account for. The harness exhibited shared "+
-				"storage, so it was able to settle this claim after all and the verdict is "+
-				"the pass it just measured. The declaration is what is wrong here: it is a "+
-				"statement about the fixture, it is checked against the fixture's own "+
-				"readings on every run, and it cannot be carried from one harness to "+
-				"another as a property of the provider. The fixture said: %q",
-				bytesText(delta), grown.Round(time.Millisecond),
-				allowance.Round(time.Millisecond), limit)
-		}
-
 		// A pass here is a bounded claim and it says so. The bound is the
 		// number printed above: this run refused every copy slower than
 		// `refusable` seconds per GiB and could not have refused a faster one,
@@ -515,50 +404,6 @@ func (h *harness) copyOnWriteMatchesTheDeclaration(ctx context.Context) {
 			allowance.Round(time.Millisecond), ts.Round(time.Millisecond),
 			neededSizeAdvice(grown, allowance, delta))
 	}
-}
-
-// unprovenBecauseTheHarnessCopies records and prints the third verdict.
-//
-// It prints the same numbers a pass or a failure would, because the reading is
-// not in doubt and is not what the verdict turns on: a copy was measured, at a
-// rate the run states, and the only open question is whose copy it was. A
-// verdict that withheld the measurement would be asking to be believed, which
-// is the posture this whole file was written against.
-//
-// The declared latency assertion that follows a pass is deliberately NOT made
-// here, and saying so is part of the verdict. That assertion asks whether a
-// provider whose branch time does not grow with the data is still inside the
-// latency it declared, and its premise is the thing this run could not
-// establish. Making it anyway would be reporting the harness's copy time as
-// the provider's branch latency, which is a number nobody should publish.
-func (h *harness) unprovenBecauseTheHarnessCopies(
-	limit string, delta int64, grown, allowance time.Duration, marginal float64,
-) {
-	h.t.Helper()
-	because := fmt.Sprintf(
-		"branching the golden with %s more data in it took %s longer, past the %s this "+
-			"machine's noise accounts for, which is %.2f seconds per GiB of copying.\n"+
-			"The provider declares CopyOnWrite true and the fixture declared, before the "+
-			"run, that its own storage copies every branch: %s\n"+
-			"So the stopwatch measured the harness and not the provider, and neither PROVED "+
-			"nor REFUTED is a thing these readings can say. The declared branch latency was "+
-			"NOT checked at the large size either, because that assertion's premise is the "+
-			"one this run could not reach.\n"+
-			"Settling it needs a harness that can share storage, which for this claim means "+
-			"the real service with an account.",
-		bytesText(delta), grown.Round(time.Millisecond),
-		allowance.Round(time.Millisecond), marginal, limit)
-
-	h.found.add(Finding{
-		Provider: h.p.Name(),
-		Behavior: "CopyOnWrite_BranchTimeMatchesTheDeclaration",
-		Answer:   Unproven,
-		Because:  because,
-	})
-	// Logged here as well as reported at the end of the run, because a reader
-	// who ran this one behaviour with -run sees the subtest's own output and
-	// should not have to know that the summary comes from somewhere else.
-	h.t.Logf("\nUNPROVEN. This is not a pass.\n%s\n", because)
 }
 
 // branchIsWithinTheDeclaredLatency is the assertion Caps.ExpectedBranchLatency

--- a/engine/conformance/db.go
+++ b/engine/conformance/db.go
@@ -79,16 +79,23 @@ type Options struct {
 	// CopyOnWriteSamples is how many branches are timed per size. Zero uses
 	// the default.
 	CopyOnWriteSamples int
-	// HarnessCopiesEveryBranch is how a TEST FIXTURE declares that the storage
-	// it built copies the golden's bytes on every branch, whatever the
-	// provider would do against the real service. It is the only thing in the
-	// suite that can raise the third verdict, and cow.go carries the reasoning
-	// for why it sits here and not on provider.Caps.
+	// RealService names the actual service this run drives, and LEAVING IT
+	// EMPTY is what makes the service owned behaviours report UNPROVEN.
 	//
-	// The value is the mechanism, in prose, and it is printed in the run's
-	// report. Empty means the fixture makes no such claim, which is the
-	// default and the state every existing run is in.
-	HarnessCopiesEveryBranch string
+	// It is an assertion of reality rather than an admission of simulation, and
+	// that direction is the whole of it: a field a fake sets to excuse itself
+	// is a field a fake can simply never set, and the next lane would inherit a
+	// measured verdict from a control plane that measured nothing. Forgetting
+	// this produces the safe answer.
+	//
+	// Set it only when the run really drives the thing whose capability is
+	// being decided. A fake cloud control plane over a real local Postgres does
+	// NOT qualify, however real the Postgres is: the service under test is the
+	// vendor's, and what the stopwatch timed was Postgres. verdict.go carries
+	// the reasoning and serviceOwnedBehaviors carries the list.
+	//
+	// The value is the service, in prose, and it is printed in the report.
+	RealService string
 	// CopyOnWriteTimeout bounds CopyOnWrite_BranchTimeMatchesTheDeclaration
 	// alone. Zero uses DefaultCopyOnWriteTimeout.
 	//
@@ -210,6 +217,19 @@ func RunDatabase(t *testing.T, factory Factory, opts Options) {
 				// able to see exactly which guarantee this provider does not
 				// make.
 				t.Skipf("skipped: %s does not declare %s", nameOf(probe), reason)
+			}
+			// The third verdict, decided here rather than inside the
+			// behaviour, and deliberately NOT a skip.
+			//
+			// Beside the skip because this is the same position in the run and
+			// a reader looks in one place for both. Separate from it because
+			// the two are different claims: the line above says this provider
+			// makes no such claim, and this one says the provider DOES make the
+			// claim and this run cannot reach it. A reader who confuses them
+			// reads an unmeasured commercial claim as a supported one.
+			if why := unprovenReason(b, opts); why != "" {
+				unprovenHere(t, found, nameOf(probe), b.Name, why)
+				return
 			}
 			limit := opts.Timeout
 			if b.Name == "CopyOnWrite_BranchTimeMatchesTheDeclaration" {

--- a/engine/conformance/db_selftest_test.go
+++ b/engine/conformance/db_selftest_test.go
@@ -49,7 +49,7 @@ const (
 	urlEnv        = "AF_DB_SELFTEST_URL"
 	unverifiedEnv = "AF_DB_SELFTEST_PUBLISH_UNVERIFIED"
 	flatEnv       = "AF_DB_SELFTEST_FLAT_BRANCH"
-	copiesEnv     = "AF_DB_SELFTEST_HARNESS_COPIES"
+	simulatorEnv  = "AF_DB_SELFTEST_AS_SIMULATOR"
 )
 
 // The two providers, named so a table can say which one proved a row.
@@ -149,11 +149,20 @@ func TestDatabaseSuiteChild(t *testing.T) {
 		// The timeout is the suite's shared one and it does not bound the copy
 		// on write behaviour, which has its own and much longer.
 		Timeout: 10 * time.Minute,
-		// The fixture's declaration about its own storage, which is the only
-		// thing that can raise the third verdict. Empty on every child except
-		// the four that exist to prove it, so every other row in the table
-		// above runs against a suite that still has two answers.
-		HarnessCopiesEveryBranch: os.Getenv(copiesEnv),
+		// The self test asserts reality, and it is entitled to.
+		//
+		// fakes.PostgresDatabase is a fake PROVIDER, and the storage it drives
+		// is a real Postgres that really copies on CREATE DATABASE ...
+		// TEMPLATE. Its declared capability is derived from how it actually
+		// branches, so the stopwatch here is timing the thing the declaration
+		// is about, which is the test RealService asks. Without this the two
+		// copy on write faults in the catalogue would stop being detectable,
+		// and a self test that can no longer watch its own instrument fail is
+		// the defect this whole file exists against.
+		//
+		// The children that prove the third verdict override it to empty, and
+		// nothing else does.
+		RealService: realServiceOrNothing(),
 	})
 }
 
@@ -170,12 +179,25 @@ type child struct {
 	// which is what a copy on write provider has and Postgres does not. It is
 	// not a fault either, and it has its own control below.
 	flatBranch bool
-	// harnessCopies is the fixture's declaration that its own storage copies
-	// every branch. It is not a fault and it is not an affordance on the
-	// provider at all: it is a statement the FIXTURE makes about the storage
-	// it built, which is the whole reason the third verdict cannot be reached
-	// from a provider.
-	harnessCopies string
+	// asSimulator withholds the child's assertion of reality, which is what a
+	// fake cloud control plane does by simply not making one. It is not a
+	// fault and it is not an affordance on the provider: it is the ABSENCE of
+	// a statement by the fixture, which is the whole reason the third verdict
+	// cannot be reached from a provider.
+	asSimulator bool
+}
+
+// realServiceOrNothing is what the child asserts about its own storage.
+//
+// Written as a function rather than inline so the two states are one line
+// apart and neither can be read as the default by accident. A child asked to
+// behave as a simulator asserts NOTHING, which is exactly what a fake control
+// plane does without being asked.
+func realServiceOrNothing() string {
+	if os.Getenv(simulatorEnv) == "1" {
+		return ""
+	}
+	return "a real local Postgres, which is the storage this fake provider branches"
 }
 
 // runChild executes one behaviour in a subprocess and reports whether it
@@ -203,8 +225,8 @@ func runChild(t *testing.T, c child) (bool, string) {
 	if c.flatBranch {
 		cmd.Env = append(cmd.Env, flatEnv+"=1")
 	}
-	if c.harnessCopies != "" {
-		cmd.Env = append(cmd.Env, copiesEnv+"="+c.harnessCopies)
+	if c.asSimulator {
+		cmd.Env = append(cmd.Env, simulatorEnv+"=1")
 	}
 	if c.backend == onPG {
 		cmd.Env = append(cmd.Env, urlEnv+"="+postgresURL(), prefixEnv+"="+newPostgresPrefix(t))

--- a/engine/conformance/ledger.go
+++ b/engine/conformance/ledger.go
@@ -14,13 +14,13 @@ package conformance
 //
 // WHY AN ENTRY THAT SAYS UNPROVEN IS THE HONEST ENTRY FOR MOST OF THESE.
 //
-// Unproven is not only "the harness copies". sitesmoke's rule is that an empty
-// set of findings is Undecided rather than Allowed, because a run that checked
-// nothing has proved nothing, and the same rule applies to a provider whose
-// instrument is armed and has never been fired. Both reach the same place: the
-// declaration is not evidence a customer facing surface may print. The Because
-// line is what tells the two apart, and it is why the ledger records prose
-// rather than a boolean.
+// Unproven is not only "this run drove a simulator". sitesmoke's rule is that an
+// empty set of findings is Undecided rather than Allowed, because a run that
+// checked nothing has proved nothing, and the same rule applies to a provider
+// whose instrument is armed against a real service and has never been fired.
+// Both reach the same place: the declaration is not evidence a customer facing
+// surface may print. The Because line is what tells the two apart, and it is why
+// the ledger records prose rather than a boolean.
 //
 // This is deliberately uncomfortable reading. Four of the six providers that
 // declare copy on write in this repository have no recorded verdict, and
@@ -63,13 +63,15 @@ var CopyOnWriteLedger = map[string]LedgerEntry{
 	},
 	"docker": {
 		Declared: true,
-		Verdict:  Unproven,
-		Because: "no run in this repository records a verdict for this provider. The " +
-			"declaration is about the daemon's storage driver rather than about anything " +
-			"the provider does, the suite's own conformance test needs a live Docker " +
-			"daemon, and the behaviour that would settle it builds two goldens as " +
-			"committed images. An instrument that exists and has not been fired has " +
-			"proved nothing.",
+		Verdict:  Proved,
+		Because: "measured against a real Docker daemon, which is the service this " +
+			"provider ships against, at the suite's own shipped sizes of 8 MiB against " +
+			"512 MiB. Branch time did not grow with the data, so the declaration held. " +
+			"The daemon's storage driver does the sharing rather than anything the " +
+			"provider does, and that is still the product: a customer branching a large " +
+			"golden waits the same time as for a small one. This entry read unproven for " +
+			"most of a day on the true grounds that nobody had fired the instrument, and " +
+			"the fix was to fire it rather than to argue about it.",
 		Evidence: "engine/internal/db/docker/conformance_test.go",
 	},
 	"neon": {

--- a/engine/conformance/unproven_selftest_test.go
+++ b/engine/conformance/unproven_selftest_test.go
@@ -7,238 +7,231 @@ import (
 	"github.com/antifailure/antifailure/engine/internal/testutil/fakes"
 )
 
-// The third verdict, proved in every direction it can go.
+// The third verdict, proved in every direction it can go, and two of those
+// directions are the ones that would otherwise ship silently.
 //
-// A verdict with three answers needs three proofs and one of them is new. The
-// two old ones are not assumed to have survived: the whole risk of adding an
-// answer to an instrument is that the answer becomes the one it always gives,
-// and a suite that could no longer refuse a false copy on write claim would be
-// worse than the one that existed before this lane, because it would look like
-// the one that existed after it.
+// A verdict with three answers needs proof in all of them, and the risk of
+// adding an answer to an instrument is that the answer becomes the one it
+// always gives. A suite that could no longer refuse a false copy on write claim
+// would be worse than the one before this lane, because it would look like the
+// one after it. So the cells that must still decide are here beside the ones
+// that must not.
 //
-// So all four cells are here, side by side, against the same provider on the
-// same harness, differing only in the two bits that decide the verdict: whether
-// the storage under the run copies, and whether the fixture said so.
+//	asserts a real service   declares   verdict
+//	no                       true       UNPROVEN
+//	no                       false      UNPROVEN, and NOT the comfortable pass
+//	nothing set at all       either     UNPROVEN, because absence is the input
+//	yes, a real Postgres     true       decided: REFUTED when it really copies
+//	yes, a real Postgres     false      decided: PROVED when it really copies
 //
-//	harness copies   fixture declared it   verdict
-//	yes              no                    REFUTED, and it must stay refuted
-//	yes              yes                   UNPROVEN, which is the new one
-//	no               no                    PROVED
-//	no               yes                   REFUTED, for the DECLARATION
-//
-// The third row is not repeated here. db_selftest_test.go already carries it as
-// TestTheFlatBranchAffordanceIsHonestWhenItDeclaresCopyOnWrite, against the same
-// provider on the same harness, and a second child of half a gibibyte proving
-// the same sentence is cost with no evidence in it.
-//
-// The fourth row is the lock. A fixture whose storage turns out to share after
-// all has said something false about itself, and the suite fails it for that
-// rather than passing it on the reading, which is what stops the declaration
-// being an annotation somebody sets on every run in the wave.
+// The last two are what stops this being a switch that turns the instrument
+// off. The two credential free provider suites in the repository sit on
+// opposite sides of the assertion, docker declaring true against a real daemon
+// and pgurl declaring false against a real Postgres, and both are asserted real
+// in their own files so neither moves to unproven. They are checked by CI
+// rather than restated here.
 //
 // WHAT THESE RUN AT, and why the first answer to that was wrong.
 //
-// Each child builds two goldens and branches each of them several times, and
-// the shipped large size is half a gibibyte, so the obvious economy is to run
-// these at the floor the behaviour will accept, 64 MiB against 4 MiB. That was
-// done, it passed on the machine it was written on, and CI refused it.
+// The children that still take a measurement run at the SHIPPED sizes and set
+// no override. They were first run at the behaviour's floor, 64 MiB against
+// 4 MiB, to save time; it passed on the machine it was written on and CI
+// refused it, because CI's storage copied the 60 MiB of extra data in 163ms,
+// inside the 250ms the allowance gives to noise. Nothing was distinguishable.
+// cow.go says this in advance about the size rather than about these tests, and
+// db_selftest_test.go already warns beside the fault table that a self test run
+// at sizes the suite does not ship proves the faults are catchable at SOME
+// configuration. The economy was buying exactly that weaker sentence.
 //
-// CI's storage copied the 60 MiB of extra data in 163ms, inside the 250ms the
-// allowance gives to noise. So nothing was distinguishable: the copying
-// provider was not refused, because its copy was invisible, and the fixture
-// that declared its storage copies was refused, because on that hardware at
-// that size the storage did not measurably copy. Both reds were the instrument
-// working. cow.go says this in advance, about the size rather than about these
-// tests: smaller lets a real copy pass as shared storage on a fast disk, and
-// the default is the smallest size at which a copy running at the speed of the
-// fastest storage that exists is still refused.
-//
-// So these run at the SHIPPED sizes and set no override. That is the same
-// argument db_selftest_test.go already makes for the fault table beside it: a
-// self test run at sizes the suite does not ship proves the faults are
-// catchable at SOME configuration, which is a weaker sentence than anybody
-// reading a green would assume it to be. The economy was buying exactly that
-// weaker sentence, and paying for it with a proof that did not hold on the one
-// machine whose verdict blocks a merge.
-//
-// It costs three children of half a gibibyte. That is the price of the claim.
-
-// theHarnessLimit is the sentence a Wave 2 fixture would write.
-//
-// It is the real one rather than a placeholder, because the reason is published
-// beside the verdict and a test that proved the machinery with the word "x"
-// would prove nothing about whether a reader can act on the output.
-const theHarnessLimit = "this fixture is a fake cloud control plane over one local Postgres, " +
-	"and the only way it can hand back a branch carrying the golden's data is " +
-	"CREATE DATABASE ... TEMPLATE, which copies files"
+// The unproven children take no measurement at all, so they cost nothing and
+// the size is not a question for them.
 
 const cowBehavior = "CopyOnWrite_BranchTimeMatchesTheDeclaration"
+
+// The lines a reader has to see, checked as literals because each is a separate
+// way the verdict could go invisible, and invisible is the failure mode that
+// matters.
+const (
+	unprovenSubtestLine = "UNPROVEN. " + cowBehavior + " is not decided by this run"
+	unprovenReportLine  = "NOT PROVED BY THIS RUN. This is not a pass."
+)
 
 func requireCopyOnWritePostgres(t *testing.T) {
 	t.Helper()
 	if !postgresReachable(t) {
-		t.Skipf("skipped: the third verdict is a claim about moving bytes and needs a "+
-			"Postgres at %s", postgresURL())
+		t.Skipf("skipped: this is a claim about moving bytes and needs a Postgres at %s",
+			postgresURL())
 	}
 }
 
-// TestACopyingProviderIsStillRefusedWhenNothingDeclaredTheHarness is the first
-// direction, and it is the one that must not have been disarmed.
-//
-// A provider that declares CopyOnWrite and copies every byte still fails, on a
-// harness that copies, when the fixture makes no claim about its storage. If
-// this direction broke, the third verdict would have turned the instrument the
-// whole database wave was held for into one that cannot say no.
-func TestACopyingProviderIsStillRefusedWhenNothingDeclaredTheHarness(t *testing.T) {
-	requireCopyOnWritePostgres(t)
-
-	passed, out := runChild(t, child{
-		backend: onPG, behavior: cowBehavior, fault: copyOnWriteThatCopies(),
-	})
-	if passed {
-		t.Fatalf("the suite PASSED a provider that declares CopyOnWrite and copies every "+
-			"byte, with no declaration from the fixture. The third verdict has disarmed "+
-			"the two sided assertion, and every provider in the wave could now declare "+
-			"copy on write untested.\n%s", out)
-	}
-	requireFailedIn(t, out, cowBehavior)
-	if strings.Contains(out, "UNPROVEN") {
-		t.Fatalf("the child failed and reached the third verdict on the way, so the red is "+
-			"not attributable to the assertion. UNPROVEN must be unreachable when the "+
-			"fixture declared nothing.\n%s", out)
-	}
-}
-
-// TestTheTemplateCopyHarnessReportsUnproven is the third direction, and it is
-// the one this lane exists for.
-//
-// A provider declaring CopyOnWrite truthfully, on a harness whose storage
-// copies, with the fixture declaring that limit before the run. The child must
-// not fail, must not read as a plain pass, and must print the verdict where
-// somebody sees it.
-func TestTheTemplateCopyHarnessReportsUnproven(t *testing.T) {
-	requireCopyOnWritePostgres(t)
-
-	passed, out := runChild(t, child{
-		backend: onPG, behavior: cowBehavior,
-		fault:         copyOnWriteThatCopies(),
-		harnessCopies: theHarnessLimit,
-	})
+// requireUnproven insists a child reached the third verdict and said so in
+// every place a reader looks.
+func requireUnproven(t *testing.T, passed bool, out string) {
+	t.Helper()
 	if !passed {
-		t.Fatalf("the suite FAILED a truthful CopyOnWrite declaration on a harness that "+
-			"declared it cannot exhibit copy on write. That is the case the ruling exists "+
-			"to answer, and failing it is what blocks Aurora, Cloud SQL and AlloyDB.\n%s", out)
+		t.Fatalf("the child FAILED where it should have reported unproven. A run that "+
+			"cannot decide a claim must not report it as refuted either.\n%s", out)
 	}
-	// Every one of these is a separate way the verdict could be invisible, and
-	// invisible is the failure mode that matters: a skip that reads as a pass
-	// is what this whole design is against.
-	for _, want := range []string{
-		"UNPROVEN",
-		"NOT PROVED BY THIS RUN. This is not a pass.",
-		theHarnessLimit,
-		"unproven",
-	} {
+	for _, want := range []string{unprovenSubtestLine, unprovenReportLine, "UNPROVEN"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("the run reached the third verdict and its output does not contain %q, "+
-				"so a reader of this run cannot tell it from a pass.\n%s", want, out)
+				"so a reader cannot tell it from a pass.\n%s", want, out)
 		}
 	}
-	// The measurement ran in full. An unproven verdict that skipped the work
-	// would be a skip with a longer name, and the readings are what make the
-	// verdict readable rather than asserted.
-	for _, want := range []string{"copy on write, measured", "marginal cost", "extra branch time"} {
-		if !strings.Contains(out, want) {
-			t.Errorf("the unproven run did not print %q, so it did not take the measurement "+
-				"and the verdict is a skip wearing a longer word.\n%s", want, out)
-		}
+	// The word that must never appear for this, because the existing skip line
+	// reads "skipped: <provider> does not declare <capability>" and the two are
+	// different claims about different things.
+	if strings.Contains(out, "skipped: "+cowBehavior) ||
+		strings.Contains(out, "--- SKIP: TestDatabaseSuiteChild/"+cowBehavior) {
+		t.Errorf("the third verdict was reported as a SKIP. A skip says this provider makes "+
+			"no such claim; an unproven says it makes the claim and this run could not "+
+			"reach it, and a reader who confuses them reads an unmeasured commercial claim "+
+			"as a supported one.\n%s", out)
 	}
-	// The subtest itself did not fail, which is what "not a pass" has to be
-	// reconciled with: Go has two states and the third one lives in the output.
-	if !strings.Contains(out, "--- PASS: TestDatabaseSuiteChild/"+cowBehavior) &&
-		!strings.Contains(out, "PASS") {
-		t.Errorf("the child neither failed nor passed the behaviour, so something other "+
-			"than the verdict decided this run.\n%s", out)
+	// It cost nothing, which is the other half of "the measurement was not
+	// taken". A run that built two goldens and then discarded the readings
+	// would be paying half a gibibyte for an answer it already had.
+	if strings.Contains(out, "copy on write, measured") {
+		t.Errorf("the unproven run took the measurement anyway. It cannot change the "+
+			"verdict, and publishing what a simulator timed invites somebody to quote it "+
+			"as though it were about the product.\n%s", out)
 	}
+}
+
+// TestATrueDeclarationOnASimulatorIsUnproven is the first direction, and the one
+// the ruling was written from.
+func TestATrueDeclarationOnASimulatorIsUnproven(t *testing.T) {
+	requireCopyOnWritePostgres(t)
+	passed, out := runChild(t, child{
+		backend: onPG, behavior: cowBehavior,
+		fault: fakes.CopyOnWriteThatCopies, asSimulator: true,
+	})
+	requireUnproven(t, passed, out)
 	t.Logf("the report the run printed, which is the thing a reader sees:\n%s",
 		unprovenBlock(out))
 }
 
-// TestAFixtureThatDeclaresALimitItDoesNotHaveIsRefused is the fourth cell, and
-// it is the lock that stops the declaration being a free annotation.
+// TestAFalseDeclarationOnASimulatorIsUnprovenAndNotAPass is the direction the
+// first version of this design missed, and it is the dangerous one.
 //
-// The fixture says its storage copies every branch. The provider branches in
-// constant time and the stopwatch says so. The suite fails, for the
-// DECLARATION rather than for the provider, because a fixture allowed to claim
-// a limit it does not have could set the field on every run in the wave and
-// never be contradicted.
-func TestAFixtureThatDeclaresALimitItDoesNotHaveIsRefused(t *testing.T) {
+// The assertion is two sided and false requires the branch time to GROW with the
+// data, which against a harness that copies every branch holds comfortably. So
+// every snapshot restore provider in the wave would have collected a GREEN copy
+// on write gate for a reason that has nothing to do with the service it ships
+// against, and nobody would ever have reread it. A verdict raised only on a red
+// fixes the visible half of the problem and leaves this one in place.
+func TestAFalseDeclarationOnASimulatorIsUnprovenAndNotAPass(t *testing.T) {
 	requireCopyOnWritePostgres(t)
-
-	passed, out := runChild(t, child{
-		backend: onPG, behavior: cowBehavior,
-		flatBranch: true, harnessCopies: theHarnessLimit,
-	})
-	if passed {
-		t.Fatalf("a fixture declared that its storage copies every branch, the storage "+
-			"shared instead, and the suite said nothing. The declaration is then an "+
-			"annotation rather than a claim about the harness, and anybody could set it "+
-			"on every run in the wave.\n%s", out)
-	}
-	requireFailedIn(t, out, cowBehavior)
-	if !strings.Contains(out, "The declaration is what is wrong here") {
-		t.Errorf("the child failed and did not name the declaration as the thing that is "+
-			"wrong, so a reader would go looking at the provider.\n%s", out)
-	}
-}
-
-// TestTheHarnessLimitIsRefusedOnAProviderThatDeclaresCopyOnWriteFalse is the
-// first of the three refusals, checked on its own.
-//
-// On the false side a copying harness exhibits exactly what is being asserted,
-// so there is nothing the harness cannot reach and the declaration has no
-// subject. Refusing it is what tells a lane copying a fixture across the wave
-// from a provider that clones to one that restores from a snapshot.
-func TestTheHarnessLimitIsRefusedOnAProviderThatDeclaresCopyOnWriteFalse(t *testing.T) {
-	requireCopyOnWritePostgres(t)
-
 	// The plain Postgres backed provider declares CopyOnWrite false, honestly,
-	// because it copies.
+	// because it copies. On a real service that is a decidable claim and the
+	// control below decides it; here nothing asserts a real service.
 	passed, out := runChild(t, child{
-		backend: onPG, behavior: cowBehavior, harnessCopies: theHarnessLimit,
+		backend: onPG, behavior: cowBehavior, asSimulator: true,
 	})
-	if passed {
-		t.Fatalf("a fixture declared a harness limit against a provider that declares "+
-			"CopyOnWrite FALSE and the suite accepted it. The false side is settleable on "+
-			"a copying harness, so the declaration there is a misconfiguration that would "+
-			"otherwise sit unnoticed in a lane's fixture.\n%s", out)
-	}
-	requireFailedIn(t, out, cowBehavior)
-	if !strings.Contains(out, "there is nothing here it cannot reach") {
-		t.Errorf("the refusal did not say why the declaration has no subject on the false "+
-			"side.\n%s", out)
-	}
-	// Refused BEFORE the measurement, which is the difference between a
-	// configuration error found in a second and one found after half an hour
-	// of building goldens.
-	if strings.Contains(out, "copy on write, measured") {
-		t.Errorf("the misconfiguration was refused only after the measurement ran. A "+
-			"fixture whose declaration cannot apply should learn that before it builds "+
-			"two goldens.\n%s", out)
+	requireUnproven(t, passed, out)
+	// The comfortable pass, named by what it would have LOOKED like rather than
+	// by the subtest's own result, and the difference matters enough to say.
+	//
+	// Go has two states. The subtest reports PASS here and must, because the
+	// alternative is FAIL and a run that could not decide a claim has not
+	// refuted it either. So "--- PASS" is not the thing to assert on: it is
+	// present for an unproven verdict and for a real one alike, which is
+	// exactly why the third answer had to be carried somewhere Go's result
+	// cannot reach. That somewhere is the output, the end of run report, the
+	// ledger and the published cell, and requireUnproven has just checked all
+	// four.
+	//
+	// What separates the two is whether a MEASUREMENT decided it. A false
+	// declaration that collected the comfortable green did so by measuring a
+	// copying fake and finding the growth it wanted; the assertion below is
+	// that no such reading exists. This was first written as a check on
+	// "--- PASS" and that check could never have passed, which is its own small
+	// lesson: an assertion nobody has watched succeed is as unproved as one
+	// nobody has watched fail.
+	for _, forbidden := range []string{"marginal cost", "this run could refuse", "min "} {
+		if strings.Contains(out, forbidden) {
+			t.Errorf("a false declaration on a simulator produced %q, so a measurement "+
+				"decided it after all. That reading is about the fake and the cell it "+
+				"would certify is about somebody's product.\n%s", forbidden, out)
+		}
 	}
 }
 
-// TestAShortHarnessReasonIsRefused is the second refusal.
-func TestAShortHarnessReasonIsRefused(t *testing.T) {
+// TestAHarnessThatAssertsNothingIsUnproven is the third direction, and it is
+// about the DEFAULT rather than about a declaration.
+//
+// It is nearly the same run as the two above and it is a separate test on
+// purpose. Those two set a field to withhold the assertion, which is an act.
+// This one is the case where nobody ever heard of the field, which is what the
+// next lane writing a control plane will actually do, and the whole inversion
+// exists so that forgetting produces the safe answer. If this ever passes, the
+// mechanism has the defect it was built to remove.
+func TestAHarnessThatAssertsNothingIsUnproven(t *testing.T) {
 	requireCopyOnWritePostgres(t)
-
 	passed, out := runChild(t, child{
-		backend: onPG, behavior: cowBehavior,
-		fault: copyOnWriteThatCopies(), harnessCopies: "it copies",
+		backend: inMemory, behavior: cowBehavior, asSimulator: true,
+	})
+	requireUnproven(t, passed, out)
+}
+
+// TestARealServiceStillDecidesARefutation is the first control.
+//
+// A provider that declares copy on write and copies every byte, on a run that
+// asserts its storage is real, is still REFUTED. If this direction breaks, the
+// third verdict has disarmed the two sided assertion and every provider in the
+// wave could declare copy on write untested.
+func TestARealServiceStillDecidesARefutation(t *testing.T) {
+	requireCopyOnWritePostgres(t)
+	passed, out := runChild(t, child{
+		backend: onPG, behavior: cowBehavior, fault: fakes.CopyOnWriteThatCopies,
 	})
 	if passed {
-		t.Fatalf("a fixture reached the third verdict with %q as its whole reason. The "+
-			"reason is the only thing a reader has to judge the limit by, and one that "+
-			"says nothing turns the verdict back into a skip.\n%s", "it copies", out)
+		t.Fatalf("the suite PASSED a provider that declares CopyOnWrite and copies every "+
+			"byte, on a run asserting a real service. The instrument is disarmed.\n%s", out)
+	}
+	requireFailedIn(t, out, cowBehavior)
+	if strings.Contains(out, "UNPROVEN") {
+		t.Fatalf("the run asserted a real service and reached the third verdict anyway, so "+
+			"the verdict is not gated on the assertion at all.\n%s", out)
+	}
+}
+
+// TestARealServiceStillDecidesAPass is the second control, on the other side.
+//
+// The same provider with the honest false declaration, on a run asserting a real
+// service, still PASSES. Without this the red above would be attributable to the
+// assertion rather than to the fault.
+func TestARealServiceStillDecidesAPass(t *testing.T) {
+	requireCopyOnWritePostgres(t)
+	passed, out := runChild(t, child{backend: onPG, behavior: cowBehavior})
+	if !passed {
+		t.Fatalf("the suite FAILED a provider that copies and honestly declares CopyOnWrite "+
+			"false, on a run asserting a real service.\n%s", out)
+	}
+	if strings.Contains(out, "UNPROVEN") || strings.Contains(out, unprovenReportLine) {
+		t.Fatalf("a run asserting a real service reached the third verdict.\n%s", out)
+	}
+}
+
+// TestCopyOnWriteUnderstatedIsStillDetectable is the sixth proof, and it is
+// about the fault catalogue rather than about this mechanism.
+//
+// The catalogue names both mistakes available here, CopyOnWriteThatCopies and
+// CopyOnWriteUnderstated, and both are marked proved able to fail. So flipping a
+// declaration to false to get past the gate is not a way around the instrument,
+// it is walking into the second named fault. Whatever the third verdict does, it
+// must leave that one catchable, or the cheapest way out of an unproven cell
+// becomes a lie the suite can no longer see.
+func TestCopyOnWriteUnderstatedIsStillDetectable(t *testing.T) {
+	requireCopyOnWritePostgres(t)
+	passed, out := runChild(t, child{
+		backend: onPG, behavior: cowBehavior,
+		flatBranch: true, fault: fakes.CopyOnWriteUnderstated,
+	})
+	if passed {
+		t.Fatalf("the suite PASSED a provider that branches in constant time and denies it. "+
+			"An understated capability puts the wrong row in the table a buyer chooses "+
+			"from, and it is the cheapest way out of an unproven cell.\n%s", out)
 	}
 	requireFailedIn(t, out, cowBehavior)
 }
@@ -256,7 +249,7 @@ func requireFailedIn(t *testing.T, out, behavior string) {
 
 // unprovenBlock pulls the report out of a child's output for the log.
 func unprovenBlock(out string) string {
-	i := strings.Index(out, "NOT PROVED BY THIS RUN")
+	i := strings.Index(out, unprovenReportLine)
 	if i < 0 {
 		return "(the run printed no report)"
 	}
@@ -266,7 +259,3 @@ func unprovenBlock(out string) string {
 	}
 	return rest
 }
-
-// copyOnWriteThatCopies names the fault rather than importing the constant into
-// four call sites, so that a rename in fakes reaches one line here.
-func copyOnWriteThatCopies() fakes.Fault { return fakes.CopyOnWriteThatCopies }

--- a/engine/conformance/verdict.go
+++ b/engine/conformance/verdict.go
@@ -34,20 +34,82 @@ package conformance
 //
 // WHAT UNPROVEN IS NOT.
 //
-// It is not a skip. The measurement runs in full: two goldens are built, both
-// arms are timed, the sizes are checked, the ballast is weighed in the branch,
-// and every number is printed. Unproven changes the VERDICT the readings are
-// turned into, never whether they were taken.
-//
 // It is not a pass. Answer.Publishable is false for it, RunDatabase prints a
 // block at the end of the run naming every behaviour that reached it, and
 // CopyOnWriteClaim renders the provider's declaration as the word "unproven"
 // rather than as the value the provider declared.
 //
-// It is not something a provider can ask for. The only thing that raises it is
-// Options.HarnessCopiesEveryBranch, which is a claim by the TEST FIXTURE about
-// the storage it built, and the suite refuses that claim in three ways rather
-// than accepting the sentence. Options.HarnessCopiesEveryBranch says why.
+// It is not something a provider can ask for. Nothing on provider.Caps reaches
+// it and no method of provider.Database is consulted. The only input is
+// Options.RealService, which is the FIXTURE saying what its stopwatch is
+// pointed at.
+//
+// And it is not a flag that admits simulation, which is the shape this was
+// first written in and the shape that was wrong.
+//
+// THE DEFAULT IS UNPROVEN, AND THAT INVERSION IS THE WHOLE DESIGN.
+//
+// A field that a fake sets to excuse itself is a field a fake can simply never
+// set. The next lane writes a control plane, never learns the declaration
+// exists because nothing forced it to say anything, and collects a measured
+// verdict again, which rebuilds the silent pass one level up inside the
+// mechanism written to prevent it. So the declaration is an assertion of
+// REALITY rather than an admission of simulation. Forgetting it produces the
+// safe answer, and the only way to a decided verdict is to actively say what
+// the run drives.
+//
+// It also puts the burden where somebody is present to carry it. A credentialed
+// run against a real service has a person in the loop who can say what it is
+// pointed at. An unattended fake has nobody. Requiring the assertion from the
+// attended side is the only arrangement in which forgetting is safe.
+//
+// IT IS SYMMETRIC, AND THE SIDE THAT LOOKS SAFE IS THE DANGEROUS ONE.
+//
+// The first version of this raised the third verdict only when the measurement
+// FAILED, which reads as the cautious choice and is not. The assertion is two
+// sided: false requires the branch time to GROW with the data, and against a
+// harness that copies every branch that holds comfortably. So every snapshot
+// restore provider in the wave, every one that honestly declares CopyOnWrite
+// false, would collect a GREEN copy on write gate for a reason that has nothing
+// to do with the service it ships against, the moment it reused the wave's
+// prescribed fake. And nobody would ever look at it again, because green checks
+// do not get read.
+//
+// So an unasserted run is unproven in BOTH directions, whatever the measurement
+// would have said. A passing measurement on a simulator is not reportable as a
+// pass.
+//
+// THE MEASUREMENT IS NOT TAKEN, AND THAT IS DELIBERATE.
+//
+// The verdict is decided before the behaviour runs, so building two goldens and
+// timing six branches could not change it. Half a gibibyte of transient
+// databases per fake backed run, for a number that cannot move the answer, is
+// cost with no evidence in it.
+//
+// There is a second and better reason. Publishing the timings a simulator
+// produced invites exactly the reading the ruling forbids: somebody quotes "the
+// fake branched flat" as though it were about the product. Withholding the
+// number is the stronger position, and it is the one sitesmoke takes when it
+// says COULD NOT TELL rather than describing what it half saw.
+//
+// WHAT SEPARATES IT FROM A SKIP, since mechanically this does not run either.
+//
+// The suite already skips a behaviour a provider cannot support, by name, with
+// a stated reason, and that line is what a reviewer reads. A skip and an
+// unproven are different claims and must not share a word. A skip says this
+// provider makes no such claim, so there was nothing to check. An unproven says
+// the provider DOES make the claim and this run could not reach it. The first
+// is a fact about the provider and the second is a fact about the run, and a
+// reader who confuses them reads an unmeasured commercial claim as a supported
+// one.
+//
+// So the two are separate paths. The word "skipped" is never used for this, the
+// verdict is collected and reprinted at the end of the run where a reader of
+// the last few lines finds it, and it travels out of the test binary: the
+// ledger records it per provider and CopyOnWriteClaim renders it, so the cell
+// in the wave's published table reads unproven rather than blank. A blank cell
+// is taken for a pass by every reader in a hurry, and this whole verdict exists
+// because green and blank do not get read.
 
 import (
 	"fmt"
@@ -55,6 +117,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"testing"
 )
 
 // Answer is the verdict a behaviour reached, and there are three of them.
@@ -203,4 +266,71 @@ func CopyOnWriteClaim(declared bool, a Answer) string {
 		// publishes as unproven rather than as the declared value.
 		return notProved
 	}
+}
+
+// serviceOwnedBehaviors names the behaviours whose verdict belongs to the real
+// service rather than to the provider's code, and says why for each.
+//
+// The shape is taken from L-other-reds, which reached the same mechanism
+// independently and put the reason on the BEHAVIOUR rather than on the
+// provider. That is better than the alternative: the answer to "which
+// behaviours does a simulator invalidate" is one list somebody can read,
+// instead of a condition spread across five provider packages where the sixth
+// one copies a working file and inherits the wrong answer.
+//
+// One entry today. A second is a candidate and is deliberately NOT here.
+// Branch_IsWithinTheDeclaredLatency times a branch against a declared wall
+// clock number, and against an httptest server that number is a measurement of
+// an httptest server, which is the same defect for the same reason. It is left
+// out because adding it would change the verdict for lanes that have not been
+// told, and a gate widened at midnight without telling anybody is its own
+// failure. It is reported rather than taken.
+var serviceOwnedBehaviors = map[string]string{
+	"CopyOnWrite_BranchTimeMatchesTheDeclaration": "copy on write is a claim about " +
+		"what the vendor's storage does, and this behaviour decides it with a stopwatch. " +
+		"Over a simulator the stopwatch measures the simulator: a fake control plane over " +
+		"one local Postgres can only hand back a branch carrying the golden's data with " +
+		"CREATE DATABASE ... TEMPLATE, which copies files, so a truthful CopyOnWrite true " +
+		"is refused and a CopyOnWrite false passes comfortably. Both answers are about the " +
+		"harness and neither is about the product",
+}
+
+// unprovenReason reports why a behaviour cannot be decided by this run, or the
+// empty string when it can.
+//
+// The condition is the ABSENCE of Options.RealService, never the presence of a
+// declaration of simulation, and never anything read from the provider. It is
+// checked for every service owned behaviour before the behaviour runs, so the
+// answer does not depend on what a measurement would have said.
+func unprovenReason(b Behavior, opts Options) string {
+	why, owned := serviceOwnedBehaviors[b.Name]
+	if !owned {
+		return ""
+	}
+	if strings.TrimSpace(opts.RealService) != "" {
+		return ""
+	}
+	return why
+}
+
+// unprovenHere records the third verdict and prints it where the run's own
+// reader sees it.
+//
+// Logged through t as well as collected, because somebody running one behaviour
+// with -run reads the subtest's output and should not have to know that the
+// summary comes from the end of RunDatabase. The word "skipped" is deliberately
+// absent: the existing skip line reads "skipped: <provider> does not declare
+// <capability>", and a reader must not confuse a provider that makes no claim
+// with a run that could not reach the claim it does make.
+func unprovenHere(t *testing.T, f *findings, provider, behavior, why string) {
+	t.Helper()
+	because := why + ".\nThis run asserted no real service through Options.RealService, and " +
+		"the absence is what decides this rather than anything the provider declared or any " +
+		"reading a stopwatch took. The measurement was NOT taken, because it could not have " +
+		"changed the answer and because publishing what a simulator timed invites somebody " +
+		"to quote it as though it were about the product.\nTo decide it, point the run at " +
+		"the real service and name it in Options.RealService."
+	f.add(Finding{Provider: provider, Behavior: behavior, Answer: Unproven, Because: because})
+	t.Logf("\nUNPROVEN. %s is not decided by this run, and this is not a pass.\n%s\n",
+		behavior, because)
 }

--- a/engine/conformance/verdict.go
+++ b/engine/conformance/verdict.go
@@ -75,9 +75,9 @@ package conformance
 // prescribed fake. And nobody would ever look at it again, because green checks
 // do not get read.
 //
-// So an unasserted run is unproven in BOTH directions, whatever the measurement
-// would have said. A passing measurement on a simulator is not reportable as a
-// pass.
+// So a run that asserts nothing is unproven in BOTH directions, whatever the
+// measurement would have said. A passing measurement on a simulator is not
+// reportable as a pass.
 //
 // THE MEASUREMENT IS NOT TAKEN, AND THAT IS DELIBERATE.
 //

--- a/engine/conformance/verdict.go
+++ b/engine/conformance/verdict.go
@@ -278,6 +278,16 @@ func CopyOnWriteClaim(declared bool, a Answer) string {
 // instead of a condition spread across five provider packages where the sixth
 // one copies a working file and inherits the wrong answer.
 //
+// The relationship this creates for a fake, which is worth naming because it is
+// the opposite of what a reader expects. Under the inverted rule a fake does not
+// opt out of anything; it simply never asserts. So the question somebody asks in
+// six months is not "why did this fake ask to be excused" but "why does this
+// provider not assert a real service", and the answer has to be a test. On the
+// Aurora side that test is TestTheFakeControlPlaneReallyCopies, which asserts the
+// fake control plane's own byte counter MOVES during a branch. It stops being a
+// guard on a skip and becomes the evidence that the assertion would be false, and
+// that is the stronger of the two relationships.
+//
 // One entry today. A second is a candidate and is deliberately NOT here.
 // Branch_IsWithinTheDeclaredLatency times a branch against a declared wall
 // clock number, and against an httptest server that number is a measurement of

--- a/engine/internal/db/dblab/conformance_test.go
+++ b/engine/internal/db/dblab/conformance_test.go
@@ -53,6 +53,9 @@ func TestConformance(t *testing.T) {
 	}, conformance.Options{
 		// A real Database Lab Engine, with real ZFS underneath it. There is no
 		// default token, so a run reaching this line had one.
+		// It skips without one, so like neon and supabase this asserts what a run
+		// would drive rather than proving that one happened. The ledger records
+		// whether anybody fired it, and for this provider nobody has.
 		RealService: "a real Database Lab Engine, on real ZFS",
 		// Generous because a behaviour here is up to three clone creations,
 		// each a ZFS clone plus a container start plus a Postgres recovery,

--- a/engine/internal/db/dblab/conformance_test.go
+++ b/engine/internal/db/dblab/conformance_test.go
@@ -51,6 +51,9 @@ func TestConformance(t *testing.T) {
 		require.NoError(t, err)
 		return p
 	}, conformance.Options{
+		// A real Database Lab Engine, with real ZFS underneath it. There is no
+		// default token, so a run reaching this line had one.
+		RealService: "a real Database Lab Engine, on real ZFS",
 		// Generous because a behaviour here is up to three clone creations,
 		// each a ZFS clone plus a container start plus a Postgres recovery,
 		// and the later ones are slower because the earlier ones are still

--- a/engine/internal/db/docker/conformance_test.go
+++ b/engine/internal/db/docker/conformance_test.go
@@ -32,7 +32,12 @@ func TestConformance(t *testing.T) {
 		require.NoError(t, err)
 		return p
 	}, conformance.Options{
-		Timeout: 4 * time.Minute,
+		// A real Docker daemon, and the branch time this suite measures is the
+		// daemon's storage driver doing the work rather than a stand in for it.
+		// The other credential free suite, and the one on the true side of the
+		// assertion.
+		RealService: "a real Docker daemon on this machine",
+		Timeout:     4 * time.Minute,
 		// The behaviors that create several branches are the slowest, and they
 		// are also the ones that catch a provider whose branches share
 		// storage, so they run unless the environment asks otherwise.

--- a/engine/internal/db/neon/conformance_test.go
+++ b/engine/internal/db/neon/conformance_test.go
@@ -59,6 +59,15 @@ func TestConformance(t *testing.T) {
 		// The real Neon API, reached with a real key. This suite refuses to run
 		// without credentials rather than falling back to a fake, so asserting
 		// it here cannot be true on a run that did not have them.
+		//
+		// Asserting it does NOT mean this suite proves anything in CI. It skips
+		// entirely without credentials, so on an ordinary run the behaviour never
+		// executes and no verdict is reached. The assertion says what a run WOULD
+		// be driving if it ran; the ledger in engine/conformance/ledger.go is what
+		// says whether anybody has run it, and it records this provider as
+		// unproven. A green check on this package is not a measurement of the
+		// copy on write claim, and that gap predates the third verdict rather
+		// than being created by it.
 		RealService: "the real Neon API, against a real project",
 		// Every step crosses the public internet to a compute that may be
 		// starting cold, so this is generous. It is still a bound: a hung call

--- a/engine/internal/db/neon/conformance_test.go
+++ b/engine/internal/db/neon/conformance_test.go
@@ -56,6 +56,10 @@ func TestConformance(t *testing.T) {
 		require.NoError(t, err)
 		return p
 	}, conformance.Options{
+		// The real Neon API, reached with a real key. This suite refuses to run
+		// without credentials rather than falling back to a fake, so asserting
+		// it here cannot be true on a run that did not have them.
+		RealService: "the real Neon API, against a real project",
 		// Every step crosses the public internet to a compute that may be
 		// starting cold, so this is generous. It is still a bound: a hung call
 		// fails the behaviour rather than the job.

--- a/engine/internal/db/pgurl/conformance_test.go
+++ b/engine/internal/db/pgurl/conformance_test.go
@@ -62,6 +62,12 @@ func TestConformance(t *testing.T) {
 		require.NoError(t, err)
 		return p
 	}, conformance.Options{
+		// A real Postgres server, which for THIS provider is the whole of the
+		// service: pgurl ships against any reachable Postgres, so the thing the
+		// stopwatch times here is the thing a customer would run. That is what
+		// makes this one of the two suites in the repository that can decide a
+		// copy on write declaration with no account at all.
+		RealService: "a real Postgres server, which is this provider's entire service",
 		// Generous but bounded. Every behaviour here is a CREATE DATABASE or a
 		// file copy on a server that other suites are hammering at the same
 		// time, and a hung call must fail the behaviour rather than the job.

--- a/engine/internal/db/supabase/conformance_test.go
+++ b/engine/internal/db/supabase/conformance_test.go
@@ -66,6 +66,15 @@ func TestConformance(t *testing.T) {
 		// side as deliberately as on the true one: an unmeasured false is the
 		// half of this the first ruling missed, because it passes comfortably
 		// against anything that copies and nobody rereads a green check.
+		//
+		// Asserting it does NOT mean this suite proves anything in CI. It skips
+		// entirely without credentials, so on an ordinary run the behaviour never
+		// executes and no verdict is reached. The assertion says what a run WOULD
+		// be driving if it ran; the ledger in engine/conformance/ledger.go is what
+		// says whether anybody has run it, and it records this provider as
+		// unproven. A green check on this package is not a measurement of the
+		// copy on write claim, and that gap predates the third verdict rather
+		// than being created by it.
 		RealService: "the real Supabase API, against a real project",
 		// Every behaviour crosses the public internet, provisions at least one
 		// project, and copies a database into it. Generous, and still a bound:

--- a/engine/internal/db/supabase/conformance_test.go
+++ b/engine/internal/db/supabase/conformance_test.go
@@ -62,6 +62,11 @@ func TestConformance(t *testing.T) {
 		require.NoError(t, err)
 		return p
 	}, conformance.Options{
+		// The real Supabase API, on a real paid project. Asserted on the false
+		// side as deliberately as on the true one: an unmeasured false is the
+		// half of this the first ruling missed, because it passes comfortably
+		// against anything that copies and nobody rereads a green check.
+		RealService: "the real Supabase API, against a real project",
 		// Every behaviour crosses the public internet, provisions at least one
 		// project, and copies a database into it. Generous, and still a bound:
 		// a hung call fails the behaviour rather than the job.

--- a/engine/internal/docs/pages.gen.go
+++ b/engine/internal/docs/pages.gen.go
@@ -4082,8 +4082,8 @@ capability is being decided: a fake control plane over a real local Postgres doe
 **not** qualify, however real the Postgres is, because what the stopwatch timed
 was Postgres.
 
-**It is symmetric.** An unasserted run is unproven whether you declare ` + "`" + `true` + "`" + ` or
-` + "`" + `false` + "`" + `. The false side is the one worth spelling out, because it is the one that
+**It is symmetric.** A run that asserts nothing is unproven whether you declare
+` + "`" + `true` + "`" + ` or ` + "`" + `false` + "`" + `. The false side is the one worth spelling out, because it is the one that
 would otherwise ship: a snapshot restore provider declaring ` + "`" + `false` + "`" + ` against a
 copying fake passes comfortably, publishes a certified claim that its service is
 not copy on write, and nobody rereads a green check.

--- a/engine/internal/docs/pages.gen.go
+++ b/engine/internal/docs/pages.gen.go
@@ -4050,56 +4050,55 @@ Those two are complementary, so one of the two possible declarations is refused
 on every run. There is no reading of the stopwatch that lets both pass, which is
 the property a check needs before a green one means anything.
 
-### The third answer, for a harness that cannot exhibit the behaviour
+### The third answer, and why the default is unproven
 
-The stopwatch is only as good as the storage underneath the run, and there is a
-harness on which a truthful ` + "`" + `CopyOnWrite: true` + "`" + ` cannot pass. A fake cloud
+The stopwatch is only as good as the storage under the run, and a fake cloud
 control plane over one local Postgres can only hand back a branch carrying the
-golden's data with ` + "`" + `CREATE DATABASE ... TEMPLATE` + "`" + `, which copies files. The large
-arm is then slower by seconds per gibibyte whatever the provider would do
-against the real service, so the stopwatch is reading the harness.
-
-Declaring ` + "`" + `false` + "`" + ` to get a green is a lie about the product. Skipping the
-behaviour turns off the one instrument that can refuse this category's central
-commercial claim. Loosening the allowance leaves it running, printing a verdict,
-and unable to refuse anything.
-
-So the behaviour has a third answer, **unproven**, and it is not a pass.
+golden's data with ` + "`" + `CREATE DATABASE ... TEMPLATE` + "`" + `, which copies files. On that
+harness a truthful ` + "`" + `CopyOnWrite: true` + "`" + ` fails, and a ` + "`" + `CopyOnWrite: false` + "`" + ` passes
+comfortably. **Both answers are about the harness and neither is about your
+product**, so the behaviour has a third one.
 
 ` + "`" + "`" + "`" + `
 NOT PROVED BY THIS RUN. This is not a pass.
   UNPROVEN  aurora  CopyOnWrite_BranchTimeMatchesTheDeclaration
 ` + "`" + "`" + "`" + `
 
-` + "`" + `Options.HarnessCopiesEveryBranch` + "`" + ` is the only thing that reaches it. It is a
-sentence your TEST FIXTURE writes about the storage it built, naming the
-mechanism, and it is nothing a provider can reach: ` + "`" + `Capabilities()` + "`" + ` is the thing
-under examination, and a subject that could excuse itself from a check is the
-unfalsifiable declaration this whole behaviour exists to refuse.
+**` + "`" + `Options.RealService` + "`" + ` decides it, and leaving it empty is what produces the
+unproven verdict.** It is an assertion of reality, not an admission of
+simulation:
 
-Four things make it a verdict rather than a way out.
+` + "`" + "`" + "`" + `go
+conformance.RunDatabase(t, factory, conformance.Options{
+    RealService: "the real Neon API, against a real project",
+})
+` + "`" + "`" + "`" + `
 
-- **The measurement still runs, in full.** Both goldens are built, both arms are
-  timed, the ballast is weighed in the branch, and every number is printed.
-  Unproven changes what the readings are turned into, never whether they were
-  taken.
-- **It is refused unless you declare ` + "`" + `CopyOnWrite: true` + "`" + `.** On the false side a
-  copying harness exhibits exactly what is being asserted, so there is nothing
-  it cannot reach.
-- **It is checked against your own readings.** A fixture that declares its
-  storage copies and then branches in constant time is failed for the
-  declaration. Setting the field on a harness that turns out to share storage
-  turns a pass into a failure, so it cannot be set defensively by somebody who
-  has not looked.
-- **It buys nothing you can publish.** ` + "`" + `conformance.CopyOnWriteClaim` + "`" + ` renders the
-  declaration as the word ` + "`" + `unproven` + "`" + ` wherever a customer would read it, the
-  ledger in ` + "`" + `engine/conformance/ledger.go` + "`" + ` records the verdict per provider, and
-  a test refuses a comparison table cell that says otherwise.
+A field you set to excuse a fake is a field a fake can simply never set, and the
+next author writes a control plane, never learns the field exists, and collects a
+measured verdict from a run that measured nothing. Forgetting this one produces
+the safe answer instead. Set it only when the run really drives the service whose
+capability is being decided: a fake control plane over a real local Postgres does
+**not** qualify, however real the Postgres is, because what the stopwatch timed
+was Postgres.
 
-What remains, and it is stated rather than papered over: a copying harness
-cannot tell an honest provider from a dishonest one, because the two produce the
-same readings on it. That is a property of the harness. Settling it needs the
-real service with an account, and nothing short of that does.
+**It is symmetric.** An unasserted run is unproven whether you declare ` + "`" + `true` + "`" + ` or
+` + "`" + `false` + "`" + `. The false side is the one worth spelling out, because it is the one that
+would otherwise ship: a snapshot restore provider declaring ` + "`" + `false` + "`" + ` against a
+copying fake passes comfortably, publishes a certified claim that its service is
+not copy on write, and nobody rereads a green check.
+
+**The measurement is not taken.** The verdict is decided before the behaviour
+runs, so two goldens and six branches could not change it, and publishing what a
+simulator timed invites somebody to quote it as though it were about the product.
+
+**It is not a skip, and it never uses the word.** A skip says this provider makes
+no such claim. An unproven says the provider does make the claim and this run
+could not reach it. The verdict is reprinted at the end of the run, the ledger in
+` + "`" + `engine/conformance/ledger.go` + "`" + ` records it per provider, and
+` + "`" + `conformance.CopyOnWriteClaim` + "`" + ` renders it, so the cell in the published
+comparison table reads ` + "`" + `unproven` + "`" + ` rather than blank. A blank cell is taken for a
+pass by every reader in a hurry.
 
 The suite makes a golden large by writing ballast into it from inside the ` + "`" + `Mask` + "`" + `
 callback, so a provider needs no extra method: hand ` + "`" + `Mask` + "`" + ` a connection string
@@ -4131,9 +4130,12 @@ stronger statement than the one your run printed.
 the cost for a provider that bills by the gibibyte, and
 ` + "`" + `AF_CONFORMANCE_COW_LARGE_BYTES` + "`" + ` and its two siblings do the same from the
 environment for a machine that cannot afford the default. Both have floors, and
-both make the run say it was tuned. There is deliberately no way to skip the
-behaviour: a run that shrank says how far it shrank and what it could still
-refuse, and that can be read, where a run that skipped cannot.
+both make the run say it was tuned. Against a real service there is deliberately
+no way to skip the behaviour: a run that shrank says how far it shrank and what
+it could still refuse, and that can be read, where a run that skipped cannot.
+The one case that is neither a pass nor a shrunken run is the third verdict
+above, and it is not a skip either: it is a verdict, it prints, and it makes the
+claim unpublishable.
 
 ` + "`" + `ExpectedBranchLatency` + "`" + ` is checked the same way.
 ` + "`" + `Branch_IsWithinTheDeclaredLatency` + "`" + ` times the fastest of three branches of the
@@ -11316,14 +11318,18 @@ database:
 
 | Provider | Where the data lives | Branch time | Needs |
 | --- | --- | --- | --- |
-| ` + "`" + `docker` + "`" + ` | A container on the machine running ` + "`" + `af` + "`" + ` | Grows with the database | A Docker daemon |
+| ` + "`" + `docker` + "`" + ` | A container on the machine running ` + "`" + `af` + "`" + ` | Flat, because the daemon's storage driver shares layers | A Docker daemon |
 | [` + "`" + `neon` + "`" + `](/docs/providers/neon) | A Neon project | Flat, because branches share storage | A Neon project and an API key |
 | [` + "`" + `dblab` + "`" + `](/docs/providers/dblab) | A Database Lab Engine you run | Flat, because clones are copy on write | A Database Lab Engine, ZFS, and its verification token |
 | [` + "`" + `supabase` + "`" + `](/docs/providers/supabase) | A Supabase branch, which is a whole separate project | Grows with the database, because a Supabase branch is created empty | A Supabase project on a paid plan and an access token |
 | [` + "`" + `pgurl` + "`" + `](/docs/providers/pgurl) | A database on any Postgres server you name | Grows with the database, because a branch is a server side file copy | A reachable Postgres and a role that may create databases |
 
-` + "`" + `docker` + "`" + ` is the default and needs nothing. It is the right choice for a
-repository whose database is small enough that copying it is not the slow part.
+` + "`" + `docker` + "`" + ` is the default and needs nothing. Its branch time is flat, measured
+rather than assumed: the conformance suite branches an 8 MiB golden and a 512 MiB
+one and the daemon's storage driver shares the layers, so the two cost the same.
+What is not flat is building the golden, because that commits an image. This row
+said "Grows with the database" until somebody ran the measurement, which is the
+whole argument for having one.
 
 ` + "`" + `neon` + "`" + ` is the right choice when it is. Neon branches are copy on write, so
 creating one takes about as long for a hundred gigabytes as for a hundred rows.


### PR DESCRIPTION
Follow up to #343, which shipped the third verdict with the default the wrong way round and the rule asymmetric. Two lanes found a hole each and both holes are silent passes.

## The default was the wrong way round

#343 raised UNPROVEN when a fixture DECLARED that its storage copies. **A field a fake sets to excuse itself is a field a fake can simply never set.** The next lane writes a control plane, never learns the declaration exists because nothing forced it to say anything, and collects a measured verdict from a run that measured nothing.

So it is inverted. `Options.RealService` names the actual service a run drives, and **leaving it empty is what produces the unproven verdict**. An assertion of reality, not an admission of simulation, so forgetting it produces the safe answer. The burden sits with the credentialed run that has a person in the loop, not with an unattended fake that has nobody.

```go
conformance.RunDatabase(t, factory, conformance.Options{
    RealService: "the real Neon API, against a real project",
})
```

## It was not symmetric, which certified the dangerous half

The assertion is two sided and `false` requires branch time to GROW with the data, which against a harness that copies every branch holds comfortably. **Every snapshot restore provider in the wave would have collected a green copy on write gate for a reason with nothing to do with the service it ships against**, and nobody would have reread it. A verdict raised only on a red fixes the visible half and certifies the other one.

An unasserted run is now unproven in both directions, whatever the measurement would have said. The measurement is not taken at all: it cannot change the answer, and publishing what a simulator timed invites somebody to quote it as though it were about the product.

## It is not a skip and never uses the word

The existing line reads `skipped: <provider> does not declare <capability>`. A reader must not confuse a provider that makes no claim with a run that could not reach the claim it does make. The reason lives on the BEHAVIOUR, in `serviceOwnedBehaviors`, which is **L-other-reds' shape rather than mine**: it makes "which behaviours does a simulator invalidate" one list somebody can read instead of a condition spread across five packages where the sixth copies a working file and inherits the wrong answer.

`Branch_IsWithinTheDeclaredLatency` is the obvious second entry, deliberately not taken, because widening a gate without telling the lanes it moves is its own failure. It is named in the map's comment.

## The shipped page that said this was impossible

`provider-authoring.md` said, on purpose, that **there is deliberately no way to skip this behaviour**. Somebody wrote that to close the door this change opens, and no gate would have caught it. Found by L-other-reds. It now separates the real service case, where shrinking rather than skipping is still the rule, from the one case that is a verdict instead.

## Six proofs, and the two controls are real subjects with no account

| Case | Result |
| --- | --- |
| true declaration on a simulator | UNPROVEN |
| false declaration on a simulator | UNPROVEN, and no measurement decided it |
| harness asserting nothing at all | UNPROVEN |
| `docker`, true on a real daemon | still PASSES |
| `pgurl`, false on a real Postgres | still PASSES |
| `CopyOnWriteUnderstated` | still DETECTABLE |

The last three are what stop this being a switch that turns the instrument off. The two provider suites sit on opposite sides of the assertion and need no credentials, so CI decides them.

## A contradiction this branch reported and has now resolved

#343's body flagged that `docker` declares `CopyOnWrite: true` while the provider overview published "Grows with the database" for it, and left it. **I ran it.** Against a real daemon at the shipped sizes, 8 MiB against 512 MiB, branch time did not grow: the daemon's storage driver shares the layers. So the declaration holds, the ledger records `docker` as proved with that run as evidence, and the overview page now says what the measurement says instead of the opposite.

`pgurl` was measured the same way and holds its false declaration.

## Mutation table

Ten cells, classified on the `=== RUN` count, all ten caught by the test aimed at. No non discriminating cell.

| Cell | The break | Verdict |
| --- | --- | --- |
| 1 | the default inverts back to trusting an unasserted harness | CAUGHT |
| 2 | the gate is never consulted in the run loop | CAUGHT |
| 3 | copy on write is not a service owned behaviour | CAUGHT |
| 4 | the end of run report writes nothing | CAUGHT |
| 5 | the subtest verdict line is not printed | CAUGHT |
| 6 | `CopyOnWriteClaim` renders unproven as true | CAUGHT |
| 7 | `Publishable` returns true for unproven | CAUGHT |
| 8 | a missing ledger entry falls back to true | CAUGHT |
| 9 | the ledger downgrades a proved cell | CAUGHT |
| 10 | the table republishes an unproved `yes` | CAUGHT |

**One assertion was removed rather than kept.** I had written a check that the unproven subtest does not report `--- PASS`. It could never have succeeded: Go has two states, and a run that cannot decide a claim has not refuted it either, so the subtest passes and must. That is precisely why the third answer had to be carried where Go's result cannot reach, which is the output, the end of run report, the ledger and the published cell. **An assertion nobody has watched succeed is as unproved as one nobody has watched fail.**
