### PR TITLE
tools: the generator that embeds the pages ran before four that write them

### DIFF
--- a/.changes/a-generate-pass-that-could-not-converge.md
+++ b/.changes/a-generate-pass-that-could-not-converge.md
@@ -1,0 +1,17 @@
+# fixed
+
+`just generate` could not finish the job in one pass, and the tree it left
+behind failed the generated file gate while every generator in it had just
+reported success.
+
+`docsembed` embeds every documentation page into the copy the MCP server
+serves. Six of those pages are themselves generated: `errors.md`, the schema
+reference, `cli.md`, `lint-findings.md`, `transforms.md` and the dashboard
+guide. `docsembed` ran sixth, ahead of four of the generators that write them,
+so one pass embedded the previous wording and a second pass was needed to
+settle. It was invisible until one of those pages actually changed, which is
+why it survived: the ordering is only wrong on the day somebody edits a schema.
+
+`docsembed` now runs last, after every generator that writes under `docs`. The
+rule is derived from the ledger that already records which generator owns which
+path, so a seventh generated page extends it without anybody remembering to.

--- a/justfile
+++ b/justfile
@@ -1458,13 +1458,24 @@ fuzz-engine seconds="60":
 # refuses a changed path no generator claims, and can do that because it runs
 # on a clean checkout. The property either way is the same: what is generated
 # matches what it is generated from.
+# docsembed runs LAST of these on purpose.
+#
+# It EMBEDS every documentation page into engine/internal/docs/pages.gen.go,
+# and six of those pages are themselves generated: errors.md by errgen,
+# lint-findings.md by lintgen, the schemas pages by schemadoc, cli.md by
+# -update-reference, transforms.md by -update-transforms and dashboard.md by
+# -update-frames. Run it before any of those and it embeds the previous
+# wording, so a single pass cannot converge and gendrift refuses a tree where
+# every generator just reported success. Measured rather than reasoned: with
+# docsembed before schemadoc, a one line schema edit left pages.gen.go with a
+# different checksum than a second docsembed produced. After it, the two
+# match.
 _generated:
     #!/usr/bin/env bash
     set -euo pipefail
     go run ./tools/errgen
     go run ./tools/lintgen
     go run ./tools/proxysrc
-    go run ./tools/docsembed
     go run ./tools/schemadoc .
     go run ./tools/notices -out THIRD_PARTY_NOTICES.md
     (cd engine && go test ./internal/policy -update-vectors)
@@ -1475,6 +1486,7 @@ _generated:
     go run ./tools/eventcheck -freeze .
     (cd engine && go test ./internal/masking -update-transforms)
     (cd engine && go test ./internal/hud -update-frames)
+    go run ./tools/docsembed
     # The OpenAPI artifact is generated too, and its generator is TypeScript
     # rather than Go. Its own --check mode is the comparison, so it is run in
     # the same form and the same directory CI runs it in: a gate is the command
@@ -1540,13 +1552,24 @@ capacityplan cpu memory manifest="antifailure.yaml":
       -node-cpu "{{cpu}}" -node-memory "{{memory}}"
 
 # Regenerate and keep the result.
+# docsembed runs LAST of these on purpose.
+#
+# It EMBEDS every documentation page into engine/internal/docs/pages.gen.go,
+# and six of those pages are themselves generated: errors.md by errgen,
+# lint-findings.md by lintgen, the schemas pages by schemadoc, cli.md by
+# -update-reference, transforms.md by -update-transforms and dashboard.md by
+# -update-frames. Run it before any of those and it embeds the previous
+# wording, so a single pass cannot converge and gendrift refuses a tree where
+# every generator just reported success. Measured rather than reasoned: with
+# docsembed before schemadoc, a one line schema edit left pages.gen.go with a
+# different checksum than a second docsembed produced. After it, the two
+# match.
 generate:
     go run ./tools/errgen
     go run ./tools/lintgen
     go run ./tools/installcheck . web || npm --prefix web ci --no-audit --no-fund
     npm --prefix web run openapi --workspace apps/api
     go run ./tools/proxysrc
-    go run ./tools/docsembed
     go run ./tools/schemadoc .
     go run ./tools/notices -out THIRD_PARTY_NOTICES.md
     cd engine && go test ./internal/policy -update-vectors
@@ -1557,6 +1580,7 @@ generate:
     go run ./tools/eventcheck -freeze .
     cd engine && go test ./internal/masking -update-transforms
     cd engine && go test ./internal/hud -update-frames
+    go run ./tools/docsembed
 
 # This machine's own credential store, against the real thing.
 #

--- a/tools/gendrift/main.go
+++ b/tools/gendrift/main.go
@@ -73,9 +73,6 @@ var ledger = []generator{
 	{"go run ./tools/proxysrc", []string{
 		"engine/internal/proxyimage/sources.gen.go",
 	}},
-	{"go run ./tools/docsembed", []string{
-		"engine/internal/docs/pages.gen.go",
-	}},
 	{"go run ./tools/schemadoc .", []string{
 		"docs/src/content/docs/reference/schemas",
 	}},
@@ -106,6 +103,9 @@ var ledger = []generator{
 	{"cd engine && go test ./internal/hud -update-frames", []string{
 		"engine/internal/hud/testdata",
 		"docs/src/content/docs/guides/dashboard.md",
+	}},
+	{"go run ./tools/docsembed", []string{
+		"engine/internal/docs/pages.gen.go",
 	}},
 }
 

--- a/tools/gendrift/main_test.go
+++ b/tools/gendrift/main_test.go
@@ -212,3 +212,110 @@ func TestTheLocalGateNamesTheDriftedArtifactAndNotYourEdits(t *testing.T) {
 	require.NotContains(t, err.Error(), "engine/internal/env/env.go")
 	require.NotContains(t, err.Error(), "no generator in tools/gendrift")
 }
+
+// The generator that EMBEDS the documentation runs after every generator that
+// WRITES a documentation page.
+//
+// docsembed packs every page under docs/ into
+// engine/internal/docs/pages.gen.go, and six of those pages are themselves
+// generated. Run it before one of them and it embeds the PREVIOUS wording, so
+// a single pass of `just generate` cannot converge: the tree it leaves behind
+// fails gendrift while every generator in it has just reported success. That
+// is the worst shape a gate failure can take, because the obvious reading is
+// that a generated file is corrupt rather than that the recipe is ordered
+// wrong.
+//
+// This is a real ordering that was wrong. docsembed sat sixth, ahead of
+// schemadoc, -update-reference, -update-transforms and -update-frames, and it
+// went unnoticed because it is INVISIBLE until one of those pages actually
+// changes. A lane adding two manifest keys found it.
+//
+// The rule is derived from the ledger rather than written down twice: anything
+// the ledger says writes under docs/ has to come first. So adding a seventh
+// generated page is enough to extend this, and no one has to remember the
+// list.
+func TestDocsembedRunsAfterEveryGeneratorThatWritesADocsPage(t *testing.T) {
+	const embedder = "go run ./tools/docsembed"
+
+	var writers []string
+	for _, g := range ledger {
+		if g.command == embedder {
+			continue
+		}
+		for _, p := range g.paths {
+			if strings.HasPrefix(p, "docs/") {
+				writers = append(writers, g.command)
+				break
+			}
+		}
+	}
+	// A rule with nothing to compare passes for the wrong reason. Six pages
+	// under docs/ are generated today and the ledger is where they are
+	// declared, so finding fewer than that means this test stopped seeing the
+	// thing it exists to order.
+	require.GreaterOrEqual(t, len(writers), 5,
+		"the ledger should name at least five generators writing under docs/, found %d", len(writers))
+
+	body, err := os.ReadFile(filepath.Join("..", "..", "justfile"))
+	require.NoError(t, err)
+
+	for _, recipe := range []string{"generate:", "_generated:"} {
+		t.Run(recipe, func(t *testing.T) {
+			lines := recipeBody(t, string(body), recipe)
+
+			embedAt := -1
+			for i, l := range lines {
+				if strings.Contains(l, embedder) {
+					embedAt = i
+					break
+				}
+			}
+			require.NotEqual(t, -1, embedAt, "%s never runs %s", recipe, embedder)
+
+			found := 0
+			for _, w := range writers {
+				for i, l := range lines {
+					if !strings.Contains(l, w) {
+						continue
+					}
+					found++
+					require.Less(t, i, embedAt,
+						"%s runs %q at line %d of the recipe, after %s at line %d.\n"+
+							"docsembed embeds the page that generator writes, so this pass embeds the previous wording.\n"+
+							"Move %s below every generator that writes under docs/.",
+						recipe, w, i, embedder, embedAt, embedder)
+					break
+				}
+			}
+			require.GreaterOrEqual(t, found, 5,
+				"%s should run at least five of the ledger's docs writers, found %d", recipe, found)
+		})
+	}
+}
+
+// recipeBody returns the indented lines of one justfile recipe.
+func recipeBody(t *testing.T, justfile, header string) []string {
+	t.Helper()
+	all := strings.Split(justfile, "\n")
+	start := -1
+	for i, l := range all {
+		if l == header {
+			start = i + 1
+			break
+		}
+	}
+	require.NotEqual(t, -1, start, "recipe %s not found in the justfile", header)
+
+	var out []string
+	for _, l := range all[start:] {
+		if strings.TrimSpace(l) == "" {
+			continue
+		}
+		if !strings.HasPrefix(l, " ") && !strings.HasPrefix(l, "\t") {
+			break
+		}
+		out = append(out, l)
+	}
+	require.NotEmpty(t, out, "recipe %s is empty", header)
+	return out
+}


### PR DESCRIPTION
tools: the generator that embeds the pages ran before four that write them

`just generate` could not converge in one pass, and the tree it left behind
failed `gendrift` while every generator in it had just reported success. That is
the worst shape a gate failure can take: the obvious reading is that a generated
file is corrupt, and the actual fault is the order of the recipe.

`docsembed` embeds every page under `docs` into `pages.gen.go`, which is the
documentation the MCP server serves. SIX of those pages are themselves
generated, and `docsembed` ran sixth, ahead of four of the generators that write
them: `schemadoc`, `-update-reference` for `cli.md`, `-update-transforms` for
`transforms.md` and `-update-frames` for the dashboard guide. Only `errgen` and
`lintgen` happened to come first. So a single pass embedded the previous wording
of four pages.

It stayed hidden because the ordering is only WRONG ON THE DAY one of those
pages changes. Every pass on a tree where nothing regenerated differently
converges, which is almost every pass. A lane adding two manifest keys hit it,
saw `gendrift` refuse `pages.gen.go` on a freshly generated tree, and had to run
`docsembed` a second time to settle it.

Measured rather than reasoned, because the ordering is exactly the kind of claim
that reads as obviously fine. With a one line schema description edit, and the
recipe's own order of `docsembed` then `schemadoc`, `pages.gen.go` finished the
pass at checksum 658dc80 and a further `docsembed` produced 300f83d. With
`schemadoc` first the pass finished at 300f83d and stayed there. The pass had
been leaving the file one generator behind.

`docsembed` now runs last in both `generate` and `_generated`. Its entry moves to
the end of the ledger too, because that list documents itself as being in the
order the generators run and it carried the same wrong order.

The guard is derived rather than written down twice.
`TestDocsembedRunsAfterEveryGeneratorThatWritesADocsPage` asks the ledger which
generators write under `docs` and requires every one of them to appear before
`docsembed` in both recipes, so a seventh generated page extends it with nobody
remembering to. It refuses to pass on an empty comparison: fewer than five
writers found in the ledger, or fewer than five matched in a recipe, is itself a
failure, because a rule with nothing to compare passes for the wrong reason.

Mutation tested rather than asserted: restoring the original position of
`docsembed` turns it red for BOTH recipes, naming `schemadoc` and the two line
numbers, and restoring the fix turns it green again.

Signed-off-by: Vir Sanghavi <67278851+VirSanghavi@users.noreply.github.com>

