### PR TITLE
ci: a readiness check a disappearing server could satisfy

### DIFF
--- a/.changes/a-readiness-check-a-disappearing-server-could-satisfy.md
+++ b/.changes/a-readiness-check-a-disappearing-server-could-satisfy.md
@@ -1,0 +1,29 @@
+# fixed
+
+The enterprise image proof asked the wrong server whether the database was
+ready, and got a yes from one that was about to shut down.
+
+`enterprise-image-proof.sh` waited with `docker exec pg_isready` and no host,
+which asks over the Unix socket. The Postgres image's own entrypoint runs a
+TEMPORARY server to apply initdb, started with `listen_addresses=''`, so it
+answers the socket and nothing else. The wait loop therefore broke on the
+bootstrap server, and the confirming probe landed in the gap while that server
+was shutting down and the real one had not yet started.
+
+On f065f64c that is exactly what happened: the loop broke and
+`FAIL: the database never became ready` was printed 1.4 seconds later, with the
+container's own log showing `received fast shutdown request` 9 milliseconds
+before the probe. The window is about 150 milliseconds against a one second
+poll, which is why this passed on the pull request and on the two mains before
+it and failed once.
+
+Both probes now ask over TCP, which the temporary server does not listen on, so
+the first yes is the server the rest of the proof talks to. Measured rather than
+reasoned: polling both every 400ms against this digest, the socket answered a
+full interval before TCP did, `socket=UP tcp=down` at one sample and both up at
+the next.
+
+Worth recording that pinning the image in the previous change is likely what
+made this fire. A digest reference is not served from a cached `postgres:17-alpine`,
+so the pull ran fresh and moved where the poll landed. The race was already
+there; the pin changed the timing that hid it.

--- a/deploy/docker/enterprise-image-proof.sh
+++ b/deploy/docker/enterprise-image-proof.sh
@@ -141,13 +141,34 @@ docker run -d --name "$pg" --network "$net" \
   -e "POSTGRES_PASSWORD=${password_migrator}" \
   postgres:17-alpine@sha256:18cfe3ef5e6815560c98237d6216d1e5119702fb0f3894c8785dd58b8bbe5d73 >/dev/null
 
+# OVER TCP, AND THE -h IS THE WHOLE FIX.
+#
+# This image's own entrypoint runs a TEMPORARY server to apply initdb, then
+# shuts it down and starts the real one. The temporary one is started with
+# listen_addresses='' so it answers the Unix socket and nothing else. A
+# `pg_isready` with no host asks over the socket, so it says yes to the
+# BOOTSTRAP server, the loop breaks early, and the confirming probe below lands
+# in the gap while that server is shutting down. That is how this failed on
+# f065f64c: the loop broke and `the database never became ready` was printed
+# 1.4 seconds later, with the container's own log showing `received fast
+# shutdown request` 9 milliseconds before the probe.
+#
+# Measured rather than reasoned. Polling both every 400ms against this exact
+# digest, the socket answered a full interval before TCP did:
+#   t=3 socket=down tcp=down
+#   t=4 socket=UP   tcp=down     <- the bootstrap server, and the old bug
+#   t=5 socket=UP   tcp=UP       <- the real one
+# So asking over TCP cannot see the temporary server, and the first yes is the
+# server the rest of this proof actually talks to. A readiness check that can
+# be satisfied by a server which is about to disappear is not a readiness
+# check.
 for _ in $(seq 1 60); do
-  if docker exec "$pg" pg_isready -U af_migrator -d antifailure >/dev/null 2>&1; then
+  if docker exec "$pg" pg_isready -h 127.0.0.1 -U af_migrator -d antifailure >/dev/null 2>&1; then
     break
   fi
   sleep 1
 done
-docker exec "$pg" pg_isready -U af_migrator -d antifailure >/dev/null \
+docker exec "$pg" pg_isready -h 127.0.0.1 -U af_migrator -d antifailure >/dev/null \
   || fail "the database never became ready"
 
 echo "== the enterprise image bootstraps its own schema"


### PR DESCRIPTION
ci: a readiness check a disappearing server could satisfy

The enterprise image proof asked the wrong server whether the database was
ready, and got a yes from one that was about to shut down.

`enterprise-image-proof.sh` waited with `docker exec pg_isready` and no host,
which asks over the Unix socket. This image's own entrypoint runs a TEMPORARY
server to apply initdb, started with `listen_addresses=''`, so it answers the
socket and nothing else. The wait loop broke on that bootstrap server, and the
confirming probe landed in the gap while it was shutting down and the real
server had not yet started.

On f065f64c the loop broke and `FAIL: the database never became ready` was
printed 1.4 seconds later, with the container's own log showing `received fast
shutdown request` 9 milliseconds before the probe. The window is roughly 150
milliseconds against a one second poll, which is why this passed on the pull
request and on the two mains before it and failed once. A race that usually
wins is still a race.

Both probes now ask over TCP. The temporary server does not listen on it, so
the first yes is the server the rest of the proof actually talks to.

Measured rather than reasoned. Polling both probes every 400ms against this
exact digest:

    t=3 socket=down tcp=down
    t=4 socket=UP   tcp=down    the bootstrap server, and the old bug
    t=5 socket=UP   tcp=UP      the real one

The socket answers a full interval before TCP does.

Two things stated rather than left out. Re-running the OLD probe with the real
one second loop on a local machine reported READY, so this reproduces the
mechanism and not the failure; that is what a race looks like. And pinning the
image in the previous change is likely what made it fire, because a digest
reference is not served from a cached `postgres:17-alpine`, so the pull ran
fresh and moved where the poll landed. The race was already there and the pin
changed the timing that hid it.

Signed-off-by: Vir Sanghavi <67278851+VirSanghavi@users.noreply.github.com>

