### PR TITLE
gates: the generator list was written out three times and the three disagreed

### DIFF
--- a/.changes/gate-parity-in-both-directions.internal.md
+++ b/.changes/gate-parity-in-both-directions.internal.md
@@ -1,0 +1,39 @@
+# fixed
+
+The generators are listed in one place now, and `tools/gatecheck` compares
+`just gate` against CI in both directions.
+
+`engine/internal/manifest/manifest.v1.json` is a copy of
+`schemas/manifest.v1.json`, read through `go:embed` because embed cannot reach
+outside the engine module. It sat stale on main for thirteen commits and no
+check could report it, because the list of generators was written out three
+times and the three disagreed. `tools/gendrift`'s ledger named fifteen,
+`just _generated` ran fifteen, and `ci.yml` ran twelve. Three of the ledger's
+rows had no generator on the CI side, so on a clean checkout the files those
+rows name were never rewritten, never showed as changed, and could never be
+reported by a tool whose only question is `git status`. The other two were
+`schemas/mockpack-vectors.json` and `schemas/webhook-vectors.json`. A developer
+running `just gate` caught this and CI structurally could not, and both reported
+under the words "generated files are current".
+
+`gendrift -generate` runs the ledger, in the ledger's order, and both callers
+use it, so there is one list and it is the same list that gets compared. The
+order was a third disagreement: `docsembed` embeds six pages other generators
+write, so it has to run last, and `ci.yml` ran it fourth of twelve.
+
+`gatecheck` exists to fail the build when the local recipe and the CI gate
+disagree, and it could not see this one, because every comparison in it started
+from a CI gate and asked whether the justfile covered it. A gate the justfile
+ran and no workflow ran was not a question anybody asked. It asks now, with its
+own exemption list and its own staleness check on that list, and the first run
+of it found three more: `just gate` ran `socketcheck`, `fieldsweep` and
+`coverage` and no workflow ran any of them. The first two are in `ci.yml` now.
+The third cannot be, because producing its coverage profile takes the better
+part of an hour, and the exemption says so rather than passing over it: the
+per package thresholds are not enforced on a pull request.
+
+Two of the seven it reported were blind spots rather than gaps, and both are
+fixed. `go run ../tools/scanrepo`, which is how `ci.yml` spells the credential
+scan, matched no pattern at all. And `go test ./...` in a directory now pairs
+with `go test` on a package under it, as its own weaker tier that the passing
+output names, rather than being reported as a gap or folded in as an equal.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,19 +171,23 @@ jobs:
         # list and the jobs API return, and three lanes went to look at the
         # wrong thing. That is what a step name asserting more than the step
         # reached costs.
-        run: |
-          go run ./tools/errgen
-          go run ./tools/lintgen
-          go run ./tools/proxysrc
-          go run ./tools/docsembed
-          go run ./tools/schemadoc .
-          go run ./tools/notices -out THIRD_PARTY_NOTICES.md
-          (cd engine && go test ./internal/policy -update-vectors)
-          (cd engine && go test ./internal/cli -update-reference)
-          (cd engine && go test ./internal/events -update-schema)
-          go run ./tools/eventcheck -freeze .
-          (cd engine && go test ./internal/masking -update-transforms)
-          (cd engine && go test ./internal/hud -update-frames)
+        #
+        # The commands themselves used to be written out here, and that is the
+        # defect this line exists to remove. tools/gendrift named FIFTEEN
+        # generators, `just _generated` ran fifteen, and this step ran TWELVE.
+        # The three it never ran included
+        # `cp schemas/manifest.v1.json engine/internal/manifest/manifest.v1.json`,
+        # so on a clean checkout that file was never rewritten, never showed as
+        # changed, and could never be reported by the step below, whose only
+        # question is `git status`. It sat stale on main for thirteen commits
+        # with this job green on every one of them. A developer running
+        # `just gate` caught it and CI structurally could not, and both reported
+        # under the same words.
+        #
+        # The order was wrong here too, and for a reason the ledger records:
+        # docsembed EMBEDS six pages that other generators write, so it has to
+        # run last or a single pass cannot converge. This step ran it fourth.
+        run: go run ./tools/gendrift -generate .
 
       - name: Generated files are current
         # Now this step fails for one reason and says which generator to run.
@@ -437,6 +441,32 @@ jobs:
         # allowed to use. It compiled here, reviewed as correct, and would have
         # failed on the first line of the first real provider anybody wrote.
         run: go run ./tools/surfacecheck .
+
+      - name: Every extension point is implementable and consulted
+        # The same question as the step above, asked about the other surface,
+        # and it ran nowhere until now. `just gate` has called `socketcheck`
+        # since it was written and no workflow ever did, so the property was
+        # held by whoever remembered to run the command rather than by anything
+        # that could stop a pull request. tools/gatecheck found it the day it
+        # learned to compare in this direction.
+        #
+        # A socket is a promise to two people and only one of them is visible
+        # to the compiler. The implementer is outside this module and cannot
+        # import engine/internal, so a signature naming a type from there is a
+        # socket nobody can implement. extension.AuditSink has an interface, a
+        # registry, an Add and a forwarding method that nothing in the engine
+        # has ever called.
+        run: go run ./tools/socketcheck .
+
+      - name: Every manifest field is read or refused
+        # Also new here, and out of a workflow for the same reason
+        # socketcheck was: `just gate` ran it and CI did not.
+        #
+        # replicas, resources.cpu, resources.memory and workflows[].tags were
+        # all in the schema, all documented, and read by nothing, so a manifest
+        # asking for three instances of a worker got one and the run went green
+        # having never started a second one.
+        run: go run ./tools/fieldsweep -root . -ambiguous
 
       - name: Vet
         run: cd engine && go vet ./...
@@ -737,7 +767,15 @@ jobs:
         working-directory: runner
 
       - name: Test
-        run: node --experimental-strip-types --test test/*.test.ts
+        # `npm test` rather than the command spelled out, so runner/package.json
+        # is the one place that says what the runner's tests are. It ran the
+        # command directly and the justfile ran `npm --prefix runner test`, and
+        # two spellings of one gate are exactly what tools/gatecheck exists to
+        # catch: it could not pair them, and reported the runner's tests as a
+        # gate no workflow runs. The script is this command with a guard in
+        # front of it, `ls test/*.test.ts > /dev/null &&`, which fails rather
+        # than passing when the glob matches nothing.
+        run: npm test
         working-directory: runner
 
   www:

--- a/justfile
+++ b/justfile
@@ -1526,7 +1526,8 @@ fuzz-engine seconds="60":
 # refuses a changed path no generator claims, and can do that because it runs
 # on a clean checkout. The property either way is the same: what is generated
 # matches what it is generated from.
-# docsembed runs LAST of these on purpose.
+# docsembed runs LAST of these on purpose, and the order now lives in the
+# ledger in tools/gendrift rather than in this recipe.
 #
 # It EMBEDS every documentation page into engine/internal/docs/pages.gen.go,
 # and six of those pages are themselves generated: errors.md by errgen,
@@ -1537,28 +1538,21 @@ fuzz-engine seconds="60":
 # every generator just reported success. Measured rather than reasoned: with
 # docsembed before schemadoc, a one line schema edit left pages.gen.go with a
 # different checksum than a second docsembed produced. After it, the two
-# match.
+# match. ci.yml ran docsembed FOURTH of twelve while this recipe ran it last,
+# which is the same disagreement as the missing generators and was invisible
+# for the same reason.
 _generated:
     #!/usr/bin/env bash
     set -euo pipefail
-    go run ./tools/errgen
-    go run ./tools/lintgen
-    go run ./tools/proxysrc
-    go run ./tools/schemadoc .
-    go run ./tools/notices -out THIRD_PARTY_NOTICES.md
-    # The engine enforces the schema's own bounds at parse time, and go:embed
-    # cannot reach outside the engine module, so it embeds a copy. A stale copy
-    # would enforce yesterday's contract while the site published today's.
-    cp schemas/manifest.v1.json engine/internal/manifest/manifest.v1.json
-    (cd engine && go test ./internal/policy -update-vectors)
-    (cd engine && go test ./internal/mockpack -update-vectors)
-    (cd engine && go test ./internal/webhook -update-vectors)
-    (cd engine && go test ./internal/cli -update-reference)
-    (cd engine && go test ./internal/events -update-schema)
-    go run ./tools/eventcheck -freeze .
-    (cd engine && go test ./internal/masking -update-transforms)
-    (cd engine && go test ./internal/hud -update-frames)
-    go run ./tools/docsembed
+    # The generators are NOT written out here any more, and that is the point.
+    # They were written out three times: in tools/gendrift's ledger, here, and
+    # in ci.yml. The ledger named fifteen, this recipe ran fifteen, and ci.yml
+    # ran twelve, so three generated files could only ever be compared by
+    # somebody running this command on a laptop. One of them,
+    # engine/internal/manifest/manifest.v1.json, sat stale on main for thirteen
+    # commits with CI green throughout. Both callers run the ledger now, so the
+    # two lists cannot disagree because there is one list.
+    go run ./tools/gendrift -generate .
     # The OpenAPI artifact is generated too, and its generator is TypeScript
     # rather than Go. Its own --check mode is the comparison, so it is run in
     # the same form and the same directory CI runs it in: a gate is the command
@@ -1624,7 +1618,8 @@ capacityplan cpu memory manifest="antifailure.yaml":
       -node-cpu "{{cpu}}" -node-memory "{{memory}}"
 
 # Regenerate and keep the result.
-# docsembed runs LAST of these on purpose.
+# docsembed runs LAST of these on purpose, and the order now lives in the
+# ledger in tools/gendrift rather than in this recipe.
 #
 # It EMBEDS every documentation page into engine/internal/docs/pages.gen.go,
 # and six of those pages are themselves generated: errors.md by errgen,
@@ -1635,25 +1630,16 @@ capacityplan cpu memory manifest="antifailure.yaml":
 # every generator just reported success. Measured rather than reasoned: with
 # docsembed before schemadoc, a one line schema edit left pages.gen.go with a
 # different checksum than a second docsembed produced. After it, the two
-# match.
+# match. ci.yml ran docsembed FOURTH of twelve while this recipe ran it last,
+# which is the same disagreement as the missing generators and was invisible
+# for the same reason.
 generate:
-    go run ./tools/errgen
-    go run ./tools/lintgen
     go run ./tools/installcheck . web || npm --prefix web ci --no-audit --no-fund
     npm --prefix web run openapi --workspace apps/api
-    go run ./tools/proxysrc
-    go run ./tools/schemadoc .
-    go run ./tools/notices -out THIRD_PARTY_NOTICES.md
-    cp schemas/manifest.v1.json engine/internal/manifest/manifest.v1.json
-    cd engine && go test ./internal/policy -update-vectors
-    cd engine && go test ./internal/mockpack -update-vectors
-    cd engine && go test ./internal/webhook -update-vectors
-    cd engine && go test ./internal/cli -update-reference
-    cd engine && go test ./internal/events -update-schema
-    go run ./tools/eventcheck -freeze .
-    cd engine && go test ./internal/masking -update-transforms
-    cd engine && go test ./internal/hud -update-frames
-    go run ./tools/docsembed
+    # Every Go generator, from the one ledger, in the one order. It is not a
+    # list here for the same reason it is not a list in ci.yml: three copies of
+    # it disagreed and nothing could say so.
+    go run ./tools/gendrift -generate .
 
 # This machine's own credential store, against the real thing.
 #

--- a/tools/gatecheck/main.go
+++ b/tools/gatecheck/main.go
@@ -62,8 +62,14 @@ const cmd = "(?:^|[\\s;&|(])"
 // became invisible here the day it started deriving its projects from the tree
 // instead of naming them. A gate this cannot see is a gate it silently stops
 // pairing, which is the failure this tool exists to prevent.
+//
+// `\.{1,2}/tools/` because ci.yml spells one of them `cd engine && go run
+// ../tools/scanrepo ..`. Against `\./tools/` that line matched nothing at all,
+// so the only credential scan this repository runs was invisible to the tool
+// whose job is to notice a gate on one side and not the other. A gate this
+// cannot see is a gate it silently stops pairing.
 var gatePatterns = []*regexp.Regexp{
-	regexp.MustCompile(cmd + `go run \./tools/(\w+)`),
+	regexp.MustCompile(cmd + `go run \.{1,2}/tools/(\w+)`),
 	regexp.MustCompile(cmd + `go (test|vet|build) ([^\s|;&]+)`),
 	regexp.MustCompile(cmd + `(npm|npx) [\w\s./"$-]*?(test|tsc)\b`),
 	regexp.MustCompile(cmd + `(npm|npx) [\w\s./"$-]*?run ([\w:.-]+)`),
@@ -190,7 +196,11 @@ func main() {
 		case pairedExactly:
 			// Nothing to say. This is the ordinary case.
 		case pairedByRuntimeDir:
-			loose = append(loose, key+"  <-  "+where)
+			loose = append(loose, key+"  <-  justfile: "+where+
+				"\n        (the justfile works its directory out at run time, so the directory was not compared)")
+		case pairedByWholeModule:
+			loose = append(loose, key+"  <-  justfile: "+where+
+				"\n        (the wider target runs this package, so the pattern was not compared)")
 		default:
 			missing = append(missing, gapFor(ciGates[key].gate, key, justGates, reachable))
 		}
@@ -205,12 +215,71 @@ func main() {
 		}
 	}
 
+	// The same comparison the other way round, which is the direction the
+	// failure that earned it lived in.
+	//
+	// `just _generated` ran `cp schemas/manifest.v1.json
+	// engine/internal/manifest/manifest.v1.json` and ci.yml did not, so the
+	// embedded schema could only ever be compared by somebody running the
+	// gate on a laptop. It sat stale on main for thirteen commits. Both sides
+	// reported under the words "generated files are current", and this tool,
+	// which exists precisely to fail the build when the local recipe and the
+	// CI gate disagree, could not see it: every comparison here started from a
+	// CI gate and asked whether the justfile covered it, so a gate the
+	// justfile ran and no workflow ran was not a question anybody asked.
+	//
+	// It is worth failing over for the reason the forward direction is worth
+	// failing over, pointed the other way. CI is the mandatory run; `just
+	// gate` is the one a contributor may or may not remember. A gate only the
+	// justfile runs does not block a pull request, so the property it guards
+	// is guarded by habit. Three of them were in that state when this was
+	// written, and one of them had already let a stale file onto main.
+	var unenforced []gap
+	var looseReverse []string
+	usedCIExemption := map[string]bool{}
+	for _, key := range sortedEntries(justGates) {
+		e := justGates[key]
+		if !anyReachable(e.blocks, reachable) {
+			continue
+		}
+		if _, ok := exemptFromCI[key]; ok {
+			usedCIExemption[key] = true
+			continue
+		}
+		switch how, where := pairedWith(e.gate, ciGates, nil); how {
+		case pairedExactly:
+			// Nothing to say. This is the ordinary case.
+		case pairedByRuntimeDir:
+			looseReverse = append(looseReverse, key+"  ->  workflow: "+where+
+				"\n        (a directory worked out at run time, so the directory was not compared)")
+		case pairedByWholeModule:
+			looseReverse = append(looseReverse, key+"  ->  workflow: "+where+
+				"\n        (the wider target runs this package, so the pattern was not compared)")
+		default:
+			unenforced = append(unenforced, gap{
+				ci:     key + " in " + strings.Join(e.blocks, ", "),
+				reason: reverseReason(e.gate, ciGates),
+			})
+		}
+	}
+	// An exemption in the other map goes stale the same way and for the same
+	// reason: it reads as a considered decision about a gate `just gate` no
+	// longer runs, and it would silently cover the next gate to take the name.
+	var staleCI []string
+	for _, g := range sortedCIExemptions() {
+		if !usedCIExemption[g] {
+			staleCI = append(staleCI, g)
+		}
+	}
+
 	// The `gate` recipe has to actually invoke the individual recipes, or the
 	// justfile could define every gate and run none of them.
 	uncalled := uncalledByGate(recipes, reachable)
 
-	if len(missing) == 0 && len(uncalled) == 0 && len(stale) == 0 {
-		report(len(workflows.paths), ciGates, len(usedExemption), loose)
+	if len(missing) == 0 && len(unenforced) == 0 && len(uncalled) == 0 &&
+		len(stale) == 0 && len(staleCI) == 0 {
+		report(len(workflows.paths), ciGates, len(usedExemption), loose,
+			len(justGates), len(usedCIExemption), looseReverse)
 		return
 	}
 
@@ -225,6 +294,18 @@ func main() {
 			"in engine and in tools are two gates, and so is `npm test` in web and in\n"+
 			"ee/web. Add a recipe that runs it where CI runs it, and call it from `gate`.\n")
 	}
+	if len(unenforced) > 0 {
+		fmt.Fprintf(os.Stderr, "\ngatecheck: `just gate` runs %d %s no pull request workflow runs:\n",
+			len(unenforced), plural(len(unenforced), "gate", "gates"))
+		for _, u := range unenforced {
+			fmt.Fprintf(os.Stderr, "  %s\n", u.ci)
+			fmt.Fprintf(os.Stderr, "      %s\n", u.reason)
+		}
+		fmt.Fprintf(os.Stderr, "\nA gate only the justfile runs does not block a pull request. Add it to a\n"+
+			"workflow that runs on one, or add it to exemptFromCI with the reason it\n"+
+			"cannot run there. `cp schemas/manifest.v1.json engine/...` was in exactly\n"+
+			"this state and let a stale file sit on main for thirteen commits.\n")
+	}
 	if len(stale) > 0 {
 		fmt.Fprintf(os.Stderr, "\ngatecheck: these gates are exempt from `just gate` but no workflow runs them:\n")
 		for _, g := range stale {
@@ -232,6 +313,14 @@ func main() {
 		}
 		fmt.Fprintf(os.Stderr, "\nRemove the exemption. A reason to skip a gate that is gone "+
 			"describes nothing, and it would quietly cover the next gate to take that name.\n")
+	}
+	if len(staleCI) > 0 {
+		fmt.Fprintf(os.Stderr, "\ngatecheck: these gates are exempt from CI but `just gate` does not run them:\n")
+		for _, g := range staleCI {
+			fmt.Fprintf(os.Stderr, "  %s\n", g)
+		}
+		fmt.Fprintf(os.Stderr, "\nRemove the exemption. A reason why a gate cannot run in CI describes "+
+			"nothing\nonce nothing runs it locally either.\n")
 	}
 	if len(uncalled) > 0 {
 		fmt.Fprintf(os.Stderr, "\ngatecheck: these recipes exist and `just gate` never calls them:\n")
@@ -260,21 +349,48 @@ func hasRunStep(source string) bool { return runStep.MatchString(source) }
 // never held to the second, so the line claimed a property it did not test.
 // This one names the number of workflows read, the fact that the directory is
 // part of the pairing, the gates that are exempt rather than paired, and the
-// gates whose directory could not be compared because the justfile works it
-// out at run time. A reader should not be able to come away believing anything
-// stronger than what ran.
-func report(workflows int, ciGates map[string]*entry, exempt int, loose []string) {
+// gates whose directory or whose package pattern could not be compared, and
+// the same three numbers for the reverse direction. A reader should not be
+// able to come away believing anything stronger than what ran.
+func report(workflows int, ciGates map[string]*entry, exempt int, loose []string,
+	justGates, ciExempt int, looseReverse []string) {
 	fmt.Printf("gatecheck: %d gates in %d pull request workflows.\n", len(ciGates), workflows)
 	fmt.Printf("  %d paired by command and directory to a recipe `just gate` calls.\n",
 		len(ciGates)-exempt-len(loose))
 	if len(loose) > 0 {
-		fmt.Printf("  %d paired by command only, against a justfile command whose directory\n"+
-			"    is computed at run time, so for these the directory was not compared:\n", len(loose))
+		fmt.Printf("  %d paired more weakly than by command AND directory, and each says\n"+
+			"    which part of it was not compared:\n", len(loose))
 		for _, l := range loose {
 			fmt.Printf("      %s\n", l)
 		}
 	}
 	fmt.Printf("  %d exempt by name in exemptFromGate, with the reason recorded there.\n", exempt)
+	fmt.Printf("And the other way: %d gates in the justfile, of which the ones `just gate`\n"+
+		"  reaches all run in a pull request workflow, bar %d exempt by name in\n"+
+		"  exemptFromCI. That direction is separate because a gate only the justfile\n"+
+		"  runs does not block a pull request.\n", justGates, ciExempt)
+	if len(looseReverse) > 0 {
+		fmt.Printf("  %d of those paired more weakly than by command AND directory:\n", len(looseReverse))
+		for _, l := range looseReverse {
+			fmt.Printf("      %s\n", l)
+		}
+	}
+}
+
+// reverseReason says HOW a justfile gate is not covered by CI, in the same
+// three shapes the forward direction uses, so that a failure names the thing to
+// go and look at rather than only the thing that is missing.
+func reverseReason(g gate, ciGates map[string]*entry) string {
+	var elsewhere []string
+	for _, k := range sortedEntries(ciGates) {
+		if ciGates[k].gate.same(g) {
+			elsewhere = append(elsewhere, k)
+		}
+	}
+	if len(elsewhere) > 0 {
+		return "the workflows run this only in " + strings.Join(elsewhere, ", ")
+	}
+	return "no workflow that runs on a pull request runs this"
 }
 
 // pairing is how a CI gate was matched on the justfile side.
@@ -284,6 +400,7 @@ const (
 	notPaired pairing = iota
 	pairedExactly
 	pairedByRuntimeDir
+	pairedByWholeModule
 )
 
 // pairedWith looks for the justfile command that covers a CI gate.
@@ -294,15 +411,15 @@ const (
 // tsconfig files in the tree rather than naming them. That match is real
 // coverage and refusing it would report drift that does not exist, but it is
 // weaker than the other, so it is counted and printed rather than folded in.
-func pairedWith(g gate, justGates map[string]*entry, reachable map[string]bool) (pairing, string) {
-	if e, ok := justGates[g.String()]; ok && anyReachable(e.blocks, reachable) {
+func pairedWith(g gate, others map[string]*entry, reachable map[string]bool) (pairing, string) {
+	if e, ok := others[g.String()]; ok && anyReachable(e.blocks, reachable) {
 		return pairedExactly, ""
 	}
 	if g.dir == "" {
 		return notPaired, ""
 	}
-	for _, key := range sortedEntries(justGates) {
-		e := justGates[key]
+	for _, key := range sortedEntries(others) {
+		e := others[key]
 		if !e.gate.same(g) || !anyReachable(e.blocks, reachable) {
 			continue
 		}
@@ -310,8 +427,28 @@ func pairedWith(g gate, justGates map[string]*entry, reachable map[string]bool) 
 		// be this one, or CI's is and the justfile's is a literal. Either way
 		// there is nothing left to compare.
 		if e.gate.dir == unknownDir || g.dir == unknownDir {
-			return pairedByRuntimeDir, "justfile: " + key + ", in " + strings.Join(e.blocks, ", ")
+			return pairedByRuntimeDir, key + ", in " + strings.Join(e.blocks, ", ")
 		}
+	}
+	// Last: `go test ./...` in a directory runs every package under it, so it
+	// covers `go test ./internal/cli` in the same directory. `just docexamples`
+	// is that case, and CI's engine job runs the whole module.
+	//
+	// A third tier rather than a normalization, because normalizing the two
+	// targets to one key would say they are the SAME gate in both directions,
+	// which they are not: the narrow one does not cover the wide one. It is
+	// counted and printed for the same reason pairedByRuntimeDir is. It is
+	// real coverage and weaker than an exact match, and a reader should be
+	// able to see which of the two they were given.
+	for _, key := range sortedEntries(others) {
+		e := others[key]
+		if e.gate.kind != "gotest" || g.kind != "gotest" {
+			continue
+		}
+		if e.gate.arg != "./..." || e.gate.dir != g.dir || !anyReachable(e.blocks, reachable) {
+			continue
+		}
+		return pairedByWholeModule, key + ", in " + strings.Join(e.blocks, ", ")
 	}
 	return notPaired, ""
 }
@@ -355,7 +492,17 @@ func plural(n int, one, many string) string {
 	return many
 }
 
+// anyReachable reports whether any of the blocks a gate was found in is one
+// `just gate` runs.
+//
+// A nil set means the question does not apply, which is the CI side: a step in
+// a workflow that runs on a pull request runs, and there is no equivalent of a
+// recipe nothing calls. Returning false there would make every CI gate look
+// unreachable and the reverse comparison would report the entire justfile.
 func anyReachable(blocks []string, reachable map[string]bool) bool {
+	if reachable == nil {
+		return true
+	}
 	for _, b := range blocks {
 		if reachable[b] {
 			return true
@@ -427,7 +574,13 @@ func gatesIn(raw, dir string) []gate {
 			// "npx", "gofmt" or "node".
 			whole := strings.TrimLeft(m[0], " \t;&|($")
 			switch {
-			case strings.HasPrefix(whole, "go run ./tools/"):
+			// Both spellings, because ci.yml runs one of these as
+			// `cd engine && go run ../tools/scanrepo ..`. Testing only the
+			// `./` prefix here sent that line to the npm branch below, which
+			// reads m[2] out of a match that has one group, and the tool
+			// panicked rather than reporting anything at all.
+			case strings.HasPrefix(whole, "go run ./tools/"),
+				strings.HasPrefix(whole, "go run ../tools/"):
 				out = append(out, gate{kind: "tool", arg: m[1]})
 			case strings.HasPrefix(whole, "go test"):
 				out = append(out, gate{"gotest", normalizeTarget(m[2]), goDir(raw, dir)})
@@ -885,6 +1038,64 @@ var exemptFromGate = map[string]string{
 		"It runs on every pull request touching infra/ in infra.yml, against both " +
 		"the staging and the production plan produced there, and only when those " +
 		"plans were made against the real state.",
+}
+
+// exemptFromCI lists gates that `just gate` runs and that no pull request
+// workflow runs, each with the reason it cannot.
+//
+// The bar is the mirror of exemptFromGate's and it is just as high. A gate here
+// is one a pull request is NOT held to, so the property it guards is guarded by
+// whoever remembered to run the command. What qualifies is a gate whose answer
+// is not a function of what CI has: a check on a developer's own working copy,
+// or one that needs an artifact CI has no way to produce inside the run.
+//
+// An exemption naming a gate `just gate` does not run fails the build. See the
+// loop that fills `staleCI`.
+var exemptFromCI = map[string]string{
+	"tool installcheck": "" +
+		"On CI it could only ever be a tautology. tools/installcheck compares a " +
+		"working copy's node_modules against the lockfile beside it, and every " +
+		"job that has a node_modules got it from `npm ci` against that same " +
+		"lockfile minutes earlier, so the answer on a runner is yes by " +
+		"construction. It runs with --drift-only in `gate` for the same reason: " +
+		"a workspace nobody has installed is reported and does not fail, and on a " +
+		"fresh checkout that is all of them. " +
+		"The failure it exists for is a laptop's, not a runner's: a week of www " +
+		"work was verified with www/node_modules holding Next 15.5.23 against a " +
+		"lockfile pinning 16.3.3, and every build, every SEO assertion and a whole " +
+		"prose sweep answered in good faith about the wrong major version. That " +
+		"cannot happen on a runner that installs from the lockfile each time. " +
+		"What IS a function of the tree is whether the lockfile and package.json " +
+		"agree, and CI checks that on every job by running `npm ci`, which fails " +
+		"when they have drifted.",
+
+	"tool coverage": "" +
+		"Its INPUT cannot be produced inside a pull request run, and that is a " +
+		"cost decision rather than a property of the tree, so this exemption is " +
+		"recording a real hole rather than explaining it away. " +
+		"tools/coverage reads .gate-reports/coverage.out, which `just " +
+		"coverage-profile` writes by running the whole engine suite with " +
+		"-coverpkg over the module, against a Docker daemon and a Postgres, for " +
+		"the better part of an hour. No pull request workflow produces that " +
+		"profile, so no pull request workflow can run this, and the per package " +
+		"thresholds in the build plan's C.5 are therefore NOT enforced on a " +
+		"branch: they are enforced by whoever runs `just coverage-profile` and " +
+		"`just coverage` by hand. " +
+		"Wiring it in means paying for that hour on every push, which is a " +
+		"maintainer's call and not this tool's. Until somebody makes it, this " +
+		"entry is the only place that says out loud which gate a green pull " +
+		"request does not include.",
+}
+
+// sortedCIExemptions keeps the failure output stable, as sortedExemptions does
+// for the other direction.
+func sortedCIExemptions() []string {
+	out := make([]string, 0, len(exemptFromCI))
+	for k := range exemptFromCI {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // workflowSet is the workflows that run on a pull request, kept with their

--- a/tools/gatecheck/main_test.go
+++ b/tools/gatecheck/main_test.go
@@ -578,8 +578,156 @@ func TestTheRealRepositoryAgrees(t *testing.T) {
 				"so the exemption is describing a gate that is not there", g)
 		}
 	}
+
+	// And the same comparison the other way round, which is the direction the
+	// failure that earned it lived in: `just _generated` ran the `cp` that
+	// writes engine/internal/manifest/manifest.v1.json and ci.yml did not, so
+	// the embedded schema sat stale on main for thirteen commits while every
+	// required context passed. Nothing here asked this question at all.
+	for key, e := range jg {
+		if !anyReachable(e.blocks, reach) {
+			continue
+		}
+		if _, exempt := exemptFromCI[key]; exempt {
+			continue
+		}
+		if how, _ := pairedWith(e.gate, ci, nil); how == notPaired {
+			t.Errorf("`just gate` runs %q (in %s) and no pull request workflow does: %s",
+				key, strings.Join(e.blocks, ", "), reverseReason(e.gate, ci))
+		}
+	}
+	for g := range exemptFromCI {
+		e, ok := jg[g]
+		if !ok || !anyReachable(e.blocks, reach) {
+			t.Errorf("%q is exempt from CI but `just gate` does not run it either, "+
+				"so the exemption is describing a gate that is not there", g)
+		}
+	}
+
 	if u := uncalledByGate(recipes, reach); len(u) > 0 {
 		t.Errorf("these recipes are gates that `just gate` never calls: %v", u)
+	}
+}
+
+func TestAGateOnlyTheJustfileRunsIsReported(t *testing.T) {
+	// The failure that earned the reverse direction. Every comparison in this
+	// tool started from a CI gate and asked whether the justfile covered it,
+	// so a gate the justfile ran and no workflow ran was not a question
+	// anybody asked. `cp schemas/manifest.v1.json
+	// engine/internal/manifest/manifest.v1.json` was in exactly that state.
+	ci := ciGates(t, "jobs:\n  one:\n    steps:\n      - run: go run ./tools/errcheck .\n")
+	src := "gate:\n    just errcheck\n    just onlyhere\n    just nowhere\n\nerrcheck:\n    go run ./tools/errcheck .\n\nonlyhere:\n    go run ./tools/onlyhere .\n\nnowhere:\n    cd elsewhere && go test ./internal/x\n"
+	just := justGates(t, src)
+	reach := reachableFromGate(justRecipes(src))
+
+	e, ok := just["tool onlyhere"]
+	if !ok {
+		t.Fatalf("the fixture does not run the gate under test; the set is %v", keys(just))
+	}
+	if !anyReachable(e.blocks, reach) {
+		t.Fatal("the fixture does not reach the gate from `just gate`, so it is not a case this asks about")
+	}
+	if how, _ := pairedWith(gateOf(t, just, "tool onlyhere"), ci, nil); how != notPaired {
+		t.Error("a gate no workflow runs was reported as covered by one")
+	}
+	// A gate that CARRIES a directory, because the two take different routes
+	// through pairedWith and only one of them was asserted here at first. A
+	// `go run ./tools/X` has no directory and returns at the top; anything
+	// with one walks the whole function and returns at the bottom. Mutating
+	// that bottom return to `pairedExactly` left this test green, which is a
+	// surviving mutation understood rather than papered over: the assertion
+	// above cannot reach the line.
+	if how, _ := pairedWith(gateOf(t, just, "gotest ./internal/x in elsewhere"), ci, nil); how != notPaired {
+		t.Error("a gate with a directory that no workflow runs was reported as covered")
+	}
+	// The direction that already worked must keep working, or this test would
+	// pass against a tool that reports everything.
+	if how, _ := pairedWith(gateOf(t, just, "tool errcheck"), ci, nil); how != pairedExactly {
+		t.Error("a gate both sides run was reported as uncovered")
+	}
+	if r := reverseReason(gateOf(t, just, "tool onlyhere"), ci); !strings.Contains(r, "no workflow") {
+		t.Errorf("the message does not say what is wrong: %q", r)
+	}
+}
+
+func TestAGateInARecipeTheGateNeverCallsIsNotHeldToCI(t *testing.T) {
+	// The reverse direction must not report a recipe `just gate` never calls.
+	// `just vuln` needs the network and is deliberately outside the one
+	// command; requiring CI to run it would be reporting drift that is not
+	// there, and worse, it would make the reverse check noisy enough to delete.
+	src := "gate:\n    just errcheck\n\nerrcheck:\n    go run ./tools/errcheck .\n\nvuln:\n    go run ./tools/vulncheck .\n"
+	just := justGates(t, src)
+	reach := reachableFromGate(justRecipes(src))
+
+	e, ok := just["tool vulncheck"]
+	if !ok {
+		t.Fatalf("the fixture does not define the gate under test; the set is %v", keys(just))
+	}
+	if anyReachable(e.blocks, reach) {
+		t.Error("a recipe `just gate` never calls was treated as one it runs")
+	}
+}
+
+func TestARelativeToolsPathIsTheSameGate(t *testing.T) {
+	// ci.yml runs `cd engine && go run ../tools/scanrepo ..`. Against a
+	// pattern anchored on `./tools/` that line matched nothing at all, so the
+	// only credential scan this repository runs was invisible to the tool
+	// whose whole job is to notice a gate on one side and not the other. It
+	// then showed up as a justfile gate no workflow ran, which is a false
+	// positive produced by a blind spot rather than by a real gap.
+	got := ciGates(t, "jobs:\n  one:\n    steps:\n      - run: cd engine && go run ../tools/scanrepo ..\n")
+	if _, ok := got["tool scanrepo"]; !ok {
+		t.Fatalf("`go run ../tools/scanrepo` was not read as a gate; the set is %v", keys(got))
+	}
+}
+
+func TestTheWholeModuleTargetCoversAPackageUnderIt(t *testing.T) {
+	// `just docexamples` runs `go test ./internal/cli -run ...` in engine and
+	// CI runs `go test ./...` there, which runs that package. Refusing to pair
+	// them would report a gap that is not one. Pairing them as EQUAL would be
+	// a different lie, because the narrow target does not cover the wide one,
+	// so it is its own tier and the passing output says which part was not
+	// compared.
+	ci := ciGates(t, "jobs:\n  one:\n    steps:\n      - run: cd engine && go test ./... -race\n")
+	src := "gate:\n    just docexamples\n\ndocexamples:\n    cd engine && go test ./internal/cli -run TestX -count=1\n"
+	just := justGates(t, src)
+
+	how, where := pairedWith(gateOf(t, just, "gotest ./internal/cli in engine"), ci, nil)
+	if how != pairedByWholeModule {
+		t.Fatalf("expected a whole module pair, got %v (CI has %v)", how, keys(ci))
+	}
+	if !strings.Contains(where, "gotest ./... in engine") {
+		t.Errorf("the pair does not say what it paired against: %q", where)
+	}
+
+	// The other way round is not coverage: running one package does not run
+	// the module. Without this the tier would be a blanket pass on any two
+	// `go test` gates in one directory.
+	if how, _ := pairedWith(gateOf(t, ci, "gotest ./... in engine"), just, reachableFromGate(justRecipes(src))); how != notPaired {
+		t.Error("a narrow target was counted as covering the whole module")
+	}
+}
+
+func TestTheWholeModuleTierDoesNotReachAcrossDirectories(t *testing.T) {
+	// A gate is the command AND the directory, and the new tier must not be
+	// the hole that forgets it: `go test ./...` in tools does not run
+	// engine/internal/cli.
+	ci := ciGates(t, "jobs:\n  one:\n    steps:\n      - run: cd tools && go test ./...\n")
+	src := "gate:\n    just docexamples\n\ndocexamples:\n    cd engine && go test ./internal/cli -run TestX\n"
+	just := justGates(t, src)
+	if how, _ := pairedWith(gateOf(t, just, "gotest ./internal/cli in engine"), ci, nil); how != notPaired {
+		t.Error("a whole module run in another directory was counted as coverage")
+	}
+}
+
+func TestEveryCIExemptionStatesWhy(t *testing.T) {
+	// The mirror of TestEveryExemptionStatesWhy. An exemption with no reason
+	// is a gate quietly dropped, and this map drops it from the run that
+	// actually blocks a pull request.
+	for g, why := range exemptFromCI {
+		if len(strings.TrimSpace(why)) < 80 {
+			t.Errorf("the exemption for %q does not say why: %q", g, why)
+		}
 	}
 }
 

--- a/tools/gendrift/main.go
+++ b/tools/gendrift/main.go
@@ -115,16 +115,86 @@ var ledger = []generator{
 func main() {
 	strict := flag.Bool("strict", false,
 		"also fail on a changed path no generator owns, for a clean checkout")
+	generate := flag.Bool("generate", false,
+		"run every generator in the ledger, in order, and compare nothing")
 	flag.Parse()
 	root := "."
 	if args := flag.Args(); len(args) > 0 {
 		root = args[0]
 	}
 
+	if *generate {
+		if err := generateAll(root, os.Stdout); err != nil {
+			fmt.Fprintf(os.Stderr, "gendrift: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
 	if err := run(root, *strict, os.Stdout); err != nil {
 		fmt.Fprintf(os.Stderr, "gendrift: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+// generateAll runs every generator the ledger names, in the order it names
+// them, and compares nothing.
+//
+// This mode exists because the list of generators was written out three times.
+// The ledger below named fifteen; `just _generated` ran fifteen; ci.yml ran
+// TWELVE. Three of the ledger's rows had no generator on the CI side, so on a
+// clean checkout the files those rows name were never rewritten, never showed
+// as changed, and could never be reported. `engine/internal/manifest/manifest.v1.json`
+// was one of them, and it sat stale on main for thirteen commits while the
+// step called "Generated files are current" passed on every one of them: the
+// ledger row was decorative, because gendrift only ever asked `git status` and
+// something else had to have done the writing.
+//
+// A ledger that names a generator and a workflow that runs a different set is
+// the disagreement no gate here could see, and the way to make it unsayable is
+// to stop saying it twice. Both callers run this now, so a row added to the
+// ledger is a generator BOTH of them run, and the only remaining way to have a
+// generated file nothing compares is to leave it out of the ledger entirely,
+// which -strict is what catches.
+//
+// It stops at the first failure and says which command failed, because a
+// generator that did not finish leaves a tree the comparison would read as
+// drift. That is the reading that sent three lanes to the wrong file on
+// 2026-09-08, and it is the reason this is a separate mode rather than a step
+// folded into the comparison: the two answer different questions and must be
+// able to fail with different words.
+func generateAll(root string, out io.Writer) error {
+	for _, g := range ledger {
+		if _, err := fmt.Fprintf(out, "  %s\n", g.command); err != nil {
+			return err
+		}
+		cmd := exec.Command("bash", "-c", g.command)
+		cmd.Dir = root
+		cmd.Stdout = out
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			// The explanation goes to the writer and the error stays one
+			// line. staticcheck's ST1005 refuses an error string that ends in
+			// punctuation or a newline, and main prints this as
+			// `gendrift: <err>`, which a paragraph does not sit under anyway.
+			//
+			// The write is returned rather than discarded, for the reason the
+			// clean case below gives: the whole value of this sentence is that
+			// somebody reads it, so a write that did not arrive has to be
+			// noticed rather than swallowed.
+			if _, werr := fmt.Fprintf(out,
+				"\nThat is a generator that did not finish, and NOT a stale file. Nothing\n"+
+					"has been compared. Fix the failure above and run this again before\n"+
+					"reading anything into what the tree looks like now.\n\n"); werr != nil {
+				return werr
+			}
+			return fmt.Errorf("the generator `%s` failed: %w", g.command, err)
+		}
+	}
+	_, err := fmt.Fprintf(out, "gendrift: ran %d %s over %d generated %s\n",
+		len(ledger), plural(len(ledger), "generator", "generators"),
+		countPaths(), plural(countPaths(), "path", "paths"))
+	return err
 }
 
 // run compares the working tree against HEAD and reports drift.

--- a/tools/gendrift/main_test.go
+++ b/tools/gendrift/main_test.go
@@ -237,18 +237,29 @@ func TestTheLocalGateNamesTheDriftedArtifactAndNotYourEdits(t *testing.T) {
 func TestDocsembedRunsAfterEveryGeneratorThatWritesADocsPage(t *testing.T) {
 	const embedder = "go run ./tools/docsembed"
 
-	var writers []string
-	for _, g := range ledger {
+	// The order is asserted on the LEDGER now, and not on two copies of it in
+	// the justfile. It used to read the `generate` and `_generated` recipes,
+	// which each wrote the generators out in full, and it could say nothing at
+	// all about ci.yml, which wrote them out a third time and ran docsembed
+	// FOURTH of twelve. Every caller runs the ledger through `-generate`, so
+	// the ledger's order is the order all three of them use, and that is what
+	// this holds.
+	embedAt := -1
+	var writers []int
+	for i, g := range ledger {
 		if g.command == embedder {
+			embedAt = i
 			continue
 		}
 		for _, p := range g.paths {
 			if strings.HasPrefix(p, "docs/") {
-				writers = append(writers, g.command)
+				writers = append(writers, i)
 				break
 			}
 		}
 	}
+	require.NotEqual(t, -1, embedAt, "the ledger does not run %s at all", embedder)
+
 	// A rule with nothing to compare passes for the wrong reason. Six pages
 	// under docs/ are generated today and the ledger is where they are
 	// declared, so finding fewer than that means this test stopped seeing the
@@ -256,41 +267,143 @@ func TestDocsembedRunsAfterEveryGeneratorThatWritesADocsPage(t *testing.T) {
 	require.GreaterOrEqual(t, len(writers), 5,
 		"the ledger should name at least five generators writing under docs/, found %d", len(writers))
 
-	body, err := os.ReadFile(filepath.Join("..", "..", "justfile"))
+	for _, i := range writers {
+		require.Less(t, i, embedAt,
+			"the ledger runs %q at position %d, after %s at position %d.\n"+
+				"docsembed embeds the page that generator writes, so this pass embeds the previous wording.\n"+
+				"Move %s below every generator that writes under docs/.",
+			ledger[i].command, i, embedder, embedAt, embedder)
+	}
+}
+
+// TestTheLedgerIsTheOnlyPlaceTheGeneratorsAreListed is the gate on the failure
+// that produced -generate.
+//
+// The list was written out three times. The ledger named fifteen generators,
+// `just _generated` ran fifteen and ci.yml ran twelve, so three generated
+// files were rewritten by nothing on a clean checkout and could never be
+// reported by a tool whose only question is `git status`.
+// engine/internal/manifest/manifest.v1.json was one of them and sat stale on
+// main for thirteen commits with the step called "Generated files are current"
+// green on every one of them.
+//
+// A second copy of the list is what has to become impossible, so this refuses
+// one. It reads every caller and requires that each reaches the generators
+// through the ledger and spells none of them out itself.
+func TestTheLedgerIsTheOnlyPlaceTheGeneratorsAreListed(t *testing.T) {
+	root := filepath.Join("..", "..")
+
+	workflow, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "ci.yml"))
+	require.NoError(t, err)
+	justfile, err := os.ReadFile(filepath.Join(root, "justfile"))
 	require.NoError(t, err)
 
-	for _, recipe := range []string{"generate:", "_generated:"} {
-		t.Run(recipe, func(t *testing.T) {
-			lines := recipeBody(t, string(body), recipe)
+	callers := map[string]string{
+		// Comments removed first. ci.yml explains this very defect in prose
+		// and names `go run ./tools/docsembed` while doing so, and a check
+		// that cannot tell a command from a sentence about a command would
+		// have to be deleted for being unsatisfiable.
+		".github/workflows/ci.yml": withoutComments(string(workflow)),
+		"justfile _generated":      withoutComments(strings.Join(recipeBody(t, string(justfile), "_generated:"), "\n")),
+		"justfile generate":        withoutComments(strings.Join(recipeBody(t, string(justfile), "generate:"), "\n")),
+	}
 
-			embedAt := -1
-			for i, l := range lines {
-				if strings.Contains(l, embedder) {
-					embedAt = i
-					break
-				}
-			}
-			require.NotEqual(t, -1, embedAt, "%s never runs %s", recipe, embedder)
+	for name, body := range callers {
+		t.Run(name, func(t *testing.T) {
+			require.Contains(t, body, "go run ./tools/gendrift -generate .",
+				"%s does not run the ledger, so it is running some other list of generators", name)
 
-			found := 0
-			for _, w := range writers {
-				for i, l := range lines {
-					if !strings.Contains(l, w) {
-						continue
-					}
-					found++
-					require.Less(t, i, embedAt,
-						"%s runs %q at line %d of the recipe, after %s at line %d.\n"+
-							"docsembed embeds the page that generator writes, so this pass embeds the previous wording.\n"+
-							"Move %s below every generator that writes under docs/.",
-						recipe, w, i, embedder, embedAt, embedder)
-					break
-				}
+			for _, g := range ledger {
+				// gendrift's own row is `go run ./tools/docsembed` and so on;
+				// a caller naming one of them is a caller keeping a second
+				// copy of the list, which is the defect.
+				require.NotContains(t, body, g.command,
+					"%s spells out %q itself. That is a second copy of the ledger, and the\n"+
+						"two copies disagreed for thirteen commits with every check green.\n"+
+						"Add the generator to the ledger in tools/gendrift and let -generate run it.",
+					name, g.command)
 			}
-			require.GreaterOrEqual(t, found, 5,
-				"%s should run at least five of the ledger's docs writers, found %d", recipe, found)
 		})
 	}
+}
+
+// TestGenerateRunsEveryLedgerCommandInOrder proves -generate does the thing its
+// callers now trust it to do.
+//
+// A mode that named the commands and ran none of them would be the same defect
+// one layer down, and it would look identical from CI: a step that passes
+// having done nothing, followed by a comparison of a tree nobody rewrote.
+func TestGenerateRunsEveryLedgerCommandInOrder(t *testing.T) {
+	root := t.TempDir()
+
+	restore := ledger
+	t.Cleanup(func() { ledger = restore })
+	ledger = []generator{
+		{"echo first >> ran.txt", []string{"ran.txt"}},
+		{"echo second >> ran.txt", []string{"ran.txt"}},
+		{"echo third >> ran.txt", []string{"ran.txt"}},
+	}
+
+	var out bytes.Buffer
+	require.NoError(t, generateAll(root, &out))
+
+	body, err := os.ReadFile(filepath.Join(root, "ran.txt"))
+	require.NoError(t, err, "no generator wrote anything, so none of them ran")
+	require.Equal(t, "first\nsecond\nthird\n", string(body),
+		"the generators did not all run, or did not run in the ledger's order")
+	require.Contains(t, out.String(), "ran 3 generators",
+		"the summary does not say how many generators ran")
+}
+
+// TestAFailingGeneratorSaysNothingWasCompared is the distinction that cost
+// three lanes an afternoon.
+//
+// A step named for a comparison, which died in a generator before reaching it,
+// reported staleness it had never measured. Running the generators and
+// comparing them are two questions and they have to be able to fail with
+// different words, which is why -generate is a separate mode rather than a
+// line folded into the comparison.
+func TestAFailingGeneratorSaysNothingWasCompared(t *testing.T) {
+	root := t.TempDir()
+
+	restore := ledger
+	t.Cleanup(func() { ledger = restore })
+	ledger = []generator{
+		{"echo first >> ran.txt", []string{"ran.txt"}},
+		{"exit 3", []string{"ran.txt"}},
+		{"echo third >> ran.txt", []string{"ran.txt"}},
+	}
+
+	var out bytes.Buffer
+	err := generateAll(root, &out)
+	require.Error(t, err, "a generator exiting 3 was reported as success")
+	require.Contains(t, err.Error(), "`exit 3` failed",
+		"the failure does not name the generator that failed")
+	require.Contains(t, out.String(), "Nothing\nhas been compared",
+		"the output does not say that this is a generator failure and not a stale file")
+
+	body, err := os.ReadFile(filepath.Join(root, "ran.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "first\n", string(body),
+		"it carried on past a failed generator, so the tree it leaves is half written")
+}
+
+// withoutComments drops whole line comments, in both YAML and just, which use
+// the same `#`.
+//
+// It is deliberately whole line only. A trailing comment on a `run:` line
+// would survive, and that is the safe direction: this feeds a NotContains, so
+// keeping too much can only fail a tree that is fine, which somebody would
+// then fix, while dropping too much would pass a tree that is not.
+func withoutComments(body string) string {
+	var out []string
+	for _, l := range strings.Split(body, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(l), "#") {
+			continue
+		}
+		out = append(out, l)
+	}
+	return strings.Join(out, "\n")
 }
 
 // recipeBody returns the indented lines of one justfile recipe.


### PR DESCRIPTION
## The failure

`engine/internal/manifest/manifest.v1.json` is a copy of
`schemas/manifest.v1.json`, read through `go:embed` because embed cannot reach
outside the engine module. It sat stale on main for thirteen commits. Every
required context was green on every one of them, and the step that is supposed
to notice is called "Generated files are current".

`tools/gendrift` NAMES that path in its ledger. Its only action is
`git status --porcelain`, so it can report drift only for a generator that
something ELSE has already run. The `cp` that writes the file lived in the
justfile's `_generated` recipe and was absent from ci.yml's generator block. On
a clean checkout the file was never rewritten, never showed as changed, and was
never reported. The ledger row was decorative in CI.

`tools/gatecheck` exists to fail the build when the local recipe and the CI gate
disagree, and it could not see this one either. Every comparison in it started
from a CI gate and asked whether the justfile covered it. A gate the justfile
ran and no workflow ran was not a question anybody asked.

So a developer running `just gate` caught this, CI structurally could not, and
both reported under the same words.

## What this changes

**One list.** `gendrift -generate` runs the ledger, in the ledger's order.
ci.yml and both justfile recipes call it, so the list cannot disagree with
itself. It is a separate mode from the comparison rather than a line folded into
it, because "a generator did not finish" and "a file is stale" are different
answers, and a step that cannot tell them apart sent three lanes to the wrong
file on 2026-09-08.

**gatecheck compares both ways.** A gate `just gate` runs that no pull request
workflow runs is now reported, with its own exemption map carrying a reason per
entry and its own staleness check on that map, mirroring the forward direction.

## The audit, and how it was enumerated

It was not one ledger row. Enumerated from `origin/main` by taking the ledger's
`command` field mechanically out of `tools/gendrift/main.go` and differencing it
against ci.yml's generator block:

| ledger row | in ci.yml | path nothing could report |
| :--- | :--- | :--- |
| `cp schemas/manifest.v1.json engine/...` | no | `engine/internal/manifest/manifest.v1.json` |
| `go test ./internal/mockpack -update-vectors` | no | `schemas/mockpack-vectors.json` |
| `go test ./internal/webhook -update-vectors` | no | `schemas/webhook-vectors.json` |

Fifteen generators in the ledger, fifteen in `just _generated`, twelve in
ci.yml. Three of the ledger's twenty one paths were unreportable, not one.

The order was a fourth disagreement. `docsembed` embeds six pages other
generators write, so it must run last; ci.yml ran it FOURTH of twelve.

Whether any generated file escapes the ledger entirely was checked three ways,
and it does not: the ledger's own twenty one paths; every tracked file matching
the `.gen.` and `.register.` naming convention, which is six and all six are in
the ledger; and a `git grep` of the tracked tree for files declaring themselves
generated, whose only hits outside the ledger are three sentences of prose.
`www/public/openapi.json` is generated and deliberately outside the ledger
because its generator is TypeScript and its own `--check` mode is the
comparison, which ci.yml runs in its own job.

## What the reverse direction found on its first run

Seven. Three real, three blind spots in the matcher, one exemption.

Real, and fixed here by adding them to ci.yml: `just gate` ran `socketcheck` and
`fieldsweep` and NO workflow ran either, so two properties this repository holds
itself to could not fail a pull request.

Real and not fixed: `just coverage` is in the same state and cannot leave it,
because its input is a profile that takes the better part of an hour to produce.
It is in `exemptFromCI` and the reason says plainly that the per package
thresholds in C.5 are therefore not enforced on a branch. That is a maintainer's
call about an hour of CI time, not this tool's, and the exemption is now the one
place that says out loud which gate a green pull request does not include.

Blind spots, all fixed:

- `go run ../tools/scanrepo`, which is how ci.yml spells the credential scan,
  matched no pattern at all. The only credential scan here was invisible to the
  tool whose job is to notice a gate on one side and not the other.
- `go test ./...` in a directory did not pair with `go test` on a package under
  it, so `just docexamples` read as uncovered. It pairs now as its own weaker
  tier that the passing output names, rather than being folded in as an equal:
  the wide target covers the narrow one and the narrow one does not cover the
  wide one, and a test asserts both halves.
- The runner's tests ran as the command spelled out in ci.yml and as `npm test`
  in the justfile. One gate, two spellings. ci.yml uses the script now, so
  `runner/package.json` is the single place that says what those tests are. The
  script is the same command with `ls test/*.test.ts > /dev/null &&` in front,
  which fails rather than passes when the glob matches nothing.

`tool installcheck` is the seventh and is exempt: it compares a working copy's
`node_modules` against the lockfile beside it, and every CI job installed from
that lockfile minutes earlier, so on a runner the answer is yes by construction.

## Verification, arm by arm

Verdict lines, not exit codes. Two of the arms below exit 1 for reasons that
are not the thing under test, which is the point of reading the words.

### The gate, against the case that produced it

This branch is cut from `ce72b05c`, main BEFORE the hotfix, so
`engine/internal/manifest/manifest.v1.json` is genuinely stale in it. The
subject was confirmed broken first: `diff` says the embedded copy does not match
the published schema. Three arms, run against that:

**Arm 1, the new wiring on the stale tree.** `go run ./tools/gendrift -generate .`
then `go run ./tools/gendrift -strict .`. The comparison said:

```
gendrift: These committed files do not match what their generator just wrote.
Run the command beside each one, or `just generate` to run them all.

  cp schemas/manifest.v1.json engine/internal/manifest/manifest.v1.json
      engine/internal/manifest/manifest.v1.json
```

One file, named, with the command that fixes it. Under the old wiring this was
the tree the same job called "Generated files are current" on thirteen times.
It also confirms the other two rows were fine: mockpack and webhook were
unreportable, not stale.

**Arm 1 also demonstrated the mode split, and it was not planned.** The masking
generator runs a package that needs a Docker container, and on this loaded
machine `TestCrossStoreLive_OneIdentityMasksToOnePersonInBothStores` hit its own
ten minute timeout waiting on `ImageInspect`. `-generate` said:

```
gendrift: the generator `cd engine && go test ./internal/masking -update-transforms` failed: exit status 1

That is a generator that did not finish, and NOT a stale file. Nothing
has been compared. Fix the failure above and run this again before
reading anything into what the tree looks like now.
```

That is the exact confusion that sent three lanes to the wrong file on
2026-09-08, answered in words, by accident, on the first real run.

**Arm 2, the third falsification arm: the same stale tree with the `cp` row
deleted from the ledger.** Break the subject AND remove the wiring, and the
check must go silent. It did. `-strict` named
`engine/internal/manifest/manifest.v1.json` NOWHERE. It exits 1, and reading the
exit code rather than the words would be the mistake this repository keeps
finding in its own instruments: the only thing it reports is
`tools/gendrift/main.go`, which is the file I edited to remove the wiring,
correctly flagged as a changed path no generator claims. Silence about the
subject is the verdict.

**Arm 3, the tree with the embedded copy brought up to date**, applied as a
local commit and then discarded, because fixing the file belongs to #358 and not
to this branch. `gendrift: 21 generated paths match their generators`, exit 0.
Break, restore, and the check follows the subject in both directions.

All three arms ran at `1a721f15`, this branch before it was rebased onto the
main that now carries #358's fix.

### Mutation testing, one break per assertion

Every cell requires the `=== RUN` line for the exact test, so a `-run` pattern
matching nothing cannot read as a pass, and tells a build failure apart from a
red assertion, so "the instrument could not look" is never counted as a catch.
All eleven controls were green on the unmutated tree first.

| test | what was broken | verdict |
| :--- | :--- | :--- |
| `TestTheLedgerIsTheOnlyPlaceTheGeneratorsAreListed` | a `cp` step added back to ci.yml | RED |
| `TestGenerateRunsEveryLedgerCommandInOrder` | `-generate` runs `true` instead of the command | RED |
| `TestAFailingGeneratorSaysNothingWasCompared` | the error from `cmd.Run` ignored | RED |
| `TestDocsembedRunsAfterEveryGeneratorThatWritesADocsPage` | docsembed moved to the front of the ledger | RED |
| `TestAGateOnlyTheJustfileRunsIsReported` | `pairedWith`'s EARLY return says `pairedExactly` | RED |
| `TestAGateOnlyTheJustfileRunsIsReported` | `pairedWith`'s TAIL return says `pairedExactly` | RED |
| `TestARelativeToolsPathIsTheSameGate` | the pattern back to `./tools/` | RED |
| `TestTheWholeModuleTargetCoversAPackageUnderIt` | the subsumption tier deleted | RED |
| `TestTheWholeModuleTierDoesNotReachAcrossDirectories` | subsumption stops comparing the directory | RED |
| `TestEveryCIExemptionStatesWhy` | an exemption with a one word reason | RED |
| `TestAGateInARecipeTheGateNeverCallsIsNotHeldToCI` | reachability stops being asked | RED |
| `TestTheRealRepositoryAgrees` | socketcheck taken back out of ci.yml | RED |

**One mutation SURVIVED and is worth recording rather than quietly fixing.**
The first pass mutated `pairedWith`'s tail `return notPaired` and
`TestAGateOnlyTheJustfileRunsIsReported` stayed GREEN. The reason is that the
test's uncovered gate was `go run ./tools/onlyhere`, which carries no directory
and returns at the TOP of the function, so the assertion could not reach the
line the mutation changed. The two routes needed two assertions. The test now
also asserts a gate that carries a directory, and both returns are mutated
separately above. That is the sixth row of the table and the fifth.

### Gates run

All on the rebased tree, all exit 0: `gatecheck` (80 CI gates, 84 justfile
gates, clean both ways), `gendrift` (21 paths match), `socketcheck` (10 of 10
sockets implementable and consulted), `fieldsweep`, `actioncheck`, `keycheck`,
`prosecheck` (979 files, 0 places where the punctuation gives it away),
`changecheck`, `execcheck`, `conflictcheck`, `gofmt` (empty, which is the
verdict, because it exits 0 while printing), `go vet`, and both tools packages'
suites.

**One thing this missed on the first push, recorded because it is the same
shape as everything above.** `engine` went red on `Lint the gates`: staticcheck's
ST1005 refuses an error string ending in punctuation, and the failure message
`-generate` returns was a paragraph ending in a full stop. I had run `go vet`
and not `just lint-tools`, which is the gate that guards the file I had just
written. The explanation now goes to the writer and the error stays one line,
which is better output anyway because `main` prints it as `gendrift: <err>`.
The write is checked rather than discarded, for the reason the clean case
already gave: the whole value of that sentence is that somebody reads it.
`TestAFailingGeneratorSaysNothingWasCompared` was re-mutated afterwards in both
halves, the failure ignored and the explanation dropped, and it is RED for each.

**Not run, and said rather than assumed:** `just gate` end to end. It needs
Docker, a Postgres, npm installs across five workspaces and the better part of
an hour on a machine whose build lock had eleven waiters tonight, and the Docker
daemon on it is loaded enough that one generator's container test timed out
above. What was run is every gate this change touches or could break.
