### PR TITLE
tools: the merge tool could not describe its own rule in a commit message

### DIFF
--- a/.changes/a-merge-tool-that-could-not-describe-its-own-rule.md
+++ b/.changes/a-merge-tool-that-could-not-describe-its-own-rule.md
@@ -1,0 +1,27 @@
+# fixed
+
+The merge tool refused a pull request for four characters inside a code span,
+on the pull request whose subject was that rule.
+
+`tools/prmerge` strips fenced blocks and inline code spans before it looks for
+an attribution trailer, and the comment on those two patterns says both are
+removed before a text is judged, naming prosecheck's punctuation exemption as
+the precedent for doing it. Only the attribution check actually did. The
+punctuation check matched its patterns against the raw text.
+
+So within one file the attribution rule could tell a mention from a use and the
+punctuation rule could not, and the punctuation rule is the one that blocks the
+merge. CLAUDE.md permits a command flag inside backticks in as many words, and
+prosecheck accepts it, so the two gates gave opposite answers about the same
+four characters and the stricter one was not the documented one.
+
+That comment already records this exact failure happening once before, to the
+attribution rule, under the heading that the rule could not tell a mention from
+a use and refused its own pull request. It happened again to the rule two
+hundred lines below it.
+
+`prose` now applies the same two replacements. Both directions are pinned by a
+test and each was mutation tested: removing the stripping refuses the code span
+case again, and stripping everything stops refusing prose punctuation. A
+markdown table separator is three hyphens and was never matched by the pattern,
+which the test records so nobody adds an exemption for it.

--- a/tools/prmerge/main.go
+++ b/tools/prmerge/main.go
@@ -606,8 +606,22 @@ func bodyFor(given, own string) (string, error) {
 }
 
 // prose refuses the characters this repository bans in a commit message.
+//
+// CODE SPANS ARE STRIPPED FIRST, and this function is the one that forgot to.
+// The comment on `fenced` and `code` says both are removed before a text is
+// judged, and names prosecheck's punctuation exemption as the precedent for
+// doing so, but only attributionIn actually did it. So within one file the
+// attribution rule could tell a mention from a use and the punctuation rule
+// could not, and the punctuation rule is the one that blocks the merge.
+//
+// It refused a pull request whose subject was the double hyphen gate, for the
+// four characters `git grep "x" -- path` inside a code span, which CLAUDE.md
+// permits in as many words and which prosecheck accepts. A repository whose
+// merge tool cannot describe its own rules in a commit message is one where the
+// rules get described somewhere nobody reads.
 func prose(what, text string) []string {
 	var problems []string
+	text = code.ReplaceAllString(fenced.ReplaceAllString(text, ""), "")
 	for _, b := range banned {
 		if b.pattern.MatchString(text) {
 			problems = append(problems, fmt.Sprintf(

--- a/tools/prmerge/main_test.go
+++ b/tools/prmerge/main_test.go
@@ -1302,3 +1302,61 @@ func TestTheReadbackRunsAgainstAMergedPullRequest(t *testing.T) {
 		}
 	})
 }
+
+// The punctuation rule tells a mention from a use, as the attribution rule
+// already did.
+//
+// BOTH DIRECTIONS, because only the second says the exemption did not disarm
+// the rule. The comment on `fenced` and `code` says both are removed before a
+// text is judged and cites prosecheck's punctuation exemption as its precedent,
+// but only attributionIn stripped them. So this tool refused a pull request
+// whose subject was the double hyphen gate, for four characters inside a code
+// span that CLAUDE.md permits in as many words.
+func TestTheDoubleHyphenRuleExemptsCodeSpansAndStillRefusesProse(t *testing.T) {
+	for _, c := range []struct {
+		name    string
+		text    string
+		refused bool
+	}{
+		{
+			name:    "an end of options marker inside a code span",
+			text:    "handovers wrote `git grep \"install(\" -- ee/web web` into it.\n",
+			refused: false,
+		},
+		{
+			name:    "the same marker inside a fenced block",
+			text:    "Run this:\n\n```\ngit grep \"install(\" -- ee/web web\n```\n",
+			refused: false,
+		},
+		{
+			name:    "a double hyphen as punctuation in prose",
+			text:    "The gate was red locally -- and green in CI.\n",
+			refused: true,
+		},
+		{
+			name:    "prose punctuation on a line that also carries a code span",
+			text:    "The `--stdin` flag is fine -- the punctuation is not.\n",
+			refused: true,
+		},
+		{
+			name:    "an em dash in prose",
+			text:    "The gate was red locally — and green in CI.\n",
+			refused: true,
+		},
+		{
+			name:    "a markdown table separator, which is three hyphens",
+			text:    "| a | b |\n| --- | --- |\n| 1 | 2 |\n",
+			refused: false,
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			problems := prose("body", c.text)
+			if c.refused && len(problems) == 0 {
+				t.Fatalf("this should have been refused and was not: %q", c.text)
+			}
+			if !c.refused && len(problems) != 0 {
+				t.Fatalf("this should have been allowed and was refused as %q: %q", problems[0], c.text)
+			}
+		})
+	}
+}


### PR DESCRIPTION
tools: the merge tool could not describe its own rule in a commit message

`tools/prmerge` refused a pull request for a double hyphen, on the pull request
whose subject was the double hyphen gate, for git's end of options marker
inside a code span.

This commit message cannot show you that marker. Until this change lands, the
tool refuses its own description, which is the shortest possible statement of
the defect.

The tool already knows how to tell a mention from a use. It strips fenced
blocks and inline code spans before looking for an attribution trailer, and the
comment on those two patterns says in as many words that both are removed
before a text is judged, citing prosecheck's punctuation exemption as the
precedent for doing it. Only `attributionIn` did the stripping. `prose` matched
its patterns against the raw text.

So one file held two rules, one that could tell a mention from a use and one
that could not, and the one that could not is the one that blocks a merge.
CLAUDE.md permits a command flag inside backticks explicitly, and prosecheck
accepts it, so the two gates answered oppositely about the same characters and
the stricter answer was not the documented one.

The comment above those patterns already records this failure happening once,
to the attribution rule, under the heading that the rule could not tell a
mention from a use and refused its own pull request. It then happened to the
rule two hundred lines below, in a way the comment's own reasoning would have
prevented.

The cost is not the refusal. It is that a repository whose merge tool cannot
describe its own rules in a commit message is one where the rules get described
somewhere nobody reads, or not at all.

`prose` now applies the same two replacements.

`TestTheDoubleHyphenRuleExemptsCodeSpansAndStillRefusesProse` pins both
directions across six cases: an end of options marker in a code span and in a
fenced block are accepted, punctuation in prose is refused, punctuation on a
line that also carries a code span is still refused, an em dash in prose is
refused, and a markdown table separator is recorded as three hyphens the
pattern never matched.

Two mutation cells, each with one subtest reporting: removing the stripping
turns the code span case red and leaves the prose case green, and stripping
everything turns the prose case red. Neither cell fires the other's assertion.

Signed-off-by: Vir Sanghavi <67278851+VirSanghavi@users.noreply.github.com>

