### PR TITLE
ee: the README sold a hash chain that nothing streams

### DIFF
--- a/.changes/siem-streaming-sold-a-chain-it-does-not-stream.md
+++ b/.changes/siem-streaming-sold-a-chain-it-does-not-stream.md
@@ -1,0 +1,34 @@
+# fixed
+
+The enterprise README sold "SIEM streaming with a tamper evident hash chain".
+Both halves are real, they are not joined to each other, and the conjunction was
+false in the way that is hardest to notice, because each half can be pointed at.
+
+What ships is `ee/engine/auditsink`, registered in `ee/engine/cmd/af/main.go`,
+asking the licence per call, forwarding the five actions the audit stream page
+lists to Splunk, Event Hubs, an object store or a webhook. Its webhook signs an
+HMAC over the exact bytes posted, so one delivery is tamper evident. Nothing in
+it chains entries together.
+
+The chain exists twice and neither copy is streamed. `audit_entries` carries
+`prev_hash` and `entry_hash` and is written by the control plane regardless of
+any licence, which is MIT and is not sold. `ee/web/audit` implements the
+forwarder that would carry that chain to a sink, with a bounded queue, four
+sinks and signed batch manifests over the chain head, and nothing imports it. It
+is not a declared dependency of any package in the workspace, including
+`ee/web/server`, so it could not be imported without a package.json change,
+while its own suite runs and passes in CI on every pull request.
+
+So the control plane's audit log reaches no sink. Single sign on logins,
+directory provisioning, operator impersonation and every admin action are
+written to `audit_entries` and forwarded nowhere.
+
+The customer facing page was already right. `docs/enterprise/audit-stream.md`
+scopes itself to the engine in its second paragraph and lists exactly the five
+engine actions. It was the one line summary in `ee/README.md`, repeated in
+`LICENSING.md`, that sold more than the product does, which is where a product
+oversells itself first.
+
+This corrects the claim rather than building the missing half. The wiring is
+enterprise side work and is described where the claim used to be, so the
+paragraph is deletable by whoever lands it.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -11,8 +11,11 @@ The community edition is complete rather than a demo. Masking, verification,
 every database provider, the egress and mocking layer, the agent runner,
 insights, load, and the control plane are MIT and stay MIT. What is in `ee/` is
 the set of things a large company requires before a rollout and an individual
-developer never uses: single sign on, SCIM, custom roles, SIEM streaming,
-policy enforcement, customer owned runtimes, and billing.
+developer never uses: single sign on, SCIM, custom roles, SIEM streaming of
+the engine's privileged actions, policy enforcement, customer owned runtimes,
+and billing. `ee/README.md` says exactly which actions those are and which
+audit log is not forwarded, because a one word summary of a feature is where a
+product oversells itself first.
 
 The reasoning behind the split, including the alternatives that were rejected,
 is in [ADR 0002](./docs/adr/0002-license-model.md).

--- a/ee/README.md
+++ b/ee/README.md
@@ -16,9 +16,41 @@ your agents, and tears everything down, and it does that completely, forever,
 for free, self hosted. What lives here is the set of things a large company
 asks for before a rollout, which is also the set of things a large company is
 willing to pay for: single sign on, SCIM provisioning, custom roles and
-approvals, SIEM streaming with a tamper evident hash chain, organization wide
+approvals, SIEM streaming of the engine's privileged actions, organization wide
 policy enforcement, customer owned runtime clusters, enterprise secret
 managers, billing and metering, and support tooling.
+
+### What that sentence used to claim, and what actually ships
+
+It said "SIEM streaming with a tamper evident hash chain". Both halves are real
+and they are not joined to each other, so the conjunction was false in the way
+that is hardest to notice: each half can be pointed at.
+
+What ships is `ee/engine/auditsink`. It is registered in
+`ee/engine/cmd/af/main.go`, it asks the licence per call, and it forwards the
+five actions that `docs/enterprise/audit-stream.md` lists, to Splunk, Event
+Hubs, an object store or a webhook. The webhook carries an HMAC over the exact
+bytes posted, which makes one delivery tamper evident. There is no chain across
+entries in it.
+
+The chain exists in two places and neither is streamed. `audit_entries` carries
+`prev_hash` and `entry_hash` and is written by the control plane regardless of
+any licence, which is MIT and is not sold. `ee/web/audit` implements the
+forwarder that would carry that chain to a sink, with a bounded queue, four
+sinks and signed batch manifests over the chain head, and **nothing imports
+it**. It is not a declared dependency of any package in this workspace,
+including `ee/web/server`, so it could not be imported without a package.json
+change, while its own suite runs and passes in CI on every pull request. Tested,
+green, and unreachable is the most convincing possible disguise for dead code.
+
+So the control plane's audit log is not forwarded anywhere. Single sign on
+logins, directory provisioning, operator impersonation and every admin action
+are in `audit_entries` and reach no sink. `docs/enterprise/audit-stream.md` was
+already accurate about this and says so in its second paragraph; it was this
+summary line that sold more than the product does. Wiring the control plane half
+is enterprise side work, since `ee/web/server/src/register.ts` already does non
+route work and is handed the pool and the clock, and when it lands this
+paragraph is what gets deleted.
 
 ## How the boundary is enforced
 


### PR DESCRIPTION
## The failure

`ee/README.md` sold "SIEM streaming with a tamper evident hash chain". Both
halves are real, they are not joined to each other, and the conjunction was
false in the hardest shape to notice: each half can be pointed at when
questioned.

**What ships.** `ee/engine/auditsink`, registered in `ee/engine/cmd/af/main.go`,
asking the licence per call, forwarding the five actions
`docs/enterprise/audit-stream.md` lists to Splunk, Event Hubs, an object store
or a webhook. Its webhook carries an HMAC over the exact bytes posted, so one
delivery is tamper evident. Nothing in it chains entries to each other.

**Where the chain is.** Twice, and neither copy is streamed. `audit_entries`
carries `prev_hash` and `entry_hash` and is written by the control plane
whatever the licence says, which is MIT and is not sold. `ee/web/audit`
implements the forwarder that would carry that chain to a sink, with a bounded
queue, four sinks and signed batch manifests over the chain head, and nothing
imports it.

**Why nobody noticed.** It is not a declared dependency of any package in the
workspace, including `ee/web/server`, so it could not be imported without a
package.json change. And the `enterprise` job runs `npm --prefix ee/web test`,
which runs every workspace, so its suite executes and passes on every pull
request. Tested, green and unreachable is the most convincing disguise dead code
can wear.

So the control plane's audit log reaches no sink. Single sign on logins,
directory provisioning, operator impersonation and every admin action are
written and forwarded nowhere.

The customer facing page was already honest: `audit-stream.md` scopes itself to
the engine in its second paragraph and lists exactly five engine actions. It was
the one line summary in `ee/README.md`, repeated in `LICENSING.md`, that sold
more than the product does.

## Why this corrects the claim rather than building the missing half

The wiring is real work with a known shape, and I established it is enterprise
side only: a cursor over `audit_entries.seq`, a poll loop started from
`ee/web/server/src/register.ts`, which already does non route work at line 176
and is already handed the pool and the clock, sink configuration, and the same
`licensed(pool, orgId, 'audit_stream', now)` gate SCIM and SSO use. The
`Extension` interface carrying only `name` and `routes` is true and is not the
constraint; that was a true fact about the wrong object, and I had twice claimed
it blocked this.

I could not build that AND prove it observably effective tonight. An audit
forwarder that has not been watched to deliver an entry end to end, with the
negative controls both ways, is exactly the class of thing this repository
refuses to call done, and shipping it unproven would have been the same defect
one layer along. So the claim is corrected now, in detail, and what building it
would mean is written where the claim used to be, so that paragraph is
**deletable** by whoever lands the forwarder.

## Follow-ups this does not close, named rather than left silent

**`ee/engine/feature/feature_test.go:61` cannot fail.**
`require.Empty(t, feature.Sites(license.FeatureCompliance))` runs in a test
binary that links none of the enforcing packages, so the set is empty whatever
the product does. The catalogue test's own comment already names this shape, and
my #360 body should have named it too and did not. It needs a Go build to change
and the lock has been up to seventeen deep tonight, so it is a follow-up rather
than a silent omission.

**The third falsification arm on #360's instrument, run now rather than
promised.** Break and restore proves a check reacts; deleting the check while
still broken proves it is the thing reacting.

| Arm | State | Result |
| --- | --- | --- |
| 1 | `air_gapped` classified, instrument present | 9 tests, 9 pass |
| 2 | `air_gapped` unclassified, instrument present | 9 tests, 8 pass, 1 fail naming air_gapped |
| 3 | `air_gapped` still unclassified, instrument deleted | 6 tests, 6 pass |

Arm 3 is the one that matters: with the catalogue still broken and my check
removed, nothing else in the file notices. The instrument is what was reacting.

## Verification

No file under `docs/src/content/docs` is touched, so `docsembed` does not apply
and `pages.gen.go` is unchanged. No code changes, so no Go build. Em dash and the
double hyphen rule both checked by hand on all three files, and `LICENSING.md` and the `.changes`
fragment are both inside `prosecheck`'s reach.

## Handoff: what building the forwarder means, concretely

Written here rather than in a note, because a note rots and this pull request's
body is what the squash carries into main. Everything below was established by
tracing, not assumed.

**It is enterprise side only.** `ee/web/server/src/register.ts:176` already calls
`setSignInPolicy(signInPolicy(options.pool))`, so the registration path already
does non route work and is already handed the pool and the clock. It can start a
background forwarder itself. The `Extension` interface at
`web/apps/api/src/extensions.ts:54` carrying only `name` and `routes` is true and
is **not** the constraint; that was a true fact about the wrong object, and it is
the reason this was mistaken for a community surface change twice.

**The pieces already fit.**

| Piece | Where it already is |
| --- | --- |
| the rows | `audit_entries`, `0001_init.sql:379`, keyed by `seq bigserial`, field for field the `Entry` interface in `ee/web/audit/src/sink.ts` |
| the forwarder | `ee/web/audit`: `Queue.enqueue`, `Queue.flush`, four sinks, `sign`/`verify` over the chain head |
| the per org gate | `licensed(pool, orgId, 'audit_stream', now)`, the same one SCIM and SSO use |
| a home for enterprise schema | `0014_sso_and_scim.sql` establishes that it lives in the community migration set |
| a periodic loop | `boot.ts` already runs `setInterval` housekeeping and `startMaintenance` |

**What has to be written:** a cursor table, a poll reading `audit_entries` above
the cursor, the licence check per organization before enqueue, `flush`, and the
cursor advancing only past what was delivered. `Queue.flush` leaves a failed
batch at the front and never throws, so not advancing on a partial flush gives
at least once delivery, and duplicates are detectable by `seq`.

**Two repository rules that bite here.** Take main's highest migration number
plus one at the moment of landing, never reserved in advance, because parallel
branches always collide. And run `writers.test.ts` before designing against the
new table, because a complete looking migration can have zero writers, which is
the same defect as this pull request one layer down.

**The bar.** An admin action produces an entry a sink actually receives, proven
end to end, with both negative controls: registration dropped and the delivery
test goes red, licence dropped and an unlicensed organization gets nothing. The
`enterprise` CI job provides Postgres and sets `AF_TEST_DATABASE_URL`, and the
harness pattern is `ee/web/scim/test/harness.ts`. Note that those suites SKIP
without a database, and a skipped test reads exactly like a passing one, so the
delivery test must be confirmed to have actually run.

When it lands, the "What that sentence used to claim" section in `ee/README.md`
is what gets deleted, and this line is the removal condition.
