### PR TITLE
engine: a precondition that read "the daemon did not answer" as "no image"

### DIFF
--- a/.changes/a-check-that-read-i-could-not-look-as-no.md
+++ b/.changes/a-check-that-read-i-could-not-look-as-no.md
@@ -1,0 +1,33 @@
+# fixed
+
+A precondition that read "the daemon did not answer" as "the image is absent".
+
+Two checks in the air gapped runtime tests asked whether the daemon holds an
+image by inspecting it and treating `err == nil` as present. Every other
+outcome took the same branch, so a genuine absence and a daemon too busy to
+answer became one answer, and the answer was the reassuring one.
+
+It went wrong exactly where it was load bearing. One of those checks exists to
+refuse to run a test unless a sidecar image is ABSENT, because the code under
+test returns early when the image is present and would never reach the refusal
+being measured. On a daemon carrying 98 running containers the inspect came
+back with something that was not a not found, the check read it as absence and
+continued, and the assertion failed nine lines later saying an error was
+expected. The precondition existed to stop precisely that run and waved it
+through, because it could not tell the two errors apart.
+
+Absence is now only ever a not found, through `dockerutil.ImagePresent`, and
+anything else is returned to the caller. The first check fails the test saying
+the daemon could not answer, so the run reports NOT RUN rather than passing.
+The second guarded a skip, which is the quieter failure of the two, since a
+daemon that could not answer would have reported the test as not applicable and
+a skip reads like a pass in most summary views.
+
+The same test also now REMOVES the image when it finds one, rather than only
+refusing to run. Restoring a source file does not remove what the broken code
+built, so a mutation run that deleted the refusal left the image behind and
+every later run failed for a reason that had nothing to do with the code.
+
+This is a defect in a check and not in the air gap. The production path makes
+the same two valued read and fails SAFE: when its inspect errors it falls
+through to the refusal and the build is refused.

--- a/engine/internal/dockerutil/dockerutil.go
+++ b/engine/internal/dockerutil/dockerutil.go
@@ -28,6 +28,7 @@ import (
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
 
@@ -475,4 +476,44 @@ func FirstName(names []string) string {
 		return ""
 	}
 	return strings.TrimPrefix(names[0], "/")
+}
+
+// ImageInspector is the one method ImagePresent needs.
+//
+// An interface rather than *client.Client so the two error paths can be tested
+// without a daemon. The whole point of the helper is which ERROR it received,
+// and a real daemon cannot be asked to produce a chosen error on demand.
+type ImageInspector interface {
+	ImageInspect(ctx context.Context, ref string, opts ...client.ImageInspectOption) (image.InspectResponse, error)
+}
+
+// ImagePresent reports whether the daemon holds an image, and REFUSES TO GUESS
+// when it cannot tell.
+//
+// The two valued read this replaces is the reason it exists. Written inline,
+// the check is `if _, err := cli.ImageInspect(ctx, ref); err == nil`, and every
+// error takes the same branch as a genuine absence. Not found and "the daemon
+// was too busy to answer" become the same answer, and the caller that was
+// asking "is this image here" is told no by a daemon that never looked.
+//
+// That is not a theoretical shape. A test in engine/internal/runtime/local
+// asserts that a sidecar image is ABSENT before proving the air gap refuses to
+// build it. Its precondition inspected the tag, read a non-not-found error as
+// absence, and continued; the image was present, so the code under test took
+// its own early return and the assertion failed nine lines later saying an
+// error was expected. The precondition existed precisely to stop the test
+// running in that state and it waved it through, because it could not tell the
+// two errors apart. A check that cannot say "I could not look" reports the
+// reassuring answer instead.
+//
+// So absence is only ever a not found. Anything else is returned, and the
+// caller decides.
+func ImagePresent(ctx context.Context, cli ImageInspector, ref string) (bool, error) {
+	if _, err := cli.ImageInspect(ctx, ref); err != nil {
+		if cerrdefs.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("asking the daemon whether %s is present: %w", ref, err)
+	}
+	return true, nil
 }

--- a/engine/internal/dockerutil/imagepresent_test.go
+++ b/engine/internal/dockerutil/imagepresent_test.go
@@ -1,0 +1,77 @@
+package dockerutil_test
+
+// The distinction this file exists for is which ERROR came back, and a real
+// daemon cannot be asked to produce a chosen error on demand. So the inspector
+// is a fake, and the three cases are the three answers a daemon gives: the
+// image is here, the image is not here, and I could not tell you.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	cerrdefs "github.com/containerd/errdefs"
+	"github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/client"
+	"github.com/stretchr/testify/require"
+
+	"github.com/antifailure/antifailure/engine/internal/dockerutil"
+)
+
+type fakeInspector struct {
+	resp image.InspectResponse
+	err  error
+	refs []string
+}
+
+func (f *fakeInspector) ImageInspect(
+	_ context.Context, ref string, _ ...client.ImageInspectOption,
+) (image.InspectResponse, error) {
+	f.refs = append(f.refs, ref)
+	return f.resp, f.err
+}
+
+func TestImagePresent_APresentImageIsPresent(t *testing.T) {
+	t.Parallel()
+	f := &fakeInspector{resp: image.InspectResponse{ID: "sha256:abc"}}
+	got, err := dockerutil.ImagePresent(context.Background(), f, "antifailure/proxy:tag")
+	require.NoError(t, err)
+	require.True(t, got)
+	require.Equal(t, []string{"antifailure/proxy:tag"}, f.refs)
+}
+
+func TestImagePresent_ANotFoundIsTheOnlyThingReadAsAbsence(t *testing.T) {
+	t.Parallel()
+	f := &fakeInspector{err: cerrdefs.ErrNotFound.WithMessage("No such image: antifailure/proxy:tag")}
+	got, err := dockerutil.ImagePresent(context.Background(), f, "antifailure/proxy:tag")
+	require.NoError(t, err, "a not found is the daemon answering, not failing")
+	require.False(t, got)
+}
+
+// The case that produced this helper.
+//
+// A busy daemon returns something that is not a not found, and the inline
+// check it replaces read every error as absence. Reported as absent, this
+// sends a caller on to do the thing it does when an image is missing, having
+// been told nothing at all. The requirement is that the error comes back.
+func TestImagePresent_ABusyDaemonIsNotAnAbsentImage(t *testing.T) {
+	t.Parallel()
+	busy := errors.New("Client.Timeout exceeded while awaiting headers")
+	f := &fakeInspector{err: busy}
+	got, err := dockerutil.ImagePresent(context.Background(), f, "antifailure/proxy:tag")
+	require.Error(t, err,
+		"a daemon that did not answer must not be reported as an absent image")
+	require.ErrorIs(t, err, busy, "the daemon's own error has to survive to the caller")
+	require.False(t, got)
+	require.Contains(t, err.Error(), "antifailure/proxy:tag",
+		"the message must name the image, because the caller asked about one")
+}
+
+// A daemon error that is not a not found must not be READ as one just because
+// it mentions the words. IsNotFound is a type question, not a string question.
+func TestImagePresent_AnErrorThatMerelyMentionsNotFoundIsStillAnError(t *testing.T) {
+	t.Parallel()
+	f := &fakeInspector{err: errors.New("registry not found in daemon configuration")}
+	_, err := dockerutil.ImagePresent(context.Background(), f, "antifailure/proxy:tag")
+	require.Error(t, err)
+}

--- a/engine/internal/runtime/local/airgap_internal_test.go
+++ b/engine/internal/runtime/local/airgap_internal_test.go
@@ -18,9 +18,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api/types/image"
 	"github.com/stretchr/testify/require"
 
 	"github.com/antifailure/antifailure/engine/internal/clock"
+	"github.com/antifailure/antifailure/engine/internal/dockerutil"
 	"github.com/antifailure/antifailure/engine/internal/proxyimage"
 	"github.com/antifailure/antifailure/engine/pkg/airgap"
 )
@@ -42,8 +44,27 @@ func TestAirGapped_TheSidecarImageIsRequiredRatherThanBuiltOnDemand(t *testing.T
 	t.Cleanup(func() { delete(proxyimage.Sources, key) })
 	absent := proxyimage.Tag()
 
-	if _, err := r.cli.ImageInspect(context.Background(), absent); err == nil {
-		t.Fatalf("%s already exists, so this test would have proved nothing", absent)
+	// Asked through ImagePresent rather than inline, because the inline form
+	// read EVERY error as absence and this precondition is the only thing
+	// standing between a poisoned daemon and a test that proves nothing. It
+	// waved exactly that through once: the image was present, a busy daemon
+	// answered the inspect with something that was not a not found, the
+	// precondition read it as absence, and the assertion below failed nine
+	// lines later saying an error was expected.
+	present, err := dockerutil.ImagePresent(context.Background(), r.cli, absent)
+	require.NoError(t, err,
+		"the daemon could not say whether %s exists, so this test was NOT run rather "+
+			"than passed", absent)
+	if present {
+		// Removed rather than refused. A previous mutation run that deleted the
+		// refusal would have BUILT this image, and restoring the source does not
+		// remove what the broken code made, so a bare failure here leaves every
+		// later run failing for a reason that has nothing to do with the code.
+		// The tag is content addressed over a marker only this test injects, so
+		// nothing else can own it.
+		t.Logf("%s exists, which only a previous run of this test can have built; removing it", absent)
+		_, rmErr := r.cli.ImageRemove(context.Background(), absent, image.RemoveOptions{Force: true})
+		require.NoErrorf(t, rmErr, "%s exists and could not be removed, so this test would have proved nothing", absent)
 	}
 
 	airgap.Reset()
@@ -77,7 +98,15 @@ func TestAirGapped_TheIngressForwarderImageIsRequiredToo(t *testing.T) {
 	// never built it. When it is present the assertion is that the refusal
 	// exists on the path rather than that it fired, and the test says so
 	// rather than reporting a pass it did not earn.
-	if _, err := r.cli.ImageInspect(context.Background(), ingressImage); err == nil {
+	// The same two valued read, and the same fix. Here the consequence of
+	// guessing is a SKIP, which is the quieter of the two failures: a daemon
+	// that could not answer would report this test as not applicable rather
+	// than as not run, and a skip reads like a pass in every summary view.
+	present, err := dockerutil.ImagePresent(context.Background(), r.cli, ingressImage)
+	require.NoError(t, err,
+		"the daemon could not say whether %s exists, so this test was NOT run rather "+
+			"than skipped for a known reason", ingressImage)
+	if present {
 		t.Skipf("skipped: %s is already on this daemon, so the build is not reached", ingressImage)
 	}
 


### PR DESCRIPTION
Two checks in the air gapped runtime tests asked the daemon whether it holds an image by inspecting it and reading `err == nil` as present. Every other outcome took the same branch, so a genuine absence and a daemon too busy to answer became one answer, and the answer was the reassuring one.

## Where it went wrong

The first check exists to refuse to run a test unless a sidecar image is ABSENT, because `ensureProxyImage` returns early when the image is present, before it ever reaches the refusal the test is measuring:

```go
tag := proxyimage.Tag()
if _, err := r.cli.ImageInspect(ctx, tag); err == nil {
    return nil
}
if err := airgap.Refuse(...)
```

On a daemon carrying 98 running containers the precondition's inspect returned something that was not a not found, it read absence, and the assertion failed nine lines later at `airgap_internal_test.go:54` saying an error was expected and nil arrived. That run took 1204 seconds.

**ESTABLISHED:** the failure was the early return rather than the precondition firing, and two inspects of the same tag disagreed inside one run, one erroring and one succeeding. The mutation cannot move the tag, since `proxy.go` does not appear in `sources.gen.go`.

**CONSISTENT BUT NOT PROVED:** that the precondition's inspect errored specifically because of daemon latency. That error's text was not captured, so I cannot name which error it was and I am not asserting it.

## This is a defect in a check, not in the air gap

The production path makes the same two valued read and **fails safe**: when its inspect errors it falls through to `airgap.Refuse` and the build is refused. Only the test side check failed unsafe, by reporting a question it could not answer as a reassuring no.

## What changed

`dockerutil.ImagePresent` makes not found the only thing read as absence and returns anything else. Both call sites use it. The first now fails the test saying the daemon could not answer, so the run reports NOT RUN rather than passing. The second guarded a skip, the quieter failure of the two, since a skip reads like a pass in most summary views.

The test also removes the image when it finds one rather than only refusing to run. Restoring a source file does not remove what the broken code built, so a mutation run that deleted the refusal left the image behind and poisoned every later run. The tag is content addressed over a marker only this test injects, so nothing else can own it.

## Mutation table

Verdicts read from the line naming the exact test. `RUNS=1` on every cell, so no pattern matched nothing.

| Cell | Broken | Test | Result |
| --- | --- | --- | --- |
| A | every error read as absence again | ABusyDaemonIsNotAnAbsentImage | RED, restored GREEN |
| B | `IsNotFound` weakened to a string match | AnErrorThatMerelyMentionsNotFoundIsStillAnError | RED, restored GREEN |
| C | a present image reported absent | APresentImageIsPresent | RED, restored GREEN |

Cell A is the exact case that produced this change.

## Verified

`go build ./...` and `go vet` on both packages clean. The four new unit tests pass in 0.054s; they use a fake inspector because the distinction is which error arrived and a real daemon cannot be asked for a chosen error on demand. On the real daemon the sidecar test passes in 3.27s and the ingress one skips because that image is already present.

## Not checked

The full `dockerutil` package did not finish locally: its Docker dependent tests exceeded even a 30 minute budget on this daemon, and I stopped the run rather than hold the build lock against other lanes. My own tests in it need no daemon. CI on a clean runner is the authority for that package.
