### PR TITLE
ee: the control plane audit log never reached a sink, and a global cursor could lose late commits

### DIFF
--- a/.changes/the-audit-log-with-the-hash-chain-reached-no-sink.md
+++ b/.changes/the-audit-log-with-the-hash-chain-reached-no-sink.md
@@ -1,0 +1,26 @@
+# added
+
+The control plane's audit log now reaches a SIEM, an archive, or a webhook.
+
+The enterprise edition sold "SIEM streaming with a tamper evident hash chain".
+Both halves were real and neither was joined to the other. The chain lives in
+`audit_entries` and is written by every sign on, every directory provisioning
+call, every operator impersonation and every admin action. The streaming was the
+engine's, forwarding five actions from a machine with no database. So the log
+with the chain in it reached no destination at all, and the sentence could point
+at a real half whenever it was questioned.
+
+The forwarder that carries it had been written, tested and left imported by
+nothing: not a declared dependency of any package in the workspace, while its
+own suite ran green on every pull request because the command that runs it runs
+every workspace. `AF_AUDIT_STREAM_SINK` now starts a poll loop over
+`audit_entries.seq` that batches per organization, signs a manifest over the
+chain head, and advances a cursor only past entries a sink accepted, so a
+collector that is down costs lag and never an entry.
+
+Two things the wiring found. `web/apps/api/src/entitlements.ts` had no
+`audit_stream` entry, so the per organization gate answered no for every
+organization on every plan and could never have been passed. And forwarding is a
+cross tenant read by nature, which now has a policy and a pool scope of its own
+rather than a reuse of the sweeper's, so the four existing sweeps do not gain
+the ability to read anybody's audit log.

--- a/.changes/the-audit-log-with-the-hash-chain-reached-no-sink.md
+++ b/.changes/the-audit-log-with-the-hash-chain-reached-no-sink.md
@@ -1,11 +1,13 @@
 # added
 
-The control plane's audit log now reaches a SIEM, an archive, or a webhook.
+The enterprise control plane can forward organization audit entries to Splunk,
+Event Hubs, or a signed webhook.
 
 The enterprise edition sold "SIEM streaming with a tamper evident hash chain".
 Both halves were real and neither was joined to the other. The chain lives in
-`audit_entries` and is written by every sign on, every directory provisioning
-call, every operator impersonation and every admin action. The streaming was the
+`audit_entries` and records organization actions including sign on, directory
+provisioning and administration. The separate global operator log is exported
+only where its writer also produces an organization entry. The streaming was the
 engine's, forwarding five actions from a machine with no database. So the log
 with the chain in it reached no destination at all, and the sentence could point
 at a real half whenever it was questioned.
@@ -15,8 +17,10 @@ nothing: not a declared dependency of any package in the workspace, while its
 own suite ran green on every pull request because the command that runs it runs
 every workspace. `AF_AUDIT_STREAM_SINK` now starts a poll loop over
 `audit_entries.seq` that batches per organization, signs a manifest over the
-chain head, and advances a cursor only past entries a sink accepted, so a
-collector that is down costs lag and never an entry.
+chain head, and tracks delivery per organization. A late commit in one
+organization cannot be skipped because another organization committed first.
+Transient failures remain pending. Permanent collector refusals are logged and
+skipped; the primary audit log is retained either way.
 
 Two things the wiring found. `web/apps/api/src/entitlements.ts` had no
 `audit_stream` entry, so the per organization gate answered no for every
@@ -24,3 +28,9 @@ organization on every plan and could never have been passed. And forwarding is a
 cross tenant read by nature, which now has a policy and a pool scope of its own
 rather than a reuse of the sweeper's, so the four existing sweeps do not gain
 the ability to read anybody's audit log.
+
+The receiver verifies the manifest's organization, count, sequence range and
+chain head against the signed entries. Remote destinations require HTTPS,
+redirects are refused, requests carry a deadline, and collector response bodies
+are cancelled rather than buffered or copied into logs. Polling stops through
+the control plane's shutdown hook.

--- a/.changes/the-audit-log-with-the-hash-chain-reached-no-sink.md
+++ b/.changes/the-audit-log-with-the-hash-chain-reached-no-sink.md
@@ -34,3 +34,7 @@ chain head against the signed entries. Remote destinations require HTTPS,
 redirects are refused, requests carry a deadline, and collector response bodies
 are cancelled rather than buffered or copied into logs. Polling stops through
 the control plane's shutdown hook.
+
+Event Hubs batches encode each message body as a JSON string and carry the
+signed manifest in event properties, so it survives delivery to a consumer.
+Splunk retains the manifest in an indexed field beside each audit event.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -12,10 +12,13 @@ every database provider, the egress and mocking layer, the agent runner,
 insights, load, and the control plane are MIT and stay MIT. What is in `ee/` is
 the set of things a large company requires before a rollout and an individual
 developer never uses: single sign on, SCIM, custom roles, SIEM streaming of
-the engine's privileged actions, policy enforcement, customer owned runtimes,
-and billing. `ee/README.md` says exactly which actions those are and which
-audit log is not forwarded, because a one word summary of a feature is where a
-product oversells itself first.
+the engine's privileged actions and of the control plane's own audit log,
+policy enforcement, customer owned runtimes, and billing. `ee/README.md` says
+exactly which actions the engine forwards and what the control plane's stream
+carries, because a one word summary of a feature is where a product oversells
+itself first, and this sentence did: it named the streaming and the hash chain
+as one thing for as long as they were two, and the control plane's log reached
+no sink at all.
 
 The reasoning behind the split, including the alternatives that were rejected,
 is in [ADR 0002](./docs/adr/0002-license-model.md).

--- a/docs/plans/2026-09-09-audit-forwarding-order.md
+++ b/docs/plans/2026-09-09-audit-forwarding-order.md
@@ -1,0 +1,71 @@
+# Audit delivery follows each organization's commit order
+
+The audit writer takes a transaction lock per organization before allocating
+its sequence number. Different organizations can commit in the opposite order
+to their allocated numbers. A global high water mark therefore skips a valid
+late commit forever.
+
+Use a delivery position per organization and join it directly to audit entries.
+No organization inventory permission is needed. Keep the singleton cursor only
+as an operational summary for existing diagnostics. It never filters delivery.
+Positions advance monotonically after a sink accepts entries or the licence
+explicitly declines them. A failed delivery leaves its organization's position
+unchanged without rewinding another organization's position.
+
+A global writer lock would serialize unrelated customer requests. A receipt
+per entry would work but grow with every audit event. Positions grow with the
+number of organizations and match the writer's existing serialization boundary.
+
+Verify with real transactions: hold one organization's append uncommitted,
+commit a later sequence for another, run a pass, commit the earlier append,
+and run again. Both must arrive. Also retain rollback gaps, restart, empty,
+partial sink failure and licence transitions. Delivery remains at least once
+across a crash between sink acceptance and checkpoint persistence.
+
+## Ordering evidence
+
+`ee/web/audit/test/forwarder.test.ts` runs against Postgres through the real
+audit writer and scoped application connection.
+
+| Ordering | Observed result |
+| --- | --- |
+| Write before first poll | The signed batch carries the stored entry and chain hash. |
+| Poll before write, then another poll | The later entry arrives without restarting the forwarder. |
+| No write | No batch or checkpoint movement. |
+| Write with no running forwarder | The first later poll reads the backlog. |
+| Lower sequence commits after another organization's higher sequence | Both entries arrive on successive polls. |
+| Sequence allocated but transaction does not commit | Later committed rows cross the gap. |
+| Restart after checkpoint | The new instance sends no already checkpointed entries. |
+| Collector accepts a prefix then fails | The next poll retries exactly the pending suffix. |
+| Permanent collector refusal between successful batches | The refused batch is logged and skipped; later batches arrive. |
+| Entitlement withdrawn or granted between polls | The same instance changes forwarding on the next poll. |
+| Organizations interleaved in one read | Each receives a separate signed batch. |
+
+The real process test in `ee/web/server/test/audit-stream.test.ts` sends a SCIM
+request over HTTP and watches its audit entry arrive at an HTTP webhook with a
+valid signature. It checks both the process licence and organization plan
+negative controls against an observed checkpoint advance, not silence alone.
+
+## Security boundary and limits
+
+The forwarder scope reads organization audit rows across tenants. Its setting
+is a trusted application declaration, not a database credential: application
+code with arbitrary SQL execution can set it. Tenant and sweeper scopes clear
+it, and the database tests exercise the resulting reads and writes. The role
+cannot rewrite or remove the primary audit log. Delivery bookkeeping is hidden
+from ordinary tenant connections.
+
+Manifest verification checks organization, count, sequence range and chain head
+against the signed entries. Real HTTP tests prove that a redirect does not
+receive the audit body and that the deadline aborts a collector request.
+Removing either transport guard fails its respective test, and restoring it
+passes. The deadline test injects the abort signal rather than waiting thirty
+seconds; it also checks the configured duration.
+
+This exports `audit_entries`, not every row in the separate global operator
+log. Organization copies of operator actions are included. One configured
+destination is shared by all forwarder replicas. A collector can fan out to
+multiple destinations. Object storage still requires an injected writer and
+cannot be selected through environment configuration. No live Splunk or Event
+Hubs service was used for this verification. Webhook receivers must deduplicate
+by organization and sequence, and signatures alone do not reject replay.

--- a/docs/plans/2026-09-09-audit-forwarding-order.md
+++ b/docs/plans/2026-09-09-audit-forwarding-order.md
@@ -69,3 +69,20 @@ multiple destinations. Object storage still requires an injected writer and
 cannot be selected through environment configuration. No live Splunk or Event
 Hubs service was used for this verification. Webhook receivers must deduplicate
 by organization and sequence, and signatures alone do not reject replay.
+
+## Collector wire formats
+
+The Event Hubs adapter follows Microsoft's
+[REST batch format](https://learn.microsoft.com/en-us/rest/api/eventhub/send-batch-events):
+each `Body` is a JSON string, and the manifest is retained in the event's
+`UserProperties`. Batch properties carried only in HTTP headers are ignored.
+The regression decodes both entries and manifests; mutations to the body type,
+body content and manifest property each fail before passing after restoration.
+
+Splunk's [HEC event format](https://help.splunk.com/en/splunk-enterprise/get-data-in/get-started-with-getting-data-in/9.4/get-data-with-http-event-collector/format-events-for-http-event-collector)
+places custom indexed metadata in a flat `fields` object. The serialized
+manifest is in `fields.antifailure_manifest`, so a stored event retains it.
+Removing that field fails the regression. The previous HTTP manifest header
+remains available for gateways, but downstream verification relies on the
+event metadata. These are protocol checks against documented formats, not
+measurements against live vendor accounts.

--- a/docs/src/content/docs/enterprise/audit-stream.md
+++ b/docs/src/content/docs/enterprise/audit-stream.md
@@ -254,7 +254,7 @@ nowhere.
 
 Transient failures are retried with at least once delivery. Each organization's
 position advances after delivery, so a collector outage causes forwarding lag.
-A crash after acceptance and before checkpointing can redeliver a batch; use
+A crash after acceptance and before saving the position can redeliver a batch; use
 `orgId` and `seq` to deduplicate. Positions are separate because transactions
 from different organizations can commit in a different order from their
 sequence numbers. The installation cursor is only an operational summary.

--- a/docs/src/content/docs/enterprise/audit-stream.md
+++ b/docs/src/content/docs/enterprise/audit-stream.md
@@ -188,9 +188,10 @@ of the one before it, so altering an old entry breaks every entry after it.
 
 ### What one batch looks like
 
-Batched rather than one entry per request, because the batch is what carries the
-proof. This is the JSON body's field schema; organization identifiers are UUID
-strings and `occurredAt` is an ISO timestamp:
+Batched rather than one entry per request, because the batch carries the proof.
+The webhook posts this JSON field schema directly. Splunk and Event Hubs wrap
+entries in their collector formats, described below. Organization identifiers
+are UUID strings and `occurredAt` is an ISO timestamp:
 
 ```typescript
 interface AuditBatch {
@@ -249,6 +250,12 @@ Event Hubs reads `AF_AUDIT_STREAM_EVENT_HUBS_URL` and
 `AF_AUDIT_STREAM_EVENT_HUBS_AUTHORIZATION`, the second being a shared access
 signature you generate, so no key reaches this process and managed identity
 stays possible.
+
+Event Hubs receives each entry as a JSON string in the event body and retains
+the signed batch manifest in the `antifailure_manifest` application property.
+Its batch API ignores properties supplied only through HTTP headers.
+Splunk stores the same manifest in the indexed `antifailure_manifest` field,
+alongside the audit entry's event data.
 
 `AF_AUDIT_STREAM_KEY` is required whenever a sink is named. A manifest signed
 under a key nobody chose is decoration rather than evidence.

--- a/docs/src/content/docs/enterprise/audit-stream.md
+++ b/docs/src/content/docs/enterprise/audit-stream.md
@@ -7,12 +7,19 @@ sidebar:
 
 *Requires an enterprise license with the `audit_stream` feature.*
 
-The engine records the privileged things it does and forwards them to
-destinations you configure. Nothing here replaces the control plane's own audit
-log, which is written regardless: a sink that is unreachable loses forwarding
-and never loses the entry.
+Two streams, from two places, and they are configured separately because they
+run on different machines. The engine forwards the privileged things it does
+from wherever you run it. The control plane forwards its own audit log, the one
+with the hash chain in it, from wherever you run that. Neither replaces the
+other and neither replaces the log itself, which is written regardless: a sink
+that is unreachable loses forwarding and never loses the entry.
 
-## What is forwarded
+Until this page said so, only the first half existed. The control plane's audit
+log carried a tamper evident chain and reached no destination at all, so single
+sign on logins, directory provisioning, operator impersonation and every admin
+action were recorded and forwarded nowhere.
+
+## What the engine forwards
 
 Five actions, and the list is deliberately short. An audit stream a security
 team can read is one where every entry is an act somebody could be asked about.
@@ -51,7 +58,7 @@ is wrong rather than evidence that is missing.
 absent. The operating system user is never consulted: on a CI runner it is
 `runner` for everybody, which reads as an attribution and is not one.
 
-## Turning it on
+## Turning the engine's stream on
 
 `AF_AUDIT_SINKS` lists the destinations, in the order they are written:
 
@@ -168,10 +175,95 @@ The environment still comes up, and the teardown still finishes. What is lost is
 the forwarding, and for the webhook not even that: an entry no receiver would
 take is in the dead letter file before `Write` returns.
 
+## The control plane's own audit log
+
+A different stream with a different shape, and the shape is the reason it is
+worth having. The engine forwards five actions from a machine with no database.
+The control plane forwards `audit_entries`, which is every sign on, every
+directory provisioning call, every operator impersonation and every
+administrative action, and which carries a hash chain: each entry holds the hash
+of the one before it, so altering an old entry breaks every entry after it.
+
+### What one batch looks like
+
+Batched rather than one entry per request, because the batch is what carries the
+proof:
+
+```json
+{"entries":[{"seq":82,"orgId":"2b8c3b13-cb7b-4a4b-b895-2ec495ac3138","actor":"scim","action":"scim.user.created","targetType":"user","targetId":"230bef84-511e-4abd-91b3-5d744778e3da","origin":"scim","detail":{"active":true,"userName":"ada@example.test"},"occurredAt":"2026-09-09T14:28:22.969Z","entryHash":"c9945c32d8080d853706af010221851cd81448008c72e7230a2967f97fc0df9e"}],"manifest":{"org":"2b8c3b13-cb7b-4a4b-b895-2ec495ac3138","count":1,"firstSeq":82,"lastSeq":82,"headHash":"c9945c32d8080d853706af010221851cd81448008c72e7230a2967f97fc0df9e","digest":"00b8b0b63b2ddaa329a59e00b3a520d870f5227ac34adde991280c6fe395029c","signature":"9bd6b494cf1f4de8a8e71af737346bb0a1d504c16f791d30bd81c517d44c58ab"}}
+```
+
+`headHash` is the chain hash of the last entry in the batch, and `digest` is a
+sha256 over the canonical batch body with `signature` an HMAC of that digest
+under `AF_AUDIT_STREAM_KEY`. That is what lets a batch sitting in an archive be
+checked without reaching back to the control plane that wrote it, which is the
+situation an auditor is usually in.
+
+One batch holds one organization. A manifest names an organization, so a batch
+carrying two would name one and cover both, and a receiver checking it would be
+checking the wrong claim.
+
+### Turning the control plane's stream on
+
+```sh
+export AF_AUDIT_STREAM_SINK=webhook
+export AF_AUDIT_STREAM_KEY="$(openssl rand -base64 32)"
+export AF_AUDIT_STREAM_WEBHOOK_URL=https://siem.example/ingest
+export AF_AUDIT_STREAM_WEBHOOK_SECRET=...
+```
+
+`AF_AUDIT_STREAM_SINK` takes `splunk`, `event_hubs` or `webhook`. Splunk reads
+`AF_AUDIT_STREAM_SPLUNK_URL` and `AF_AUDIT_STREAM_SPLUNK_TOKEN`, with
+`AF_AUDIT_STREAM_SPLUNK_INDEX` and `AF_AUDIT_STREAM_SPLUNK_SOURCETYPE` optional.
+Event Hubs reads `AF_AUDIT_STREAM_EVENT_HUBS_URL` and
+`AF_AUDIT_STREAM_EVENT_HUBS_AUTHORIZATION`, the second being a shared access
+signature you generate, so no key reaches this process and managed identity
+stays possible.
+
+`AF_AUDIT_STREAM_KEY` is required whenever a sink is named. A manifest signed
+under a key nobody chose is decoration rather than evidence.
+
+`AF_AUDIT_STREAM_INTERVAL_MS` is how often a pass runs, ten seconds by default.
+`AF_AUDIT_STREAM_BATCH` is how many entries one pass reads, 500 by default, and
+`AF_AUDIT_STREAM_DELIVERY_BATCH` is how many one request carries, defaulting to
+the pass size. They are two numbers rather than one because how fast the
+forwarder catches up and what your collector accepts in one request are
+different questions.
+
+A sink named with its variables missing stops the control plane at startup with
+the reason, for the same reason the engine's does.
+
+An object store sink exists in the code and cannot be turned on from the
+environment, because it needs a request signer this half of the product does not
+carry. Naming one is refused rather than accepted and then silently writing
+nowhere.
+
+### Delivery, and what happens when your collector is down
+
+At least once, never at most once. The cursor advances only past entries a sink
+accepted, so a collector that is down costs forwarding lag and never an entry,
+and the entries are redelivered when it comes back. A duplicate is visible in
+`seq`; a gap would not be visible at all, which is why the trade is made in that
+direction.
+
+A batch your endpoint will never accept, meaning it answers 400, 401, 403, 404
+or 413, is given up on rather than retried forever, because one batch nobody
+will ever take must not stop every entry behind it. The rest of the stream
+continues.
+
+### What is not forwarded, and it is stated rather than implied
+
+An organization that is not entitled to `audit_stream` is skipped and the stream
+moves on past it. It is not held for an entitlement that might arrive later, and
+that is the same behaviour the engine has. The cursor is one number for the
+whole installation, so an organization that never buys audit streaming would
+otherwise stall the stream for every organization that did.
+
 ## The licence is asked per action, not at startup
 
 Every sink checks `audit_stream` on every entry rather than once when it is
-registered. A licence that lapses while a long lived process is running stops
+registered, and the control plane's forwarder asks it once per organization on
+every pass. A licence that lapses while a long lived process is running stops
 forwarding immediately, without a restart, and one that renews starts again the
 same way. A configured sink on an installation without the feature accepts every
 entry and writes none, which is correct and is also silence, so the engine says

--- a/docs/src/content/docs/enterprise/audit-stream.md
+++ b/docs/src/content/docs/enterprise/audit-stream.md
@@ -303,13 +303,14 @@ these deliberately declined entries are not reconsidered on every pass.
 
 ## The licence is asked per action, not at startup
 
-Every sink checks `audit_stream` on every entry rather than once when it is
-registered, and the control plane's forwarder asks it once per organization on
-every pass. A licence that lapses while a long lived process is running stops
-forwarding immediately, without a restart, and one that renews starts again the
-same way. A configured sink on an installation without the feature accepts every
-entry and writes none, which is correct and is also silence, so the engine says
-so once at startup:
+The engine checks `audit_stream` on every entry. The control plane checks its
+process licence status and organization entitlement on each pass, so expiry or
+an entitlement withdrawal takes effect on the next pass without a restart.
+Organization entitlement grants also take effect on the next pass. Replacing
+the control plane's `AF_LICENSE_KEY` requires restarting the process, because
+the key is parsed at startup. A configured sink on an installation without the
+feature accepts every entry and writes none, so the engine says so once at
+startup:
 
 ```
 af: audit sink: configured, and audit_stream is not licensed on this

--- a/docs/src/content/docs/enterprise/audit-stream.md
+++ b/docs/src/content/docs/enterprise/audit-stream.md
@@ -16,8 +16,8 @@ that is unreachable loses forwarding and never loses the entry.
 
 Until this page said so, only the first half existed. The control plane's audit
 log carried a tamper evident chain and reached no destination at all, so single
-sign on logins, directory provisioning, operator impersonation and every admin
-action were recorded and forwarded nowhere.
+organization sign on, directory provisioning and administrative actions were
+recorded and forwarded nowhere.
 
 ## What the engine forwards
 
@@ -179,9 +179,11 @@ take is in the dead letter file before `Write` returns.
 
 A different stream with a different shape, and the shape is the reason it is
 worth having. The engine forwards five actions from a machine with no database.
-The control plane forwards `audit_entries`, which is every sign on, every
-directory provisioning call, every operator impersonation and every
-administrative action, and which carries a hash chain: each entry holds the hash
+The control plane forwards `audit_entries`, the organization log covering
+actions including sign on, directory provisioning and administration. The
+separate global operator log, `admin_audit_entries`, is forwarded only where its
+writer also produces an organization entry. Each organization has its own hash
+chain: each entry holds the hash
 of the one before it, so altering an old entry breaks every entry after it.
 
 ### What one batch looks like
@@ -198,6 +200,11 @@ sha256 over the canonical batch body with `signature` an HMAC of that digest
 under `AF_AUDIT_STREAM_KEY`. That is what lets a batch sitting in an archive be
 checked without reaching back to the control plane that wrote it, which is the
 situation an auditor is usually in.
+
+For webhooks, `x-antifailure-timestamp` is the first entry's event time, not
+the delivery time. Catching up after an outage can deliver old events. Verify
+the signature and deduplicate by organization and sequence; signature
+verification alone does not reject replay.
 
 One batch holds one organization. A manifest names an organization, so a batch
 carrying two would name one and cover both, and a receiver checking it would be
@@ -223,6 +230,11 @@ stays possible.
 `AF_AUDIT_STREAM_KEY` is required whenever a sink is named. A manifest signed
 under a key nobody chose is decoration rather than evidence.
 
+Remote collector URLs require HTTPS and cannot contain user information.
+Loopback HTTP is permitted for a local collector. Redirects are refused, each
+request carries a thirty second deadline, and response bodies are discarded
+without being buffered or included in error logs.
+
 `AF_AUDIT_STREAM_INTERVAL_MS` is how often a pass runs, ten seconds by default.
 `AF_AUDIT_STREAM_BATCH` is how many entries one pass reads, 500 by default, and
 `AF_AUDIT_STREAM_DELIVERY_BATCH` is how many one request carries, defaulting to
@@ -240,11 +252,12 @@ nowhere.
 
 ### Delivery, and what happens when your collector is down
 
-At least once, never at most once. The cursor advances only past entries a sink
-accepted, so a collector that is down costs forwarding lag and never an entry,
-and the entries are redelivered when it comes back. A duplicate is visible in
-`seq`; a gap would not be visible at all, which is why the trade is made in that
-direction.
+Transient failures are retried with at least once delivery. Each organization's
+position advances after delivery, so a collector outage causes forwarding lag.
+A crash after acceptance and before checkpointing can redeliver a batch; use
+`orgId` and `seq` to deduplicate. Positions are separate because transactions
+from different organizations can commit in a different order from their
+sequence numbers. The installation cursor is only an operational summary.
 
 A batch your endpoint will never accept, meaning it answers 400, 401, 403, 404
 or 413, is given up on rather than retried forever, because one batch nobody
@@ -255,9 +268,8 @@ continues.
 
 An organization that is not entitled to `audit_stream` is skipped and the stream
 moves on past it. It is not held for an entitlement that might arrive later, and
-that is the same behaviour the engine has. The cursor is one number for the
-whole installation, so an organization that never buys audit streaming would
-otherwise stall the stream for every organization that did.
+that is the same behaviour the engine has. Its delivery position advances so
+these deliberately declined entries are not reconsidered on every pass.
 
 ## The licence is asked per action, not at startup
 

--- a/docs/src/content/docs/enterprise/audit-stream.md
+++ b/docs/src/content/docs/enterprise/audit-stream.md
@@ -189,10 +189,33 @@ of the one before it, so altering an old entry breaks every entry after it.
 ### What one batch looks like
 
 Batched rather than one entry per request, because the batch is what carries the
-proof:
+proof. This is the JSON body's field schema; organization identifiers are UUID
+strings and `occurredAt` is an ISO timestamp:
 
-```json
-{"entries":[{"seq":82,"orgId":"2b8c3b13-cb7b-4a4b-b895-2ec495ac3138","actor":"scim","action":"scim.user.created","targetType":"user","targetId":"230bef84-511e-4abd-91b3-5d744778e3da","origin":"scim","detail":{"active":true,"userName":"ada@example.test"},"occurredAt":"2026-09-09T14:28:22.969Z","entryHash":"c9945c32d8080d853706af010221851cd81448008c72e7230a2967f97fc0df9e"}],"manifest":{"org":"2b8c3b13-cb7b-4a4b-b895-2ec495ac3138","count":1,"firstSeq":82,"lastSeq":82,"headHash":"c9945c32d8080d853706af010221851cd81448008c72e7230a2967f97fc0df9e","digest":"00b8b0b63b2ddaa329a59e00b3a520d870f5227ac34adde991280c6fe395029c","signature":"9bd6b494cf1f4de8a8e71af737346bb0a1d504c16f791d30bd81c517d44c58ab"}}
+```typescript
+interface AuditBatch {
+  entries: Array<{
+    seq: number
+    orgId: string
+    actor: string
+    action: string
+    targetType: string
+    targetId: string | null
+    origin: string
+    detail: Record<string, unknown>
+    occurredAt: string
+    entryHash: string
+  }>
+  manifest: {
+    org: string
+    count: number
+    firstSeq: number
+    lastSeq: number
+    headHash: string
+    digest: string
+    signature: string
+  }
+}
 ```
 
 `headHash` is the chain hash of the last entry in the batch, and `digest` is a

--- a/docs/src/content/docs/enterprise/licensing.md
+++ b/docs/src/content/docs/enterprise/licensing.md
@@ -115,7 +115,7 @@ The features a license can name are `air_gapped`, `audit_stream`, `billing`, `cl
 <!-- entitlement-names:end -->
 
 <!-- entitlement-count:start -->
-Of the 14 features a license can carry, **10 are refused when the license does not name them**, 8 by the engine and 2 by the control plane. The rest are listed here anyway, with what actually happens without each one, because a feature that is sold and never checked is worth knowing about and the number is only useful if it can come back unflattering.
+Of the 14 features a license can carry, **10 are refused when the license does not name them**, 8 by the engine and 3 by the control plane, with some checked by both. The rest are listed here anyway, with what actually happens without each one, because a feature that is sold and never checked is worth knowing about and the number is only useful if it can come back unflattering.
 <!-- entitlement-count:end -->
 
 The table is generated from `ee/engine/feature/catalogue.go`, which is the one
@@ -136,7 +136,7 @@ is where it gets published.
 | Feature | What it is | Without it |
 | --- | --- | --- |
 | `air_gapped` | An installation that reaches nothing outside the operator's own network. | Withheld. `airgapped/airgapped.go:RegisterFromEnvironment` asks the license, and the feature is off when the answer is no. |
-| `audit_stream` | Privileged actions forwarded to the organization's own SIEM. | Withheld. `auditsink/auditsink.go:auditsink.permitted` asks the license, and the feature is off when the answer is no. |
+| `audit_stream` | Privileged actions forwarded to the organization's own SIEM. | Withheld by both the engine at `auditsink/auditsink.go:auditsink.permitted` and the control plane at `ee/web/server/src/register.ts:startAuditStream`. Each checks the license. |
 | `billing` | Subscriptions, invoices and the plan an organization is on. | Nothing changes, because the capability is not built yet. |
 | `cloud_database` | Managed cloud database providers, the ones that need an organization behind them rather than a developer's own card. | Withheld. `cloudgate/cloudgate.go:gatedDatabase.Branch` asks the license, and the feature is off when the answer is no. |
 | `cloud_runtime` | Managed cloud runtime providers, on the same rule as the databases. | Withheld. `cloudgate/cloudgate.go:gatedRuntime.Up` asks the license, and the feature is off when the answer is no. |

--- a/ee/README.md
+++ b/ee/README.md
@@ -20,37 +20,42 @@ approvals, SIEM streaming of the engine's privileged actions, organization wide
 policy enforcement, customer owned runtime clusters, enterprise secret
 managers, billing and metering, and support tooling.
 
-### What that sentence used to claim, and what actually ships
+### What "SIEM streaming with a tamper evident hash chain" means, exactly
 
-It said "SIEM streaming with a tamper evident hash chain". Both halves are real
-and they are not joined to each other, so the conjunction was false in the way
-that is hardest to notice: each half can be pointed at.
+It is two mechanisms and they are now joined to each other. They were not, for
+as long as both existed, and the conjunction was false in the way that is
+hardest to notice, because each half could be pointed at when questioned.
 
-What ships is `ee/engine/auditsink`. It is registered in
-`ee/engine/cmd/af/main.go`, it asks the licence per call, and it forwards the
-five actions that `docs/enterprise/audit-stream.md` lists, to Splunk, Event
-Hubs, an object store or a webhook. The webhook carries an HMAC over the exact
-bytes posted, which makes one delivery tamper evident. There is no chain across
-entries in it.
+**The engine's half.** `ee/engine/auditsink`, registered in
+`ee/engine/cmd/af/main.go`, asks the licence per call and forwards the five
+actions `docs/enterprise/audit-stream.md` lists to syslog, a webhook or an
+object store. Its webhook carries an HMAC over the exact bytes posted, so one
+delivery is tamper evident. Nothing in it chains entries to each other, because
+the engine runs on a machine with no database.
 
-The chain exists in two places and neither is streamed. `audit_entries` carries
-`prev_hash` and `entry_hash` and is written by the control plane regardless of
-any licence, which is MIT and is not sold. `ee/web/audit` implements the
-forwarder that would carry that chain to a sink, with a bounded queue, four
-sinks and signed batch manifests over the chain head, and **nothing imports
-it**. It is not a declared dependency of any package in this workspace,
-including `ee/web/server`, so it could not be imported without a package.json
-change, while its own suite runs and passes in CI on every pull request. Tested,
-green, and unreachable is the most convincing possible disguise for dead code.
+**The control plane's half.** `audit_entries` carries `prev_hash` and
+`entry_hash`, is written by every sign on, every provisioning call, every
+operator impersonation and every admin action, and is MIT. `ee/web/audit`
+carries it to a sink: a bounded queue, four destinations, and a batch manifest
+signed over the chain head so an archived batch can be checked without asking
+this control plane anything. `ee/web/server/src/register.ts` starts the poll
+loop, which is what was missing.
 
-So the control plane's audit log is not forwarded anywhere. Single sign on
-logins, directory provisioning, operator impersonation and every admin action
-are in `audit_entries` and reach no sink. `docs/enterprise/audit-stream.md` was
-already accurate about this and says so in its second paragraph; it was this
-summary line that sold more than the product does. Wiring the control plane half
-is enterprise side work, since `ee/web/server/src/register.ts` already does non
-route work and is handed the pool and the clock, and when it lands this
-paragraph is what gets deleted.
+**What was wrong and how long it lasted.** `ee/web/audit` was complete, tested
+and imported by nothing. It was not a declared dependency of any package in this
+workspace, so it could not be imported without a package.json change, while
+`npm --prefix ee/web test` ran its suite green on every pull request because
+that command runs every workspace. Tested, green and unreachable is the most
+convincing disguise dead code can wear, and the summary line above it sold the
+conjunction the whole time.
+
+Two things the wiring found that the sentence above could not have:
+`web/apps/api/src/entitlements.ts` had no `audit_stream` entry at all, so
+`licensed(pool, orgId, 'audit_stream', now)` answered false for every
+organization on every plan and the gate could never have been passed; and the
+audit log is a cross tenant read by nature, which needed a policy and a pool
+scope of its own rather than a reuse of the sweeper's. Migration 0043 carries
+that argument.
 
 ## How the boundary is enforced
 
@@ -140,7 +145,7 @@ maintenance.mjs` mean exactly what they mean in the community image. A Helm
 release or a container app pointed at the enterprise repository instead of the
 community one needs no other change.
 
-Five variables are read only by this edition. Two of them are required and the
+Five variables configure the edition itself. Two of them are required and the
 process says so and exits rather than starting half configured:
 
 - `AF_EE_SSO_KEY`, **required**, 32 bytes of base64. Single sign-on encrypts the
@@ -161,6 +166,46 @@ A licence that does not parse is refused at startup rather than degraded. That
 is a deployment mistake and not a commercial state, and starting anyway would
 mean an enterprise deployment quietly serving 402 to its own identity provider
 because somebody pasted a truncated key.
+
+### Streaming the control plane's audit log
+
+Off unless a destination is named, and the process says which state it is in on
+every start, because an installation that forwards and one that does not
+produced identical logs until that line existed.
+
+- `AF_AUDIT_STREAM_SINK`, one of `splunk`, `event_hubs` or `webhook`. Unset
+  means the audit log is written and not forwarded, which is said out loud.
+- `AF_AUDIT_STREAM_KEY`, **required when a sink is named**. Batch manifests are
+  signed under it, and a manifest signed under a key nobody chose is decoration
+  rather than evidence. Generate one with `openssl rand -base64 32`.
+- `AF_AUDIT_STREAM_SPLUNK_URL` and `AF_AUDIT_STREAM_SPLUNK_TOKEN` for the HTTP
+  Event Collector, with `AF_AUDIT_STREAM_SPLUNK_INDEX` and
+  `AF_AUDIT_STREAM_SPLUNK_SOURCETYPE` optional so entries land where the
+  customer's existing searches already look.
+- `AF_AUDIT_STREAM_EVENT_HUBS_URL` and `AF_AUDIT_STREAM_EVENT_HUBS_AUTHORIZATION`,
+  the second being a shared access signature the operator generates, so no key
+  reaches this process and managed identity stays possible.
+- `AF_AUDIT_STREAM_WEBHOOK_URL` and `AF_AUDIT_STREAM_WEBHOOK_SECRET`, which
+  signs the body and a timestamp outside it so a delivery cannot be replayed
+  forever.
+- `AF_AUDIT_STREAM_INTERVAL_MS`, how often a pass runs, ten seconds by default.
+- `AF_AUDIT_STREAM_BATCH`, how many entries one pass reads, 500 by default, and
+  `AF_AUDIT_STREAM_DELIVERY_BATCH`, how many one request carries, defaulting to
+  the pass size. Two knobs rather than one because a pass size is how fast the
+  forwarder catches up and a delivery size is what somebody else's collector
+  will accept in one request.
+
+A sink named with its variables missing **refuses to start**, naming the
+variable. That is the same rule the engine's sink follows and for the same
+reason: somebody who set the variable has said every privileged action must
+reach their SIEM, and starting anyway forwards nothing and says nothing, which
+is indistinguishable from a quiet week.
+
+The object store sink in `ee/web/audit/src/sinks.ts` **cannot be configured from
+the environment**, because it takes a `put` callback and this side of the
+product carries no S3 or Blob signer to supply one. It is reachable by an
+embedder that passes a `Sink` directly. Naming it in the variable is refused
+rather than accepted and then silently writing nowhere.
 
 **With no licence the enterprise routes are mounted and answer 402**, naming
 the feature and the variable to set. They are not left unmounted. A 404 says

--- a/ee/README.md
+++ b/ee/README.md
@@ -34,8 +34,9 @@ delivery is tamper evident. Nothing in it chains entries to each other, because
 the engine runs on a machine with no database.
 
 **The control plane's half.** `audit_entries` carries `prev_hash` and
-`entry_hash`, is written by every sign on, every provisioning call, every
-operator impersonation and every admin action, and is MIT. `ee/web/audit`
+`entry_hash`, records organization actions including sign on, provisioning and
+administration, and is MIT. Global operator actions in `admin_audit_entries`
+are forwarded only when they also produce an organization entry. `ee/web/audit`
 carries it to a sink: a bounded queue, four destinations, and a batch manifest
 signed over the chain head so an archived batch can be checked without asking
 this control plane anything. `ee/web/server/src/register.ts` starts the poll
@@ -186,8 +187,9 @@ produced identical logs until that line existed.
   the second being a shared access signature the operator generates, so no key
   reaches this process and managed identity stays possible.
 - `AF_AUDIT_STREAM_WEBHOOK_URL` and `AF_AUDIT_STREAM_WEBHOOK_SECRET`, which
-  signs the body and a timestamp outside it so a delivery cannot be replayed
-  forever.
+  signs the body and its first entry's event timestamp. Receivers must
+  deduplicate by organization and sequence; signature verification alone does
+  not reject replay.
 - `AF_AUDIT_STREAM_INTERVAL_MS`, how often a pass runs, ten seconds by default.
 - `AF_AUDIT_STREAM_BATCH`, how many entries one pass reads, 500 by default, and
   `AF_AUDIT_STREAM_DELIVERY_BATCH`, how many one request carries, defaulting to

--- a/ee/engine/feature/catalogue.go
+++ b/ee/engine/feature/catalogue.go
@@ -265,8 +265,9 @@ var catalogue = []Entitlement{
 		// import that would have enforced that is the one the dependency
 		// forbids, so a test in ee/engine/cmd/af asserts they are equal from a
 		// binary that links both. See TestTheAuditSiteIsTheOneAuditsinkDeclares.
-		EnforcedAt: "auditsink/auditsink.go:auditsink.permitted",
-		State:      StateGated,
+		EnforcedAt:     "auditsink/auditsink.go:auditsink.permitted",
+		ControlPlaneAt: "ee/web/server/src/register.ts:startAuditStream",
+		State:          StateGated,
 	},
 	{
 		Feature: license.FeatureBilling,
@@ -510,7 +511,7 @@ func SplitSite(site string) (file, symbol string, ok bool) {
 func ControlPlaneGatedFeatures() []license.Feature {
 	out := []license.Feature{}
 	for _, e := range catalogue {
-		if e.State == StateControlPlaneGated {
+		if e.State == StateControlPlaneGated || (e.State == StateGated && e.ControlPlaneAt != "") {
 			out = append(out, e.Feature)
 		}
 	}

--- a/ee/engine/feature/reference_test.go
+++ b/ee/engine/feature/reference_test.go
@@ -61,6 +61,9 @@ const (
 func effect(e feature.Entitlement) string {
 	switch e.State {
 	case feature.StateGated:
+		if e.ControlPlaneAt != "" {
+			return "Withheld by both the engine at `" + e.EnforcedAt + "` and the control plane at `" + e.ControlPlaneAt + "`. Each checks the license."
+		}
 		// "Withheld" rather than "refused", because for one of the three the
 		// licensed behaviour IS a refusal: an unlicensed policy hook permits.
 		// "Refused" in that row would read as the environment being refused,
@@ -145,6 +148,12 @@ func countSentence() string {
 	engine := len(feature.GatedFeatures()) + len(feature.EditionGatedFeatures())
 	plane := len(feature.ControlPlaneGatedFeatures())
 	total := len(license.AllFeatures())
+	unique := map[license.Feature]bool{}
+	for _, group := range [][]license.Feature{feature.GatedFeatures(), feature.EditionGatedFeatures(), feature.ControlPlaneGatedFeatures()} {
+		for _, f := range group {
+			unique[f] = true
+		}
+	}
 	// Split, because one number hid the error this page was corrected for.
 	// Counting only the engine's gates reported three of twelve and read as
 	// "nine of these do nothing", when two of the nine were being refused by
@@ -152,11 +161,11 @@ func countSentence() string {
 	// is what stops the next reader drawing the old conclusion from it.
 	return fmt.Sprintf(
 		"Of the %d features a license can carry, **%d are refused when the license does not "+
-			"name them**, %d by the engine and %d by the control plane. The rest are listed "+
+			"name them**, %d by the engine and %d by the control plane, with some checked by both. The rest are listed "+
 			"here anyway, with what actually happens without each one, because a feature that "+
 			"is sold and never checked is worth knowing about and the number is only useful "+
 			"if it can come back unflattering.\n",
-		total, engine+plane, engine, plane)
+		total, len(unique), engine, plane)
 }
 
 // splice replaces the block between one pair of markers.

--- a/ee/web/audit/package.json
+++ b/ee/web/audit/package.json
@@ -4,11 +4,19 @@
   "private": true,
   "license": "SEE LICENSE IN ../../LICENSE.md",
   "type": "module",
-  "exports": { ".": "./src/index.ts" },
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "scripts": {
-    "test": "node --test test/*.test.ts",
+    "test": "node --test --test-concurrency=1 test/*.test.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
-  "dependencies": { "@antifailure/db": "file:../../../web/packages/db" },
-  "devDependencies": { "@types/node": "^24.0.0", "typescript": "^5.9.0" }
+  "dependencies": {
+    "@antifailure/db": "file:../../../web/packages/db"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "postgres": "^3.4.9",
+    "typescript": "^5.9.0"
+  }
 }

--- a/ee/web/audit/src/configure.ts
+++ b/ee/web/audit/src/configure.ts
@@ -1,0 +1,181 @@
+// Reading the sink an installation has actually configured.
+//
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+//
+// The rule is `ee/engine/auditsink/configure.go`'s and it is the same rule for
+// the same reason. Somebody who writes AF_AUDIT_STREAM_SINK=splunk has said
+// that every privileged action in this control plane must reach their SIEM.
+// Starting anyway with the sink unbuilt means nothing is forwarded and nothing
+// says so, which is indistinguishable from a quiet week. That is not a degraded
+// feature; it is a compliance control reporting itself as held while holding
+// nothing, which is the exact defect this whole file exists downstream of.
+//
+// So a named sink that cannot be built REFUSES, with the variable that is
+// missing named in the message. An unset variable builds nothing and says so
+// once, which is the ordinary case. Nothing is ever detected: a control plane
+// that happens to carry a webhook URL for something unrelated must not decide
+// on its own to start posting an organization's audit trail to it.
+//
+// WHAT IS NOT HERE, SAID PLAINLY RATHER THAN IMPLIED BY ITS ABSENCE.
+// `ObjectStoreSink` exists in sinks.ts and cannot be built from the
+// environment, because it takes a `put` callback and this side of the product
+// has no S3 or Blob signer to supply one. It is reachable by an embedder that
+// passes a Sink directly and it is not reachable from a container's
+// configuration, and `Known()` below lists only what an operator can actually
+// turn on. A name accepted here that then wrote nowhere would be the same
+// failure one layer along.
+
+import {
+  EventHubsSink,
+  SplunkSink,
+  WebhookSink,
+  type Fetcher,
+} from './sinks.ts'
+import type { Sink } from './sink.ts'
+
+/** Names the variable that chooses the destination. */
+export const SinkEnv = 'AF_AUDIT_STREAM_SINK'
+
+/** The variables each sink reads. Constants rather than inline strings so that
+ *  the message listing what is missing and the code reading it cannot drift. */
+export const KeyEnv = 'AF_AUDIT_STREAM_KEY'
+export const IntervalEnv = 'AF_AUDIT_STREAM_INTERVAL_MS'
+export const BatchEnv = 'AF_AUDIT_STREAM_BATCH'
+export const DeliveryBatchEnv = 'AF_AUDIT_STREAM_DELIVERY_BATCH'
+
+export const SplunkUrlEnv = 'AF_AUDIT_STREAM_SPLUNK_URL'
+export const SplunkTokenEnv = 'AF_AUDIT_STREAM_SPLUNK_TOKEN'
+export const SplunkIndexEnv = 'AF_AUDIT_STREAM_SPLUNK_INDEX'
+export const SplunkSourcetypeEnv = 'AF_AUDIT_STREAM_SPLUNK_SOURCETYPE'
+
+export const EventHubsUrlEnv = 'AF_AUDIT_STREAM_EVENT_HUBS_URL'
+export const EventHubsAuthorizationEnv = 'AF_AUDIT_STREAM_EVENT_HUBS_AUTHORIZATION'
+
+export const WebhookUrlEnv = 'AF_AUDIT_STREAM_WEBHOOK_URL'
+export const WebhookSecretEnv = 'AF_AUDIT_STREAM_WEBHOOK_SECRET'
+
+/** The destinations an operator can name. Sorted, for the message that lists
+ *  them when somebody names one that does not exist. */
+export function known(): string[] {
+  return ['event_hubs', 'splunk', 'webhook']
+}
+
+/** A configuration mistake, separated from every other error so the caller can
+ *  refuse to start rather than log and continue. */
+export class SinkRefused extends Error {}
+
+export interface StreamConfig {
+  sink: Sink
+  key: string
+  intervalMs: number
+  /** Entries one pass reads. */
+  batchSize: number
+  /** Entries one delivery carries. A different question from the one above: a
+   *  pass size is how fast the forwarder catches up and a delivery size is what
+   *  one request to somebody else's collector may hold. Defaults to the pass
+   *  size, so an operator who does not care sets one number. */
+  deliveryBatchSize: number
+}
+
+/** How often a pass runs when nothing says otherwise. Ten seconds, because an
+ *  audit stream is read during an incident and five minutes of lag is five
+ *  minutes of a security team seeing nothing after something started. */
+export const DEFAULT_INTERVAL_MS = 10_000
+
+/** How many entries one pass reads when nothing says otherwise. */
+export const DEFAULT_BATCH = 500
+
+/**
+ * Builds the configured sink, or null when none is configured.
+ *
+ * `fetch` is a parameter for the reason sinks.ts gives about its own: it is
+ * what lets an operator route through their own proxy or add a header their
+ * gateway requires, and it is what lets a test hold a real receiver.
+ */
+export function fromEnvironment(
+  env: NodeJS.ProcessEnv,
+  fetcher: Fetcher = (url, init) => fetch(url, init),
+): StreamConfig | null {
+  const name = (env[SinkEnv] ?? '').trim().toLowerCase()
+  if (name === '') return null
+
+  if (!known().includes(name)) {
+    throw new SinkRefused(
+      `${SinkEnv} names ${name} and this build has no such sink. It knows ${known().join(', ')}. ` +
+        'An object store sink exists in the code and cannot be configured from the environment, ' +
+        'because it needs a signer this side of the product does not carry.',
+    )
+  }
+
+  const key = (env[KeyEnv] ?? '').trim()
+  if (key === '') {
+    // Required rather than defaulted. The manifest is what lets an auditor
+    // check a batch without asking this control plane anything, and a manifest
+    // signed under a key everybody knows is a decoration rather than evidence.
+    throw new SinkRefused(
+      `${SinkEnv} is set to ${name} and ${KeyEnv} is not. Batch manifests are signed under it, ` +
+        'and a signature under a key nobody chose proves nothing. Generate one with ' +
+        '`openssl rand -base64 32`.',
+    )
+  }
+
+  const batchSize = positive(env, BatchEnv, DEFAULT_BATCH)
+  return {
+    sink: build(name, env, fetcher),
+    key,
+    intervalMs: positive(env, IntervalEnv, DEFAULT_INTERVAL_MS),
+    batchSize,
+    deliveryBatchSize: positive(env, DeliveryBatchEnv, batchSize),
+  }
+}
+
+function build(name: string, env: NodeJS.ProcessEnv, fetcher: Fetcher): Sink {
+  switch (name) {
+    case 'splunk':
+      return new SplunkSink({
+        url: required(env, SplunkUrlEnv, name),
+        token: required(env, SplunkTokenEnv, name),
+        fetch: fetcher,
+        ...(env[SplunkIndexEnv] ? { index: env[SplunkIndexEnv] } : {}),
+        ...(env[SplunkSourcetypeEnv] ? { sourcetype: env[SplunkSourcetypeEnv] } : {}),
+      })
+    case 'event_hubs':
+      return new EventHubsSink({
+        url: required(env, EventHubsUrlEnv, name),
+        authorization: required(env, EventHubsAuthorizationEnv, name),
+        fetch: fetcher,
+      })
+    default:
+      return new WebhookSink({
+        url: required(env, WebhookUrlEnv, name),
+        secret: required(env, WebhookSecretEnv, name),
+        fetch: fetcher,
+      })
+  }
+}
+
+function required(env: NodeJS.ProcessEnv, variable: string, sink: string): string {
+  const value = (env[variable] ?? '').trim()
+  if (value === '') {
+    throw new SinkRefused(
+      `${SinkEnv} is set to ${sink} and ${variable} is not set. Refusing to start rather than ` +
+        'forwarding nothing quietly.',
+    )
+  }
+  return value
+}
+
+/** A whole number above zero, or the default. Refuses anything else rather than
+ *  falling back, because a typo that silently becomes ten seconds is a
+ *  configuration an operator believes they changed. */
+function positive(env: NodeJS.ProcessEnv, variable: string, fallback: number): number {
+  const raw = (env[variable] ?? '').trim()
+  if (raw === '') return fallback
+  const value = Number(raw)
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new SinkRefused(
+      `${variable} is ${JSON.stringify(raw)}; it has to be a whole number above zero.`,
+    )
+  }
+  return value
+}

--- a/ee/web/audit/src/forwarder.ts
+++ b/ee/web/audit/src/forwarder.ts
@@ -42,9 +42,9 @@
 // naming one of them and covering both, and a receiver checking the manifest
 // against the batch would be checking the wrong claim.
 //
-// FOUR: the entitlement is asked per pass, per organization, never cached. A
-// licence that lapses while the process runs stops forwarding on the next pass
-// without a restart, and one that renews starts again the same way. That is the
+// FOUR: the entitlement is asked per pass, per organization, never cached. An
+// organization entitlement that is withdrawn stops forwarding on the next pass
+// without a restart, and one that is granted starts it the same way. That is the
 // rule `ee/engine/auditsink` already follows per action, and the reason both
 // follow it is that a gate evaluated once at startup is a gate that cannot
 // expire.

--- a/ee/web/audit/src/forwarder.ts
+++ b/ee/web/audit/src/forwarder.ts
@@ -14,7 +14,9 @@
 //
 // So this file is deliberately small and is the whole of what was absent: read
 // the rows above a cursor, ask whether each organization is entitled, hand the
-// entitled ones to the queue, and move the cursor only past what a sink took.
+// entitled ones to the queue, and persist each organization's position.
+// Writers serialize within an organization, so a global sequence cursor would
+// skip an earlier allocated row that commits after another organization's row.
 //
 // ---------------------------------------------------------------------------
 // The five decisions in here, each of which has a wrong answer that looks fine
@@ -51,9 +53,7 @@
 // and the cursor advances past it. It is not held for a licence that might
 // arrive later. That is the behaviour docs/enterprise/audit-stream.md already
 // describes for the engine, "accepts every entry and writes none", and here it
-// is also forced: the cursor is one number for the whole installation, so one
-// organization that never buys the feature would otherwise stall the stream for
-// every organization that did.
+// avoids repeatedly reading entries deliberately declined by the licence.
 
 // `sql` through @antifailure/db rather than from drizzle-orm directly, for the
 // reason web/packages/db/src/index.ts opens with: a second physical copy of
@@ -65,9 +65,8 @@ import { Queue, type Clock, type Entry, type Sink } from './sink.ts'
 export interface ForwarderOptions {
   pool: Pool
   clock: Clock
-  /** Where entries go. One, because an installation that wants two runs two
-   *  forwarders and the ordering between them is then explicit rather than
-   *  hidden inside a fan-out nobody can see the state of. */
+  /** One destination per installation. Replicas share delivery positions.
+   *  Multiple destinations require a collector that fans out after receiving. */
   sink: Sink
   /** Signs the batch manifests, so an object sitting in an archive can be
    *  checked without reaching back to the control plane that wrote it. */
@@ -205,11 +204,12 @@ export class Forwarder {
 
     const rows = await this.opts.pool.withAuditForwarder(async (db) =>
       db.execute<Row>(sql`
-        SELECT seq, org_id, actor_label, action, target_type, target_id,
-               origin, detail, occurred_at, entry_hash
-        FROM audit_entries
-        WHERE seq > ${from}
-        ORDER BY seq ASC
+        SELECT a.seq, a.org_id, a.actor_label, a.action, a.target_type, a.target_id,
+               a.origin, a.detail, a.occurred_at, a.entry_hash
+        FROM audit_entries a
+        LEFT JOIN audit_stream_positions p ON p.org_id = a.org_id
+        WHERE a.seq > coalesce(p.delivered_seq, 0)
+        ORDER BY a.seq ASC
         LIMIT ${this.batchSize}`),
     )
 
@@ -236,6 +236,7 @@ export class Forwarder {
     for (const [orgId, forOrg] of byOrg) {
       if (!(await this.opts.permitted(orgId, now))) {
         unlicensed += forOrg.length
+        await this.advanceOrganization(orgId, forOrg[forOrg.length - 1]!.seq)
         continue
       }
 
@@ -244,11 +245,16 @@ export class Forwarder {
         clock: this.opts.clock,
         key: this.opts.key,
         batchSize: this.deliveryBatchSize,
+        capacity: Math.max(10_000, forOrg.length),
       })
       for (const entry of forOrg) queue.enqueue(entry)
 
       const sent = await queue.flush()
       delivered += sent
+      const completed = forOrg.length - queue.depth
+      if (completed > 0) {
+        await this.advanceOrganization(orgId, forOrg[completed - 1]!.seq)
+      }
 
       // WHAT STILL WAITS, NOT WHAT WAS NOT DELIVERED, and the difference is the
       // whole correctness of the cursor.
@@ -286,7 +292,7 @@ export class Forwarder {
     }
 
     const highest = entries[entries.length - 1]!.seq
-    const to = blocked === null ? highest : blocked - 1
+    const to = Math.max(from, blocked === null ? highest : blocked - 1)
     if (to > from) await this.advance(to)
 
     return {
@@ -335,6 +341,17 @@ export class Forwarder {
         WHERE id AND delivered_seq < ${to}`)
     })
   }
+
+  private async advanceOrganization(orgId: string, to: number): Promise<void> {
+    await this.opts.pool.withAuditForwarder(async (db) => {
+      await db.execute(sql`
+        INSERT INTO audit_stream_positions (org_id, delivered_seq, updated_at)
+        VALUES (${orgId}, ${to}, ${this.opts.clock.now().toISOString()})
+        ON CONFLICT (org_id) DO UPDATE
+        SET delivered_seq = greatest(audit_stream_positions.delivered_seq, EXCLUDED.delivered_seq),
+            updated_at = EXCLUDED.updated_at`)
+    })
+  }
 }
 
 export interface ForwarderHandle {
@@ -362,7 +379,7 @@ export interface ForwarderHandle {
  * slow destination into a duplicate storm.
  */
 export function startForwarder(
-  forwarder: Forwarder,
+  forwarder: Pick<Forwarder, 'pass'>,
   intervalMs: number,
   onError?: (err: unknown) => void,
 ): ForwarderHandle {

--- a/ee/web/audit/src/forwarder.ts
+++ b/ee/web/audit/src/forwarder.ts
@@ -1,0 +1,394 @@
+// The loop that carries the control plane's audit log to a sink.
+//
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+//
+// WHAT WAS MISSING, AND WHY IT LOOKED PRESENT.
+//
+// sink.ts and sinks.ts have been complete for as long as this package has
+// existed: a bounded queue, four destinations, retries, backoff, and signed
+// batch manifests over the chain head. Nothing called any of it. The package
+// was not a declared dependency of `ee/web/server`, or of anything else in the
+// workspace, so it could not be imported without a package.json change, and
+// `npm --prefix ee/web test` ran its suite green on every pull request anyway
+// because that command runs every workspace. Tested, green and unreachable.
+//
+// So this file is deliberately small and is the whole of what was absent: read
+// the rows above a cursor, ask whether each organization is entitled, hand the
+// entitled ones to the queue, and move the cursor only past what a sink took.
+//
+// ---------------------------------------------------------------------------
+// The five decisions in here, each of which has a wrong answer that looks fine
+// ---------------------------------------------------------------------------
+//
+// ONE: the cursor advances only past entries a sink ACCEPTED. `Queue.flush`
+// leaves a failed batch at the front and never throws, and it reports how many
+// entries it delivered, so the first undelivered sequence number is knowable
+// exactly. Stopping there makes delivery at least once: a duplicate is
+// detectable by `seq` and a gap is not detectable at all, and an audit stream
+// has to pick the failure its reader can see.
+//
+// TWO: a fresh queue per pass, not one held across passes. A queue that
+// survives the pass would hold entries the cursor has not advanced past, so the
+// next pass would read them again and enqueue a second copy. Retrying is
+// therefore reading again from the cursor, and the poll interval is the
+// backoff. `Queue.backoffMs` is for a caller that holds its queue; this one
+// does not, and the honest version of that is to say so rather than to call a
+// method whose value nothing uses.
+//
+// THREE: one queue per organization within a pass. `sign` takes the org from
+// the FIRST entry, so a batch mixing two organizations would carry a manifest
+// naming one of them and covering both, and a receiver checking the manifest
+// against the batch would be checking the wrong claim.
+//
+// FOUR: the entitlement is asked per pass, per organization, never cached. A
+// licence that lapses while the process runs stops forwarding on the next pass
+// without a restart, and one that renews starts again the same way. That is the
+// rule `ee/engine/auditsink` already follows per action, and the reason both
+// follow it is that a gate evaluated once at startup is a gate that cannot
+// expire.
+//
+// FIVE: an entry belonging to an organization that is NOT entitled is skipped
+// and the cursor advances past it. It is not held for a licence that might
+// arrive later. That is the behaviour docs/enterprise/audit-stream.md already
+// describes for the engine, "accepts every entry and writes none", and here it
+// is also forced: the cursor is one number for the whole installation, so one
+// organization that never buys the feature would otherwise stall the stream for
+// every organization that did.
+
+// `sql` through @antifailure/db rather than from drizzle-orm directly, for the
+// reason web/packages/db/src/index.ts opens with: a second physical copy of
+// drizzle gives a nominally different SQL type and the compile error names a
+// private field rather than the cause.
+import { sql, type Pool } from '@antifailure/db'
+import { Queue, type Clock, type Entry, type Sink } from './sink.ts'
+
+export interface ForwarderOptions {
+  pool: Pool
+  clock: Clock
+  /** Where entries go. One, because an installation that wants two runs two
+   *  forwarders and the ordering between them is then explicit rather than
+   *  hidden inside a fan-out nobody can see the state of. */
+  sink: Sink
+  /** Signs the batch manifests, so an object sitting in an archive can be
+   *  checked without reaching back to the control plane that wrote it. */
+  key: string
+  /**
+   * Whether one organization may have its audit log forwarded, right now.
+   *
+   * Supplied rather than implemented, because the answer needs both the licence
+   * key this process was started with and the entitlement the control plane
+   * holds for that organization, and neither belongs in a package about
+   * carrying rows to a sink.
+   */
+  permitted: (orgId: string, now: Date) => Promise<boolean>
+  /** How many entries one pass reads. A ceiling, so a forwarder that has been
+   *  stopped for a week catches up over several passes rather than reading a
+   *  week of audit log into memory at once. */
+  batchSize?: number
+  /**
+   * How many entries go in one delivery, which is a different question.
+   *
+   * Not the same knob as `batchSize` and it was one knob until a test caught
+   * it. A pass reads what the forwarder can catch up on; a delivery is what one
+   * HTTP request may carry, and Splunk's collector and Event Hubs both have a
+   * payload ceiling that has nothing to do with how far behind the cursor is.
+   * Sharing one number means raising the catch up rate silently raises the
+   * request size until an endpoint answers 413, which `permanent()` correctly
+   * reads as "never going to work" and gives up on.
+   *
+   * Defaults to the pass size, so an installation that does not care sets one
+   * number and gets one batch per pass.
+   */
+  deliveryBatchSize?: number
+  log?: (line: string) => void
+}
+
+/** What one pass did, in enough detail that a test can tell "nothing to do"
+ *  from "nothing was allowed" from "nothing was accepted". Three states that a
+ *  count of delivered entries renders identically as zero. */
+export interface Pass {
+  /** Entries read above the cursor. */
+  read: number
+  /** Entries a sink accepted. */
+  delivered: number
+  /** Entries skipped because their organization is not entitled. */
+  unlicensed: number
+  /** The cursor before and after. Equal means the pass moved nothing, which is
+   *  correct for an empty log and is a stuck stream for a failing sink. */
+  from: number
+  to: number
+  /** The organizations this pass touched, sorted, so a test can name a cell
+   *  rather than count one. */
+  organizations: string[]
+}
+
+interface Row extends Record<string, unknown> {
+  seq: string | number
+  org_id: string
+  actor_label: string
+  action: string
+  target_type: string
+  target_id: string | null
+  origin: string
+  detail: unknown
+  occurred_at: Date | string
+  entry_hash: string
+}
+
+/**
+ * Turns a stored row into the entry a sink receives.
+ *
+ * `seq` is read as a string by the driver, because it is a bigint and a bigint
+ * does not fit a JavaScript number in general. Every value this product can
+ * produce does, so it is converted here rather than carried as a string through
+ * a comparison that would then be lexicographic: '9' is greater than '10' as
+ * text, and a cursor that compared that way would stop advancing at the tenth
+ * entry and look like a stalled sink.
+ *
+ * `detail` is jsonb and arrives as an object. A row whose detail is null gets
+ * an empty object rather than null, because the canonical form the manifest is
+ * computed over sorts keys and cannot sort a null.
+ */
+function toEntry(row: Row): Entry {
+  const occurredAt =
+    row.occurred_at instanceof Date ? row.occurred_at : new Date(row.occurred_at)
+  return {
+    seq: Number(row.seq),
+    orgId: row.org_id,
+    actor: row.actor_label,
+    action: row.action,
+    targetType: row.target_type,
+    targetId: row.target_id,
+    origin: row.origin,
+    detail:
+      row.detail !== null && typeof row.detail === 'object' && !Array.isArray(row.detail)
+        ? (row.detail as Record<string, unknown>)
+        : {},
+    occurredAt: occurredAt.toISOString(),
+    entryHash: row.entry_hash,
+  }
+}
+
+/**
+ * Reads the audit log above a cursor and forwards it.
+ *
+ * Every method is safe to call on a control plane with no audit entries, no
+ * cursor movement and no licence, and none of them throws for any of those:
+ * a forwarder that raised on an idle installation would be a process that
+ * restarts all night for no reason.
+ */
+export class Forwarder {
+  private readonly opts: ForwarderOptions
+  private readonly batchSize: number
+  private readonly deliveryBatchSize: number
+  private readonly log: (line: string) => void
+
+  constructor(options: ForwarderOptions) {
+    this.opts = options
+    this.batchSize = options.batchSize ?? 500
+    this.deliveryBatchSize = options.deliveryBatchSize ?? this.batchSize
+    this.log = options.log ?? (() => {})
+  }
+
+  /**
+   * One pass: read, gate, deliver, advance.
+   *
+   * The read and the advance are separate transactions on purpose. The
+   * entitlement check opens its own tenant transaction, and asking it from
+   * inside the read would hold a connection while waiting for another one,
+   * which is how a pool of three deadlocks against itself on an installation
+   * with four organizations.
+   */
+  async pass(): Promise<Pass> {
+    const now = this.opts.clock.now()
+    const from = await this.cursor()
+
+    const rows = await this.opts.pool.withAuditForwarder(async (db) =>
+      db.execute<Row>(sql`
+        SELECT seq, org_id, actor_label, action, target_type, target_id,
+               origin, detail, occurred_at, entry_hash
+        FROM audit_entries
+        WHERE seq > ${from}
+        ORDER BY seq ASC
+        LIMIT ${this.batchSize}`),
+    )
+
+    const entries = rows.map(toEntry)
+    if (entries.length === 0) {
+      return { read: 0, delivered: 0, unlicensed: 0, from, to: from, organizations: [] }
+    }
+
+    // Grouped in sequence order within each organization, which is what the
+    // queue delivers in and what `verify` checks a batch for.
+    const byOrg = new Map<string, Entry[]>()
+    for (const entry of entries) {
+      const held = byOrg.get(entry.orgId)
+      if (held) held.push(entry)
+      else byOrg.set(entry.orgId, [entry])
+    }
+
+    let delivered = 0
+    let unlicensed = 0
+    // The lowest sequence number that was neither delivered nor deliberately
+    // skipped. The cursor stops below it, so the next pass reads it again.
+    let blocked: number | null = null
+
+    for (const [orgId, forOrg] of byOrg) {
+      if (!(await this.opts.permitted(orgId, now))) {
+        unlicensed += forOrg.length
+        continue
+      }
+
+      const queue = new Queue({
+        sink: this.opts.sink,
+        clock: this.opts.clock,
+        key: this.opts.key,
+        batchSize: this.deliveryBatchSize,
+      })
+      for (const entry of forOrg) queue.enqueue(entry)
+
+      const sent = await queue.flush()
+      delivered += sent
+
+      // WHAT STILL WAITS, NOT WHAT WAS NOT DELIVERED, and the difference is the
+      // whole correctness of the cursor.
+      //
+      // `flush` has three outcomes per batch and only one of them means "come
+      // back for this". Delivered is delivered. A PermanentError, meaning a
+      // credential or a payload the endpoint will never accept, DROPS the batch
+      // and carries on, because one entry nobody will ever take must not stop
+      // every entry behind it. Only a transient failure leaves the batch at the
+      // front, and `depth` is the count of exactly those.
+      //
+      // Reading `forOrg.length - sent` here instead would treat a dropped batch
+      // as still owed, so the cursor would stop below it, the next pass would
+      // read it again, drop it again, and the stream would stall on it forever
+      // while reporting a healthy sink.
+      //
+      // Delivery is in order and drops happen from the front, so what is left
+      // is always a suffix and the first entry of that suffix is the one the
+      // cursor must stop below.
+      if (queue.depth > 0) {
+        const stuck = forOrg[forOrg.length - queue.depth]!.seq
+        blocked = blocked === null ? stuck : Math.min(blocked, stuck)
+      }
+      if (sent < forOrg.length) {
+        // `state` carries the sink's own words, which is the only place a
+        // reason for a stalled or a lossy stream exists.
+        const state = queue.state
+        this.log(
+          `audit stream: ${this.opts.sink.name()} took ${String(sent)} of ` +
+            `${String(forOrg.length)} entries for ${orgId}, ${String(queue.depth)} waiting, ` +
+            `${String(queue.dropped)} given up on, and is ${state.state}` +
+            ('reason' in state ? `: ${state.reason}` : ''),
+        )
+      }
+    }
+
+    const highest = entries[entries.length - 1]!.seq
+    const to = blocked === null ? highest : blocked - 1
+    if (to > from) await this.advance(to)
+
+    return {
+      read: entries.length,
+      delivered,
+      unlicensed,
+      from,
+      to,
+      organizations: [...byOrg.keys()].sort(),
+    }
+  }
+
+  /** Where the last pass got to. Zero on an installation that has never
+   *  forwarded anything, which is not the same as up to date and is why the row
+   *  exists rather than being inferred from an empty sink. */
+  async cursor(): Promise<number> {
+    return this.opts.pool.withAuditForwarder(async (db) => {
+      const rows = await db.execute<{ delivered_seq: string | number }>(
+        sql`SELECT delivered_seq FROM audit_stream_cursor WHERE id`,
+      )
+      // No row means the policy denied, which on this scope means the migration
+      // that creates the row has not run. Saying so beats reporting zero, which
+      // reads as a fresh installation and would re-stream the whole log the
+      // moment the policy started working.
+      if (rows.length === 0) {
+        throw new Error(
+          'audit_stream_cursor has no row this connection can read. Migration 0043 creates it ' +
+            'and grants the read to the audit forwarder scope; a control plane that has not ' +
+            'applied it cannot forward, and reporting a cursor of zero here would re-stream ' +
+            'the entire audit log to the sink the first time it did.',
+        )
+      }
+      return Number(rows[0]!.delivered_seq)
+    })
+  }
+
+  /** Moves the cursor forward, never backward. The guard is in the statement
+   *  rather than in this process, because two control plane replicas both
+   *  forwarding is a duplicate and a cursor that went backwards is a replay of
+   *  an organization's whole audit history into somebody's SIEM. */
+  private async advance(to: number): Promise<void> {
+    await this.opts.pool.withAuditForwarder(async (db) => {
+      await db.execute(sql`
+        UPDATE audit_stream_cursor
+        SET delivered_seq = ${to}, updated_at = ${this.opts.clock.now().toISOString()}
+        WHERE id AND delivered_seq < ${to}`)
+    })
+  }
+}
+
+export interface ForwarderHandle {
+  /** Stops the schedule. A pass already in flight finishes on its own.
+   *
+   *  There is deliberately nothing to flush here, and that is a property of the
+   *  design rather than an omission. A pass holds its queue for the length of
+   *  the pass, so a process that stops mid pass leaves every undelivered entry
+   *  ABOVE the cursor, where the next process reads it. boot.ts flushes the
+   *  failure store on shutdown because that one buffers in memory across ticks;
+   *  this one has nothing that a restart would not pick up. */
+  stop(): void
+}
+
+/**
+ * Runs a pass now and then on an interval.
+ *
+ * A failure is logged and the schedule continues, which is the rule
+ * startMaintenance already follows and for the same reason: the failure that
+ * matters is a sink being unreachable for a while, and giving up after the
+ * first one is how forwarding stops quietly.
+ *
+ * Passes never overlap. A slow sink would otherwise have two passes reading the
+ * same rows above the same cursor and delivering both copies, which turns one
+ * slow destination into a duplicate storm.
+ */
+export function startForwarder(
+  forwarder: Forwarder,
+  intervalMs: number,
+  onError?: (err: unknown) => void,
+): ForwarderHandle {
+  const report = onError ?? ((err: unknown) => console.error('audit stream', err))
+  let busy = false
+
+  const tick = (): void => {
+    if (busy) return
+    busy = true
+    void (async () => {
+      try {
+        await forwarder.pass()
+      } catch (err) {
+        report(err)
+      } finally {
+        busy = false
+      }
+    })()
+  }
+
+  tick()
+  const timer = setInterval(tick, intervalMs)
+  // Unreferenced, so a forwarder never holds a process open on its own. The
+  // control plane's own server is what keeps it alive, and a timer that kept
+  // node running would make every test that starts one hang at teardown.
+  timer.unref()
+
+  return { stop: () => clearInterval(timer) }
+}

--- a/ee/web/audit/src/index.ts
+++ b/ee/web/audit/src/index.ts
@@ -28,3 +28,33 @@ export {
   type ObjectStoreOptions,
   type WebhookOptions,
 } from './sinks.ts'
+
+export {
+  Forwarder,
+  startForwarder,
+  type ForwarderOptions,
+  type ForwarderHandle,
+  type Pass,
+} from './forwarder.ts'
+
+export {
+  fromEnvironment,
+  known,
+  SinkRefused,
+  SinkEnv,
+  KeyEnv,
+  IntervalEnv,
+  BatchEnv,
+  DeliveryBatchEnv,
+  SplunkUrlEnv,
+  SplunkTokenEnv,
+  SplunkIndexEnv,
+  SplunkSourcetypeEnv,
+  EventHubsUrlEnv,
+  EventHubsAuthorizationEnv,
+  WebhookUrlEnv,
+  WebhookSecretEnv,
+  DEFAULT_INTERVAL_MS,
+  DEFAULT_BATCH,
+  type StreamConfig,
+} from './configure.ts'

--- a/ee/web/audit/src/sink.ts
+++ b/ee/web/audit/src/sink.ts
@@ -247,6 +247,11 @@ export function verify(batch: Batch, key: string): { ok: boolean; problem: strin
   if (expected.signature !== batch.manifest.signature) {
     return { ok: false, problem: 'the signature does not verify under this key' }
   }
+  for (const field of ['org', 'count', 'firstSeq', 'lastSeq', 'headHash'] as const) {
+    if (expected[field] !== batch.manifest[field]) {
+      return { ok: false, problem: `the manifest ${field} does not match the signed entries` }
+    }
+  }
   for (let i = 1; i < batch.entries.length; i += 1) {
     if (batch.entries[i]!.seq <= batch.entries[i - 1]!.seq) {
       return { ok: false, problem: `entries ${i - 1} and ${i} are out of order` }

--- a/ee/web/audit/src/sinks.ts
+++ b/ee/web/audit/src/sinks.ts
@@ -21,6 +21,15 @@ import { PermanentError, type Batch, type Sink } from './sink.ts'
 /** The fetch a sink uses. */
 export type Fetcher = (url: string, init: RequestInit) => Promise<Response>
 
+function validateDestination(raw: string): void {
+  let url: URL
+  try { url = new URL(raw) } catch { throw new Error('The audit destination must be an absolute HTTPS URL.') }
+  const local = ['127.0.0.1', '[::1]', 'localhost'].includes(url.hostname)
+  if (url.username || url.password || (url.protocol !== 'https:' && !(url.protocol === 'http:' && local))) {
+    throw new Error('The audit destination requires HTTPS without URL credentials; HTTP is allowed only for a loopback collector.')
+  }
+}
+
 /**
  * Decides whether a status means "never going to work".
  *
@@ -41,19 +50,18 @@ async function send(
 ): Promise<void> {
   let res: Response
   try {
-    res = await fetcher(url, init)
+    res = await fetcher(url, { ...init, redirect: 'error', signal: AbortSignal.timeout(30_000) })
   } catch (err) {
     // A transport failure is temporary by assumption. A hostname that does not
     // resolve looks the same as one that is briefly unreachable, and guessing
     // wrong towards permanent would discard entries over a DNS blip.
     throw new Error(`${what}: ${err instanceof Error ? err.message : String(err)}`)
   }
+  // Do not buffer or quote a collector response. It can echo private audit
+  // data, and truncating after text() has already read an unbounded body.
+  await res.body?.cancel().catch(() => {})
   if (res.ok) return
-
-  // Bounded, because an error path must not read an unbounded body from an
-  // endpoint that may not be the one intended.
-  const body = (await res.text().catch(() => '')).slice(0, 500)
-  const message = `${what} answered ${res.status}${body ? `: ${body}` : ''}`
+  const message = `${what} answered ${res.status}`
   throw permanent(res.status) ? new PermanentError(message) : new Error(message)
 }
 
@@ -76,6 +84,7 @@ export class SplunkSink implements Sink {
   private readonly opts: SplunkOptions
 
   constructor(opts: SplunkOptions) {
+    validateDestination(opts.url)
     this.opts = opts
   }
 
@@ -134,6 +143,7 @@ export class EventHubsSink implements Sink {
   private readonly opts: EventHubsOptions
 
   constructor(opts: EventHubsOptions) {
+    validateDestination(opts.url)
     this.opts = opts
   }
 
@@ -229,13 +239,15 @@ export interface WebhookOptions {
  * A signed webhook, for everything with no adapter.
  *
  * The signature covers the body and a timestamp, and the timestamp is outside
- * the body so a receiver can reject an old delivery without parsing it. A
- * signature over the body alone is replayable forever.
+ * the body so a receiver can inspect the event time before parsing it.
+ * Receivers deduplicate by organization and sequence: backlog delivery can
+ * legitimately contain old events, and signature verification permits replay.
  */
 export class WebhookSink implements Sink {
   private readonly opts: WebhookOptions
 
   constructor(opts: WebhookOptions) {
+    validateDestination(opts.url)
     this.opts = opts
   }
 

--- a/ee/web/audit/src/sinks.ts
+++ b/ee/web/audit/src/sinks.ts
@@ -103,6 +103,9 @@ export class SplunkSink implements Sink {
           source: 'antifailure-audit',
           sourcetype: this.opts.sourcetype ?? 'antifailure:audit',
           ...(this.opts.index ? { index: this.opts.index } : {}),
+          // HEC indexes custom fields from this flat object. A manifest only
+          // carried in an HTTP header never reaches the stored event.
+          fields: { antifailure_manifest: JSON.stringify(batch.manifest) },
           event: entry,
         }),
       )
@@ -116,8 +119,6 @@ export class SplunkSink implements Sink {
         headers: {
           authorization: `Splunk ${this.opts.token}`,
           'content-type': 'application/json',
-          // The manifest travels in a header so that the body stays exactly
-          // what Splunk expects and an operator can still check the batch.
           'x-antifailure-manifest': JSON.stringify(batch.manifest),
         },
         body,
@@ -162,7 +163,14 @@ export class EventHubsSink implements Sink {
           'content-type': 'application/vnd.microsoft.servicebus.json',
           'x-antifailure-manifest': JSON.stringify(batch.manifest),
         },
-        body: JSON.stringify(batch.entries.map((entry) => ({ Body: entry }))),
+        // The REST batch format requires a string Body. Batch properties in
+        // HTTP headers are ignored, so the signed manifest must travel with
+        // each event for a downstream consumer to retain and verify it.
+        // https://learn.microsoft.com/en-us/rest/api/eventhub/send-batch-events
+        body: JSON.stringify(batch.entries.map((entry) => ({
+          Body: JSON.stringify(entry),
+          UserProperties: { antifailure_manifest: JSON.stringify(batch.manifest) },
+        }))),
       },
       'event hubs',
     )

--- a/ee/web/audit/test/forwarder.test.ts
+++ b/ee/web/audit/test/forwarder.test.ts
@@ -1,0 +1,468 @@
+// The orderings an audit forwarder actually meets, one test per cell.
+//
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+//
+// WHY A TABLE OF ORDERINGS RATHER THAN A LIST OF STATES. This is event driven:
+// an entry is written by one path and delivered by another, and the two are not
+// synchronised with each other. A suite that only ever writes an entry and then
+// runs a pass tests one arrival order out of six, which is exactly the failure
+// this repository has already paid for elsewhere. So every case below names the
+// ordering it covers in its own title, and the cells are:
+//
+//   before      an entry exists before the forwarder ever runs
+//   during      an entry is written between two passes of a running forwarder
+//   gap         a sequence number is missing, because a transaction rolled back
+//               after taking one
+//   empty       the forwarder starts against a log with nothing above the cursor
+//   restart     a second forwarder over the same cursor delivers nothing twice
+//   partial     a sink refuses part way through a pass
+//   permanent   a sink will never accept a batch, so it is given up on
+//   licensed    an entitled organization is forwarded
+//   unlicensed  an organization that is not entitled is not forwarded
+//   lapses      an entitlement withdrawn while the process runs stops it
+//   arrives     an entitlement granted while the process runs starts it
+//   two orgs    two organizations in one read get one batch each
+//   origins     every origin any entry point writes is carried
+//
+// Nothing here uses a fake database, a fake pool or a hand written INSERT. The
+// entries are written by the real `appendAudit` inside a real tenant
+// transaction against real row level security, because the defect being closed
+// is that the rows the product already writes reached nothing.
+
+import { after, before, describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile, readdir } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { Forwarder, PermanentError, verify } from '../src/index.ts'
+import {
+  RecordingSink,
+  TestClock,
+  available,
+  dropTenant,
+  seedTenant,
+  start,
+  type Harness,
+  type Tenant,
+} from './harness.ts'
+
+const hasDatabase = await available()
+
+const KEY = 'a-manifest-signing-key-for-this-run'
+
+/** Every organization the file seeds, so teardown removes them whatever
+ *  happened to the case that made one. */
+const seeded: string[] = []
+
+describe(
+  'the control plane audit log reaches a sink',
+  { skip: hasDatabase ? false : 'no Postgres at AF_TEST_DATABASE_URL' },
+  () => {
+    let h: Harness
+
+    before(async () => {
+      h = await start()
+    })
+
+    after(async () => {
+      for (const orgId of seeded) await dropTenant(h, orgId)
+      await h.close()
+    })
+
+    /** A tenant, and the cursor parked at the current head so the case reads
+     *  only what it writes. Every case starts this way; see harness.maxSeq. */
+    async function tenant(plan = 'enterprise'): Promise<Tenant> {
+      const t = await seedTenant(h, plan)
+      seeded.push(t.orgId)
+      await h.setCursor(await h.maxSeq())
+      return t
+    }
+
+    /** A forwarder over a recording sink, entitled by the plan in the database
+     *  rather than by a callback that says yes. `permitted` here is the real
+     *  question the enterprise entry point asks, minus the licence key half,
+     *  which entrypoint-level tests cover because it needs a real process. */
+    function forwarderFor(
+      sink: RecordingSink,
+      clock: TestClock,
+      permitted: (orgId: string, now: Date) => Promise<boolean>,
+      deliveryBatchSize = 500,
+    ): Forwarder {
+      // The pass size is left at its default and only the DELIVERY size moves.
+      // Those were one number until this file was first run: a case that set
+      // two entries per delivery also read two entries per pass, so a batch
+      // that was supposed to be the second of three was never read at all and
+      // the assertion about the third could not have failed for the right
+      // reason.
+      return new Forwarder({
+        pool: h.pool, clock, sink, key: KEY, permitted, deliveryBatchSize,
+      })
+    }
+
+    /** The entitlement as the product asks it, through the catalogue and the
+     *  organization's plan. Imported lazily so this file does not become a
+     *  dependency of the features package's own graph. */
+    async function entitled(orgId: string, now: Date): Promise<boolean> {
+      const { licensed } = await import('@antifailure-ee/features')
+      return licensed(h.pool, orgId, 'audit_stream', now)
+    }
+
+    // -----------------------------------------------------------------------
+
+    it('before: an entry written before the forwarder ever runs is delivered', async () => {
+      const org = await tenant()
+      const seq = await h.write(org.orgId, 'sso.login')
+
+      const sink = new RecordingSink()
+      const f = forwarderFor(sink, new TestClock(), entitled)
+      const pass = await f.pass()
+
+      assert.equal(pass.read, 1, 'the pass read something other than the one entry written')
+      assert.equal(pass.delivered, 1, 'the entry was read and not delivered')
+      assert.deepEqual(sink.seqs(), [seq], 'the sink was given the wrong entry')
+      assert.equal(await h.readCursor(), seq, 'the cursor did not advance past a delivered entry')
+
+      // The entry a security team would actually read, checked field by field
+      // rather than counted. A forwarder that delivered an empty object would
+      // pass every count in this file.
+      const got = sink.entries()[0]!
+      assert.equal(got.orgId, org.orgId)
+      assert.equal(got.action, 'sso.login')
+      assert.equal(got.actor, 'harness')
+      assert.equal(got.origin, 'system')
+      assert.match(got.entryHash, /^[0-9a-f]{64}$/, 'the chain hash did not travel with the entry')
+      assert.equal(got.entryHash, await chainHash(h, seq), 'the hash forwarded is not the stored one')
+    })
+
+    it('before: the batch manifest verifies over the chain head', async () => {
+      const org = await tenant()
+      await h.write(org.orgId, 'sso.login')
+      const last = await h.write(org.orgId, 'scim.user.created')
+
+      const sink = new RecordingSink()
+      await forwarderFor(sink, new TestClock(), entitled).pass()
+
+      const batch = sink.batches[0]!
+      assert.equal(verify(batch, KEY).ok, true, verify(batch, KEY).problem)
+      assert.equal(batch.manifest.org, org.orgId, 'the manifest names the wrong organization')
+      assert.equal(batch.manifest.lastSeq, last)
+      assert.equal(
+        batch.manifest.headHash,
+        await chainHash(h, last),
+        'the manifest head is not the last entry chain hash, so a chain of batches cannot be ' +
+          'joined end to end',
+      )
+      assert.equal(
+        verify(batch, 'a different key').ok,
+        false,
+        'the manifest verifies under a key that did not sign it, so the signature proves nothing',
+      )
+    })
+
+    it('during: an entry written between two passes is delivered without a restart', async () => {
+      const org = await tenant()
+      const sink = new RecordingSink()
+      const f = forwarderFor(sink, new TestClock(), entitled)
+
+      const first = await h.write(org.orgId, 'admin.impersonated')
+      assert.equal((await f.pass()).delivered, 1)
+
+      // The ordering that matters: the forwarder object is the same one, the
+      // cursor is where the first pass left it, and the entry did not exist
+      // when it started.
+      const second = await h.write(org.orgId, 'member.removed')
+      const pass = await f.pass()
+
+      assert.equal(pass.read, 1, 'the second pass re-read the first entry')
+      assert.equal(pass.delivered, 1)
+      assert.deepEqual(sink.seqs(), [first, second], 'the sink saw the wrong entries or the wrong order')
+      assert.equal(await h.readCursor(), second)
+    })
+
+    it('gap: a sequence number burned by a rolled back write does not stall the stream', async () => {
+      const org = await tenant()
+      const before = await h.write(org.orgId, 'first')
+
+      // A real gap, made the way real gaps are made. appendAudit reads nextval
+      // and then inserts; a transaction that rolls back after the read leaves
+      // the number consumed and no row, and a sequence is not transactional so
+      // the number never comes back. A forwarder that waited for the missing
+      // number would stop here and look like a dead sink.
+      const burned = await h.burnSequence()
+      const after = await h.write(org.orgId, 'second')
+      assert.ok(burned > before && burned < after, 'the gap was not made where this case needs it')
+
+      const sink = new RecordingSink()
+      const pass = await forwarderFor(sink, new TestClock(), entitled).pass()
+
+      assert.deepEqual(sink.seqs(), [before, after], 'the forwarder did not read across the gap')
+      assert.equal(pass.read, 2)
+      assert.equal(
+        await h.readCursor(),
+        after,
+        'the cursor stopped at the gap, so every entry after a rolled back write would be lost',
+      )
+    })
+
+    it('empty: a forwarder over a log with nothing above the cursor moves nothing', async () => {
+      await tenant()
+      const sink = new RecordingSink()
+      const at = await h.readCursor()
+      const pass = await forwarderFor(sink, new TestClock(), entitled).pass()
+
+      assert.equal(pass.read, 0)
+      assert.equal(pass.delivered, 0)
+      assert.deepEqual(sink.batches, [], 'an empty pass sent a batch, which a receiver counts')
+      assert.equal(await h.readCursor(), at, 'an empty pass moved the cursor')
+      assert.equal(pass.from, pass.to, 'an empty pass reported the cursor as having moved')
+    })
+
+    it('restart: a second forwarder over the same cursor delivers nothing twice', async () => {
+      const org = await tenant()
+      const seq = await h.write(org.orgId, 'org.deleted')
+
+      const first = new RecordingSink()
+      await forwarderFor(first, new TestClock(), entitled).pass()
+      assert.deepEqual(first.seqs(), [seq])
+
+      // A new Forwarder, a new sink, the same cursor row: the process restarted.
+      const second = new RecordingSink()
+      const pass = await forwarderFor(second, new TestClock(), entitled).pass()
+
+      assert.equal(pass.read, 0, 'a restarted forwarder re-read an entry it had already delivered')
+      assert.deepEqual(
+        second.seqs(), [],
+        'a restart re-delivered the audit log, which is how a SIEM ends up with two of every entry',
+      )
+    })
+
+    it('partial: a sink that refuses part way through leaves the cursor below what it refused', async () => {
+      const org = await tenant()
+      const seqs: number[] = []
+      for (let i = 0; i < 6; i += 1) seqs.push(await h.write(org.orgId, `entry.${String(i)}`))
+
+      const sink = new RecordingSink()
+      // Two per batch, and the second batch is refused with an ordinary error,
+      // which means "try again later" rather than "never".
+      sink.fail = (batch) => (batch.entries[0]!.seq === seqs[2] ? new Error('collector timed out') : null)
+
+      const f = forwarderFor(sink, new TestClock(), entitled, 2)
+      const pass = await f.pass()
+
+      assert.equal(pass.delivered, 2, 'the sink took a different number of entries than it accepted')
+      assert.deepEqual(sink.seqs(), [seqs[0], seqs[1]])
+      assert.equal(
+        await h.readCursor(),
+        seqs[1],
+        'the cursor advanced past an entry no sink accepted, which loses it silently',
+      )
+
+      // And the next pass redelivers from there, which is what makes this at
+      // least once rather than lossy.
+      sink.fail = null
+      const again = await f.pass()
+      assert.equal(again.read, 4, 'the retry did not re-read exactly what was left owing')
+      assert.deepEqual(sink.seqs(), seqs, 'the entries the sink refused never arrived')
+      assert.equal(await h.readCursor(), seqs[5])
+    })
+
+    it('permanent: a batch the sink will never accept is given up on and does not stall the rest', async () => {
+      const org = await tenant()
+      const seqs: number[] = []
+      for (let i = 0; i < 6; i += 1) seqs.push(await h.write(org.orgId, `entry.${String(i)}`))
+
+      const sink = new RecordingSink()
+      sink.fail = (batch) =>
+        batch.entries[0]!.seq === seqs[2] ? new PermanentError('collector answered 413') : null
+
+      const pass = await forwarderFor(sink, new TestClock(), entitled, 2).pass()
+
+      assert.deepEqual(
+        sink.seqs(),
+        [seqs[0], seqs[1], seqs[4], seqs[5]],
+        'a batch the endpoint will never accept was not skipped, or took the ones behind it with it',
+      )
+      assert.equal(pass.delivered, 4)
+      assert.equal(
+        await h.readCursor(),
+        seqs[5],
+        'the cursor stopped below a batch that was given up on, so every pass from now on would ' +
+          'read it, drop it, and stall the stream while reporting a healthy sink',
+      )
+    })
+
+    it('licensed and unlicensed: the entitlement decides, and the cursor advances either way', async () => {
+      const paying = await tenant('enterprise')
+      const free = await tenant('free')
+
+      const paid = await h.write(paying.orgId, 'sso.login')
+      const unpaid = await h.write(free.orgId, 'sso.login')
+
+      const sink = new RecordingSink()
+      const pass = await forwarderFor(sink, new TestClock(), entitled).pass()
+
+      assert.equal(pass.read, 2, 'the forwarder did not read both organizations')
+      assert.deepEqual(
+        sink.seqs(), [paid],
+        'an organization on the free plan had its audit log forwarded, or an entitled one did not',
+      )
+      assert.equal(pass.unlicensed, 1, 'the pass did not report the entry it skipped')
+      assert.equal(
+        await h.readCursor(), unpaid,
+        'the cursor stopped at an unlicensed entry, so one organization that never buys audit ' +
+          'streaming would stall the stream for every organization that did',
+      )
+    })
+
+    it('lapses: an entitlement withdrawn while the process runs stops forwarding with no restart', async () => {
+      const org = await tenant('enterprise')
+      const sink = new RecordingSink()
+      const f = forwarderFor(sink, new TestClock(), entitled)
+
+      const before = await h.write(org.orgId, 'sso.login')
+      assert.deepEqual((await f.pass()).organizations, [org.orgId])
+      assert.deepEqual(sink.seqs(), [before], 'the entitled entry was not forwarded to begin with')
+
+      // The plan changes under a forwarder that is already running. No restart,
+      // no new Forwarder, no new sink.
+      await h.setPlan(org.orgId, 'free')
+      const after = await h.write(org.orgId, 'sso.login')
+      const pass = await f.pass()
+
+      assert.equal(pass.read, 1)
+      assert.equal(pass.delivered, 0, 'forwarding continued after the entitlement was withdrawn')
+      assert.equal(pass.unlicensed, 1)
+      assert.deepEqual(sink.seqs(), [before])
+      assert.equal(await h.readCursor(), after)
+    })
+
+    it('arrives: an entitlement granted while the process runs starts forwarding with no restart', async () => {
+      const org = await tenant('free')
+      const sink = new RecordingSink()
+      const f = forwarderFor(sink, new TestClock(), entitled)
+
+      await h.write(org.orgId, 'sso.login')
+      assert.equal((await f.pass()).delivered, 0, 'a free plan organization was forwarded')
+
+      await h.setPlan(org.orgId, 'enterprise')
+      const paid = await h.write(org.orgId, 'sso.login')
+      const pass = await f.pass()
+
+      assert.equal(
+        pass.delivered, 1,
+        'a renewal did not start forwarding again, so the entitlement is cached somewhere it ' +
+          'should not be and only a restart would fix it',
+      )
+      assert.deepEqual(sink.seqs(), [paid])
+    })
+
+    it('two organizations in one read get one batch each, each manifest naming its own', async () => {
+      const a = await tenant('enterprise')
+      const b = await seedTenant(h, 'enterprise')
+      seeded.push(b.orgId)
+
+      // Interleaved on purpose, so a forwarder that batched by read order
+      // rather than by organization would produce a batch holding both.
+      const a1 = await h.write(a.orgId, 'first')
+      const b1 = await h.write(b.orgId, 'first')
+      const a2 = await h.write(a.orgId, 'second')
+
+      const sink = new RecordingSink()
+      const pass = await forwarderFor(sink, new TestClock(), entitled).pass()
+
+      assert.equal(pass.read, 3)
+      assert.equal(pass.delivered, 3)
+      assert.deepEqual(pass.organizations, [a.orgId, b.orgId].sort())
+      assert.equal(sink.batches.length, 2, 'two organizations were put in one batch')
+
+      for (const batch of sink.batches) {
+        const orgs = new Set(batch.entries.map((e) => e.orgId))
+        assert.equal(
+          orgs.size, 1,
+          'a batch carried entries from two organizations, so its manifest names one and ' +
+            'covers both, and a receiver checking it would be checking the wrong claim',
+        )
+        assert.equal(batch.manifest.org, [...orgs][0])
+        assert.equal(verify(batch, KEY).ok, true)
+      }
+
+      const forA = sink.batches.find((x) => x.manifest.org === a.orgId)!
+      assert.deepEqual(forA.entries.map((e) => e.seq), [a1, a2])
+      const forB = sink.batches.find((x) => x.manifest.org === b.orgId)!
+      assert.deepEqual(forB.entries.map((e) => e.seq), [b1])
+    })
+
+    it('origins: every entry point that writes an audit entry is carried', async () => {
+      // EVERY ENTRY POINT, SCRAPED RATHER THAN LISTED. The forwarder has no
+      // WHERE clause on action or origin, so it is entry point independent by
+      // construction, and this is the check that the construction is what
+      // shipped. The origins come out of the source of every appendAudit call
+      // site in the tree, so an entry point added later with an origin nothing
+      // here covers fails this test rather than being silently missing from a
+      // customer's SIEM.
+      const origins = await originsInProduction()
+      assert.ok(
+        origins.length >= 5,
+        `only ${String(origins.length)} origins were scraped out of the source, so the scan is ` +
+          'not reading the call sites and this test would pass while carrying nothing',
+      )
+
+      const org = await tenant('enterprise')
+      const written: number[] = []
+      for (const origin of origins) written.push(await h.write(org.orgId, 'entry', { origin }))
+
+      const sink = new RecordingSink()
+      await forwarderFor(sink, new TestClock(), entitled).pass()
+
+      assert.deepEqual(
+        sink.entries().map((e) => e.origin).sort(),
+        [...origins].sort(),
+        'an origin some entry point writes did not reach the sink',
+      )
+      assert.deepEqual(sink.seqs(), written)
+    })
+  },
+)
+
+// ---------------------------------------------------------------------------
+
+/** The chain hash the database stored for one sequence number, so a test can
+ *  compare what a sink received against what was written rather than against
+ *  itself. */
+async function chainHash(h: Harness, seq: number): Promise<string> {
+  const rows = await h.admin<{ entry_hash: string }[]>`
+    SELECT entry_hash FROM audit_entries WHERE seq = ${seq}`
+  return rows[0]!.entry_hash
+}
+
+/**
+ * Every `origin:` an appendAudit call site in this repository writes.
+ *
+ * Read out of the source rather than written down, for the reason the writers
+ * suite gives about its own scan: a list maintained by hand goes stale on the
+ * entry point nobody remembered, and that entry point is the one whose entries
+ * would be missing from a SIEM.
+ */
+async function originsInProduction(): Promise<string[]> {
+  const here = path.dirname(fileURLToPath(import.meta.url))
+  const repo = path.resolve(here, '..', '..', '..', '..')
+  const roots = ['web/apps/api/src', 'web/packages/db/src', 'ee/web']
+  const found = new Set<string>()
+
+  for (const root of roots) {
+    let entries
+    try {
+      entries = await readdir(path.join(repo, root), { withFileTypes: true, recursive: true })
+    } catch {
+      continue
+    }
+    for (const e of entries) {
+      if (!e.isFile() || !e.name.endsWith('.ts')) continue
+      const full = path.join(e.parentPath, e.name)
+      if (full.includes('node_modules') || full.includes(`${path.sep}test${path.sep}`)) continue
+      const source = await readFile(full, 'utf8')
+      for (const m of source.matchAll(/origin: '([a-z_]+)'/g)) found.add(m[1]!)
+    }
+  }
+  return [...found].sort()
+}

--- a/ee/web/audit/test/forwarder.test.ts
+++ b/ee/web/audit/test/forwarder.test.ts
@@ -35,6 +35,7 @@ import { readFile, readdir } from 'node:fs/promises'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { Forwarder, PermanentError, verify } from '../src/index.ts'
+import { appendAudit, sql } from '@antifailure/db'
 import {
   RecordingSink,
   TestClock,
@@ -202,6 +203,56 @@ describe(
         after,
         'the cursor stopped at the gap, so every entry after a rolled back write would be lost',
       )
+    })
+
+    it('concurrent: a lower sequence that commits after another organization remains deliverable', async () => {
+      const slow = await tenant()
+      const fast = await tenant()
+      let announce!: (seq: number) => void
+      const allocated = new Promise<number>((resolve) => { announce = resolve })
+      let release!: () => void
+      const allowedToCommit = new Promise<void>((resolve) => { release = resolve })
+      const pending = h.pool.withTenant({ orgId: slow.orgId }, async (db) => {
+        const entry = await appendAudit(db, {
+          orgId: slow.orgId, actorLabel: 'harness', action: 'late.commit',
+          targetType: 'organization', origin: 'system',
+        })
+        announce(entry.seq)
+        await allowedToCommit
+      })
+      try {
+        const lower = await allocated
+        const higher = await h.write(fast.orgId, 'early.commit')
+        assert.ok(higher > lower)
+        const sink = new RecordingSink()
+        const f = forwarderFor(sink, new TestClock(), entitled)
+        await f.pass()
+        assert.deepEqual(sink.seqs(), [higher])
+        release()
+        await pending
+        await f.pass()
+        assert.deepEqual(sink.seqs(), [higher, lower], 'a committed audit entry was skipped forever')
+        await f.pass()
+        assert.deepEqual(sink.seqs(), [higher, lower], 'the late commit was replayed')
+      } finally {
+        release()
+        await pending
+      }
+    })
+
+    it('positions: a tenant cannot read or advance delivery state and the forwarder can', async () => {
+      const org = await tenant()
+      const seq = await h.write(org.orgId, 'position.boundary')
+      await forwarderFor(new RecordingSink(), new TestClock(), entitled).pass()
+      const hidden = await h.pool.withTenant({ orgId: org.orgId }, (db) =>
+        db.execute(sql`SELECT * FROM audit_stream_positions WHERE org_id = ${org.orgId}`))
+      assert.equal(hidden.length, 0)
+      await h.pool.withTenant({ orgId: org.orgId }, (db) =>
+        db.execute(sql`UPDATE audit_stream_positions SET delivered_seq = 0 WHERE org_id = ${org.orgId}`))
+      const visible = await h.pool.withAuditForwarder((db) =>
+        db.execute<{ delivered_seq: string }>(sql`
+          SELECT delivered_seq FROM audit_stream_positions WHERE org_id = ${org.orgId}`))
+      assert.equal(Number(visible[0]!.delivered_seq), seq)
     })
 
     it('empty: a forwarder over a log with nothing above the cursor moves nothing', async () => {

--- a/ee/web/audit/test/harness.ts
+++ b/ee/web/audit/test/harness.ts
@@ -1,0 +1,213 @@
+// A real control plane database, a real audit chain, and a sink that records.
+//
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+//
+// Entries are written with the real `appendAudit` and never with an INSERT of
+// this file's own. That is the point of the whole exercise: the defect being
+// closed is that the rows every entry point already writes reached nothing, so
+// a harness that wrote its own rows would be proving something about a shape it
+// invented rather than about the shape the product produces. `appendAudit`
+// takes the advisory lock, assigns the sequence from the table's own sequence
+// and chains each entry to the one before it, and the manifest the sink
+// receives is signed over `entry_hash`, so a fixture that skipped any of that
+// would sign a chain that does not exist.
+
+import postgres from 'postgres'
+import { randomUUID } from 'node:crypto'
+import { appendAudit, createPool, migrate, type Pool } from '@antifailure/db'
+import type { Batch, Clock, Sink } from '../src/index.ts'
+import { PermanentError } from '../src/index.ts'
+
+export const adminUrl =
+  process.env.AF_TEST_DATABASE_URL ?? 'postgres://postgres:test@127.0.0.1:55432/antifailure'
+
+export async function available(): Promise<boolean> {
+  // Retried, and fatal when a database was named explicitly, which is the rule
+  // every harness in this repository follows and the reason is worth repeating
+  // here: a skipped suite and a passing suite are the same green tick, and this
+  // one is the only proof that an audit entry reaches a sink at all.
+  let last: unknown = null
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      const probe = postgres(adminUrl, { max: 1, connect_timeout: 15, onnotice: () => {} })
+      await probe`SELECT 1`
+      await probe.end({ timeout: 5 })
+      return true
+    } catch (err) {
+      last = err
+    }
+  }
+  if (process.env.AF_TEST_DATABASE_URL || process.env.AF_REQUIRE_DATABASE === '1') {
+    throw new Error(
+      `AF_TEST_DATABASE_URL is ${adminUrl} and nothing answered after three attempts. ` +
+        `Refusing to skip: this suite is the only place an audit entry is watched to reach a ` +
+        `sink, and a run that proves nothing is worse than a red one. Underlying error: ` +
+        `${last instanceof Error ? last.message : String(last)}`,
+    )
+  }
+  return false
+}
+
+/** A clock a test moves, so a licence can be made to lapse without waiting for
+ *  one to. */
+export class TestClock implements Clock {
+  private at: Date
+  constructor(at = new Date('2026-09-09T12:00:00.000Z')) {
+    this.at = at
+  }
+  now(): Date {
+    return this.at
+  }
+  advance(ms: number): void {
+    this.at = new Date(this.at.getTime() + ms)
+  }
+}
+
+/**
+ * A sink that records what it was given and can be made to fail.
+ *
+ * `fail` is a function of the batch rather than a flag, so a test can refuse
+ * one batch and accept the next without racing a mutable boolean, and so
+ * "fails mid batch" is expressible: the queue delivers in order, so refusing
+ * the batch that contains a chosen sequence number is exactly a failure part
+ * way through.
+ */
+export class RecordingSink implements Sink {
+  readonly batches: Batch[] = []
+  fail: ((batch: Batch) => Error | null) | null = null
+
+  name(): string {
+    return 'recording'
+  }
+
+  async deliver(batch: Batch): Promise<void> {
+    const err = this.fail?.(batch) ?? null
+    if (err) throw err
+    this.batches.push(batch)
+  }
+
+  /** Every sequence number this sink has been given, in the order it saw them.
+   *  Duplicates are kept, because at least once delivery means a duplicate is
+   *  the thing a test has to be able to see. */
+  seqs(): number[] {
+    return this.batches.flatMap((b) => b.entries.map((e) => e.seq))
+  }
+
+  entries() {
+    return this.batches.flatMap((b) => b.entries)
+  }
+}
+
+export { PermanentError }
+
+export interface Harness {
+  admin: postgres.Sql
+  pool: Pool
+  close(): Promise<void>
+  /** Writes one entry through the real appendAudit, inside a tenant
+   *  transaction, exactly as every production call site does. */
+  write(orgId: string, action: string, extra?: { origin?: string; detail?: Record<string, unknown> }): Promise<number>
+  /** Puts the cursor where a test needs it. Uses the admin connection, because
+   *  the application role is granted UPDATE and no INSERT and can only move the
+   *  cursor forward, which is the property under test rather than a tool. */
+  setCursor(to: number): Promise<void>
+  readCursor(): Promise<number>
+  /** The highest sequence number in the table right now.
+   *
+   *  Every case starts by parking the cursor here, because the enterprise CI
+   *  job runs every workspace against one database and the provisioning and
+   *  sign on suites leave their own audit entries in it. Without this a case
+   *  would read rows it did not write, and its counts would depend on which
+   *  suites had run before it. */
+  maxSeq(): Promise<number>
+  /** Consumes a sequence number without writing a row, which is exactly what a
+   *  transaction that rolls back after appendAudit has read nextval leaves
+   *  behind. Returns the number that is now missing forever. */
+  burnSequence(): Promise<number>
+  /** Moves an organization onto another plan, so an entitlement can be
+   *  withdrawn or granted under a forwarder that is already running. */
+  setPlan(orgId: string, plan: string): Promise<void>
+}
+
+export async function start(): Promise<Harness> {
+  const admin = postgres(adminUrl, { max: 3, connect_timeout: 30, onnotice: () => {} })
+  await migrate(admin)
+  await admin.unsafe(`ALTER ROLE antifailure_app LOGIN PASSWORD 'app-test-password'`)
+
+  const url = new URL(adminUrl)
+  url.username = 'antifailure_app'
+  url.password = 'app-test-password'
+  const pool = createPool({
+    url: url.toString(),
+    max: 4,
+    connectTimeoutSeconds: 30,
+    statementTimeoutSeconds: 60,
+  })
+
+  return {
+    admin,
+    pool,
+    async write(orgId, action, extra = {}) {
+      const written = await pool.withTenant({ orgId }, (db) =>
+        appendAudit(db, {
+          orgId,
+          actorLabel: 'harness',
+          action,
+          targetType: 'organization',
+          targetId: orgId,
+          origin: extra.origin ?? 'system',
+          detail: extra.detail ?? { written: 'by appendAudit' },
+        }),
+      )
+      return written.seq
+    },
+    async setCursor(to) {
+      await admin`UPDATE audit_stream_cursor SET delivered_seq = ${to} WHERE id`
+    },
+    async burnSequence() {
+      const rows = await admin<{ nextval: string }[]>`SELECT nextval('audit_entries_seq_seq')`
+      return Number(rows[0]!.nextval)
+    },
+    async setPlan(orgId, plan) {
+      await admin`UPDATE organizations SET plan = ${plan} WHERE id = ${orgId}`
+    },
+    async maxSeq() {
+      const rows = await admin<{ seq: string | null }[]>`
+        SELECT coalesce(max(seq), 0) AS seq FROM audit_entries`
+      return Number(rows[0]!.seq)
+    },
+    async readCursor() {
+      const rows = await admin<{ delivered_seq: string }[]>`
+        SELECT delivered_seq FROM audit_stream_cursor WHERE id`
+      return Number(rows[0]!.delivered_seq)
+    },
+    async close() {
+      await pool.close()
+      await admin.end({ timeout: 5 })
+    },
+  }
+}
+
+export interface Tenant {
+  orgId: string
+  slug: string
+}
+
+/**
+ * One organization on a plan.
+ *
+ * The plan decides the entitlement, which is the negative control this suite
+ * needs both ways: `enterprise` carries `audit_stream` and `free` does not, so
+ * an unlicensed organization is a seeded row rather than a mocked answer.
+ */
+export async function seedTenant(h: Harness, plan = 'enterprise'): Promise<Tenant> {
+  const slug = `audit-${randomUUID().slice(0, 8)}`
+  const [org] = await h.admin<{ id: string }[]>`
+    INSERT INTO organizations (slug, name, plan) VALUES (${slug}, 'Audit', ${plan}) RETURNING id`
+  return { orgId: org!.id, slug }
+}
+
+export async function dropTenant(h: Harness, orgId: string): Promise<void> {
+  await h.admin`DELETE FROM audit_entries WHERE org_id = ${orgId}`
+  await h.admin`DELETE FROM organizations WHERE id = ${orgId}`
+}

--- a/ee/web/audit/test/harness.ts
+++ b/ee/web/audit/test/harness.ts
@@ -39,7 +39,7 @@ export async function available(): Promise<boolean> {
   }
   if (process.env.AF_TEST_DATABASE_URL || process.env.AF_REQUIRE_DATABASE === '1') {
     throw new Error(
-      `AF_TEST_DATABASE_URL is ${adminUrl} and nothing answered after three attempts. ` +
+      'The test database did not answer after three attempts. ' +
         `Refusing to skip: this suite is the only place an audit entry is watched to reach a ` +
         `sink, and a run that proves nothing is worse than a red one. Underlying error: ` +
         `${last instanceof Error ? last.message : String(last)}`,
@@ -131,8 +131,13 @@ export interface Harness {
 
 export async function start(): Promise<Harness> {
   const admin = postgres(adminUrl, { max: 3, connect_timeout: 30, onnotice: () => {} })
-  await migrate(admin)
-  await admin.unsafe(`ALTER ROLE antifailure_app LOGIN PASSWORD 'app-test-password'`)
+  try {
+    await migrate(admin)
+    await admin.unsafe(`ALTER ROLE antifailure_app LOGIN PASSWORD 'app-test-password'`)
+  } catch (err) {
+    await admin.end({ timeout: 5 })
+    throw err
+  }
 
   const url = new URL(adminUrl)
   url.username = 'antifailure_app'
@@ -163,6 +168,10 @@ export async function start(): Promise<Harness> {
     },
     async setCursor(to) {
       await admin`UPDATE audit_stream_cursor SET delivered_seq = ${to} WHERE id`
+      await admin`
+        INSERT INTO audit_stream_positions (org_id, delivered_seq)
+        SELECT org_id, max(seq) FROM audit_entries WHERE seq <= ${to} GROUP BY org_id
+        ON CONFLICT (org_id) DO UPDATE SET delivered_seq = EXCLUDED.delivered_seq`
     },
     async burnSequence() {
       const rows = await admin<{ nextval: string }[]>`SELECT nextval('audit_entries_seq_seq')`

--- a/ee/web/audit/test/schedule.test.ts
+++ b/ee/web/audit/test/schedule.test.ts
@@ -1,0 +1,49 @@
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+
+import { it } from 'node:test'
+import assert from 'node:assert/strict'
+import { startForwarder } from '../src/index.ts'
+
+const empty = { read: 0, delivered: 0, unlicensed: 0, from: 0, to: 0, organizations: [] }
+
+it('a stopped forwarder makes no subsequent pass', async (t) => {
+  t.mock.timers.enable({ apis: ['setInterval'] })
+  let calls = 0
+  const forwarder = { pass: async () => { calls += 1; return empty } }
+  const running = startForwarder(forwarder, 10)
+  assert.equal(calls, 1)
+  await Promise.resolve()
+  running.stop()
+  t.mock.timers.tick(100)
+  assert.equal(calls, 1, 'shutdown left the audit polling loop running')
+})
+
+it('an unfinished pass prevents an overlapping pass', async (t) => {
+  t.mock.timers.enable({ apis: ['setInterval'] })
+  let calls = 0
+  let finish!: (value: typeof empty) => void
+  const forwarder = {
+    pass: () => { calls += 1; return new Promise<typeof empty>((resolve) => { finish = resolve }) },
+  }
+  const running = startForwarder(forwarder, 10)
+  t.mock.timers.tick(100)
+  assert.equal(calls, 1, 'one slow collector caused overlapping deliveries')
+  running.stop()
+  finish(empty)
+  await Promise.resolve()
+})
+
+it('a failed pass is reported and the next scheduled pass still runs', async (t) => {
+  t.mock.timers.enable({ apis: ['setInterval'] })
+  let calls = 0
+  const errors: unknown[] = []
+  const forwarder = {
+    pass: async () => { calls += 1; if (calls === 1) throw new Error('collector unavailable'); return empty },
+  }
+  const running = startForwarder(forwarder, 10, (err) => errors.push(err))
+  await Promise.resolve()
+  assert.equal(errors.length, 1)
+  t.mock.timers.tick(10)
+  assert.equal(calls, 2, 'one collector failure disabled the schedule')
+  running.stop()
+})

--- a/ee/web/audit/test/sink.test.ts
+++ b/ee/web/audit/test/sink.test.ts
@@ -151,6 +151,14 @@ describe('forwarding', () => {
 })
 
 describe('batch manifests', () => {
+  for (const field of ['org', 'count', 'firstSeq', 'lastSeq', 'headHash'] as const) {
+    it(`rejects altered ${field} metadata even when the digest and signature remain intact`, () => {
+      const entries = [entry(1), entry(2)]
+      const manifest = sign(entries, KEY)
+      const changed = { ...manifest, [field]: typeof manifest[field] === 'number' ? 99 : 'forged' }
+      assert.equal(verify({ entries, manifest: changed }, KEY).ok, false)
+    })
+  }
   it('verify under the right key', () => {
     const entries = [entry(1), entry(2)]
     const batch: Batch = { entries, manifest: sign(entries, KEY) }

--- a/ee/web/audit/test/sinks.test.ts
+++ b/ee/web/audit/test/sinks.test.ts
@@ -146,28 +146,38 @@ describe('splunk', () => {
     assert.equal(event.sourcetype, 'acme:audit')
   })
 
-  it('carries the manifest so a batch can still be checked', async () => {
+  it('carries the manifest in indexed fields so stored events can still be checked', async () => {
     const { fetch, calls } = capturing()
     const b = batch(2)
     await new SplunkSink({ url: 'https://splunk.test/x', token: 't', fetch }).deliver(b)
 
     const headers = calls[0]!.init.headers as Record<string, string>
     assert.deepEqual(JSON.parse(headers['x-antifailure-manifest']!), b.manifest)
+    const records = String(calls[0]!.init.body).split('\n').map(line => JSON.parse(line))
+    for (let i = 0; i < records.length; i += 1) {
+      assert.deepEqual(records[i].event, b.entries[i])
+      assert.deepEqual(JSON.parse(records[i].fields.antifailure_manifest), b.manifest)
+    }
   })
 })
 
 describe('event hubs', () => {
-  it('sends a JSON array of records', async () => {
+  it('sends string event bodies and persistent manifest properties in the documented REST format', async () => {
     const { fetch, calls } = capturing(201)
+    const expected = batch(2)
     await new EventHubsSink({
       url: 'https://ns.servicebus.windows.net/hub/messages',
       authorization: 'SharedAccessSignature sr=...',
       fetch,
-    }).deliver(batch(2))
+    }).deliver(expected)
 
     const records = JSON.parse(String(calls[0]!.init.body))
     assert.equal(records.length, 2)
-    assert.equal(records[0].Body.seq, 1)
+    for (let i = 0; i < records.length; i += 1) {
+      assert.equal(typeof records[i].Body, 'string')
+      assert.deepEqual(JSON.parse(records[i].Body), expected.entries[i])
+      assert.deepEqual(JSON.parse(records[i].UserProperties.antifailure_manifest), expected.manifest)
+    }
     const headers = calls[0]!.init.headers as Record<string, string>
     assert.match(headers['content-type']!, /servicebus/)
   })

--- a/ee/web/audit/test/sinks.test.ts
+++ b/ee/web/audit/test/sinks.test.ts
@@ -5,6 +5,8 @@
 
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
+import { createServer } from 'node:http'
+import type { AddressInfo } from 'node:net'
 import {
   SplunkSink, EventHubsSink, ObjectStoreSink, WebhookSink, verifyWebhook,
   PermanentError, sign, type Batch, type Entry, type Fetcher,
@@ -39,6 +41,81 @@ function capturing(status = 200, body = ''): { fetch: Fetcher; calls: Capture[] 
     },
   }
 }
+
+describe('audit destination protection', () => {
+  it('a real redirect never receives the audit body at its target', async () => {
+    let received = 0
+    const server = createServer((req, res) => {
+      req.resume()
+      if (req.url === '/redirect') res.writeHead(307, { location: '/target' }).end()
+      else { received += 1; res.writeHead(200).end() }
+    })
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+    const url = `http://127.0.0.1:${(server.address() as AddressInfo).port}/redirect`
+    try {
+      await assert.rejects(new WebhookSink({ url, secret: 'AF_FAKE_SECRET', fetch }).deliver(batch()))
+      assert.equal(received, 0, 'the redirected destination received the private audit body')
+    } finally {
+      server.closeAllConnections()
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+  })
+  it('the deadline aborts a real collector request before its response', async (t) => {
+    const deadline = new AbortController()
+    let requested = false
+    const server = createServer((req, res) => {
+      req.resume()
+      requested = true
+      deadline.abort(new Error('synthetic collector deadline'))
+      // Finish on the next event-loop turn if the abort was ignored. This
+      // makes the negative control fail by accepting a response, not hang.
+      setImmediate(() => res.writeHead(200).end())
+    })
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+    const timeout = t.mock.method(AbortSignal, 'timeout', () => deadline.signal)
+    const url = `http://127.0.0.1:${(server.address() as AddressInfo).port}/never`
+    try {
+      await assert.rejects(new WebhookSink({ url, secret: 'AF_FAKE_SECRET', fetch }).deliver(batch()), /deadline/)
+      assert.equal(requested, true)
+      assert.deepEqual(timeout.mock.calls[0]!.arguments, [30_000])
+    } finally {
+      server.closeAllConnections()
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+  })
+  const constructors = {
+    splunk: (url: string) => new SplunkSink({ url, token: 't', fetch: capturing().fetch }),
+    eventHubs: (url: string) => new EventHubsSink({ url, authorization: 't', fetch: capturing().fetch }),
+    webhook: (url: string) => new WebhookSink({ url, secret: 's', fetch: capturing().fetch }),
+  }
+  for (const [name, build] of Object.entries(constructors)) {
+    it(`${name} refuses plaintext delivery to a remote collector`, () => {
+      assert.throws(() => build('http://collector.example.test/ingest'), /requires HTTPS/)
+    })
+    it(`${name} refuses credentials embedded in a destination URL`, () => {
+      assert.throws(() => build('https://user:password@collector.example.test/ingest'), /requires HTTPS/)
+    })
+  }
+  it('refuses redirects instead of forwarding the audit body to another destination', async () => {
+    const { fetch, calls } = capturing()
+    await new WebhookSink({ url: 'https://collector.test/ingest', secret: 's', fetch }).deliver(batch())
+    assert.equal(calls[0]!.init.redirect, 'error')
+  })
+  it('bounds collector requests with an abort signal', async () => {
+    const { fetch, calls } = capturing()
+    await new WebhookSink({ url: 'https://collector.test/ingest', secret: 's', fetch }).deliver(batch())
+    assert.ok(calls[0]!.init.signal instanceof AbortSignal)
+  })
+  it('cancels an unfinished collector response without buffering it', async () => {
+    let cancelled = false
+    const fetch: Fetcher = async () => new Response(new ReadableStream({
+      start(controller) { controller.enqueue(new TextEncoder().encode('AF_FAKE_PRIVATE_DETAIL')) },
+      cancel() { cancelled = true },
+    }), { status: 500 })
+    await assert.rejects(new WebhookSink({ url: 'https://collector.test/ingest', secret: 's', fetch }).deliver(batch()))
+    assert.equal(cancelled, true)
+  })
+})
 
 describe('splunk', () => {
   it('sends newline-delimited events, not an array', async () => {

--- a/ee/web/features/package.json
+++ b/ee/web/features/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@antifailure-ee/scim": "*",
+    "@antifailure-ee/server": "*",
     "@antifailure-ee/sso": "*",
     "@types/node": "^24.0.0",
     "postgres": "^3.4.9",

--- a/ee/web/features/test/catalogue.test.ts
+++ b/ee/web/features/test/catalogue.test.ts
@@ -507,8 +507,9 @@ describe('the two languages agree about who refuses what', () => {
     const states = goCatalogueStates(catalogueGo, licenseGo)
     assert.ok(states.size > 0, 'no catalogue entries were parsed, so this test proves nothing')
     for (const feature of declared()) {
-      assert.equal(
-        states.get(feature), CONTROL_PLANE_GATED,
+      assert.ok(
+        states.get(feature) === CONTROL_PLANE_GATED ||
+          (states.get(feature) === 'gated' && goControlPlaneAt(catalogueGo, licenseGo, feature) !== null),
         `${feature} declares an enforcement site in this process and the Go catalogue calls ` +
           `it ${states.get(feature)}. A feature this control plane refuses by name is being ` +
           'published as one nobody is refused, which is what the catalogue exists to prevent.',
@@ -523,7 +524,8 @@ describe('the two languages agree about who refuses what', () => {
     // otherwise stand with nothing behind it.
     const states = goCatalogueStates(catalogueGo, licenseGo)
     const claimed = [...states.entries()]
-      .filter(([, state]) => state === CONTROL_PLANE_GATED)
+      .filter(([name, state]) => state === CONTROL_PLANE_GATED ||
+        (state === 'gated' && goControlPlaneAt(catalogueGo, licenseGo, name) !== null))
       .map(([feature]) => feature)
       .sort()
     assert.ok(

--- a/ee/web/features/test/catalogue.test.ts
+++ b/ee/web/features/test/catalogue.test.ts
@@ -49,6 +49,10 @@ import { FEATURES, declared, sites, type Feature } from '../src/index.ts'
 // worse than no check, and it was living inside the file it was checking.
 import '@antifailure-ee/sso'
 import '@antifailure-ee/scim'
+// The audit stream's site is declared by the enterprise entry point rather than
+// by ee/web/audit, because forwarding is not a route and the licence question
+// is asked where the forwarder is built, not where the bytes are sent.
+import '@antifailure-ee/server'
 
 const here = path.dirname(fileURLToPath(import.meta.url))
 const repo = path.resolve(here, '..', '..', '..', '..')
@@ -183,7 +187,7 @@ describe('every declared enforcement site names something that can refuse', () =
     // twelve here would be asserting something false about a different process.
     // What is asserted is that the features enforced HERE say so.
     assert.deepEqual(
-      declared(), ['scim', 'sso'] as Feature[],
+      declared(), ['audit_stream', 'scim', 'sso'] as Feature[],
       'the set of features enforced in the control plane changed. If one was added, import ' +
         'its package at the top of this file so the registry can see it and add it here. If ' +
         'one disappeared, a declare() call was removed and a feature is silently free again.',

--- a/ee/web/package-lock.json
+++ b/ee/web/package-lock.json
@@ -74,6 +74,7 @@
       },
       "devDependencies": {
         "@types/node": "^24.0.0",
+        "postgres": "^3.4.9",
         "typescript": "^5.9.0"
       }
     },
@@ -87,6 +88,7 @@
       },
       "devDependencies": {
         "@antifailure-ee/scim": "*",
+        "@antifailure-ee/server": "*",
         "@antifailure-ee/sso": "*",
         "@types/node": "^24.0.0",
         "postgres": "^3.4.9",
@@ -299,6 +301,8 @@
       "version": "1.3.4",
       "license": "SEE LICENSE IN ../../LICENSE.md",
       "dependencies": {
+        "@antifailure-ee/audit": "*",
+        "@antifailure-ee/features": "*",
         "@antifailure-ee/scim": "*",
         "@antifailure-ee/sso": "*",
         "@antifailure/api": "file:../../../web/apps/api",

--- a/ee/web/server/package.json
+++ b/ee/web/server/package.json
@@ -12,10 +12,12 @@
   },
   "scripts": {
     "start": "node src/main.ts",
-    "test": "node --test --test-concurrency=1 test/license.test.ts && node --test --test-concurrency=1 test/entrypoint.test.ts && node --test --test-concurrency=1 test/vectors.test.ts",
+    "test": "node --test --test-concurrency=1 test/license.test.ts && node --test --test-concurrency=1 test/entrypoint.test.ts && node --test --test-concurrency=1 test/vectors.test.ts && node --test --test-concurrency=1 test/audit-stream.test.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
+    "@antifailure-ee/audit": "*",
+    "@antifailure-ee/features": "*",
     "@antifailure-ee/scim": "*",
     "@antifailure-ee/sso": "*",
     "@antifailure/api": "file:../../../web/apps/api",

--- a/ee/web/server/src/main.ts
+++ b/ee/web/server/src/main.ts
@@ -35,7 +35,9 @@
 // week and produced a bug only a paying customer could reproduce.
 
 import { startControlPlane } from '@antifailure/api/boot'
-import { registerEnterprise } from './register.ts'
+import { registerEnterprise, type Registered } from './register.ts'
+
+let registered: Registered | undefined
 
 await startControlPlane({
   beforeServer: (ctx) => {
@@ -65,7 +67,7 @@ await startControlPlane({
         : `enterprise routes publish themselves at ${baseUrl} (from AF_APP_BASE_URL)`,
     )
 
-    registerEnterprise({
+    registered = registerEnterprise({
       pool: ctx.pool,
       clock: ctx.clock,
       baseUrl,
@@ -75,4 +77,5 @@ await startControlPlane({
       log: ctx.log,
     })
   },
+  beforeClose: () => registered?.auditStream?.stop(),
 })

--- a/ee/web/server/src/register.ts
+++ b/ee/web/server/src/register.ts
@@ -11,8 +11,24 @@ import { registerExtension, setSignInPolicy, type Clock } from '@antifailure/api
 import type { Pool } from '@antifailure/db'
 import { ssoExtension, signInPolicy, keyFromEnv } from '@antifailure-ee/sso'
 import { scimExtension } from '@antifailure-ee/scim'
-import { gated } from './gate.ts'
+import { declare, licensed } from '@antifailure-ee/features'
+import {
+  Forwarder,
+  fromEnvironment,
+  startForwarder,
+  SinkEnv,
+  SinkRefused,
+  type ForwarderHandle,
+} from '@antifailure-ee/audit'
+import { gated, statusNow } from './gate.ts'
 import { licenseFromEnv, LicenseRefused, ALL_FEATURES, type Claims, type Status } from './license.ts'
+
+// Recorded at module scope, so importing this module is what puts the site in
+// the registry and a module nothing imports declares nothing. The site is
+// `startAuditStream` because that is the function that builds the `permitted`
+// callback the forwarder asks on every pass; the licence question is asked
+// there and nowhere else on this path.
+declare('audit_stream', 'ee/web/server/src/register.ts:startAuditStream')
 
 export interface RegisterOptions {
   pool: Pool
@@ -39,6 +55,10 @@ export interface Registered {
   /** The extensions this entry point mounted, whether or not the licence
    *  permits them. Mounted and refused is the point: see gate.ts. */
   mounted: string[]
+  /** The audit stream forwarder, when one is configured, so the process that
+   *  started it can stop it and a suite can wait for a pass rather than sleep.
+   *  Null when AF_AUDIT_STREAM_SINK is unset, which is the ordinary case. */
+  auditStream: ForwarderHandle | null
 }
 
 /**
@@ -175,5 +195,97 @@ export function registerEnterprise(options: RegisterOptions): Registered {
   registerExtension(scim)
   setSignInPolicy(signInPolicy(options.pool))
 
-  return { claims, mounted: [sso.name, scim.name] }
+  return {
+    claims,
+    mounted: [sso.name, scim.name],
+    auditStream: startAuditStream(options, gate),
+  }
+}
+
+/**
+ * Starts the audit stream forwarder, if one is configured.
+ *
+ * NOT AN EXTENSION, and that is the fact this was mistaken about twice. An
+ * extension is routes; forwarding is a poll loop with no route at all, and the
+ * `Extension` interface carrying only `name` and `routes` was cited as the
+ * blocker for building this when it is simply the wrong object. This function
+ * is registration doing non route work, which is what the line above it,
+ * `setSignInPolicy`, already was.
+ *
+ * WHAT THIS CLOSES. `audit_entries` carries a tamper evident hash chain and is
+ * written by every sign on, every provisioning call, every impersonation and
+ * every admin action. It reached no sink at all, while ee/README.md sold "SIEM
+ * streaming with a tamper evident hash chain" and could point at a real half
+ * whenever it was questioned: the chain is real, the streaming is real, and
+ * they were not joined to each other.
+ */
+function startAuditStream(
+  options: RegisterOptions,
+  gate: { claims: Claims | null; org: string; now: () => Date; revoked: ReadonlySet<string> },
+): ForwarderHandle | null {
+  let config
+  try {
+    config = fromEnvironment(options.env)
+  } catch (err) {
+    if (err instanceof SinkRefused) {
+      // Refused, not degraded, and the same rule the engine's sink follows.
+      // Somebody who set this variable has said every privileged action must
+      // reach their SIEM; starting with the sink unbuilt forwards nothing and
+      // says nothing, which is a compliance control reporting itself as held.
+      options.log(`the audit stream sink was refused: ${err.message}`)
+      process.exit(2)
+    }
+    throw err
+  }
+
+  if (!config) {
+    // Said out loud, in the state that forwards nothing, for the reason
+    // readLicense says its own line out loud: an installation that forwards and
+    // one that does not produced identical logs, and the first person to
+    // discover the difference was an auditor asking where the entries went.
+    options.log(
+      `no ${SinkEnv} is set, so the control plane's audit log is written and not forwarded. ` +
+        'The log itself is unaffected: it is written whatever a sink does.',
+    )
+    return null
+  }
+
+  const forwarder = new Forwarder({
+    pool: options.pool,
+    clock: options.clock,
+    sink: config.sink,
+    key: config.key,
+    batchSize: config.batchSize,
+    deliveryBatchSize: config.deliveryBatchSize,
+    log: options.log,
+    // BOTH GATES, ASKED PER PASS, AND NEITHER IS THE OTHER.
+    //
+    // `statusNow` is the licence key this process was started with: whether
+    // this INSTALLATION bought audit streaming, evaluated against the clock so
+    // a licence that lapses tonight stops forwarding on the next pass without a
+    // restart. `licensed` is the control plane's own entitlement catalogue:
+    // whether THIS ORGANIZATION is entitled, which an operator can grant or
+    // withdraw with no deploy. SCIM and single sign on ask both for the same
+    // reason, and either one alone would forward for somebody who is not
+    // supposed to have it.
+    //
+    // Asked here, per pass, rather than captured at startup. The whole argument
+    // in gate.ts applies unchanged: a gate decided at boot cannot expire, and a
+    // control plane up for six weeks would keep streaming under a licence that
+    // ran out in the third.
+    permitted: async (orgId, now) => {
+      if (!statusNow(gate).enabled('audit_stream')) return false
+      return licensed(options.pool, orgId, 'audit_stream', now)
+    },
+  })
+
+  options.log(
+    `audit stream: forwarding the control plane's audit log to ${config.sink.name()} ` +
+      `every ${String(config.intervalMs)}ms, ${String(config.batchSize)} entries a pass ` +
+      `and ${String(config.deliveryBatchSize)} a delivery`,
+  )
+
+  return startForwarder(forwarder, config.intervalMs, (err) =>
+    options.log(`audit stream: ${err instanceof Error ? err.message : String(err)}`),
+  )
 }

--- a/ee/web/server/src/register.ts
+++ b/ee/web/server/src/register.ts
@@ -213,8 +213,8 @@ export function registerEnterprise(options: RegisterOptions): Registered {
  * `setSignInPolicy`, already was.
  *
  * WHAT THIS CLOSES. `audit_entries` carries a tamper evident hash chain and is
- * written by every sign on, every provisioning call, every impersonation and
- * every admin action. It reached no sink at all, while ee/README.md sold "SIEM
+ * records organization actions including sign on, provisioning and
+ * administration. It reached no sink at all, while ee/README.md sold "SIEM
  * streaming with a tamper evident hash chain" and could point at a real half
  * whenever it was questioned: the chain is real, the streaming is real, and
  * they were not joined to each other.

--- a/ee/web/server/test/audit-stream.test.ts
+++ b/ee/web/server/test/audit-stream.test.ts
@@ -1,0 +1,395 @@
+// An audit entry, written by a real route, watched arriving at a real sink.
+//
+// Not MIT. Covered by the Antifailure Enterprise License; see ee/LICENSE.md.
+//
+// WHY THIS FILE EXISTS WHEN ee/web/audit ALREADY HAS A SUITE. That one drives
+// the Forwarder directly and proves every ordering it can meet. What it cannot
+// prove is the thing that was actually wrong, which is that anything starts one
+// at all: `ee/web/audit` was a complete, tested, green package that no code
+// path imported, and a suite that constructs the class under test would have
+// stayed green through the entire defect. It did, for as long as the package
+// existed.
+//
+// So this one starts `src/main.ts` as a process with nothing but an
+// environment, POSTs a SCIM user to it over TCP, and waits on a socket of its
+// own for the audit entry that provisioning writes. Every link is real:
+// boot.ts reads the variables, registerEnterprise builds the forwarder from
+// AF_AUDIT_STREAM_SINK, the SCIM route authenticates a real bearer token,
+// appendAudit chains the entry, the poll loop reads it across tenants under the
+// policy migration 0043 adds, and the webhook sink signs and posts it.
+//
+// THE NEGATIVE CONTROLS ARE THE POINT AND BOTH ARE SHAPED TO BE ABLE TO SAY NO.
+// "Nothing arrived in five seconds" is satisfied by a broken receiver, a
+// process that never started, and a firewall. So neither negative here waits
+// for silence. Each waits for a POSITIVE signal that the forwarder ran and made
+// a decision, which is the cursor advancing past the entry, and only then
+// asserts that the entry was not sent.
+
+import { after, before, describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { createServer, type Server } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import postgres from 'postgres'
+import { createHash, randomBytes, randomUUID } from 'node:crypto'
+import { verifyWebhook } from '@antifailure-ee/audit'
+import {
+  ENTERPRISE_ENTRY,
+  adminUrl,
+  available,
+  licenseFor,
+  signingKey,
+  startEntryPoint,
+  stopAll,
+} from './harness.ts'
+
+const hasDatabase = await available()
+
+/** One delivery as the receiver saw it, before anything is parsed, so the
+ *  signature can be checked over the exact bytes. */
+interface Delivery {
+  body: string
+  timestamp: string
+  signature: string
+}
+
+/** A real HTTP receiver, because the claim is that entries reach a sink and a
+ *  sink is somebody else's socket. */
+async function receiver(): Promise<{
+  url: string
+  deliveries: Delivery[]
+  entries: () => { seq: number; orgId: string; action: string; entryHash: string }[]
+  close: () => Promise<void>
+}> {
+  const deliveries: Delivery[] = []
+  const server: Server = createServer((req, res) => {
+    let body = ''
+    req.on('data', (c) => { body += String(c) })
+    req.on('end', () => {
+      deliveries.push({
+        body,
+        timestamp: String(req.headers['x-antifailure-timestamp'] ?? ''),
+        signature: String(req.headers['x-antifailure-signature'] ?? ''),
+      })
+      res.writeHead(200).end('{}')
+    })
+  })
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const port = (server.address() as AddressInfo).port
+  return {
+    url: `http://127.0.0.1:${String(port)}/ingest`,
+    deliveries,
+    entries: () =>
+      deliveries.flatMap(
+        (d) => (JSON.parse(d.body) as { entries: { seq: number; orgId: string; action: string; entryHash: string }[] }).entries,
+      ),
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  }
+}
+
+/** Waits for a condition, or fails saying what it was still waiting for.
+ *  Polling rather than sleeping, so a fast machine is fast and a slow one is
+ *  not flaky. */
+async function until(what: string, check: () => Promise<boolean> | boolean, ms = 30_000): Promise<void> {
+  const deadline = Date.now() + ms
+  for (;;) {
+    if (await check()) return
+    if (Date.now() > deadline) throw new Error(`timed out after ${String(ms)}ms waiting for ${what}`)
+    await new Promise((r) => setTimeout(r, 100))
+  }
+}
+
+describe(
+  'the control plane audit log reaches a sink from the real entry point',
+  { skip: hasDatabase ? false : 'no Postgres at AF_TEST_DATABASE_URL' },
+  () => {
+    let admin: postgres.Sql
+
+    before(async () => {
+      admin = postgres(adminUrl, { max: 3, connect_timeout: 30, onnotice: () => {} })
+    })
+
+    after(async () => {
+      await stopAll()
+      await admin.end({ timeout: 5 })
+    })
+
+    /** An organization on a plan, with a SCIM bearer token so a real
+     *  provisioning request can be made against the running process. */
+    async function seedOrg(plan: string): Promise<{ orgId: string; slug: string; token: string }> {
+      const slug = `stream-${randomUUID().slice(0, 8)}`
+      const [org] = await admin<{ id: string }[]>`
+        INSERT INTO organizations (slug, name, plan) VALUES (${slug}, 'Stream', ${plan})
+        RETURNING id`
+      const token = `afs_${randomBytes(24).toString('base64url')}`
+      await admin`
+        INSERT INTO scim_tokens (org_id, name, token_hash, prefix)
+        VALUES (${org!.id}, 'directory', ${createHash('sha256').update(token, 'utf8').digest()},
+                ${token.slice(0, 10)})`
+      return { orgId: org!.id, slug, token }
+    }
+
+    /** Parks the global cursor at the head, so a case reads only what it
+     *  writes. The enterprise job runs every suite against one database. */
+    async function parkCursor(): Promise<number> {
+      const rows = await admin<{ seq: string }[]>`
+        SELECT coalesce(max(seq), 0) AS seq FROM audit_entries`
+      const at = Number(rows[0]!.seq)
+      await admin`UPDATE audit_stream_cursor SET delivered_seq = ${at} WHERE id`
+      return at
+    }
+
+    async function cursor(): Promise<number> {
+      const rows = await admin<{ delivered_seq: string }[]>`
+        SELECT delivered_seq FROM audit_stream_cursor WHERE id`
+      return Number(rows[0]!.delivered_seq)
+    }
+
+    async function highestFor(orgId: string): Promise<number> {
+      const rows = await admin<{ seq: string | null }[]>`
+        SELECT coalesce(max(seq), 0) AS seq FROM audit_entries WHERE org_id = ${orgId}`
+      return Number(rows[0]!.seq)
+    }
+
+    // -----------------------------------------------------------------------
+
+    it('a SCIM user created over HTTP arrives at the sink, signed, with its chain hash', async () => {
+      const sink = await receiver()
+      const org = await seedOrg('enterprise')
+      const unlicensed = await seedOrg('free')
+      await parkCursor()
+
+      const key = signingKey()
+      const secret = randomBytes(32).toString('base64')
+      const running = await startEntryPoint(ENTERPRISE_ENTRY, {
+        AF_LICENSE_PUBLIC_KEYS: key.publicKeys,
+        AF_LICENSE_KEY: licenseFor(key, org.slug, ['sso', 'scim', 'audit_stream']),
+        AF_ORG: org.slug,
+        AF_AUDIT_STREAM_SINK: 'webhook',
+        AF_AUDIT_STREAM_WEBHOOK_URL: sink.url,
+        AF_AUDIT_STREAM_WEBHOOK_SECRET: secret,
+        AF_AUDIT_STREAM_KEY: randomBytes(32).toString('base64'),
+        // Fast, because this suite is waiting on it. The default is ten
+        // seconds, which is right for a control plane and wrong for a test.
+        AF_AUDIT_STREAM_INTERVAL_MS: '200',
+      })
+
+      try {
+        assert.match(
+          running.output(),
+          /audit stream: forwarding the control plane's audit log to webhook/,
+          `the process did not say it had started a forwarder. It said:\n${running.output()}`,
+        )
+
+        // THE ENTRY, WRITTEN BY A ROUTE AND NOT BY THIS FILE. usersCreate calls
+        // appendAudit with action scim.user.created, inside the same
+        // transaction as the membership, on a request authenticated by a real
+        // bearer token against a real scim_tokens row.
+        const userName = `ada-${randomUUID().slice(0, 8)}@example.test`
+        const created = await fetch(`http://127.0.0.1:${String(running.port)}/scim/v2/Users`, {
+          method: 'POST',
+          headers: {
+            authorization: `Bearer ${org.token}`,
+            'content-type': 'application/scim+json',
+            'x-forwarded-for': '198.51.100.7',
+          },
+          body: JSON.stringify({
+            schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
+            userName,
+            name: { givenName: 'Ada', familyName: 'Lovelace' },
+            emails: [{ value: userName, type: 'work', primary: true }],
+            active: true,
+          }),
+        })
+        assert.equal(created.status, 201, `SCIM refused the create: ${await created.text()}`)
+
+        // And one for the organization that is not entitled, written through
+        // the same appendAudit every entry point uses. It cannot be written
+        // through SCIM, because the entitlement gate refuses that request
+        // first, which would prove the wrong gate.
+        const { createPool, appendAudit } = await import('@antifailure/db')
+        const appUrlValue = new URL(adminUrl)
+        appUrlValue.username = 'antifailure_app'
+        appUrlValue.password = 'app-test-password'
+        const pool = createPool({ url: appUrlValue.toString(), max: 2, connectTimeoutSeconds: 30 })
+        let refusedSeq = 0
+        try {
+          const written = await pool.withTenant({ orgId: unlicensed.orgId }, (db) =>
+            appendAudit(db, {
+              orgId: unlicensed.orgId,
+              actorLabel: 'directory',
+              action: 'scim.user.created',
+              targetType: 'user',
+              origin: 'scim',
+              detail: { userName: 'nobody@example.test' },
+            }),
+          )
+          refusedSeq = written.seq
+        } finally {
+          await pool.close()
+        }
+
+        // THE THING THIS WHOLE LANE IS ABOUT.
+        await until('the SCIM entry to arrive at the webhook', () =>
+          sink.entries().some((e) => e.orgId === org.orgId && e.action === 'scim.user.created'),
+        )
+
+        const got = sink.entries().find((e) => e.orgId === org.orgId && e.action === 'scim.user.created')!
+        const stored = await admin<{ entry_hash: string; seq: string }[]>`
+          SELECT entry_hash, seq FROM audit_entries
+          WHERE org_id = ${org.orgId} AND action = 'scim.user.created'
+          ORDER BY seq DESC LIMIT 1`
+        assert.equal(
+          got.entryHash, stored[0]!.entry_hash,
+          'the hash that arrived is not the one the chain stored, so the tamper evidence does ' +
+            'not survive the trip and the sentence in ee/README.md is still false',
+        )
+        assert.equal(got.seq, Number(stored[0]!.seq))
+
+        // Signed over the exact bytes, checked with the function that ships for
+        // a receiver to use. A delivery anybody could forge is not evidence.
+        const delivery = sink.deliveries.find((d) => d.body.includes(got.entryHash))!
+        assert.ok(delivery, 'no delivery carried the entry, so the entry above came from nowhere')
+        assert.equal(
+          verifyWebhook(secret, delivery.timestamp, delivery.body, delivery.signature), true,
+          'the delivery does not verify under the secret the process was given',
+        )
+        assert.equal(
+          verifyWebhook('the wrong secret', delivery.timestamp, delivery.body, delivery.signature),
+          false,
+          'the delivery verifies under a secret that did not sign it, so the check proves nothing',
+        )
+
+        // THE ENTITLEMENT NEGATIVE, and it waits for a decision rather than for
+        // silence: the cursor moving past that sequence number is the forwarder
+        // saying it read the entry and chose. Only then is "nothing was sent"
+        // a statement about the gate.
+        await until(
+          'the forwarder to have read and decided about the unlicensed entry',
+          async () => (await cursor()) >= refusedSeq,
+        )
+        assert.equal(
+          sink.entries().filter((e) => e.orgId === unlicensed.orgId).length, 0,
+          'an organization on the free plan had its audit log forwarded, so the entitlement ' +
+            'gate is not gating',
+        )
+      } finally {
+        await running.stop()
+        await sink.close()
+      }
+    })
+
+    it('a licence that does not permit audit_stream forwards nothing, having read the entry', async () => {
+      const sink = await receiver()
+      const org = await seedOrg('enterprise')
+      await parkCursor()
+
+      const key = signingKey()
+      // Entitled by plan, refused by the licence key. The two gates are
+      // separate authorities and this case is the one that proves the second
+      // one is asked at all: the organization is on the enterprise plan, so
+      // `licensed` says yes, and only the key can refuse.
+      const running = await startEntryPoint(ENTERPRISE_ENTRY, {
+        AF_LICENSE_PUBLIC_KEYS: key.publicKeys,
+        AF_LICENSE_KEY: licenseFor(key, org.slug, ['sso', 'scim']),
+        AF_ORG: org.slug,
+        AF_AUDIT_STREAM_SINK: 'webhook',
+        AF_AUDIT_STREAM_WEBHOOK_URL: sink.url,
+        AF_AUDIT_STREAM_WEBHOOK_SECRET: randomBytes(32).toString('base64'),
+        AF_AUDIT_STREAM_KEY: randomBytes(32).toString('base64'),
+        AF_AUDIT_STREAM_INTERVAL_MS: '200',
+      })
+
+      try {
+        assert.match(
+          running.output(),
+          /enterprise features permitted right now: scim, sso/,
+          'the process did not start without audit_stream, so this case is about the wrong licence',
+        )
+
+        const userName = `ada-${randomUUID().slice(0, 8)}@example.test`
+        const created = await fetch(`http://127.0.0.1:${String(running.port)}/scim/v2/Users`, {
+          method: 'POST',
+          headers: {
+            authorization: `Bearer ${org.token}`,
+            'content-type': 'application/scim+json',
+            'x-forwarded-for': '198.51.100.8',
+          },
+          body: JSON.stringify({
+            schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
+            userName,
+            emails: [{ value: userName, type: 'work', primary: true }],
+            active: true,
+          }),
+        })
+        assert.equal(created.status, 201, `SCIM refused the create: ${await created.text()}`)
+
+        const seq = await highestFor(org.orgId)
+        assert.ok(seq > 0, 'the SCIM create wrote no audit entry, so there is nothing to not forward')
+
+        await until(
+          'the forwarder to have read and decided about the entry',
+          async () => (await cursor()) >= seq,
+        )
+        assert.deepEqual(
+          sink.entries(), [],
+          'a licence that does not name audit_stream forwarded the audit log anyway',
+        )
+      } finally {
+        await running.stop()
+        await sink.close()
+      }
+    })
+
+    it('a sink named with its variables missing refuses to start rather than forwarding nothing', async () => {
+      const org = await seedOrg('enterprise')
+      const key = signingKey()
+      let started = false
+      try {
+        const running = await startEntryPoint(ENTERPRISE_ENTRY, {
+          AF_LICENSE_PUBLIC_KEYS: key.publicKeys,
+          AF_LICENSE_KEY: licenseFor(key, org.slug, ['audit_stream']),
+          AF_ORG: org.slug,
+          AF_AUDIT_STREAM_SINK: 'splunk',
+          AF_AUDIT_STREAM_KEY: randomBytes(32).toString('base64'),
+        })
+        started = true
+        await running.stop()
+      } catch (err) {
+        // The refusal names the variable, which is the whole difference between
+        // this and a process that starts and forwards nowhere.
+        assert.match(
+          String(err),
+          /AF_AUDIT_STREAM_SPLUNK_URL/,
+          `the process failed for a reason that was not the missing variable: ${String(err)}`,
+        )
+      }
+      assert.equal(
+        started, false,
+        'a control plane told to forward to Splunk with no Splunk URL started anyway, which is ' +
+          'a compliance control reporting itself as held while holding nothing',
+      )
+    })
+
+    it('with no sink configured the process says the audit log is not forwarded', async () => {
+      const org = await seedOrg('enterprise')
+      const key = signingKey()
+      const running = await startEntryPoint(ENTERPRISE_ENTRY, {
+        AF_LICENSE_PUBLIC_KEYS: key.publicKeys,
+        AF_LICENSE_KEY: licenseFor(key, org.slug, ['audit_stream']),
+        AF_ORG: org.slug,
+      })
+      try {
+        // Said out loud in the state that forwards nothing, for the reason
+        // readLicense says its own line out loud. An installation that forwards
+        // and one that does not produced identical logs.
+        assert.match(
+          running.output(),
+          /no AF_AUDIT_STREAM_SINK is set, so the control plane's audit log is written and not forwarded/,
+          `the silent state was silent. It said:\n${running.output()}`,
+        )
+      } finally {
+        await running.stop()
+      }
+    })
+  },
+)

--- a/ee/web/server/test/audit-stream.test.ts
+++ b/ee/web/server/test/audit-stream.test.ts
@@ -135,6 +135,10 @@ describe(
         SELECT coalesce(max(seq), 0) AS seq FROM audit_entries`
       const at = Number(rows[0]!.seq)
       await admin`UPDATE audit_stream_cursor SET delivered_seq = ${at} WHERE id`
+      await admin`
+        INSERT INTO audit_stream_positions (org_id, delivered_seq)
+        SELECT org_id, max(seq) FROM audit_entries GROUP BY org_id
+        ON CONFLICT (org_id) DO UPDATE SET delivered_seq = EXCLUDED.delivered_seq`
       return at
     }
 

--- a/engine/internal/docs/pages.gen.go
+++ b/engine/internal/docs/pages.gen.go
@@ -4763,10 +4763,33 @@ of the one before it, so altering an old entry breaks every entry after it.
 ### What one batch looks like
 
 Batched rather than one entry per request, because the batch is what carries the
-proof:
+proof. This is the JSON body's field schema; organization identifiers are UUID
+strings and ` + "`" + `occurredAt` + "`" + ` is an ISO timestamp:
 
-` + "`" + "`" + "`" + `json
-{"entries":[{"seq":82,"orgId":"2b8c3b13-cb7b-4a4b-b895-2ec495ac3138","actor":"scim","action":"scim.user.created","targetType":"user","targetId":"230bef84-511e-4abd-91b3-5d744778e3da","origin":"scim","detail":{"active":true,"userName":"ada@example.test"},"occurredAt":"2026-09-09T14:28:22.969Z","entryHash":"c9945c32d8080d853706af010221851cd81448008c72e7230a2967f97fc0df9e"}],"manifest":{"org":"2b8c3b13-cb7b-4a4b-b895-2ec495ac3138","count":1,"firstSeq":82,"lastSeq":82,"headHash":"c9945c32d8080d853706af010221851cd81448008c72e7230a2967f97fc0df9e","digest":"00b8b0b63b2ddaa329a59e00b3a520d870f5227ac34adde991280c6fe395029c","signature":"9bd6b494cf1f4de8a8e71af737346bb0a1d504c16f791d30bd81c517d44c58ab"}}
+` + "`" + "`" + "`" + `typescript
+interface AuditBatch {
+  entries: Array<{
+    seq: number
+    orgId: string
+    actor: string
+    action: string
+    targetType: string
+    targetId: string | null
+    origin: string
+    detail: Record<string, unknown>
+    occurredAt: string
+    entryHash: string
+  }>
+  manifest: {
+    org: string
+    count: number
+    firstSeq: number
+    lastSeq: number
+    headHash: string
+    digest: string
+    signature: string
+  }
+}
 ` + "`" + "`" + "`" + `
 
 ` + "`" + `headHash` + "`" + ` is the chain hash of the last entry in the batch, and ` + "`" + `digest` + "`" + ` is a

--- a/engine/internal/docs/pages.gen.go
+++ b/engine/internal/docs/pages.gen.go
@@ -4877,13 +4877,14 @@ these deliberately declined entries are not reconsidered on every pass.
 
 ## The licence is asked per action, not at startup
 
-Every sink checks ` + "`" + `audit_stream` + "`" + ` on every entry rather than once when it is
-registered, and the control plane's forwarder asks it once per organization on
-every pass. A licence that lapses while a long lived process is running stops
-forwarding immediately, without a restart, and one that renews starts again the
-same way. A configured sink on an installation without the feature accepts every
-entry and writes none, which is correct and is also silence, so the engine says
-so once at startup:
+The engine checks ` + "`" + `audit_stream` + "`" + ` on every entry. The control plane checks its
+process licence status and organization entitlement on each pass, so expiry or
+an entitlement withdrawal takes effect on the next pass without a restart.
+Organization entitlement grants also take effect on the next pass. Replacing
+the control plane's ` + "`" + `AF_LICENSE_KEY` + "`" + ` requires restarting the process, because
+the key is parsed at startup. A configured sink on an installation without the
+feature accepts every entry and writes none, so the engine says so once at
+startup:
 
 ` + "`" + "`" + "`" + `
 af: audit sink: configured, and audit_stream is not licensed on this

--- a/engine/internal/docs/pages.gen.go
+++ b/engine/internal/docs/pages.gen.go
@@ -4590,8 +4590,8 @@ that is unreachable loses forwarding and never loses the entry.
 
 Until this page said so, only the first half existed. The control plane's audit
 log carried a tamper evident chain and reached no destination at all, so single
-sign on logins, directory provisioning, operator impersonation and every admin
-action were recorded and forwarded nowhere.
+organization sign on, directory provisioning and administrative actions were
+recorded and forwarded nowhere.
 
 ## What the engine forwards
 
@@ -4753,9 +4753,11 @@ take is in the dead letter file before ` + "`" + `Write` + "`" + ` returns.
 
 A different stream with a different shape, and the shape is the reason it is
 worth having. The engine forwards five actions from a machine with no database.
-The control plane forwards ` + "`" + `audit_entries` + "`" + `, which is every sign on, every
-directory provisioning call, every operator impersonation and every
-administrative action, and which carries a hash chain: each entry holds the hash
+The control plane forwards ` + "`" + `audit_entries` + "`" + `, the organization log covering
+actions including sign on, directory provisioning and administration. The
+separate global operator log, ` + "`" + `admin_audit_entries` + "`" + `, is forwarded only where its
+writer also produces an organization entry. Each organization has its own hash
+chain: each entry holds the hash
 of the one before it, so altering an old entry breaks every entry after it.
 
 ### What one batch looks like
@@ -4772,6 +4774,11 @@ sha256 over the canonical batch body with ` + "`" + `signature` + "`" + ` an HMA
 under ` + "`" + `AF_AUDIT_STREAM_KEY` + "`" + `. That is what lets a batch sitting in an archive be
 checked without reaching back to the control plane that wrote it, which is the
 situation an auditor is usually in.
+
+For webhooks, ` + "`" + `x-antifailure-timestamp` + "`" + ` is the first entry's event time, not
+the delivery time. Catching up after an outage can deliver old events. Verify
+the signature and deduplicate by organization and sequence; signature
+verification alone does not reject replay.
 
 One batch holds one organization. A manifest names an organization, so a batch
 carrying two would name one and cover both, and a receiver checking it would be
@@ -4797,6 +4804,11 @@ stays possible.
 ` + "`" + `AF_AUDIT_STREAM_KEY` + "`" + ` is required whenever a sink is named. A manifest signed
 under a key nobody chose is decoration rather than evidence.
 
+Remote collector URLs require HTTPS and cannot contain user information.
+Loopback HTTP is permitted for a local collector. Redirects are refused, each
+request carries a thirty second deadline, and response bodies are discarded
+without being buffered or included in error logs.
+
 ` + "`" + `AF_AUDIT_STREAM_INTERVAL_MS` + "`" + ` is how often a pass runs, ten seconds by default.
 ` + "`" + `AF_AUDIT_STREAM_BATCH` + "`" + ` is how many entries one pass reads, 500 by default, and
 ` + "`" + `AF_AUDIT_STREAM_DELIVERY_BATCH` + "`" + ` is how many one request carries, defaulting to
@@ -4814,11 +4826,12 @@ nowhere.
 
 ### Delivery, and what happens when your collector is down
 
-At least once, never at most once. The cursor advances only past entries a sink
-accepted, so a collector that is down costs forwarding lag and never an entry,
-and the entries are redelivered when it comes back. A duplicate is visible in
-` + "`" + `seq` + "`" + `; a gap would not be visible at all, which is why the trade is made in that
-direction.
+Transient failures are retried with at least once delivery. Each organization's
+position advances after delivery, so a collector outage causes forwarding lag.
+A crash after acceptance and before checkpointing can redeliver a batch; use
+` + "`" + `orgId` + "`" + ` and ` + "`" + `seq` + "`" + ` to deduplicate. Positions are separate because transactions
+from different organizations can commit in a different order from their
+sequence numbers. The installation cursor is only an operational summary.
 
 A batch your endpoint will never accept, meaning it answers 400, 401, 403, 404
 or 413, is given up on rather than retried forever, because one batch nobody
@@ -4829,9 +4842,8 @@ continues.
 
 An organization that is not entitled to ` + "`" + `audit_stream` + "`" + ` is skipped and the stream
 moves on past it. It is not held for an entitlement that might arrive later, and
-that is the same behaviour the engine has. The cursor is one number for the
-whole installation, so an organization that never buys audit streaming would
-otherwise stall the stream for every organization that did.
+that is the same behaviour the engine has. Its delivery position advances so
+these deliberately declined entries are not reconsidered on every pass.
 
 ## The licence is asked per action, not at startup
 
@@ -5419,7 +5431,7 @@ The features a license can name are ` + "`" + `air_gapped` + "`" + `, ` + "`" + 
 <!-- entitlement-names:end -->
 
 <!-- entitlement-count:start -->
-Of the 14 features a license can carry, **10 are refused when the license does not name them**, 8 by the engine and 2 by the control plane. The rest are listed here anyway, with what actually happens without each one, because a feature that is sold and never checked is worth knowing about and the number is only useful if it can come back unflattering.
+Of the 14 features a license can carry, **10 are refused when the license does not name them**, 8 by the engine and 3 by the control plane, with some checked by both. The rest are listed here anyway, with what actually happens without each one, because a feature that is sold and never checked is worth knowing about and the number is only useful if it can come back unflattering.
 <!-- entitlement-count:end -->
 
 The table is generated from ` + "`" + `ee/engine/feature/catalogue.go` + "`" + `, which is the one
@@ -5440,7 +5452,7 @@ is where it gets published.
 | Feature | What it is | Without it |
 | --- | --- | --- |
 | ` + "`" + `air_gapped` + "`" + ` | An installation that reaches nothing outside the operator's own network. | Withheld. ` + "`" + `airgapped/airgapped.go:RegisterFromEnvironment` + "`" + ` asks the license, and the feature is off when the answer is no. |
-| ` + "`" + `audit_stream` + "`" + ` | Privileged actions forwarded to the organization's own SIEM. | Withheld. ` + "`" + `auditsink/auditsink.go:auditsink.permitted` + "`" + ` asks the license, and the feature is off when the answer is no. |
+| ` + "`" + `audit_stream` + "`" + ` | Privileged actions forwarded to the organization's own SIEM. | Withheld by both the engine at ` + "`" + `auditsink/auditsink.go:auditsink.permitted` + "`" + ` and the control plane at ` + "`" + `ee/web/server/src/register.ts:startAuditStream` + "`" + `. Each checks the license. |
 | ` + "`" + `billing` + "`" + ` | Subscriptions, invoices and the plan an organization is on. | Nothing changes, because the capability is not built yet. |
 | ` + "`" + `cloud_database` + "`" + ` | Managed cloud database providers, the ones that need an organization behind them rather than a developer's own card. | Withheld. ` + "`" + `cloudgate/cloudgate.go:gatedDatabase.Branch` + "`" + ` asks the license, and the feature is off when the answer is no. |
 | ` + "`" + `cloud_runtime` + "`" + ` | Managed cloud runtime providers, on the same rule as the databases. | Withheld. ` + "`" + `cloudgate/cloudgate.go:gatedRuntime.Up` + "`" + ` asks the license, and the feature is off when the answer is no. |

--- a/engine/internal/docs/pages.gen.go
+++ b/engine/internal/docs/pages.gen.go
@@ -4762,9 +4762,10 @@ of the one before it, so altering an old entry breaks every entry after it.
 
 ### What one batch looks like
 
-Batched rather than one entry per request, because the batch is what carries the
-proof. This is the JSON body's field schema; organization identifiers are UUID
-strings and ` + "`" + `occurredAt` + "`" + ` is an ISO timestamp:
+Batched rather than one entry per request, because the batch carries the proof.
+The webhook posts this JSON field schema directly. Splunk and Event Hubs wrap
+entries in their collector formats, described below. Organization identifiers
+are UUID strings and ` + "`" + `occurredAt` + "`" + ` is an ISO timestamp:
 
 ` + "`" + "`" + "`" + `typescript
 interface AuditBatch {
@@ -4823,6 +4824,12 @@ Event Hubs reads ` + "`" + `AF_AUDIT_STREAM_EVENT_HUBS_URL` + "`" + ` and
 ` + "`" + `AF_AUDIT_STREAM_EVENT_HUBS_AUTHORIZATION` + "`" + `, the second being a shared access
 signature you generate, so no key reaches this process and managed identity
 stays possible.
+
+Event Hubs receives each entry as a JSON string in the event body and retains
+the signed batch manifest in the ` + "`" + `antifailure_manifest` + "`" + ` application property.
+Its batch API ignores properties supplied only through HTTP headers.
+Splunk stores the same manifest in the indexed ` + "`" + `antifailure_manifest` + "`" + ` field,
+alongside the audit entry's event data.
 
 ` + "`" + `AF_AUDIT_STREAM_KEY` + "`" + ` is required whenever a sink is named. A manifest signed
 under a key nobody chose is decoration rather than evidence.

--- a/engine/internal/docs/pages.gen.go
+++ b/engine/internal/docs/pages.gen.go
@@ -4581,12 +4581,19 @@ sidebar:
 
 *Requires an enterprise license with the ` + "`" + `audit_stream` + "`" + ` feature.*
 
-The engine records the privileged things it does and forwards them to
-destinations you configure. Nothing here replaces the control plane's own audit
-log, which is written regardless: a sink that is unreachable loses forwarding
-and never loses the entry.
+Two streams, from two places, and they are configured separately because they
+run on different machines. The engine forwards the privileged things it does
+from wherever you run it. The control plane forwards its own audit log, the one
+with the hash chain in it, from wherever you run that. Neither replaces the
+other and neither replaces the log itself, which is written regardless: a sink
+that is unreachable loses forwarding and never loses the entry.
 
-## What is forwarded
+Until this page said so, only the first half existed. The control plane's audit
+log carried a tamper evident chain and reached no destination at all, so single
+sign on logins, directory provisioning, operator impersonation and every admin
+action were recorded and forwarded nowhere.
+
+## What the engine forwards
 
 Five actions, and the list is deliberately short. An audit stream a security
 team can read is one where every entry is an act somebody could be asked about.
@@ -4625,7 +4632,7 @@ is wrong rather than evidence that is missing.
 absent. The operating system user is never consulted: on a CI runner it is
 ` + "`" + `runner` + "`" + ` for everybody, which reads as an attribution and is not one.
 
-## Turning it on
+## Turning the engine's stream on
 
 ` + "`" + `AF_AUDIT_SINKS` + "`" + ` lists the destinations, in the order they are written:
 
@@ -4742,10 +4749,95 @@ The environment still comes up, and the teardown still finishes. What is lost is
 the forwarding, and for the webhook not even that: an entry no receiver would
 take is in the dead letter file before ` + "`" + `Write` + "`" + ` returns.
 
+## The control plane's own audit log
+
+A different stream with a different shape, and the shape is the reason it is
+worth having. The engine forwards five actions from a machine with no database.
+The control plane forwards ` + "`" + `audit_entries` + "`" + `, which is every sign on, every
+directory provisioning call, every operator impersonation and every
+administrative action, and which carries a hash chain: each entry holds the hash
+of the one before it, so altering an old entry breaks every entry after it.
+
+### What one batch looks like
+
+Batched rather than one entry per request, because the batch is what carries the
+proof:
+
+` + "`" + "`" + "`" + `json
+{"entries":[{"seq":82,"orgId":"2b8c3b13-cb7b-4a4b-b895-2ec495ac3138","actor":"scim","action":"scim.user.created","targetType":"user","targetId":"230bef84-511e-4abd-91b3-5d744778e3da","origin":"scim","detail":{"active":true,"userName":"ada@example.test"},"occurredAt":"2026-09-09T14:28:22.969Z","entryHash":"c9945c32d8080d853706af010221851cd81448008c72e7230a2967f97fc0df9e"}],"manifest":{"org":"2b8c3b13-cb7b-4a4b-b895-2ec495ac3138","count":1,"firstSeq":82,"lastSeq":82,"headHash":"c9945c32d8080d853706af010221851cd81448008c72e7230a2967f97fc0df9e","digest":"00b8b0b63b2ddaa329a59e00b3a520d870f5227ac34adde991280c6fe395029c","signature":"9bd6b494cf1f4de8a8e71af737346bb0a1d504c16f791d30bd81c517d44c58ab"}}
+` + "`" + "`" + "`" + `
+
+` + "`" + `headHash` + "`" + ` is the chain hash of the last entry in the batch, and ` + "`" + `digest` + "`" + ` is a
+sha256 over the canonical batch body with ` + "`" + `signature` + "`" + ` an HMAC of that digest
+under ` + "`" + `AF_AUDIT_STREAM_KEY` + "`" + `. That is what lets a batch sitting in an archive be
+checked without reaching back to the control plane that wrote it, which is the
+situation an auditor is usually in.
+
+One batch holds one organization. A manifest names an organization, so a batch
+carrying two would name one and cover both, and a receiver checking it would be
+checking the wrong claim.
+
+### Turning the control plane's stream on
+
+` + "`" + "`" + "`" + `sh
+export AF_AUDIT_STREAM_SINK=webhook
+export AF_AUDIT_STREAM_KEY="$(openssl rand -base64 32)"
+export AF_AUDIT_STREAM_WEBHOOK_URL=https://siem.example/ingest
+export AF_AUDIT_STREAM_WEBHOOK_SECRET=...
+` + "`" + "`" + "`" + `
+
+` + "`" + `AF_AUDIT_STREAM_SINK` + "`" + ` takes ` + "`" + `splunk` + "`" + `, ` + "`" + `event_hubs` + "`" + ` or ` + "`" + `webhook` + "`" + `. Splunk reads
+` + "`" + `AF_AUDIT_STREAM_SPLUNK_URL` + "`" + ` and ` + "`" + `AF_AUDIT_STREAM_SPLUNK_TOKEN` + "`" + `, with
+` + "`" + `AF_AUDIT_STREAM_SPLUNK_INDEX` + "`" + ` and ` + "`" + `AF_AUDIT_STREAM_SPLUNK_SOURCETYPE` + "`" + ` optional.
+Event Hubs reads ` + "`" + `AF_AUDIT_STREAM_EVENT_HUBS_URL` + "`" + ` and
+` + "`" + `AF_AUDIT_STREAM_EVENT_HUBS_AUTHORIZATION` + "`" + `, the second being a shared access
+signature you generate, so no key reaches this process and managed identity
+stays possible.
+
+` + "`" + `AF_AUDIT_STREAM_KEY` + "`" + ` is required whenever a sink is named. A manifest signed
+under a key nobody chose is decoration rather than evidence.
+
+` + "`" + `AF_AUDIT_STREAM_INTERVAL_MS` + "`" + ` is how often a pass runs, ten seconds by default.
+` + "`" + `AF_AUDIT_STREAM_BATCH` + "`" + ` is how many entries one pass reads, 500 by default, and
+` + "`" + `AF_AUDIT_STREAM_DELIVERY_BATCH` + "`" + ` is how many one request carries, defaulting to
+the pass size. They are two numbers rather than one because how fast the
+forwarder catches up and what your collector accepts in one request are
+different questions.
+
+A sink named with its variables missing stops the control plane at startup with
+the reason, for the same reason the engine's does.
+
+An object store sink exists in the code and cannot be turned on from the
+environment, because it needs a request signer this half of the product does not
+carry. Naming one is refused rather than accepted and then silently writing
+nowhere.
+
+### Delivery, and what happens when your collector is down
+
+At least once, never at most once. The cursor advances only past entries a sink
+accepted, so a collector that is down costs forwarding lag and never an entry,
+and the entries are redelivered when it comes back. A duplicate is visible in
+` + "`" + `seq` + "`" + `; a gap would not be visible at all, which is why the trade is made in that
+direction.
+
+A batch your endpoint will never accept, meaning it answers 400, 401, 403, 404
+or 413, is given up on rather than retried forever, because one batch nobody
+will ever take must not stop every entry behind it. The rest of the stream
+continues.
+
+### What is not forwarded, and it is stated rather than implied
+
+An organization that is not entitled to ` + "`" + `audit_stream` + "`" + ` is skipped and the stream
+moves on past it. It is not held for an entitlement that might arrive later, and
+that is the same behaviour the engine has. The cursor is one number for the
+whole installation, so an organization that never buys audit streaming would
+otherwise stall the stream for every organization that did.
+
 ## The licence is asked per action, not at startup
 
 Every sink checks ` + "`" + `audit_stream` + "`" + ` on every entry rather than once when it is
-registered. A licence that lapses while a long lived process is running stops
+registered, and the control plane's forwarder asks it once per organization on
+every pass. A licence that lapses while a long lived process is running stops
 forwarding immediately, without a restart, and one that renews starts again the
 same way. A configured sink on an installation without the feature accepts every
 entry and writes none, which is correct and is also silence, so the engine says

--- a/engine/internal/docs/pages.gen.go
+++ b/engine/internal/docs/pages.gen.go
@@ -4828,7 +4828,7 @@ nowhere.
 
 Transient failures are retried with at least once delivery. Each organization's
 position advances after delivery, so a collector outage causes forwarding lag.
-A crash after acceptance and before checkpointing can redeliver a batch; use
+A crash after acceptance and before saving the position can redeliver a batch; use
 ` + "`" + `orgId` + "`" + ` and ` + "`" + `seq` + "`" + ` to deduplicate. Positions are separate because transactions
 from different organizations can commit in a different order from their
 sequence numbers. The installation cursor is only an operational summary.

--- a/web/apps/api/src/boot.ts
+++ b/web/apps/api/src/boot.ts
@@ -127,6 +127,8 @@ export interface BootHooks {
    * is discovering it in production.
    */
   beforeServer?: (ctx: BootContext) => void | Promise<void>
+  /** Stops edition-owned scheduling before the shared database pool closes. */
+  beforeClose?: () => void | Promise<void>
 }
 
 /** The running process, for a caller that wants to stop it. */
@@ -795,8 +797,9 @@ export async function startControlPlane(hooks: BootHooks = {}): Promise<ControlP
         // Flushed before the pool closes, for the same reason the sink is:
         // whatever the last ten seconds grouped is otherwise lost on every
         // deploy, and a deploy is exactly when an operator is looking.
-        void failures
-          .flush()
+        void Promise.resolve()
+          .then(() => hooks.beforeClose?.())
+          .then(() => failures.flush())
           .catch((err) => console.error('failure store flush on shutdown', err))
           .then(() => postHogSink.shutdown())
           .then(() => pool.close())
@@ -819,8 +822,9 @@ export async function startControlPlane(hooks: BootHooks = {}): Promise<ControlP
             reject(err)
             return
           }
-          void failures
-            .flush()
+          void Promise.resolve()
+            .then(() => hooks.beforeClose?.())
+            .then(() => failures.flush())
             .catch((err) => console.error('failure store flush on close', err))
             .then(() => postHogSink.shutdown())
             .then(() => pool.close())

--- a/web/apps/api/src/entitlements.ts
+++ b/web/apps/api/src/entitlements.ts
@@ -239,6 +239,35 @@ export const ENTITLEMENTS: Record<string, EntitlementSpec> = {
       'checks this entitlement in the one function every SCIM route is authenticated by, so ' +
       'a route added later cannot be the one that forgot.',
   },
+  audit_stream: {
+    kind: 'boolean',
+    description:
+      "Forward this organization's audit log, with its hash chain, to a SIEM or an archive.",
+    byPlan: { free: false, team: false, enterprise: true },
+    // THE ENTRY THAT WAS MISSING WHILE THE NAME EXISTED EVERYWHERE ELSE.
+    //
+    // `audit_stream` has been in the licence catalogue, in licensegen, in the
+    // pricing page and in the enterprise feature package since each of those
+    // was written. Named in prose rather than by path, because this file is
+    // community code and the edition boundary job greps this tree for the
+    // enterprise scope and for its directory, which is the correct boundary and
+    // catches a comment as readily as an import.
+    //
+    // It was never in THIS file, which is the authority for a hosted organization,
+    // so `licensed(pool, orgId, 'audit_stream', now)` resolved to undefined and
+    // answered false for every organization on every plan. That is the correct
+    // direction to fail in and it is still a gate nobody could ever pass, which
+    // would have been indistinguishable from a forwarder that did not work.
+    enforcedAt: null,
+    enforcedInTheEditionThatHasIt: true,
+    notEnforcedBecause:
+      'The community build writes the audit log and has nothing that forwards it, so there is ' +
+      'no forwarding for a check to refuse. The edition that carries the forwarder asks this ' +
+      'entitlement once per organization on every pass of the poll loop rather than once at ' +
+      'startup, so an organization whose entitlement is withdrawn stops being forwarded ' +
+      'without a restart, and the log itself is unaffected either way: it is written whatever ' +
+      'a sink does.',
+  },
   rbac: {
     kind: 'boolean',
     description: 'Custom roles and per repository scopes, beyond the four built-in roles.',

--- a/web/packages/db/migrations/0043_the_audit_log_the_control_plane_forwarded_nowhere.sql
+++ b/web/packages/db/migrations/0043_the_audit_log_the_control_plane_forwarded_nowhere.sql
@@ -1,0 +1,186 @@
+-- The audit log the control plane forwarded nowhere.
+--
+-- THE FAILURE THIS EXISTS FOR, and it is a compliance control that reported
+-- itself as held while holding nothing.
+--
+-- `ee/README.md` sold "SIEM streaming with a tamper evident hash chain". Both
+-- halves were real and neither was joined to the other. The hash chain is
+-- `audit_entries.prev_hash` and `audit_entries.entry_hash`, written by the
+-- control plane in 0001. The streaming is `ee/engine/auditsink`, which forwards
+-- five ENGINE actions from a machine that has no database connection. So single
+-- sign on logins, directory provisioning, operator impersonation and every
+-- admin action were written into `audit_entries` and forwarded to nothing at
+-- all, and the sentence that said otherwise could point at a real half whenever
+-- it was questioned.
+--
+-- The forwarder that carries the chain to a sink already existed, in
+-- `ee/web/audit`, with a bounded queue, four sinks and signed batch manifests
+-- over the chain head. Nothing imported it. It was not a declared dependency of
+-- any package in the enterprise workspace, so it could not be imported without
+-- a package.json change, while `npm --prefix ee/web test` ran its suite green on
+-- every pull request. Tested, green and unreachable is the most convincing
+-- disguise dead code can wear.
+--
+-- What was missing from the database, and is here, is the two rows of state
+-- that let a poll loop say where it got to.
+--
+-- ---------------------------------------------------------------------------
+-- THE PROBLEM THIS FILE IS MOSTLY ABOUT: forwarding is a cross tenant read
+-- ---------------------------------------------------------------------------
+--
+-- Every policy on `audit_entries` today keys on the tenant, and that is right
+-- for every reader it has: a customer reads their own audit log. A forwarder
+-- does not. An operator who has configured a SIEM has asked for EVERY
+-- organization's privileged actions, in one stream, in sequence order, because
+-- that is what a security team's alerts run against. There is no tenant to
+-- scope the read to and pretending otherwise would mean the feature cannot
+-- exist.
+--
+-- Postgres ORs permissive policies, so a policy whose USING clause names no
+-- tenant WIDENS every other policy on the table rather than narrowing anything.
+-- 0021 records the cross tenant suite catching exactly that: "bob can read 1 of
+-- alice's teardown_requests rows". So the widening has to be confined to the
+-- one caller that needs it, and the mechanism is the one 0021, 0013 and 0014
+-- already use: the caller declares a value, and the policy is false for
+-- everybody who has not declared it.
+--
+-- `antifailure.audit_forwarder` is that declaration. It is not a credential and
+-- it does not pretend to be one: it is a boolean, and what makes it believable
+-- is that only `Pool.withAuditForwarder` sets it and every other scope in
+-- client.ts clears it by name, which admin.test.ts checks by reading the source
+-- rather than by trusting the comment.
+--
+-- WHY NOT `current_sweeper()`, WHICH ALREADY EXISTS AND IS THE SAME SHAPE. It
+-- is entered by the session sweep, the device sweep, the sign in state sweep
+-- and the pull request lifecycle sweep. Keying the audit read on it would hand
+-- every one of those the whole audit log of every tenant to buy one fewer
+-- setting. A declaration that is reused is a declaration that grants more than
+-- the thing that asked for it.
+--
+-- ---------------------------------------------------------------------------
+-- The second decision: one cursor, not one per organization
+-- ---------------------------------------------------------------------------
+--
+-- `audit_entries.seq` comes from ONE sequence for the whole installation, not
+-- one per tenant, so a single number is a complete description of where the
+-- forwarder got to. A cursor per organization would need the list of
+-- organizations before it could read anything, which is a second cross tenant
+-- read to avoid a number.
+--
+-- The cursor advances past an entry that was deliberately NOT forwarded, which
+-- is the unlicensed case, and that is a decision rather than an oversight. It
+-- is the behaviour `ee/engine/auditsink` already has, written down on
+-- docs/enterprise/audit-stream.md as "accepts every entry and writes none". It
+-- is also forced by the cursor being global: one organization that never buys
+-- audit streaming would otherwise stall the stream for every organization that
+-- did, forever.
+--
+-- The cursor is advanced only past entries a sink ACCEPTED, so a sink that is
+-- down costs forwarding lag and never an entry. Delivery is therefore at least
+-- once and a duplicate is detectable by `seq`, which is the trade every audit
+-- forwarder has to pick a side of, and losing an entry is the wrong side.
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- The declaration
+-- ---------------------------------------------------------------------------
+
+-- Declared by the audit forwarder and by nothing else.
+--
+-- The same shape as current_sweeper() and current_github_account(): the value
+-- is not a secret, and what makes it believable is that one scope sets it and
+-- every other scope clears it. `true` for the third argument so that a
+-- connection which has never set it reads the empty string rather than raising,
+-- which is what makes the policies below deny for every ordinary request.
+CREATE OR REPLACE FUNCTION current_audit_forwarder() RETURNS boolean
+  LANGUAGE sql STABLE
+  AS $$ SELECT coalesce(current_setting('antifailure.audit_forwarder', true), '') = 'on' $$;
+
+-- ---------------------------------------------------------------------------
+-- Where the forwarder got to
+-- ---------------------------------------------------------------------------
+
+-- One row, the same shape and for the same reason as analytics_rollup_state: a
+-- forwarder that has never run and one that ran and found nothing are different
+-- states, and a table with no row cannot tell them apart.
+CREATE TABLE audit_stream_cursor (
+  id              boolean PRIMARY KEY DEFAULT true,
+  -- The highest audit_entries.seq a sink has accepted. Zero means nothing has
+  -- been forwarded yet, which is the state a fresh installation is in and is
+  -- not the same as "up to date".
+  delivered_seq   bigint      NOT NULL DEFAULT 0,
+  -- When the cursor last moved. Read by nothing today and written by the
+  -- forwarder, so that an operator asking "is the stream stuck" has an answer
+  -- that does not require reading the sink's own logs.
+  updated_at      timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT audit_stream_cursor_is_one_row CHECK (id)
+);
+
+INSERT INTO audit_stream_cursor (id) VALUES (true);
+
+-- ---------------------------------------------------------------------------
+-- Grants
+--
+-- SELECT and UPDATE, and no INSERT and no DELETE, so the application role
+-- cannot create a second cursor row or remove the one there is. The row is
+-- created here, once, by the migration role.
+--
+-- The operator credential gets SELECT so the administrative portal can show how
+-- far behind the stream is, and no UPDATE: rewinding the cursor would republish
+-- an organization's audit history to a sink, which is a decision nobody makes
+-- from a portal by accident.
+-- ---------------------------------------------------------------------------
+
+GRANT SELECT, UPDATE ON audit_stream_cursor TO antifailure_app;
+GRANT SELECT ON audit_stream_cursor TO antifailure_admin;
+
+-- ---------------------------------------------------------------------------
+-- Isolation
+--
+-- The cursor carries no org_id because it belongs to the installation rather
+-- than to any tenant, the same classification platform_controls and
+-- analytics_rollup_state carry. What confines it is the declaration: a request
+-- that arrived from outside has not set it, so both policies are false and the
+-- table reads as empty rather than as an error.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE audit_stream_cursor ENABLE ROW LEVEL SECURITY;
+ALTER TABLE audit_stream_cursor FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY audit_stream_cursor_is_read_by_the_forwarder ON audit_stream_cursor
+  FOR SELECT TO antifailure_app
+  USING (current_audit_forwarder());
+
+-- Defence in depth that no tenant facing test can exercise, and that is
+-- recorded rather than implied. Widening this one to USING (true) leaves the
+-- cross tenant suite GREEN, established by mutation and not by reading: an
+-- UPDATE has to satisfy the SELECT policies as well, so a caller that cannot
+-- see the row cannot update it whatever this says. What actually holds the row
+-- is the SELECT policy above and the grant above that. This is here so a
+-- widening of the SELECT policy is not a widening of both at once.
+CREATE POLICY audit_stream_cursor_is_advanced_by_the_forwarder ON audit_stream_cursor
+  FOR UPDATE TO antifailure_app
+  USING (current_audit_forwarder())
+  WITH CHECK (current_audit_forwarder());
+
+-- ---------------------------------------------------------------------------
+-- What the forwarder may read
+--
+-- SELECT and nothing else. The forwarder copies; it must never be able to
+-- write, amend or remove an entry, and 0002 already revokes UPDATE, DELETE and
+-- TRUNCATE on this table from the application role, so this adds a read and
+-- cannot add anything else.
+--
+-- This is the widest policy in the schema keyed on a declaration, and saying so
+-- here is the point: it reads every organization's audit log. That is what an
+-- audit stream IS, it is bounded by the one scope that can declare it, and the
+-- cross tenant suite proves an ordinary tenant connection still reaches
+-- nobody's rows but its own.
+-- ---------------------------------------------------------------------------
+
+CREATE POLICY audit_entries_are_forwarded ON audit_entries
+  FOR SELECT TO antifailure_app
+  USING (current_audit_forwarder());
+
+COMMIT;

--- a/web/packages/db/migrations/0043_the_audit_log_the_control_plane_forwarded_nowhere.sql
+++ b/web/packages/db/migrations/0043_the_audit_log_the_control_plane_forwarded_nowhere.sql
@@ -8,8 +8,8 @@
 -- `audit_entries.prev_hash` and `audit_entries.entry_hash`, written by the
 -- control plane in 0001. The streaming is `ee/engine/auditsink`, which forwards
 -- five ENGINE actions from a machine that has no database connection. So single
--- sign on logins, directory provisioning, operator impersonation and every
--- admin action were written into `audit_entries` and forwarded to nothing at
+-- organization sign on, directory provisioning and administrative actions
+-- were written into `audit_entries` and forwarded to nothing at
 -- all, and the sentence that said otherwise could point at a real half whenever
 -- it was questioned.
 --
@@ -21,7 +21,7 @@
 -- every pull request. Tested, green and unreachable is the most convincing
 -- disguise dead code can wear.
 --
--- What was missing from the database, and is here, is the two rows of state
+-- What was missing from the database, and is here, is the delivery state
 -- that let a poll loop say where it got to.
 --
 -- ---------------------------------------------------------------------------
@@ -58,27 +58,23 @@
 -- the thing that asked for it.
 --
 -- ---------------------------------------------------------------------------
--- The second decision: one cursor, not one per organization
+-- The second decision: delivery positions follow the writer's lock boundary
 -- ---------------------------------------------------------------------------
 --
--- `audit_entries.seq` comes from ONE sequence for the whole installation, not
--- one per tenant, so a single number is a complete description of where the
--- forwarder got to. A cursor per organization would need the list of
--- organizations before it could read anything, which is a second cross tenant
--- read to avoid a number.
+-- Sequence allocation does not imply commit order across organizations.
+-- appendAudit serializes only writers to the same organization's chain. The
+-- delivery query joins audit entries to per organization positions, requiring
+-- no organization inventory read. The singleton cursor is only a summary.
 --
 -- The cursor advances past an entry that was deliberately NOT forwarded, which
 -- is the unlicensed case, and that is a decision rather than an oversight. It
 -- is the behaviour `ee/engine/auditsink` already has, written down on
 -- docs/enterprise/audit-stream.md as "accepts every entry and writes none". It
--- is also forced by the cursor being global: one organization that never buys
--- audit streaming would otherwise stall the stream for every organization that
--- did, forever.
+-- avoids repeatedly reading entries deliberately declined by the licence.
 --
--- The cursor is advanced only past entries a sink ACCEPTED, so a sink that is
--- down costs forwarding lag and never an entry. Delivery is therefore at least
--- once and a duplicate is detectable by `seq`, which is the trade every audit
--- forwarder has to pick a side of, and losing an entry is the wrong side.
+-- Delivery positions advance after acceptance or an explicit permanent refusal.
+-- Transient failures stay pending; permanent refusals are logged and skipped.
+-- A crash after acceptance but before checkpointing can redeliver a batch.
 
 BEGIN;
 
@@ -106,9 +102,8 @@ CREATE OR REPLACE FUNCTION current_audit_forwarder() RETURNS boolean
 -- states, and a table with no row cannot tell them apart.
 CREATE TABLE audit_stream_cursor (
   id              boolean PRIMARY KEY DEFAULT true,
-  -- The highest audit_entries.seq a sink has accepted. Zero means nothing has
-  -- been forwarded yet, which is the state a fresh installation is in and is
-  -- not the same as "up to date".
+  -- A monotonic summary of processed sequence numbers, including deliberate
+  -- licence declines and permanent refusals. It never filters pending work.
   delivered_seq   bigint      NOT NULL DEFAULT 0,
   -- When the cursor last moved. Read by nothing today and written by the
   -- forwarder, so that an operator asking "is the stream stuck" has an answer
@@ -182,5 +177,24 @@ CREATE POLICY audit_stream_cursor_is_advanced_by_the_forwarder ON audit_stream_c
 CREATE POLICY audit_entries_are_forwarded ON audit_entries
   FOR SELECT TO antifailure_app
   USING (current_audit_forwarder());
+
+/* Sequence allocation is ordered only inside one organization's writer lock.
+   These positions, rather than the summary cursor, determine pending work. */
+CREATE TABLE audit_stream_positions (
+  org_id uuid PRIMARY KEY REFERENCES organizations(id) ON DELETE CASCADE,
+  delivered_seq bigint NOT NULL DEFAULT 0 CHECK (delivered_seq >= 0),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+GRANT SELECT, INSERT, UPDATE ON audit_stream_positions TO antifailure_app;
+GRANT SELECT ON audit_stream_positions TO antifailure_admin;
+ALTER TABLE audit_stream_positions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE audit_stream_positions FORCE ROW LEVEL SECURITY;
+CREATE POLICY audit_stream_positions_read ON audit_stream_positions
+  FOR SELECT TO antifailure_app USING (current_audit_forwarder());
+CREATE POLICY audit_stream_positions_insert ON audit_stream_positions
+  FOR INSERT TO antifailure_app WITH CHECK (current_audit_forwarder());
+CREATE POLICY audit_stream_positions_update ON audit_stream_positions
+  FOR UPDATE TO antifailure_app USING (current_audit_forwarder())
+  WITH CHECK (current_audit_forwarder());
 
 COMMIT;

--- a/web/packages/db/src/client.ts
+++ b/web/packages/db/src/client.ts
@@ -253,6 +253,30 @@ export interface Pool {
    */
   withExpirySweeper<T>(fn: (db: Db) => Promise<T>): Promise<T>
   /**
+   * Runs fn as the audit stream forwarder, which reads across tenants.
+   *
+   * The only scope here other than withPlatformAdmin that does, and unlike that
+   * one it declares a boolean rather than a credential, so the argument for why
+   * it is safe has to be made rather than assumed. It is made in migration
+   * 0043 and it is this: an operator who configures a SIEM has asked for every
+   * organization's privileged actions in one stream, so there is no tenant to
+   * scope the read to and the feature cannot exist without a policy that names
+   * none. Postgres ORs permissive policies, so such a policy WIDENS the table
+   * for whoever the predicate is true for, and what keeps that bounded is that
+   * this is the only scope that sets `antifailure.audit_forwarder` and every
+   * other scope in this file clears it by name.
+   *
+   * SELECT only, on audit_entries and on the one row of audit_stream_cursor.
+   * The forwarder copies: 0002 already withholds UPDATE, DELETE and TRUNCATE on
+   * audit_entries from this role, so a forwarder cannot amend the log it is
+   * reading even if a policy said it could.
+   *
+   * NOT withSweeper, though the shape is identical. That declaration is set by
+   * four sweeps that have no business reading an audit log, and reusing it to
+   * save a setting would hand all four the whole audit trail of every tenant.
+   */
+  withAuditForwarder<T>(fn: (db: Db) => Promise<T>): Promise<T>
+  /**
    * Runs fn as an operator, for the administrative portal.
    *
    * The only scope in this file that can read across tenants, and the shape is
@@ -387,6 +411,7 @@ export function createPool(options: PoolOptions): Pool {
           'antifailure.github_delivery': '',
           'antifailure.pr_callback_hash': '',
           'antifailure.sweeper': '',
+          'antifailure.audit_forwarder': '',
           // Cleared for the same reason as every setting above it, and this pair
           // matters more than most: the policies they key are the only ones in the
           // schema that read ACROSS tenants.
@@ -445,6 +470,7 @@ export function createPool(options: PoolOptions): Pool {
           'antifailure.github_delivery': '',
           'antifailure.pr_callback_hash': '',
           'antifailure.sweeper': '',
+          'antifailure.audit_forwarder': '',
           // Cleared for the same reason as every setting above it, and this pair
           // matters more than most: the policies they key are the only ones in the
           // schema that read ACROSS tenants.
@@ -489,6 +515,7 @@ export function createPool(options: PoolOptions): Pool {
           'antifailure.github_delivery': '',
           'antifailure.pr_callback_hash': '',
           'antifailure.sweeper': '',
+          'antifailure.audit_forwarder': '',
           // Cleared for the same reason as every setting above it, and this pair
           // matters more than most: the policies they key are the only ones in the
           // schema that read ACROSS tenants.
@@ -533,6 +560,7 @@ export function createPool(options: PoolOptions): Pool {
           'antifailure.github_delivery': '',
           'antifailure.pr_callback_hash': '',
           'antifailure.sweeper': '',
+          'antifailure.audit_forwarder': '',
           // Cleared for the same reason as every setting above it, and this pair
           // matters more than most: the policies they key are the only ones in the
           // schema that read ACROSS tenants.
@@ -573,6 +601,7 @@ export function createPool(options: PoolOptions): Pool {
           'antifailure.github_delivery': id,
           'antifailure.pr_callback_hash': '',
           'antifailure.sweeper': '',
+          'antifailure.audit_forwarder': '',
           // Cleared for the same reason as every setting above it, and this pair
           // matters more than most: the policies they key are the only ones in the
           // schema that read ACROSS tenants.
@@ -609,6 +638,7 @@ export function createPool(options: PoolOptions): Pool {
           'antifailure.github_delivery': '',
           'antifailure.pr_callback_hash': hash.toString('hex'),
           'antifailure.sweeper': '',
+          'antifailure.audit_forwarder': '',
           // Cleared for the same reason as every setting above it, and this pair
           // matters more than most: the policies they key are the only ones in the
           // schema that read ACROSS tenants.
@@ -642,6 +672,7 @@ export function createPool(options: PoolOptions): Pool {
           'antifailure.github_delivery': '',
           'antifailure.pr_callback_hash': '',
           'antifailure.sweeper': 'on',
+          'antifailure.audit_forwarder': '',
           // Cleared for the same reason as every setting above it, and this pair
           // matters more than most: the policies they key are the only ones in the
           // schema that read ACROSS tenants.
@@ -652,6 +683,34 @@ export function createPool(options: PoolOptions): Pool {
           // reason given at the top of the file for writing every other setting
           // out longhand too. admin.test.ts checks the source for exactly that
           // and fails when a scope does not name both.
+          'antifailure.admin_session_hash': '',
+          'antifailure.admin_email': '',
+        },
+        fn,
+      )
+    },
+    withAuditForwarder(fn) {
+      return scoped(
+        {
+          'antifailure.org_id': '',
+          'antifailure.user_id': '',
+          'antifailure.session_hash': '',
+          'antifailure.engine_token_hash': '',
+          'antifailure.github_ids': '',
+          'antifailure.signin_user_id': '',
+          'antifailure.github_logins': '',
+          'antifailure.device_code_hash': '',
+          'antifailure.device_user_code': '',
+          'antifailure.github_account': '',
+          'antifailure.stripe_customer': '',
+          'antifailure.github_delivery': '',
+          'antifailure.pr_callback_hash': '',
+          // Cleared, not shared. The sweeps that enter withSweeper have no
+          // business reading an audit log, and a declaration that two callers
+          // set is a declaration that grants more than the one that asked for
+          // it. See migration 0043.
+          'antifailure.sweeper': '',
+          'antifailure.audit_forwarder': 'on',
           'antifailure.admin_session_hash': '',
           'antifailure.admin_email': '',
         },
@@ -682,6 +741,7 @@ export function createPool(options: PoolOptions): Pool {
           'antifailure.github_delivery': '',
           'antifailure.pr_callback_hash': '',
           'antifailure.sweeper': '',
+          'antifailure.audit_forwarder': '',
           'antifailure.admin_session_hash': sessionHash.toString('hex'),
           // Cleared even here. This scope resolves an operator by their live
           // session, never by the email somebody typed, and leaving the sign-in
@@ -713,6 +773,7 @@ export function createPool(options: PoolOptions): Pool {
           'antifailure.github_delivery': '',
           'antifailure.pr_callback_hash': '',
           'antifailure.sweeper': '',
+          'antifailure.audit_forwarder': '',
           // Lower-cased here rather than at the call site, for the reason
           // withGitHubAccount gives: the column is lower-cased by a CHECK
           // constraint, and one caller forgetting would produce a statement
@@ -747,6 +808,7 @@ export function createPool(options: PoolOptions): Pool {
           'antifailure.github_delivery': '',
           'antifailure.pr_callback_hash': '',
           'antifailure.sweeper': '',
+          'antifailure.audit_forwarder': '',
           'antifailure.invitation_token_hash': '',
           'antifailure.deletion_token_hash': '',
           'antifailure.mcp_client_id': '',

--- a/web/packages/db/src/client.ts
+++ b/web/packages/db/src/client.ts
@@ -266,7 +266,7 @@ export interface Pool {
    * this is the only scope that sets `antifailure.audit_forwarder` and every
    * other scope in this file clears it by name.
    *
-   * SELECT only, on audit_entries and on the one row of audit_stream_cursor.
+   * SELECT only on audit_entries, with writes confined to delivery bookkeeping.
    * The forwarder copies: 0002 already withholds UPDATE, DELETE and TRUNCATE on
    * audit_entries from this role, so a forwarder cannot amend the log it is
    * reading even if a policy said it could.

--- a/web/packages/db/src/schema.ts
+++ b/web/packages/db/src/schema.ts
@@ -1648,3 +1648,18 @@ export const controlPlaneFailures = pgTable(
   },
   (t) => [index('control_plane_failures_last_seen_idx').on(t.lastSeenAt)],
 )
+
+/* ---------------------------------------------------------------------------
+ * Where the audit stream forwarder got to
+ *
+ * One row for the whole installation, because audit_entries.seq comes from one
+ * sequence rather than one per tenant, so a single number says where the
+ * forwarder is. See migration 0043 for why the read it guards is the widest
+ * declaration keyed policy in this schema and what confines it.
+ * ------------------------------------------------------------------------ */
+
+export const auditStreamCursor = pgTable('audit_stream_cursor', {
+  id: boolean('id').primaryKey().default(true),
+  deliveredSeq: bigint('delivered_seq', { mode: 'number' }).notNull().default(0),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
+})

--- a/web/packages/db/src/schema.ts
+++ b/web/packages/db/src/schema.ts
@@ -1547,11 +1547,18 @@ export const environmentUsageDaily = pgTable('environment_usage_daily', {
   measuredAt: timestamp('measured_at', { withTimezone: true }).notNull(),
 }, (t) => [primaryKey({ columns: [t.orgId, t.day] })])
 
+/** Organization-owned positions, readable and writable only by the forwarder. */
+export const auditStreamPositions = pgTable('audit_stream_positions', {
+  orgId: uuid('org_id').primaryKey().references(() => organizations.id, { onDelete: 'cascade' }),
+  deliveredSeq: bigint('delivered_seq', { mode: 'number' }).notNull().default(0),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
+})
+
 export const tenantScopedTables = [
   environmentUsage, environmentUsageDaily, usageRollupState,
   members, githubInstallations, repositories, environments, goldenVersions,
   runs, verdicts, artifacts, maskingRules, networkRules, runtimes, engineTokens,
-  events, auditEntries, providerKeys, providerBudgets,
+  events, auditEntries, auditStreamPositions, providerKeys, providerBudgets,
   ssoConnections, ssoConnectionSecrets, ssoDomains, ssoLoginStates,
   ssoAssertionsSeen, ssoBreakGlassCodes,
   scimTokens, scimResources, scimGroups, scimGroupMembers,
@@ -1659,13 +1666,6 @@ export const controlPlaneFailures = pgTable(
 
 export const auditStreamCursor = pgTable('audit_stream_cursor', {
   id: boolean('id').primaryKey().default(true),
-  deliveredSeq: bigint('delivered_seq', { mode: 'number' }).notNull().default(0),
-  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
-})
-
-/** Delivery positions follow the writer's per organization transaction lock. */
-export const auditStreamPositions = pgTable('audit_stream_positions', {
-  orgId: uuid('org_id').primaryKey().references(() => organizations.id, { onDelete: 'cascade' }),
   deliveredSeq: bigint('delivered_seq', { mode: 'number' }).notNull().default(0),
   updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
 })

--- a/web/packages/db/src/schema.ts
+++ b/web/packages/db/src/schema.ts
@@ -1652,14 +1652,20 @@ export const controlPlaneFailures = pgTable(
 /* ---------------------------------------------------------------------------
  * Where the audit stream forwarder got to
  *
- * One row for the whole installation, because audit_entries.seq comes from one
- * sequence rather than one per tenant, so a single number says where the
- * forwarder is. See migration 0043 for why the read it guards is the widest
- * declaration keyed policy in this schema and what confines it.
+ * One summary row for operational diagnostics. Per organization positions
+ * determine delivery because sequence allocation and commit order differ.
+ * See migration 0043 for the policies confining these reads.
  * ------------------------------------------------------------------------ */
 
 export const auditStreamCursor = pgTable('audit_stream_cursor', {
   id: boolean('id').primaryKey().default(true),
+  deliveredSeq: bigint('delivered_seq', { mode: 'number' }).notNull().default(0),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
+})
+
+/** Delivery positions follow the writer's per organization transaction lock. */
+export const auditStreamPositions = pgTable('audit_stream_positions', {
+  orgId: uuid('org_id').primaryKey().references(() => organizations.id, { onDelete: 'cascade' }),
   deliveredSeq: bigint('delivered_seq', { mode: 'number' }).notNull().default(0),
   updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
 })

--- a/web/packages/db/test/admin.test.ts
+++ b/web/packages/db/test/admin.test.ts
@@ -113,6 +113,7 @@ describe('the operator boundary', { skip: hasDb ? false : 'no database' }, () =>
         (p, read) => p.withPullRequestCallback(Buffer.from('abcd', 'hex'), read),
       ],
       ['withSweeper', (p, read) => p.withSweeper(read)],
+      ['withAuditForwarder', (p, read) => p.withAuditForwarder(read)],
     ]
 
     for (const [name, enter] of entered) {
@@ -144,7 +145,17 @@ describe('the operator boundary', { skip: hasDb ? false : 'no database' }, () =>
       const scopes = source.match(/return scoped\(/g)?.length ?? 0
       assert.ok(scopes >= 8, `found only ${scopes} scopes in client.ts, so this is not reading it`)
 
-      for (const setting of ['antifailure.admin_session_hash', 'antifailure.admin_email']) {
+      // The audit forwarder's declaration is held to the same rule and for the
+      // same reason. It keys the third policy in this schema that reads ACROSS
+      // tenants, migration 0043 says so in those words, and transaction
+      // locality already makes it empty on entry, so naming it in every scope
+      // is what makes the invariant checkable by READING client.ts rather than
+      // by trusting that nothing ever changes how these settings are applied.
+      for (const setting of [
+        'antifailure.admin_session_hash',
+        'antifailure.admin_email',
+        'antifailure.audit_forwarder',
+      ]) {
         const mentions = source.match(new RegExp(`'${setting.replace('.', '\\.')}':`, 'g'))?.length ?? 0
         assert.equal(
           mentions,

--- a/web/packages/db/test/tenancy.test.ts
+++ b/web/packages/db/test/tenancy.test.ts
@@ -17,6 +17,7 @@ import { fileURLToPath } from 'node:url'
 import assert from 'node:assert/strict'
 import { sql } from 'drizzle-orm'
 import { createPool } from '../src/client.ts'
+import { appendAudit } from '../src/audit.ts'
 import {
   available,
   appUrl,
@@ -189,6 +190,21 @@ describe('cross-tenant isolation', { skip: hasDatabase ? false : 'no Postgres at
       ['analytics_retention_cohorts', 'a cohort grid of counts, with no identifier in it'],
       ['analytics_funnel_weeks', 'counts of how far subjects got, with no identifier in them'],
       [
+        'audit_stream_cursor',
+        'one row of bookkeeping about how far the audit stream forwarder has got, the same ' +
+          'shape as analytics_rollup_state. It carries no org_id because it belongs to the ' +
+          'INSTALLATION rather than to a tenant: audit_entries.seq comes from one sequence for ' +
+          'the whole database, so one number describes the forwarder completely and a cursor ' +
+          'per organization would need the list of organizations before it could read anything, ' +
+          'which is a second cross tenant read to avoid a number. What confines the application ' +
+          'role is the declaration the policies key on, which only Pool.withAuditForwarder sets ' +
+          'and every other scope in client.ts clears, plus grants of SELECT and UPDATE with no ' +
+          'INSERT and no DELETE so it cannot create a second cursor or remove the one there is. ' +
+          'The test below proves an ordinary tenant reaches neither this row nor another ' +
+          'tenant\'s audit entries, and that the forwarder scope reaches both. See ' +
+          'migrations/0043.',
+      ],
+      [
         'control_plane_failures',
         'what the CONTROL PLANE caught in itself, grouped: one row per fingerprint over the ' +
           'declared route key, the HTTP method, the error class and the driver code, with a ' +
@@ -300,6 +316,134 @@ describe('cross-tenant isolation', { skip: hasDatabase ? false : 'no Postgres at
     assert.equal(Number(left!.n), 1, 'the refusal above was a statement that matched nothing')
 
     await h.admin`DELETE FROM control_plane_failures WHERE fingerprint = ${fingerprint}`
+  })
+
+  /**
+   * The audit stream forwarder's reach, both ways.
+   *
+   * Migration 0043 adds the widest declaration keyed policy in this schema: a
+   * SELECT on audit_entries with no tenant in its USING clause, because an
+   * operator who configures a SIEM has asked for every organization's
+   * privileged actions in one stream and there is no tenant to scope that to.
+   * Postgres ORs permissive policies, so a policy naming no tenant WIDENS the
+   * table for whoever its predicate is true for, which is exactly the failure
+   * 0021 records the first version of the sweeper policies causing here.
+   *
+   * So both directions are asserted in one test. Bob, on the strongest position
+   * an ordinary request is ever in, reaches neither alice's audit entries nor
+   * the cursor row. The forwarder scope reaches both, which is what stops the
+   * two denials above being a boundary that is simply broken for everybody.
+   */
+  it('only the forwarder scope reads across tenants, and it does read', async () => {
+    await h.pool.withTenant({ orgId: alice.orgId, userId: alice.userId }, (db) =>
+      appendAudit(db, {
+        orgId: alice.orgId,
+        actorLabel: 'the fixture',
+        action: 'audit.stream.isolation',
+        targetType: 'organization',
+        targetId: alice.orgId,
+        origin: 'system',
+      }),
+    )
+
+    // Bob's own connection, with a tenant set, which is the position every
+    // request handler in the product runs in.
+    const seenByBob = await h.pool.withTenant(
+      { orgId: bob.orgId, userId: bob.userId },
+      async (db) =>
+        db.execute<{ n: string }>(sql`
+          SELECT count(*) AS n FROM audit_entries WHERE org_id = ${alice.orgId}`),
+    )
+    assert.equal(
+      Number(seenByBob[0]!.n), 0,
+      "bob read alice's audit entries. The forwarder policy names no tenant, so it widened " +
+        'audit_entries for every ordinary request rather than for the one scope that declares ' +
+        'itself.',
+    )
+
+    const cursorForBob = await h.pool.withTenant(
+      { orgId: bob.orgId, userId: bob.userId },
+      async (db) => db.execute<{ n: string }>(sql`SELECT count(*) AS n FROM audit_stream_cursor`),
+    )
+    assert.equal(
+      Number(cursorForBob[0]!.n), 0,
+      'a tenant connection read the audit stream cursor, so the forwarder policies are true ' +
+        'for callers that never declared themselves',
+    )
+
+    // A tenant cannot move the cursor either. Rewinding it would republish an
+    // organization's whole audit history to whatever sink is configured.
+    //
+    // WHAT THIS ASSERTION CAN AND CANNOT SAY NO ABOUT, established by mutation
+    // rather than by reading. Widening the UPDATE policy to `USING (true)`
+    // leaves this green, and that is not a weak test: an UPDATE has to satisfy
+    // the SELECT policies as well, which the test above this file already
+    // proves in its own case, so a caller who cannot SEE the row cannot update
+    // it whatever the UPDATE policy says. The UPDATE policy is defence in depth
+    // that no tenant facing test can exercise while the SELECT policy denies,
+    // and the pair of assertions this comment sits between is what is really
+    // holding the row. Said here rather than left implied, because an
+    // assertion nothing can break reads exactly like one that is doing work.
+    const moved = await h.pool.withTenant(
+      { orgId: bob.orgId, userId: bob.userId },
+      async (db) => db.execute(sql`UPDATE audit_stream_cursor SET delivered_seq = 0 WHERE id`),
+    )
+    assert.equal(
+      (moved as unknown as { count?: number }).count ?? 0, 0,
+      'a tenant connection moved the audit stream cursor',
+    )
+
+    // And the half that IS independently breakable, which is the grant rather
+    // than a policy. 0043 gives the application role SELECT and UPDATE and
+    // nothing else, so it cannot create a second cursor row or remove the one
+    // there is, and a statement that tried is refused by the database before
+    // any policy is consulted. Asserted as 42501 specifically: a statement that
+    // merely affected no rows would pass a weaker assertion and would mean the
+    // opposite, that the table IS writable.
+    for (const [what, statement] of [
+      ['create a second cursor', sql`INSERT INTO audit_stream_cursor (id) VALUES (false)`],
+      ['delete the cursor', sql`DELETE FROM audit_stream_cursor WHERE id`],
+    ] as const) {
+      const refused = await h.pool
+        .withTenant({ orgId: bob.orgId, userId: bob.userId }, async (db) => {
+          await db.execute(statement)
+        })
+        .then(() => null, (e: unknown) => pgError(e))
+      assert.equal(
+        refused?.code, '42501',
+        `the application role could ${what}, so a forwarder's own bookkeeping is writable from ` +
+          'a request path',
+      )
+    }
+
+    const [cursorsLeft] = await h.admin<{ n: string }[]>`
+      SELECT count(*) AS n FROM audit_stream_cursor`
+    assert.equal(
+      Number(cursorsLeft!.n), 1,
+      'the refusals above were statements that quietly matched nothing',
+    )
+
+    // THE POSITIVE CONTROL, without which every assertion above is satisfied by
+    // a policy nobody can pass and a feature that cannot work.
+    const seenByForwarder = await h.pool.withAuditForwarder(async (db) =>
+      db.execute<{ n: string }>(sql`
+        SELECT count(*) AS n FROM audit_entries WHERE org_id = ${alice.orgId}`),
+    )
+    assert.ok(
+      Number(seenByForwarder[0]!.n) > 0,
+      'the forwarder scope cannot read the audit log it exists to forward, so the three ' +
+        'refusals above are a boundary that is broken for everybody rather than isolation',
+    )
+    const cursorForForwarder = await h.pool.withAuditForwarder(async (db) =>
+      db.execute<{ n: string }>(sql`SELECT count(*) AS n FROM audit_stream_cursor`),
+    )
+    assert.equal(
+      Number(cursorForForwarder[0]!.n), 1,
+      'the forwarder scope cannot read its own cursor row, so it would re-stream the whole ' +
+        'audit log every time it started',
+    )
+
+    await h.admin`DELETE FROM audit_entries WHERE action = 'audit.stream.isolation'`
   })
 
   it('the application role cannot read or write an operator\'s notes', async () => {

--- a/web/packages/db/test/tenancy.test.ts
+++ b/web/packages/db/test/tenancy.test.ts
@@ -56,6 +56,7 @@ describe('cross-tenant isolation', { skip: hasDatabase ? false : 'no Postgres at
   // separate test proves nothing fell out of it.
   const isolatedByUser = new Map<string, string>([
     ['sessions', 'belongs to a user, not an organization; covered by its own test below'],
+    ['audit_stream_positions', 'forwarder bookkeeping; tenant access is refused and tested explicitly'],
   ])
 
   // relkind r and p. A partitioned table's parent is p, not r, so a filter on
@@ -193,10 +194,8 @@ describe('cross-tenant isolation', { skip: hasDatabase ? false : 'no Postgres at
         'audit_stream_cursor',
         'one row of bookkeeping about how far the audit stream forwarder has got, the same ' +
           'shape as analytics_rollup_state. It carries no org_id because it belongs to the ' +
-          'INSTALLATION rather than to a tenant: audit_entries.seq comes from one sequence for ' +
-          'the whole database, so one number describes the forwarder completely and a cursor ' +
-          'per organization would need the list of organizations before it could read anything, ' +
-          'which is a second cross tenant read to avoid a number. What confines the application ' +
+          'INSTALLATION rather than to a tenant. It is a summary, while per organization ' +
+          'positions determine which rows remain pending. What confines the application ' +
           'role is the declaration the policies key on, which only Pool.withAuditForwarder sets ' +
           'and every other scope in client.ts clears, plus grants of SELECT and UPDATE with no ' +
           'INSERT and no DELETE so it cannot create a second cursor or remove the one there is. ' +


### PR DESCRIPTION
## What changed

The control plane recorded a chained organization audit log but never started the component that could forward it. The enterprise entry point now starts a configured Splunk, Event Hubs or signed webhook stream, checking both the installation licence and organization entitlement on every pass.

Delivery positions follow the writer's per organization transaction lock. A lower sequence that commits after another organization's higher sequence is still delivered. The global cursor is only a diagnostic summary. Transient failures stay pending; permanent collector refusals are logged and skipped while the primary log remains intact. The scheduler stops through the shared shutdown hook. Organization entitlement changes apply on the next pass; replacing the process licence key requires a restart.

Collector envelopes now preserve the signed manifest through their documented event metadata. Event Hubs receives string bodies with the manifest in UserProperties, and Splunk receives the manifest in indexed fields. Both retain their existing HTTP header for gateways. See [Microsoft's batch protocol](https://learn.microsoft.com/en-us/rest/api/eventhub/send-batch-events) and [Splunk's event protocol](https://help.splunk.com/en/splunk-enterprise/get-data-in/get-started-with-getting-data-in/9.4/get-data-with-http-event-collector/format-events-for-http-event-collector).

## Failure paths covered

| Failure path | Test |
| --- | --- |
| Production process never starts the forwarder | a SCIM user created over HTTP arrives at the sink, signed, with its chain hash |
| Late transaction falls behind the delivery checkpoint | concurrent: a lower sequence that commits after another organization remains deliverable |
| Organization-owned table omitted from the typed roster | names every typed table that carries an org_id |
| Tenant reads or advances delivery state | positions: a tenant cannot read or advance delivery state and the forwarder can |
| Partial delivery, restart, gaps, entitlement changes and interleaved organizations | named ordering cases in forwarder.test.ts |
| Signed entries carry altered manifest metadata | rejects altered org, count, firstSeq, lastSeq and headHash cases |
| Redirect leaks an audit body | a real redirect never receives the audit body at its target |
| Collector ignores the deadline | the deadline aborts a real collector request before its response |
| Response buffering exposes private details | cancels an unfinished collector response without buffering it |
| Polls overlap, stop retrying or continue after shutdown | all three schedule.test.ts cases |
| Collector loses the manifest or receives the wrong body type | indexed fields and documented REST format cases in sinks.test.ts |

## Security considerations

This adds an operator configured outbound collector connection and delivery bookkeeping, using existing organization audit entries and signing keys. Remote URLs require HTTPS and cannot contain userinfo; loopback HTTP supports local collectors. Redirects are refused, requests have a thirty second deadline, and response bodies are cancelled rather than buffered or logged.

The application role receives a declaration-scoped cross tenant audit read and bookkeeping writes. Tenant and sweeper scopes clear the declaration. It is a trusted application setting, not an independent credential or protection against arbitrary SQL execution by that role. Existing grants prevent rewriting the primary log. Untrusted repositories and pull requests gain no new reach. The added test dependency is the existing MIT-licensed postgres package; runtime dependencies are local workspace packages.

The exported log is audit_entries. Global operator-only rows in admin_audit_entries are not exported; organization copies are. Webhook receivers must deduplicate by organization and sequence. Object storage remains an injected-writer API and cannot be configured through environment variables. Live Splunk and Event Hubs accounts were not exercised; their request shapes were checked against official documentation.

## Exit criteria evidence

Complete enterprise workspace suite against an isolated Postgres database, with availability required:

```text
Tests:   299
Passed:  299
Failed:    0
Skipped:   0

Database-scoped suites on a clean owned database:
Tests:   119
Passed:  119
Failed:    0
Skipped:   0

All six enterprise workspace strict typechecks and API typecheck: PASS
Final sink suite after preserving gateway headers: 25/25, zero skips
CSpell: Files checked: 109, Issues found: 0 in 0 files.
forbidden: 110 documents, 0 forbidden tokens
docsembed: 103 pages packaged
prosecheck: 999 files, 0 places where the punctuation gives it away
Go feature suite: PASS
```

Mutation controls fail when their subjects are broken and pass after restoration: typed table roster membership, late commit selection, checkpoint persistence, position SELECT policy, five manifest fields, six invalid URLs, response cancellation, scheduler stop/overlap/error reporting/retry, real HTTP redirect and abort behavior, Event Hubs body type/content/manifest property, and Splunk indexed manifest field. The abort test injects the signal and checks the configured thirty second duration.

The local database-scoped run excludes bootstrap, migration-runner and admin-pool suites because those mutate cluster-wide roles or create separate databases; CI runs the complete package in its isolated Postgres service.

The revised guide was rendered and inspected at 1440 by 1000 and 390 by 844, under light and dark preferences. The schema and delivery prose are readable with no document overflow; the site intentionally retains its light palette. The optional unused-symbol pass found no audit symbols but exited on seven existing transitive API declarations. No local full just gate or production deployment is claimed.

[CI 34440590567](https://github.com/antifailure/antifailure/actions/runs/34440590567) reports SUCCESS for dfbd8907c1ee4cdff79bf87fb7a2b2d3d3241c85. All six workflows and all nine required contexts report SUCCESS. The complete control-plane job passed 145 DB tests, 53 policy tests and 2318 API tests, with zero failures or skips. There are no unresolved review threads.

## Checklist

- [x] Commits are signed off
- [x] A changelog fragment exists
- [x] Documentation is updated
- [x] No new error code was introduced
- [x] No secret or real customer record is included
