### PR TITLE
ee: the order of two statements decided whether a licence was enforced

### DIFF
--- a/.changes/the-order-of-two-statements-decided-whether-a-licence-was-enforced.md
+++ b/.changes/the-order-of-two-statements-decided-whether-a-licence-was-enforced.md
@@ -1,0 +1,4 @@
+The enterprise binary's licence gate over the managed cloud providers now has a
+test that says no when a provider is registered after it. The gate wraps what is
+registered at the moment it runs, so a registration placed below it is served
+ungated, and nothing else in the tree could tell the two orders apart.

--- a/.changes/the-order-of-two-statements-decided-whether-a-licence-was-enforced.md
+++ b/.changes/the-order-of-two-statements-decided-whether-a-licence-was-enforced.md
@@ -1,3 +1,5 @@
+# fixed
+
 The enterprise binary's licence gate over the managed cloud providers now has a
 test that says no when a provider is registered after it. The gate wraps what is
 registered at the moment it runs, so a registration placed below it is served

--- a/ee/engine/cmd/af/cloudgate_order_test.go
+++ b/ee/engine/cmd/af/cloudgate_order_test.go
@@ -1,0 +1,121 @@
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+
+package main_test
+
+// The one thing that can say no about the order of the registrations in
+// main.go.
+//
+// cloudgate.Wrap puts the managed cloud providers behind the cloud_database
+// and cloud_runtime features by wrapping what is registered AT THE MOMENT IT
+// RUNS. A provider registered after it is not wrapped, so it is not gated, so
+// an unlicensed build serves it.
+//
+// Every other instrument in this repository is blind to that. The wrong order
+// compiles. go vet is clean. Each registration still appears exactly once with
+// its import, which is the rule a keep both merge resolution is checked
+// against, so the resolution reviews as correct. The provider is really
+// registered, so nothing that asserts registration fails. The defect is
+// entirely in the ORDER of two statements, and order is the thing a diff, a
+// compiler and a symbol count all agree to ignore.
+//
+// So this reads the syntax tree rather than the behaviour, deliberately: the
+// behaviour it is protecting is "a licence is required", and a test that
+// exercised that would be asserting the gate works rather than that the gate
+// is reached. What goes wrong here is reachability, and position is what
+// decides it.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// mentionsTheRegistry reports whether a call hands extension.Default to
+// something, either as `extension.Default.Add...(x)` or as a function taking
+// the registry, which are the two shapes every registration in main.go uses.
+func mentionsTheRegistry(call *ast.CallExpr) bool {
+	isDefault := func(n ast.Node) bool {
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "Default" {
+			return false
+		}
+		id, ok := sel.X.(*ast.Ident)
+		return ok && id.Name == "extension"
+	}
+	for _, a := range call.Args {
+		if isDefault(a) {
+			return true
+		}
+	}
+	if sel, ok := call.Fun.(*ast.SelectorExpr); ok && isDefault(sel.X) {
+		return true
+	}
+	return false
+}
+
+func TestTheCloudGateWrapsLast(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "main.go", nil, 0)
+	require.NoError(t, err)
+
+	var wrap token.Pos
+	var lastRegistration token.Pos
+	var lastName string
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if pkg, ok := sel.X.(*ast.Ident); ok && pkg.Name == "cloudgate" && sel.Sel.Name == "Wrap" {
+			wrap = call.Lparen
+			// The gate takes the registry too, so it must not count as one of
+			// the registrations it is being compared against.
+			return true
+		}
+		if mentionsTheRegistry(call) && call.Lparen > lastRegistration {
+			lastRegistration = call.Lparen
+			lastName = types(fset, call)
+		}
+		return true
+	})
+
+	require.NotEqualf(t, token.NoPos, wrap,
+		"main.go does not call cloudgate.Wrap at all, so nothing puts the managed cloud "+
+			"providers behind their features and this test would otherwise pass by finding nothing")
+	require.NotEqualf(t, token.NoPos, lastRegistration,
+		"main.go registers nothing against extension.Default, which cannot be true while "+
+			"providers ship, so this test is reading the wrong thing rather than passing")
+
+	require.Lessf(t, int(lastRegistration), int(wrap),
+		"%s is at line %d and cloudgate.Wrap is at line %d, so that registration happens AFTER "+
+			"the licence gate and is never wrapped by it. The provider still works, still "+
+			"appears once, still compiles and still vets, and it is served by a build with no "+
+			"licence for it. Move the registration above the cloudgate.Wrap call.",
+		lastName, fset.Position(lastRegistration).Line, fset.Position(wrap).Line)
+}
+
+// types renders the called function for the failure message, so the refusal
+// names the registration that moved rather than only a line number.
+func types(fset *token.FileSet, call *ast.CallExpr) string {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return "a registration"
+	}
+	if x, ok := sel.X.(*ast.Ident); ok {
+		return x.Name + "." + sel.Sel.Name
+	}
+	if inner, ok := sel.X.(*ast.SelectorExpr); ok {
+		if id, ok := inner.X.(*ast.Ident); ok {
+			return id.Name + "." + inner.Sel.Name + "." + sel.Sel.Name
+		}
+	}
+	return sel.Sel.Name
+}

--- a/ee/engine/cmd/af/main.go
+++ b/ee/engine/cmd/af/main.go
@@ -215,6 +215,19 @@ func main() {
 	// definition of "cloud" here rather than a list of vendor names somebody
 	// has to keep in step.
 	//
+	// NOTHING IN THIS REPOSITORY CATCHES THE WRONG ORDER, which is why this
+	// paragraph exists rather than the sentence above being left to carry it.
+	// A registration placed BELOW this call is silently ungated: the binary
+	// compiles, go vet is clean, every symbol still appears exactly once with
+	// its import so a keep both merge resolution reviews as correct, and the
+	// registration tests still pass, because the provider genuinely IS
+	// registered. Only the gating is gone, and no gate here can see the
+	// difference between the two orders. It was found resolving a conflict
+	// between a new provider's registration and this call, where the right
+	// answer and a licence bypass were both green on every instrument in the
+	// tree. TestTheCloudGateWrapsLast is the only thing that says no, so put
+	// a new registration ABOVE this call.
+	//
 	// Unconditional rather than under a licence, for the reason the policy
 	// hook above gives: the gate asks the licence per call, so a licence that
 	// lapses mid process stops enforcement without a restart, and gating the


### PR DESCRIPTION
`cloudgate.Wrap` puts the managed cloud providers behind the `cloud_database`
and `cloud_runtime` features by wrapping what is registered AT THE MOMENT IT
RUNS. Its comment in `ee/engine/cmd/af/main.go` already said it must go last.
What it did not say, and what this change adds, is that nothing in this
repository catches the other order.

## The hazard

A provider registered BELOW that call is not wrapped, so it is not gated, so a
build with no licence for it serves it.

Every instrument here is blind to that, and this is measured rather than
asserted. With `aurora.Register(extension.Default)` moved below the
`cloudgate.Wrap` block:

    mutated_build_exit=0
    mutated_vet_exit=0

It compiles and it vets. Each registration still appears exactly once with its
import, which is the rule a keep both merge resolution gets checked against, so
the resolution reviews as correct. The provider genuinely is registered, so
nothing that asserts registration fails. The entire defect is the position of
two statements, and position is what a diff, a compiler and a symbol count all
agree to ignore.

It was found resolving a real conflict, not imagined. A new database provider's
registration and this call collided in a rebase of #314, and the two candidate
resolutions were a correct one and a licence bypass, both green on everything in
the tree.

## What says no

`TestTheCloudGateWrapsLast` parses `main.go`, finds every call that hands
`extension.Default` to something, and requires the last of them to precede
`cloudgate.Wrap`. It reads position rather than behaviour deliberately: a test
that exercised the gate would be asserting the gate works, and what goes wrong
here is that the gate is never reached.

It refuses by name rather than by line number alone:

    aurora.Register is at line 240 and cloudgate.Wrap is at line 235, so that
    registration happens AFTER the licence gate and is never wrapped by it.

It also fails when it is looking at nothing, which is the usual failure mode for
a check of this shape. If `cloudgate.Wrap` is absent from `main.go` it fails, and
if no registration against `extension.Default` is found it fails, rather than
finding zero of each and passing by comparing them.

## Mutation tested, three cells, one test started in each

    baseline   exit=0  tests_started=1   PASS
    mutated    exit=1  tests_started=1   FAIL, naming aurora.Register and both lines
    restored   exit=0  tests_started=1   PASS

The started count is reported per cell because a `-run` that matches nothing
exits 0 and reads exactly like a pass.

## Why a comment and not a document

The person who breaks this is adding a registration during a conflict
resolution, and the only text they are certain to have in front of them is that
file. A limitation written above the thing it constrains is read at the moment
it matters. The same note in a house rules document or a pull request body is
read once, by whoever reviewed it.
