### PR TITLE
engine: the schema gate reported red about a manifest it had already refused

### DIFF
--- a/.changes/the-schema-gate-measured-nothing-and-said-red.md
+++ b/.changes/the-schema-gate-measured-nothing-and-said-red.md
@@ -24,3 +24,10 @@ failure that was never theirs.
 
 The override is the field's own documented default of 336h, beside the two
 `max_age` overrides already present for the same reason.
+
+The pinned constraint count moves from 593 to 600 in the same change, and it is
+the same defect one layer down. `require` stops at the first failure, so once
+the base manifest was refused the count assertion below it was never reached.
+593 was written down by a lane that could not have run it, and the seven that
+were missing are exactly `load.traffic`: `profile` and `max_age` with a type and
+a maxLength each, plus the block's own type, additionalProperties and required.

--- a/.changes/the-schema-gate-measured-nothing-and-said-red.md
+++ b/.changes/the-schema-gate-measured-nothing-and-said-red.md
@@ -1,0 +1,26 @@
+# fixed
+
+The 593 constraint schema gate had been measuring nothing, and saying red while
+it did.
+
+`TestEverySchemaConstraintIsEnforced` builds a base manifest by filling every
+field the schema declares, then breaks one cell at a time and requires the
+validator to refuse each break. #315 added `load.traffic.max_age` to
+`schemas/manifest.v1.json` without a tuning override, so the fixture filled that
+field with the application's name and the validator refused "web" as a duration.
+The base manifest was therefore refused before any cell was broken, and in the
+test's own words every cell measured against it says nothing. The gate reported
+a failure it had not found.
+
+Separately #327 created `engine/internal/manifest/manifest.v1.json`, a copy of
+the published schema read through go:embed, from a base that predated that same
+field. Neither pull request conflicted with the other and both passed their own
+gates, because the two changes travelled different paths and git had nothing to
+compare.
+
+Main carried both for thirteen commits. Every branch inherited the red through
+the merge ref, and three separate lanes spent time hunting their own code for a
+failure that was never theirs.
+
+The override is the field's own documented default of 336h, beside the two
+`max_age` overrides already present for the same reason.

--- a/engine/internal/manifest/manifest.v1.json
+++ b/engine/internal/manifest/manifest.v1.json
@@ -1390,7 +1390,7 @@
               "type": "number",
               "minimum": 0,
               "default": 0.25,
-              "description": "How much slower than production a route may get, as a ratio. It divides a measured p95 by production's own p95 for that route, so it needs a source that carries one: the default applies under source otel, and the engine refuses this key under access_log or none, where a route arrives with no baseline and the threshold could never fire."
+              "description": "How much slower than production a route may get, as a ratio. It divides a measured p95 by production's own p95 for that route, so it needs a source that carries one: the default applies under source otel, and the engine refuses this key under access_log or none unless load.traffic.profile is declared, because a route then arrives with no baseline and the threshold could never fire. A declared traffic profile supplies production's own p95 per route, which is the second place a baseline can come from."
             },
             "error_rate": {
               "type": "number",
@@ -1406,6 +1406,9 @@
               "description": "Not read by anything, and refused by the engine. A load run counts requests, not statements. The check that compares statement counts against the base branch is insights.query_regression, and how much growth fails it is insights.regression_factor."
             }
           }
+        },
+        "traffic": {
+          "$ref": "#/$defs/traffic"
         }
       }
     },
@@ -1885,6 +1888,28 @@
           "type": "string",
           "maxLength": 253,
           "description": "Which cluster this target is. Two targets resolving to the same cluster are refused, because a placement decision between them decides nothing."
+        }
+      }
+    },
+    "traffic": {
+      "title": "Traffic",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "profile"
+      ],
+      "description": "The committed record of what production actually serves, which is the denominator every route in a load run is measured against. Without one safe_routes is a list written from memory and nothing says how much of production it misses. Measured on this repository on 2026-09-06: a migration held an exclusive lock on nine relations for thirty seconds and the run over four hand written routes reported 0.0 percent failed, because none of the four reads the locked table.",
+      "properties": {
+        "profile": {
+          "type": "string",
+          "maxLength": 512,
+          "description": "The profile file, relative to the repository root. Written by af traffic record from an OpenTelemetry trace export or a combined format access log, and committed, because the machine that reads it on a pull request cannot reach production. It carries the endpoint mix, the arrival rate, the peak concurrency and the per route p95, and no request body, header, query string or identifier."
+        },
+        "max_age": {
+          "type": "string",
+          "maxLength": 32,
+          "default": "336h",
+          "description": "How old the profile may be before it is refused. A stale profile is not a smaller number, it is an unknown one, so it is refused the way a stale golden is rather than quoted. Fourteen days by default rather than the volume profile's thirty, because an endpoint mix moves at the rate a team ships rather than at the rate a business grows."
         }
       }
     }

--- a/engine/internal/manifest/schema_constraints_test.go
+++ b/engine/internal/manifest/schema_constraints_test.go
@@ -1133,7 +1133,18 @@ func TestSchemaConstraintReport(t *testing.T) {
 // driven by the published document: a bound another lane writes into the
 // schema is kept the moment it lands, and the only thing this constant does is
 // refuse to let one leave without somebody saying so.
-const wantConstraints = 593
+//
+// It is 600 rather than 593 because #315 added load.traffic, whose seven
+// constraints are profile and max_age with a type and a maxLength each, plus
+// the block's own type, additionalProperties and required. 593 was never
+// measured against a working fixture. #315 also omitted the tuning override for
+// load.traffic.max_age, so the base manifest this test builds was itself
+// refused from that commit onward and execution never reached this assertion.
+// The number was then written down by a later lane that could not have run it
+// either. So the pin held a figure nobody had been able to check for as long as
+// the fixture was broken, which is the failure mode of a gate that stops at its
+// first assertion: everything below it looks alive and is unreachable.
+const wantConstraints = 600
 
 // wantExceptions is how many constraints schemabounds.go deliberately does not
 // enforce. Every one is a published row that is wrong rather than a gap, and

--- a/engine/internal/manifest/schema_constraints_test.go
+++ b/engine/internal/manifest/schema_constraints_test.go
@@ -684,6 +684,7 @@ const defaultTuning = `{
         "explore.goals[].name": "explore-goal",
         "invariants[].sql": "SELECT id FROM orders WHERE id IS NULL",
         "load.source": "otel",
+        "load.traffic.max_age": "336h",
         "load.unsafe_routes": [
           "/admin"
         ],
@@ -731,6 +732,7 @@ const defaultTuning = `{
         "explore.goals[].name": "explore-goal",
         "invariants[].sql": "SELECT id FROM orders WHERE id IS NULL",
         "load.source": "otel",
+        "load.traffic.max_age": "336h",
         "load.unsafe_routes": [
           "/admin"
         ],


### PR DESCRIPTION
The 593 constraint schema gate had been measuring nothing, and reporting red while it did.

`TestEverySchemaConstraintIsEnforced` builds a base manifest by filling every field the schema declares, then breaks one cell at a time and requires the validator to refuse each break. #315 added `load.traffic.max_age` to `schemas/manifest.v1.json` with no tuning override, so the fixture filled that field with the application's name and the validator refused `"web"` as a duration. The base manifest was refused before a single cell was broken, so in the test's own words every cell measured against it says nothing.

That is a red meaning "I could not check at all" wearing the costume of a red meaning "I checked and found a problem". It is not on the list of false reds in CLAUDE.md, and it cost three separate lanes time hunting their own code for a failure that was never theirs. The list now carries it as an eighth entry.

Separately #327 created `engine/internal/manifest/manifest.v1.json`, the `go:embed` copy of the published schema, from a base that predated that same field. Neither pull request conflicted with the other and both passed their own gates, because the two changes travelled different paths and git had nothing to compare. That is a semantic merge, the same family as the duplicate symbol case CLAUDE.md already records: both instruments pass and the tree they produce is wrong.

Main carried both for thirteen commits, `engine` is a required context, so nothing could merge and staging has been serving `c566b41a` from #328 the whole time.

## Why no gate caught the stale copy

`tools/gendrift` names that exact path in its ledger, and its only action is `git status --porcelain`. So it can report drift only for a generator that something else already ran. The `cp` that writes the file is absent from ci.yml's generator block; it lives only in the justfile's `_generated` recipe, which `just gate` runs under the same display name as the CI step.

So a developer running `just gate` locally would have caught this, CI structurally cannot, and both report under one label. `tools/gatecheck` exists to fail the build when the local recipe and the CI gate disagree, and a shared display name over different content is the one disagreement it cannot see. That is a follow-up and is deliberately not fixed here.

## What is in the diff

Three things and nothing else, because nine pull requests are waiting on this.

- `cp schemas/manifest.v1.json engine/internal/manifest/manifest.v1.json`, restoring `$defs.traffic`, the `load.properties.traffic` ref and one reworded threshold description. 77961 bytes to 79860.
- `"load.traffic.max_age": "336h"` in both bases of `defaultTuning`, beside the `database.golden.max_age` and `database.volume.max_age` overrides already there for the same reason. 336h is the field's own documented default in the schema, not a value chosen here.
- This changelog entry.

## What was verified, and what was not

Verified without a Go build, because the shared build lock had eleven waiters and nine lanes were blocked behind this:

- The published and embedded schemas are now byte identical at 79860 bytes, both non zero.
- The embedded copy parses, carries `$defs.traffic`, and carries the `load.properties.traffic` reference.
- `defaultTuning` parses as JSON and the override is present in both bases, `source` and `seed`, asserted per base rather than by a single count.
- The edit landed exactly twice, asserted against the anchor rather than trusted from the editor.

**Not verified locally: the test run itself.** CI is the authority for that and it is not behind the local lock. The two failing tests are `TestEverySchemaConstraintIsEnforced` and `TestTheEmbeddedSchemaIsThePublishedOne`, both in `engine/internal/manifest`.

## The two fixes are not independent, and the first framing undersold the copy

I described these as one abort and one unrelated byte comparison. That understates the `cp`, and the correction came from the lane that diagnosed the original defect.

`schema_constraints_test.go:98` reads the PUBLISHED schema to build its fixture, so the missing override was always the whole cause of the abort, independent of the copy. But `schemabounds.go:55` embeds the COPY, and `schemaBounds` parses that at `:96` to decide what the engine actually enforces. A node absent from the copy therefore gets no bounds at all. With the override alone and no `cp`, this gate would have cleared the abort, cleared the count, and failed at the `unenforced` assertion instead, naming `load.traffic.profile maxLength` and `load.traffic.max_age maxLength` as promises the schema publishes and nothing keeps.

So both fixes are needed for one test, and they clear two different assertions inside it, with the byte comparison as a third test on top. That is reasoning from those two lines rather than a measurement, and it is labelled as such.

## The count moved to 600, and that is a third instance of the same defect

CI on `e98551c3` reported 600 constraints against a pin of 593. The seven are exactly `load.traffic`: `profile` and `max_age` with a type and a maxLength each, plus the block's own type, `additionalProperties` and `required`, so the arithmetic closes with nothing left over.

`require` stops at the first failure, so from the moment the base manifest was refused the count assertion below it was never reached. 593 was written down by a lane that could not have run it, and nothing changed the published schema afterwards, so it was never a measurement of the tree it was committed against. A value nobody could check, inside a test whose whole subject is values nobody can check.

I predicted this would NOT fire, on the grounds that the pin was set after the `traffic` block landed. That reasoning ignored that the author who set it was behind the same broken fixture. The date a number was written is not evidence that anything checked it.

The runtime is the better evidence that the repair worked: `TestEverySchemaConstraintIsEnforced` takes 11.46s here against 0.06s on `ce72b05c`, which is the difference between a gate abandoning at a refused fixture and one generating and measuring 600 cells.
