### PR TITLE
enterprise: a feature the licence granted, that nothing anywhere enforced

### DIFF
--- a/.changes/a-feature-enforced-nowhere-and-recorded-nowhere.md
+++ b/.changes/a-feature-enforced-nowhere-and-recorded-nowhere.md
@@ -1,0 +1,39 @@
+# fixed
+
+Record the two enterprise features that a license names and nothing gates, and
+add the check that could have found them.
+
+Twelve features can be named in an enterprise license. Seven are enforced at a
+real site, two are refused at issue and at evaluation because nothing implements
+them, and three were neither. Two of those three said so in prose. `air_gapped`
+said so nowhere: every occurrence of the name in the repository was a copy of
+the catalogue, the license vectors, a line of documentation, or a test. A
+license naming it verified, reported itself active, printed in
+`af license status`, and granted nothing, which from outside is what a working
+feature looks like.
+
+Nothing could have caught it, and that is the more useful half. The control
+plane's registry test asserts that the features enforced THERE have declared a
+site, and correctly declines to speak for the engine. The engine's own registry
+test asserts a site set is empty from a test binary that links none of the
+enforcing packages, so it cannot fail. Between one check that will not look at
+the engine and one that cannot look at anything, nobody ever asked whether every
+feature does something somewhere.
+
+`unenforced` in `ee/engine/license/license.go` now records a feature that ships
+and is gated nowhere, with the reason stored beside the name, the way
+`notShipped` already records one that does not ship at all. The two are
+different answers: absent cannot be sold, a feature we do not gate can be, and
+only the first is
+a reason to refuse a request. So `tools/licensegen` warns rather than refuses,
+naming the feature beside the key it just signed, and permits nothing new and
+refuses nothing that used to work.
+
+The check that spans both halves lives in the control plane's catalogue test,
+which already reads `license.go` and `licensegen` as text because no import
+joins them. It requires every feature to be refused, recorded as unenforced, or
+enforced at a site it can find in the engine, the control plane, or the
+community entitlement catalogue. Each of its three scanners carries a positive
+control naming a feature it must find, so a scanner that has stopped reading its
+input says so instead of quietly reclassifying a feature nothing gates as
+enforced.

--- a/docs/src/content/docs/enterprise/issuing-licenses.md
+++ b/docs/src/content/docs/enterprise/issuing-licenses.md
@@ -108,6 +108,26 @@ acting on it, and the generator is the only place the set can be closed.
 Before that check existed, `"features": ["ssoo"]` signed cleanly, verified
 cleanly, reported the license active, and permitted nothing.
 
+## Features that are issued with a warning
+
+`rbac` and `air_gapped` are issued, and the generator prints a warning naming
+them beside the key. Both are real: the custom roles library is written and
+tested, and air gapped operation is a property every installation already has.
+What is not true of either is that the license is what grants it, so withdrawing
+the license would not withdraw the capability, and a renewal conversation that
+treats one of them as a thing being bought is a conversation about nothing.
+
+That is a warning rather than a refusal on purpose. Refusing would refuse a
+customer something they can have, and a refusal placed where somebody has
+already promised the feature is a refusal that acquires an override flag within
+a week. The person who needs the sentence is the one issuing the key, before
+they answer a question about it, which is where it prints.
+
+The two lists are different answers and the generator keeps them apart.
+`billing` and `enterprise_dashboard` are not built, so they cannot be sold.
+These two are built and are not gated, so they can be sold and should not be
+described as something the license turns on.
+
 ## Features that cannot be issued
 
 `billing` and `enterprise_dashboard` are in the set above, and a request naming

--- a/docs/src/content/docs/enterprise/licensing.md
+++ b/docs/src/content/docs/enterprise/licensing.md
@@ -131,16 +131,39 @@ working feature from every direction and is harder to find than the gap it
 covers. A feature nobody can buy and nobody can be granted cannot be mistaken
 for one that ships.
 
-`rbac` is a third case and a different one. The custom roles library is complete
-and tested, and nothing stores a role model, so an organization has no way to
-have one. It is reported and not enforced, and it is written down here rather
-than gated for the same reason: a check on a path nothing reaches is worse than
-no check.
+### Two more are not enforced
 
-Both lists are held to the code by a test rather than by a habit. `notShipped`
-in `ee/engine/license/license.go` is the single place either statement lives,
-and this page, the generator and the enterprise feature registry are all checked
-against it in both directions.
+A third case, and a different one from the two above: `rbac` and `air_gapped`.
+Both name something real, and in neither case is the license what provides it.
+
+The custom roles library is complete and tested, and nothing stores a role
+model, so an organization has no way to have one. Air gapped operation is a
+property every installation already has, licensed or not: verification is a
+signature check against keys stamped into the binary, so it needs no network
+whichever features a license names.
+
+They are reported and not enforced, and that is written down rather than gated,
+for the reason the paragraph above gives: a check on a path nothing reaches is
+worse than no check. Unlike `billing` and `enterprise_dashboard` they are not
+refused at issue, because refusing them would refuse a customer a capability
+they can have. `tools/licensegen` prints a warning naming them beside the key it
+signs instead, so that whoever issues it reads what the license does and does
+not grant before a customer asks.
+
+`air_gapped` was in this state and said so nowhere until 2026-09-08. Every
+occurrence of the name in the repository was a copy of the catalogue, the
+license vectors, a line of documentation, or a test, so a license naming it
+verified, reported itself active, printed in `af license status`, and granted
+nothing. That is the same failure the two refused names above exist to prevent,
+reached through the case they do not cover.
+
+All three lists are held to the code by a test rather than by a habit.
+`notShipped` and `unenforced` in `ee/engine/license/license.go` are the single
+place each statement lives, and this page, the generator and the enterprise
+feature registry are all checked against them in both directions. A fourth
+check asks the question none of those could: that every feature a license can
+grant is refused, recorded as unenforced, or gated at a real site in one half of
+the product or the other.
 
 ## Contributing
 

--- a/ee/engine/license/license.go
+++ b/ee/engine/license/license.go
@@ -137,6 +137,84 @@ func NotShippedFeatures() []Feature {
 	return out
 }
 
+// unenforced names every feature this build ships, permits, and gates nowhere,
+// and says so where the catalogue is for the same reason notShipped does.
+//
+// A THIRD ANSWER, and the reason there has to be one. notShipped divides the
+// catalogue in two: a feature is either enforced somewhere or it is a name that
+// can never be sold. Two features fit neither half. The custom roles library is
+// complete and reaches nothing, and air gapped operation is a real property of
+// every installation that no code consults. Both were invisible, because a
+// catalogue with two buckets records a feature belonging to neither by saying
+// nothing about it, and saying nothing is exactly what "enforced somewhere"
+// already looks like from the outside.
+//
+// air_gapped is the one that shows the gap was structural rather than an
+// oversight. Every occurrence of the name in this repository is a copy of the
+// catalogue, the licence vectors, two lines of documentation, or a test. No
+// engine site declares it, no control plane route asks for it, and the
+// entitlement catalogue has no key for it. A licence naming it verifies,
+// reports active, prints in af license status, and changes nothing, which is
+// the failure notShipped exists to close arriving through the door notShipped
+// does not cover.
+//
+// WHY THESE ARE STILL PERMITTED AND notShipped IS NOT. Shipped's own comment
+// draws the line: absent says we did not build it, ungated says we built it and
+// do not charge for it, and only the first is a reason not to sell. Refusing to
+// permit air gapped operation would be refusing a customer a capability they
+// already have. So this map changes no runtime behaviour at all. It is a
+// declaration, read by licensegen so that whoever issues a licence naming one
+// of these reads what they are actually selling, and read by the catalogue test
+// so that a feature can no longer be enforced nowhere and recorded nowhere at
+// the same time.
+//
+// The reason is stored beside the name because "unenforced" alone is
+// indistinguishable from an oversight, and because the sentence has to be
+// deletable: gating one of these means removing the entry, and the entry says
+// what gating it would mean.
+var unenforced = map[Feature]string{
+	FeatureRBAC: "Custom roles exist as a library and not as a feature. ee/web/rbac " +
+		"validates a role model, resolves scopes and decides approvals, and nothing " +
+		"outside its own tests imports it: no table stores a model, no route defines " +
+		"one, no loader reads one. Gating it would declare an enforcement site that " +
+		"never runs, which is why it is recorded here instead. Building it means a " +
+		"table, a route and a loader, and then a real site to declare.",
+	FeatureAirGapped: "Air gapped operation is not gated and cannot usefully be. " +
+		"Licence verification is a signature check against keys stamped into the " +
+		"binary, so it needs no network for any installation, licensed or not, and " +
+		"tools/proxysrc exists so that an air gapped user needs no release either. No " +
+		"code path behaves differently when this is granted, so selling it sells " +
+		"something every installation already has. Building it means deciding what an " +
+		"air gapped MODE would refuse that the ordinary one permits, and gating that.",
+}
+
+// Unenforced reports whether this build ships a feature and gates it nowhere.
+//
+// A different question from Shipped, which asks whether the capability exists
+// at all. A feature can be shipped and unenforced, which is the ungated case,
+// and the two have different answers for a buyer: one is a capability we built
+// and do not charge for, the other is a name with nothing behind it.
+func Unenforced(f Feature) bool {
+	_, yes := unenforced[f]
+	return yes
+}
+
+// UnenforcedBecause is why a feature is gated nowhere, or the empty string when
+// it is enforced somewhere. Printed beside the licence licensegen just signed,
+// so the reason reaches whoever is selling it.
+func UnenforcedBecause(f Feature) string { return unenforced[f] }
+
+// UnenforcedFeatures is every feature this build ships and gates nowhere,
+// sorted.
+func UnenforcedFeatures() []Feature {
+	out := make([]Feature, 0, len(unenforced))
+	for f := range unenforced {
+		out = append(out, f)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
 // AllFeatures is every feature a license can carry, sorted, for the comparison
 // page and for the entitlement matrix test.
 func AllFeatures() []Feature {

--- a/ee/web/features/test/catalogue.test.ts
+++ b/ee/web/features/test/catalogue.test.ts
@@ -32,7 +32,7 @@
 
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { readFile } from 'node:fs/promises'
+import { readdir, readFile } from 'node:fs/promises'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { FEATURES, declared, sites, type Feature } from '../src/index.ts'
@@ -59,6 +59,8 @@ const licensingDoc = await readFile(
   path.join(repo, 'docs/src/content/docs/enterprise/licensing.md'), 'utf8')
 const issuingDoc = await readFile(
   path.join(repo, 'docs/src/content/docs/enterprise/issuing-licenses.md'), 'utf8')
+const entitlementsTs = await readFile(
+  path.join(repo, 'web/apps/api/src/entitlements.ts'), 'utf8')
 
 /**
  * The string values of the Feature constants in license.go.
@@ -77,19 +79,28 @@ function goFeatures(source: string): string[] {
   return out.sort()
 }
 
-/** The keys of the notShipped map, resolved through the constants. */
-function goNotShipped(source: string): string[] {
+/**
+ * The keys of a named Feature-keyed map in license.go, resolved through the
+ * constants.
+ *
+ * Two maps are read by this file, notShipped and unenforced, and one reader for
+ * both is what stops the second from being held by a weaker check than the
+ * first. A map name that is not in the file asserts rather than returning
+ * empty: "the map is gone" and "the map is empty" are different facts and a
+ * reader that answered the same for both could not say no about either.
+ */
+function goFeatureMap(source: string, mapName: string): string[] {
   const constants = new Map<string, string>()
   for (const line of source.split('\n')) {
     const m = /^\s*(Feature[A-Za-z]+)\s+Feature\s*=\s*"([a-z_]+)"\s*$/.exec(line)
     if (m?.[1] && m[2]) constants.set(m[1], m[2])
   }
-  const block = /var notShipped = map\[Feature\]string\{([\s\S]*?)\n\}/.exec(source)
-  assert.ok(block?.[1], 'no notShipped map was found in license.go')
+  const block = new RegExp(`var ${mapName} = map\\[Feature\\]string\\{([\\s\\S]*?)\\n\\}`).exec(source)
+  assert.ok(block?.[1], `no ${mapName} map was found in license.go`)
   const out: string[] = []
   for (const m of block[1].matchAll(/^\t(Feature[A-Za-z]+):/gm)) {
     const name = constants.get(m[1]!)
-    assert.ok(name, `notShipped names ${m[1]}, which is not a Feature constant`)
+    assert.ok(name, `${mapName} names ${m[1]}, which is not a Feature constant`)
     out.push(name)
   }
   return out.sort()
@@ -148,7 +159,7 @@ describe('the feature catalogue is one answer in four places', () => {
     // The one asymmetry that is allowed and has to be stated. Two names in the
     // catalogue are refused at issue and at evaluation, so a page that lists
     // them without saying so is selling them.
-    const refused = goNotShipped(licenseGo)
+    const refused = goFeatureMap(licenseGo, 'notShipped')
     assert.ok(refused.length > 0, 'nothing is marked unshipped, so this test proves nothing')
     for (const feature of refused) {
       assert.match(
@@ -207,5 +218,196 @@ describe('every declared enforcement site names something that can refuse', () =
       }
     }
     assert.ok(checked >= 3, `only ${checked} sites were checked, and there are at least three`)
+  })
+})
+
+
+// ---------------------------------------------------------------------------
+// Is every feature accounted for, anywhere in the product
+// ---------------------------------------------------------------------------
+//
+// THE GAP THIS CLOSES, and it is a gap between two checks rather than inside
+// either of them. The block above asserts that the features enforced in the
+// CONTROL PLANE have declared a site, and it is deliberately not a count of
+// twelve, because most of them are enforced in the engine where this registry
+// cannot see them. The engine has its own registry and its own test, and that
+// test asserts Sites(FeatureCompliance) is EMPTY from a test binary linking
+// none of the enforcing packages, so it cannot fail. Between one check that
+// correctly declines to look at the engine and one that cannot look at
+// anything, nothing in this repository ever asked the whole question: does
+// every feature a licence can grant do something, somewhere, in either half.
+//
+// It was measured on 2026-09-08 and the answer was no. Seven of the twelve are
+// enforced, two are refused at issue and at evaluation, and THREE were neither.
+// Two of those three had the fact written down in prose. air_gapped had it
+// written down nowhere: every occurrence of the name in the repository is a
+// copy of the catalogue, the licence vectors, two lines of documentation, or a
+// test, and a licence naming it verifies, reports active, prints in af license
+// status, and grants nothing.
+//
+// So the question this asks is a partition. Every feature must be in exactly
+// one of three states and each state must be RECORDED, because the whole
+// failure is that "enforced somewhere" and "nobody has looked" are the same
+// silence:
+//
+//   refused    in notShipped, so licensegen will not sign it and Evaluate will
+//              not permit it
+//   unenforced in unenforced, which ships and gates nothing, with the reason
+//              stored beside the name
+//   enforced   at a site this test can find, in either half of the product
+//
+// WHY THE SCANNERS CARRY POSITIVE CONTROLS. A scanner that stops matching
+// reports no sites, which turns every enforced feature into an unrecorded one
+// and fails loudly, so that direction is safe. The dangerous direction is a
+// pattern loose enough to match prose, which would quietly reclassify a
+// genuinely ungated feature as enforced. Each scanner is therefore asserted to
+// find one specific feature it must find, so "I could not look" is a distinct
+// answer from "there is nothing there".
+
+/** Every path under a directory, recursively. */
+async function filesUnder(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true, recursive: true })
+  return entries
+    .filter((e) => e.isFile())
+    .map((e) => path.join(e.parentPath ?? e.path, e.name))
+}
+
+/**
+ * Features declared at an enforcement site in the enterprise ENGINE.
+ *
+ * Read out of the source rather than out of the engine's own registry, because
+ * that registry is Go and lives in a process this test cannot start. Only
+ * `feature.Declare(license.FeatureX` counts, which is the call that records a
+ * site, and test files are excluded: a declaration made by a test is a
+ * statement about the test binary and not about the product.
+ */
+async function engineSites(constants: Map<string, string>): Promise<Set<string>> {
+  const out = new Set<string>()
+  for (const file of await filesUnder(path.join(repo, 'ee/engine'))) {
+    if (!file.endsWith('.go') || file.endsWith('_test.go')) continue
+    const source = await readFile(file, 'utf8')
+    for (const m of source.matchAll(/feature\.Declare\(\s*license\.(Feature[A-Za-z]+)/g)) {
+      const name = constants.get(m[1]!)
+      assert.ok(name, `${file} declares license.${m[1]}, which is not a Feature constant`)
+      out.add(name)
+    }
+  }
+  return out
+}
+
+/**
+ * Features with a non-null `enforcedAt` in the community control plane's
+ * entitlement catalogue.
+ *
+ * The third authority, and the one neither registry can see. support_access is
+ * enforced in MIT code at admin/customers.ts and is therefore absent from the
+ * enterprise registry above, which would read as unenforced without this.
+ */
+function communitySites(source: string): Set<string> {
+  const out = new Set<string>()
+  for (const m of source.matchAll(/^ {2}([a-z_]+): \{\n([\s\S]*?)\n {2}\},/gm)) {
+    const key = m[1]!
+    if (!(FEATURES as readonly string[]).includes(key)) continue
+    if (/enforcedAt: '[^']+'/.test(m[2]!)) out.add(key)
+  }
+  return out
+}
+
+describe('every feature a licence can grant is accounted for somewhere', () => {
+  it('partitions the catalogue into refused, unenforced, and enforced', async () => {
+    const constants = new Map<string, string>()
+    for (const line of licenseGo.split('\n')) {
+      const m = /^\s*(Feature[A-Za-z]+)\s+Feature\s*=\s*"([a-z_]+)"\s*$/.exec(line)
+      if (m?.[1] && m[2]) constants.set(m[1], m[2])
+    }
+    assert.ok(constants.size > 0, 'no Feature constants were read, so nothing below can resolve')
+
+    const refused = new Set(goFeatureMap(licenseGo, 'notShipped'))
+    const ungated = new Set(goFeatureMap(licenseGo, 'unenforced'))
+    const engine = await engineSites(constants)
+    const controlPlane = new Set<string>(declared())
+    const community = communitySites(entitlementsTs)
+
+    // The positive controls, one per scanner. Each names a feature that is
+    // enforced beyond doubt at a site of that scanner's kind, so a scanner that
+    // has stopped seeing its input fails here saying so, rather than passing
+    // this test by reporting a feature as ungated.
+    assert.ok(
+      engine.has('multi_runtime'),
+      'the engine scanner found no site for multi_runtime, which is declared in ' +
+        'ee/engine/cmd/af/placement.go. The scanner is not reading the engine, so every ' +
+        'engine enforced feature below would read as unenforced.',
+    )
+    assert.ok(
+      controlPlane.has('sso'),
+      'the control plane registry holds no site for sso. The packages imported at the top ' +
+        'of this file are what populate it, so this means an import was dropped.',
+    )
+    assert.ok(
+      community.has('support_access'),
+      'the entitlement catalogue scanner found no enforcedAt for support_access, which ' +
+        'names admin/customers.ts:supportAccessVerdict. The block pattern no longer ' +
+        'matches entitlements.ts, so every community enforced feature would read as ungated.',
+    )
+
+    const unaccounted: string[] = []
+    const both: string[] = []
+    for (const feature of FEATURES) {
+      const enforced = engine.has(feature) || controlPlane.has(feature) || community.has(feature)
+      const recorded = refused.has(feature) || ungated.has(feature)
+      if (!enforced && !recorded) unaccounted.push(feature)
+      // Recorded as granting nothing AND enforced somewhere is the other way
+      // this can be wrong, and it is the one that goes stale silently: somebody
+      // builds the gate and leaves the entry saying there is none.
+      if (enforced && recorded) both.push(feature)
+    }
+
+    assert.deepEqual(
+      unaccounted, [],
+      `${unaccounted.join(', ')} can be named in a licence and is enforced nowhere in either ` +
+        `half of the product, and nothing records that. A licence naming one verifies, ` +
+        `reports active, prints in af license status, and grants nothing, which is ` +
+        `indistinguishable from a working feature from the outside. Either gate it at a real ` +
+        `site, or add it to notShipped in ee/engine/license/license.go so it cannot be sold, ` +
+        `or add it to unenforced there with the reason it is not gated.`,
+    )
+    assert.deepEqual(
+      both, [],
+      `${both.join(', ')} is recorded in license.go as granting nothing and is also enforced ` +
+        `at a real site. One of the two is now false. If the gate was built, delete the ` +
+        `entry; the entry says what building it would mean.`,
+    )
+  })
+
+  it('the two recorded sets are disjoint and neither is empty', () => {
+    const refused = goFeatureMap(licenseGo, 'notShipped')
+    const ungated = goFeatureMap(licenseGo, 'unenforced')
+    // Empty would make the partition above pass by having nothing to compare,
+    // which is the shape of check this repository keeps finding in its own
+    // instruments.
+    assert.ok(refused.length > 0, 'notShipped is empty, so the partition proves less than it says')
+    assert.ok(ungated.length > 0, 'unenforced is empty, so the partition proves less than it says')
+
+    const overlap = refused.filter((f) => ungated.includes(f))
+    assert.deepEqual(
+      overlap, [],
+      `${overlap.join(', ')} is in both notShipped and unenforced. Those are different ` +
+        `answers: the first says we did not build it and refuses to sell it, the second ` +
+        `says we built it and do not gate it. They cannot both be true.`,
+    )
+  })
+
+  it('a feature recorded as unenforced is named as such in the documentation', () => {
+    // The same rule the refused features already carry, and for the same
+    // reason: a page that lists a feature and never says the licence does not
+    // grant it is a page selling the licence rather than the capability.
+    const ungated = goFeatureMap(licenseGo, 'unenforced')
+    assert.ok(ungated.length > 0, 'nothing is recorded as unenforced, so this test proves nothing')
+    for (const feature of ungated) {
+      assert.match(
+        licensingDoc, new RegExp(`not enforced[\\s\\S]*\`${feature}\``),
+        `licensing.md lists ${feature} and never says the licence does not enforce it`,
+      )
+    }
   })
 })

--- a/ee/web/features/test/catalogue.test.ts
+++ b/ee/web/features/test/catalogue.test.ts
@@ -269,7 +269,7 @@ async function filesUnder(dir: string): Promise<string[]> {
   const entries = await readdir(dir, { withFileTypes: true, recursive: true })
   return entries
     .filter((e) => e.isFile())
-    .map((e) => path.join(e.parentPath ?? e.path, e.name))
+    .map((e) => path.join(e.parentPath, e.name))
 }
 
 /**

--- a/engine/internal/docs/pages.gen.go
+++ b/engine/internal/docs/pages.gen.go
@@ -4797,6 +4797,26 @@ acting on it, and the generator is the only place the set can be closed.
 Before that check existed, ` + "`" + `"features": ["ssoo"]` + "`" + ` signed cleanly, verified
 cleanly, reported the license active, and permitted nothing.
 
+## Features that are issued with a warning
+
+` + "`" + `rbac` + "`" + ` and ` + "`" + `air_gapped` + "`" + ` are issued, and the generator prints a warning naming
+them beside the key. Both are real: the custom roles library is written and
+tested, and air gapped operation is a property every installation already has.
+What is not true of either is that the license is what grants it, so withdrawing
+the license would not withdraw the capability, and a renewal conversation that
+treats one of them as a thing being bought is a conversation about nothing.
+
+That is a warning rather than a refusal on purpose. Refusing would refuse a
+customer something they can have, and a refusal placed where somebody has
+already promised the feature is a refusal that acquires an override flag within
+a week. The person who needs the sentence is the one issuing the key, before
+they answer a question about it, which is where it prints.
+
+The two lists are different answers and the generator keeps them apart.
+` + "`" + `billing` + "`" + ` and ` + "`" + `enterprise_dashboard` + "`" + ` are not built, so they cannot be sold.
+These two are built and are not gated, so they can be sold and should not be
+described as something the license turns on.
+
 ## Features that cannot be issued
 
 ` + "`" + `billing` + "`" + ` and ` + "`" + `enterprise_dashboard` + "`" + ` are in the set above, and a request naming
@@ -5062,16 +5082,39 @@ working feature from every direction and is harder to find than the gap it
 covers. A feature nobody can buy and nobody can be granted cannot be mistaken
 for one that ships.
 
-` + "`" + `rbac` + "`" + ` is a third case and a different one. The custom roles library is complete
-and tested, and nothing stores a role model, so an organization has no way to
-have one. It is reported and not enforced, and it is written down here rather
-than gated for the same reason: a check on a path nothing reaches is worse than
-no check.
+### Two more are not enforced
 
-Both lists are held to the code by a test rather than by a habit. ` + "`" + `notShipped` + "`" + `
-in ` + "`" + `ee/engine/license/license.go` + "`" + ` is the single place either statement lives,
-and this page, the generator and the enterprise feature registry are all checked
-against it in both directions.
+A third case, and a different one from the two above: ` + "`" + `rbac` + "`" + ` and ` + "`" + `air_gapped` + "`" + `.
+Both name something real, and in neither case is the license what provides it.
+
+The custom roles library is complete and tested, and nothing stores a role
+model, so an organization has no way to have one. Air gapped operation is a
+property every installation already has, licensed or not: verification is a
+signature check against keys stamped into the binary, so it needs no network
+whichever features a license names.
+
+They are reported and not enforced, and that is written down rather than gated,
+for the reason the paragraph above gives: a check on a path nothing reaches is
+worse than no check. Unlike ` + "`" + `billing` + "`" + ` and ` + "`" + `enterprise_dashboard` + "`" + ` they are not
+refused at issue, because refusing them would refuse a customer a capability
+they can have. ` + "`" + `tools/licensegen` + "`" + ` prints a warning naming them beside the key it
+signs instead, so that whoever issues it reads what the license does and does
+not grant before a customer asks.
+
+` + "`" + `air_gapped` + "`" + ` was in this state and said so nowhere until 2026-09-08. Every
+occurrence of the name in the repository was a copy of the catalogue, the
+license vectors, a line of documentation, or a test, so a license naming it
+verified, reported itself active, printed in ` + "`" + `af license status` + "`" + `, and granted
+nothing. That is the same failure the two refused names above exist to prevent,
+reached through the case they do not cover.
+
+All three lists are held to the code by a test rather than by a habit.
+` + "`" + `notShipped` + "`" + ` and ` + "`" + `unenforced` + "`" + ` in ` + "`" + `ee/engine/license/license.go` + "`" + ` are the single
+place each statement lives, and this page, the generator and the enterprise
+feature registry are all checked against them in both directions. A fourth
+check asks the question none of those could: that every feature a license can
+grant is refused, recorded as unenforced, or gated at a real site in one half of
+the product or the other.
 
 ## Contributing
 

--- a/tools/licensegen/main.go
+++ b/tools/licensegen/main.go
@@ -173,6 +173,29 @@ var notShipped = []string{
 	"enterprise_dashboard",
 }
 
+// unenforced is the subset of knownFeatures that this product ships and gates
+// nowhere, and it is a third COPY for the reason the two above are copies: this
+// tool is MIT and ee/engine/license is not. Held to the original by
+// TestUnenforcedMatchesTheVerifier, which parses the map out of license.go.
+//
+// A WARNING RATHER THAN A REFUSAL, and the difference from notShipped above is
+// the whole point of having a separate list. Those two names have nothing
+// behind them and never have, so signing one is selling nothing and is refused
+// outright. These two name capabilities that are real: the custom roles library
+// is written and tested, and air gapped operation is a property every
+// installation already has. Refusing to sell them would be refusing a customer
+// something they can have. What is wrong is only that the licence is not what
+// makes it so, and the person who needs to know that is the one issuing the
+// key, before they answer a question about it.
+//
+// So this prints and does not stop. A refusal here would be overridden within a
+// week by whoever had already promised it, and an override flag is a refusal
+// that has agreed in advance to be ignored.
+var unenforced = []string{
+	"air_gapped",
+	"rbac",
+}
+
 func issue(args []string) error {
 	fs := flag.NewFlagSet("issue", flag.ContinueOnError)
 	file := fs.String("request", "", "path to the issuance request, or - for standard input")
@@ -276,6 +299,9 @@ func issue(args []string) error {
 	// be done before the key is sent.
 	fmt.Fprintf(os.Stderr, "signed %s for %s: %d seats, %d months, features %s\n",
 		*id, req.Org, *req.Seats, req.Months, describeFeatures(req.Features))
+	if warning := warnUnenforced(req.Features); warning != "" {
+		fmt.Fprintln(os.Stderr, warning)
+	}
 	fmt.Fprintf(os.Stderr,
 		"key id %s must name this public key in the verifier: %s\n",
 		*keyID, base64.RawURLEncoding.EncodeToString(priv.Public().(ed25519.PublicKey)))
@@ -335,6 +361,31 @@ func checkFeatures(features []string) error {
 			strings.Join(absent, ", "))
 	}
 	return nil
+}
+
+// warnUnenforced is the line printed beside a licence that names a feature
+// nothing gates, or empty when it names none.
+//
+// Named for what it does rather than folded into describeFeatures, because the
+// receipt line has to stay readable as a receipt: this is a second sentence
+// about the same licence, not a decoration on the first.
+func warnUnenforced(features []string) string {
+	var named []string
+	for _, f := range features {
+		for _, u := range unenforced {
+			if f == u {
+				named = append(named, f)
+			}
+		}
+	}
+	if len(named) == 0 {
+		return ""
+	}
+	return fmt.Sprintf(
+		"WARNING: this licence names %s, which this product ships and gates nowhere. The "+
+			"licence is not what grants it and withdrawing the licence will not withdraw it. "+
+			"Say so before it is described to a customer as something they are buying",
+		strings.Join(named, ", "))
 }
 
 // describeFeatures renders the feature list for the receipt.

--- a/tools/licensegen/main_test.go
+++ b/tools/licensegen/main_test.go
@@ -98,7 +98,7 @@ func featuresDeclaredBy(t *testing.T, path string) []string {
 // mechanism exists to prevent; the reverse refuses a request for something that
 // does ship, which somebody notices within a minute of trying it.
 func TestNotShippedMatchesTheVerifier(t *testing.T) {
-	want := notShippedDeclaredBy(t, verifierSource)
+	want := featureMapDeclaredBy(t, verifierSource, "notShipped")
 	if len(want) == 0 {
 		t.Fatalf("%s marks nothing unshipped, so this test and the refusal it guards "+
 			"are both proving nothing. If every feature now ships, delete the refusal "+
@@ -157,14 +157,108 @@ func TestIssueRefusesAFeatureNothingEnforces(t *testing.T) {
 	}
 }
 
-// notShippedDeclaredBy reads the keys of the notShipped map out of license.go.
+// TestUnenforcedMatchesTheVerifier holds this tool's third copy to its
+// original, the same way the two tests above hold the first and the second.
+//
+// Drift here is silent in the direction that costs a conversation rather than a
+// refund, which is why the guard is a warning and the test is not. A feature
+// recorded as unenforced in license.go and missing here signs with no warning
+// at all, so the person issuing the key learns what they sold from the customer
+// instead of from the receipt.
+func TestUnenforcedMatchesTheVerifier(t *testing.T) {
+	want := featureMapDeclaredBy(t, verifierSource, "unenforced")
+	if len(want) == 0 {
+		t.Fatalf("%s records nothing as unenforced, so this test and the warning it guards "+
+			"are both proving nothing. If every shipped feature is now gated somewhere, "+
+			"delete warnUnenforced rather than leaving a warning that cannot fire",
+			verifierSource)
+	}
+
+	got := append([]string(nil), unenforced...)
+	sort.Strings(got)
+	sort.Strings(want)
+
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("unenforced and the verifier's unenforced set differ.\n"+
+			"licensegen has: %s\n%s has: %s\n"+
+			"Update unenforced in main.go. A feature the verifier records as gated "+
+			"nowhere and this tool signs in silence is a capability sold as though the "+
+			"licence granted it.",
+			strings.Join(got, ", "), verifierSource, strings.Join(want, ", "))
+	}
+
+	// Every unenforced name is also a known one, for the reason the unshipped
+	// check next door gives: a name in only this list would be refused as
+	// unknown before the warning could ever print, so the entry would be dead.
+	known := map[string]bool{}
+	for _, f := range knownFeatures {
+		known[f] = true
+	}
+	for _, f := range got {
+		if !known[f] {
+			t.Errorf("%s is recorded as unenforced and is not a feature at all", f)
+		}
+	}
+
+	// And the two lists are disjoint. A name in both would be refused outright
+	// by checkFeatures, so its warning could never print, and the entry would
+	// say the product ships something it also says it does not.
+	absent := map[string]bool{}
+	for _, f := range notShipped {
+		absent[f] = true
+	}
+	for _, f := range got {
+		if absent[f] {
+			t.Errorf("%s is recorded as both unshipped and unenforced, which are "+
+				"different answers and cannot both be true", f)
+		}
+	}
+}
+
+// TestTheReceiptWarnsAboutAFeatureNothingGates points the warning at the exact
+// case that produced it, and at a case that must stay silent.
+//
+// Separate inputs and separate assertions, so that the silent case cannot be
+// hidden by the loud one passing.
+func TestTheReceiptWarnsAboutAFeatureNothingGates(t *testing.T) {
+	// Named, so the reason reaches whoever reads the receipt.
+	warning := warnUnenforced([]string{"sso", "air_gapped"})
+	if !strings.Contains(warning, "air_gapped") {
+		t.Errorf("a licence naming air_gapped produced no warning naming it: %q", warning)
+	}
+	if !strings.Contains(warning, "gates nowhere") {
+		t.Errorf("the warning does not say what is wrong: %q", warning)
+	}
+	if strings.Contains(warning, "sso") {
+		t.Errorf("the warning names sso, which is gated at a real site: %q", warning)
+	}
+
+	// And silent when there is nothing to say. A warning on every licence is a
+	// warning nobody reads, which would make the case above invisible.
+	if quiet := warnUnenforced([]string{"sso", "scim"}); quiet != "" {
+		t.Errorf("a licence naming only gated features produced a warning: %q", quiet)
+	}
+	if none := warnUnenforced(nil); none != "" {
+		t.Errorf("a licence naming no feature produced a warning: %q", none)
+	}
+}
+
+// featureMapDeclaredBy reads the keys of a named Feature-keyed map out of
+// license.go. Two maps are held to this tool's copies by it, notShipped and
+// unenforced, and one parser for both is what stops the second from being held
+// by a weaker check than the first.
 //
 // The keys are constant identifiers rather than strings, so the constants are
 // read first and the identifiers resolved through them. Parsed rather than
 // grepped for the same reason featuresDeclaredBy is: the names appear in prose
 // in that file, and a grep would find the paragraph explaining the map as
 // readily as the map.
-func notShippedDeclaredBy(t *testing.T, path string) []string {
+//
+// A map name that is not in the file returns nothing rather than failing, which
+// would be a check that cannot say no. Every caller therefore fails on an empty
+// result and says what an empty result would mean, because "the map is gone"
+// and "the map is empty" have to be distinguishable here.
+func featureMapDeclaredBy(t *testing.T, path, mapName string) []string {
 	t.Helper()
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
@@ -213,7 +307,7 @@ func notShippedDeclaredBy(t *testing.T, path string) []string {
 		}
 		for _, spec := range gen.Specs {
 			value, ok := spec.(*ast.ValueSpec)
-			if !ok || len(value.Names) != 1 || value.Names[0].Name != "notShipped" {
+			if !ok || len(value.Names) != 1 || value.Names[0].Name != mapName {
 				continue
 			}
 			for _, v := range value.Values {
@@ -232,7 +326,7 @@ func notShippedDeclaredBy(t *testing.T, path string) []string {
 					}
 					name, ok := values[key.Name]
 					if !ok {
-						t.Fatalf("notShipped names %s, which is not a Feature constant", key.Name)
+						t.Fatalf("%s names %s, which is not a Feature constant", mapName, key.Name)
 					}
 					out = append(out, name)
 				}


### PR DESCRIPTION
## The failure

Twelve features can be named in an enterprise licence. Seven are enforced at a
real site, two are refused at issue and at evaluation because nothing implements
them, and three were neither. Two of those three said so in prose. `air_gapped`
said so nowhere.

Every occurrence of that name in the repository was a copy of the catalogue, the
licence vectors, a line of documentation, or a test. No engine site declared it,
no control plane route asked for it, and the entitlement catalogue had no key for
it. A licence naming it verified, reported itself active, printed in
`af license status`, and granted nothing, which from outside the product is
exactly what a working feature looks like. That is the failure `notShipped` was
written to close, arriving through the one case `notShipped` does not cover.

## Why nothing could have caught it

The control plane's catalogue test asserts that the features enforced THERE have
declared a site, and it deliberately declines to speak for the engine, where the
licence key lives and where most of them are. The engine's own registry test
asserts a site set is empty from a test binary that links none of the enforcing
packages, so it cannot fail; the control plane test's own comment already says
so. Between one check that will not look at the engine and one that cannot look
at anything, nobody ever asked whether every feature does something somewhere.

## What this changes

`unenforced` in `ee/engine/license/license.go` records a feature that ships and
is gated nowhere, with the reason stored beside the name, the way `notShipped`
already records one that does not ship at all. It carries `rbac`, which was
documented in two other places and not here, and `air_gapped`, which was
documented nowhere.

**This permits nothing new and refuses nothing that used to work.** The map is a
declaration; no runtime behaviour reads it.

`tools/licensegen` warns rather than refuses, naming the feature beside the key
it just signed. The two lists are different answers and `Shipped`'s own comment
is where that line was already drawn: absent says we did not build it, a feature
we do not gate says we built it and do not charge for it, and only the first is a
reason to refuse a request.

The check that spans both halves lives in the control plane's catalogue test,
which already reads `license.go` and `licensegen` as text because no import joins
them. It requires every feature to be refused, recorded as unenforced, or
enforced at a site it can find in the engine, in the control plane registry, or
in the community entitlement catalogue. It fails in the other direction too, when
a feature is recorded as granting nothing and has since been gated.

Each of its three scanners carries a positive control naming a feature it must
find. A scanner that stops reading its input reports no sites, which would
silently reclassify every feature it covers as ungated; the control makes it say
it cannot see instead.

## The ambiguous decision, and the conservative reading

Whether `air_gapped` is absent or merely not gated is a genuine commercial
question and I did not settle it silently.

`notShipped` would have been the aggressive reading: it stops `licensegen`
signing the name at all. I did not take it, because air gapped operation is a
real property of every installation. Verification is a signature check against
keys stamped into the binary, so it needs no network whether or not a licence
names it, and `tools/proxysrc` exists so an air gapped user needs no release
either. Refusing to sell it would refuse a customer a capability they already
have, and the repository's own `Shipped` comment says that ungated is not a
reason not to sell.

**The tradeoff:** `air_gapped` stays sellable, and a customer can still be
invoiced for a name the licence does not enforce. What changes is that nobody can
now do that without reading why. If the commercial answer is that it should not
be sold at all, moving the entry from `unenforced` to `notShipped` is a one line
change and the tests already require the documentation to follow.

The same reading is why `rbac` keeps its existing treatment rather than being
gated. A check on a path nothing reaches is a declared enforcement site that
never runs, which is harder to find than the gap it covers. That was already this
repository's decision; this only makes the Go catalogue say it too.

## Verification

Mutation tested, one break per assertion, on the exact test name, with each
mutation proven to have landed before its result was read.

| Break | Cell | Result |
| --- | --- | --- |
| remove `air_gapped` from `unenforced` | partition | red, naming air_gapped as enforced nowhere and recorded nowhere |
| record `sso`, which is gated, as unenforced | partition, other direction | red, naming the stale entry |
| point the engine scanner at a tree with no `Declare` | positive control | red, naming multi_runtime, not a catalogue verdict |
| break the entitlement block pattern | positive control | red, naming support_access |
| drop the `sso` side-effect import | positive control | red, naming sso |
| put one name in both maps | disjointness | red, as an overlap |
| empty `unenforced` | non-emptiness | red, "proves less than it says" |
| stop naming air_gapped after the phrase in `licensing.md` | documentation arm | red |
| drop `air_gapped` from licensegen's copy | `TestUnenforcedMatchesTheVerifier` | red |
| silence `warnUnenforced` | `TestTheReceiptWarnsAboutAFeatureNothingGates` | red, both assertions |
| fire `warnUnenforced` on every licence | same test, silent half | red, both assertions |

Green after every restore: the catalogue suite at 9 of 9, `tools/licensegen`, and
the whole of `ee/engine` including `cmd/af`. `gofmt` clean. `prosecheck` 971
files clean, `changecheck` files the fragment, `docscheck` 95 pages, `cspell`
clean on the pages and the fragment.

### Two of my own instruments were wrong first

Worth recording, because both are the shapes this repository keeps finding.

The proof that the `licensegen` mutation had landed grepped for a line that
appears identically in `knownFeatures`, so it counted the wrong one and reported
the mutation absent while the test's own message showed it had landed. A proof
that answers a nearby question.

The first attempt at silencing the warning left a variable unused, so the package
stopped compiling. That red was the compiler, not the test, which is the
instrument unable to look rather than a catch. Both cells were redone with
mutations that compile, and only the redone results are in the table above.

### What I could not run

`just edition`'s `go build` half. The build lock had nine waiters and the recipe
timed out queueing rather than running, so I ran its two greps, which are the
part this change could affect, and both are clean: no Go file under `engine` or
`tools` names `antifailure/antifailure/ee`, and nothing under `web/apps` or
`web/packages` names `antifailure-ee`. The diff touches nothing under `engine/`,
so the community binary is unchanged. CI runs the whole job.

## The larger finding this does not fix

The audit behind this turned up one gap that is feature sized rather than a
wiring mistake, so it is reported rather than patched here.

`ee/web/audit` implements SIEM streaming for the **control plane** audit log: a
bounded queue, Splunk, Event Hubs, object store and webhook sinks, and signed
batch manifests over the hash chain. Nothing outside its own two test files
imports it. It is not in `ee/web/server/src/register.ts`, which mounts single
sign-on and SCIM and nothing else, and the control plane's `Extension` interface
carries a name and routes and nothing else, so there is no socket to plug it
into.

The engine forwards its five environment actions and that half works. Single
sign-on logins, directory provisioning, operator impersonation and every admin
action are forwarded nowhere. Closing it means a new audit sink extension point
in MIT code, which is a change to the community extension surface and a decision
worth making deliberately rather than at the end of an audit.

## What CI caught that I had not

Recorded here rather than quietly force pushed away, because both are the shapes
this repository keeps finding and a squash makes the branch commits unreachable.

**`enterprise` failed on a typecheck, not a test.**
`catalogue.test.ts(272,45): error TS2339: Property 'path' does not exist on type
'Dirent<string>'`. The directory walker wrote `e.parentPath ?? e.path`, and the
pinned `@types/node` has no `Dirent.path`. I had run `node --test`, read 9 of 9
green, and never run `npm run typecheck`, which is the other half of the same CI
step and the half covering the file I had just written. Running the gates I
judged relevant and skipping the one guarding my own new code.

The fallback is removed. The test's own positive control is what proves the
walker still reads the engine afterwards: it asserts `multi_runtime` is found, so
a walker returning an empty list fails there rather than silently reclassifying
five engine features as ungated.

**`engine` failed on `gendrift -strict`.** The two pages I edited under
`docs/src/content/docs/enterprise/` are embedded into the engine binary by
`tools/docsembed`, and I changed the source without rerunning the generator.
Regenerated rather than hand edited. Only `docsembed` drifted; the other eleven
generators in that step were already current, and `gendrift` now reports 21
generated paths matching their generators, exit 0.

Neither failure was inherited. Both were mine.

## Final state

All nine required contexts at `success`, read by name from the live branch
protection rather than inferred: `engine`, `control plane`, `edition boundary`,
`enterprise`, `runner`, `www`, `known vulnerabilities`, `no credentials in the
tree`, `commits are attributed to their author`. `known vulnerabilities` lives in
the `Security` workflow, so a sweep of CI's own jobs would have missed it.
