### PR TITLE
gate: the image pin check read files git has never heard of

### DIFF
--- a/.changes/a-gate-that-refused-a-file-git-never-heard-of.md
+++ b/.changes/a-gate-that-refused-a-file-git-never-heard-of.md
@@ -1,0 +1,22 @@
+# fixed
+
+The image pin gate read files git has never heard of, and refused a fully
+pinned repository because of one.
+
+The check added in #338 enumerated what it scans by walking the working tree
+for shell scripts. A working tree holds more than a repository declares. The
+harness that mutation tested that very gate is an untracked script in a lane's
+worktree, it carries a moving tag in one variable and a deliberately wrong
+digest in another, and the gate read both and reported the tree as unpinned
+while every real declaration in it was correct.
+
+Every required context stayed green throughout, because a clean checkout has no
+scratch file. So the only person who could ever see this is somebody running
+`just gate` with a scratch script open, and from there it reads as the gate
+being broken rather than as the gate looking at the wrong thing. That is how a
+working gate gets switched off.
+
+The enumeration now comes from `git ls-files`, because what this repository
+declares is what git tracks. A listing that cannot be obtained fails the test
+rather than skipping it, since "I could not look" and "there was nothing to
+find" are different answers and only one of them is a pass.

--- a/tools/gatecheck/main_test.go
+++ b/tools/gatecheck/main_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1633,41 +1632,50 @@ func unpinnedImages(name, body string) []imageFinding {
 }
 
 // filesThatStartContainers is every file in this repository that can start
-// one. The workflows, the justfile, and every shell script, found by walking
-// rather than by a list, so a new script is covered on the day it is written
-// rather than on the day somebody remembers to add it here.
+// one: the workflows, the justfile, and every shell script.
+//
+// TRACKED FILES ONLY, and that is the whole of what changed here. This walked
+// the WORKING TREE when it landed in #338, which meant it read files git has
+// never heard of. The harness that mutation tested this very gate is an
+// untracked shell script in a lane's worktree, it carries `postgres:17-alpine`
+// in a variable and a deliberately wrong digest in another, and the gate read
+// both and refused a tree whose every real declaration was pinned.
+//
+// CI WAS GREEN THROUGH ALL OF IT, which is the half worth keeping. A clean
+// checkout has no scratch file, so the required contexts saw nothing wrong.
+// The only person who could ever hit it is somebody running `just gate` with a
+// scratch script open, and from there it reads as the gate being broken rather
+// than as the gate looking at the wrong thing. That is how a real gate gets
+// switched off, and this one is four commits old.
+//
+// What this repository declares is what git tracks. An untracked file is not a
+// declaration, it is somebody's afternoon.
 func filesThatStartContainers(t *testing.T) []string {
 	t.Helper()
 	root := filepath.Join("..", "..")
-	files, err := filepath.Glob(filepath.Join(root, ".github", "workflows", "*.yml"))
+	cmd := exec.Command("git", "ls-files", "-z")
+	cmd.Dir = root
+	listed, err := cmd.Output()
 	if err != nil {
-		t.Fatal(err)
+		// Not a skip. "I could not look" and "there was nothing to find" are
+		// different answers and only one of them is a pass, so a listing this
+		// gate cannot obtain fails it.
+		t.Fatalf("git ls-files could not enumerate the tree, so nothing was checked: %v", err)
 	}
-	files = append(files, filepath.Join(root, "justfile"))
-	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return nil
+	var files []string
+	for _, name := range strings.Split(strings.TrimRight(string(listed), "\x00"), "\x00") {
+		switch {
+		case strings.HasPrefix(name, ".github/workflows/") && strings.HasSuffix(name, ".yml"),
+			name == "justfile",
+			strings.HasSuffix(name, ".sh"):
+			files = append(files, filepath.Join(root, filepath.FromSlash(name)))
 		}
-		if d.IsDir() {
-			switch d.Name() {
-			case "node_modules", ".git", "testdata", "dist", "build":
-				return fs.SkipDir
-			}
-			return nil
-		}
-		if strings.HasSuffix(d.Name(), ".sh") {
-			files = append(files, path)
-		}
-		return nil
-	})
-	if err != nil {
-		t.Fatal(err)
 	}
-	// A glob or a walk that quietly stops matching reads exactly like a clean
-	// tree, which is the failure this repository keeps finding in its own
+	// A listing that quietly stops matching reads exactly like a clean tree,
+	// which is the failure this repository keeps finding in its own
 	// instruments.
 	if len(files) < 25 {
-		t.Fatalf("only %d files were found to scan; the walk has probably stopped matching", len(files))
+		t.Fatalf("only %d files were found to scan; the listing has probably stopped matching", len(files))
 	}
 	return files
 }
@@ -1896,5 +1904,36 @@ func TestAPortMappingIsNotAContainerImage(t *testing.T) {
 	// And the boundary has not cost the pattern the thing it is for.
 	if got := unpinnedImages("ci.yml", "        image: postgres:17-alpine\n"); len(got) != 1 {
 		t.Errorf("a real moving tag stopped being found: %v", got)
+	}
+}
+
+func TestAnUntrackedScratchFileIsNotScanned(t *testing.T) {
+	// The defect this gate had against itself for four commits, found by the
+	// mutation harness that was testing it rather than by anything in the
+	// tree. The harness is an untracked shell script naming a moving tag; the
+	// walk read it and the gate refused a fully pinned repository, while every
+	// required context stayed green because a clean checkout has no such file.
+	//
+	// The fixture is a real `docker run` rather than an assignment, because an
+	// earlier version of this test used `IMAGE=postgres:17-alpine` on its own
+	// line, which the checker correctly does not refuse: a variable assignment
+	// is not a command and the image may still be pinned where it is used. The
+	// second assertion is what caught that, and it is why it is here.
+	scratch := filepath.Join("..", "..", ".gatecheck-scratch-for-a-test.sh")
+	body := "#!/usr/bin/env bash\ndocker run -d --name x postgres:17-alpine\n"
+	if err := os.WriteFile(scratch, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Remove(scratch) })
+
+	for _, f := range filesThatStartContainers(t) {
+		if filepath.Base(f) == ".gatecheck-scratch-for-a-test.sh" {
+			t.Fatalf("an untracked scratch file was scanned: %s", f)
+		}
+	}
+	// And it really would have been refused had it been tracked, so the
+	// assertion above is about tracking and not about a harmless fixture.
+	if got := unpinnedImages("scratch.sh", body); len(got) == 0 {
+		t.Error("the fixture does not name a moving tag, so this test proves nothing")
 	}
 }


### PR DESCRIPTION
## The failure

The image pin gate added in #338 enumerated what it scans by walking the
WORKING TREE for shell scripts, on top of the workflows and the justfile. A
working tree holds more than a repository declares.

The harness that mutation tested that very gate is an untracked shell script in
a lane's worktree. It carries `postgres:17-alpine` in one variable, because
that is the string the mutation reverts a site to, and a deliberately wrong
digest in another, because that is how the half finished bump cell is built.
The gate read both and reported the tree as unpinned while every real
declaration in the repository was correct:

    main_test.go:1584: postgres is pinned to sha256:0000...0000 in [../../.lane/matrix.sh]
    main_test.go:1586: postgres is pinned to 2 different digests

**The instrument caught itself, and that is the only reason this was found.**
Nothing in the tree was wrong, so no other check was ever going to point at it.

## Why CI could never have told anyone

**Every required context stayed green through all of it.** A clean checkout has
no scratch file, so `engine` passed on #338 and on the four commits after it.
The only person who can hit this is somebody running `just gate` or
`go test ./tools/...` with a scratch script open in their worktree, and from
there it reads as the gate being broken rather than as the gate looking at the
wrong thing.

That is the shape that gets a working gate switched off, and it is worse than an
ordinary false positive because the failure is invisible to the machine that
would otherwise arbitrate. This one was four commits old.

## The fix

`git ls-files` instead of a working tree walk. **What this repository declares
is what git tracks; an untracked file is not a declaration, it is somebody's
afternoon.**

A listing that cannot be obtained now fails the test rather than skipping it,
which is the rule this repository already keeps for its own instruments: "I
could not look" and "there was nothing to find" are different answers and only
one of them is a pass.

## The test, and the guard inside it that earned its place

`TestAnUntrackedScratchFileIsNotScanned` writes a scratch script naming a moving
tag, asserts it is not scanned, and then asserts SEPARATELY that the same
fixture would have been refused had it been tracked.

That second assertion is not decoration. **The first version of this test used
`IMAGE=postgres:17-alpine` on a line of its own, and the checker correctly does
not refuse that**: a variable assignment is not a command, and the image may
still be pinned at the point it is used. Without the guard, the test would have
asserted that a harmless file is not scanned, which says nothing whatsoever
about tracking. The guard caught it on the first run and the fixture is now a
real `docker run`.

## Verification

Five cells, each red for the test it was aimed at, one `=== RUN` line each, run
under a single lock hold with a snapshot restore between cells.

| cell | mutation | expected | result |
| --- | --- | --- | --- |
| A | enumeration includes untracked files again | red | red, naming the scratch file |
| B | a TRACKED site reverts to a moving tag | red | red |
| C | one site pinned to a different digest | red | red |
| D | `git ls-files` cannot run | red | red, fails rather than skips |
| E | the fixture no longer names a moving tag | red | red, caught by its own guard |

Baseline green before and after, and the whole `gatecheck` package passes in
26s. Working tree clean afterwards, so the scratch file the test writes is
removed by its `t.Cleanup`.

**One cell reported a pass and had tested nothing, and it is recorded rather
than quietly redone.** The first attempt at cell A mutated the enumeration
using `find -printf`, which is GNU find; this machine's `find` does not have it,
the `|| true` swallowed the error, and the enumeration was never actually
changed. It reported the gate as failing to catch its own defect when in fact
nothing had been mutated. A mutation that does not mutate reads exactly like a
gate that cannot say no, which is the same class of defect as the one this pull
request fixes.

## Scope

This is the enumeration only, forty lines in one function plus one test.
`unpinnedImages` is untouched, including everything #350 added to it for build
matrix blocks. That is deliberate: my worktree still held the pre #350 copy of
that function, and pushing the file wholesale would have silently reverted the
matrix handling with both git and the compiler passing it.
