### PR TITLE
tools: a gate that was red locally and green in CI, on the same tree, forever

### DIFF
--- a/.changes/a-gate-that-was-red-locally-and-green-in-ci-forever.md
+++ b/.changes/a-gate-that-was-red-locally-and-green-in-ci-forever.md
@@ -1,0 +1,33 @@
+# fixed
+
+The prose gate refused files that can never ship, so it was red on a working
+copy and green in CI on the same tree, permanently.
+
+`prosecheck` selects files by walking the filesystem. CI checks out from git. So
+a file that exists on a working copy and not in the repository is scanned by one
+and invisible to the other. `PROGRESS.md` is exactly that: it sits at the
+repository root, it is hidden through `.git/info/exclude` so it never appears in
+a diff, and earlier handovers wrote commands of the shape
+`git grep "install(" -- ee/web web` into it. Those are end of options markers
+and they are correct as written, which is the collision that already stops the
+double hyphen rule from being widened past the gated trees.
+
+The result was five findings locally and none in CI, on every checkout, with no
+way for CI to see the disagreement. Anyone running the gate before pushing got a
+red that was not theirs, on a file they could not commit, and the two obvious
+reactions, editing the handover or believing their own change broke it, were
+both wrong.
+
+The gate now skips what git IGNORES, and that is not the same as what git does
+not yet track. An ignored file can never be committed, so it can never ship, so
+styling it is meaningless. A merely untracked file is one `git add` from
+shipping and is still read, because skipping it would pass a new page locally
+and fail it in CI, which is the same disagreement pointing the other way. Both
+directions are pinned by a test, and each was mutation tested: removing the
+filter refuses the ignored and excluded files again, and widening it to drop
+untracked files refuses the untracked one.
+
+Outside a work tree, or when git cannot answer, every file is kept. This gate's
+own tests drive it with temporary directories, and a check that quietly stopped
+looking there would be worse than one that occasionally reads a file it need
+not.

--- a/tools/prosecheck/main.go
+++ b/tools/prosecheck/main.go
@@ -34,11 +34,13 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -423,7 +425,65 @@ func collect(root string, dirs []string, keep func(string) bool) ([]string, erro
 		}
 	}
 	sort.Strings(out)
-	return out, nil
+	return ignoreExcluded(root, out), nil
+}
+
+// ignoreExcluded drops the paths git refuses to track.
+//
+// WHY THIS EXISTS, and it is the reverse of the disagreement `gatecheck`
+// catches. This walks the FILESYSTEM and CI checks out from GIT, so a file that
+// exists on a working copy and not in the repository is scanned here and
+// invisible there. `PROGRESS.md` is exactly that: it sits at the repository
+// root, it is excluded through `.git/info/exclude` so it never appears in a
+// diff, and earlier handovers wrote `git grep "x" -- path` into it. Those are
+// end of options markers and they are correct as written, so the local gate
+// reported five findings and CI reported none, on the same tree, permanently.
+// A person running the gate before pushing then gets a red that is not theirs,
+// on a file they cannot commit, and the two obvious reactions, editing the
+// handover or believing their own change broke it, are both wrong.
+//
+// IGNORED RATHER THAN UNTRACKED, which is the whole of the distinction. A file
+// git ignores can never be committed, so it can never ship, so styling it is
+// meaningless. A file that is merely untracked is one `git add` from shipping
+// and MUST still be read, or this gate would pass a new page locally and fail
+// it in CI, which is the same defect pointing the other way.
+//
+// Outside a work tree, and if git cannot be run at all, everything is kept.
+// This gate's own tests drive it with temporary directories that are not
+// repositories, and a check that silently stopped looking there would be worse
+// than one that occasionally reads a file it need not.
+func ignoreExcluded(root string, paths []string) []string {
+	if len(paths) == 0 {
+		return paths
+	}
+	cmd := exec.Command("git", "-C", root, "check-ignore", "--stdin")
+	cmd.Stdin = strings.NewReader(strings.Join(paths, "\n") + "\n")
+	var found bytes.Buffer
+	cmd.Stdout = &found
+	// Exit 1 means nothing matched and is the ordinary answer; any other
+	// failure means git could not tell us, and then we keep everything.
+	if err := cmd.Run(); err != nil {
+		var exit *exec.ExitError
+		if !errors.As(err, &exit) || exit.ExitCode() != 1 {
+			return paths
+		}
+	}
+	excluded := map[string]bool{}
+	for _, line := range strings.Split(found.String(), "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			excluded[filepath.ToSlash(line)] = true
+		}
+	}
+	if len(excluded) == 0 {
+		return paths
+	}
+	kept := paths[:0:0]
+	for _, p := range paths {
+		if !excluded[p] {
+			kept = append(kept, p)
+		}
+	}
+	return kept
 }
 
 // plural picks the word for a count, so a failing run does not report

--- a/tools/prosecheck/main_test.go
+++ b/tools/prosecheck/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -350,4 +351,65 @@ func contains(files []string, want string) bool {
 		}
 	}
 	return false
+}
+
+// An excluded file is not scanned, and an untracked one still is.
+//
+// BOTH DIRECTIONS, because only the second says the filter did not open a hole.
+// This gate walks the filesystem and CI checks out from git, so a file present
+// on a working copy and absent from the repository is read here and invisible
+// there. `PROGRESS.md` is exactly that, and it carries `git grep "x" -- path`
+// lines written by earlier handovers, which are end of options markers and are
+// correct. The local gate reported five findings and CI reported none, on the
+// same tree, permanently.
+//
+// The fix skips what git IGNORES rather than what it does not yet track. A file
+// git ignores can never be committed and so can never ship. A merely untracked
+// file is one `git add` from shipping, and skipping it would pass a new page
+// locally and fail it in CI, which is the same disagreement pointing the other
+// way. The second case below is what holds that line.
+func TestAnExcludedFileIsSkippedAndAnUntrackedOneIsNot(t *testing.T) {
+	root := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", root}, args...)...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	run("init", "-q")
+
+	// The same defect in three files: one ignored through .gitignore, one
+	// ignored through .git/info/exclude, which is how PROGRESS.md is hidden,
+	// and one merely untracked.
+	body := []byte("A sentence -- with punctuation nobody wrote.\n")
+	for _, name := range []string{"ignored.md", "excluded.md", "untracked.md"} {
+		if err := os.WriteFile(filepath.Join(root, name), body, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte("ignored.md\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".git", "info", "exclude"), []byte("excluded.md\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	files, err := markdown(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]bool{}
+	for _, f := range files {
+		got[f] = true
+	}
+	if got["ignored.md"] {
+		t.Error("a .gitignore'd file was scanned; it can never ship, so styling it is a red nobody can fix")
+	}
+	if got["excluded.md"] {
+		t.Error("a .git/info/exclude'd file was scanned; this is the PROGRESS.md case the filter exists for")
+	}
+	if !got["untracked.md"] {
+		t.Error("an untracked file was skipped; it is one git add from shipping, so this gate would pass it locally and CI would refuse it")
+	}
 }


### PR DESCRIPTION
tools: a gate that was red locally and green in CI, on the same tree, forever

`prosecheck` selects files by walking the filesystem. CI checks out from git.
So a file present on a working copy and absent from the repository is scanned
by one and invisible to the other.

`PROGRESS.md` is exactly that file. It sits at the repository root, it is
hidden through `.git/info/exclude` so it never reaches a diff, and earlier
handovers wrote commands of the shape `git grep "install(" -- ee/web web` into
it. Those are end of options markers and they are correct as written; this is
the same collision that already stops the double hyphen rule from being widened
past the gated trees, and it is recorded in CLAUDE.md for that reason.

So the local gate reported five findings, at lines 6474, 6475, 7535, 11878 and
11879, and CI reported none. Not intermittently: on every checkout, with no way
for CI to see the disagreement at all. That is the reverse of the divergence
`tools/gatecheck` exists to catch, and it is invisible from the CI side by
construction.

The cost is not the red. It is that the red is unfixable and belongs to nobody.
Anyone running the prose gate before pushing gets a failure on a file they
cannot commit, and the two obvious reactions, editing the shared handover or
concluding their own change broke it, are both wrong.

IGNORED, NOT UNTRACKED, and the distinction is the whole of the fix. A file git
ignores can never be committed, so it can never ship, so styling it is
meaningless. A file that is merely untracked is one `git add` from shipping and
must still be read, or this gate would pass a new page locally and CI would
refuse it, which is the same defect pointing the other way.

Verified against the real symptom rather than a fixture: with the filter
removed, a tree carrying `PROGRESS.md` reports `956 files, 5 places`, and every
one of the five is in that file. With it, `955 files, 0 places`.

`TestAnExcludedFileIsSkippedAndAnUntrackedOneIsNot` pins both directions with a
`.gitignore` entry, a `.git/info/exclude` entry, and an untracked file carrying
the identical defect. Two mutation cells, each naming the assertion that moved:
removing the filter turns the two ignored cases red and leaves the untracked one
green, and widening it to drop untracked files turns only the untracked case
red. Neither cell fires the other's assertion.

Signed-off-by: Vir Sanghavi <67278851+VirSanghavi@users.noreply.github.com>

