### PR TITLE
control plane: an operator invited through the portal could never be given a way in

### DIFF
--- a/.changes/an-operator-you-invited-could-never-sign-in.md
+++ b/.changes/an-operator-you-invited-could-never-sign-in.md
@@ -1,0 +1,35 @@
+# added
+
+An operator invited through the portal could never sign in.
+
+Creating one writes the row with no password, on purpose, and told the reader
+to "set a password out of band before it is usable". There was no out of band
+that a person in the portal could reach: the only thing in this repository that
+had ever written `admin_users.password_hash` was the `set-operator-password`
+command, which runs on a connection string row level security does not apply
+to. So every account created from that panel sat in the directory reading
+`Not provisioned` and `Never`, and finishing the invitation needed a shell and
+the admin database URL.
+
+`admin.operators.setPassword` is the other half, under an operator session and
+recorded in the platform audit chain at critical severity. The console asks for
+the password in the panel that created the account and in the account's own
+drawer, offers to generate one in the browser, and shows it once with the
+sentence that says nothing on the platform can read it back. The server never
+chooses a password and still mints none.
+
+Setting your own password needs your current one as well, which nothing else on
+this router asks for. The danger there is the opposite of the one setRole and
+suspend guard: an operator cookie lasts twelve hours, and without the check a
+stolen one buys the account permanently, because the thief sets a password and
+the revoke below cuts every session the real owner had.
+
+Every live session belonging to that operator is revoked in the same
+transaction, except the one making the request. A password changed because it
+leaked, that leaves the sessions it opened alive, is a reset that resets
+nothing.
+
+The length floor and the refusal of a stray newline now live in one module that
+both writers ask, because a rule enforced in one of two writers is a rule with a
+way around it, and the way around it would have been the one reachable from a
+browser.

--- a/console/app/admin/administration/admins/page.tsx
+++ b/console/app/admin/administration/admins/page.tsx
@@ -8,6 +8,7 @@ import {
   Card,
   CardSkeleton,
   Confirm,
+  CopyButton,
   Field,
   Loaded,
   TableSkeleton,
@@ -29,6 +30,7 @@ import { operatorMay, useAdminContext, useOperators, type Operator } from "@/lib
 import {
   createOperator,
   restoreOperator,
+  setOperatorPassword,
   setOperatorRole,
   suspendOperator,
   useAdminCatalog,
@@ -386,7 +388,13 @@ function OperatorDrawer({
               label: "Can sign in",
               value: operator.provisioned
                 ? "Yes"
-                : "No. A password has never been set, so this account cannot be signed in to.",
+                : mayWrite
+                  // Not "finishes the invitation", which is right for somebody
+                  // a colleague created and wrong for the root operator, who
+                  // was provisioned rather than invited and reaches this same
+                  // panel with no password on a fresh installation.
+                  ? "No. A password has never been set. Setting one below is what makes this account usable."
+                  : "No. A password has never been set, so this account cannot be signed in to.",
             },
             {
               label: "Last signed in",
@@ -413,61 +421,85 @@ function OperatorDrawer({
             read of the entire customer base.
           </p>
         ) : (
-          <div className="border-t border-rule px-4 py-4">
-            <Field
-              label="Role"
-              hint={
-                isSelf
-                  ? "The server refuses to let an operator change their own role. Ask another owner."
-                  : operator.isRoot
-                    ? "A database trigger refuses to demote the root operator."
-                    : "Takes effect on their next request."
-              }
-            >
-              <select
-                className={selectClass}
-                value={role}
-                onChange={(e) => setRole(e.target.value)}
+          <>
+            <div className="border-t border-rule px-4 py-4">
+              <Field
+                label="Role"
+                hint={
+                  isSelf
+                    ? "The server refuses to let an operator change their own role. Ask another owner."
+                    : operator.isRoot
+                      ? "A database trigger refuses to demote the root operator."
+                      : "Takes effect on their next request."
+                }
               >
-                {(roles.length > 0 ? roles : [operator.role]).map((r) => (
-                  <option key={r} value={r}>
-                    {r.replace(/_/g, " ")}
-                  </option>
-                ))}
-              </select>
-            </Field>
+                <select
+                  className={selectClass}
+                  value={role}
+                  onChange={(e) => setRole(e.target.value)}
+                >
+                  {(roles.length > 0 ? roles : [operator.role]).map((r) => (
+                    <option key={r} value={r}>
+                      {r.replace(/_/g, " ")}
+                    </option>
+                  ))}
+                </select>
+              </Field>
 
-            <div className="mt-3 flex flex-wrap gap-2">
-              <Button
-                variant="primary"
-                disabled={role === operator.role}
-                busy={busy === "role"}
-                onClick={() => run("role", () => setOperatorRole(operator.id, role))}
-              >
-                Change role
-              </Button>
-              {operator.suspended ? (
-                <Button busy={busy === "restore"} onClick={() => setConfirming("restore")}>
-                  Restore
+              <div className="mt-3 flex flex-wrap gap-2">
+                <Button
+                  variant="primary"
+                  disabled={role === operator.role}
+                  busy={busy === "role"}
+                  onClick={() => run("role", () => setOperatorRole(operator.id, role))}
+                >
+                  Change role
                 </Button>
-              ) : (
-                <Button variant="danger" onClick={() => setConfirming("suspend")}>
-                  Suspend
-                </Button>
-              )}
+                {operator.suspended ? (
+                  <Button busy={busy === "restore"} onClick={() => setConfirming("restore")}>
+                    Restore
+                  </Button>
+                ) : (
+                  <Button variant="danger" onClick={() => setConfirming("suspend")}>
+                    Suspend
+                  </Button>
+                )}
+              </div>
+
+              {error ? (
+                <p role="alert" className="mt-3 text-[13px] leading-6 text-fail">
+                  {error}
+                </p>
+              ) : null}
+              {done ? (
+                <p role="status" className="mt-3 text-[13px] leading-6 text-pass">
+                  {done}
+                </p>
+              ) : null}
             </div>
 
-            {error ? (
-              <p role="alert" className="mt-3 text-[13px] leading-6 text-fail">
-                {error}
-              </p>
-            ) : null}
-            {done ? (
-              <p role="status" className="mt-3 text-[13px] leading-6 text-pass">
-                {done}
-              </p>
-            ) : null}
-          </div>
+            {/* NOT KEYED on `operator.provisioned`, and that was a bug in
+                this file for exactly as long as it took to look at the
+                rendered page. Keying it there reads as tidy: the label should
+                say "Replace the password" once the account has one. What it
+                actually did was remount the component the instant the write
+                succeeded, because the reload flips that prop, which threw away
+                the panel showing the password that had just been set. The
+                write worked, the directory updated, and the one thing the
+                operator needed, the value to send the person, was on screen
+                for no frames at all. The component reads the prop on every
+                render, so the label is right without a remount. */}
+            <SetPassword
+              target={{
+                id: operator.id,
+                email: operator.email,
+                provisioned: operator.provisioned,
+                isRoot: operator.isRoot,
+              }}
+              isSelf={isSelf}
+              onSet={onChanged}
+            />
+          </>
         )}
       </Drawer>
 
@@ -547,17 +579,28 @@ function CreateOperator({
   const [role, setRole] = useState("read_only");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [effect, setEffect] = useState<string | null>(null);
+  const [created, setCreated] = useState<{ id: string; email: string; effect: string } | null>(null);
+  /** Set once the second half of the invitation has happened, so that the
+   *  first half's sentence about an account that cannot sign in stops being
+   *  rendered directly above one saying it now can. */
+  const [provisioned, setProvisioned] = useState(false);
 
   async function submit() {
     setBusy(true);
     setError(null);
     try {
-      const result = await createOperator({ email: email.trim(), name: name.trim(), role });
-      // The server's own sentence about what it did, which says the account is
-      // unusable until somebody provisions a password out of band. Replacing it
-      // with "Created" here would hide the one thing the reader has to do next.
-      setEffect(result.effect);
+      const address = email.trim().toLowerCase();
+      const result = await createOperator({ email: address, name: name.trim(), role });
+      // The id is kept, which is what lets this panel finish the invitation
+      // rather than reporting that an unusable account now exists and sending
+      // somebody to a shell with a connection string.
+      //
+      // The address is lowercased here as well as on the server, because this
+      // one is used locally: it is the phrase the confirmation asks to be
+      // typed and the address the panel says to send the password to, and an
+      // operator who typed a capital would otherwise be shown one address and
+      // asked to type another.
+      setCreated({ id: result.id, email: address, effect: result.effect });
       onCreated();
     } catch (e) {
       setError(e instanceof ApiError ? e.message : "That did not work.");
@@ -568,22 +611,45 @@ function CreateOperator({
 
   return (
     <Drawer open title="New operator" onClose={onClose}>
-      {effect ? (
-        <div className="px-4 py-4">
-          <p role="status" className="text-[13px] leading-6 text-ink">
-            {effect}
-          </p>
-          <p className="mt-3 text-[13px] leading-6 text-muted">
-            The row lands with no password, so it cannot be signed in to. There is no default
-            credential anywhere in this product: somebody has to set one out of band before this
-            account works.
-          </p>
-          <div className="mt-4">
-            <Button variant="primary" onClick={onClose}>
-              Done
-            </Button>
-          </div>
-        </div>
+      {created ? (
+        <>
+          {provisioned ? null : (
+            <div className="px-4 py-4">
+              <p role="status" className="text-[13px] leading-6 text-ink">
+                {created.effect}
+              </p>
+              <p className="mt-3 text-[13px] leading-6 text-muted">
+                Set one below to finish the invitation, or leave it and do that later from this
+                operator's own panel. Whichever password is used is made in this browser and the
+                server keeps only a hash of it.
+              </p>
+            </div>
+          )}
+
+          {/* The second half of the invitation, in the panel that sent it.
+              Leaving the reader with "set a password out of band" and a Done
+              button is what made every account created here unusable until
+              somebody found a shell and the admin database URL. */}
+          <SetPassword
+            target={{ id: created.id, email: created.email, provisioned, isRoot: false }}
+            isSelf={false}
+            onSet={() => {
+              setProvisioned(true);
+              onCreated();
+            }}
+            onFinished={onClose}
+          />
+
+          {provisioned ? null : (
+            <div className="px-4 py-4">
+              {/* Not "Cancel", which would read as undoing the account, and not
+                  "Done", which would claim the invitation is finished. The row
+                  exists and cannot sign in, and leaving now is a real choice
+                  that the drawer on the operator can complete later. */}
+              <Button onClick={onClose}>Set it later</Button>
+            </div>
+          )}
+        </>
       ) : (
         <form
           className="px-4 py-4"
@@ -639,6 +705,357 @@ function CreateOperator({
         </form>
       )}
     </Drawer>
+  );
+}
+
+/* -------------------------------------------------------------------------
+ * The password, which is the half of an invitation nothing here could finish
+ * ---------------------------------------------------------------------- */
+
+/**
+ * The unambiguous alphabet, and why it is not the whole of one.
+ *
+ * A password set here is READ OUT or PASTED INTO A MESSAGE by the person
+ * setting it, because that is the only way it reaches the person it belongs to.
+ * So the characters that cannot survive that trip are gone: `l` against `1`,
+ * `O` against `0`, and capitals entirely, which are the difference between a
+ * password that works and one that works when it is typed carefully. Thirty one
+ * symbols over twenty characters is about ninety nine bits, which is far past
+ * anything scrypt at this work factor needs to be safe.
+ */
+const PASSWORD_ALPHABET = "abcdefghjkmnpqrstuvwxyz23456789";
+
+/** Characters per group, and groups, in a generated password. Twenty
+ *  characters, grouped so a human can read them aloud without losing their
+ *  place, and joined with single hyphens that count toward the length. */
+const PASSWORD_GROUP = 5;
+const PASSWORD_GROUPS = 4;
+
+/**
+ * A password the browser makes, which the server never chooses.
+ *
+ * THE GENERATION IS HERE AND NOT IN THE ROUTE, deliberately. A route that
+ * generated a starting credential would put a value the server picked into the
+ * row, and every log, proxy and error report between here and there would have
+ * had a chance at it. This runs in the operator's own browser, the value goes
+ * out once in the body of one request, and the server stores only a scrypt hash
+ * of it. Nothing on the platform can read it back, which is why the panel says
+ * so before it lets the reader close it.
+ *
+ * REJECTION SAMPLING RATHER THAN A MODULO. 256 is not a multiple of 31, so
+ * `byte % 31` makes the first eight letters of the alphabet appear about twelve
+ * percent more often than the rest. It is a small bias and it is a real one,
+ * and discarding the eight byte values above the last whole multiple costs
+ * nothing to do correctly.
+ */
+function generatePassword(): string {
+  const limit = 256 - (256 % PASSWORD_ALPHABET.length);
+  const wanted = PASSWORD_GROUP * PASSWORD_GROUPS;
+  const picked: string[] = [];
+  const bytes = new Uint8Array(64);
+  while (picked.length < wanted) {
+    crypto.getRandomValues(bytes);
+    for (const byte of bytes) {
+      if (picked.length === wanted) break;
+      if (byte >= limit) continue;
+      picked.push(PASSWORD_ALPHABET[byte % PASSWORD_ALPHABET.length]!);
+    }
+  }
+  const groups: string[] = [];
+  for (let i = 0; i < wanted; i += PASSWORD_GROUP) {
+    groups.push(picked.slice(i, i + PASSWORD_GROUP).join(""));
+  }
+  return groups.join("-");
+}
+
+/** Everything this form needs to know about who it is acting on. Smaller than
+ *  `Operator` on purpose: the create panel has an id and an address and nothing
+ *  else, and it needs this form as much as the drawer does. */
+type PasswordTarget = {
+  id: string;
+  email: string;
+  /** Whether a working credential is being REPLACED rather than an invitation
+   *  finished. The two are different events and get different words, a
+   *  different button and, for the first, a typed confirmation. */
+  provisioned: boolean;
+  isRoot: boolean;
+};
+
+/**
+ * Setting somebody's password, in the two places an operator arrives at it.
+ *
+ * WHAT THIS FIXES. `admin.operators.create` writes a row with no password and
+ * says "Set a password out of band before it is usable", and the only out of
+ * band that existed was a command holding the admin database connection string.
+ * So a person invited through this portal appeared in the directory reading
+ * `Not provisioned` and `Never`, and finishing the invitation needed a shell.
+ * The route behind this form is what makes the invitation completable by the
+ * person who sent it.
+ *
+ * IT DOES NOT PREDICT THE SERVER'S RULES, which is the same choice the role
+ * control on this page makes. The minimum length, the refusal of a stray
+ * newline, the demand for the current password when the target is you: all of
+ * those are enforced and worded by the server, and rendered here as its own
+ * sentence. A form that reimplemented them would be a second copy of a security
+ * rule, drifting quietly, and hiding the button on a guess about the rules is
+ * how a control disappears the day the rules change with nobody finding out.
+ *
+ * WHAT IT DOES DECIDE LOCALLY is which of two events this is. Finishing an
+ * invitation is ordinary and needs one press. Replacing a password that works
+ * ends every session that operator has and locks out whoever was using the old
+ * one, so it asks for the address to be typed first, exactly as suspending
+ * does. Root gets the same treatment for a different reason: the account the
+ * database refuses to delete, demote or suspend is the one where a new password
+ * is the whole of taking it over.
+ */
+function SetPassword({
+  target,
+  isSelf,
+  onSet,
+  onFinished,
+}: {
+  target: PasswordTarget;
+  /** The server demands the current password only in this case. See the route. */
+  isSelf: boolean;
+  onSet: () => void;
+  /**
+   * What "I have sent it" does when this form is the LAST step of something
+   * larger. In the drawer there is nothing after it, so dismissing the value
+   * returns to the form. In the create panel the invitation is finished at
+   * that moment, so the panel closes instead, and the button says so. Without
+   * this the create panel offered two finishing buttons stacked on each other,
+   * which is the shape of a screen nobody read after it was assembled.
+   */
+  onFinished?: () => void;
+}) {
+  const [password, setPassword] = useState("");
+  const [current, setCurrent] = useState("");
+  const [shown, setShown] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [effect, setEffect] = useState<string | null>(null);
+  const [confirming, setConfirming] = useState(false);
+
+  // Replacing a credential that works, or touching root, is the shape that
+  // gets a typed confirmation. Finishing an invitation is not.
+  const grave = target.provisioned || target.isRoot;
+
+  async function run() {
+    setBusy(true);
+    setError(null);
+    try {
+      const result = await setOperatorPassword({
+        adminUserId: target.id,
+        password,
+        // Sent only when it can be needed. An empty string here would be a
+        // wrong current password rather than an absent one, and the server
+        // says different things about those two.
+        ...(isSelf ? { currentPassword: current } : {}),
+      });
+      setConfirming(false);
+      setCurrent("");
+      // The server's own sentence, which is the only thing that knows how many
+      // sessions it cut and whether the account is suspended anyway.
+      setEffect(result.effect);
+      onSet();
+    } catch (e) {
+      setConfirming(false);
+      setError(e instanceof ApiError ? e.message : "That did not work.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function dismiss() {
+    // The value leaves the browser here, and the form comes back reading the
+    // account's NEW state, because `target` is a prop rather than something
+    // captured when this mounted.
+    setEffect(null);
+    setPassword("");
+    setShown(false);
+  }
+
+  if (effect) {
+    return (
+      <div className="border-t border-rule px-4 py-4">
+        <p role="status" className="text-[13px] leading-6 text-pass">
+          {effect}
+        </p>
+        {isSelf ? null : (
+          <>
+            <p className="mt-3 text-[13px] leading-6 text-muted">
+              This is the last time this password is on screen. Send it to {target.email} through
+              something you would send a password through, and ask them to change it once they are
+              in.
+            </p>
+            <div className="mt-3 flex flex-wrap items-start justify-between gap-3">
+              {/* The same surface CommandBlock uses, and not that component:
+                  a command wraps on its spaces and a password has none, so
+                  this one breaks anywhere rather than running off the edge of
+                  a phone with no scrollbar and no ellipsis. */}
+              {/* basis-full below the small breakpoint, and that is not a
+                  cosmetic preference. Sharing the row with the button at 390px
+                  left about 210px for the value, and `break-all` then split a
+                  generated password after its twenty second character, so the
+                  line ended in a lone `c`. A password is READ OFF THIS SCREEN
+                  and retyped; a break in the middle of a group is a character
+                  somebody loses or reads as part of the separator. Full width
+                  first, side by side only where there is room for both. */}
+              <code className="min-w-0 basis-full select-all break-all rounded-md border border-rule bg-[rgba(16,16,16,0.03)] px-3 py-2.5 font-mono text-[12.5px] leading-6 text-ink sm:flex-1 sm:basis-0">
+                {password}
+              </code>
+              <CopyButton
+                value={password}
+                label="Copy the password"
+                said="Password copied to the clipboard"
+              />
+            </div>
+          </>
+        )}
+        <div className="mt-4">
+          {/* The only thing that takes the password off the screen. It is not
+              a timer and not the drawer closing: an operator who is halfway
+              through pasting it into a message should decide when it goes. */}
+          <Button onClick={onFinished ?? dismiss} variant={onFinished ? "primary" : "secondary"}>
+            {onFinished ? "Done" : isSelf ? "Done" : "I have sent it"}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <form
+        className="border-t border-rule px-4 py-4"
+        onSubmit={(e) => {
+          e.preventDefault();
+          if (grave) setConfirming(true);
+          else void run();
+        }}
+      >
+        <div className="grid gap-3">
+          <Field
+            label={target.provisioned ? "New password" : "Password"}
+            hint={
+              isSelf
+                ? "You will stay signed in here. Every other session you have ends."
+                : target.provisioned
+                  ? "Replaces the one they have. Every session they are in ends on its next request."
+                  : "The account cannot sign in until this is set. Nothing on the platform can read it back afterwards, so keep it until you have passed it on."
+            }
+          >
+            <input
+              className={inputClass}
+              // Toggled rather than fixed. A password being set FOR somebody
+              // else has to be read off the screen to be passed on, and one
+              // being typed in an office should not sit there in plain text.
+              type={shown ? "text" : "password"}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              autoComplete="new-password"
+              spellCheck={false}
+              required
+            />
+          </Field>
+
+          <div className="flex flex-wrap gap-2">
+            <Button
+              onClick={() => {
+                setPassword(generatePassword());
+                // Generating one and hiding it is a control that does nothing:
+                // the operator cannot pass on what they cannot see.
+                setShown(true);
+              }}
+            >
+              Generate one
+            </Button>
+            <Button onClick={() => setShown(!shown)} pressed={shown}>
+              {shown ? "Hide" : "Show"}
+            </Button>
+            {password ? (
+              <CopyButton value={password} label="Copy" said="Password copied to the clipboard" />
+            ) : null}
+          </div>
+
+          {isSelf ? (
+            <Field
+              label="Your current password"
+              hint="Asked for because this is your own account. An operator session lasts twelve hours, and without this a stolen one would be permanent."
+            >
+              <input
+                className={inputClass}
+                type="password"
+                value={current}
+                onChange={(e) => setCurrent(e.target.value)}
+                autoComplete="current-password"
+                required
+              />
+            </Field>
+          ) : null}
+        </div>
+
+        <div className="mt-4 flex flex-wrap gap-2">
+          <Button
+            type="submit"
+            variant={target.provisioned ? "danger" : "primary"}
+            disabled={password === ""}
+            busy={busy && !grave}
+          >
+            {target.provisioned ? "Replace the password" : "Set the password"}
+          </Button>
+        </div>
+
+        {error ? (
+          <p role="alert" className="mt-3 text-[13px] leading-6 text-fail">
+            {error}
+          </p>
+        ) : null}
+      </form>
+
+      <Confirm
+        open={confirming}
+        // The title says which of the two things this is, rather than always
+        // saying the loud one. The root operator reaches this dialog with no
+        // password at all, and a heading reading "Replace the password"
+        // directly above "nothing is being replaced" is a dialog arguing with
+        // itself in the one place a reader is being asked to be careful.
+        title={`${target.provisioned ? "Replace" : "Set"} the password for ${target.email}`}
+        // The account's own address rather than a fixed word, the same as
+        // suspending. Typing a word proves somebody read a dialog; typing the
+        // address proves they read WHICH account.
+        phrase={target.email}
+        confirmLabel={target.provisioned ? "Replace it" : "Set it"}
+        // Danger only when something is being taken away. Replacing a working
+        // password ends every session that operator holds; giving a first one
+        // to an account that has never had any is the same shape as restoring
+        // a suspended operator, which this component's own note explains is
+        // why `primary` exists. A red button beside "Not now" would say the
+        // opposite of what pressing it does.
+        tone={target.provisioned ? "danger" : "primary"}
+        cancelLabel={target.provisioned ? "Keep it" : "Not now"}
+        busy={busy}
+        error={error}
+        onCancel={() => {
+          setConfirming(false);
+          setError(null);
+        }}
+        onConfirm={() => void run()}
+      >
+        <p className="text-[13px] leading-6 text-muted">
+          {target.provisioned
+            ? "Their current password stops working, and every operator session they hold stops resolving on its next request. If they are in the middle of something, this ends it."
+            : "This account has never had a password, so nothing is being replaced and nobody is being signed out. It is being given a way in."}
+        </p>
+        {target.isRoot ? (
+          <p className="mt-3 text-[13px] leading-6 text-muted">
+            This is the root operator, the account the database refuses to delete, demote or
+            suspend. Setting its password is the one way its holder changes. This is recorded in
+            the platform audit chain at critical severity under your address.
+          </p>
+        ) : null}
+      </Confirm>
+    </>
   );
 }
 

--- a/console/lib/admin-administration.ts
+++ b/console/lib/admin-administration.ts
@@ -243,7 +243,7 @@ export function useAdminCatalog(enabled = true) {
 }
 
 /*
- * The four operator writes.
+ * The five operator writes.
  *
  * They have existed in web/apps/api/src/admin/router.ts since 0029 and until
  * now had ZERO CALL SITES anywhere in the console: the operators page was read
@@ -281,4 +281,33 @@ export async function suspendOperator(adminUserId: string, reason: string) {
 
 export async function restoreOperator(adminUserId: string) {
   return adminMutate<{ suspended: boolean }>("admin.operators.restore", { adminUserId });
+}
+
+/**
+ * Gives an operator a password, which is what turns a created account into one
+ * that can sign in.
+ *
+ * THE PASSWORD IS NEVER PUT IN A URL, a query string or anything this console
+ * stores. It travels in the POST body that adminMutate already sends, exactly
+ * as the sign-in form's does, and the response carries no part of it back. The
+ * value exists in the field the operator typed it into until the panel closes.
+ *
+ * `currentPassword` is required by the server when, and only when, the target
+ * is the caller: setting your own password without proving you know the current
+ * one would let a stolen operator cookie, which expires in twelve hours, buy
+ * the account permanently. The page asks for it in that one case rather than
+ * always, because for every other target the caller is exercising a permission
+ * on somebody else's account and the audit chain names them for it.
+ */
+export async function setOperatorPassword(input: {
+  adminUserId: string;
+  password: string;
+  currentPassword?: string;
+}) {
+  return adminMutate<{
+    provisioned: boolean;
+    replacedAPassword: boolean;
+    sessionsRevoked: number;
+    effect: string;
+  }>("admin.operators.setPassword", input);
 }

--- a/web/apps/api/src/admin/bootstrap.ts
+++ b/web/apps/api/src/admin/bootstrap.ts
@@ -8,7 +8,7 @@
 // loop and the operator portal is unreachable by anybody, forever.
 //
 // It is worse one level down. `admin.operators.create` writes the row with a
-// NULL password and tells the caller, in its own words, "The account exists and
+// NULL password and told the caller, in its own words, "The account exists and
 // cannot sign in. Set a password out of band before it is usable." There was no
 // out of band. Nothing anywhere in this repository ever wrote
 // `admin_users.password_hash`, so even an operator who existed could not be
@@ -21,6 +21,18 @@
 //   `set-operator-password`  gives a password to an operator that already
 //                            exists, which is what makes `operators.create`
 //                            usable at all.
+//
+// THE SECOND ONE IS NO LONGER THE ONLY WAY, and the paragraph above needs
+// reading with that in mind. `admin.operators.setPassword` now does the same
+// write from the operator portal, under a named operator session, so finishing
+// an invitation no longer needs a shell and a connection string. This command
+// stays, and stays privileged, because it is what works when NOBODY can sign
+// in: a portal route cannot recover an installation whose only operators have
+// all forgotten their passwords, and that is the case this command was written
+// for. The two differ in exactly one behaviour, and it is deliberate on both
+// sides: the route will set the root operator's password and this command
+// refuses to, because the route has a person's name attached to the act and a
+// connection string does not.
 //
 // WHY THE PASSWORD IS NOT AN ARGUMENT. A command line argument is visible in
 // `ps` to every user on the machine, lands in the shell history file, and on a
@@ -39,25 +51,22 @@
 
 import { createPool, appendAdminAudit, sql, type Pool } from '@antifailure/db'
 import { hashPassword } from './session.ts'
+import { passwordRefusal } from './password.ts'
 import { ADMIN_ROLES, type AdminRole } from './permissions.ts'
 
 export class OperatorBootstrapRefused extends Error {}
 
 /**
- * The shortest password this will write.
+ * Re-exported so that `--help`, the command's own refusal text and this
+ * module's callers keep naming one number.
  *
- * Twelve rather than eight, and it is a floor rather than a policy: what is
- * behind this credential is every tenant on the instance, and the online
- * guessing rate is already held to one attempt per two seconds by the limit on
- * POST /v1/admin/signin. Twelve characters is what makes offline guessing
- * against a leaked hash hopeless rather than merely slow, given scrypt at
- * N = 2^15.
- *
- * There is deliberately no character class rule. A rule demanding a symbol
- * produces `Password1!` and refuses a passphrase, which is the wrong trade in
- * both directions.
+ * The rule itself moved to password.ts when a SECOND thing learned to write
+ * `admin_users.password_hash`: `admin.operators.setPassword`, which an owner
+ * reaches from the operator portal rather than from a shell with a connection
+ * string. Two writers enforcing their own floor is one writer enforcing a
+ * floor, and the one that would drift is the one reachable from a browser.
  */
-export const MIN_PASSWORD_LENGTH = 12
+export { MIN_PASSWORD_LENGTH } from './password.ts'
 
 export interface BootstrapOperatorInput {
   /** A connection string row-level security does not apply to. */
@@ -353,23 +362,11 @@ function normaliseEmail(value: string): string {
 }
 
 function assertUsablePassword(password: string): void {
-  if (password.length < MIN_PASSWORD_LENGTH) {
-    throw new OperatorBootstrapRefused(
-      `That password is ${password.length} characters. It has to be at least ` +
-        `${MIN_PASSWORD_LENGTH}, because what is behind this credential is every tenant on ` +
-        'this instance. A passphrase is fine and is better than a short one with a symbol in it.',
-    )
-  }
-  if (password.trim() !== password) {
-    // Almost always a trailing newline that a heredoc or a copy and paste
-    // added, and it would be part of the password forever with no way to see
-    // it. Refusing is kinder than accepting a credential nobody can retype.
-    throw new OperatorBootstrapRefused(
-      'That password begins or ends with whitespace, which is almost always a stray newline ' +
-        'from a paste or a heredoc. It would be part of the password and invisible in every ' +
-        'attempt to type it again.',
-    )
-  }
+  // The rule is password.ts's, and the error class is this module's. Both
+  // writers refuse the same passwords in the same words; only the type of the
+  // refusal differs, because a command prints and a route becomes a status.
+  const refusal = passwordRefusal(password)
+  if (refusal) throw new OperatorBootstrapRefused(refusal)
 }
 
 /**

--- a/web/apps/api/src/admin/password.ts
+++ b/web/apps/api/src/admin/password.ts
@@ -1,0 +1,129 @@
+// What a password has to clear, and how the current one is proved, for the two
+// things that write `admin_users.password_hash`.
+//
+// WHY THIS FILE EXISTS AT ALL. Until now there was exactly one writer, the
+// `set-operator-password` command in bootstrap.ts, and its rules could live
+// beside it. There are now two: that command, which runs on a privileged
+// connection string, and `admin.operators.setPassword`, which runs under an
+// operator session in the portal. A floor enforced in one of two writers is a
+// floor with a way around it, and the way around it would be the one anybody
+// can reach from a browser. So the rules moved here and both callers ask.
+//
+// WHY IT REPORTS A SENTENCE RATHER THAN THROWING. The two callers owe their
+// readers different error types: the command raises `OperatorBootstrapRefused`
+// and prints, the route raises a `TRPCError` that becomes an HTTP status. A
+// shared function that threw would force one of them to catch a foreign error
+// class and re-wrap it, and the usual result of that is a caught error whose
+// message is replaced by a generic one. The refusal text is the valuable part,
+// so it is what crosses the boundary.
+//
+// NOTHING HERE EVER LOGS, RETURNS OR EMBEDS A PASSWORD. The refusals name the
+// LENGTH and the SHAPE of what was rejected and never the value, because a
+// refusal that quotes the password writes it into every log that catches it.
+
+import { sql } from 'drizzle-orm'
+import type { Db } from '@antifailure/db'
+import { passwordMatches } from './session.ts'
+
+/**
+ * The shortest password either writer will accept.
+ *
+ * Twelve rather than eight, and it is a floor rather than a policy: what is
+ * behind this credential is every tenant on the instance, and the online
+ * guessing rate is already held to one attempt per two seconds by the limit on
+ * POST /v1/admin/signin. Twelve characters is what makes offline guessing
+ * against a leaked hash hopeless rather than merely slow, given scrypt at
+ * N = 2^15.
+ *
+ * There is deliberately no character class rule. A rule demanding a symbol
+ * produces `Password1!` and refuses a passphrase, which is the wrong trade in
+ * both directions.
+ */
+export const MIN_PASSWORD_LENGTH = 12
+
+/**
+ * The longest one, which is a denial of service bound and not an opinion.
+ *
+ * scrypt at this work factor is deliberately expensive, and it is expensive in
+ * MEMORY as much as in time. An unbounded field is an invitation to spend the
+ * process's memory budget on one request, and the route that takes this input
+ * is reachable by any operator holding admin.operators.write. Nothing a human
+ * types or a generator produces comes close to this.
+ */
+export const MAX_PASSWORD_LENGTH = 1024
+
+/**
+ * Why this password cannot be written, or null when it can.
+ *
+ * Null is the ACCEPTING answer, which is the direction worth stating out loud
+ * because it is the one a mistake inverts: a caller that treats a truthy return
+ * as "fine" accepts every password this function rejects and rejects every one
+ * it accepts. Both writers have a test that watches a short password get
+ * refused, which is what would catch that.
+ */
+export function passwordRefusal(password: string): string | null {
+  if (password.length < MIN_PASSWORD_LENGTH) {
+    return (
+      `That password is ${password.length} characters. It has to be at least ` +
+      `${MIN_PASSWORD_LENGTH}, because what is behind this credential is every tenant on ` +
+      'this instance. A passphrase is fine and is better than a short one with a symbol in it.'
+    )
+  }
+  if (password.length > MAX_PASSWORD_LENGTH) {
+    return (
+      `That password is ${password.length} characters, and the limit is ${MAX_PASSWORD_LENGTH}. ` +
+      'The bound is about the cost of hashing it rather than about the password being too good.'
+    )
+  }
+  if (password.trim() !== password) {
+    // Almost always a trailing newline that a heredoc or a copy and paste
+    // added, and it would be part of the password forever with no way to see
+    // it. Refusing is kinder than accepting a credential nobody can retype.
+    return (
+      'That password begins or ends with whitespace, which is almost always a stray newline ' +
+      'from a paste or a heredoc. It would be part of the password and invisible in every ' +
+      'attempt to type it again.'
+    )
+  }
+  return null
+}
+
+/**
+ * Whether `password` is the password that operator currently has.
+ *
+ * THE READ OF `password_hash` LIVES HERE RATHER THAN IN A ROUTE, and that is
+ * the reason this function exists instead of two lines at the call site.
+ * router.ts states a rule at SAFE_COLUMNS: every query in it names its columns
+ * from a list, and none of those lists names a secret. The one caller that
+ * genuinely needs the stored hash is the self check on setPassword, and letting
+ * it name the column would put `password_hash` into the file whose stated
+ * invariant is that the column appears nowhere in it. So the column is named
+ * once, here, in a function whose only possible return value is a boolean: the
+ * bytes cannot escape it even by accident.
+ *
+ * IT TAKES THE SCOPE RATHER THAN A HANDLE, so that the scrypt runs with no
+ * transaction open. `adminDb` is a transaction, and the operator pool is small;
+ * scrypt at N = 2^15 takes roughly a tenth of a second, and doing it between
+ * two statements would hold a pooled connection and its snapshot open for the
+ * length of it, on the credential that holds BYPASSRLS. Passing `c.adminDb`
+ * itself lets the read commit and close before any work starts.
+ *
+ * FALSE FOR AN UNPROVISIONED OPERATOR, at the same cost as a wrong password,
+ * because `passwordMatches` does the scrypt work before it looks at the stored
+ * hash. An early return on NULL would make "has never been given a password"
+ * distinguishable from "guessed wrong" by timing alone.
+ */
+export async function operatorPasswordMatches(
+  scope: <T>(fn: (db: Db) => Promise<T>) => Promise<T>,
+  adminUserId: string,
+  password: string,
+): Promise<boolean> {
+  const stored = await scope(async (db) => {
+    const rows = await db.execute<{ password_hash: Buffer | null; password_salt: Buffer | null }>(
+      sql`SELECT password_hash, password_salt FROM admin_users WHERE id = ${adminUserId}::uuid`,
+    )
+    return rows[0] ?? null
+  })
+  if (!stored) return false
+  return passwordMatches(password, { hash: stored.password_hash, salt: stored.password_salt })
+}

--- a/web/apps/api/src/admin/router.ts
+++ b/web/apps/api/src/admin/router.ts
@@ -45,6 +45,8 @@ import { securityRouter } from './security.ts'
 // check, so the audit chain routes come in on their own.
 import { auditChainRoutes } from './security.ts'
 import { adminProcedure, adminAudit, type AdminContext } from './trpc.ts'
+import { hashPassword } from './session.ts'
+import { MAX_PASSWORD_LENGTH, operatorPasswordMatches, passwordRefusal } from './password.ts'
 import {
   adminBillingRouter,
   adminEntitlementsRouter,
@@ -661,8 +663,217 @@ export const adminRouter = router({
           return {
             id: rows[0]!.id,
             provisioned: false,
+            // "Out of band" was the honest word for this when nothing in the
+            // portal could write a password, and it is the wrong word now that
+            // `setPassword` exists: it sent the reader out of the product to
+            // find a shell. What is unchanged, and is the part worth saying, is
+            // that this route mints nothing.
             effect:
-              'The account exists and cannot sign in. Set a password out of band before it is usable.',
+              'The account exists and cannot sign in. Nothing here minted a password for it, so it stays unusable until somebody gives it one.',
+          }
+        })
+      }),
+
+    /**
+     * Gives an operator a password, which is the half of `create` that was
+     * missing from every screen in this portal.
+     *
+     * WHAT WAS ACTUALLY BROKEN. `create` above writes the row with a NULL
+     * password_hash and returns the sentence "Set a password out of band before
+     * it is usable." The only out of band that has ever existed is the
+     * `set-operator-password` command in bootstrap.ts, which runs on a
+     * connection string row level security does not apply to. So inviting a
+     * colleague through the portal produced an account that could not sign in,
+     * and finishing the invitation needed a shell, the admin database URL, and
+     * somebody who knew both. The directory said `Not provisioned` and `Never`
+     * beside their name and offered nothing to do about it.
+     *
+     * THIS DOES NOT MINT A PASSWORD AND NEVER GENERATES ONE. The caller sends a
+     * password they chose, exactly as the command takes one on stdin. A route
+     * that invented a starting credential would put a value the server knows
+     * into a row, and `create`'s comment is right that it would be the single
+     * worst thing in the portal. The console offers to generate one in the
+     * BROWSER, which is a different thing: the server never sees a password it
+     * was not given.
+     *
+     * WHAT IT WILL DO THAT THE COMMAND REFUSES. It sets the ROOT operator's
+     * password. bootstrap.ts declines to take root over and says so, because a
+     * connection string is not a person; here the caller is a named operator
+     * holding admin.operators.write, the action is in the audit chain at
+     * critical severity under their address, and root is the account most
+     * likely to need a password set by somebody who is not holding a database
+     * credential at the time. The triggers in 0029 are untouched by this: root
+     * still cannot be deleted, demoted or suspended, and this route does not go
+     * near those columns.
+     *
+     * WHY SELF NEEDS THE CURRENT PASSWORD when nothing else on this router
+     * does. setRole and suspend refuse self outright, because their danger is
+     * an operator widening their own privilege. This one is the opposite shape:
+     * setting your own password is ordinary and useful, and the risk is that
+     * somebody ELSE is holding your session. An operator cookie lasts twelve
+     * hours; without this check a stolen one buys a permanent takeover, because
+     * the thief sets a password and the revoke below cuts every session the
+     * real owner had. Proving knowledge of the current password is what keeps a
+     * stolen session bounded by its own expiry.
+     *
+     * THE ORDER OF THE WRITES IS NOT A STYLE CHOICE. The audit entry goes first,
+     * exactly as it does in every route beside it, because appendAdminAudit
+     * takes `pg_advisory_xact_lock(hashtext(admin_audit))`, one global lock that
+     * every audited transaction serialises on. A route that took a row lock on
+     * admin_users and THEN asked for the audit lock would invert the ordering
+     * its neighbours use, which is a deadlock between two operators acting on
+     * one account. That is also why the entry cannot carry the number of
+     * sessions revoked: it is written before the statement that learns it. The
+     * caller is told, and the entry says the revocation is unconditional.
+     */
+    setPassword: adminProcedure('admin.operators.write')
+      .input(
+        z.object({
+          adminUserId: z.string().uuid(),
+          // No `.min()` here, deliberately. Zod would answer a short password
+          // with a schema error naming a number, and the useful answer is
+          // password.ts's sentence about why the number is that number.
+          password: z.string().max(MAX_PASSWORD_LENGTH),
+          /** Required when, and only when, the target is the caller. */
+          currentPassword: z.string().max(MAX_PASSWORD_LENGTH).optional(),
+        }),
+      )
+      .mutation(async ({ ctx, input }) => {
+        const c = ctx as AdminContext
+        const refusal = passwordRefusal(input.password)
+        if (refusal) throw new TRPCError({ code: 'BAD_REQUEST', message: refusal })
+
+        const isSelf = input.adminUserId === c.admin.adminUserId
+
+        // Existence only, and on its own transaction, so that an id nobody
+        // holds costs no scrypt. Every FACT about the account is read below
+        // instead, inside the transaction that writes: reading them here and
+        // using them there would describe the row as it was before a hash that
+        // takes about a tenth of a second, and an audit entry is worth more
+        // when it describes what was actually changed.
+        //
+        // Hashing outside a transaction rather than between two statements is
+        // the other half of the same point. `adminDb` is a transaction on the
+        // operator pool, scrypt at N = 2^15 costs that tenth of a second and
+        // 32MB, and doing it inside would hold a BYPASSRLS connection open for
+        // the length of it.
+        const exists = await c.adminDb(async (db) => {
+          const rows = await db.execute<{ id: string }>(
+            sql`SELECT id FROM admin_users WHERE id = ${input.adminUserId}::uuid`,
+          )
+          return rows.length > 0
+        })
+        if (!exists) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'No operator with that id.' })
+        }
+
+        if (isSelf) {
+          if (!input.currentPassword) {
+            throw new TRPCError({
+              code: 'BAD_REQUEST',
+              message:
+                'Setting your own password needs your current one as well. Every other operator here is somebody else deciding; your own account is the one where a stolen session would otherwise be enough.',
+            })
+          }
+          // Named password.ts rather than read here, so that no query in this
+          // file names password_hash. See SAFE_COLUMNS.
+          const knows = await operatorPasswordMatches(
+            c.adminDb,
+            c.admin.adminUserId,
+            input.currentPassword,
+          )
+          if (!knows) {
+            throw new TRPCError({
+              code: 'FORBIDDEN',
+              message: 'That is not your current password, so nothing was changed.',
+            })
+          }
+        }
+
+        const { hash, salt } = await hashPassword(input.password)
+        const now = c.clock.now()
+
+        return c.adminDb(async (db) => {
+          // Every fact the entry and the sentence use, read here rather than
+          // above, so they describe one snapshot rather than two. No FOR
+          // UPDATE: see the note on the route about lock ordering. The row can
+          // still be gone, because the check above committed and released.
+          const fresh = await db.execute<{
+            email: string
+            is_root: boolean
+            suspended_at: Date | string | null
+            provisioned: boolean
+          }>(sql`
+            SELECT email, is_root, suspended_at, (password_hash IS NOT NULL) AS provisioned
+            FROM admin_users WHERE id = ${input.adminUserId}::uuid`)
+          const row = fresh[0]
+          if (!row) {
+            throw new TRPCError({ code: 'NOT_FOUND', message: 'No operator with that id.' })
+          }
+          const suspended = row.suspended_at !== null
+
+          await adminAudit(db, c, {
+            action: 'operator.password_set',
+            targetType: 'admin_user',
+            targetId: input.adminUserId,
+            severity: 'critical',
+            // The password is not here and is not derivable from anything that
+            // is. What an investigator needs is whether a WORKING credential
+            // was replaced, which is the difference between finishing an
+            // invitation and taking an account over.
+            detail: {
+              email: row.email,
+              replacedAPassword: row.provisioned,
+              isRoot: row.is_root,
+              self: isSelf,
+              // "Every OTHER" when the target is the caller, because the
+              // session making the request is the one the revoke spares. A
+              // fixed sentence would have been wrong in exactly the case an
+              // investigator is most likely to be reading about.
+              sessions: isSelf
+                ? 'every other live session for this operator was revoked in this transaction'
+                : 'every live session for this operator was revoked in this transaction',
+            },
+          })
+
+          await db.execute(sql`
+            UPDATE admin_users
+            SET password_hash = ${hash}, password_salt = ${salt},
+                password_set_at = ${now.toISOString()}, updated_at = ${now.toISOString()}
+            WHERE id = ${input.adminUserId}::uuid`)
+
+          // Changing a password because it leaked, and leaving the sessions it
+          // opened alive, is a reset that resets nothing: an operator session
+          // lasts twelve hours and reads every tenant for all of them.
+          //
+          // The caller's own session is excluded unconditionally rather than
+          // only when the target is themselves. When the target is somebody
+          // else the clause matches nothing, because that session belongs to a
+          // different admin_user_id; when the target IS themselves it is the
+          // difference between changing your password and signing yourself out
+          // mid sentence. One statement, no branch to get wrong.
+          const revoked = await db.execute<{ id: string }>(sql`
+            UPDATE admin_sessions SET revoked_at = ${now.toISOString()}
+            WHERE admin_user_id = ${input.adminUserId}::uuid
+              AND revoked_at IS NULL
+              AND expires_at > ${now.toISOString()}
+              AND id <> ${c.admin.sessionId}::uuid
+            RETURNING id`)
+
+          return {
+            provisioned: true,
+            /** Whether a working credential was replaced, rather than an
+             *  invitation finished. The console says a different sentence for
+             *  each, because they are different events. */
+            replacedAPassword: row.provisioned,
+            sessionsRevoked: revoked.length,
+            effect: effectOfSettingAPassword({
+              email: row.email,
+              replaced: row.provisioned,
+              sessionsRevoked: revoked.length,
+              isSelf,
+              suspended,
+            }),
           }
         })
       }),
@@ -919,4 +1130,76 @@ function pageOf<Row, Out>(
 
 function iso(value: Date | string): string {
   return value instanceof Date ? value.toISOString() : new Date(value).toISOString()
+}
+
+/**
+ * The sentence an operator reads after setting somebody's password.
+ *
+ * COMPOSED ON THE SERVER, for the same reason `create`'s effect string is: the
+ * route knows four things the console would have to re-derive, and a console
+ * that re-derived them would eventually say one of them wrongly. Finishing an
+ * invitation and replacing a working credential are different events and get
+ * different sentences; a suspended target and a self change each add the fact
+ * that changes what the reader should do next.
+ *
+ * It never contains the password. The value exists in the browser that produced
+ * it and in the hash, and nowhere else this system can read.
+ */
+function effectOfSettingAPassword(facts: {
+  email: string
+  replaced: boolean
+  sessionsRevoked: number
+  isSelf: boolean
+  suspended: boolean
+}): string {
+  const parts: string[] = []
+  if (facts.isSelf) {
+    parts.push('Your password is changed. The session you are reading this in is still valid.')
+  } else if (facts.replaced) {
+    parts.push(
+      `${facts.email} had a working password and now has this one. The old one no longer signs in.`,
+    )
+  } else {
+    parts.push(`${facts.email} can sign in now, for the first time.`)
+  }
+
+  if (facts.sessionsRevoked > 0) {
+    const n = facts.sessionsRevoked
+    const many = n === 1 ? 'session was' : 'sessions were'
+    // THE CLAUSE ABOUT AN OLD CREDENTIAL IS CONDITIONAL ON THERE HAVING BEEN
+    // ONE. Composing this sentence out of two independent facts produced
+    // "can sign in now, for the first time. 1 live session was revoked, so
+    // anybody holding the old credential is out", which is two true halves
+    // making a false whole. Reached by nulling a password_hash by hand and so
+    // not a state the product can enter, which is exactly why it would have
+    // survived: nothing would have said it out loud until somebody read it.
+    parts.push(
+      facts.isSelf
+        ? `Your ${n} other operator ${many} revoked.`
+        : facts.replaced
+          ? `${n} live operator ${many} revoked, so anybody holding the old credential is out on their next request.`
+          : `${n} live operator ${many} revoked.`,
+    )
+  }
+
+  if (facts.suspended) {
+    // Said rather than refused. adminSignIn checks the suspension before the
+    // password, so this changes nothing about their access, and somebody who
+    // sets a password, watches the sign in fail and is told nothing concludes
+    // the button is broken.
+    parts.push(
+      'They are suspended, so this password will not let them in until the account is restored.',
+    )
+  }
+
+  if (!facts.isSelf) {
+    // Only for somebody else's account, where the password still has to travel
+    // to a person. Telling an operator who just changed their OWN password to
+    // pass it on is the wrong instruction in the one case where it is nobody
+    // else's to have.
+    parts.push(
+      'It is not stored anywhere you can read it back, so pass it on before you close this.',
+    )
+  }
+  return parts.join(' ')
 }

--- a/web/apps/api/test/admin-routes.test.ts
+++ b/web/apps/api/test/admin-routes.test.ts
@@ -44,7 +44,10 @@ describe('every operator route declares a permission', () => {
     // SHRINKING router still clears is an assertion that has quietly stopped
     // checking whether routes moved out of this tree, which is the one thing it
     // exists for.
-    atLeast: 85,
+    // 89 taken by running the walk on this branch's merged tree, the way the
+    // paragraph above says to, rather than by adding one to the number that was
+    // here. This branch adds admin.operators.setPassword.
+    atLeast: 89,
   })
 })
 
@@ -498,6 +501,279 @@ describe('the operator routes', { skip: hasDb ? false : 'no database' }, () => {
         () => adminSignIn(h.pool, { email, password: '' }, new Date()),
         AdminSignInError,
       )
+    })
+
+    describe('setting a password, which is what finishes an invitation', () => {
+      // WHY THIS SUITE IS LONG. The route above proves an invited operator
+      // CANNOT sign in, and that was the whole provisioning story until now:
+      // the only thing that could finish the invitation was a command holding a
+      // connection string. What follows is the other half, and every assertion
+      // reads the row or the sign in back rather than trusting a return value,
+      // because "the mutation resolved" is exactly what a route that writes
+      // nothing also does.
+
+      /** An operator who has never been given a password, as `create` leaves
+       *  one. Made through the ROUTE rather than by INSERT, so the suite is
+       *  testing the pair of routes a person actually uses. */
+      async function invited(caller: Awaited<ReturnType<typeof callerForWithId>>['caller']) {
+        const email = `invited-${randomUUID().slice(0, 8)}@example.test`
+        const made = await caller.admin.operators.create({ email, name: 'Invited', role: 'support' })
+        return { id: made.id, email }
+      }
+
+      async function hashOf(id: string): Promise<Buffer | null> {
+        const [row] = await h.admin<{ password_hash: Buffer | null }[]>`
+          SELECT password_hash FROM admin_users WHERE id = ${id}::uuid`
+        return row!.password_hash
+      }
+
+      test('an invited operator can sign in afterwards, which is the whole point', async () => {
+        const { caller } = await callerForWithId('owner')
+        const { id, email } = await invited(caller)
+        assert.equal(await hashOf(id), null, 'the invitation started with a credential')
+
+        const chosen = 'a-passphrase-chosen-by-the-owner'
+        const result = await caller.admin.operators.setPassword({ adminUserId: id, password: chosen })
+        assert.equal(result.provisioned, true)
+        assert.equal(result.replacedAPassword, false, 'finishing an invitation reported a replacement')
+
+        // The end to end proof. Not "password_hash is not null", which a route
+        // writing garbage would also satisfy: the credential has to open a
+        // session through the real sign in path.
+        const signedIn = await adminSignIn(h.pool, { email, password: chosen }, new Date())
+        assert.ok(signedIn.token, 'the operator still could not sign in after a password was set')
+
+        const listed = await caller.admin.operators.list()
+        assert.equal(
+          listed.find((o) => o.id === id)?.provisioned,
+          true,
+          'the directory still shows the account as unprovisioned',
+        )
+      })
+
+      test('a password under the floor is refused, and the account stays unsignable', async () => {
+        const { caller } = await callerForWithId('owner')
+        const { id } = await invited(caller)
+        await assert.rejects(
+          () => caller.admin.operators.setPassword({ adminUserId: id, password: 'eleven-char' }),
+          (err: Error) => /at least 12/.test(err.message),
+        )
+        assert.equal(await hashOf(id), null, 'a refused password was written anyway')
+      })
+
+      test('a password with a stray newline is refused rather than silently kept', async () => {
+        // The heredoc case. Accepting it writes a credential nobody can ever
+        // retype, because the newline is invisible in every attempt.
+        const { caller } = await callerForWithId('owner')
+        const { id } = await invited(caller)
+        await assert.rejects(
+          () =>
+            caller.admin.operators.setPassword({
+              adminUserId: id,
+              password: 'a-perfectly-fine-passphrase\n',
+            }),
+          (err: Error) => /whitespace/.test(err.message),
+        )
+        assert.equal(await hashOf(id), null, 'a password with a trailing newline was written')
+      })
+
+      test('a reset stops the old password and the sessions it had already opened', async () => {
+        // A password changed because it leaked, that leaves the sessions it
+        // opened alive, is a reset that resets nothing: an operator session
+        // lasts twelve hours and reads every tenant for all of them.
+        const { caller } = await callerForWithId('owner')
+        const { id, email } = await invited(caller)
+        const first = 'the-first-password-they-had'
+        await caller.admin.operators.setPassword({ adminUserId: id, password: first })
+        const theirs = await adminSignIn(h.pool, { email, password: first }, new Date())
+
+        const second = 'the-replacement-password-now'
+        const result = await caller.admin.operators.setPassword({ adminUserId: id, password: second })
+        assert.equal(result.replacedAPassword, true, 'replacing a working password reported an invitation')
+        assert.equal(result.sessionsRevoked, 1, 'the session the old password opened was left alive')
+
+        await assert.rejects(
+          () => adminSignIn(h.pool, { email, password: first }, new Date()),
+          'the old password still signs in',
+        )
+        const again = await adminSignIn(h.pool, { email, password: second }, new Date())
+        assert.ok(again.token, 'the new password does not sign in')
+
+        const { resolveAdminSession } = await import('../src/admin/session.ts')
+        assert.equal(
+          await resolveAdminSession(h.pool, theirs.token, new Date()),
+          null,
+          'a session opened with the old password still resolves',
+        )
+      })
+
+      test('the root operator gets a password, and is still the root operator', async () => {
+        // A DELIBERATE DIFFERENCE FROM THE COMMAND. `set-operator-password`
+        // declines to touch root, because a connection string is not a person.
+        // Here the caller is a named operator and the act is in the chain under
+        // their address. What must not change is everything else about root,
+        // and that is what the reads below are for: this route goes nowhere
+        // near is_root, role or suspended_at, and the 0029 triggers still hold.
+        const { caller } = await callerForWithId('owner')
+        const email = `rootpw-${randomUUID().slice(0, 8)}@example.test`
+        const [made] = await h.admin<{ id: string }[]>`
+          INSERT INTO admin_users (email, name, role, is_root)
+          VALUES (${email}, 'Root', 'owner', true)
+          RETURNING id`
+        const rootId = made!.id
+        try {
+          const password = 'the-root-operators-new-passphrase'
+          await caller.admin.operators.setPassword({ adminUserId: rootId, password })
+          const signedIn = await adminSignIn(h.pool, { email, password }, new Date())
+          assert.ok(signedIn.token, 'the root operator could not sign in with the password just set')
+
+          const [row] = await h.admin<{ is_root: boolean; role: string; suspended_at: Date | null }[]>`
+            SELECT is_root, role, suspended_at FROM admin_users WHERE id = ${rootId}::uuid`
+          assert.equal(row!.is_root, true, 'setting a password stopped root being root')
+          assert.equal(row!.role, 'owner', 'setting a password moved root off owner')
+          assert.equal(row!.suspended_at, null, 'setting a password suspended root')
+        } finally {
+          await h.admin`ALTER TABLE admin_users DISABLE TRIGGER admin_root_is_permanent_del`
+          await h.admin`DELETE FROM admin_users WHERE id = ${rootId}::uuid`
+          await h.admin`ALTER TABLE admin_users ENABLE TRIGGER admin_root_is_permanent_del`
+        }
+      })
+
+      test('setting your own password needs the current one, so a stolen session is not permanent', async () => {
+        // The single reason this check exists. An operator cookie lasts twelve
+        // hours; without it a stolen one buys the account forever, because the
+        // thief sets a password and the revoke cuts the real owner out.
+        const { caller, adminUserId } = await callerForWithId('owner')
+        const before = await hashOf(adminUserId)
+
+        await assert.rejects(
+          () =>
+            caller.admin.operators.setPassword({
+              adminUserId,
+              password: 'a-thief-would-choose-this',
+            }),
+          (err: Error) => /needs your current one/.test(err.message),
+          'an operator set their own password without proving they knew it',
+        )
+        await assert.rejects(
+          () =>
+            caller.admin.operators.setPassword({
+              adminUserId,
+              password: 'a-thief-would-choose-this',
+              currentPassword: 'not-the-current-password',
+            }),
+          (err: Error) => /not your current password/.test(err.message),
+          'a wrong current password was accepted',
+        )
+        assert.deepEqual(await hashOf(adminUserId), before, 'a refused self change wrote a password anyway')
+      })
+
+      test('changing your own password keeps the session doing it and revokes the others', async () => {
+        // The control for the test above, and the behaviour that stops this
+        // being useless: proving knowledge of the current password gets you
+        // through. Signing the operator out of the session they are typing in
+        // would make an ordinary rotation feel like a fault.
+        const email = `self-${randomUUID().slice(0, 8)}@example.test`
+        const { hash, salt } = await hashPassword(password)
+        const [row] = await h.admin<{ id: string }[]>`
+          INSERT INTO admin_users (email, name, role, password_hash, password_salt, password_set_at)
+          VALUES (${email}, 'Self', 'owner', ${hash}, ${salt}, now())
+          RETURNING id`
+        const mine = await adminSignIn(h.pool, { email, password }, new Date())
+        const other = await adminSignIn(h.pool, { email, password }, new Date())
+        const caller = await callerWithToken(mine.token)
+
+        const next = 'the-password-i-rotated-to'
+        const result = await caller.admin.operators.setPassword({
+          adminUserId: row!.id,
+          password: next,
+          currentPassword: password,
+        })
+        assert.equal(result.sessionsRevoked, 1, 'the operators other session was not revoked')
+
+        const { resolveAdminSession } = await import('../src/admin/session.ts')
+        assert.ok(
+          await resolveAdminSession(h.pool, mine.token, new Date()),
+          'the session that changed the password was signed out by doing it',
+        )
+        assert.equal(
+          await resolveAdminSession(h.pool, other.token, new Date()),
+          null,
+          'another session belonging to the same operator survived the change',
+        )
+        assert.ok(await adminSignIn(h.pool, { email, password: next }, new Date()))
+      })
+
+      test('the chain records it at critical and the password is in no part of the entry', async () => {
+        const { caller } = await callerForWithId('owner')
+        const { id, email } = await invited(caller)
+        const secret = 'a-value-that-must-never-be-logged'
+        await caller.admin.operators.setPassword({ adminUserId: id, password: secret })
+
+        const [entry] = await h.admin<{
+          action: string
+          severity: string
+          actor_label: string
+          detail: unknown
+        }[]>`
+          SELECT action, severity, actor_label, detail FROM admin_audit_entries
+          WHERE action = 'operator.password_set' AND target_id = ${id}
+          ORDER BY seq DESC LIMIT 1`
+        assert.ok(entry, 'setting a password left no entry in the operator chain')
+        assert.equal(entry!.severity, 'critical')
+        assert.match(entry!.actor_label, /@/, 'the entry is not attributed to a person')
+        assert.equal(
+          JSON.stringify(entry!.detail).includes(secret),
+          false,
+          'the audit entry carried the password itself',
+        )
+        assert.ok(
+          JSON.stringify(entry!.detail).includes(email),
+          'the entry does not say whose password it was',
+        )
+      })
+
+      test('a suspended operator is told so rather than left to conclude the button is broken', async () => {
+        // Not refused. adminSignIn checks the suspension before the password,
+        // so this changes nothing about their access, and somebody who sets a
+        // password, watches the sign in fail and is told nothing concludes the
+        // route is broken.
+        const { caller } = await callerForWithId('owner')
+        const { id, email } = await invited(caller)
+        await caller.admin.operators.suspend({ adminUserId: id, reason: 'while we check' })
+        const result = await caller.admin.operators.setPassword({
+          adminUserId: id,
+          password: 'a-password-they-cannot-use-yet',
+        })
+        assert.match(result.effect, /suspended/)
+        await assert.rejects(
+          () => adminSignIn(h.pool, { email, password: 'a-password-they-cannot-use-yet' }, new Date()),
+          'a suspended operator signed in',
+        )
+      })
+
+      test('an id nobody holds is a refusal rather than a quiet success', async () => {
+        const { caller } = await callerForWithId('owner')
+        await assert.rejects(
+          () =>
+            caller.admin.operators.setPassword({
+              adminUserId: randomUUID(),
+              password: 'a-password-for-nobody-at-all',
+            }),
+          (err: Error) => /No operator with that id/.test(err.message),
+        )
+      })
+
+      test('a role without admin.operators.write cannot set anybody a password', async () => {
+        const { caller: owner } = await callerForWithId('owner')
+        const { id } = await invited(owner)
+        const { caller: support } = await callerForWithId('support')
+        await assert.rejects(
+          () => support.admin.operators.setPassword({ adminUserId: id, password: 'support-should-not-do-this' }),
+          (err: Error) => /admin\.operators\.write/.test(err.message),
+        )
+        assert.equal(await hashOf(id), null, 'a refused caller still provisioned the account')
+      })
     })
 
     test('support cannot administer operators at all', async () => {


### PR DESCRIPTION
## What was broken

`admin.operators.create` writes the row with a NULL `password_hash` on purpose
and returned the sentence "Set a password out of band before it is usable."
There was no out of band that a person in the portal could reach. The only
thing in this repository that had ever written `admin_users.password_hash` was
the `set-operator-password` command, which runs on a connection string row
level security does not apply to.

So inviting a colleague through the portal produced an account that could not
sign in. The row sat in the directory reading `Not provisioned` and `Never`,
and the panel that made it offered a Done button. Every step succeeded and the
feature did nothing.

## What this adds

`admin.operators.setPassword`, guarded by `admin.operators.write`:

- hashes with the same scrypt parameters as the sign-in path
- records the act in the platform audit chain at critical severity under the
  caller's address, and never puts the password in the entry
- revokes every live session belonging to that operator in the same
  transaction, sparing only the session making the request

It still mints nothing. The caller sends a password they chose, exactly as the
command takes one on stdin. The console offers to generate one in the BROWSER,
which is a different thing: the server never sees a value it was not given.

The console asks for it in the panel that created the account, so an invitation
is finished where it was sent, and in the operator's own drawer for everything
after that.

## Two decisions worth reviewing

**Setting your own password needs your current one**, which nothing else on
this router asks for. `setRole` and `suspend` refuse self outright because
their danger is an operator widening their own privilege. This is the opposite
shape: rotating your own password is ordinary, and the risk is that somebody
else is holding your session. An operator cookie lasts twelve hours; without
the check a stolen one buys the account permanently, because the thief sets a
password and the revoke cuts every session the real owner had.

**It will set the root operator's password and the bootstrap command will
not.** That difference is deliberate on both sides. `bootstrap.ts` declines
because a connection string is not a person; here the caller is a named
operator and the act is in the chain under their address. The 0029 triggers are
untouched: root still cannot be deleted, demoted or suspended, and this route
goes nowhere near those columns. The console asks for the account's own address
to be typed first, the same proof suspending asks for.

## Where the rules live now

The length floor and the refusal of a stray newline moved to
`web/apps/api/src/admin/password.ts`, which both writers ask. A rule enforced
in one of two writers is a rule with a way around it, and the way around it
would have been the one reachable from a browser. That module also owns the one
query that names `password_hash`, so `router.ts` keeps the invariant it states
at `SAFE_COLUMNS`: no query in that file names a secret, and the bytes cannot
escape a function whose only return type is a boolean.

The audit entry goes before the writes, exactly as in every route beside it,
because `appendAdminAudit` takes `pg_advisory_xact_lock(hashtext(admin_audit))`
and a route that took a row lock first would invert its neighbours' ordering.
That is a deadlock between two operators acting on one account.

## Found by looking at the render, not the code

- The panel showing the new password was keyed on `provisioned`, so the reload
  after a successful write remounted the component and destroyed it. The write
  worked, the directory updated, and the value the operator had to send the
  person was on screen for no frames at all.
- At 390px the revealed password shared its row with the copy button, and
  `break-all` split a generated one after its twenty second character, leaving
  a line ending in a lone `c`. A password is read off that screen and retyped.
- The server's effect sentence was composed from two independent facts and
  could say "can sign in now, for the first time" followed by "anybody holding
  the old credential is out". Two true halves making a false whole.

## Verification

Eleven new tests, every one mutation tested: the production line each is meant
to catch was broken, the test was watched going red with exactly `tests 1 /
fail 1`, and the line restored. All twelve cells red, including one that puts
the password into the audit detail and one that refuses root, so the decision
above is asserted rather than assumed.

Proven over real HTTP against a control plane serving the built console: an
invited account signs in 200 after the password is set, a wrong password is
401, and after a replacement the old password is 401 while the new one is 200.

The operator route floor moves from 85 to 89, taken by running the walk rather
than by adding one to the number that was there.
