### PR TITLE
control plane: the 5xx count went up and nothing could say what had failed

### DIFF
--- a/.changes/a-self-hoster-could-see-the-5xx-count-and-never-what-failed.md
+++ b/.changes/a-self-hoster-could-see-the-5xx-count-and-never-what-failed.md
@@ -1,0 +1,33 @@
+# added
+
+A self hosted control plane could see its 5xx count go up and never see what
+had failed.
+
+Both error handlers already caught every unexpected failure and both already
+wrote a line naming the error class, the driver's code, the method and the
+route. That line went to standard output. On the hosted control plane something
+ships standard output somewhere searchable; on a self hosted one it is a line in
+`docker logs`, with no count, no first seen and no grouping. The one number an
+operator could reach, `af_http_requests_total{status_class="5xx"}`, says how
+many and never says what. The Logs & Error Explorer said in its own header that
+this product records no fingerprint and no occurrence counter, which was true of
+the engine's exceptions and needed nothing from anybody to stop being true of
+the control plane's own.
+
+So the control plane now groups its own failures into a table it writes to its
+own Postgres, and the operator portal reads them and updates itself every ten
+seconds without a refresh. A row is a group rather than an occurrence, so the
+table's size is a function of the code and not of how badly the day is going: a
+self hoster's disk filling on the day their control plane starts failing would
+be an incident caused by the feature meant to help with incidents. The store
+holds at most five hundred groups and says on the page when it has reached that,
+because a store that quietly under-reports is worse than none.
+
+It keeps no message, no stack and no payload, for the reason already written on
+the handler above it: a query failure from this stack renders as the whole
+statement with its parameters after it, so a message here can carry a tenant's
+data. It keeps no organization either, so it cannot say how many tenants a
+failure touched, and the page says that in words rather than showing a zero.
+
+Nothing records a stack trace from a customer's run. That still needs the engine
+to report one.

--- a/console/app/admin/operations/logs/page.tsx
+++ b/console/app/admin/operations/logs/page.tsx
@@ -3,21 +3,35 @@
 /**
  * Logs & Error Explorer.
  *
- * WHAT THIS PAGE IS HONEST ABOUT, before anything else. There is no
- * error-tracking table in this product. No exception group, no fingerprint, no
- * occurrence counter, no stack trace store, no log line store. Anything here
- * resembling Sentry would be invented, and an invented error explorer is worse
- * than none: an operator reads "0 errors" during an incident and stops looking.
+ * WHAT THIS PAGE IS HONEST ABOUT, before anything else. There is still no
+ * error-tracking table for the ENGINE in this product. No exception group for a
+ * customer's run, no stack trace store, no log line store. Anything here
+ * resembling Sentry for the engine would be invented, and an invented error
+ * explorer is worse than none: an operator reads "0 errors" during an incident
+ * and stops looking.
  *
- * So this is built out of what the control plane genuinely records, and it says
- * so on the page rather than only in this comment:
+ * WHAT CHANGED, and the distinction is the whole of it. That statement was
+ * always about the engine's exceptions, which need the engine to report them.
+ * It was also true of the control plane's OWN failures, and those need nothing
+ * from anybody: this process already catches every one of them in two handlers
+ * that had already decided what is safe to write down, and threw the result
+ * away everywhere except a container's stdout. A self hoster with no log
+ * aggregation could see `af_http_requests_total{status_class="5xx"}` go up and
+ * could not see what any of it was. So there is now a real store, it is a
+ * GROUP per fingerprint rather than a log line, and the "What this page cannot
+ * show you" card below says exactly where its edge is.
  *
+ * So this is built out of what the control plane genuinely records:
+ *
+ *   control_plane_failures       the control plane's own failures, grouped by a
+ *                                fingerprint over the declared route, the
+ *                                method, the error class and the driver code.
  *   workload_runs.failure_code   grouped, which is the closest thing to a
- *                                fingerprint this product has.
+ *                                fingerprint the ENGINE's side has.
  *   verdicts                     which workflows are failing, across tenants.
  *   events                       what is arriving, how fast, and how far behind.
  *
- * That turns out to answer the question an operator actually opens this page
+ * Between them they answer the question an operator actually opens this page
  * with, which is not "show me a stack trace" but "what is failing right now,
  * how many customers does it touch, and did it start when we deployed".
  *
@@ -25,10 +39,28 @@
  * payload is the customer's data. The route returns the key names and the byte
  * size, the page says that out loud, and the boundary is the column list in the
  * query, because row level security cannot restrict a column and the operator
- * pool bypasses it anyway.
+ * pool bypasses it anyway. The failure store inherits exactly that standard:
+ * no message, no stack, no payload, and the boundary is the signature of
+ * `recordFailure` rather than a policy.
+ *
+ * WHY THIS PAGE POLLS RATHER THAN HOLDING A STREAM OPEN. Server sent events
+ * were the alternative and they lose here on two facts about this deployment.
+ * The control plane runs as a container app in multiple revision mode with more
+ * than one replica behind one ingress, so a held connection pins the operator
+ * to whichever replica answered and dies on every revision swap, which is
+ * exactly the moment an operator is watching. And everything on this page is
+ * already an aggregate over Postgres, which every replica shares, so a poll
+ * gets the same answer from any of them and gains the reconnection behaviour
+ * for free. The cost is latency bounded by the interval, which for a page
+ * measuring things in seconds and minutes is not a cost.
+ *
+ * WHAT THE LIVE TICK DELIBERATELY DOES NOT REFRESH: the event stream, because
+ * it is paged. Refreshing a list somebody has pressed More on three times
+ * throws away three pages and puts them back at the top, which is worse than
+ * being a minute behind. It keeps its own Refresh.
  */
 
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import {
   Badge,
   Button,
@@ -39,6 +71,7 @@ import {
   When,
 } from "@/components/ui";
 import { More } from "@/components/pagination";
+import { useInterval } from "@/components/load/polling";
 import {
   AdminPage,
   DataTable,
@@ -50,36 +83,81 @@ import {
 } from "@/components/admin/primitives";
 import {
   WINDOWS,
+  startedInOneBuild,
   useEventStream,
+  useFailureStore,
   useLogsOverview,
+  type ControlPlaneFailure,
   type EventRow,
   type EventTypeSummary,
   type FailureGroup,
+  type FailureStoreStatus,
+  type FailureStoreView,
   type WorkflowFailure,
 } from "@/lib/admin-operations";
+
+/**
+ * How often the page asks again.
+ *
+ * The same ten seconds the control plane flushes its failure buffer at, so a
+ * failure is on screen within about two ticks of happening. Faster would be
+ * asking for an answer that has not changed; slower and an operator watching an
+ * incident start would be watching a page that says nothing is wrong.
+ */
+const LIVE_MS = 10_000;
 
 export default function OperationsLogsPage() {
   const [hours, setHours] = useState("24");
   const [type, setType] = useState("");
+  const [live, setLive] = useState(true);
   const overview = useLogsOverview(hours, "");
+  const failures = useFailureStore(hours);
   const stream = useEventStream(hours, type, "");
+
+  // The two aggregates only. The stream is paged and keeps its own Refresh; see
+  // the header for why refreshing it on a tick would be a regression.
+  const tick = useCallback(() => {
+    overview.reload();
+    failures.reload();
+  }, [overview, failures]);
+
+  useInterval(live, LIVE_MS, tick);
+
+  // The freshness claim comes from the control plane's OWN clock, carried back
+  // in `at`, rather than from `new Date()` here. Every timestamp in the rows
+  // below is on that clock, so a browser whose clock is minutes out would
+  // otherwise be told the rows are from the future.
+  const at = failures.data?.status ? failures.data.at : (overview.data?.at ?? null);
+  const refreshFailed = failures.refreshError ?? overview.refreshError;
 
   return (
     <AdminPage
       href="/admin/operations/logs"
-      lede="What is failing across every organization, and what is arriving from the engines. Built from run outcomes and the event stream, which is what this control plane records."
+      lede="What is failing across every organization, and what is arriving from the engines. Built from the control plane's own failures, run outcomes and the event stream, which is what this installation records."
       actions={
-        <Button
-          onClick={() => {
-            overview.reload();
-            stream.reload();
-          }}
-        >
-          Refresh
-        </Button>
+        <>
+          <Button
+            pressed={live}
+            onClick={() => setLive((on) => !on)}
+            aria-label={live ? "Turn live updates off" : "Turn live updates on"}
+          >
+            {live ? "Live updates on" : "Live updates off"}
+          </Button>
+          <Button
+            onClick={() => {
+              tick();
+              stream.reload();
+            }}
+            busy={overview.refreshing || failures.refreshing}
+          >
+            Refresh
+          </Button>
+        </>
       }
     >
       <div className="space-y-6">
+        <Freshness at={at} live={live} failed={refreshFailed !== null} />
+
         <Card>
           <FilterBar
             filters={[
@@ -103,6 +181,30 @@ export default function OperationsLogsPage() {
               <div className="px-4 py-4">
                 <MetricRow
                   metrics={[
+                    // FIRST, and it was not here when this row was first drawn.
+                    // Looking at the rendered page found the defect: the four
+                    // numbers below are all about the engine side, so an
+                    // installation whose CONTROL PLANE was failing two hundred
+                    // times an hour showed four zeros at the top of the page,
+                    // which is the exact "0 errors during an incident" reading
+                    // this page's header exists to prevent.
+                    //
+                    // Null rather than zero until the store has answered, which
+                    // is what Metric prints as "Not measured": a zero here
+                    // before the second request lands would be a reassurance
+                    // nobody measured.
+                    //
+                    // "This control plane" rather than "Control plane
+                    // failures", which is not a wording preference: the longer
+                    // label wraps to two lines in this column while the other
+                    // four do not, and the number under it then sits a line
+                    // lower than every number beside it. The word "failures"
+                    // lives in the note, where it has room.
+                    {
+                      label: "This control plane",
+                      value: failuresInWindow(failures.data),
+                      note: noteForFailures(failures.data),
+                    },
                     {
                       label: "Failing runs",
                       value: o.failures.reduce((n, f) => n + f.runs, 0),
@@ -136,6 +238,7 @@ export default function OperationsLogsPage() {
           </Loaded>
         </Card>
 
+        <ControlPlaneFailuresCard state={failures} />
         <FailuresCard state={overview} />
         <WorkflowsCard state={overview} />
         <EventTypesCard state={overview} selected={type} onSelect={setType} />
@@ -143,6 +246,266 @@ export default function OperationsLogsPage() {
         <WhatIsNotRecorded />
       </div>
     </AdminPage>
+  );
+}
+
+/* -------------------------------------------------------------------------
+ * The headline number for the store
+ * ---------------------------------------------------------------------- */
+
+/**
+ * Occurrences in the window, or null when the store has not answered yet.
+ *
+ * Null and zero are different answers and this is the place that refuses to
+ * confuse them: `Metric` prints null as "Not measured" and zero as a zero, and
+ * a zero printed before the store has replied is a reassurance nobody measured.
+ */
+function failuresInWindow(view: FailureStoreView | null): number | null {
+  if (!view) return null;
+  return view.failures.reduce((n, f) => n + f.occurrences, 0);
+}
+
+/** What the number is over, including the two ways it is short of the truth. */
+function noteForFailures(view: FailureStoreView | null): string {
+  if (!view) return "failures it caught in itself";
+  if (!view.status.recording) return "failures: nothing is being recorded on this replica";
+  if (view.truncated) {
+    return `failures, across the ${view.limit} most recent groups, which is a cut list`;
+  }
+  const groups = view.failures.length;
+  return `failures it caught in itself, across ${groups} ${groups === 1 ? "group" : "groups"}`;
+}
+
+/* -------------------------------------------------------------------------
+ * Freshness
+ * ---------------------------------------------------------------------- */
+
+/**
+ * How old the numbers are, said in words, once for the page.
+ *
+ * DELIBERATELY NOT A LIVE INDICATOR. No dot, nothing pulsing, nothing pinging.
+ * A throbbing badge on a page that is working correctly is an animation running
+ * forever while the reader does nothing, and it says less than the sentence
+ * does: "Updated 4s ago" is the actual freshness, which is the thing an
+ * operator has to decide with, and a green dot is not.
+ *
+ * AND DELIBERATELY NOT A SECOND `StaleNotice`. The first version put one at the
+ * top of the page as well, and the rendered result said the same thing three
+ * times: `Loaded` already puts "Could not refresh. Showing the last answer."
+ * with a retry on every card whose reload failed, which is the house treatment
+ * and is beside the data it qualifies. What was missing above the fold was not
+ * another banner but the timestamp, so that is all this is, with one clause
+ * that changes when a refresh has failed.
+ *
+ * `When` renders both the relative and the absolute time, the latter as the
+ * title and the accessible label, so "4s ago" can be compared against a log
+ * line rather than only felt.
+ */
+function Freshness({
+  at,
+  live,
+  failed,
+}: {
+  at: string | null;
+  live: boolean;
+  failed: boolean;
+}) {
+  if (!at) {
+    return (
+      <p role="status" className="text-[12.5px] leading-6 text-muted">
+        Nothing has loaded yet.
+      </p>
+    );
+  }
+  return (
+    <p role="status" className={`text-[12.5px] leading-6 ${failed ? "text-warn" : "text-muted"}`}>
+      Updated <When value={at} />, by the control plane&apos;s clock.{" "}
+      {failed
+        ? `The last refresh did not land, so these are the last good numbers. It keeps trying every ${LIVE_MS / 1000} seconds.`
+        : live
+          ? `Asking again every ${LIVE_MS / 1000} seconds while this tab is in front. The event stream below is paged and refreshes only when you ask it to.`
+          : "Live updates are off, so these numbers stay as they are until you press Refresh."}
+    </p>
+  );
+}
+
+/* -------------------------------------------------------------------------
+ * The control plane's own failures
+ * ---------------------------------------------------------------------- */
+
+const CONTROL_PLANE_COLUMNS: Column<ControlPlaneFailure>[] = [
+  {
+    key: "what",
+    header: "Failure",
+    cell: (f) => (
+      <>
+        <span className="block truncate font-mono text-[12px] font-medium text-ink">{f.kind}</span>
+        <span className="mt-0.5 block truncate font-mono text-[12px] text-muted">{f.route}</span>
+        {f.providerCode ? (
+          <span className="mt-0.5 block font-mono text-[12px] text-dim">
+            driver code {f.providerCode}
+          </span>
+        ) : null}
+      </>
+    ),
+  },
+  {
+    key: "where",
+    header: "Caught by",
+    cell: (f) => (
+      <>
+        <StatusChip value={f.source === "trpc" ? "tRPC" : "HTTP"} tone="neutral" />
+        <span className="mt-0.5 block font-mono text-[12px] text-dim">{f.method}</span>
+      </>
+    ),
+  },
+  {
+    key: "occurrences",
+    header: "Occurrences",
+    numeric: true,
+    cell: (f) => f.occurrences.toLocaleString(),
+  },
+  {
+    key: "build",
+    header: "Build",
+    cell: (f) => (
+      <>
+        <span className="block font-mono text-[12px] text-ink">{f.lastSeenVersion}</span>
+        {/* The deploy overlay, as a comparison rather than a chart. There is no
+            deployment table in this product, so a line on a graph would be
+            invented. Two builds named is the honest form of the same answer. */}
+        <span className="mt-0.5 block text-[12px] text-dim">
+          {startedInOneBuild(f)
+            ? "first seen on this build"
+            : `first seen on ${f.firstSeenVersion}`}
+        </span>
+      </>
+    ),
+  },
+  { key: "first", header: "First seen", cell: (f) => <When value={f.firstSeen} /> },
+  { key: "last", header: "Last seen", cell: (f) => <When value={f.lastSeen} /> },
+  {
+    key: "request",
+    header: "Latest request id",
+    mono: true,
+    cell: (f) =>
+      f.lastRequestId ? (
+        <span className="break-all text-[12px]">{f.lastRequestId}</span>
+      ) : (
+        <span className="text-dim">none recorded</span>
+      ),
+  },
+];
+
+function ControlPlaneFailuresCard({ state }: { state: ReturnType<typeof useFailureStore> }) {
+  return (
+    <Card
+      title="Control plane failures"
+      note="What this control plane caught in itself, grouped. A row is a kind of failure on a route, not a single occurrence, which is what keeps the table's size a function of the code rather than of how badly the day is going."
+    >
+      <Loaded state={state} skeleton={<TableSkeleton rows={4} cols={7} />}>
+        {(view) => (
+          <>
+            <StoreState status={view.status} />
+            <DataTable
+              columns={CONTROL_PLANE_COLUMNS}
+              rows={view.failures}
+              keyOf={(f) => f.fingerprint}
+              empty={
+                view.status.recording ? (
+                  <EmptyList title="This control plane has not failed in this window">
+                    No request reached either error handler in the period selected above. That is
+                    what a working installation looks like. Widen the window if you are looking for
+                    something older, and read the line above for whether anything is being recorded
+                    at all.
+                  </EmptyList>
+                ) : (
+                  <EmptyList title="Nothing is being recorded">
+                    This replica has AF_FAILURE_STORE turned off, so an empty list here means
+                    nothing was written down, not that nothing failed. Unset the variable and
+                    restart to record again.
+                  </EmptyList>
+                )
+              }
+              footer={
+                <div className="border-t border-rule px-4 py-3">
+                  <span className="text-[12.5px] text-muted">
+                    {view.truncated
+                      ? `The ${view.failures.length} most recent groups, cut at ${view.limit}. The store holds ${view.status.groups.toLocaleString()} in total.`
+                      : `All ${view.failures.length} ${view.failures.length === 1 ? "group" : "groups"} seen in this window. The store holds ${view.status.groups.toLocaleString()} in total, across every window.`}
+                  </span>
+                </div>
+              }
+            />
+          </>
+        )}
+      </Loaded>
+    </Card>
+  );
+}
+
+/**
+ * What the store itself is doing, above the rows it produced.
+ *
+ * This exists because a short list looks the same whether nothing failed or
+ * nothing was recorded, and those are opposite facts. Every sentence here names
+ * a way the list below might be shorter than the truth. The row is present on a
+ * healthy installation too, saying so plainly, because a notice that only ever
+ * appears when something is wrong is a notice nobody has learned to read.
+ */
+function StoreState({ status }: { status: FailureStoreStatus }) {
+  // Each problem carries its own short label rather than a shared "read this
+  // first". Two reasons, and the second is what the rendered page showed: a
+  // label naming the condition is what a scanner needs, and a three word badge
+  // in a flex row wrapped to three stacked lines beside its own paragraph.
+  const problems: { label: string; text: string }[] = [];
+  if (!status.recording) {
+    problems.push({
+      label: "not recording",
+      text: "The replica that answered has AF_FAILURE_STORE turned off, so it is writing nothing. During a rolling deploy one revision can be recording while another is not.",
+    });
+  }
+  if (status.atCap) {
+    problems.push({
+      label: "at the cap",
+      text: `The store is holding ${status.groups.toLocaleString()} groups against a cap of ${status.cap.toLocaleString()}, so a NEW kind of failure is being refused a row right now. Groups already here keep counting. The capped outcome on af_control_plane_failures_total counts what is being lost.`,
+    });
+  }
+  if (status.retentionDays === null) {
+    problems.push({
+      label: "no retention",
+      text: "Nothing on this installation sweeps old groups: the retention pass needs AF_MAINTENANCE_DATABASE_URL or AF_MIGRATION_DATABASE_URL, because the application role is deliberately given no DELETE here. A group stays until somebody removes it, so read the dates rather than assuming a row is current.",
+    });
+  }
+
+  return (
+    <div className="border-b border-rule px-4 py-3">
+      {problems.length === 0 ? (
+        <p className="max-w-[76ch] text-[12.5px] leading-6 text-muted">
+          <Badge tone="pass">recording</Badge> Holding{" "}
+          {status.groups.toLocaleString()} of at most {status.cap.toLocaleString()} groups, each
+          kept for {status.retentionDays} days past its last occurrence.
+        </p>
+      ) : (
+        <ul className="space-y-2">
+          {problems.map((p) => (
+            <li
+              key={p.label}
+              className="flex max-w-[80ch] flex-wrap items-baseline gap-x-2 gap-y-1 text-[12.5px] leading-6 text-warn"
+            >
+              <span className="shrink-0 whitespace-nowrap">
+                <Badge tone="warn">{p.label}</Badge>
+              </span>
+              {/* Full width below the phone breakpoint, so the badge sits on
+                  its own line and the sentence gets the whole column. Beside
+                  the badge at 320 the text had about 120 pixels to work with
+                  and ran to eleven lines. */}
+              <span className="w-full sm:w-auto sm:min-w-0 sm:flex-1">{p.text}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
   );
 }
 
@@ -464,15 +827,36 @@ function StreamCard({
  * On the page rather than only in a comment, because the reader who needs it is
  * the operator who came here looking for a stack trace and is about to conclude
  * there were no errors.
+ *
+ * KEPT AND NARROWED rather than deleted when the control plane's own failures
+ * became a real store. The half that is now false is one sentence; the rest of
+ * it is still exactly true, and a page that quietly dropped its own list of
+ * limits the moment one of them was fixed would be teaching the reader that the
+ * list is decoration.
  */
 function WhatIsNotRecorded() {
   return (
     <Card title="What this page cannot show you">
       <div className="space-y-3 px-4 py-4 text-[13px] leading-6 text-muted">
         <p className="max-w-[70ch]">
-          There is no error-tracking store in this product. Nothing records an exception, a stack
-          trace, a fingerprint, an occurrence count or a log line. Everything above is arithmetic
-          over run outcomes and the event stream, which is what the control plane genuinely writes.
+          The control plane&apos;s own failures are grouped and counted, above. The
+          engine&apos;s are not. Nothing records an exception, a stack trace or a log line from a
+          run: those happen in a customer&apos;s environment and would need the engine to report
+          them. What you have for the engine side is arithmetic over run outcomes and the event
+          stream.
+        </p>
+        <p className="max-w-[70ch]">
+          The control plane store keeps no message and no stack, and that is a boundary rather than
+          an omission. A query failure from this stack renders as the whole statement with its
+          parameters after it, so an error message here can carry a tenant&apos;s event payload.
+          What is kept is the declared route, the method, the error class and the driver code, which
+          is exactly what the log line beside it already carried.
+        </p>
+        <p className="max-w-[70ch]">
+          It also carries no organization, so it cannot tell you how many tenants a control plane
+          failure touched. Writing one next to a failure would turn a small operational table into
+          tenant data. &quot;Failures by code&quot; above answers the per tenant question for the
+          engine side, which is where it is normally asked.
         </p>
         <p className="max-w-[70ch]">
           Event payloads are deliberately not returned. The payload is the customer&apos;s data:
@@ -482,9 +866,10 @@ function WhatIsNotRecorded() {
           on this page is recorded against the operator who made it.
         </p>
         <p className="max-w-[70ch] text-dim">
-          <Badge tone="neutral">what would change this</Badge> Grouped exceptions would need a
-          table with a fingerprint, an occurrence count and a stack trace, plus something on the
-          engine side that reports them. That is a schema change and an engine change, not a page.
+          <Badge tone="neutral">what would change this</Badge> Grouped exceptions from a run would
+          need a table with a fingerprint, an occurrence count and a stack trace, plus something on
+          the engine side that reports them. That is a schema change and an engine change, not a
+          page.
         </p>
       </div>
     </Card>

--- a/console/lib/admin-operations.ts
+++ b/console/lib/admin-operations.ts
@@ -35,6 +35,7 @@ import {
   type ControlState,
   type EmailStatus,
   type EventRow,
+  type FailureStoreView,
   type FirewallSummary,
   type Finding,
   type FleetTeardownResult,
@@ -158,6 +159,33 @@ export function useEventStream(hours: string, type: string, orgId: string) {
       return { rows: page.rows, next: page.nextCursor };
     },
     [hours, type, orgId],
+  );
+}
+
+/* -------------------------------------------------------------------------
+ * The control plane's own failures
+ * ---------------------------------------------------------------------- */
+
+/**
+ * The grouped record of what the control plane caught in itself.
+ *
+ * `useApi` and not `useLive`, and that is a decision rather than an oversight.
+ * `useLive` was written because `useApi` blanked a populated screen to a
+ * skeleton on every reload; `useApi` no longer does. It keeps the held data
+ * across a reload with the same dependencies, puts the failure in
+ * `refreshError` instead of throwing the rows away, and it carries a sequence
+ * guard that `useLive` does not, so two polls landing out of order cannot let
+ * the older answer overwrite the newer. On a page that polls, that last one is
+ * the difference between a count going up and a count flickering.
+ *
+ * So there is still exactly one polling hook in play here and no second one was
+ * written: this is `useApi` driven by `useInterval` from the same module
+ * `useLive` lives in, which is the composition the run detail already uses.
+ */
+export function useFailureStore(hours: string) {
+  return useApi<FailureStoreView>(
+    () => query("admin.operations.failures.store", { hours: Number(hours) }),
+    [hours],
   );
 }
 

--- a/console/lib/operations-shapes.test.ts
+++ b/console/lib/operations-shapes.test.ts
@@ -23,6 +23,7 @@ import assert from "node:assert/strict";
 import {
   FINDING_LABEL,
   STANDING_LABEL,
+  startedInOneBuild,
   WINDOWS,
   toneForStanding,
   toneForVerdict,
@@ -92,4 +93,28 @@ test("every window offered is one the routes accept", () => {
     assert.ok(accepted.has(w.value), `${w.value} hours is not a window the route accepts`);
     assert.ok(w.label.length > 0);
   }
+});
+
+test("a failure group says whether it has only ever come from one build", () => {
+  // The deploy overlay, and it is a comparison rather than a chart because
+  // there is no deployment table in this product and drawing a line for one
+  // would be inventing the data. Both directions asserted: a check that has
+  // only been seen say yes has not been shown to be able to say no, and this
+  // one is what an operator reads to decide whether a deploy caused a failure.
+  const group = {
+    fingerprint: "a".repeat(64),
+    source: "trpc",
+    route: "environments.list",
+    method: "query",
+    kind: "DrizzleQueryError",
+    providerCode: "42P01",
+    occurrences: 3,
+    firstSeen: "2026-09-08T00:00:00.000Z",
+    lastSeen: "2026-09-09T00:00:00.000Z",
+    firstSeenVersion: "1.3.4",
+    lastSeenVersion: "1.3.4",
+    lastRequestId: null,
+  };
+  assert.equal(startedInOneBuild(group), true);
+  assert.equal(startedInOneBuild({ ...group, firstSeenVersion: "1.3.2" }), false);
 });

--- a/console/lib/operations-shapes.ts
+++ b/console/lib/operations-shapes.ts
@@ -222,6 +222,79 @@ export interface LogsOverview {
   truncated: { failures: boolean; workflows: boolean; eventTypes: boolean };
   limit: number;
 }
+/**
+ * One group of failures the control plane caught in ITSELF.
+ *
+ * Not the engine's exceptions, which this product still does not record and
+ * which would need the engine to report them. These are the failures the
+ * control plane's own two error handlers already catch, already log, and until
+ * now threw away everywhere except a container's stdout.
+ *
+ * Every field is one those handlers had already decided was safe to write
+ * down. There is no message, no stack, no payload and no organization, and the
+ * reasons are in migration 0042 and web/apps/api/src/failures.ts. The page
+ * prints what is missing rather than leaving the reader to infer it.
+ */
+export interface ControlPlaneFailure {
+  fingerprint: string;
+  /** Which handler caught it: the HTTP one or the tRPC one. */
+  source: string;
+  /** The declared route key, never the path that matched it. */
+  route: string;
+  method: string;
+  /** The error's class name. Code, not data. */
+  kind: string;
+  /** The driver's own code, when the cause carried one. */
+  providerCode: string | null;
+  occurrences: number;
+  firstSeen: string;
+  lastSeen: string;
+  firstSeenVersion: string;
+  lastSeenVersion: string;
+  /** The id the 500 response handed the caller. The join to `af logs web`. */
+  lastRequestId: string | null;
+}
+
+/**
+ * What the store is doing, which is what stops the list above being read as
+ * complete when it is not.
+ */
+export interface FailureStoreStatus {
+  /** Whether the replica that answered is recording. */
+  recording: boolean;
+  /** Groups held, across all time rather than the window. */
+  groups: number;
+  cap: number;
+  atCap: boolean;
+  /** Null when nothing on this installation sweeps, which is a different
+   *  statement from a retention of zero. */
+  retentionDays: number | null;
+}
+
+export interface FailureStoreView {
+  hours: number;
+  from: string;
+  at: string;
+  status: FailureStoreStatus;
+  truncated: boolean;
+  limit: number;
+  failures: ControlPlaneFailure[];
+}
+
+/**
+ * Whether a group has only ever been produced by one build.
+ *
+ * This is the deploy overlay, and it is a comparison rather than a chart
+ * because there is no deployment table in this product and drawing a line for
+ * one would be inventing the data. Equal versions mean the failure appeared and
+ * has stayed inside a single build, which is the reading an operator wants when
+ * asking whether a deploy caused it. Different versions mean it survived at
+ * least one.
+ */
+export function startedInOneBuild(f: ControlPlaneFailure): boolean {
+  return f.firstSeenVersion === f.lastSeenVersion;
+}
+
 export interface EventRow {
   id: string;
   occurredAt: string;

--- a/deploy/helm/antifailure-control-plane/templates/deployment.yaml
+++ b/deploy/helm/antifailure-control-plane/templates/deployment.yaml
@@ -246,6 +246,18 @@ spec:
             - name: AF_ANALYTICS_RETENTION_DAYS
               value: {{ .Values.analytics.retentionDays | quote }}
             {{- end }}
+            # The grouped store of the control plane's own failures. Emitted
+            # only when it is being turned off, because on is the image's
+            # default and an env var restating a default is one more place for
+            # the two to disagree.
+            {{- if not .Values.failureStore.enabled }}
+            - name: AF_FAILURE_STORE
+              value: "off"
+            {{- end }}
+            {{- if .Values.failureStore.retentionDays }}
+            - name: AF_FAILURE_RETENTION_DAYS
+              value: {{ .Values.failureStore.retentionDays | quote }}
+            {{- end }}
             # AF_MIGRATE is deliberately absent. Migrations are the bootstrap
             # Job's work, once, and not something every replica races to do on
             # startup.

--- a/deploy/helm/antifailure-control-plane/values.yaml
+++ b/deploy/helm/antifailure-control-plane/values.yaml
@@ -251,6 +251,25 @@ stripe:
     secretKey: AF_STRIPE_SECRET_KEY
     webhookSecret: AF_STRIPE_WEBHOOK_SECRET
 
+# The grouped record of the control plane's OWN failures, which the operator
+# portal's Logs page reads.
+#
+# Both of these have a working default in the image, so neither is here to make
+# the feature run. They are here because a value a chart cannot set is a switch
+# an operator cannot reach.
+failureStore:
+  # One row per kind of failure, never one per occurrence, so the table's size is
+  # set by the code rather than by how badly the day is going, and it holds at
+  # most 500 groups. False writes nothing, and the Logs page says nothing is
+  # being recorded rather than showing an empty list that reads as a quiet day.
+  enabled: true
+  # Delete a group this many days after its LAST occurrence, not its first: a
+  # failure first seen in March and last seen this morning is the most
+  # interesting row on the page. Empty takes the image's default of 30. Applied
+  # only when the maintenance pass can run, because the application role is
+  # deliberately granted no DELETE on that table.
+  retentionDays: ""
+
 # The analytics the marketing site's beacon feeds.
 analytics:
   # 64 hex characters, which is 32 bytes, from `openssl rand -hex 32`. The key

--- a/docs/src/content/docs/reference/control-plane.md
+++ b/docs/src/content/docs/reference/control-plane.md
@@ -428,6 +428,21 @@ rather than held idle between them.
 | `AF_MAINTENANCE_DATABASE_URL` | falls back to `AF_MIGRATION_DATABASE_URL` | The role that creates and drops partitions. When neither is set, this process logs a warning at startup and does not keep the partitions ahead. Something else must. |
 | `AF_EVENT_RETENTION_MONTHS` | unset | Drop event partitions entirely older than this many whole months. Unset keeps everything forever, which is the default because retention is an operator's decision. A value that is not a whole number of months at least 1 stops the process at startup rather than silently keeping everything. |
 | `AF_EVENT_ARCHIVE_DIR` | unset | Write a month out as newline delimited JSON here before dropping it. |
+| `AF_FAILURE_RETENTION_DAYS` | 30 | How long a group in `control_plane_failures` survives past its LAST occurrence, not its first: a failure first seen in March and last seen this morning is the most interesting row on the page, and sweeping by its age would delete exactly the long running failure an operator is trying to date. Applied only when this maintenance pass can run, because the application role is granted no `DELETE` on that table on purpose. A value that is not a whole number of days at least 1 stops the process at startup. |
+
+### The store of the control plane's own failures
+
+Both error handlers write what they caught to standard output and to a grouped
+table, so an installation with no log aggregation can still answer "what is
+failing right now" from the operator portal. A row is a fingerprint over the
+declared route, the method, the error class and the driver code, with a count,
+so the table's size is set by the code and not by traffic. It holds at most 500
+groups and never a message, a stack, a payload or an organization. See
+[operations](/docs/self-hosting/operations) for what it can and cannot answer.
+
+| Variable | Default | What it does |
+| --- | --- | --- |
+| `AF_FAILURE_STORE` | on | `off`, `0` or `false` records nothing. The Logs page then says nothing is being recorded, rather than showing an empty list that reads as a healthy day. The default is on because the table is bounded by the code, the writes are one statement per distinct group per ten seconds rather than one per failure, and a healthy installation writes nothing at all. |
 
 ### What a pass does, in order
 

--- a/docs/src/content/docs/self-hosting/operations.md
+++ b/docs/src/content/docs/self-hosting/operations.md
@@ -69,6 +69,13 @@ down by `code` answers this. One error code across many organizations is a
 platform fault. Many codes in one organization is that organization's
 repository, and is not your problem tonight.
 
+**And what actually failed?** Open **Operations, Logs & Error Explorer** in the
+operator portal. The first card is the control plane's own failures, grouped, in
+a table it writes to its own Postgres. You need no Prometheus, no Grafana and no
+log aggregation to read it, which is the point: without it, a 5xx count going up
+is the whole of what a self hosted installation can see. See [What the control
+plane records about its own failures](#what-the-control-plane-records-about-its-own-failures).
+
 ## What the alerts mean
 
 Every rule in `observability/alerts/antifailure.rules.yml` links back here. They
@@ -469,6 +476,82 @@ per-caller rate limits did, for a single caller sending across every route at
 once. An operator sizing a real deployment should raise `AF_POOL_MAX` to match
 expected concurrent callers rather than assuming the rate limiter is the only
 ceiling in the system.
+
+## What the control plane records about its own failures
+
+The control plane catches every unexpected failure of its own in two handlers,
+one for HTTP and one for tRPC procedures. Both write a line to standard output.
+On a deployment with log aggregation that line is searchable; on a self hosted
+one it is a line in `docker logs`, which is no count, no first seen and no
+grouping. So the same fields are also written to a table, and the operator
+portal reads it.
+
+**What a row is.** One GROUP, not one occurrence. The fingerprint is the
+declared route key, the HTTP method, the error class name and the driver's own
+code, and it carries a count, the first and last time it was seen, the build
+running at each of those, and the request id of the most recent occurrence.
+
+**What bounds it.** The cardinality of a row's five fields is set by the code
+rather than by traffic: the routes come from the endpoint table that ships in
+the container, the procedure paths from the router, and a class name is a
+JavaScript identifier. A bad day adds occurrences to existing rows and no rows.
+On top of that the table holds at most 500 groups, and the page says out loud
+when it is at that cap rather than quietly showing you fewer failures than are
+happening.
+
+**What it costs in storage.** At most 500 rows of about 200 bytes, so on the
+order of 100 kilobytes, whatever happens. The writes are one statement per
+distinct group per ten seconds rather than one per failure, and an installation
+that is not failing writes nothing at all.
+
+**What never goes in it.** No error message, no stack, no request body, no query
+string, no parameters, no payload, no organization, no user and no email. That
+is a boundary and not an oversight: a query failure from this stack renders as
+the whole statement with its parameters after it, so an error message here can
+carry a tenant's data. It is enforced by the signature of `recordFailure` in
+`web/apps/api/src/failures.ts`, which takes five bounded strings and has no
+parameter that could carry one of those values.
+
+**What it therefore cannot tell you.** How many tenants a control plane failure
+touched. Answering that means writing an organization identifier next to a
+failure, which turns a small operational table into tenant data. The Failures by
+code card on the same page answers the per tenant question for the engine side,
+where it is normally asked.
+
+**What you configure.**
+
+| Variable | Default | What it does |
+| --- | --- | --- |
+| `AF_FAILURE_STORE` | on | Set to `off` to record nothing. The page then says nothing is being recorded, rather than showing an empty list that reads as a healthy day. |
+| `AF_FAILURE_RETENTION_DAYS` | 30 | How long a group survives past its LAST occurrence. Only applied when the maintenance pass can run. |
+
+Retention rides the daily maintenance pass, which needs
+`AF_MAINTENANCE_DATABASE_URL` or `AF_MIGRATION_DATABASE_URL`. The application
+role is deliberately granted no `DELETE` on this table, so a role reached
+through a request path cannot erase the record of what it did to get there. With
+no administrative connection string configured, nothing sweeps: the table stays
+bounded by the cap regardless, and the portal says that no retention is in
+force so you read the dates rather than assuming a row is current.
+
+The page updates itself every ten seconds while the tab is in front. It polls
+rather than holding a stream open, because the control plane runs more than one
+replica behind one ingress and a held connection pins you to one of them and
+dies on every deploy, which is exactly when you are watching. A refresh that
+does not land leaves the last good numbers on screen and says how old they are.
+
+Three counters say when the store itself is the thing that is failing, and two
+alert rules watch them:
+`af_control_plane_failures_total{outcome="capped"}` for a new group refused,
+`{outcome="dropped"}` for the in-process buffer full, and `{outcome="failed"}`
+for a write that raised and will be retried. Anything above zero on those means
+the page is counting fewer failures than happened.
+
+### What is still not recorded
+
+Nothing records an exception, a stack trace or a log line from a customer's
+RUN. Those happen in the engine, in an environment the control plane does not
+own, and would need the engine to report them. `af logs web` and the run
+outcomes on the same page are what you have for that side.
 
 ## Where the numbers come from
 

--- a/engine/internal/docs/pages.gen.go
+++ b/engine/internal/docs/pages.gen.go
@@ -16658,6 +16658,21 @@ rather than held idle between them.
 | ` + "`" + `AF_MAINTENANCE_DATABASE_URL` + "`" + ` | falls back to ` + "`" + `AF_MIGRATION_DATABASE_URL` + "`" + ` | The role that creates and drops partitions. When neither is set, this process logs a warning at startup and does not keep the partitions ahead. Something else must. |
 | ` + "`" + `AF_EVENT_RETENTION_MONTHS` + "`" + ` | unset | Drop event partitions entirely older than this many whole months. Unset keeps everything forever, which is the default because retention is an operator's decision. A value that is not a whole number of months at least 1 stops the process at startup rather than silently keeping everything. |
 | ` + "`" + `AF_EVENT_ARCHIVE_DIR` + "`" + ` | unset | Write a month out as newline delimited JSON here before dropping it. |
+| ` + "`" + `AF_FAILURE_RETENTION_DAYS` + "`" + ` | 30 | How long a group in ` + "`" + `control_plane_failures` + "`" + ` survives past its LAST occurrence, not its first: a failure first seen in March and last seen this morning is the most interesting row on the page, and sweeping by its age would delete exactly the long running failure an operator is trying to date. Applied only when this maintenance pass can run, because the application role is granted no ` + "`" + `DELETE` + "`" + ` on that table on purpose. A value that is not a whole number of days at least 1 stops the process at startup. |
+
+### The store of the control plane's own failures
+
+Both error handlers write what they caught to standard output and to a grouped
+table, so an installation with no log aggregation can still answer "what is
+failing right now" from the operator portal. A row is a fingerprint over the
+declared route, the method, the error class and the driver code, with a count,
+so the table's size is set by the code and not by traffic. It holds at most 500
+groups and never a message, a stack, a payload or an organization. See
+[operations](/docs/self-hosting/operations) for what it can and cannot answer.
+
+| Variable | Default | What it does |
+| --- | --- | --- |
+| ` + "`" + `AF_FAILURE_STORE` + "`" + ` | on | ` + "`" + `off` + "`" + `, ` + "`" + `0` + "`" + ` or ` + "`" + `false` + "`" + ` records nothing. The Logs page then says nothing is being recorded, rather than showing an empty list that reads as a healthy day. The default is on because the table is bounded by the code, the writes are one statement per distinct group per ten seconds rather than one per failure, and a healthy installation writes nothing at all. |
 
 ### What a pass does, in order
 
@@ -23726,6 +23741,13 @@ down by ` + "`" + `code` + "`" + ` answers this. One error code across many orga
 platform fault. Many codes in one organization is that organization's
 repository, and is not your problem tonight.
 
+**And what actually failed?** Open **Operations, Logs & Error Explorer** in the
+operator portal. The first card is the control plane's own failures, grouped, in
+a table it writes to its own Postgres. You need no Prometheus, no Grafana and no
+log aggregation to read it, which is the point: without it, a 5xx count going up
+is the whole of what a self hosted installation can see. See [What the control
+plane records about its own failures](#what-the-control-plane-records-about-its-own-failures).
+
 ## What the alerts mean
 
 Every rule in ` + "`" + `observability/alerts/antifailure.rules.yml` + "`" + ` links back here. They
@@ -24126,6 +24148,82 @@ per-caller rate limits did, for a single caller sending across every route at
 once. An operator sizing a real deployment should raise ` + "`" + `AF_POOL_MAX` + "`" + ` to match
 expected concurrent callers rather than assuming the rate limiter is the only
 ceiling in the system.
+
+## What the control plane records about its own failures
+
+The control plane catches every unexpected failure of its own in two handlers,
+one for HTTP and one for tRPC procedures. Both write a line to standard output.
+On a deployment with log aggregation that line is searchable; on a self hosted
+one it is a line in ` + "`" + `docker logs` + "`" + `, which is no count, no first seen and no
+grouping. So the same fields are also written to a table, and the operator
+portal reads it.
+
+**What a row is.** One GROUP, not one occurrence. The fingerprint is the
+declared route key, the HTTP method, the error class name and the driver's own
+code, and it carries a count, the first and last time it was seen, the build
+running at each of those, and the request id of the most recent occurrence.
+
+**What bounds it.** The cardinality of a row's five fields is set by the code
+rather than by traffic: the routes come from the endpoint table that ships in
+the container, the procedure paths from the router, and a class name is a
+JavaScript identifier. A bad day adds occurrences to existing rows and no rows.
+On top of that the table holds at most 500 groups, and the page says out loud
+when it is at that cap rather than quietly showing you fewer failures than are
+happening.
+
+**What it costs in storage.** At most 500 rows of about 200 bytes, so on the
+order of 100 kilobytes, whatever happens. The writes are one statement per
+distinct group per ten seconds rather than one per failure, and an installation
+that is not failing writes nothing at all.
+
+**What never goes in it.** No error message, no stack, no request body, no query
+string, no parameters, no payload, no organization, no user and no email. That
+is a boundary and not an oversight: a query failure from this stack renders as
+the whole statement with its parameters after it, so an error message here can
+carry a tenant's data. It is enforced by the signature of ` + "`" + `recordFailure` + "`" + ` in
+` + "`" + `web/apps/api/src/failures.ts` + "`" + `, which takes five bounded strings and has no
+parameter that could carry one of those values.
+
+**What it therefore cannot tell you.** How many tenants a control plane failure
+touched. Answering that means writing an organization identifier next to a
+failure, which turns a small operational table into tenant data. The Failures by
+code card on the same page answers the per tenant question for the engine side,
+where it is normally asked.
+
+**What you configure.**
+
+| Variable | Default | What it does |
+| --- | --- | --- |
+| ` + "`" + `AF_FAILURE_STORE` + "`" + ` | on | Set to ` + "`" + `off` + "`" + ` to record nothing. The page then says nothing is being recorded, rather than showing an empty list that reads as a healthy day. |
+| ` + "`" + `AF_FAILURE_RETENTION_DAYS` + "`" + ` | 30 | How long a group survives past its LAST occurrence. Only applied when the maintenance pass can run. |
+
+Retention rides the daily maintenance pass, which needs
+` + "`" + `AF_MAINTENANCE_DATABASE_URL` + "`" + ` or ` + "`" + `AF_MIGRATION_DATABASE_URL` + "`" + `. The application
+role is deliberately granted no ` + "`" + `DELETE` + "`" + ` on this table, so a role reached
+through a request path cannot erase the record of what it did to get there. With
+no administrative connection string configured, nothing sweeps: the table stays
+bounded by the cap regardless, and the portal says that no retention is in
+force so you read the dates rather than assuming a row is current.
+
+The page updates itself every ten seconds while the tab is in front. It polls
+rather than holding a stream open, because the control plane runs more than one
+replica behind one ingress and a held connection pins you to one of them and
+dies on every deploy, which is exactly when you are watching. A refresh that
+does not land leaves the last good numbers on screen and says how old they are.
+
+Three counters say when the store itself is the thing that is failing, and two
+alert rules watch them:
+` + "`" + `af_control_plane_failures_total{outcome="capped"}` + "`" + ` for a new group refused,
+` + "`" + `{outcome="dropped"}` + "`" + ` for the in-process buffer full, and ` + "`" + `{outcome="failed"}` + "`" + `
+for a write that raised and will be retried. Anything above zero on those means
+the page is counting fewer failures than happened.
+
+### What is still not recorded
+
+Nothing records an exception, a stack trace or a log line from a customer's
+RUN. Those happen in the engine, in an environment the control plane does not
+own, and would need the engine to report them. ` + "`" + `af logs web` + "`" + ` and the run
+outcomes on the same page are what you have for that side.
 
 ## Where the numbers come from
 

--- a/infra/terraform/modules/control-plane/app.tf
+++ b/infra/terraform/modules/control-plane/app.tf
@@ -527,6 +527,31 @@ resource "azurerm_container_app" "this" {
         }
       }
 
+      # The grouped store of the control plane's own failures.
+      #
+      # Emitted only when it is being turned OFF, because on is the image's
+      # default and an env var restating a default is one more place for the two
+      # to disagree. The variable is a bool rather than the string the process
+      # reads, so a deployment cannot half turn it off with a spelling the
+      # process does not recognise.
+      dynamic "env" {
+        for_each = var.failure_store ? [] : ["off"]
+        content {
+          name  = "AF_FAILURE_STORE"
+          value = env.value
+        }
+      }
+
+      # How long a grouped failure survives past its LAST occurrence. Null takes
+      # the image's default of 30 days, for the same reason as above.
+      dynamic "env" {
+        for_each = var.failure_retention_days == null ? [] : [var.failure_retention_days]
+        content {
+          name  = "AF_FAILURE_RETENTION_DAYS"
+          value = tostring(env.value)
+        }
+      }
+
       # Every origin the marketing site is served from, for the beacon, the
       # enterprise lead form and the careers application form.
       #

--- a/infra/terraform/modules/control-plane/variables.tf
+++ b/infra/terraform/modules/control-plane/variables.tf
@@ -499,6 +499,25 @@ variable "analytics_retention_days" {
   description = "Delete raw analytics events older than this many days. Null keeps them forever, because retention is an operator's decision."
 }
 
+# The grouped record of the control plane's own failures.
+#
+# Both of these have a working default in the image, so neither is here to make
+# the feature run. They are here because a variable a deployment cannot set is a
+# switch an operator cannot reach: the store is on by default, and an operator
+# who wants it off has to be able to say so where they deploy rather than by
+# rebuilding an image.
+variable "failure_store" {
+  type        = bool
+  default     = true
+  description = "Record the control plane's own failures, grouped, for the operator portal. False writes nothing and the Logs page says so rather than showing an empty list."
+}
+
+variable "failure_retention_days" {
+  type        = number
+  default     = null
+  description = "Delete a grouped failure this many days after its LAST occurrence. Null takes the image's default of 30. Applied only when the maintenance pass can run, because the application role holds no DELETE on that table."
+}
+
 # Every origin the marketing site is served from, for the three things a
 # browser on it calls cross origin: the analytics beacon, the enterprise lead
 # form and the careers application form.

--- a/observability/alerts/antifailure.rules.yml
+++ b/observability/alerts/antifailure.rules.yml
@@ -186,3 +186,52 @@ groups:
           description: >-
             The statement timeout is fifteen seconds, so this is well short of failing and
             well past comfortable. Usually the database rather than the process.
+
+  - name: antifailure-failure-store
+    interval: 30s
+    rules:
+      # The store that answers "what is failing" has to be able to say when it
+      # is the thing that is failing. Three of the four outcomes on this counter
+      # mean the Logs page is counting fewer failures than actually happened,
+      # and a store that under-reports without saying so is worse than none: an
+      # operator reads a small number during an incident and stops looking.
+      #
+      # `capped` and `dropped` are grouped into one alert because the operator
+      # action is the same. Both mean the installation is producing more
+      # distinct kinds of failure than the store will hold, which is either a
+      # genuinely broken deploy or a route label that has stopped being bounded.
+      - alert: TheFailureStoreIsLosingFailures
+        expr: |
+          sum(rate(af_control_plane_failures_total{outcome=~"capped|dropped"}[15m])) > 0
+        for: 15m
+        labels:
+          severity: ticket
+        annotations:
+          summary: The grouped failure store is refusing to record new kinds of failure.
+          runbook: https://antifailure.dev/docs/self-hosting/operations
+          description: >-
+            The control plane is producing more distinct kinds of failure than the store
+            will hold, so the Logs page is now showing fewer than are happening. The store
+            is bounded by the code, so reaching the cap normally means a route label has
+            stopped being bounded rather than that the day is going badly. Compare
+            af_control_plane_failures_total by outcome against the observed count.
+
+      # Separated from the one above because the operator action is different.
+      # This one is the database, not the store, and it is self healing: the
+      # occurrences go back in the buffer and are written when Postgres returns.
+      # It firing and then stopping is the recovery, which is worth being able
+      # to see rather than being told about only while it is broken.
+      - alert: TheFailureStoreCannotWrite
+        expr: |
+          sum(rate(af_control_plane_failures_total{outcome="failed"}[10m])) > 0
+        for: 10m
+        labels:
+          severity: ticket
+        annotations:
+          summary: The control plane cannot write down what is failing in it.
+          runbook: https://antifailure.dev/docs/self-hosting/operations
+          description: >-
+            The flush into control_plane_failures is raising. The occurrences are held in
+            memory and written when the database returns, so nothing is lost yet, but the
+            Logs page is behind by however long this has been true. Usually the same cause
+            as whatever is producing the failures being recorded.

--- a/observability/dashboards/control-plane.json
+++ b/observability/dashboards/control-plane.json
@@ -633,6 +633,87 @@
         },
         "overrides": []
       }
+    },
+    {
+      "id": 500,
+      "type": "row",
+      "title": "The failure store",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 41
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 40,
+      "type": "timeseries",
+      "title": "Failures the handlers caught",
+      "description": "Every failure the control plane's own two error handlers saw, whether or not the grouped store recorded it. The denominator the other series here are read against.",
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 42
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(af_control_plane_failures_total{outcome=\"observed\"}[5m]))",
+          "legendFormat": "observed"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {}
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 41,
+      "type": "timeseries",
+      "title": "Failures the store did NOT record",
+      "description": "Anything above zero here means the Logs page in the operator portal is counting fewer failures than actually happened. capped is the group cap, dropped is the in-process buffer, failed is a write that raised and will be retried.",
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 42
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(af_control_plane_failures_total{outcome=~\"capped|dropped|failed\"}[5m])) by (outcome)",
+          "legendFormat": "{{outcome}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {}
+        },
+        "overrides": []
+      }
     }
   ],
   "description": "Every metric on this dashboard is exported by web/apps/api/src/metrics.ts, and a test fails if one is not. A panel querying a metric that does not exist draws an empty graph, which reads as a quiet system rather than as a broken dashboard."

--- a/tools/inputcheck/surface-v1.tsv
+++ b/tools/inputcheck/surface-v1.tsv
@@ -61,6 +61,8 @@ helm	value	database.secretKeys.migrationUrl	string	optional
 helm	value	database.secretKeys.url	string	optional
 helm	value	database.url	string	optional
 helm	value	extraEnv	list	optional
+helm	value	failureStore.enabled	bool	optional
+helm	value	failureStore.retentionDays	string	optional
 helm	value	fullnameOverride	string	optional
 helm	value	github.apiBase	string	optional
 helm	value	github.appId	string	optional
@@ -205,6 +207,8 @@ terraform:modules/control-plane	variable	diagnostics_enabled	bool	optional
 terraform:modules/control-plane	variable	dns_zone_name	string	optional
 terraform:modules/control-plane	variable	dns_zone_resource_group	string	optional
 terraform:modules/control-plane	variable	event_retention_months	number	optional
+terraform:modules/control-plane	variable	failure_retention_days	number	optional
+terraform:modules/control-plane	variable	failure_store	bool	optional
 terraform:modules/control-plane	variable	geo_redundant_backup	bool	optional
 terraform:modules/control-plane	variable	github_api_base	string	optional
 terraform:modules/control-plane	variable	github_app_id	string	optional

--- a/web/apps/api/src/admin/operations.ts
+++ b/web/apps/api/src/admin/operations.ts
@@ -57,6 +57,7 @@ import type { Db } from '@antifailure/db'
 import { router } from '../trpc.ts'
 import { adminProcedure, type AdminContext } from './trpc.ts'
 import { RecordingMailer, ResendMailer } from '../auth/mail.ts'
+import { failureStoreConfig, statusOf } from '../failures.ts'
 
 /**
  * How far back a page looks.
@@ -527,6 +528,149 @@ const logsRouter = router({
     }),
 })
 
+/* -------------------------------------------------------------------------
+ * The control plane's own failures
+ * ---------------------------------------------------------------------- */
+
+/**
+ * One group of failures the control plane caught in itself.
+ *
+ * Every field is one the two error handlers in server.ts already decided was
+ * safe to write to a log line. There is no message, no stack, no payload and no
+ * organization. See migration 0042 and src/failures.ts for why, and for what
+ * this deliberately cannot answer.
+ */
+export interface ControlPlaneFailure {
+  fingerprint: string
+  source: string
+  route: string
+  method: string
+  kind: string
+  providerCode: string | null
+  occurrences: number
+  firstSeen: string
+  lastSeen: string
+  /** The build running the first and the most recent time this was seen. Equal
+   *  means the group has only ever been produced by one build, which is the
+   *  answer to "did it start when we deployed" that needs no deploy table. */
+  firstSeenVersion: string
+  lastSeenVersion: string
+  /** The id the 500 response handed the caller, for the most recent
+   *  occurrence. It is the join to a line in `af logs web`. */
+  lastRequestId: string | null
+}
+
+/**
+ * What the store itself is doing, returned beside the rows.
+ *
+ * This is the half that stops the page lying. A list of groups with no context
+ * looks complete whether or not it is, and every one of these fields names a
+ * way it might not be: a store switched off, a store at its cap, a store nobody
+ * sweeps. An operator reading a short list during an incident has to be able to
+ * tell "nothing else failed" from "nothing else was recorded".
+ */
+export interface FailureStoreStatus {
+  /** Whether THIS replica writes. A rolling deploy can have one revision
+   *  writing and another not, so this is the answering replica's answer and the
+   *  page says so. */
+  recording: boolean
+  /** Groups in the table, across all time rather than the window. */
+  groups: number
+  /** The most groups the table will hold. */
+  cap: number
+  /** True when a new kind of failure is being refused a row right now. */
+  atCap: boolean
+  /** Days a group survives past its last occurrence, or null when nothing on
+   *  this installation is configured to sweep. */
+  retentionDays: number | null
+}
+
+const failuresRouter = router({
+  /**
+   * The groups, newest occurrence first, with the store's own state.
+   *
+   * One route rather than two, for the same reason `overview` is one route: a
+   * page that fetches the rows and the cap separately can render a full list
+   * beside a stale "not at cap", which is the combination that reads as an
+   * answer and is not one.
+   *
+   * No cursor. This is capped at GROUP_LIMIT like the other aggregates on this
+   * page, and unlike them the cap is not the real bound: the table itself holds
+   * at most `cap` rows, so the count beside the list says exactly how much is
+   * not shown.
+   */
+  store: adminProcedure('admin.logs.read')
+    .input(z.object({ hours: windowHours }).optional())
+    .query(async ({ ctx, input }) => {
+      const c = ctx as AdminContext
+      const now = c.clock.now()
+      const hours: WindowHours = input?.hours ?? 24
+      const from = since(now, hours)
+      const config = failureStoreConfig(process.env)
+
+      return c.adminDb(async (db) => {
+        const [rows, totals] = await Promise.all([
+          db.execute<{
+            fingerprint: string
+            source: string
+            route: string
+            method: string
+            kind: string
+            provider_code: string | null
+            occurrences: string | number
+            first_seen_at: Date | string
+            last_seen_at: Date | string
+            first_seen_version: string
+            last_seen_version: string
+            last_request_id: string | null
+          }>(sql`
+            SELECT fingerprint, source, route, method, kind, provider_code,
+                   occurrences, first_seen_at, last_seen_at,
+                   first_seen_version, last_seen_version, last_request_id
+            FROM control_plane_failures
+            WHERE last_seen_at >= ${from.toISOString()}::timestamptz
+            ORDER BY last_seen_at DESC
+            LIMIT ${GROUP_LIMIT + 1}`),
+          // Counted across all time rather than the window on purpose: this is
+          // what the cap applies to, so a window count could read as "far from
+          // the cap" while the table is full of groups that stopped happening.
+          db.execute<{ n: string }>(sql`SELECT count(*) AS n FROM control_plane_failures`),
+        ])
+
+        const groups = Number(totals[0]?.n ?? 0)
+        const truncated = rows.length > GROUP_LIMIT
+        const visible = truncated ? rows.slice(0, GROUP_LIMIT) : rows
+
+        const status: FailureStoreStatus = statusOf(groups, config)
+
+        return {
+          hours,
+          from: from.toISOString(),
+          at: now.toISOString(),
+          status,
+          truncated,
+          limit: GROUP_LIMIT,
+          failures: visible.map(
+            (r): ControlPlaneFailure => ({
+              fingerprint: r.fingerprint,
+              source: r.source,
+              route: r.route,
+              method: r.method,
+              kind: r.kind,
+              providerCode: r.provider_code,
+              occurrences: Number(r.occurrences),
+              firstSeen: iso(r.first_seen_at),
+              lastSeen: iso(r.last_seen_at),
+              firstSeenVersion: r.first_seen_version,
+              lastSeenVersion: r.last_seen_version,
+              lastRequestId: r.last_request_id,
+            }),
+          ),
+        }
+      })
+    }),
+})
+
 const emailRouter = router({
   /**
    * Whether this installation can send email at all, and what it has tried to
@@ -675,5 +819,6 @@ const emailRouter = router({
  */
 export const operationsRouter = router({
   logs: logsRouter,
+  failures: failuresRouter,
   email: emailRouter,
 })

--- a/web/apps/api/src/boot.ts
+++ b/web/apps/api/src/boot.ts
@@ -38,6 +38,7 @@ import { serve } from '@hono/node-server'
 import { createPool, createAdminPool, migrate, type AdminPool, type Pool } from '@antifailure/db'
 import postgres from 'postgres'
 import { createServer } from './server.ts'
+import { failureRetentionFrom } from './failures.ts'
 import { registeredExtensions } from './extensions.ts'
 import { describeTrustedProxyHops, trustedProxyHopsFrom } from './clientaddress.ts'
 import { RealGitHubClient } from './auth/github.ts'
@@ -134,6 +135,16 @@ export interface ControlPlane {
   port: number
   close(): Promise<void>
 }
+
+/**
+ * How often the grouped failure store writes what it accumulated.
+ *
+ * Ten seconds, matching the Logs page's poll, so a failure reaches the screen
+ * within about two ticks. Shorter would put a write on the error path in all
+ * but name; longer would leave an operator watching a page that says nothing is
+ * wrong while it is.
+ */
+const FAILURE_FLUSH_MS = 10_000
 
 export async function startControlPlane(hooks: BootHooks = {}): Promise<ControlPlane> {
 
@@ -547,7 +558,7 @@ export async function startControlPlane(hooks: BootHooks = {}): Promise<ControlP
     }
   }
 
-  const { app, ingestLimiter, authLimiter } = createServer({
+  const { app, ingestLimiter, authLimiter, failures } = createServer({
     pool,
     adminPool,
     github,
@@ -608,6 +619,11 @@ export async function startControlPlane(hooks: BootHooks = {}): Promise<ControlP
         // and writes one it can only select from. A second scheduler would be a
         // second thing to notice had stopped.
         analyticsRetentionDays: analyticsRetentionFromEnv(process.env),
+        // The grouped failure store's retention rides the same pass, on the
+        // same credential, for the same reason: 0042 gives the application role
+        // no DELETE, and a second scheduler is a second thing to notice had
+        // stopped.
+        failureRetentionDays: failureRetentionFrom(process.env),
         log: (line) => console.log(line),
       },
       systemClock,
@@ -621,6 +637,28 @@ export async function startControlPlane(hooks: BootHooks = {}): Promise<ControlP
 
   // Housekeeping, not enforcement: expiry is checked when a session is resolved,
   // so a sweeper that is late costs table size and nothing else.
+  // The failure store's flush.
+  //
+  // ON ITS OWN TIMER, and much faster than the five minute housekeeping pass,
+  // because this is the one thing on that list a person is watching. Ten
+  // seconds is the interval the Logs page polls at, so a failure is on screen
+  // within about two ticks of happening.
+  //
+  // Separate from housekeeping for a second reason: every sweep in that pass is
+  // about table size and being late costs rows. This one is about a number an
+  // operator is reading during an incident, and being five minutes late means
+  // the page says nothing is wrong for five minutes after it started going
+  // wrong.
+  //
+  // `void` with a catch, and the catch is not decoration. `flush` already puts
+  // failed groups back in the buffer and increments a counter, so an
+  // unhandled rejection here would be a second report of something already
+  // reported, on the path least able to afford one.
+  const failureFlush = setInterval(() => {
+    void failures.flush().catch((err) => console.error('failure store flush', err))
+  }, FAILURE_FLUSH_MS)
+  failureFlush.unref()
+
   const housekeeping = setInterval(
     () => {
       void sweepSessions(pool, systemClock).catch((err) => console.error('session sweep', err))
@@ -754,8 +792,13 @@ export async function startControlPlane(hooks: BootHooks = {}): Promise<ControlP
         // It swallows its own failures, so a vendor being unreachable delays this
         // by its own timeout and never turns a clean shutdown into a bad exit
         // status.
-        void postHogSink
-          .shutdown()
+        // Flushed before the pool closes, for the same reason the sink is:
+        // whatever the last ten seconds grouped is otherwise lost on every
+        // deploy, and a deploy is exactly when an operator is looking.
+        void failures
+          .flush()
+          .catch((err) => console.error('failure store flush on shutdown', err))
+          .then(() => postHogSink.shutdown())
           .then(() => pool.close())
           .then(() => process.exit(0))
       })
@@ -776,8 +819,10 @@ export async function startControlPlane(hooks: BootHooks = {}): Promise<ControlP
             reject(err)
             return
           }
-          void postHogSink
-            .shutdown()
+          void failures
+            .flush()
+            .catch((err) => console.error('failure store flush on close', err))
+            .then(() => postHogSink.shutdown())
             .then(() => pool.close())
             .then(() => resolve())
             .catch(reject)

--- a/web/apps/api/src/failures.ts
+++ b/web/apps/api/src/failures.ts
@@ -1,0 +1,508 @@
+// What failed in the control plane itself, grouped, counted, and kept where the
+// operator portal can read it.
+//
+// THE FAILURE THIS ANSWERS. `app.onError` and the tRPC `onError` both already
+// catch every unexpected failure this process has, and both already write a
+// line naming the class, the driver code, the method and the route. That line
+// goes to stdout. On the hosted control plane something ships stdout somewhere
+// searchable. A self hoster running this container against their own Postgres,
+// with no Log Analytics and no Grafana, has `docker logs`: no count, no first
+// seen, no grouping, and so no answer to "what is failing right now" or "did it
+// start when we deployed". The metric beside it, af_http_requests_total with a
+// 5xx status class, says how many and never says what.
+//
+// WHY THIS IS NOT A SECOND METRICS SYSTEM, which the plan explicitly refuses.
+// The counters in metrics.ts stay exactly as they are and this adds four series
+// to that same registry. What it does not do is answer through them. Prometheus
+// counters are per replica, the control plane runs in multiple revision mode
+// with more than one replica behind one ingress, and a console request reaches
+// whichever replica the ingress picked. A count read that way walks up and down
+// as the load balancer moves, which is indistinguishable from a failure rate
+// that is walking up and down. Postgres is shared by every replica, so a row
+// here is the fleet's answer rather than one replica's, and it survives the
+// revision swap that ends every replica's process memory.
+//
+// WHY A GROUP AND NOT A LOG LINE. A row per occurrence makes the table's size a
+// function of how badly the installation is behaving, so the day the control
+// plane starts failing is the day the disk fills. That is a self hoster's
+// incident, caused by the thing we added to help them with incidents. One row
+// per fingerprint is bounded by the CODE: the route keys come from
+// ENDPOINT_LIMITS, the tRPC paths from the router, the class name is a
+// JavaScript identifier and the provider code is a driver's enum. A bad day
+// adds occurrences and no rows.
+//
+// WHAT NEVER ENTERS THE STORE, and this is the boundary the plan asks to be
+// named. Not the message, not the stack, not a body, a query string, a
+// parameter or a payload; not an org, a user, an email or an environment. The
+// reason is specific rather than hygienic and it is already written on
+// `app.onError`: Drizzle renders a query failure as "Failed query: <the whole
+// statement>" with the parameters after it, so an error message from this stack
+// can carry a tenant's event payload. THE BOUNDARY IS THIS MODULE'S SIGNATURE.
+// `record` takes five bounded strings and a request id and has no parameter
+// that could carry one of those values, so a caller cannot pass one by mistake.
+// It is not enforced by a row level policy and cannot be: policies are row
+// level, and the operator pool bypasses them anyway. Same argument as
+// SAFE_COLUMNS in admin/router.ts.
+//
+// WHAT THIS DELIBERATELY CANNOT ANSWER. How many tenants a failure touched.
+// That needs an organization identifier written next to a failure, which turns
+// a bounded operational table into tenant data carrying its own retention
+// argument. The Logs page says so in words rather than showing a zero, and
+// points at workload_runs.failure_code, which it already groups, for the
+// per-tenant count.
+
+import { createHash } from 'node:crypto'
+import { sql } from 'drizzle-orm'
+import type { Pool } from '@antifailure/db'
+import type { Counter } from './metrics.ts'
+import type { Clock } from './clock.ts'
+
+/** One failure, as the two handlers see it. Every field is a bounded string. */
+export interface Failure {
+  source: 'http' | 'trpc'
+  /** The DECLARED route key, never the path that matched it. */
+  route: string
+  method: string
+  /** The error's class name. */
+  kind: string
+  /** The driver's own code, when the cause carried one. */
+  providerCode: string | null
+  /** The id already on the 500 response and already on the log line. It names a
+   *  request, not a person. */
+  requestId: string | null
+}
+
+/**
+ * The identity of a group.
+ *
+ * SHA-256 over the five bounded fields, so every replica and every restart
+ * agrees without coordinating. The columns themselves would serve as a natural
+ * key; the hash is what lets the console carry one opaque identifier per row.
+ *
+ * LENGTH PREFIXED RATHER THAN JOINED ON A SEPARATOR, and that is the whole
+ * reason this is a function rather than a template string. Any separator is a
+ * character some field might one day contain, and the moment one does, two
+ * different failures hash to the same group. The reading that produces is the
+ * worst one this feature can produce: a failure that appears to have stopped,
+ * because its occurrences are being added to somebody else's row. A length
+ * prefix has no such character, so the encoding is injective by construction
+ * and stays injective if `err.name` ever carries something strange.
+ */
+export function fingerprintOf(f: Failure): string {
+  const hash = createHash('sha256')
+  for (const field of [f.source, f.method, f.route, f.kind, f.providerCode ?? '']) {
+    hash.update(`${field.length}:${field}`)
+  }
+  return hash.digest('hex')
+}
+
+/**
+ * Column bounds, mirrored from the CHECK constraints in migration 0042.
+ *
+ * Truncated here rather than left to the database, because a value over the
+ * bound would raise 23514 at flush time and take the whole batch with it. A
+ * class name of 101 characters is not worth losing a flush over, and silently
+ * dropping the failure it describes is exactly the outcome this store exists to
+ * prevent.
+ */
+const BOUNDS = { route: 200, method: 16, kind: 100, providerCode: 64, requestId: 100 } as const
+
+function clamp(value: string, max: number): string {
+  return value.length <= max ? value : value.slice(0, max)
+}
+
+interface Pending {
+  source: 'http' | 'trpc'
+  route: string
+  method: string
+  kind: string
+  providerCode: string | null
+  count: number
+  firstAt: Date
+  lastAt: Date
+  lastRequestId: string | null
+}
+
+export interface FlushResult {
+  /** Groups whose accumulated occurrences reached the table. */
+  applied: number
+  /** Groups the table refused because it is already at its group cap. Their
+   *  occurrences are discarded rather than retried: the cap is not going to
+   *  move on the next tick. */
+  capped: number
+  /** Groups whose write raised. Their occurrences go back in the buffer. */
+  failed: number
+}
+
+export interface FailureStore {
+  /** False when no store is configured. Every method still works and records
+   *  nothing, so no caller has to check first. Same arrangement as analytics. */
+  readonly enabled: boolean
+  /** Never throws, never awaits, never touches the network. */
+  record(f: Failure): void
+  flush(): Promise<FlushResult>
+  /** How many groups are waiting. For the shutdown path and for tests. */
+  buffered(): number
+}
+
+export interface FailureStoreOptions {
+  pool: Pool | null
+  clock: Clock
+  /** The build string, the same one af_control_plane_info carries. */
+  version: string
+  /** Increments with an `outcome` label. Optional so a test can omit it. */
+  counter?: Counter
+  /**
+   * The most groups the table may hold.
+   *
+   * A second bound on top of "bounded by the code", because bounded by the code
+   * is an argument and a LIMIT is a fact. Five hundred is far above the real
+   * cardinality: there are fewer than a hundred declared routes and a handful of
+   * error classes that reach these handlers.
+   */
+  groupCap?: number
+  /**
+   * The most groups the in-process buffer may hold between flushes.
+   *
+   * Reached only when the table is being asked to hold more distinct groups than
+   * the cap allows anyway, so it is the same bound one tick earlier. A new
+   * fingerprint arriving at a full buffer is DROPPED and counted, because
+   * growing the buffer during an incident is how a process that was reporting an
+   * outage becomes part of it.
+   */
+  bufferCap?: number
+}
+
+export const DEFAULT_GROUP_CAP = 500
+export const DEFAULT_BUFFER_CAP = 500
+
+/**
+ * Reads the switch.
+ *
+ * The default is ON, and the reason it is safe to default on is the bound
+ * above: the table cannot exceed the group cap, the writes are one statement per
+ * distinct group per flush rather than one per failure, and a healthy
+ * installation produces no failures and therefore no writes at all. A self
+ * hoster on a small machine pays nothing until something breaks, which is when
+ * they want it.
+ */
+export function failureStoreEnabledFrom(env: NodeJS.ProcessEnv): boolean {
+  const raw = (env.AF_FAILURE_STORE ?? '').trim().toLowerCase()
+  return raw !== 'off' && raw !== '0' && raw !== 'false'
+}
+
+/**
+ * Builds the store.
+ *
+ * A null pool, or the switch off, gives a store that accepts everything and
+ * writes nothing. That is not a stub: `record` is called from an error handler,
+ * and an error handler that can itself fail because a store is not configured is
+ * a worse failure than the one it was reporting.
+ */
+export function createFailureStore(options: FailureStoreOptions): FailureStore {
+  const groupCap = options.groupCap ?? DEFAULT_GROUP_CAP
+  const bufferCap = options.bufferCap ?? DEFAULT_BUFFER_CAP
+  const enabled = options.pool !== null
+  let buffer = new Map<string, Pending>()
+
+  function count(outcome: string, by = 1): void {
+    options.counter?.inc({ outcome }, by)
+  }
+
+  /** Adds occurrences to the buffer, obeying the buffer cap. Shared by `record`
+   *  and by the merge back a failed flush performs, so a retry cannot grow the
+   *  buffer past the bound that a first arrival obeys. */
+  function accumulate(key: string, incoming: Pending): void {
+    const existing = buffer.get(key)
+    if (existing) {
+      existing.count += incoming.count
+      if (incoming.firstAt < existing.firstAt) existing.firstAt = incoming.firstAt
+      // Not `>` : a retry merging back a batch stamped in the same millisecond
+      // as a newer arrival must not move the request id backwards. The newer
+      // one is already in `existing`, so ties keep it.
+      if (incoming.lastAt > existing.lastAt) {
+        existing.lastAt = incoming.lastAt
+        existing.lastRequestId = incoming.lastRequestId
+      }
+      return
+    }
+    if (buffer.size >= bufferCap) {
+      count('dropped', incoming.count)
+      return
+    }
+    buffer.set(key, incoming)
+  }
+
+  return {
+    enabled,
+
+    record(f) {
+      count('observed')
+      if (!enabled) return
+      const bounded: Failure = {
+        source: f.source,
+        route: clamp(f.route, BOUNDS.route) || 'unknown',
+        method: clamp(f.method, BOUNDS.method) || 'unknown',
+        kind: clamp(f.kind, BOUNDS.kind) || 'unknown',
+        providerCode: f.providerCode ? clamp(f.providerCode, BOUNDS.providerCode) : null,
+        requestId: f.requestId ? clamp(f.requestId, BOUNDS.requestId) : null,
+      }
+      const at = options.clock.now()
+      accumulate(fingerprintOf(bounded), {
+        source: bounded.source,
+        route: bounded.route,
+        method: bounded.method,
+        kind: bounded.kind,
+        providerCode: bounded.providerCode,
+        count: 1,
+        firstAt: at,
+        lastAt: at,
+        lastRequestId: bounded.requestId,
+      })
+    },
+
+    async flush() {
+      const result: FlushResult = { applied: 0, capped: 0, failed: 0 }
+      const pool = options.pool
+      if (!pool || buffer.size === 0) return result
+
+      // Swapped rather than drained, so a failure arriving during the flush
+      // lands in the new buffer and is not counted twice when a failed write is
+      // merged back.
+      const batch = buffer
+      buffer = new Map()
+
+      for (const [key, p] of batch) {
+        try {
+          const applied = await writeGroup(pool, key, p, options.version, groupCap)
+          if (applied) {
+            result.applied += 1
+          } else {
+            // The table is full of other groups. Retrying on the next tick
+            // would fail identically, so the occurrences are discarded and the
+            // fact that they were is a metric and a line on the page, never a
+            // silence.
+            result.capped += 1
+            count('capped', p.count)
+          }
+        } catch {
+          // The occurrences go back. A control plane whose database is down
+          // fails every request, which is exactly when the buffer must hold
+          // rather than shed, so that the store backfills the shape of the
+          // outage the moment the database returns.
+          result.failed += 1
+          count('failed', p.count)
+          accumulate(key, p)
+        }
+      }
+      return result
+    },
+
+    buffered() {
+      return buffer.size
+    },
+  }
+}
+
+/**
+ * One group, in one statement.
+ *
+ * THE CAP AND THE UPSERT ARE THE SAME STATEMENT, and the order of the two
+ * conditions is the whole of it. `EXISTS` first means a group already in the
+ * table keeps counting up after the cap is reached; only a NEW fingerprint is
+ * refused. The first version tested only the count, so at the cap every group
+ * stopped counting, which reads as an outage that ended.
+ *
+ * Two replicas inserting two different new fingerprints at cap minus one can
+ * both see the count pass and both insert, so the cap is exceeded by at most
+ * the number of concurrent flushes. That is a stated bound rather than an
+ * unbounded one, and tightening it would mean taking a lock on a table on the
+ * error path.
+ *
+ * Returns whether a row was written. `RETURNING` gives a row on both the insert
+ * and the conflict update, and none at all when the WHERE refused, so the
+ * refusal is observable rather than inferred from an unchanged count.
+ */
+async function writeGroup(
+  pool: Pool,
+  fingerprint: string,
+  p: Pending,
+  version: string,
+  groupCap: number,
+): Promise<boolean> {
+  // withoutTenant: this table carries no org_id and there is nothing for a
+  // tenant setting to key on. See migration 0042.
+  return pool.withoutTenant(async (db) => {
+    const rows = await db.execute(sql`
+      INSERT INTO control_plane_failures (
+        fingerprint, source, route, method, kind, provider_code,
+        occurrences, first_seen_at, last_seen_at,
+        first_seen_version, last_seen_version, last_request_id)
+      SELECT ${fingerprint}, ${p.source}, ${p.route}, ${p.method}, ${p.kind}, ${p.providerCode},
+             ${p.count}, ${p.firstAt.toISOString()}, ${p.lastAt.toISOString()},
+             ${version}, ${version}, ${p.lastRequestId}
+      WHERE EXISTS (SELECT 1 FROM control_plane_failures WHERE fingerprint = ${fingerprint})
+         OR (SELECT count(*) FROM control_plane_failures) < ${groupCap}
+      ON CONFLICT (fingerprint) DO UPDATE SET
+        occurrences = control_plane_failures.occurrences + EXCLUDED.occurrences,
+        first_seen_at = LEAST(control_plane_failures.first_seen_at, EXCLUDED.first_seen_at),
+        last_seen_at = GREATEST(control_plane_failures.last_seen_at, EXCLUDED.last_seen_at),
+        -- The version columns follow their timestamps rather than the write
+        -- order. A replica flushing late, or one still on the previous revision
+        -- during a rollout, must not relabel a group with a build that is not
+        -- the newest one to have produced it.
+        first_seen_version = CASE
+          WHEN EXCLUDED.first_seen_at < control_plane_failures.first_seen_at
+          THEN EXCLUDED.first_seen_version ELSE control_plane_failures.first_seen_version END,
+        last_seen_version = CASE
+          WHEN EXCLUDED.last_seen_at >= control_plane_failures.last_seen_at
+          THEN EXCLUDED.last_seen_version ELSE control_plane_failures.last_seen_version END,
+        last_request_id = CASE
+          WHEN EXCLUDED.last_seen_at >= control_plane_failures.last_seen_at
+          THEN EXCLUDED.last_request_id ELSE control_plane_failures.last_request_id END
+      RETURNING fingerprint`)
+    return rowCountOf(rows) > 0
+  })
+}
+
+/**
+ * How many rows came back.
+ *
+ * `db.execute` in this codebase resolves to the rows array, which every caller
+ * in admin/ reads as `rows[0]`. The object form is handled as well rather than
+ * assumed away, because reading the wrong one yields `undefined`, whose length
+ * is `undefined`, which compares false against zero and would report every
+ * successful write as capped. A store that reports itself full is a store the
+ * operator stops believing.
+ */
+function rowCountOf(result: unknown): number {
+  if (Array.isArray(result)) return result.length
+  const rows = (result as { rows?: unknown } | null)?.rows
+  return Array.isArray(rows) ? rows.length : 0
+}
+
+/**
+ * Retention, on the credential that owns the table.
+ *
+ * The application role is given no DELETE in 0042, deliberately: a role reached
+ * through a request path should not be able to erase the record of what it did
+ * to get there. So this runs beside the partition maintenance, on the same
+ * administrative connection and on the same daily pass, because a second
+ * scheduler is a second thing to notice had stopped.
+ *
+ * Retention here bounds STALENESS, not size. Size is bounded by the group cap,
+ * which holds whether or not anything ever sweeps. An installation with no
+ * administrative connection string configured therefore keeps a group whose
+ * last occurrence was a year ago, and the page prints that date rather than
+ * implying the failure is current.
+ */
+export const DEFAULT_FAILURE_RETENTION_DAYS = 30
+
+export function failureRetentionFrom(env: NodeJS.ProcessEnv): number {
+  const raw = (env.AF_FAILURE_RETENTION_DAYS ?? '').trim()
+  if (raw === '') return DEFAULT_FAILURE_RETENTION_DAYS
+  const days = Number(raw)
+  if (!Number.isInteger(days) || days < 1) {
+    throw new Error(
+      'AF_FAILURE_RETENTION_DAYS has to be a whole number of days, one or more. ' +
+        'Unset it to keep the default of ' +
+        DEFAULT_FAILURE_RETENTION_DAYS +
+        ' days.',
+    )
+  }
+  return days
+}
+
+/**
+ * What the page prints above the rows, from a count and the configuration.
+ *
+ * A PURE FUNCTION rather than three expressions inside the route, because the
+ * one field here that matters most cannot be exercised through the route at
+ * all: `atCap` needs five hundred groups in the table to turn true, so a route
+ * test can only ever watch it say false. A check that has only been seen say
+ * one thing has not been shown to be able to say the other, and `atCap` is the
+ * field that tells an operator the list below is shorter than the truth.
+ */
+export function statusOf(
+  groups: number,
+  config: { recording: boolean; cap: number; retentionDays: number | null },
+): { recording: boolean; groups: number; cap: number; atCap: boolean; retentionDays: number | null } {
+  return {
+    recording: config.recording,
+    groups,
+    cap: config.cap,
+    // At, not past. A table holding exactly `cap` groups is one that will
+    // refuse the next new fingerprint, and telling the operator only after it
+    // has already started losing them is telling them too late.
+    atCap: groups >= config.cap,
+    retentionDays: config.retentionDays,
+  }
+}
+
+/**
+ * What the store is actually doing on this installation, for the page to print.
+ *
+ * READ FROM THE ENVIRONMENT AT CALL TIME rather than captured at boot, because
+ * every value here is a fact about the process answering the request and the
+ * page says so. A rolling deploy has two revisions serving at once and they can
+ * disagree about all three.
+ *
+ * `retentionDays` is null when nothing sweeps, and the condition is the
+ * administrative connection string rather than the retention number. Migration
+ * 0042 gives the application role no DELETE, so the sweep runs on the
+ * maintenance credential; an installation without one keeps every group for
+ * good, and reporting the configured number there would be reporting a policy
+ * nothing enforces. That is the shape of lie this whole feature exists to
+ * avoid.
+ */
+export function failureStoreConfig(env: NodeJS.ProcessEnv): {
+  recording: boolean
+  cap: number
+  retentionDays: number | null
+} {
+  const sweeps = Boolean(env.AF_MAINTENANCE_DATABASE_URL ?? env.AF_MIGRATION_DATABASE_URL)
+  return {
+    recording: failureStoreEnabledFrom(env),
+    cap: DEFAULT_GROUP_CAP,
+    retentionDays: sweeps ? failureRetentionFrom(env) : null,
+  }
+}
+
+/**
+ * The driver's own code, from anywhere in the cause chain.
+ *
+ * WALKED RATHER THAN READ ONE LEVEL DOWN, and the two error handlers need
+ * different depths, which is why this is a function rather than a property
+ * access repeated twice. A Drizzle failure escaping a REST route arrives as
+ * `DrizzleQueryError` whose `cause` is the Postgres error, so one level finds
+ * `42P01`. The same failure inside a procedure arrives wrapped again, as
+ * `TRPCError` whose cause is the Drizzle error whose cause is the Postgres one,
+ * and one level finds nothing at all.
+ *
+ * Reading one level in both places is what the first version did, and the
+ * result was not an error: it was a null in the column that separates a missing
+ * table from a connection reset, on the arm that produces most of this control
+ * plane's failures. Every one of them would have fingerprinted into a single
+ * group per procedure.
+ *
+ * Bounded depth and a seen set, because a cause chain is a linked list built by
+ * whatever threw, and an error whose cause is itself would otherwise hang the
+ * error handler.
+ *
+ * It returns the FIRST string `code` it finds, so the caller decides where the
+ * walk starts. The tRPC handler starts at the cause rather than the error,
+ * because a TRPCError carries a `code` of its own which is the tRPC enum and is
+ * INTERNAL_SERVER_ERROR for every failure that reaches this store.
+ */
+export function providerCodeOf(err: unknown): string | null {
+  const seen = new Set<unknown>()
+  let current: unknown = err
+  for (let depth = 0; depth < 8 && current !== null && typeof current === 'object'; depth++) {
+    if (seen.has(current)) return null
+    seen.add(current)
+    const code = (current as { code?: unknown }).code
+    if (typeof code === 'string' && code !== '') return code
+    current = (current as { cause?: unknown }).cause
+  }
+  return null
+}

--- a/web/apps/api/src/maintenance.ts
+++ b/web/apps/api/src/maintenance.ts
@@ -51,6 +51,18 @@ export interface MaintenanceConfig {
    * and the counts stay.
    */
   analyticsRetentionDays?: number
+  /**
+   * Delete grouped control plane failures whose most recent occurrence is older
+   * than this many days. Undefined never deletes, which is the default for the
+   * same reason retentionMonths is.
+   *
+   * This bounds STALENESS, not size. Size is bounded by the group cap in
+   * failures.ts, which holds whether or not anything ever sweeps, so an
+   * installation with no administrative connection string configured keeps a
+   * bounded table of groups whose last occurrence may be old. The page prints
+   * the date rather than implying the failure is current.
+   */
+  failureRetentionDays?: number
   /** How often to run. */
   intervalMs?: number
   log?: (line: string) => void
@@ -67,6 +79,8 @@ export interface MaintenanceRun {
   /** Raw analytics events deleted by retention. */
   analyticsPruned: number
   usageOrganizations: number
+  /** Grouped control plane failures deleted by retention. */
+  failuresPruned: number
 }
 
 const DAY_MS = 24 * 60 * 60 * 1000
@@ -165,6 +179,28 @@ export async function runMaintenance(
     const usage = await admin<{ count: string }[]>`
       SELECT roll_up_environment_usage(${now.toISOString()}::timestamptz) AS count`
 
+    // The grouped record of the control plane's own failures.
+    //
+    // HERE RATHER THAN IN THE APPLICATION, because 0042 grants the application
+    // role no DELETE on purpose: a role reached through a request path should
+    // not be able to erase the record of what it did to get there. This
+    // connection owns the table.
+    //
+    // By last_seen_at and never by first_seen_at. A group first seen four
+    // months ago and last seen this morning is the most interesting row on the
+    // page, and sweeping by its age would delete exactly the long running
+    // failure an operator is trying to date.
+    let failuresPruned = 0
+    if (config.failureRetentionDays !== undefined) {
+      const gone = await admin<{ fingerprint: string }[]>`
+        DELETE FROM control_plane_failures
+        WHERE last_seen_at < ${new Date(
+          now.getTime() - config.failureRetentionDays * DAY_MS,
+        ).toISOString()}::timestamptz
+        RETURNING fingerprint`
+      failuresPruned = gone.length
+    }
+
     // Recruitment is separate from analytics and tenant usage. Personal
     // application details expire even if no operator has reviewed the queue.
     await admin`DELETE FROM recruitment_applications WHERE created_at < ${new Date(now.getTime() - 180 * DAY_MS).toISOString()}::timestamptz`
@@ -177,6 +213,7 @@ export async function runMaintenance(
       rolledUp: rolled.days,
       analyticsPruned: rolled.pruned,
       usageOrganizations: Number(usage[0]?.count ?? 0),
+      failuresPruned,
     }
   } finally {
     await admin.end({ timeout: 10 })

--- a/web/apps/api/src/metrics.ts
+++ b/web/apps/api/src/metrics.ts
@@ -231,6 +231,7 @@ export interface ControlPlaneMetrics {
   runVerdicts: Counter
   analyticsEvents: Counter
   analyticsRejections: Counter
+  controlPlaneFailures: Counter
 }
 
 export function createMetrics(version = 'dev'): ControlPlaneMetrics {
@@ -330,6 +331,29 @@ export function createMetrics(version = 'dev'): ControlPlaneMetrics {
         'Analytics events refused, by which rule refused them. The closed schema is only a '
         + 'guarantee if somebody can see it firing, and unknown_field is the one worth watching: '
         + 'it means a producer started sending something nobody declared.',
+      ),
+    ),
+
+    // The failure store's own view of itself, which is the only thing that can
+    // say the store is lying. Three of the four outcomes mean a number on the
+    // Logs page is lower than the truth, and a store that under-reports without
+    // saying so is worse than no store: an operator reads a small count during
+    // an incident and stops looking, which is the exact defect the Logs page
+    // header exists to prevent.
+    //
+    //   observed  every failure the two handlers saw, whether or not a store is
+    //             configured. Counted before anything else, so it is the
+    //             denominator the other three are read against.
+    //   dropped   the in-process buffer was full of other groups.
+    //   capped    the table is at its group cap, so a new group was refused.
+    //   failed    the write raised. These occurrences are retried, so this one
+    //             firing and then stopping is a database that came back.
+    controlPlaneFailures: registry.register(
+      new Counter(
+        'af_control_plane_failures_total',
+        'Failures the control plane caught in its own handlers, by what became of them: '
+        + 'observed, dropped, capped, or failed. Anything but observed means the grouped '
+        + 'store on the Logs page is counting fewer than actually happened.',
       ),
     ),
   }

--- a/web/apps/api/src/server.ts
+++ b/web/apps/api/src/server.ts
@@ -175,6 +175,12 @@ import {
   limitFor, bucketFor, bodyLimitFor, servedRoute, ENDPOINT_LIMITS, type EndpointLimit,
 } from './limits.ts'
 import { createMetrics, routeLabel, statusClass, type ControlPlaneMetrics } from './metrics.ts'
+import {
+  createFailureStore,
+  failureStoreEnabledFrom,
+  providerCodeOf,
+  type FailureStore,
+} from './failures.ts'
 import { apiNotFound } from './notfound.ts'
 import { engagedReason } from './admin/controls.ts'
 import {
@@ -312,6 +318,16 @@ export interface ServerOptions {
    *  gets its own, deliberately not module state: two servers in one process
    *  sharing counters means one test passes because of another. */
   metrics?: ControlPlaneMetrics
+  /**
+   * Where the grouped record of this process's own failures goes.
+   *
+   * Supplied by boot so that one store is shared with the flush timer, and by a
+   * test that wants to read what was recorded. Unset builds one over
+   * `options.pool`, which is what a test constructing a bare server gets, and
+   * `AF_FAILURE_STORE=off` makes it a store that accepts everything and writes
+   * nothing rather than an absent one, so no error handler has to check first.
+   */
+  failures?: FailureStore
   /**
    * The key organization surrogates are computed under.
    *
@@ -563,6 +579,19 @@ export function createServer(options: ServerOptions) {
   const secure = options.secureCookies ?? true
   const trustedProxyHops = options.trustedProxyHops ?? DEFAULT_TRUSTED_PROXY_HOPS
   const metrics = options.metrics ?? createMetrics(options.version ?? 'dev')
+
+  // The grouped record of this process's own failures. Built here rather than
+  // in boot so that a server constructed directly by a test has one too: an
+  // error handler whose store is undefined is an error handler that can fail
+  // while reporting a failure.
+  const failures =
+    options.failures ??
+    createFailureStore({
+      pool: failureStoreEnabledFrom(process.env) ? options.pool : null,
+      clock,
+      version: options.version ?? 'dev',
+      counter: metrics.controlPlaneFailures,
+    })
   const hostedRequiredPlan = options.hostedRequiredPlan ?? null
   const operatorSetsPlan = options.operatorSetsPlan ?? false
   // Every cross origin route on this server reads THIS, through matchSiteOrigin
@@ -608,14 +637,33 @@ export function createServer(options: ServerOptions) {
   // anything else a caller sent. This is the same reason the tRPC formatter
   // withholds the stack, applied to the member beside it.
   app.onError((err, c) => {
-    const cause = (err as { cause?: { code?: unknown } }).cause
     const requestId = c.get('requestId') ?? 'unassigned'
+    const kind = err instanceof Error ? err.name : typeof err
+    // Walked rather than read one level down, and the log line and the grouped
+    // store take the same answer from the same function. Two readers of one
+    // field is how a log line and a table come to disagree about which failure
+    // this was; see providerCodeOf for the depths involved.
+    const providerCode = providerCodeOf(err) ?? undefined
     console.error('unhandled request error', {
       requestId,
       method: c.req.method,
       route: c.req.routePath,
-      type: err instanceof Error ? err.name : typeof err,
-      providerCode: typeof cause?.code === 'string' ? cause.code : undefined,
+      type: kind,
+      providerCode,
+    })
+    // The same five fields the line above carries, grouped and counted where an
+    // operator with no log aggregation can read them. Deliberately the SAME
+    // fields: this handler already decided what is safe to write down, and the
+    // reason is on the comment above it. The route is the declared key rather
+    // than `c.req.routePath`, so that this and af_http_requests_total name a
+    // route the same way and a count here can be read against a rate there.
+    failures.record({
+      source: 'http',
+      route: routeLabel(c.req.method, new URL(c.req.url).pathname, declaredRoutes),
+      method: c.req.method,
+      kind,
+      providerCode: providerCode ?? null,
+      requestId,
     })
     c.header('x-request-id', requestId)
     return c.json(
@@ -3489,6 +3537,32 @@ export function createServer(options: ServerOptions) {
           },
           error.cause ?? error,
         )
+        // Grouped beside the line, as on app.onError.
+        //
+        // NOT `error.cause ?? error` as the line above passes to console: that
+        // is the whole error object, and the store takes a class name. The name
+        // comes off the cause when there is one, because a TRPCError wrapping a
+        // Postgres failure is a TRPCError under every group and useless as a
+        // fingerprint, while the cause's name separates a unique violation from
+        // a connection reset.
+        //
+        // The procedure path is the route. It is bounded by the router, which
+        // is the same property routeLabel gives the HTTP side.
+        const cause = error.cause as { name?: unknown } | undefined
+        failures.record({
+          source: 'trpc',
+          route: path ?? 'unknown',
+          method: type,
+          kind: typeof cause?.name === 'string' ? cause.name : error.name,
+          // From the CAUSE and not from the error. A TRPCError carries a
+          // `code` of its own, which is the tRPC enum and is
+          // INTERNAL_SERVER_ERROR for every one of these, so walking from the
+          // error would put that constant in the driver code column of every
+          // row and the fingerprint would lose the only field separating a
+          // missing table from a connection reset.
+          providerCode: providerCodeOf(error.cause),
+          requestId: ctx?.requestId ?? null,
+        })
       },
       createContext: async (_opts, c) => {
         const token = readCookie(c.req.header('cookie'), SESSION_COOKIE)
@@ -3590,7 +3664,7 @@ export function createServer(options: ServerOptions) {
     })
   }
 
-  return { app, ingestLimiter, authLimiter, metrics, analytics }
+  return { app, ingestLimiter, authLimiter, metrics, analytics, failures }
 }
 
 /**

--- a/web/apps/api/test/adminoperations.test.ts
+++ b/web/apps/api/test/adminoperations.test.ts
@@ -491,6 +491,94 @@ describe('the operations routes', { skip: hasDb ? false : 'no database' }, () =>
    * The gate
    * ------------------------------------------------------------------ */
 
+  /* -----------------------------------------------------------------------
+   * The control plane's own failures
+   * -------------------------------------------------------------------- */
+
+  test('the store route returns a group and says what the store is doing', async () => {
+    // Seeded through the store that ships rather than by INSERT, so this is a
+    // test of the route reading what the writer wrote. Two of them at the same
+    // instant as everything else here, so the window filter below is being
+    // asked the question it is for.
+    const { createFailureStore } = await import('../src/failures.ts')
+    const store = createFailureStore({ pool: h.pool, clock: h.clock, version: 'v-test' })
+    store.record({
+      source: 'http',
+      route: 'POST /v1/events',
+      method: 'POST',
+      kind: 'DrizzleQueryError',
+      providerCode: '23514',
+      requestId: 'req-seeded',
+    })
+    store.record({
+      source: 'http',
+      route: 'POST /v1/events',
+      method: 'POST',
+      kind: 'DrizzleQueryError',
+      providerCode: '23514',
+      requestId: 'req-seeded',
+    })
+    assert.deepEqual(await store.flush(), { applied: 1, capped: 0, failed: 0 })
+
+    const caller = await callerFor('infrastructure')
+    const view = await caller.admin.operations.failures.store({ hours: 24 })
+
+    const group = view.failures.find((f) => f.route === 'POST /v1/events')
+    assert.ok(group, 'the group the store just wrote is not in the answer')
+    assert.equal(group.occurrences, 2, 'two occurrences are one group of two')
+    assert.equal(group.kind, 'DrizzleQueryError')
+    assert.equal(group.providerCode, '23514')
+    assert.equal(group.firstSeenVersion, 'v-test')
+    assert.equal(group.lastRequestId, 'req-seeded')
+
+    // The status half. Without it a short list looks the same whether nothing
+    // failed or nothing was recorded, and those are opposite facts.
+    assert.equal(view.status.recording, true)
+    assert.ok(view.status.groups >= 1)
+    assert.equal(view.status.atCap, false)
+    assert.ok(view.status.cap > view.status.groups)
+  })
+
+  test('the window is a filter here too, not decoration', async () => {
+    // The same defect the overview route had: a window that is read and not
+    // applied returns everything and looks entirely reasonable doing it.
+    const { createFailureStore } = await import('../src/failures.ts')
+    const { FakeClock } = await import('../src/clock.ts')
+    const old = createFailureStore({
+      pool: h.pool,
+      // A year before the harness clock, which is what the route's own window
+      // is computed from.
+      clock: new FakeClock(new Date(h.clock.now().getTime() - 365 * 24 * 3600 * 1000)),
+      version: 'v-old',
+    })
+    old.record({
+      source: 'trpc',
+      route: 'a.route.that.stopped.failing',
+      method: 'query',
+      kind: 'TypeError',
+      providerCode: null,
+      requestId: null,
+    })
+    await old.flush()
+
+    const caller = await callerFor('infrastructure')
+    const recent = await caller.admin.operations.failures.store({ hours: 24 })
+    assert.equal(
+      recent.failures.some((f) => f.route === 'a.route.that.stopped.failing'),
+      false,
+      'a group last seen a year ago is inside the last day',
+    )
+
+    // And it is still there, which is what makes the absence above a filter
+    // rather than a store that lost the row.
+    const wide = await caller.admin.operations.failures.store({ hours: 168 })
+    assert.ok(wide.status.groups >= 1)
+    const [kept] = await h.admin<{ n: string }[]>`
+      SELECT count(*) AS n FROM control_plane_failures
+      WHERE route = 'a.route.that.stopped.failing'`
+    assert.equal(Number(kept!.n), 1)
+  })
+
   test('a role without the permission is refused rather than answered', async () => {
     const caller = await callerFor('analytics')
     await assert.rejects(
@@ -501,6 +589,14 @@ describe('the operations routes', { skip: hasDb ? false : 'no database' }, () =>
     await assert.rejects(
       () => caller.admin.operations.email.status({ hours: 168 }),
       (err: { message?: string }) => /admin\.email\.read/.test(err.message ?? ''),
+    )
+    // The new route is on the same permission and is asserted separately
+    // rather than assumed: a route added without a guard is the way access
+    // control actually breaks here, and the two above passing says nothing
+    // about a third.
+    await assert.rejects(
+      () => caller.admin.operations.failures.store({ hours: 24 }),
+      (err: { message?: string }) => /admin\.logs\.read/.test(err.message ?? ''),
     )
   })
 

--- a/web/apps/api/test/failures-endtoend.test.ts
+++ b/web/apps/api/test/failures-endtoend.test.ts
@@ -1,0 +1,170 @@
+// The failure store is reachable from a real failure, on both arms.
+//
+// WHY THIS FILE EXISTS SEPARATELY FROM failures.test.ts. That file proves the
+// store behaves. This one proves it is WIRED: that a request which genuinely
+// fails reaches `record`, through the handler that ships, with the fields the
+// handler chose rather than the fields a test passed in by hand. A store with a
+// correct upsert and no caller is a dead shippable gap that looks exactly like
+// a working feature, and this repository has shipped that shape before.
+//
+// So the failures here are real ones, produced the way the two existing suites
+// produce them: a CHECK constraint that cannot pass, and a table renamed out
+// from under a route. Nothing throws a fixture.
+
+import { after, before, describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { randomUUID, createHash } from 'node:crypto'
+import {
+  dropOrg,
+  seedOrg,
+  signInAs,
+  startApi,
+  available,
+  type ApiHarness,
+  type Org,
+} from './harness.ts'
+
+const hasDatabase = await available()
+
+describe('a real failure reaches the grouped store', { skip: hasDatabase ? false : 'no Postgres at AF_TEST_DATABASE_URL' }, () => {
+  let h: ApiHarness
+  let org: Org
+  let token: string
+
+  before(async () => {
+    h = await startApi()
+    org = await seedOrg(h.admin, 'failwire')
+    token = `aft_${randomUUID().replace(/-/g, '')}`
+    await h.admin`
+      INSERT INTO engine_tokens (org_id, name, token_hash, prefix)
+      VALUES (${org.orgId}, 'ci', ${createHash('sha256').update(token).digest()}, 'aft_test')`
+  })
+
+  after(async () => {
+    if (org) await dropOrg(h.admin, org.orgId)
+    if (h) await h.close()
+  })
+
+  async function rows() {
+    return h.admin`
+      SELECT source, route, method, kind, provider_code, occurrences, last_request_id
+      FROM control_plane_failures ORDER BY route`
+  }
+
+  it('through the HTTP handler, with the declared route and the driver code', async () => {
+    await h.admin`DELETE FROM control_plane_failures`
+    await h.admin`ALTER TABLE events ADD CONSTRAINT wire_forced_failure CHECK (false) NOT VALID`
+    let requestId: string | null
+    try {
+      const response = await h.fetch('/v1/events', {
+        method: 'POST',
+        headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+        body: JSON.stringify({
+          events: [
+            {
+              id: randomUUID(),
+              type: 'environment.ready',
+              envId: org.envId,
+              sequence: 1,
+              // The harness clock, not the wall clock. Ingestion refuses an
+              // event whose stamp is too far from now, and a refusal is a 207
+              // with a per-event reason rather than the escaped failure this
+              // test is aimed at.
+              occurredAt: h.clock.now().toISOString(),
+              payload: {},
+            },
+          ],
+        }),
+      })
+      assert.equal(response.status, 500, 'the request under test did not actually fail')
+      requestId = response.headers.get('x-request-id')
+    } finally {
+      await h.admin`ALTER TABLE events DROP CONSTRAINT wire_forced_failure`
+    }
+
+    // Nothing is written until the flush, which is the whole design: the error
+    // path never touches the network. Asserting the table is empty first is
+    // what makes the assertion after the flush mean something.
+    assert.equal((await rows()).length, 0, 'the error path wrote to the database inline')
+    await h.failures.flush()
+
+    const found = await rows()
+    assert.equal(found.length, 1)
+    const row = found[0]!
+    assert.equal(row.source, 'http')
+    // The DECLARED route key, not the path. A path here would mean an
+    // unbounded label, which is the defect routeLabel exists to prevent and
+    // which this table would turn into unbounded rows.
+    assert.equal(row.route, 'POST /v1/events')
+    assert.equal(row.method, 'POST')
+    // 23514 is check_violation. The driver's own code is what separates a
+    // constraint failure from a connection reset on the same route, and it is
+    // the field a fingerprint most needs.
+    assert.equal(row.provider_code, '23514')
+    assert.equal(Number(row.occurrences), 1)
+    assert.equal(row.last_request_id, requestId)
+
+    // And the boundary. The statement that failed carried the event payload,
+    // and none of it is here.
+    const everything = JSON.stringify(found)
+    assert.ok(!everything.includes('Failed query'), `the driver wrapper was stored: ${everything}`)
+    assert.ok(!everything.includes('SELECT'), `a statement was stored: ${everything}`)
+    assert.ok(!everything.includes('INSERT'), `a statement was stored: ${everything}`)
+    assert.ok(!everything.includes(org.orgId), `an organization was stored: ${everything}`)
+  })
+
+  it('through the tRPC handler, grouped by the procedure and the cause', async () => {
+    await h.admin`DELETE FROM control_plane_failures`
+    const member = await signInAs(h, org, 'owner')
+    await h.admin.unsafe('ALTER TABLE environments RENAME TO environments_moved')
+    try {
+      const response = await h.fetch(
+        `/trpc/environments.list?input=${encodeURIComponent(JSON.stringify({ limit: 5 }))}`,
+        { headers: { cookie: member.cookie } },
+      )
+      assert.equal(response.status, 500, 'the request under test did not actually fail')
+    } finally {
+      await h.admin.unsafe('ALTER TABLE environments_moved RENAME TO environments')
+    }
+
+    await h.failures.flush()
+    const found = await rows()
+    assert.equal(found.length, 1)
+    const row = found[0]!
+    assert.equal(row.source, 'trpc')
+    // The procedure path, which the router bounds. Not "trpc", which every
+    // tRPC failure on the installation would share.
+    assert.equal(row.route, 'environments.list')
+    assert.equal(row.method, 'query')
+    // The CAUSE's class, not TRPCError. Every internal tRPC failure is a
+    // TRPCError, so fingerprinting on it would put a missing table and a
+    // connection reset in the same group.
+    assert.notEqual(row.kind, 'TRPCError')
+    assert.equal(row.provider_code, '42P01')
+  })
+
+  it('two occurrences of the same failure are one group with a count of two', async () => {
+    // The property the whole table depends on. If this were two rows, the
+    // store's size would be a function of how badly the day is going, which is
+    // the disk exhaustion this design exists to avoid.
+    await h.admin`DELETE FROM control_plane_failures`
+    const member = await signInAs(h, org, 'owner')
+    await h.admin.unsafe('ALTER TABLE environments RENAME TO environments_moved')
+    try {
+      for (let i = 0; i < 2; i++) {
+        const response = await h.fetch(
+          `/trpc/environments.list?input=${encodeURIComponent(JSON.stringify({ limit: 5 }))}`,
+          { headers: { cookie: member.cookie } },
+        )
+        assert.equal(response.status, 500)
+      }
+    } finally {
+      await h.admin.unsafe('ALTER TABLE environments_moved RENAME TO environments')
+    }
+
+    await h.failures.flush()
+    const found = await rows()
+    assert.equal(found.length, 1, 'a second occurrence created a second row')
+    assert.equal(Number(found[0]!.occurrences), 2)
+  })
+})

--- a/web/apps/api/test/failures.test.ts
+++ b/web/apps/api/test/failures.test.ts
@@ -1,0 +1,451 @@
+// The grouped store of the control plane's own failures.
+//
+// WHAT EACH TEST IS AIMED AT. This store's failure modes are all quiet ones: it
+// under-reports and the page still looks like an answer. So every test here is
+// pointed at a specific way a number could be lower than the truth without
+// anybody noticing, and the database-backed half of the file is written against
+// real SQL because the two properties that matter most, the cap and the
+// monotonic timestamps, live in one statement and cannot be checked anywhere
+// else.
+
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import postgres from 'postgres'
+import { createPool, migrate, type Pool } from '@antifailure/db'
+import {
+  DEFAULT_FAILURE_RETENTION_DAYS,
+  createFailureStore,
+  failureRetentionFrom,
+  failureStoreConfig,
+  failureStoreEnabledFrom,
+  fingerprintOf,
+  statusOf,
+  type Failure,
+} from '../src/failures.ts'
+import { runMaintenance } from '../src/maintenance.ts'
+import { Counter } from '../src/metrics.ts'
+import { FakeClock } from '../src/clock.ts'
+import { adminUrl, appUrl, available } from './harness.ts'
+
+function failure(over: Partial<Failure> = {}): Failure {
+  return {
+    source: 'http',
+    route: 'GET /v1/environments/:envId',
+    method: 'GET',
+    kind: 'DrizzleQueryError',
+    providerCode: '42501',
+    requestId: 'req-1',
+    ...over,
+  }
+}
+
+/* -------------------------------------------------------------------------
+ * The fingerprint
+ * ---------------------------------------------------------------------- */
+
+describe('the fingerprint', () => {
+  it('is the same for the same failure and different for every field that differs', () => {
+    const base = fingerprintOf(failure())
+    assert.equal(base, fingerprintOf(failure({ requestId: 'req-99' })))
+
+    // One break per assertion: `assert` stops at the first failure, so five
+    // separate statements is five separate reports rather than one.
+    assert.notEqual(base, fingerprintOf(failure({ source: 'trpc' })))
+    assert.notEqual(base, fingerprintOf(failure({ method: 'POST' })))
+    assert.notEqual(base, fingerprintOf(failure({ route: 'GET /v1/runs/:runId' })))
+    assert.notEqual(base, fingerprintOf(failure({ kind: 'TypeError' })))
+    assert.notEqual(base, fingerprintOf(failure({ providerCode: '23505' })))
+    assert.notEqual(base, fingerprintOf(failure({ providerCode: null })))
+  })
+
+  it('cannot be made to collide by moving a character from one field to the next', () => {
+    // The reading a collision produces is the worst this feature can produce: a
+    // failure that looks like it stopped, because its occurrences are being
+    // added to somebody else's row. A separator, any separator, is a character
+    // some field might one day carry.
+    const a = fingerprintOf(failure({ route: 'AB', kind: 'C' }))
+    const b = fingerprintOf(failure({ route: 'A', kind: 'BC' }))
+    assert.notEqual(a, b)
+
+    const c = fingerprintOf(failure({ route: 'A\nB', kind: 'C' }))
+    const d = fingerprintOf(failure({ route: 'A', kind: 'B\nC' }))
+    assert.notEqual(c, d)
+  })
+})
+
+/* -------------------------------------------------------------------------
+ * The buffer, with no database
+ * ---------------------------------------------------------------------- */
+
+describe('the in-process buffer', () => {
+  function store(over: Parameters<typeof createFailureStore>[0]['bufferCap'] = undefined) {
+    const counter = new Counter('af_control_plane_failures_total', 'test')
+    const s = createFailureStore({
+      pool: null,
+      clock: new FakeClock(),
+      version: 'test',
+      counter,
+      ...(over === undefined ? {} : { bufferCap: over }),
+    })
+    return { s, counter }
+  }
+
+  it('counts every failure as observed even when there is nowhere to write it', () => {
+    const { s, counter } = store()
+    assert.equal(s.enabled, false)
+    s.record(failure())
+    s.record(failure())
+    // The denominator. Without it, a store that is switched off and a control
+    // plane that is not failing produce the identical absence.
+    assert.equal(counter.get({ outcome: 'observed' }), 2)
+    assert.equal(s.buffered(), 0)
+  })
+
+  it('drops a NEW group at a full buffer and lets an existing one keep counting', async () => {
+    // Both halves matter and they fail differently. Dropping the new one is the
+    // bound; letting the existing one keep counting is what stops a full buffer
+    // reading as an outage that ended.
+    const pool = fakePool()
+    const counter = new Counter('af_control_plane_failures_total', 'test')
+    const s = createFailureStore({
+      pool: pool.pool,
+      clock: new FakeClock(),
+      version: 'test',
+      counter,
+      bufferCap: 2,
+    })
+
+    s.record(failure({ route: 'A' }))
+    s.record(failure({ route: 'B' }))
+    assert.equal(s.buffered(), 2)
+
+    s.record(failure({ route: 'C' }))
+    assert.equal(s.buffered(), 2, 'a third distinct group must not be admitted')
+    assert.equal(counter.get({ outcome: 'dropped' }), 1)
+
+    s.record(failure({ route: 'A' }))
+    assert.equal(s.buffered(), 2)
+    await s.flush()
+    const a = pool.written.find((w) => w.route === 'A')
+    assert.equal(a?.count, 2, 'an existing group keeps counting at a full buffer')
+  })
+
+  it('clamps a field past its column bound rather than letting the batch be refused', async () => {
+    const pool = fakePool()
+    const s = createFailureStore({
+      pool: pool.pool,
+      clock: new FakeClock(),
+      version: 'test',
+    })
+    s.record(failure({ kind: 'K'.repeat(400) }))
+    await s.flush()
+    // 100 is the CHECK constraint in migration 0042. Over it, the flush raises
+    // 23514 and takes every other group in the batch with it.
+    assert.equal(pool.written[0]?.kind.length, 100)
+  })
+})
+
+/* -------------------------------------------------------------------------
+ * Orderings, with a pool that can be made to fail
+ * ---------------------------------------------------------------------- */
+
+/**
+ * A pool that records what the store asked it to write and can be told to
+ * raise.
+ *
+ * Deliberately not a real database for these three: what is under test is the
+ * ORDER of events around a flush, and a real database makes the interesting
+ * orderings hard to reach and the assertions about them indirect.
+ */
+/**
+ * The values the store bound into one upsert, read positionally.
+ *
+ * A drizzle `sql` template holds its literal text as StringChunk objects and
+ * its interpolated values as the values themselves, so the parameters are
+ * every chunk that is not a StringChunk, in order.
+ *
+ * THE LENGTH CHECK IS THE POINT. Reading index 2 out of a list this fake
+ * guessed the shape of is exactly the kind of instrument that answers a nearby
+ * question: if `writeGroup` ever binds a value in a different place, every
+ * assertion below would go on comparing the wrong field against the right
+ * answer and passing. Fourteen is what failures.ts binds, and being wrong about
+ * it has to be a failure rather than a silence.
+ */
+function paramsOf(query: unknown): { route: string; kind: string; count: number } {
+  const chunks = (query as { queryChunks?: unknown[] }).queryChunks
+  assert.ok(Array.isArray(chunks), 'the store did not pass a drizzle sql template')
+  const params = chunks.filter((c) => c === null || typeof c !== 'object')
+  assert.equal(
+    params.length,
+    14,
+    'writeGroup binds a different number of values than this fake reads positions from',
+  )
+  return { route: String(params[2]), kind: String(params[4]), count: Number(params[6]) }
+}
+
+function fakePool() {
+  const written: { route: string; kind: string; count: number }[] = []
+  let raise = false
+  let onWrite: (() => void) | null = null
+  const pool = {
+    async withoutTenant<T>(fn: (db: unknown) => Promise<T>): Promise<T> {
+      return fn({
+        async execute(query: unknown) {
+          if (raise) throw new Error('the database did not answer')
+          written.push(paramsOf(query))
+          onWrite?.()
+          return [{ fingerprint: 'x' }]
+        },
+      } as unknown as Parameters<typeof fn>[0])
+    },
+  } as unknown as Pool
+  return {
+    pool,
+    written,
+    fail(on: boolean) {
+      raise = on
+    },
+    duringWrite(fn: (() => void) | null) {
+      onWrite = fn
+    },
+  }
+}
+
+describe('the orderings around a flush', () => {
+  it('a flush with nothing buffered writes nothing and says so', async () => {
+    const pool = fakePool()
+    const s = createFailureStore({ pool: pool.pool, clock: new FakeClock(), version: 'v' })
+    assert.deepEqual(await s.flush(), { applied: 0, capped: 0, failed: 0 })
+    assert.equal(pool.written.length, 0)
+  })
+
+  it('a failed flush holds the occurrences and the next one writes all of them', async () => {
+    // The ordering that matters most: the control plane's database being
+    // unreachable is exactly when every request fails, so shedding the buffer
+    // there would discard the shape of the outage the store exists to record.
+    const pool = fakePool()
+    const counter = new Counter('af_control_plane_failures_total', 'test')
+    const s = createFailureStore({
+      pool: pool.pool,
+      clock: new FakeClock(),
+      version: 'v',
+      counter,
+    })
+
+    pool.fail(true)
+    s.record(failure())
+    s.record(failure())
+    const first = await s.flush()
+    assert.equal(first.failed, 1)
+    assert.equal(pool.written.length, 0)
+    assert.equal(counter.get({ outcome: 'failed' }), 2)
+    assert.equal(s.buffered(), 1, 'the group is back in the buffer')
+
+    pool.fail(false)
+    s.record(failure())
+    const second = await s.flush()
+    assert.equal(second.applied, 1)
+    assert.equal(pool.written[0]?.count, 3, 'nothing was lost and nothing was double counted')
+    assert.equal(s.buffered(), 0)
+  })
+
+  it('a failure arriving DURING a flush is written by the next one, exactly once', async () => {
+    // The buffer is swapped rather than drained for this. Draining would let an
+    // arrival land in the map being iterated, which is either lost or counted
+    // twice depending on where the iterator was.
+    const pool = fakePool()
+    const s = createFailureStore({ pool: pool.pool, clock: new FakeClock(), version: 'v' })
+    s.record(failure())
+    pool.duringWrite(() => s.record(failure()))
+    await s.flush()
+    assert.equal(pool.written[0]?.count, 1)
+
+    pool.duringWrite(null)
+    await s.flush()
+    assert.equal(pool.written.length, 2)
+    assert.equal(pool.written[1]?.count, 1, 'the arrival is written once, not twice and not never')
+  })
+})
+
+/* -------------------------------------------------------------------------
+ * Configuration
+ * ---------------------------------------------------------------------- */
+
+describe('the configuration', () => {
+  it('records by default and stops only when told to', () => {
+    assert.equal(failureStoreEnabledFrom({}), true)
+    assert.equal(failureStoreEnabledFrom({ AF_FAILURE_STORE: 'off' }), false)
+    assert.equal(failureStoreEnabledFrom({ AF_FAILURE_STORE: '0' }), false)
+    assert.equal(failureStoreEnabledFrom({ AF_FAILURE_STORE: 'on' }), true)
+  })
+
+  it('refuses a retention that is not a whole number of days rather than picking one', () => {
+    assert.equal(failureRetentionFrom({}), DEFAULT_FAILURE_RETENTION_DAYS)
+    assert.equal(failureRetentionFrom({ AF_FAILURE_RETENTION_DAYS: '7' }), 7)
+    assert.throws(() => failureRetentionFrom({ AF_FAILURE_RETENTION_DAYS: '0' }))
+    assert.throws(() => failureRetentionFrom({ AF_FAILURE_RETENTION_DAYS: 'a week' }))
+  })
+
+  it('says the store is full at the cap and not one group later', () => {
+    // The field an operator reads to know the list below is shorter than the
+    // truth. It cannot be exercised through the route, which would need five
+    // hundred groups in the table, so it is asserted here in both directions.
+    const config = { recording: true, cap: 500, retentionDays: 30 }
+    assert.equal(statusOf(499, config).atCap, false)
+    assert.equal(statusOf(500, config).atCap, true)
+    assert.equal(statusOf(501, config).atCap, true)
+    assert.equal(statusOf(0, { ...config, recording: false }).recording, false)
+    assert.equal(statusOf(0, { ...config, retentionDays: null }).retentionDays, null)
+  })
+
+  it('reports no retention at all when nothing on the installation can sweep', () => {
+    // The page prints this, and printing a configured number that nothing
+    // enforces is the shape of lie the whole feature exists to avoid. The
+    // application role has no DELETE, so the sweep needs the maintenance
+    // credential and its absence is the real answer.
+    assert.equal(failureStoreConfig({}).retentionDays, null)
+    assert.equal(
+      failureStoreConfig({ AF_MAINTENANCE_DATABASE_URL: 'postgres://x' }).retentionDays,
+      DEFAULT_FAILURE_RETENTION_DAYS,
+    )
+    assert.equal(
+      failureStoreConfig({ AF_MIGRATION_DATABASE_URL: 'postgres://x' }).retentionDays,
+      DEFAULT_FAILURE_RETENTION_DAYS,
+    )
+  })
+})
+
+/* -------------------------------------------------------------------------
+ * The statement itself
+ * ---------------------------------------------------------------------- */
+
+describe('the upsert, against real SQL', { skip: (await available()) ? false : 'no Postgres at AF_TEST_DATABASE_URL' }, () => {
+  let admin: postgres.Sql
+  let pool: Pool
+
+  before(async () => {
+    admin = postgres(adminUrl, { max: 2, onnotice: () => {} })
+    await migrate(admin)
+    await admin.unsafe(`ALTER ROLE antifailure_app LOGIN PASSWORD 'app-test-password'`)
+    pool = createPool({ url: appUrl(), max: 3 })
+  })
+
+  after(async () => {
+    await pool.close()
+    await admin.end({ timeout: 5 })
+  })
+
+  async function clear() {
+    await admin`DELETE FROM control_plane_failures`
+  }
+
+  function storeAt(at: string, version = 'v1', groupCap?: number) {
+    return createFailureStore({
+      pool,
+      clock: new FakeClock(at),
+      version,
+      ...(groupCap === undefined ? {} : { groupCap }),
+    })
+  }
+
+  it('adds occurrences to a group rather than replacing it', async () => {
+    await clear()
+    const a = storeAt('2026-01-01T00:00:00.000Z')
+    a.record(failure())
+    a.record(failure())
+    await a.flush()
+
+    const b = storeAt('2026-01-01T00:05:00.000Z')
+    b.record(failure())
+    await b.flush()
+
+    const rows = await admin`SELECT occurrences, first_seen_at, last_seen_at FROM control_plane_failures`
+    assert.equal(rows.length, 1)
+    assert.equal(Number(rows[0]!.occurrences), 3)
+    assert.equal(new Date(rows[0]!.first_seen_at).toISOString(), '2026-01-01T00:00:00.000Z')
+    assert.equal(new Date(rows[0]!.last_seen_at).toISOString(), '2026-01-01T00:05:00.000Z')
+  })
+
+  it('never moves last seen backwards, however late a replica flushes', async () => {
+    // Several replicas write this table and a slow one can flush a batch that
+    // is minutes old. Without GREATEST, that batch would relabel the group as
+    // last seen in the past, which reads as a failure that has stopped.
+    await clear()
+    const now = storeAt('2026-01-01T12:00:00.000Z', 'v2')
+    now.record(failure({ requestId: 'newest' }))
+    await now.flush()
+
+    const late = storeAt('2026-01-01T11:00:00.000Z', 'v1')
+    late.record(failure({ requestId: 'older' }))
+    await late.flush()
+
+    const rows = await admin`
+      SELECT last_seen_at, first_seen_at, last_request_id, last_seen_version, first_seen_version
+      FROM control_plane_failures`
+    assert.equal(new Date(rows[0]!.last_seen_at).toISOString(), '2026-01-01T12:00:00.000Z')
+    assert.equal(rows[0]!.last_request_id, 'newest')
+    assert.equal(rows[0]!.last_seen_version, 'v2')
+    // The older flush DOES move first seen and the build that first produced
+    // it, which is the half that is supposed to move.
+    assert.equal(new Date(rows[0]!.first_seen_at).toISOString(), '2026-01-01T11:00:00.000Z')
+    assert.equal(rows[0]!.first_seen_version, 'v1')
+  })
+
+  it('refuses a NEW group at the cap and keeps counting the ones already there', async () => {
+    // Both halves in one test because the statement is one statement, and the
+    // first version of it tested only the count, so at the cap EVERY group
+    // stopped counting. On a page that reads as an incident that ended.
+    await clear()
+    const capped = storeAt('2026-01-01T00:00:00.000Z', 'v1', 2)
+    capped.record(failure({ route: 'A' }))
+    capped.record(failure({ route: 'B' }))
+    await capped.flush()
+    assert.equal(Number((await admin`SELECT count(*) AS n FROM control_plane_failures`)[0]!.n), 2)
+
+    const more = storeAt('2026-01-01T00:01:00.000Z', 'v1', 2)
+    more.record(failure({ route: 'C' }))
+    more.record(failure({ route: 'A' }))
+    const result = await more.flush()
+
+    assert.equal(result.capped, 1, 'the new group is refused')
+    assert.equal(result.applied, 1, 'the existing group is not')
+    const rows = await admin`SELECT route, occurrences FROM control_plane_failures ORDER BY route`
+    assert.deepEqual(rows.map((r) => r.route), ['A', 'B'])
+    assert.equal(Number(rows[0]!.occurrences), 2, 'A kept counting past the cap')
+  })
+
+  it('sweeps by the last occurrence and not the first', async () => {
+    // A group first seen four months ago and last seen this morning is the most
+    // interesting row on the page. Sweeping by its age would delete exactly the
+    // long running failure an operator is trying to date.
+    await clear()
+    const old = storeAt('2026-01-01T00:00:00.000Z')
+    old.record(failure({ route: 'gone' }))
+    await old.flush()
+
+    const longRunning = storeAt('2026-01-01T00:00:00.000Z')
+    longRunning.record(failure({ route: 'kept' }))
+    await longRunning.flush()
+    const stillHappening = storeAt('2026-06-01T00:00:00.000Z')
+    stillHappening.record(failure({ route: 'kept' }))
+    await stillHappening.flush()
+
+    const run = await runMaintenance(
+      { adminUrl, failureRetentionDays: 30, log: () => {} },
+      new FakeClock('2026-06-02T00:00:00.000Z'),
+    )
+    assert.equal(run.failuresPruned, 1)
+    const rows = await admin`SELECT route FROM control_plane_failures`
+    assert.deepEqual(rows.map((r) => r.route), ['kept'])
+  })
+
+  it('keeps everything when no retention is configured', async () => {
+    await clear()
+    const old = storeAt('2020-01-01T00:00:00.000Z')
+    old.record(failure({ route: 'ancient' }))
+    await old.flush()
+    const run = await runMaintenance({ adminUrl, log: () => {} }, new FakeClock('2026-06-02T00:00:00.000Z'))
+    assert.equal(run.failuresPruned, 0)
+    assert.equal(Number((await admin`SELECT count(*) AS n FROM control_plane_failures`)[0]!.n), 1)
+  })
+})

--- a/web/apps/api/test/harness.ts
+++ b/web/apps/api/test/harness.ts
@@ -74,6 +74,10 @@ export interface ApiHarness {
   /** The same recorder the server's own producers use, so a test asserts
    *  against what shipped rather than against a second one it built. */
   analytics: ReturnType<typeof createServer>['analytics']
+  /** The same grouped failure store the server's own error handlers write to,
+   *  for the same reason `analytics` is the real one: a suite asserting against
+   *  a store it built itself proves nothing about the store that ships. */
+  failures: ReturnType<typeof createServer>['failures']
   admin: postgres.Sql
   pool: Pool
   /**
@@ -260,7 +264,7 @@ export async function startApi(options: StartApiOptions = {}): Promise<ApiHarnes
   const clock = new FakeClock()
   const github = new FakeGitHub(clock)
   const mailer = new RecordingMailer()
-  const { app, analytics } = createServer({
+  const { app, analytics, failures } = createServer({
     pool,
     adminPool,
     github,
@@ -311,6 +315,7 @@ export async function startApi(options: StartApiOptions = {}): Promise<ApiHarnes
   return {
     app,
     analytics,
+    failures,
     admin,
     pool,
     adminPool,

--- a/web/packages/db/migrations/0042_the_control_plane_could_not_say_what_had_failed.sql
+++ b/web/packages/db/migrations/0042_the_control_plane_could_not_say_what_had_failed.sql
@@ -1,0 +1,168 @@
+-- The control plane counted its own failures and could not say what any of them was.
+--
+-- THE FAILURE THIS EXISTS FOR. `af_http_requests_total{status_class="5xx"}`
+-- goes up. That is the whole of what an operator can see. The line that says
+-- WHICH route, WHICH error class and WHICH driver code went to stdout, where it
+-- is one line among the day's traffic in a container's log buffer. On the
+-- hosted control plane that is shipped somewhere searchable. A self hoster
+-- running this container against their own Postgres, with no Log Analytics and
+-- no Grafana, has `docker logs`, no aggregation, no count, no first seen, and
+-- therefore no answer to the two questions an operator opens a portal with:
+-- what is failing right now, and did it start when we deployed.
+--
+-- The Logs & Error Explorer says in its own header that this product has no
+-- error group, no fingerprint and no occurrence counter, and that inventing one
+-- would be worse than having none. That statement is correct about the ENGINE's
+-- exceptions, which would need the engine to report them. It was also true of
+-- the control plane's own failures, and those need nothing from anybody: the
+-- process already catches every one of them in two handlers that already
+-- decided what is safe to write down.
+--
+-- WHY THIS IS AN AGGREGATE AND NOT A LOG LINE STORE.
+--
+-- A row per occurrence is a table whose size is set by how badly the
+-- installation is behaving, which is the worst possible coupling: the day the
+-- control plane starts failing is the day its disk fills. One row per
+-- FINGERPRINT is bounded by the code instead. The fingerprint is built from the
+-- declared route key, the HTTP method, the error class name and the driver's
+-- own code, and each of those is a bounded vocabulary that ships in the
+-- container. A busy day adds occurrences to existing rows and no rows.
+--
+-- The cap and the retention below are belt and braces on top of that, because
+-- "bounded by the code" is an argument and a LIMIT is a fact.
+--
+-- WHAT NEVER ENTERS THIS TABLE, and where the boundary is enforced.
+--
+-- Not the error message. Not the stack. Not the request body, the query string,
+-- the parameters or any payload. Not an org_id, a user id, an email or an
+-- environment. The reason is written on `app.onError` in server.ts already, and
+-- it is specific rather than general: Drizzle writes a query failure as
+-- "Failed query: <the whole statement>" with the parameters after it, so an
+-- error MESSAGE from this stack can carry an event payload. That is why the
+-- existing log line records the class and the driver code and not the error.
+-- This table inherits exactly that column list.
+--
+-- The boundary is enforced in `recordFailure` in web/apps/api/src/failures.ts,
+-- which takes five bounded strings and has no parameter that could carry one of
+-- the forbidden values. It is not enforced by a policy here and cannot be: row
+-- level security is row level, and the operator role bypasses it anyway. Same
+-- argument as SAFE_COLUMNS in admin/router.ts and as the event stream in
+-- admin/operations.ts.
+--
+-- WHAT IS DELIBERATELY MISSING FROM THE ANSWER, so nobody reads its absence as
+-- a zero. There is no tenant count. "How many organizations does this failure
+-- touch" is a question this table cannot answer, because answering it means
+-- writing an organization identifier next to a failure, and that turns a
+-- bounded operational table into tenant data with a second retention argument
+-- attached. The page says so in words. `workload_runs.failure_code`, which the
+-- same page already groups, is where a per-tenant count comes from.
+
+BEGIN;
+
+CREATE TABLE control_plane_failures (
+  -- Sixty-four hex characters of SHA-256 over the five bounded fields below,
+  -- computed in the application so that every replica and every restart agrees
+  -- on the identity of a group without coordinating. A natural key over the
+  -- columns themselves would do the same job; the hash is what lets the console
+  -- carry one opaque identifier for a row rather than five.
+  fingerprint     text PRIMARY KEY,
+
+  -- Which handler caught it. Two exist and both are in server.ts.
+  source          text NOT NULL,
+  -- The DECLARED route key that matched, never the path that matched it. See
+  -- routeLabel in metrics.ts: the first version of that function reported the
+  -- path, so every environment identifier anybody fetched became its own
+  -- series, and this table would have grown a row for each. For a tRPC failure
+  -- this is the procedure path, which is bounded by the router.
+  route           text NOT NULL,
+  method          text NOT NULL,
+  -- The error's class name. Code, not data.
+  kind            text NOT NULL,
+  -- The driver's own code, when the cause carried one: a Postgres SQLSTATE, an
+  -- undici code. Null when the error had no cause with a code.
+  provider_code   text,
+
+  occurrences     bigint NOT NULL DEFAULT 0,
+  first_seen_at   timestamptz NOT NULL,
+  last_seen_at    timestamptz NOT NULL,
+
+  -- The build that was running the first and the most recent time this group
+  -- was seen, from the same version string af_control_plane_info carries. This
+  -- is the deploy overlay, and it is a column rather than a join because there
+  -- is no deployment table in this schema and inventing one to draw a line on a
+  -- chart would be exactly the kind of thing the Logs page refuses to do.
+  first_seen_version text NOT NULL,
+  last_seen_version  text NOT NULL,
+
+  -- The request id of the most recent occurrence. It is the one identifier the
+  -- 500 response already hands the caller and the only thing that ties this row
+  -- to a line in `af logs web`. It names a request, not a person.
+  last_request_id text,
+
+  CONSTRAINT control_plane_failures_source_is_known CHECK (
+    source IN ('http', 'trpc')),
+  CONSTRAINT control_plane_failures_fingerprint_is_a_hash CHECK (
+    fingerprint ~ '^[0-9a-f]{64}$'),
+  -- Bounds, so that a bug upstream cannot turn a bounded vocabulary into free
+  -- text. Every one of these is far above the longest real value: the longest
+  -- declared route key in ENDPOINT_LIMITS is well under 100 characters and a
+  -- class name is a JavaScript identifier.
+  CONSTRAINT control_plane_failures_fields_are_bounded CHECK (
+    length(route) BETWEEN 1 AND 200
+    AND length(method) BETWEEN 1 AND 16
+    AND length(kind) BETWEEN 1 AND 100
+    AND (provider_code IS NULL OR length(provider_code) BETWEEN 1 AND 64)
+    AND length(first_seen_version) BETWEEN 1 AND 64
+    AND length(last_seen_version) BETWEEN 1 AND 64
+    AND (last_request_id IS NULL OR length(last_request_id) BETWEEN 1 AND 100)),
+  CONSTRAINT control_plane_failures_occurrences_do_not_go_negative CHECK (
+    occurrences >= 0),
+  -- A group cannot have been last seen before it was first seen. The flush
+  -- takes LEAST and GREATEST on both, so a late flush from a replica whose
+  -- clock is behind cannot move either one the wrong way, and this is what
+  -- proves that stayed true.
+  CONSTRAINT control_plane_failures_seen_in_order CHECK (
+    last_seen_at >= first_seen_at)
+);
+
+-- The page orders by last_seen_at descending and filters on a window, and the
+-- sweep deletes by last_seen_at. One index serves all three.
+CREATE INDEX control_plane_failures_last_seen_idx
+  ON control_plane_failures (last_seen_at DESC);
+
+-- ---------------------------------------------------------------------------
+-- Grants
+--
+-- The application writes and reads: the flush needs to know whether the group
+-- already exists before the cap can decide, and that read is the cap. The
+-- operator role reads, which is what the portal is.
+--
+-- The application is given no DELETE. The retention sweep runs on the operator
+-- credential beside the other administrative maintenance, so an application
+-- role compromised through a request path cannot erase the record of what it
+-- did to get there.
+-- ---------------------------------------------------------------------------
+
+GRANT SELECT, INSERT, UPDATE ON control_plane_failures TO antifailure_app;
+GRANT SELECT, DELETE ON control_plane_failures TO antifailure_admin;
+
+-- ---------------------------------------------------------------------------
+-- Isolation
+--
+-- This table carries no org_id, on purpose and as stated above, so tenant
+-- isolation has nothing to key on. What the policy does is the same second lock
+-- analytics_events has: the grants above are the real protection, and a policy
+-- means a GRANT added later by somebody who did not read this file still cannot
+-- turn the application role into something that can delete its own history.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE control_plane_failures ENABLE ROW LEVEL SECURITY;
+ALTER TABLE control_plane_failures FORCE ROW LEVEL SECURITY;
+CREATE POLICY control_plane_failures_are_operational ON control_plane_failures
+  FOR SELECT TO antifailure_app USING (true);
+CREATE POLICY control_plane_failures_are_written_by_the_app ON control_plane_failures
+  FOR INSERT TO antifailure_app WITH CHECK (true);
+CREATE POLICY control_plane_failures_are_counted_up ON control_plane_failures
+  FOR UPDATE TO antifailure_app USING (true) WITH CHECK (true);
+
+COMMIT;

--- a/web/packages/db/src/schema.ts
+++ b/web/packages/db/src/schema.ts
@@ -1615,3 +1615,36 @@ export const enterpriseLeads = pgTable('enterprise_leads', {
   handledBy: uuid('handled_by'),
   handledNote: text('handled_note'),
 })
+
+/* ---------------------------------------------------------------------------
+ * The control plane's own failures, one row per fingerprint.
+ *
+ * Not a log line store. A row is a GROUP: the declared route, the method, the
+ * error class and the driver code, with a count and the first and last time it
+ * was seen. Its size is bounded by the code rather than by how badly the
+ * installation is behaving, which is the property that makes it safe to leave
+ * on by default on a self hoster's small machine.
+ *
+ * Nothing that could carry a payload is in this list. See migration 0042 for
+ * the column-by-column reasoning and for where the boundary is enforced, which
+ * is `recordFailure` and not a policy here.
+ * ------------------------------------------------------------------------ */
+
+export const controlPlaneFailures = pgTable(
+  'control_plane_failures',
+  {
+    fingerprint: text('fingerprint').primaryKey(),
+    source: text('source').notNull(),
+    route: text('route').notNull(),
+    method: text('method').notNull(),
+    kind: text('kind').notNull(),
+    providerCode: text('provider_code'),
+    occurrences: bigint('occurrences', { mode: 'number' }).notNull().default(0),
+    firstSeenAt: timestamp('first_seen_at', { withTimezone: true }).notNull(),
+    lastSeenAt: timestamp('last_seen_at', { withTimezone: true }).notNull(),
+    firstSeenVersion: text('first_seen_version').notNull(),
+    lastSeenVersion: text('last_seen_version').notNull(),
+    lastRequestId: text('last_request_id'),
+  },
+  (t) => [index('control_plane_failures_last_seen_idx').on(t.lastSeenAt)],
+)

--- a/web/packages/db/test/tenancy.test.ts
+++ b/web/packages/db/test/tenancy.test.ts
@@ -188,6 +188,22 @@ describe('cross-tenant isolation', { skip: hasDatabase ? false : 'no Postgres at
       ['analytics_actives', 'distinct counts over a window, with no identifier in them'],
       ['analytics_retention_cohorts', 'a cohort grid of counts, with no identifier in it'],
       ['analytics_funnel_weeks', 'counts of how far subjects got, with no identifier in them'],
+      [
+        'control_plane_failures',
+        'what the CONTROL PLANE caught in itself, grouped: one row per fingerprint over the ' +
+          'declared route key, the HTTP method, the error class and the driver code, with a ' +
+          'count. It has no org_id because it holds nothing belonging to a tenant, and that is ' +
+          'a boundary rather than an omission. The reason is on app.onError already: Drizzle ' +
+          'renders a query failure as the whole statement with its parameters after it, so an ' +
+          'error message from this stack can carry a tenant\'s event payload, and the store ' +
+          'therefore keeps no message, no stack, no payload and no organization. Adding an ' +
+          'org_id to answer "how many tenants did this touch" would turn a small operational ' +
+          'table into tenant data, so the page says it cannot answer that instead. The same ' +
+          'shape as platform_controls: reading is open to the application role on purpose, ' +
+          'because the flush has to know whether a group already exists before the cap can ' +
+          'decide, and DELETE is not granted to it at all, which the test below proves. See ' +
+          'migrations/0042.',
+      ],
     ])
 
     // Partitions are excluded because a partition is storage for its parent
@@ -229,6 +245,63 @@ describe('cross-tenant isolation', { skip: hasDatabase ? false : 'no Postgres at
    * would mean the table IS reachable and simply happened to be empty, which
    * is the state this suite exists to distinguish from isolation.
    */
+  /**
+   * The claim the classification makes about the failure store, tested.
+   *
+   * The sentence in the list above says the application role cannot erase the
+   * record of what it did, and a sentence is not a mechanism. What enforces it
+   * is that migration 0042 grants the application role SELECT, INSERT and
+   * UPDATE and no DELETE, and writes no FOR DELETE policy, so a statement it
+   * constructs is refused by the database before any policy is consulted.
+   *
+   * The reason that matters more than tidiness: this table is the record of
+   * every failure the control plane had, and the request path is exactly where
+   * a compromised application role would be reached from. A role that can erase
+   * that record can erase the evidence of how it got there.
+   *
+   * Asserted as 42501 specifically, and then the row is counted again. A DELETE
+   * that merely affected no rows would pass a weaker assertion and would mean
+   * the opposite thing: that the table IS writable and the WHERE happened to
+   * match nothing.
+   */
+  it('the application role can count the failure store and cannot erase it', async () => {
+    const fingerprint = 'f'.repeat(64)
+    await h.admin`
+      INSERT INTO control_plane_failures (
+        fingerprint, source, route, method, kind, occurrences,
+        first_seen_at, last_seen_at, first_seen_version, last_seen_version)
+      VALUES (${fingerprint}, 'http', 'GET other', 'GET', 'TypeError', 1,
+              now(), now(), 'test', 'test')`
+
+    // Reading IS allowed, and is asserted rather than assumed: the flush's cap
+    // check is a read, so a migration that revoked SELECT to look tidy would
+    // stop the cap working and the failure would be a store that silently
+    // records nothing new.
+    const read = await h.pool
+      .withTenant({ orgId: alice.orgId, userId: alice.userId }, async (db) => {
+        await db.execute(sql`SELECT count(*) FROM control_plane_failures`)
+      })
+      .then(() => null, (e: unknown) => pgError(e))
+    assert.equal(read, null, 'the application role cannot count the store, so the cap cannot work')
+
+    const erase = await h.pool
+      .withTenant({ orgId: alice.orgId, userId: alice.userId }, async (db) => {
+        await db.execute(sql`DELETE FROM control_plane_failures WHERE fingerprint = ${fingerprint}`)
+      })
+      .then(() => null, (e: unknown) => pgError(e))
+    assert.equal(
+      erase?.code,
+      '42501',
+      'the application role could delete the record of what the control plane had failed at',
+    )
+
+    const [left] = await h.admin<{ n: string }[]>`
+      SELECT count(*) AS n FROM control_plane_failures WHERE fingerprint = ${fingerprint}`
+    assert.equal(Number(left!.n), 1, 'the refusal above was a statement that matched nothing')
+
+    await h.admin`DELETE FROM control_plane_failures WHERE fingerprint = ${fingerprint}`
+  })
+
   it('the application role cannot read or write an operator\'s notes', async () => {
     const [note] = await h.admin<{ id: string }[]>`
       INSERT INTO admin_notes (subject_type, subject_id, body, author_label)


### PR DESCRIPTION
A self hosted control plane could see its 5xx count go up and never see what
had failed.

## The failure

Both of this process's error handlers already catch every unexpected failure it
has, and both already write a line naming the error class, the driver's code,
the method and the route. That line goes to standard output. On the hosted
control plane something ships standard output somewhere searchable. On a self
hosted one it is a line in `docker logs`: no count, no first seen, no grouping,
and no way to tell one bad afternoon from a regression that landed with the last
deploy. The one number an operator could actually reach,
`af_http_requests_total{status_class="5xx"}`, says how many and never says what.

The Logs & Error Explorer said in its own header that this product records no
exception group, no fingerprint and no occurrence counter, and that inventing
one would be worse than having none, because an operator reads "0 errors" during
an incident and stops looking. That statement is correct about the ENGINE's
exceptions, which happen in a customer's environment and would need the engine
to report them. It was also true of the control plane's own failures, and those
need nothing from anybody.

## What I found before building, since most of this half already existed

- `console/components/load/polling.tsx` holds `useLive`, written because
  `useApi` blanked a populated screen to a skeleton on every reload. **`useApi`
  no longer does that.** It keeps the held data across a reload with the same
  dependencies, puts the failure in `refreshError` rather than discarding the
  rows, and carries a sequence guard `useLive` does not have, so two polls
  landing out of order cannot let the older answer overwrite the newer. On a
  page that polls, that last one is the difference between a count going up and
  a count flickering. So this page uses `useApi` driven by `useInterval` from
  the same module `useLive` lives in, which is the composition
  `components/load/run.tsx` already uses. No second polling hook was written.
- `web/apps/api/src/metrics.ts` and `GET /metrics` already exist and are
  untouched in shape. This adds four series to that same registry and nothing
  else. No second metrics system.
- `console/app/admin/operations/infrastructure/page.tsx` is **not Azure specific
  at all**: `grep -rin azure console/app/admin/operations web/apps/api/src/admin/operations.ts`
  returns nothing. Every panel is an aggregate over the control plane's own
  Postgres. So the self hosting requirement did not need that page changed.
- `observability/alerts/antifailure.rules.yml` and the Grafana dashboard exist,
  and `metrics.test.ts` fails on a rule or panel naming a metric nothing
  exports. Two rules and two panels were added and that test still passes.
- `console/app/admin/README.md` names the files a lane may touch. This touches
  its page and its routes, plus the Operations lane's own two client modules.
  `console/lib/admin-nav.ts` and `web/apps/api/src/admin/router.ts` are
  untouched.

## What this builds, and what bounds it

`control_plane_failures`: one row per FINGERPRINT, not per occurrence. The
fingerprint is the declared route key, the HTTP method, the error class name and
the driver's own code, and the row carries a count, first and last seen, the
build running at each of those, and the request id of the most recent
occurrence.

**A group and not a log line, because a row per occurrence makes the table's
size a function of how badly the installation is behaving.** The day a self
hoster's control plane starts failing would be the day their disk fills, caused
by the feature meant to help them with incidents. The cardinality here is set by
the code instead: the route keys come from `ENDPOINT_LIMITS`, the procedure
paths from the router, a class name is a JavaScript identifier and a driver code
is an enum. A bad day adds occurrences and no rows.

On top of that, at most 500 groups, about 100 kilobytes whatever happens, and
the page says out loud when the store is at that cap rather than quietly showing
fewer failures than are happening. Retention is 30 days past a group's LAST
occurrence, on the maintenance pass.

**Nothing touches the database on the error path.** `record` is synchronous,
returns void and buffers in process; a timer flushes every ten seconds, one
statement per distinct group. A failed flush puts the occurrences back rather
than shedding them, because a control plane whose database is unreachable is
failing every request, which is exactly when the store must hold and backfill
the shape of the outage.

## The decisions, and the tradeoff on each

**Where log lines are stored, and what bounds the size.** Above. The size bound
is structural rather than a policy: it is bounded by the code with a hard cap
underneath. The tradeoff is that individual occurrences are not recoverable, so
you cannot read the third failure of the afternoon. `last_request_id` gives you
the most recent one to search for in `af logs web`, and that is what the 500
response already told the caller to quote.

**What must never enter the store.** No message, no stack, no body, no query
string, no parameters, no payload, no organization, no user, no email. The
reason is specific and was already written on `app.onError`: Drizzle renders a
query failure as "Failed query: the whole statement" with the parameters after
it, so an error message from this stack can carry a tenant's event payload. The
boundary is the SIGNATURE of `recordFailure` in `web/apps/api/src/failures.ts`,
which takes five bounded strings and has no parameter that could carry one of
those values. It is not a policy and cannot be: policies are row level and the
operator pool bypasses them anyway. Same argument as `SAFE_COLUMNS` and as the
event stream on the same page. `failures-endtoend.test.ts` asserts against the
stored row that no statement, no wrapper text and no organization id is in it.

**The tenant count is deliberately absent.** "How many tenants does this touch"
is one of the four questions an operator asks, and answering it means writing an
organization identifier next to a failure, which turns a small bounded
operational table into tenant data with its own retention argument. Conservative
option taken: it is not recorded, the page says so in words rather than showing
a zero, and it points at Failures by code on the same page, which already
answers the per tenant question for the engine side.

**Polling and not server sent events.** The control plane runs as a container
app in multiple revision mode with more than one replica behind one ingress, so
a held connection pins the operator to whichever replica answered and dies on
every revision swap, which is exactly the moment an operator is watching.
Everything on the page is an aggregate over Postgres, which every replica
shares, so a poll gets the same answer from any of them and gets reconnection
for free. The cost is latency bounded by the interval, which for a page
measuring things in seconds and minutes is not a cost. This is also why the
store is in Postgres rather than answered from the Prometheus counters: those
are per replica, and a count read through the ingress walks up and down as the
load balancer moves, which is indistinguishable from a failure rate that is
walking up and down.

**The live tick deliberately does not refresh the event stream**, which is
paged. Refreshing a list somebody has pressed More on three times throws away
three pages and returns them to the top, which is worse than being a minute
behind. It keeps its own Refresh and the page says so.

**What a self hoster configures, and the safe default.** `AF_FAILURE_STORE` is
on by default: the table is bounded by the code, the writes are one statement
per distinct group per ten seconds rather than one per failure, and a healthy
installation writes nothing at all, so a small machine pays nothing until
something breaks. `AF_FAILURE_RETENTION_DAYS` defaults to 30. Retention needs
`AF_MAINTENANCE_DATABASE_URL` or `AF_MIGRATION_DATABASE_URL`, because migration
0042 grants the application role no `DELETE` on purpose: a role reached through
a request path should not be able to erase the record of what it did to get
there. With neither set, nothing sweeps, the cap still holds, and the page says
"no retention" rather than printing a policy nothing enforces.

**Migration 0042**, taken as main's highest plus one at the moment of pushing.

## Degrading, and saying so

Every way this can be short of the truth is named on the page rather than
rendering an empty panel that reads as a quiet day:

- **not recording**: the answering replica has the store switched off. During a
  rolling deploy one revision can be recording while another is not, and the
  panel says which one answered.
- **at the cap**: a new kind of failure is being refused a row right now, while
  groups already there keep counting.
- **no retention**: nothing on this installation sweeps, so read the dates.
- Empty with recording on says "this control plane has not failed in this
  window", which is a different sentence from "nothing was written down".

Three counters carry the same three facts to anything scraping `/metrics`, and
two alert rules watch them. `af_control_plane_failures_total` by `outcome`:
`observed` is the denominator, and `capped`, `dropped` and `failed` each mean
the page is counting fewer than happened.

## What was verified, and how

**Mutation tested, 26 cells, every one aimed by exact test name with a required
test count so a pattern matching nothing could not read as a pass.** Each cell
proves the edit landed and the file changed before believing its red.
Twenty-five caught. The one survivor is recorded in this history rather than
hidden: replacing the buffer swap with `new Map(buffer)` plus `clear()` is the
same behaviour written differently, so it survived because it was not a
mutation. The cell that does break the property, writing out of the live buffer,
is caught.

**End to end on both arms, through failures the suite genuinely causes** rather
than thrown fixtures: a `CHECK (false)` on `events` for the HTTP handler and a
renamed table for the tRPC one. Both assert the declared route key rather than
the path, the driver's SQLSTATE, the count, the request id matching the response
header, and that nothing resembling a statement or an organization is in the
stored row. Deleting either `record` call turns the matching test red.

Two defects were found by these tests rather than by reading:

1. The tRPC arm read the driver code one level down, which finds nothing,
   because a `TRPCError` wraps the Drizzle error which wraps the Postgres one.
   Every internal tRPC failure would have fingerprinted into one group per
   procedure with a null driver code. `providerCodeOf` now walks the chain, with
   a bounded depth and a seen set, and the log line beside it takes the same
   answer from the same function so the two cannot drift.
2. Walking from the error rather than the cause on that arm picks up
   `TRPCError.code`, which is `INTERNAL_SERVER_ERROR` for every one of these and
   would have filled the driver code column with a constant.

**Looked at the real rendered pixels**, against a control plane and console
running locally on Postgres, at 1512, 1440, 1280, 390 and 320, and found two
things reading the source had not:

1. The headline metric row was four numbers about the engine side, so an
   installation whose control plane was failing 263 times showed four zeros at
   the top of the page. That is the exact "0 errors during an incident" reading
   the page header exists to prevent. It now leads with the control plane's own
   count, and the label is short enough not to wrap, because the longer one
   pushed its number a line below every number beside it.
2. A page level `StaleNotice` said the same thing `Loaded` already says on every
   card, three banners for one dropped connection. Removed; what was missing
   above the fold was the timestamp, so that is all the line is now.

No `animate-pulse` and no `animate-ping` anywhere in the diff, asserted in the
browser as well: `document.querySelectorAll('[class*="animate-pulse"],[class*="animate-ping"]')`
is empty on the rendered page at every width. No horizontal overflow and no
console errors at any of the five widths.

**Live behaviour proved by cutting the connection in the browser**, not by
reading the hook: with `/trpc/**` aborted for two poll intervals the rows and
the counts stay on screen, the freshness line turns and says the last refresh
did not land, and when the route is restored the notice clears on its own with
no user action. A first load that is refused renders the error state.

## What is still not recorded

Nothing records an exception, a stack trace or a log line from a customer's RUN.
That happens in the engine, in an environment the control plane does not own,
and needs the engine to report it. The page says so, in the card that already
said it, narrowed by one sentence rather than deleted.
