### PR TITLE
gates: a comparison that could not say it had not looked

### DIFF
--- a/.changes/a-gate-that-could-not-say-it-had-not-looked.internal.md
+++ b/.changes/a-gate-that-could-not-say-it-had-not-looked.internal.md
@@ -1,0 +1,38 @@
+# fixed
+
+`tools/gendrift` refuses to report a clean tree unless a generator has actually
+run in it.
+
+The list of generators is written in one place since #363, and both callers run
+it, so the three copies cannot disagree any more. That closed the cause and left
+the shape. The two halves are still two processes and nothing coupled them:
+`go run ./tools/gendrift .` on its own ran no generator, compared the committed
+bytes against themselves, and printed
+
+    gendrift: 21 generated paths match their generators
+
+That is the identical sentence a rebuilt tree prints. It was printed on thirteen
+commits while `engine/internal/manifest/manifest.v1.json` sat stale on main, and
+an edit to `ci.yml` that dropped or reordered the `-generate` step would have it
+printed again, with the gate green throughout. A check that cannot say "I could
+not look" as something different from "I looked and it is clean" is worse than
+no check, because the reassuring sentence is what stops anybody asking.
+
+`-generate` now leaves a receipt naming the commit it ran against and a hash of
+the ledger it ran, and the comparison refuses to answer without one that matches
+this tree. Three different refusals, because they are three different facts: no
+receipt at all means no generator has run here; a receipt from another commit
+means the generators saw a different tree; a receipt from another ledger means a
+row has been added whose generator has never run, which is the original defect
+one turn later. The receipt is cleared BEFORE the generators run rather than
+after a failure, so there is no ordering in which it survives a run that died
+half way and vouches for a half written tree.
+
+The enumeration the ledger cannot do for itself is checked too. `-strict`
+catches a generated file no row claims only when something wrote it during the
+run, so it is blind to a generator that is in neither the ledger nor any
+workflow: nothing rewrites the file, nothing changes, and the comparison passes.
+Every tracked Go file that declares itself generated must now be claimed by the
+ledger. Four do and four are claimed. That covers Go only, and it says so: the
+marker is a Go convention, and the generated JSON, Markdown and golden frames
+here carry no uniform equivalent.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,14 @@ jobs:
         # does not claim means something writes an artifact that nothing
         # compares. `just gate` runs the same tool without it, because a
         # developer is always in the middle of an edit.
+        #
+        # It also refuses to answer at all unless the step above actually ran.
+        # That step leaves a receipt naming the commit and the ledger it ran,
+        # and without a matching one this fails saying nothing was compared.
+        # Delete or reorder the step above and this goes red rather than
+        # printing "21 generated paths match their generators" about a tree
+        # nobody rebuilt, which is the sentence that covered thirteen stale
+        # commits.
         run: go run ./tools/gendrift -strict .
 
       - name: The engine's parsers survive arbitrary input

--- a/.gitignore
+++ b/.gitignore
@@ -320,6 +320,19 @@ web/apps/api/zzserve.ts
 # tools/preview.
 /preview
 
+# The receipt `go run ./tools/gendrift -generate .` leaves to say that it ran,
+# read by the comparison that follows it and by nothing else. It names the
+# commit and a hash of the generator ledger, so the comparison can tell a tree
+# whose generators just ran from one where none did, which printed the same
+# sentence until it existed.
+#
+# Never committed. A receipt inside the tree is a receipt that vouches for that
+# tree by being in it, and the whole value of the file is that it is evidence
+# about one run on one machine. tools/gendrift skips it in the comparison as
+# well, so a deletion of this line is noise in a diff rather than a gate that
+# starts passing.
+/.gendrift-receipt.json
+
 # `go build ./tools/prmerge` writes ./prmerge at the repository root, for the
 # same reason /preview is here: tools/gatecheck refuses any tools directory
 # whose name is not ignored, because the next `git add -A` would otherwise

--- a/justfile
+++ b/justfile
@@ -1619,6 +1619,11 @@ _generated:
     #
     # No -strict here, unlike CI. You are always in the middle of an edit, and
     # a gate that fails on your uncommitted work is a gate you learn to skip.
+    #
+    # This refuses unless the -generate above ran in this checkout, which is
+    # why running it on its own now fails rather than reporting a clean tree.
+    # Without that step it compares the committed bytes against themselves and
+    # prints the sentence a rebuilt tree prints.
     go run ./tools/gendrift .
 
 # Every manifest field either does something or is refused.

--- a/tools/gendrift/main.go
+++ b/tools/gendrift/main.go
@@ -33,6 +33,9 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
@@ -112,6 +115,169 @@ var ledger = []generator{
 	}},
 }
 
+// receiptName is the file `-generate` leaves behind to say it ran, and the
+// only evidence `run` will accept that anything was rebuilt.
+//
+// The failure it exists for is the one that survived #363. That change made
+// both callers run the ledger, so the three lists cannot disagree any more.
+// It did not couple the two halves: `go run ./tools/gendrift .` on its own
+// still ran no generator and still printed "N generated paths match their
+// generators", which is a sentence about committed bytes compared against
+// themselves. Drop or reorder the `-generate` step in ci.yml and the gate
+// goes back to printing that line about a tree nobody rebuilt, which is
+// exactly the state main was in for the thirteen commits
+// engine/internal/manifest/manifest.v1.json sat stale.
+//
+// So "I could not check" is now a different answer from "I checked and it is
+// clean", and it is a failure rather than a pass. A gate whose reassuring
+// sentence can be true of a tree it never looked at is worse than no gate,
+// because the sentence is what stops anybody asking.
+//
+// It is ignored by git and skipped by changedPaths, for two independent
+// reasons that would each be enough: a receipt in a diff is noise, and a
+// receipt reported as drift by the tool that wrote it is a gate arguing with
+// itself.
+const receiptName = ".gendrift-receipt.json"
+
+// receiptVersion invalidates every receipt written by an older shape of this
+// file. A field added here without it would be read as its zero value out of
+// an old receipt and compared as if somebody had checked it.
+const receiptVersion = 1
+
+// receipt is what one complete run of `-generate` attests to.
+//
+// Head and Ledger are what make it about THIS tree rather than about some
+// earlier one. A receipt left by a run at another commit says nothing about
+// this one, and a ledger that gained a row since is a ledger whose new
+// generator has never run, which is the whole defect one layer up.
+type receipt struct {
+	Version int    `json:"version"`
+	Head    string `json:"head"`
+	Ledger  string `json:"ledger"`
+}
+
+// ledgerFingerprint is a hash over every command and every path, in order.
+//
+// Order is included on purpose. docsembed has to run last or a single pass
+// cannot converge, so a reordered ledger is a ledger that produces different
+// bytes, and a receipt from before the reorder is not evidence about after it.
+func ledgerFingerprint() string {
+	var lines []string
+	for _, g := range ledger {
+		lines = append(lines, g.command)
+		for _, p := range g.paths {
+			lines = append(lines, "\t"+p)
+		}
+	}
+	sum := sha256.Sum256([]byte(strings.Join(lines, "\n")))
+	return hex.EncodeToString(sum[:])
+}
+
+// headSHA is the commit the generators ran against.
+//
+// A failure to read it is returned rather than swallowed. A receipt carrying
+// an empty head would match another receipt carrying an empty head, so
+// "git could not answer" would quietly become a passing comparison, which is
+// the shape of every defect this tool is about.
+func headSHA(root string) (string, error) {
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = root
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("reading HEAD, which a receipt has to name: %w", err)
+	}
+	sha := strings.TrimSpace(string(out))
+	if sha == "" {
+		return "", fmt.Errorf("git named no commit, so there is nothing a receipt could be about")
+	}
+	return sha, nil
+}
+
+// writeReceipt records a completed run of every generator in the ledger.
+func writeReceipt(root string) error {
+	head, err := headSHA(root)
+	if err != nil {
+		return err
+	}
+	body, err := json.MarshalIndent(receipt{
+		Version: receiptVersion,
+		Head:    head,
+		Ledger:  ledgerFingerprint(),
+	}, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(root, receiptName), append(body, '\n'), 0o644)
+}
+
+// removeReceipt drops any earlier receipt.
+//
+// It runs BEFORE the generators rather than after a failure, and the ordering
+// is the point. A run that dies at the eighth of fifteen generators leaves a
+// half written tree, and if an earlier receipt survived that, the comparison
+// would answer with full confidence about it. There is no ordering in which
+// this file exists and the generators have not just finished.
+func removeReceipt(root string) error {
+	err := os.Remove(filepath.Join(root, receiptName))
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("clearing the previous receipt: %w", err)
+	}
+	return nil
+}
+
+// requireReceipt refuses to compare a tree no generator has rebuilt.
+//
+// The three refusals say different things because they are different facts,
+// and this repository has been bitten every time two of those were printed
+// under one sentence.
+func requireReceipt(root string) error {
+	body, err := os.ReadFile(filepath.Join(root, receiptName))
+	if err != nil {
+		return fmt.Errorf("no generator has run in this checkout, so NOTHING has been compared.\n" +
+			"      `go run ./tools/gendrift -generate .` leaves a receipt naming the commit and\n" +
+			"      the ledger it ran against, and this refuses to answer without one. Run it,\n" +
+			"      or `just generate`, and then run this again.\n" +
+			"      Without that step the comparison is the committed bytes against themselves,\n" +
+			"      and it prints the same sentence a rebuilt clean tree prints. That sentence\n" +
+			"      was printed on thirteen commits while\n" +
+			"      engine/internal/manifest/manifest.v1.json sat stale on main")
+	}
+
+	var r receipt
+	if err := json.Unmarshal(body, &r); err != nil {
+		return fmt.Errorf("the receipt at %s is not readable, so it says nothing about this tree: %w",
+			receiptName, err)
+	}
+	if r.Version != receiptVersion {
+		return fmt.Errorf("the receipt at %s was written by version %d of this tool and this is version %d,\n"+
+			"      so what it attests to is not what is being asked. Run `-generate` again",
+			receiptName, r.Version, receiptVersion)
+	}
+
+	head, err := headSHA(root)
+	if err != nil {
+		return err
+	}
+	if r.Head != head {
+		return fmt.Errorf("the generators last ran against commit %s and this tree is at %s,\n"+
+			"      so the receipt is about a different tree. Run `-generate` again",
+			short(r.Head), short(head))
+	}
+	if r.Ledger != ledgerFingerprint() {
+		return fmt.Errorf("the ledger has changed since the generators last ran, so at least one\n" +
+			"      generator in it has never run here and the file it writes has never been\n" +
+			"      compared. Run `-generate` again")
+	}
+	return nil
+}
+
+func short(sha string) string {
+	if len(sha) > 12 {
+		return sha[:12]
+	}
+	return sha
+}
+
 func main() {
 	strict := flag.Bool("strict", false,
 		"also fail on a changed path no generator owns, for a clean checkout")
@@ -164,6 +330,11 @@ func main() {
 // folded into the comparison: the two answer different questions and must be
 // able to fail with different words.
 func generateAll(root string, out io.Writer) error {
+	// Before anything, so that there is no window in which a stale receipt
+	// vouches for a tree this run is part way through rewriting.
+	if err := removeReceipt(root); err != nil {
+		return err
+	}
 	for _, g := range ledger {
 		if _, err := fmt.Fprintf(out, "  %s\n", g.command); err != nil {
 			return err
@@ -191,9 +362,15 @@ func generateAll(root string, out io.Writer) error {
 			return fmt.Errorf("the generator `%s` failed: %w", g.command, err)
 		}
 	}
-	_, err := fmt.Fprintf(out, "gendrift: ran %d %s over %d generated %s\n",
+	// Only now, with every generator finished. This is what the comparison
+	// reads, and it is the difference between "I checked and it is clean" and
+	// "I could not check", which printed the same sentence until it existed.
+	if err := writeReceipt(root); err != nil {
+		return err
+	}
+	_, err := fmt.Fprintf(out, "gendrift: ran %d %s over %d generated %s, receipt in %s\n",
 		len(ledger), plural(len(ledger), "generator", "generators"),
-		countPaths(), plural(countPaths(), "path", "paths"))
+		countPaths(), plural(countPaths(), "path", "paths"), receiptName)
 	return err
 }
 
@@ -208,6 +385,18 @@ func generateAll(root string, out io.Writer) error {
 // could previously ask different questions, and naming it is what keeps them
 // asking the same one.
 func run(root string, strict bool, out io.Writer) error {
+	// First, because every other answer below is a statement about a tree the
+	// generators have just rewritten, and without this there is nothing
+	// saying they did. checkLedger and the comparison both go on producing
+	// confident output on a checkout where no generator ever ran.
+	//
+	// In both modes. A developer running this by hand is comparing committed
+	// bytes against themselves exactly as CI would be, and a local pass that
+	// means less than the CI pass is how the two gates start disagreeing
+	// again.
+	if err := requireReceipt(root); err != nil {
+		return err
+	}
 	if err := checkLedger(root); err != nil {
 		return err
 	}
@@ -313,7 +502,16 @@ func changedPaths(root string) ([]string, error) {
 		if i := strings.Index(p, " -> "); i >= 0 {
 			p = p[i+4:]
 		}
-		paths = append(paths, strings.Trim(p, `"`))
+		p = strings.Trim(p, `"`)
+		// The tool's own receipt is not an artifact anybody generated, and
+		// -strict would otherwise report it as a changed path no generator
+		// claims. It is in .gitignore as well, so this is the second of two
+		// independent reasons it stays out of the comparison rather than the
+		// only one.
+		if p == receiptName {
+			continue
+		}
+		paths = append(paths, p)
 	}
 	return paths, nil
 }

--- a/tools/gendrift/main_test.go
+++ b/tools/gendrift/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -10,6 +11,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/tools/internal/generated"
 )
 
 // repoWithLedger is a git repository carrying every path the ledger claims,
@@ -22,16 +25,7 @@ import (
 func repoWithLedger(t *testing.T) string {
 	t.Helper()
 	root := t.TempDir()
-
-	run := func(args ...string) {
-		cmd := exec.Command("git", args...)
-		cmd.Dir = root
-		cmd.Env = append(os.Environ(),
-			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
-			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
-		out, err := cmd.CombinedOutput()
-		require.NoError(t, err, "git %s: %s", strings.Join(args, " "), out)
-	}
+	run := gitIn(t, root)
 	run("init", "-q")
 
 	for _, g := range ledger {
@@ -52,7 +46,63 @@ func repoWithLedger(t *testing.T) string {
 	}
 	run("add", "-A")
 	run("commit", "-qm", "the generated tree")
+
+	// The receipt the generators would have left. Every case below is about a
+	// tree that has just been rebuilt, because that is the only tree the
+	// comparison will now speak about at all, and a fixture without one would
+	// make every test here pass or fail on the receipt rather than on what it
+	// is actually asking.
+	//
+	// Written with the production function on purpose. A receipt this file
+	// spelled out itself would be a second copy of the format, and two copies
+	// of a thing that has to agree is the defect gendrift exists for.
+	require.NoError(t, writeReceipt(root))
 	return root
+}
+
+// gitIn is a git runner rooted at one directory.
+func gitIn(t *testing.T, root string) func(args ...string) {
+	t.Helper()
+	return func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = root
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %s: %s", strings.Join(args, " "), out)
+	}
+}
+
+// emptyRepo is a git repository with one commit and nothing in it.
+//
+// generateAll needs a commit because a receipt names one, and the two cases
+// that drive it with a fake ledger have no reason to carry the real tree.
+func emptyRepo(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	run := gitIn(t, root)
+	run("init", "-q")
+	run("commit", "-q", "--allow-empty", "-m", "nothing yet")
+	return root
+}
+
+// currentReceipt is what the tool wrote, read back.
+func currentReceipt(t *testing.T, root string) receipt {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join(root, receiptName))
+	require.NoError(t, err, "no receipt at %s", receiptName)
+	var r receipt
+	require.NoError(t, json.Unmarshal(body, &r))
+	return r
+}
+
+// putReceipt writes a receipt saying exactly what the caller wants it to say.
+func putReceipt(t *testing.T, root string, r receipt) {
+	t.Helper()
+	body, err := json.Marshal(r)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(root, receiptName), body, 0o644))
 }
 
 func write(t *testing.T, root, rel, body string) {
@@ -334,7 +384,7 @@ func TestTheLedgerIsTheOnlyPlaceTheGeneratorsAreListed(t *testing.T) {
 // one layer down, and it would look identical from CI: a step that passes
 // having done nothing, followed by a comparison of a tree nobody rewrote.
 func TestGenerateRunsEveryLedgerCommandInOrder(t *testing.T) {
-	root := t.TempDir()
+	root := emptyRepo(t)
 
 	restore := ledger
 	t.Cleanup(func() { ledger = restore })
@@ -364,7 +414,7 @@ func TestGenerateRunsEveryLedgerCommandInOrder(t *testing.T) {
 // different words, which is why -generate is a separate mode rather than a
 // line folded into the comparison.
 func TestAFailingGeneratorSaysNothingWasCompared(t *testing.T) {
-	root := t.TempDir()
+	root := emptyRepo(t)
 
 	restore := ledger
 	t.Cleanup(func() { ledger = restore })
@@ -431,4 +481,206 @@ func recipeBody(t *testing.T, justfile, header string) []string {
 	}
 	require.NotEmpty(t, out, "recipe %s is empty", header)
 	return out
+}
+
+// TestAComparisonWithNoReceiptRefusesInsteadOfPrintingAMatch is the gate on
+// what #363 left open.
+//
+// That change made both callers run the ledger through -generate, so the three
+// lists of generators cannot disagree any more. It did not couple the two
+// halves. `go run ./tools/gendrift .` on its own ran no generator and printed
+// "N generated paths match their generators" about committed bytes compared
+// against themselves, and that sentence is indistinguishable from the one a
+// rebuilt tree prints. Drop the -generate step from ci.yml and the gate
+// returns to exactly the state main was in for thirteen commits with
+// engine/internal/manifest/manifest.v1.json stale.
+//
+// So the refusal has to happen in both modes and it has to say WHY, because
+// "I could not check" and "I checked and it is clean" being the same sentence
+// is the defect.
+func TestAComparisonWithNoReceiptRefusesInsteadOfPrintingAMatch(t *testing.T) {
+	for _, strict := range []bool{true, false} {
+		t.Run(map[bool]string{true: "strict", false: "local"}[strict], func(t *testing.T) {
+			root := repoWithLedger(t)
+			require.NoError(t, os.Remove(filepath.Join(root, receiptName)))
+
+			var out bytes.Buffer
+			err := run(root, strict, &out)
+			require.Error(t, err, "a checkout where no generator ran was reported as clean")
+			require.Contains(t, err.Error(), "no generator has run in this checkout")
+			require.Contains(t, err.Error(), "NOTHING has been compared")
+			require.NotContains(t, out.String(), "match their generators",
+				"it printed the reassuring sentence anyway")
+		})
+	}
+}
+
+// TestGenerateLeavesAReceiptNamingTheCommitAndTheLedger.
+//
+// The two fields are what make the receipt about THIS tree. A receipt with
+// neither would be a file whose presence means only that somebody once ran a
+// generator somewhere, which is the kind of evidence that reads as proof and
+// is not.
+func TestGenerateLeavesAReceiptNamingTheCommitAndTheLedger(t *testing.T) {
+	root := emptyRepo(t)
+
+	restore := ledger
+	t.Cleanup(func() { ledger = restore })
+	ledger = []generator{{"echo one > ran.txt", []string{"ran.txt"}}}
+
+	var out bytes.Buffer
+	require.NoError(t, generateAll(root, &out))
+
+	r := currentReceipt(t, root)
+	require.Equal(t, receiptVersion, r.Version)
+	require.Equal(t, ledgerFingerprint(), r.Ledger, "the receipt does not name the ledger it ran")
+
+	head, err := headSHA(root)
+	require.NoError(t, err)
+	require.Equal(t, head, r.Head, "the receipt does not name the commit it ran against")
+	require.Contains(t, out.String(), receiptName, "the run does not say where it left the receipt")
+}
+
+// TestAReceiptFromAnotherCommitIsRefused.
+//
+// A receipt is not a permanent licence. Generating at one commit and comparing
+// at another is comparing a tree the generators never saw, and the failure it
+// would hide is the ordinary one: a pull request whose new commit changes a
+// generator's input.
+func TestAReceiptFromAnotherCommitIsRefused(t *testing.T) {
+	root := repoWithLedger(t)
+	r := currentReceipt(t, root)
+	r.Head = strings.Repeat("a", 40)
+	putReceipt(t, root, r)
+
+	var out bytes.Buffer
+	err := run(root, true, &out)
+	require.Error(t, err, "a receipt from a different commit was accepted")
+	require.Contains(t, err.Error(), "about a different tree")
+	require.Contains(t, err.Error(), "aaaaaaaaaaaa")
+}
+
+// TestAReceiptFromADifferentLedgerIsRefused.
+//
+// This is the case that catches the next version of the original failure. A
+// row added to the ledger is a generator that has never run in this checkout,
+// so the file it writes has never been compared, and a receipt from before the
+// row would vouch for it. The row would be decorative exactly as the `cp` row
+// was, and the sentence printed would be exactly as reassuring.
+func TestAReceiptFromADifferentLedgerIsRefused(t *testing.T) {
+	root := repoWithLedger(t)
+
+	restore := ledger
+	t.Cleanup(func() { ledger = restore })
+	ledger = append(append([]generator{}, ledger...),
+		generator{"go run ./tools/somethingnew", []string{"engine/internal/docs/pages.gen.go"}})
+
+	var out bytes.Buffer
+	err := run(root, true, &out)
+	require.Error(t, err, "a receipt written before a ledger row was added was accepted")
+	require.Contains(t, err.Error(), "the ledger has changed since the generators last ran")
+}
+
+// TestAFailedGenerateLeavesNoReceiptForTheComparisonToTrust is the ordering
+// this is most likely to be got wrong in.
+//
+// A run that dies at the eighth of fifteen generators leaves a half written
+// tree. If the receipt from the previous successful run survived that, the
+// comparison would answer about the half written tree with full confidence,
+// which is worse than the state before any of this: a wrong answer wearing the
+// evidence of a right one.
+func TestAFailedGenerateLeavesNoReceiptForTheComparisonToTrust(t *testing.T) {
+	root := repoWithLedger(t)
+	require.FileExists(t, filepath.Join(root, receiptName), "the fixture has no receipt to invalidate")
+
+	restore := ledger
+	t.Cleanup(func() { ledger = restore })
+	ledger = []generator{{"exit 3", []string{"engine/internal/docs/pages.gen.go"}}}
+
+	var genOut bytes.Buffer
+	require.Error(t, generateAll(root, &genOut))
+	require.NoFileExists(t, filepath.Join(root, receiptName),
+		"a failed generate left the previous receipt in place, so the next comparison speaks about a half written tree")
+
+	ledger = restore
+	var out bytes.Buffer
+	err := run(root, true, &out)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no generator has run in this checkout")
+}
+
+// TestStrictIsSilentAboutTheReceiptItsOwnGeneratorWrote.
+//
+// -strict refuses any changed path no generator claims, and the receipt is a
+// changed path no generator claims. A gate that fails on its own artifact is a
+// gate that gets turned off, and the fix must not be a ledger row, because a
+// ledger row would mean the comparison compares the receipt against itself.
+func TestStrictIsSilentAboutTheReceiptItsOwnGeneratorWrote(t *testing.T) {
+	root := repoWithLedger(t)
+
+	var out bytes.Buffer
+	require.NoError(t, run(root, true, &out), "strict mode reported the receipt as drift")
+	require.Contains(t, out.String(), "match their generators")
+	require.NotContains(t, out.String(), receiptName)
+}
+
+// TestTheReceiptIsIgnoredByGit.
+//
+// The skip inside changedPaths is one of two independent reasons the receipt
+// stays out of the comparison, and this is the other. Without the .gitignore
+// line the first `git add -A` in a worktree where the gate has run commits it,
+// and a committed receipt is a receipt that vouches for a tree by being in it.
+func TestTheReceiptIsIgnoredByGit(t *testing.T) {
+	root := filepath.Join("..", "..")
+	cmd := exec.Command("git", "check-ignore", "-q", receiptName)
+	cmd.Dir = root
+	require.NoError(t, cmd.Run(),
+		"%s is not ignored by git, so a `git add -A` after a gate run commits it", receiptName)
+}
+
+// TestEveryGeneratedGoFileIsClaimedByTheLedger is the enumeration the ledger
+// cannot do for itself.
+//
+// -strict catches a generated file nothing claims only when something WROTE
+// it during the run, so it cannot see a generator that is in neither the
+// ledger nor any workflow: nothing rewrites that file, nothing changes, and
+// the comparison passes. The repository already answers "was this written by
+// a person" in one place, tools/internal/generated, and every gate here reads
+// that answer, so this asks it of every tracked file and requires the ledger
+// to claim each one.
+//
+// It covers Go and nothing else, said plainly rather than implied: the marker
+// is a Go convention and the generated JSON, Markdown and golden frames in
+// this tree carry no uniform equivalent. What is checked is checked, and what
+// is not is named.
+func TestEveryGeneratedGoFileIsClaimedByTheLedger(t *testing.T) {
+	root := filepath.Join("..", "..")
+
+	cmd := exec.Command("git", "ls-files")
+	cmd.Dir = root
+	out, err := cmd.Output()
+	require.NoError(t, err)
+
+	var found []string
+	for _, rel := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if !strings.HasSuffix(rel, ".go") {
+			continue
+		}
+		if !generated.Is(filepath.Join(root, filepath.FromSlash(rel))) {
+			continue
+		}
+		found = append(found, rel)
+		_, ok := ownerOf(rel)
+		require.True(t, ok,
+			"%s declares itself generated and no row in tools/gendrift claims it, so no\n"+
+				"generator rewrites it here and nothing compares it. Add it to the ledger\n"+
+				"beside the command that writes it.", rel)
+	}
+
+	// A sweep that found nothing would pass having looked at an empty list,
+	// which is the failure every check in this file is about. Four Go files
+	// carry the marker today and all four are in the ledger.
+	require.GreaterOrEqual(t, len(found), 4,
+		"only %d generated Go files were found, so this stopped seeing its subject: %v",
+		len(found), found)
 }


### PR DESCRIPTION
## The failure

#363 closed the cause of the thirteen stale commits and left the shape of it
standing.

The list of generators is written once now and both callers run it, so the
three copies cannot disagree. What it did not do is couple the two halves.
`go run ./tools/gendrift .` on its own runs no generator, compares the
committed bytes against themselves, and prints

    gendrift: 21 generated paths match their generators

which is the identical sentence a rebuilt tree prints. That sentence was
printed on every one of the thirteen commits that carried a stale
`engine/internal/manifest/manifest.v1.json`. An edit to `ci.yml` that dropped
or reordered the `-generate` step would have it printed again, about a tree
nobody rebuilt, with the gate green throughout.

Measured rather than asserted, on the same clean checkout with no generator
run:

`origin/main`'s binary printed `gendrift: 21 generated paths match their
generators` and exited 0. This branch's binary refused, said in its own words
that nothing had been compared, and exited 1.

A check that cannot say "I could not look" as something different from
"I looked and it is clean" is worse than no check, because the reassuring
sentence is what stops anybody asking.

## What this does

`-generate` clears any earlier receipt, runs the ledger, and on complete
success writes `.gendrift-receipt.json` naming the commit it ran against and a
sha256 over the ledger's commands and paths in order. The comparison refuses
to answer without a receipt that matches this tree.

Three refusals with different words, because they are three different facts:

- no receipt at all, so no generator has run in this checkout
- a receipt from another commit, so the generators saw a different tree
- a receipt from another ledger, so a row has been added whose generator has
  never run here, which is the original defect one turn later

The receipt is cleared BEFORE the generators run rather than after a failure.
There is no ordering in which a run that died half way leaves a receipt that
vouches for the tree it left behind. `-generate` and the comparison stay
separate modes and still fail with different words, which is the distinction
that sent three lanes to the wrong file on 2026-09-08.

The receipt is refused in the local mode too. A developer running this by hand
is comparing committed bytes against themselves exactly as CI would be, and a
local pass that means less than the CI pass is how the two gates start
disagreeing again.

## The enumeration the ledger cannot do for itself

`-strict` catches a generated file no row claims only when something WROTE it
during the run. It is blind to a generator in neither the ledger nor any
workflow: nothing rewrites the file, nothing changes, and the comparison
passes.

So every tracked Go file that declares itself generated must now be claimed by
the ledger, read through `tools/internal/generated`, which is where this
repository already answers "was this written by a person". Four carry the
marker today and all four are claimed. The test refuses a sweep that finds
fewer than four, so it cannot pass by having looked at an empty list.

That covers Go and says so. The marker is a Go convention, and the generated
JSON, Markdown and golden frames here carry no uniform equivalent.

## What was checked and found correct

`engine/api/packages.txt` is not generated. It is a hand written policy file
that `tools/surfacecheck` READS, so it correctly has no ledger row. Its
neighbour `engine/api/v1.0.0.txt` is generated by surfacecheck and is
deliberately outside `just generate`, and its own header says why: a frozen
baseline that regenerates itself is a baseline that cannot refuse anything.

Three other `-update` goldens are outside the ledger and each has a consumer
that compares it on an ordinary run: `engine/internal/fidelity/testdata/database-only-report.txt`,
`tools/inputcheck/surface-v1.tsv` and `ee/license-vectors.json`. None of them
is in the state `manifest.v1.json` was in.
