### PR TITLE
engine: two published bounds the engine had already tightened

### DIFF
--- a/.changes/two-published-bounds-the-engine-had-already-tightened.md
+++ b/.changes/two-published-bounds-the-engine-had-already-tightened.md
@@ -1,0 +1,5 @@
+The manifest schema now publishes the duration pattern on
+`database.volume.max_age` and `load.traffic.max_age`. The engine already refused
+anything that was not a duration in both places, so the reference page was
+telling readers that any string up to 32 characters would be accepted when it
+would not.

--- a/.changes/two-published-bounds-the-engine-had-already-tightened.md
+++ b/.changes/two-published-bounds-the-engine-had-already-tightened.md
@@ -1,3 +1,5 @@
+# fixed
+
 The manifest schema now publishes the duration pattern on
 `database.volume.max_age` and `load.traffic.max_age`. The engine already refused
 anything that was not a duration in both places, so the reference page was

--- a/docs/src/content/docs/reference/schemas/manifest-v1.md
+++ b/docs/src/content/docs/reference/schemas/manifest-v1.md
@@ -487,7 +487,7 @@ The committed record of what production actually serves, which is the denominato
 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
-| `max_age` | string | no | How old the profile may be before it is refused. A stale profile is not a smaller number, it is an unknown one, so it is refused the way a stale golden is rather than quoted. Fourteen days by default rather than the volume profile's thirty, because an endpoint mix moves at the rate a team ships rather than at the rate a business grows. Defaults to `336h`. Max length 32. |
+| `max_age` | string | no | How old the profile may be before it is refused. A stale profile is not a smaller number, it is an unknown one, so it is refused the way a stale golden is rather than quoted. Fourteen days by default rather than the volume profile's thirty, because an endpoint mix moves at the rate a team ships rather than at the rate a business grows. Defaults to `336h`. Max length 32, matches `^[0-9]+(ms\|s\|m\|h\|d)$`. |
 | `profile` | string | **yes** | The profile file, relative to the repository root. Written by af traffic record from an OpenTelemetry trace export or a combined format access log, and committed, because the machine that reads it on a pull request cannot reach production. It carries the endpoint mix, the arrival rate, the peak concurrency and the per route p95, and no request body, header, query string or identifier. Max length 512. |
 
 ## Volume
@@ -496,7 +496,7 @@ The committed record of what production holds, which is the denominator every ro
 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
-| `max_age` | string | no | How old the profile may be before it is refused. A stale profile is not a smaller number, it is an unknown one, so it is refused the way a stale golden is rather than quoted. Thirty days by default rather than the golden's seven, because a profile is the shape of the data rather than the data. Defaults to `720h`. Max length 32. |
+| `max_age` | string | no | How old the profile may be before it is refused. A stale profile is not a smaller number, it is an unknown one, so it is refused the way a stale golden is rather than quoted. Thirty days by default rather than the golden's seven, because a profile is the shape of the data rather than the data. Defaults to `720h`. Max length 32, matches `^[0-9]+(ms\|s\|m\|h\|d)$`. |
 | `profile` | string | **yes** | The profile file, relative to the repository root. Written by af volume record from a read only connection to production or a replica, and committed, because the machine that reads it on a pull request cannot reach production. It carries counts, sizes, partition shape and key cardinality, and no data. Max length 512. |
 
 ## Workflow

--- a/engine/internal/docs/pages.gen.go
+++ b/engine/internal/docs/pages.gen.go
@@ -21513,7 +21513,7 @@ The committed record of what production actually serves, which is the denominato
 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
-| ` + "`" + `max_age` + "`" + ` | string | no | How old the profile may be before it is refused. A stale profile is not a smaller number, it is an unknown one, so it is refused the way a stale golden is rather than quoted. Fourteen days by default rather than the volume profile's thirty, because an endpoint mix moves at the rate a team ships rather than at the rate a business grows. Defaults to ` + "`" + `336h` + "`" + `. Max length 32. |
+| ` + "`" + `max_age` + "`" + ` | string | no | How old the profile may be before it is refused. A stale profile is not a smaller number, it is an unknown one, so it is refused the way a stale golden is rather than quoted. Fourteen days by default rather than the volume profile's thirty, because an endpoint mix moves at the rate a team ships rather than at the rate a business grows. Defaults to ` + "`" + `336h` + "`" + `. Max length 32, matches ` + "`" + `^[0-9]+(ms\|s\|m\|h\|d)$` + "`" + `. |
 | ` + "`" + `profile` + "`" + ` | string | **yes** | The profile file, relative to the repository root. Written by af traffic record from an OpenTelemetry trace export or a combined format access log, and committed, because the machine that reads it on a pull request cannot reach production. It carries the endpoint mix, the arrival rate, the peak concurrency and the per route p95, and no request body, header, query string or identifier. Max length 512. |
 
 ## Volume
@@ -21522,7 +21522,7 @@ The committed record of what production holds, which is the denominator every ro
 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
-| ` + "`" + `max_age` + "`" + ` | string | no | How old the profile may be before it is refused. A stale profile is not a smaller number, it is an unknown one, so it is refused the way a stale golden is rather than quoted. Thirty days by default rather than the golden's seven, because a profile is the shape of the data rather than the data. Defaults to ` + "`" + `720h` + "`" + `. Max length 32. |
+| ` + "`" + `max_age` + "`" + ` | string | no | How old the profile may be before it is refused. A stale profile is not a smaller number, it is an unknown one, so it is refused the way a stale golden is rather than quoted. Thirty days by default rather than the golden's seven, because a profile is the shape of the data rather than the data. Defaults to ` + "`" + `720h` + "`" + `. Max length 32, matches ` + "`" + `^[0-9]+(ms\|s\|m\|h\|d)$` + "`" + `. |
 | ` + "`" + `profile` + "`" + ` | string | **yes** | The profile file, relative to the repository root. Written by af volume record from a read only connection to production or a replica, and committed, because the machine that reads it on a pull request cannot reach production. It carries counts, sizes, partition shape and key cardinality, and no data. Max length 512. |
 
 ## Workflow

--- a/engine/internal/manifest/manifest.v1.json
+++ b/engine/internal/manifest/manifest.v1.json
@@ -557,6 +557,7 @@
         "max_age": {
           "type": "string",
           "maxLength": 32,
+          "pattern": "^[0-9]+(ms|s|m|h|d)$",
           "default": "720h",
           "description": "How old the profile may be before it is refused. A stale profile is not a smaller number, it is an unknown one, so it is refused the way a stale golden is rather than quoted. Thirty days by default rather than the golden's seven, because a profile is the shape of the data rather than the data."
         }
@@ -1979,6 +1980,7 @@
         "max_age": {
           "type": "string",
           "maxLength": 32,
+          "pattern": "^[0-9]+(ms|s|m|h|d)$",
           "default": "336h",
           "description": "How old the profile may be before it is refused. A stale profile is not a smaller number, it is an unknown one, so it is refused the way a stale golden is rather than quoted. Fourteen days by default rather than the volume profile's thirty, because an endpoint mix moves at the rate a team ships rather than at the rate a business grows."
         }

--- a/engine/internal/manifest/schema_constraints_test.go
+++ b/engine/internal/manifest/schema_constraints_test.go
@@ -1209,7 +1209,7 @@ func TestSchemaConstraintReport(t *testing.T) {
 // twenty five sit on top of the seven above, so this is the first number here
 // in some time that was measured against a fixture the engine accepts rather
 // than inherited from a run that stopped before it got here.
-const wantConstraints = 625
+const wantConstraints = 627
 
 // wantExceptions is how many constraints schemabounds.go deliberately does not
 // enforce. Every one is a published row that is wrong rather than a gap, and

--- a/schemas/manifest.v1.json
+++ b/schemas/manifest.v1.json
@@ -557,6 +557,7 @@
         "max_age": {
           "type": "string",
           "maxLength": 32,
+          "pattern": "^[0-9]+(ms|s|m|h|d)$",
           "default": "720h",
           "description": "How old the profile may be before it is refused. A stale profile is not a smaller number, it is an unknown one, so it is refused the way a stale golden is rather than quoted. Thirty days by default rather than the golden's seven, because a profile is the shape of the data rather than the data."
         }
@@ -1979,6 +1980,7 @@
         "max_age": {
           "type": "string",
           "maxLength": 32,
+          "pattern": "^[0-9]+(ms|s|m|h|d)$",
           "default": "336h",
           "description": "How old the profile may be before it is refused. A stale profile is not a smaller number, it is an unknown one, so it is refused the way a stale golden is rather than quoted. Fourteen days by default rather than the volume profile's thirty, because an endpoint mix moves at the rate a team ships rather than at the rate a business grows."
         }


### PR DESCRIPTION
`database.golden.max_age` carries `"pattern": "^[0-9]+(ms|s|m|h|d)$"` in
`schemas/manifest.v1.json`. `database.volume.max_age` and `load.traffic.max_age`
did not, and `engine/internal/manifest/validate.go` duration checks all three,
at 515, 537 and 1347.

So the published schema was WEAKER than what the engine enforces. The generated
reference page told a reader that any string up to 32 characters was acceptable
in two places where the engine refuses everything that is not a duration.

## The same defect as #327, running the other way

#327 measured 168 published constraints kept by nothing: promises the document
made that the engine did not keep. These two are the mirror image, bounds the
engine keeps that the document did not publish, and they deserve the same
attention. A reader plans against the document. A rule that only appears when
their manifest is refused is one they meet as a failure rather than as a
constraint.

Nothing here changes behaviour. Both values were already refused. What changes is
that the schema says so, which is what `tools/schemadoc` renders into the
reference and what an editor validates against.

## The count was verified, and it needed to be

`wantConstraints` moves 625 to 627, one per pattern.

It was 600 when this change was planned, a short time earlier, and main moved
twice in between. Predicting 602 would have been wrong. The figure is read off
the run, which reports what it measured against what it was written for.

## The instrument reacts to the change rather than permitting it

    before the pin moved:  FAIL, declares 627 constraints and this test
                                 was written against 625
    after:                 PASS, tests_started=2

The pass is the load bearing half. Had the engine NOT enforced the two
constraints the schema now declares, they would have been reported as published
and kept by nothing, and it would have failed for that reason instead. So the
green says the document and the engine now agree, not merely that a number was
updated. Both cells report `tests_started=2`, because a `-run` matching nothing
exits 0 and reads exactly like a pass.

`engine/internal/manifest/manifest.v1.json` moves with the schema, since it is a
verbatim copy made by the `cp` in `just generate`, and
`TestTheEmbeddedSchemaIsThePublishedOne` passes.

## Restating a hazard from #366, because a squash is the record

#366 adds this to `ee/engine/cmd/af/main.go`, and it is repeated here so it lands
in a second squash message if that one slips.

`cloudgate.Wrap` gates the managed cloud providers by wrapping what is
registered AT THE MOMENT IT RUNS. A provider registered BELOW that call is not
wrapped, so it is not gated, so a build with no licence for it serves it. Nothing
in this repository catches the wrong order, and that is measured rather than
asserted: with a registration moved below the call, `build_exit=0` and
`vet_exit=0`, every symbol still appears exactly once with its import so a keep
both merge resolution reviews as correct, and the registration tests still pass
because the provider genuinely is registered. Only the gating is gone.

It was found resolving a real conflict during a rebase of #314, where the correct
resolution and a licence bypass were both green on every instrument in the tree.
