### PR TITLE
tools: the worktree collector would have deleted commits written after a merge

### DIFF
--- a/.changes/a-worktree-gc-that-could-delete-unmerged-work.internal.md
+++ b/.changes/a-worktree-gc-that-could-delete-unmerged-work.internal.md
@@ -1,0 +1,52 @@
+# fixed
+
+The worktree collector decided a branch was disposable from two signals when it
+needed three, and the third is the only one that can see work written after a
+merge.
+
+It matched the branch NAME against GitHub's merged pull request list and checked
+that the working tree was clean. Both are true of a branch that landed. Both are
+also true of a branch that landed and then carried on, because `just merge`
+squashes: the squash is a new commit on main, the branch is left behind pointing
+at its own history, and a commit written after the merge is invisible to a name
+match. On 2026-09-11 six branches in this repository were in that state and
+three of them had clean worktrees, so the collector would have removed the
+worktree and run `git branch -D` over work that is in no other place:
+
+    w-runtime-aca                9 commits after pull request 316
+    w-detect-clouds-datastores   7 commits after pull request 308
+    w-engine-red                 1 commit  after pull request 333
+
+The third signal is now required and comes in two shapes. Either the branch has
+zero commits main cannot already reach, so deleting the ref cannot orphan a
+commit at all, or the branch tip is byte identical to the exact commit its
+merged pull request squashed, so the branch holds nothing written after it.
+Content diffing is not a substitute and is deliberately not used: a squash
+followed by further evolution of the same files on main makes even a branch
+merged hours ago report conflicts, which would have refused most of the 81
+branches that really had landed.
+
+The first run of the fixed collector against the real machine found the next
+hole. A lane that has just branched from main has no commits of its own, so the
+first shape calls it disposable, and it called seven live lanes removable, one
+of them a session that was writing files that minute. A clean tree is not an
+idle one, because a lane's handover and scratch are ignored by design and
+`git worktree remove` deletes ignored files without asking. So three more
+signals now stand between a proof and a removal: nothing ignored may be anything
+but build output, no process may be working inside the worktree, and nothing in
+it may have been written in the last day. Each worktree is judged again
+immediately before it is removed, and the branch is deleted by compare and swap
+against the tip that was proven, so a lane committing mid run fails the
+deletion rather than losing the commit.
+
+The collector also prints what it could NOT establish, by worktree and by
+missing signal, and exits nonzero when that list is not empty, because a
+collector that silently passes over a worktree it could not read looks exactly
+like one that found nothing wrong. And it writes every tip it deletes to a ref
+under `refs/worktree-gc/` first, so each deletion is reversible with one
+command.
+
+It lives in the repository now, as `tools/worktreegc`, with tests against real
+fixture repositories. It was an untracked file in one checkout, which is why a
+program that runs `git branch -D` had no history, no review and no test for as
+long as it existed.

--- a/.gitignore
+++ b/.gitignore
@@ -193,6 +193,7 @@ runner/artifacts/
 /vulncheck
 /walkthrough
 /wirecheck
+/worktreegc
 engine/af-proxy
 engine/af
 

--- a/tools/worktreegc/main.go
+++ b/tools/worktreegc/main.go
@@ -1,0 +1,1044 @@
+// Command worktreegc removes a git worktree, and deletes the branch that
+// worktree held, only when it has PROVEN that doing so orphans nothing and that
+// nobody is working there.
+//
+// Why this exists as a program rather than as advice.
+//
+// `git branch --merged` is the instrument everyone reaches for and it is wrong
+// in this repository. `just merge` squashes, so a squash merged branch is never
+// an ancestor of main and ancestry answers false for every branch that actually
+// landed. Measured on 2026-09-06: it reported 0 removable worktrees when the
+// true answer was 77 holding 28.5 GB.
+//
+// What replaced it was a NAME match against GitHub's merged pull request list,
+// crossed with a clean working tree. That is two signals and it needs three,
+// because a squash merge leaves the branch behind. A branch can have a merged
+// pull request AND carry commits written after the merge, and nothing in those
+// two signals can see them. On 2026-09-11 six branches in this repository were
+// in exactly that state, and three of them had clean worktrees, so the two
+// signal predicate called them disposable and would have run `git branch -D`
+// over work that is not in main:
+//
+//	w-runtime-aca                9 commits after pull request 316
+//	w-detect-clouds-datastores   7 commits after pull request 308
+//	w-engine-red                 1 commit after pull request 333
+//
+// The third signal is the one this program refuses to act without, and it comes
+// in two shapes. Either the branch has zero commits that main cannot already
+// reach, so deleting the ref cannot orphan a commit at all. Or the branch tip
+// is byte identical to the exact commit its merged pull request squashed, so
+// the branch holds nothing written after the merge and every commit under it is
+// in main as that squash.
+//
+// Content diffing is NOT a substitute for either shape and is deliberately not
+// used. A squash, followed by further evolution of the same files on main,
+// makes even a branch merged hours ago report conflicts against main. Diffing
+// would have refused most of the 81 branches that really were landed.
+//
+// The first run of this program against the real machine found the next hole.
+// A lane that has just branched from main has no commits of its own, so the
+// ancestry shape calls it disposable, and it called seven live lanes removable,
+// one of them a session that was writing files at that minute. A clean tree does
+// not mean an idle one: the scratch a lane keeps is ignored by design, through
+// .git/info/exclude, so `git status` cannot see it and `git worktree remove`
+// deletes it without asking. So three more signals stand between a proof and a
+// removal. No ignored file may be anything but build output, no process may be
+// working inside the worktree, and nothing in it may have been written inside
+// the idle window.
+//
+// Two other habits this program is built to break. It reports what it could NOT
+// establish, by name and by missing signal, and exits nonzero when that list is
+// not empty, because a tool that silently passes over what it could not parse
+// looks exactly like a tool that found nothing wrong. And before it deletes a
+// branch it writes the tip to a backup ref under refs/worktree-gc/, so the
+// objects stay reachable and every deletion this program makes is reversible
+// with one command.
+//
+// Dry run by default. Pass -apply to act.
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// protectedBranches are never removed whatever the signals say. `status-data`
+// is an orphan data branch that a workflow writes every five minutes and it
+// holds the status page's history, so it reads as many commits ahead of main and
+// that is correct. `hosted-loop` and `hl` belong to another session.
+var protectedBranches = map[string]bool{
+	"main":        true,
+	"status-data": true,
+	"hosted-loop": true,
+	"hl":          true,
+}
+
+// protectedPaths are worktrees belonging to another session on this machine.
+var protectedPaths = []string{
+	"/Users/vir/af-hosted-loop",
+	"/Users/vir/af-work/infra",
+}
+
+// regenerableDirs are directory names a build writes and a build can write
+// again. An ignored path under one of them is not work, and it is the bulk of
+// the disk this program exists to free. Anything else that git ignores is kept,
+// because the ignored files in a lane's worktree are exactly its handover, its
+// evidence and its scratch.
+var regenerableDirs = map[string]bool{
+	"node_modules":  true,
+	".next":         true,
+	"out":           true,
+	"dist":          true,
+	"build":         true,
+	".gate-reports": true,
+	"coverage":      true,
+	".turbo":        true,
+	"__pycache__":   true,
+}
+
+// regenerableFiles are single files a build writes at a fixed name.
+var regenerableFiles = map[string]bool{
+	"next-env.d.ts": true,
+}
+
+// backupRefPrefix holds the tip of every branch this program deletes. A ref
+// keeps the objects reachable, so `git gc` cannot collect them and any deletion
+// can be undone. It does not make the third signal optional: these refs are
+// local to one machine and somebody will eventually delete them, and a deleted
+// backup of unmerged work is the same loss one step later.
+const backupRefPrefix = "refs/worktree-gc/"
+
+// result is one external command's outcome. The exit code is carried separately
+// from err because `git merge-base --is-ancestor` answers no with exit code 1,
+// and a program that read that as a failed command would treat "this commit is
+// not an ancestor" and "git could not run" as the same fact. They are the two
+// halves of the distinction this whole program is about.
+type result struct {
+	stdout string
+	stderr string
+	code   int
+	// err is set only when the command could not be started or its exit
+	// status could not be read. A nonzero exit is not an err.
+	err error
+}
+
+type runner interface {
+	run(dir, name string, args ...string) result
+}
+
+// local runs commands for real.
+type local struct{}
+
+func (local) run(dir, name string, args ...string) result {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	var out, errBuf strings.Builder
+	cmd.Stdout, cmd.Stderr = &out, &errBuf
+	err := cmd.Run()
+	r := result{stdout: out.String(), stderr: errBuf.String()}
+	if err == nil {
+		return r
+	}
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		r.code = ee.ExitCode()
+		return r
+	}
+	// A missing binary lands here. Without this branch, no `gh` on PATH
+	// produced a crash instead of the refusal below, which is the
+	// difference between a tool that says no and a tool that falls over.
+	r.code = -1
+	r.err = fmt.Errorf("%s %s: %w", name, strings.Join(args, " "), err)
+	return r
+}
+
+// repo is a git repository reached through whatever runner it was given.
+type repo struct {
+	runner runner
+	dir    string
+}
+
+func (g repo) git(args ...string) result { return g.runner.run(g.dir, "git", args...) }
+
+func (g repo) gh(args ...string) result { return g.runner.run(g.dir, "gh", args...) }
+
+// rev resolves one revision to a full object name.
+func (g repo) rev(spec string) (string, error) {
+	r := g.git("rev-parse", "--verify", spec+"^{commit}")
+	if r.err != nil {
+		return "", r.err
+	}
+	if r.code != 0 {
+		return "", fmt.Errorf("git rev-parse %s exited %d: %s", spec, r.code, oneLine(r.stderr))
+	}
+	sha := strings.TrimSpace(r.stdout)
+	if len(sha) != 40 {
+		return "", fmt.Errorf("git rev-parse %s returned %q, which is not an object name", spec, sha)
+	}
+	return sha, nil
+}
+
+// isAncestor answers whether a is reachable from b. The three way return is the
+// point: exit 0 is yes, exit 1 is no, and anything else is a question that was
+// never answered, which this program must never read as either answer.
+func (g repo) isAncestor(a, b string) (bool, error) {
+	r := g.git("merge-base", "--is-ancestor", a, b)
+	if r.err != nil {
+		return false, r.err
+	}
+	switch r.code {
+	case 0:
+		return true, nil
+	case 1:
+		return false, nil
+	default:
+		return false, fmt.Errorf("git merge-base --is-ancestor %s %s exited %d: %s",
+			a, b, r.code, oneLine(r.stderr))
+	}
+}
+
+// countUnreachable is how many commits are reachable from tip and not from
+// mainRef. Zero means deleting the ref cannot orphan a commit.
+func (g repo) countUnreachable(tip, mainRef string) (int, error) {
+	r := g.git("rev-list", "--count", tip, "--not", mainRef)
+	if r.err != nil {
+		return 0, r.err
+	}
+	if r.code != 0 {
+		return 0, fmt.Errorf("git rev-list --count %s --not %s exited %d: %s",
+			tip, mainRef, r.code, oneLine(r.stderr))
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(r.stdout))
+	if err != nil {
+		return 0, fmt.Errorf("git rev-list --count returned %q, which is not a number",
+			strings.TrimSpace(r.stdout))
+	}
+	return n, nil
+}
+
+// pull is the part of a pull request this program reasons about. headRefOid is
+// the field that carries the whole fix: it is the exact commit GitHub squashed,
+// and comparing the branch tip against it is the third signal.
+type pull struct {
+	Number      int    `json:"number"`
+	State       string `json:"state"`
+	HeadRefName string `json:"headRefName"`
+	HeadRefOid  string `json:"headRefOid"`
+	MergeCommit *struct {
+		Oid string `json:"oid"`
+	} `json:"mergeCommit"`
+}
+
+const pullLimit = 500
+
+// mergedPulls is GitHub's own record of what landed, indexed by head ref name.
+// The second return says the list may have been truncated, which can only make
+// this program keep more than it had to, never delete more.
+func (g repo) mergedPulls() (map[string][]pull, bool, error) {
+	r := g.gh("pr", "list", "--state", "merged", "--limit", strconv.Itoa(pullLimit),
+		"--json", "number,state,headRefName,headRefOid,mergeCommit")
+	if r.err != nil {
+		return nil, false, r.err
+	}
+	if r.code != 0 {
+		return nil, false, fmt.Errorf("gh pr list exited %d: %s", r.code, oneLine(r.stderr))
+	}
+	var pulls []pull
+	if err := json.Unmarshal([]byte(strings.TrimSpace(r.stdout)), &pulls); err != nil {
+		return nil, false, fmt.Errorf("gh pr list returned something this cannot read: %w", err)
+	}
+	by := map[string][]pull{}
+	for _, p := range pulls {
+		if p.State != "MERGED" {
+			continue
+		}
+		by[p.HeadRefName] = append(by[p.HeadRefName], p)
+	}
+	for name := range by {
+		sort.Slice(by[name], func(i, j int) bool { return by[name][i].Number > by[name][j].Number })
+	}
+	return by, len(pulls) >= pullLimit, nil
+}
+
+// proc is one process and the directory it is working in.
+type proc struct {
+	pid string
+	cwd string
+}
+
+// processCwds lists every process this user can see, with its working
+// directory. A listing that does not include this program's own process is
+// refused, because lsof exits zero on a listing it could only partly read, and
+// a listing that cannot see the one process known to exist cannot be trusted to
+// see a lane's.
+func (g repo) processCwds() ([]proc, error) {
+	r := g.runner.run(g.dir, "lsof", "-a", "-d", "cwd", "-F", "pn")
+	if r.err != nil {
+		return nil, r.err
+	}
+	var procs []proc
+	var pid string
+	sawSelf := false
+	self := strconv.Itoa(os.Getpid())
+	for _, line := range strings.Split(r.stdout, "\n") {
+		switch {
+		case strings.HasPrefix(line, "p"):
+			pid = line[1:]
+			if pid == self {
+				sawSelf = true
+			}
+		case strings.HasPrefix(line, "n") && pid != "":
+			procs = append(procs, proc{pid: pid, cwd: line[1:]})
+		}
+	}
+	if !sawSelf {
+		return nil, fmt.Errorf("lsof exited %d and listed %d process(es) without this one, so its listing cannot be trusted to show a lane's: %s",
+			r.code, len(procs), oneLine(r.stderr))
+	}
+	return procs, nil
+}
+
+// worktree is one record from `git worktree list --porcelain`.
+type worktree struct {
+	path     string
+	head     string
+	branch   string // empty when detached or bare
+	detached bool
+	bare     bool
+	locked   bool
+	prunable bool
+	// malformed says the record could not be read, so this worktree is
+	// unjudged rather than judged safe.
+	malformed string
+}
+
+// parseWorktrees reads the porcelain listing strictly. Anything it cannot
+// account for becomes a malformed record rather than a silently skipped line,
+// because a worktree this program never saw and a worktree it decided to keep
+// look identical in a summary.
+func parseWorktrees(out string) []worktree {
+	var all []worktree
+	var cur *worktree
+	flush := func() {
+		if cur == nil {
+			return
+		}
+		if cur.head == "" && !cur.bare {
+			cur.malformed = "the porcelain record carried no HEAD line"
+		}
+		if !cur.bare && !cur.detached && cur.branch == "" && cur.malformed == "" {
+			cur.malformed = "the porcelain record named neither a branch nor a detached HEAD"
+		}
+		all = append(all, *cur)
+		cur = nil
+	}
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimRight(line, "\r")
+		switch {
+		case strings.HasPrefix(line, "worktree "):
+			flush()
+			cur = &worktree{path: strings.TrimPrefix(line, "worktree ")}
+		case cur == nil:
+			// A line before any worktree line, or trailing blank lines.
+			if strings.TrimSpace(line) != "" {
+				all = append(all, worktree{malformed: "a porcelain line arrived before any worktree line: " + line})
+			}
+		case strings.HasPrefix(line, "HEAD "):
+			cur.head = strings.TrimPrefix(line, "HEAD ")
+		case strings.HasPrefix(line, "branch "):
+			cur.branch = strings.TrimPrefix(strings.TrimPrefix(line, "branch "), "refs/heads/")
+		case line == "detached":
+			cur.detached = true
+		case line == "bare":
+			cur.bare = true
+		case line == "locked" || strings.HasPrefix(line, "locked "):
+			cur.locked = true
+		case line == "prunable" || strings.HasPrefix(line, "prunable "):
+			cur.prunable = true
+		case line == "":
+			flush()
+		default:
+			cur.malformed = "the porcelain record carried a line this does not understand: " + line
+		}
+	}
+	flush()
+	return all
+}
+
+// judgment is what this program concluded about one worktree, and it has three
+// shapes rather than two. removable and kept are both decisions. unproven is
+// the absence of one, and it is reported separately and fails the run.
+type judgment struct {
+	wt        worktree
+	removable bool
+	// reason is the proof when removable, and why not when kept.
+	reason string
+	// unproven names the signal that could not be established. When it is
+	// set, removable is false and reason is empty.
+	unproven string
+	// route says which shape of the third signal carried a removal, so the
+	// report can distinguish a deletion that orphans no commit object at
+	// all from one that orphans pre squash commits whose content is in main.
+	route string
+	// tip is the branch tip the proof was taken against.
+	tip string
+}
+
+// env is everything a judgment is measured against, taken once per pass so every
+// worktree in a pass is judged against the same main and the same process list.
+type env struct {
+	mainRef string
+	merged  map[string][]pull
+	// idle is how long nothing in a worktree may have been written before it
+	// can be removed. Zero switches the recency signal off.
+	idle    time.Duration
+	now     time.Time
+	procs   []proc
+	procErr error
+	self    string
+}
+
+// scan judges every worktree.
+func scan(g repo, e env) ([]judgment, error) {
+	r := g.git("worktree", "list", "--porcelain")
+	if r.err != nil {
+		return nil, r.err
+	}
+	if r.code != 0 {
+		return nil, fmt.Errorf("git worktree list exited %d: %s", r.code, oneLine(r.stderr))
+	}
+	all := parseWorktrees(r.stdout)
+	var out []judgment
+	for i, wt := range all {
+		j := judgment{wt: wt}
+		switch {
+		case wt.malformed != "":
+			j.unproven = wt.malformed
+		case i == 0:
+			// `git worktree list` always reports the main working tree
+			// first, and git refuses to remove it. Saying so beats
+			// letting the removal fail later.
+			j.reason = "this is the repository's main working tree and is never removed"
+		case wt.bare:
+			j.reason = "a bare repository holds no working tree to remove"
+		case wt.locked:
+			j.reason = "the worktree is locked, so somebody marked it as not disposable"
+		case wt.prunable:
+			j.unproven = "git reports the worktree as prunable, so its directory is gone and no working tree could be read"
+		case e.self != "" && within(wt.path, e.self):
+			j.reason = "this program is running inside that worktree"
+		case protectedPath(wt.path):
+			j.reason = "the path belongs to another session"
+		case wt.detached:
+			j = judgeDetached(g, wt, e.mainRef)
+		case protectedBranches[wt.branch]:
+			j.reason = wt.branch + " is protected and is never removed"
+		default:
+			j = judgeBranch(g, wt, e)
+		}
+		out = append(out, j)
+	}
+	return out, nil
+}
+
+// judgeDetached keeps a detached worktree and says what its HEAD holds. This
+// program only removes worktrees that hold a branch, so the ancestry is here to
+// make the reason specific rather than to license anything.
+func judgeDetached(g repo, wt worktree, mainRef string) judgment {
+	j := judgment{wt: wt}
+	n, err := g.countUnreachable(wt.head, mainRef)
+	if err != nil {
+		j.unproven = "the worktree has a detached HEAD and what it holds could not be counted: " + err.Error()
+		return j
+	}
+	if n > 0 {
+		j.reason = fmt.Sprintf("detached at %s, which holds %d commit(s) %s cannot reach and no branch names, so removing it would leave them reachable from nothing else",
+			short(wt.head), n, mainRef)
+		return j
+	}
+	j.reason = fmt.Sprintf("detached at %s, which %s already holds. This removes only worktrees that hold a branch, so it is kept",
+		short(wt.head), mainRef)
+	return j
+}
+
+// judgeBranch applies the signals in order: the directory must be readable, the
+// working tree clean, nothing ignored may be anything but build output, nobody
+// may be working there, and nothing may be orphaned.
+func judgeBranch(g repo, wt worktree, e env) judgment {
+	j := judgment{wt: wt}
+
+	if _, err := os.Stat(wt.path); err != nil {
+		j.unproven = "the worktree directory could not be read, so nothing about its working tree was established: " + err.Error()
+		return j
+	}
+
+	// No optional locks, so the scan never rewrites a lane's index. That
+	// matters twice: a live lane's index is its to write, and an index this
+	// program touched would make every worktree look recently used.
+	st := g.runner.run(wt.path, "git", "--no-optional-locks", "status", "--porcelain", "--ignored=matching")
+	if st.err != nil {
+		j.unproven = "git status could not run in the worktree, so whether it holds uncommitted work is unknown: " + st.err.Error()
+		return j
+	}
+	if st.code != 0 {
+		j.unproven = fmt.Sprintf("git status exited %d in the worktree, so whether it holds uncommitted work is unknown: %s",
+			st.code, oneLine(st.stderr))
+		return j
+	}
+	var dirty, ignored []string
+	for _, line := range strings.Split(strings.TrimRight(st.stdout, "\n"), "\n") {
+		switch {
+		case line == "":
+		case strings.HasPrefix(line, "!! "):
+			ignored = append(ignored, strings.TrimPrefix(line, "!! "))
+		default:
+			dirty = append(dirty, line)
+		}
+	}
+	if len(dirty) > 0 {
+		j.reason = fmt.Sprintf("UNCOMMITTED CHANGES in %d path(s), somebody's work in progress", len(dirty))
+		return j
+	}
+	if work := notBuildOutput(ignored); len(work) > 0 {
+		j.reason = fmt.Sprintf("%d ignored path(s) that no build writes would be deleted with the worktree, and a lane's scratch and handover are ignored by design: %s",
+			len(work), strings.Join(firstN(work, 4), ", "))
+		return j
+	}
+
+	if e.procErr != nil {
+		j.unproven = "whether a process is working in it could not be established: " + e.procErr.Error()
+		return j
+	}
+	for _, p := range e.procs {
+		if within(wt.path, p.cwd) {
+			j.reason = fmt.Sprintf("process %s is working in it, at %s", p.pid, p.cwd)
+			return j
+		}
+	}
+
+	if e.idle > 0 {
+		newest, name, err := newestWrite(wt.path)
+		if err != nil {
+			j.unproven = "when anything in it was last written could not be read: " + err.Error()
+			return j
+		}
+		if age := e.now.Sub(newest); age < e.idle {
+			j.reason = fmt.Sprintf("%s was written %s ago, inside the %s idle window, so a lane may be working here",
+				name, age.Round(time.Minute), e.idle)
+			return j
+		}
+	}
+
+	tip, err := g.rev(wt.branch)
+	if err != nil {
+		j.unproven = "the branch tip could not be resolved, so nothing about what it holds was established: " + err.Error()
+		return j
+	}
+	j.tip = tip
+
+	proof, route, refusal, err := proveNothingOrphaned(g, wt.branch, tip, e.mainRef, e.merged)
+	if err != nil {
+		j.unproven = err.Error()
+		return j
+	}
+	if refusal != "" {
+		j.reason = refusal
+		return j
+	}
+	j.removable, j.reason, j.route = true, proof, route
+	return j
+}
+
+// notBuildOutput filters an ignored listing down to what a build could not
+// write again.
+func notBuildOutput(ignored []string) []string {
+	var work []string
+	for _, p := range ignored {
+		clean := strings.TrimSuffix(p, "/")
+		regen := regenerableFiles[filepath.Base(clean)]
+		for _, seg := range strings.Split(clean, "/") {
+			if regenerableDirs[seg] {
+				regen = true
+			}
+		}
+		if !regen {
+			work = append(work, p)
+		}
+	}
+	return work
+}
+
+// newestWrite finds the most recently modified file in a worktree, skipping the
+// .git link and dependency trees, whose times say when an install ran rather
+// than when somebody worked.
+func newestWrite(root string) (time.Time, string, error) {
+	var newest time.Time
+	var name string
+	err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if p == root {
+				return err
+			}
+			return nil
+		}
+		if d.Name() == ".git" || d.Name() == "node_modules" {
+			if d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		info, ierr := d.Info()
+		if ierr != nil {
+			return nil
+		}
+		if info.ModTime().After(newest) {
+			newest = info.ModTime()
+			name = p
+		}
+		return nil
+	})
+	if err != nil {
+		return time.Time{}, "", err
+	}
+	if rel, rerr := filepath.Rel(root, name); rerr == nil {
+		name = rel
+	}
+	return newest, name, nil
+}
+
+// proveNothingOrphaned is the third signal, and the reason this file exists.
+//
+// It returns a proof and a route when it holds, a refusal when it provably does
+// not, and an error when it could not be established either way. Those are
+// three different facts and collapsing any two of them is how the previous
+// predicate came to delete unmerged work.
+func proveNothingOrphaned(g repo, branch, tip, mainRef string, merged map[string][]pull) (proof, route, refusal string, err error) {
+	unreachable, err := g.countUnreachable(tip, mainRef)
+	if err != nil {
+		return "", "", "", fmt.Errorf("the count of commits this branch holds and %s does not could not be taken, so nothing was established: %w", mainRef, err)
+	}
+	if unreachable == 0 {
+		// Redundant with the count, and kept because the two answers
+		// disagreeing would mean one of them is wrong and this program
+		// must not pick a side silently.
+		anc, aerr := g.isAncestor(tip, mainRef)
+		if aerr != nil {
+			return "", "", "", fmt.Errorf("ancestry against %s could not be read, so nothing was established: %w", mainRef, aerr)
+		}
+		if !anc {
+			return "", "", "", fmt.Errorf("git reports zero commits on this branch that %s cannot reach, and also reports the tip is not an ancestor of %s. Those cannot both be true, so nothing is established", mainRef, mainRef)
+		}
+		return fmt.Sprintf("zero commits are reachable from this branch and not from %s, and the tip %s is an ancestor of it, so deleting the ref cannot orphan a commit",
+			mainRef, short(tip)), "no distinct commits", "", nil
+	}
+
+	candidates := merged[branch]
+	if len(candidates) == 0 {
+		return "", "", fmt.Sprintf("%d commit(s) here are not reachable from %s and GitHub reports no merged pull request from this branch, so they are in no other place",
+			unreachable, mainRef), nil
+	}
+
+	var tried []string
+	for _, p := range candidates {
+		if p.MergeCommit == nil || p.MergeCommit.Oid == "" {
+			tried = append(tried, fmt.Sprintf("pull request %d is merged but GitHub named no merge commit for it", p.Number))
+			continue
+		}
+		anc, aerr := g.isAncestor(p.MergeCommit.Oid, mainRef)
+		if aerr != nil {
+			return "", "", "", fmt.Errorf("whether pull request %d's merge commit %s is in %s could not be read, so nothing was established: %w",
+				p.Number, short(p.MergeCommit.Oid), mainRef, aerr)
+		}
+		if !anc {
+			tried = append(tried, fmt.Sprintf("pull request %d's merge commit %s is not an ancestor of %s, so it did not land here",
+				p.Number, short(p.MergeCommit.Oid), mainRef))
+			continue
+		}
+		if len(p.HeadRefOid) != 40 {
+			return "", "", "", fmt.Errorf("pull request %d's head object name is %q, which is not an object name, so the tip could not be compared against it",
+				p.Number, p.HeadRefOid)
+		}
+		if p.HeadRefOid != tip {
+			// The measured defect. The pull request merged, its squash
+			// is in main, and the branch carries commits written after
+			// it. Count them so the refusal says how much would have
+			// been lost.
+			after, cerr := g.countUnreachable(tip, p.HeadRefOid)
+			if cerr != nil {
+				return "", "", "", fmt.Errorf("pull request %d merged %s and this branch is at %s, and how far ahead it is could not be counted, so nothing was established: %w",
+					p.Number, short(p.HeadRefOid), short(tip), cerr)
+			}
+			tried = append(tried, fmt.Sprintf("pull request %d squashed %s but the branch is at %s, which is %d commit(s) later, so the branch holds work written after the merge",
+				p.Number, short(p.HeadRefOid), short(tip), after))
+			continue
+		}
+		return fmt.Sprintf("pull request %d is merged, its merge commit %s is an ancestor of %s, and the branch tip %s is the exact commit it squashed, so the branch holds nothing written after the merge",
+			p.Number, short(p.MergeCommit.Oid), mainRef, short(tip)), "squashed by a merged pull request", "", nil
+	}
+	return "", "", fmt.Sprintf("%d commit(s) here are not reachable from %s and no merged pull request accounts for them: %s",
+		unreachable, mainRef, strings.Join(tried, "; ")), nil
+}
+
+// apply removes the worktrees and deletes the branches that were proven
+// disposable. The scan and the removal are two events, and five lanes work on
+// this machine at once, so every worktree is judged AGAIN immediately before it
+// is touched, against a fresh process list and a fresh clock. A worktree that
+// stopped being disposable in between is a refusal, not a race this program
+// wins. The branch is then deleted by compare and swap against the tip that was
+// proven, so a commit landing in the last millisecond fails the deletion rather
+// than being deleted with it.
+func apply(g repo, js []judgment, e env, out io.Writer) (removed int, refused int) {
+	for _, j := range js {
+		if !j.removable {
+			continue
+		}
+		again := judgeBranch(g, j.wt, e)
+		if again.unproven != "" {
+			_, _ = fmt.Fprintf(out, "  kept %s: a signal could not be re-established just before removing it: %s\n", j.wt.path, again.unproven)
+			refused++
+			continue
+		}
+		if !again.removable {
+			_, _ = fmt.Fprintf(out, "  kept %s: it stopped being disposable between the scan and now: %s\n", j.wt.path, again.reason)
+			refused++
+			continue
+		}
+		tip := again.tip
+
+		// The backup ref first, so nothing is unreachable at any moment.
+		ref := backupRefPrefix + j.wt.branch
+		if r := g.git("update-ref", ref, tip); r.err != nil || r.code != 0 {
+			_, _ = fmt.Fprintf(out, "  kept %s: the backup ref %s could not be written, so the deletion would not be reversible: %s\n",
+				j.wt.path, ref, firstNonEmpty(errText(r.err), oneLine(r.stderr), "git update-ref exited "+strconv.Itoa(r.code)))
+			refused++
+			continue
+		}
+		if got, err := g.rev(ref); err != nil || got != tip {
+			_, _ = fmt.Fprintf(out, "  kept %s: the backup ref %s does not read back as %s, so the deletion would not be reversible\n",
+				j.wt.path, ref, short(tip))
+			refused++
+			continue
+		}
+
+		if r := g.git("worktree", "remove", j.wt.path); r.err != nil || r.code != 0 {
+			_, _ = fmt.Fprintf(out, "  kept %s: %s\n", j.wt.path,
+				firstNonEmpty(errText(r.err), oneLine(r.stderr), "git worktree remove exited "+strconv.Itoa(r.code)))
+			refused++
+			continue
+		}
+		if r := g.git("update-ref", "-d", "refs/heads/"+j.wt.branch, tip); r.err != nil || r.code != 0 {
+			_, _ = fmt.Fprintf(out, "  removed %s but kept the branch %s, which is no longer at the proven tip %s: %s\n",
+				j.wt.path, j.wt.branch, short(tip),
+				firstNonEmpty(errText(r.err), oneLine(r.stderr), "git update-ref -d exited "+strconv.Itoa(r.code)))
+			refused++
+			continue
+		}
+		// What `git branch -D` would also have removed. Absent for most
+		// branches, and its absence is not a failure.
+		g.git("config", "--remove-section", "branch."+j.wt.branch)
+		_, _ = fmt.Fprintf(out, "  removed %s and deleted %s (was %s, kept at %s)\n",
+			j.wt.path, j.wt.branch, short(tip), ref)
+		removed++
+	}
+	g.git("worktree", "prune")
+	return removed, refused
+}
+
+func report(js []judgment, truncated bool, e env, mainSha string, branchesWithoutWorktree []string, out io.Writer) {
+	var removable, kept, unproven []judgment
+	for _, j := range js {
+		switch {
+		case j.unproven != "":
+			unproven = append(unproven, j)
+		case j.removable:
+			removable = append(removable, j)
+		default:
+			kept = append(kept, j)
+		}
+	}
+
+	_, _ = fmt.Fprintf(out, "%s is %s\n", e.mainRef, mainSha)
+	_, _ = fmt.Fprintf(out, "%d removable, %d kept, %d NOT CHECKED\n\n", len(removable), len(kept), len(unproven))
+
+	var freed float64
+	if len(removable) > 0 {
+		_, _ = fmt.Fprintln(out, "REMOVABLE, proven to orphan nothing and to be idle")
+		for _, j := range removable {
+			gb := sizeGB(j.wt.path)
+			freed += gb
+			_, _ = fmt.Fprintf(out, "  %6.2f GB  %s  [%s]\n", gb, j.wt.path, j.wt.branch)
+			_, _ = fmt.Fprintf(out, "            %s: %s\n", j.route, j.reason)
+		}
+		_, _ = fmt.Fprintf(out, "\n  %.1f GB total\n\n", freed)
+	}
+
+	if len(kept) > 0 {
+		_, _ = fmt.Fprintln(out, "KEPT, a signal says no")
+		for _, j := range kept {
+			_, _ = fmt.Fprintf(out, "  %s  [%s]\n            %s\n", j.wt.path, nameOr(j.wt.branch, "detached"), j.reason)
+		}
+		_, _ = fmt.Fprintln(out)
+	}
+
+	// The section that exists because a tool which passes over what it could
+	// not read looks exactly like a tool that found nothing wrong.
+	_, _ = fmt.Fprintln(out, "NOT CHECKED, a signal could not be established")
+	if len(unproven) == 0 {
+		_, _ = fmt.Fprintln(out, "  nothing. Every worktree above was judged on established signals.")
+	}
+	for _, j := range unproven {
+		_, _ = fmt.Fprintf(out, "  %s  [%s]\n            %s\n", j.wt.path, nameOr(j.wt.branch, "detached"), j.unproven)
+	}
+	_, _ = fmt.Fprintln(out)
+
+	_, _ = fmt.Fprintln(out, "OUT OF SCOPE, stated rather than left to be assumed")
+	_, _ = fmt.Fprintf(out, "  %d local branch(es) have no worktree. This command removes worktrees and the\n", len(branchesWithoutWorktree))
+	_, _ = fmt.Fprintln(out, "  branches they held, so a branch with no worktree is never judged and never")
+	_, _ = fmt.Fprintln(out, "  deleted here, however landed it is.")
+	if len(branchesWithoutWorktree) > 0 {
+		_, _ = fmt.Fprintf(out, "  %s\n", strings.Join(branchesWithoutWorktree, " "))
+	}
+	names := make([]string, 0, len(regenerableDirs))
+	for n := range regenerableDirs {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	_, _ = fmt.Fprintf(out, "  Ignored files under %s are treated as build output and are\n", strings.Join(names, ", "))
+	_, _ = fmt.Fprintln(out, "  deleted with a worktree without being counted as work.")
+	_, _ = fmt.Fprintln(out, "  Processes are read with lsof as this user, so another user's process working in")
+	_, _ = fmt.Fprintln(out, "  a worktree is not seen.")
+	if e.idle > 0 {
+		_, _ = fmt.Fprintf(out, "  A worktree with any file written in the last %s is kept as possibly in use.\n", e.idle)
+	} else {
+		_, _ = fmt.Fprintln(out, "  The recency signal was switched off with -idle 0, so a lane that is working without")
+		_, _ = fmt.Fprintln(out, "  a process inside its worktree and without ignored scratch would not be seen.")
+	}
+	if truncated {
+		_, _ = fmt.Fprintf(out, "  gh returned the full %d pull requests it was asked for, so the merged list may\n", pullLimit)
+		_, _ = fmt.Fprintln(out, "  be truncated. That can only make this keep a branch it could have removed.")
+	}
+	_, _ = fmt.Fprintln(out)
+}
+
+// branchesWithoutWorktrees is the out of scope list the report prints.
+func branchesWithoutWorktrees(g repo, js []judgment) ([]string, error) {
+	r := g.git("for-each-ref", "--format=%(refname:short)", "refs/heads")
+	if r.err != nil {
+		return nil, r.err
+	}
+	if r.code != 0 {
+		return nil, fmt.Errorf("git for-each-ref exited %d: %s", r.code, oneLine(r.stderr))
+	}
+	held := map[string]bool{}
+	for _, j := range js {
+		if j.wt.branch != "" {
+			held[j.wt.branch] = true
+		}
+	}
+	var out []string
+	for _, line := range strings.Split(strings.TrimSpace(r.stdout), "\n") {
+		name := strings.TrimSpace(line)
+		if name == "" || held[name] {
+			continue
+		}
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// options are what the command line decides.
+type options struct {
+	mainRef string
+	fetch   bool
+	act     bool
+	idle    time.Duration
+}
+
+func run(g repo, o options, out io.Writer) int {
+	if o.fetch {
+		// A stale main can only make this program keep a branch it could
+		// have removed, so the fetch is not what makes it safe. It blocks
+		// -apply anyway, because the report names one exact object name as
+		// the main every proof was measured against, and a failed fetch
+		// means that name may not be main.
+		r := g.git("fetch", "origin", "--quiet")
+		if r.err != nil || r.code != 0 {
+			_, _ = fmt.Fprintf(out, "git fetch origin failed: %s\n",
+				firstNonEmpty(errText(r.err), oneLine(r.stderr), "exit "+strconv.Itoa(r.code)))
+			_, _ = fmt.Fprintf(out, "So %s may not be main, and every proof below would name an object that is not it.\n", o.mainRef)
+			if o.act {
+				_, _ = fmt.Fprintln(out, "Refusing to remove anything. Pass -no-fetch to measure against the "+o.mainRef+" already on disk.")
+				return 1
+			}
+		}
+	}
+
+	mainSha, err := g.rev(o.mainRef)
+	if err != nil {
+		_, _ = fmt.Fprintf(out, "%s could not be resolved, so nothing can be judged safe. Refusing rather than guessing.\n%v\n", o.mainRef, err)
+		return 1
+	}
+
+	merged, truncated, err := g.mergedPulls()
+	if err != nil {
+		_, _ = fmt.Fprintf(out, "gh could not list merged pull requests, so nothing can be judged safe. Refusing rather than guessing.\n%v\n", err)
+		return 1
+	}
+
+	e := env{mainRef: o.mainRef, merged: merged, idle: o.idle, now: time.Now()}
+	e.self, _ = os.Getwd()
+	e.procs, e.procErr = g.processCwds()
+
+	js, err := scan(g, e)
+	if err != nil {
+		_, _ = fmt.Fprintf(out, "the worktree list could not be read, so nothing can be judged safe. Refusing rather than guessing.\n%v\n", err)
+		return 1
+	}
+
+	loose, err := branchesWithoutWorktrees(g, js)
+	if err != nil {
+		_, _ = fmt.Fprintf(out, "the branch list could not be read, so what is out of scope could not be stated.\n%v\n", err)
+		return 1
+	}
+
+	report(js, truncated, e, mainSha, loose, out)
+
+	unproven := 0
+	for _, j := range js {
+		if j.unproven != "" {
+			unproven++
+		}
+	}
+
+	if !o.act {
+		_, _ = fmt.Fprintln(out, "Dry run. Nothing was removed. Pass -apply to act.")
+		if unproven > 0 {
+			return 1
+		}
+		return 0
+	}
+
+	// Fresh for the second judgment, which is the point of taking it.
+	e.now = time.Now()
+	e.procs, e.procErr = g.processCwds()
+	removed, refused := apply(g, js, e, out)
+	_, _ = fmt.Fprintf(out, "\nDone. %d removed, %d refused at the last moment.\n", removed, refused)
+	if removed > 0 {
+		_, _ = fmt.Fprintf(out, "Every deleted tip is at %s<branch>. Restore one with\n", backupRefPrefix)
+		_, _ = fmt.Fprintf(out, "  git branch <name> %s<name>\n", backupRefPrefix)
+		_, _ = fmt.Fprintf(out, "and list them with `git for-each-ref %s`.\n", backupRefPrefix)
+	}
+	if unproven > 0 || refused > 0 {
+		return 1
+	}
+	return 0
+}
+
+func main() {
+	dir := flag.String("C", ".", "the repository to work in")
+	mainRef := flag.String("main", "origin/main", "the revision landed work must be reachable from")
+	act := flag.Bool("apply", false, "actually remove. Without it this only reports.")
+	noFetch := flag.Bool("no-fetch", false, "do not fetch origin first")
+	idle := flag.Duration("idle", 24*time.Hour, "keep a worktree with any file written this recently. 0 switches the signal off.")
+	flag.Parse()
+
+	abs, err := filepath.Abs(*dir)
+	if err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	os.Exit(run(repo{runner: local{}, dir: abs},
+		options{mainRef: *mainRef, fetch: !*noFetch, act: *act, idle: *idle}, os.Stdout))
+}
+
+func short(sha string) string {
+	if len(sha) > 9 {
+		return sha[:9]
+	}
+	return sha
+}
+
+func oneLine(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+func errText(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func firstN(s []string, n int) []string {
+	if len(s) > n {
+		return append(append([]string{}, s[:n]...), fmt.Sprintf("and %d more", len(s)-n))
+	}
+	return s
+}
+
+func nameOr(s, fallback string) string {
+	if s == "" {
+		return fallback
+	}
+	return s
+}
+
+func protectedPath(path string) bool {
+	for _, p := range protectedPaths {
+		if within(p, path) {
+			return true
+		}
+	}
+	return false
+}
+
+// within answers whether path is prefix or lies under it, on path boundaries, so
+// /Users/vir/af-work/infra does not also protect /Users/vir/af-work/infrastructure.
+func within(prefix, path string) bool {
+	prefix = filepath.Clean(prefix)
+	path = filepath.Clean(path)
+	if path == prefix {
+		return true
+	}
+	return strings.HasPrefix(path, prefix+string(filepath.Separator))
+}
+
+func sizeGB(path string) float64 {
+	var total int64
+	// The error is dropped on purpose: a size this could not finish measuring is
+	// a smaller number in a report, and never a reason to keep or remove anything.
+	_ = filepath.WalkDir(path, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if info, ierr := d.Info(); ierr == nil && !info.IsDir() {
+			total += info.Size()
+		}
+		return nil
+	})
+	return float64(total) / 1e9
+}

--- a/tools/worktreegc/main_test.go
+++ b/tools/worktreegc/main_test.go
@@ -1,0 +1,973 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Every test in this file runs the real decision path against a REAL git
+// repository built in a temporary directory. Only `gh` is replaced, because
+// GitHub's merged pull request list is the one signal that cannot be
+// constructed locally. Ancestry, the commit counts, the worktree listing, the
+// status of each working tree, the branch deletion and the backup ref are all
+// done by git, so a test that says a branch survived means git still holds it.
+//
+// Nothing here asserts that the source contains a word. The structural shape of
+// this program is not what went wrong: the previous predicate read correctly and
+// was missing a signal, and only a run against a branch in that exact state can
+// tell the difference.
+
+// fakeGH answers `gh` and hands everything else to the real git.
+type fakeGH struct {
+	inner      local
+	pulls      string
+	ghCode     int
+	ghErr      error
+	fetchFails bool
+	// lsof is the process listing to hand back. Empty means a listing that
+	// holds only this test process, working in the package directory, which
+	// is what a machine with no lane working in any fixture looks like.
+	lsof    string
+	lsofErr error
+	calls   []string
+}
+
+func (f *fakeGH) run(dir, name string, args ...string) result {
+	f.calls = append(f.calls, name+" "+strings.Join(args, " "))
+	if name == "gh" {
+		return result{stdout: f.pulls, code: f.ghCode, err: f.ghErr, stderr: "gh was told to fail"}
+	}
+	if name == "lsof" {
+		if f.lsofErr != nil {
+			return result{code: -1, err: f.lsofErr}
+		}
+		if f.lsof == "" {
+			wd, _ := os.Getwd()
+			return result{stdout: "p" + strconv.Itoa(os.Getpid()) + "\nfcwd\nn" + wd + "\n"}
+		}
+		return result{stdout: f.lsof}
+	}
+	if f.fetchFails && len(args) > 0 && args[0] == "fetch" {
+		return result{code: 128, stderr: "could not read from remote repository"}
+	}
+	return f.inner.run(dir, name, args...)
+}
+
+// did answers whether any command matching every one of these fragments was run.
+func (f *fakeGH) did(fragments ...string) bool {
+	for _, c := range f.calls {
+		all := true
+		for _, frag := range fragments {
+			if !strings.Contains(c, frag) {
+				all = false
+			}
+		}
+		if all {
+			return true
+		}
+	}
+	return false
+}
+
+type fixture struct {
+	t      *testing.T
+	dir    string
+	origin string
+	gh     *fakeGH
+	repo   repo
+}
+
+func newFixture(t *testing.T) *fixture {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is not on PATH, so nothing here could be established")
+	}
+	root := t.TempDir()
+	f := &fixture{
+		t:      t,
+		dir:    filepath.Join(root, "work"),
+		origin: filepath.Join(root, "origin.git"),
+		gh:     &fakeGH{pulls: "[]"},
+	}
+	f.repo = repo{runner: f.gh, dir: f.dir}
+
+	f.run(root, "git", "init", "--quiet", "--bare", "-b", "main", f.origin)
+	f.run(root, "git", "init", "--quiet", "-b", "main", f.dir)
+	f.git("config", "user.email", "lane@example.invalid")
+	f.git("config", "user.name", "Lane")
+	f.git("config", "commit.gpgsign", "false")
+	// The repository's own hooks add a sign-off and check the author address.
+	// A fixture has neither, and inheriting a hooks path from an outer clone
+	// would make these tests depend on it.
+	f.git("config", "core.hooksPath", filepath.Join(root, "no-hooks"))
+	f.git("remote", "add", "origin", f.origin)
+	f.write("base.txt", "base\n")
+	f.git("add", "-A")
+	f.git("commit", "--quiet", "-m", "base")
+	f.git("push", "--quiet", "origin", "main")
+	f.git("fetch", "--quiet", "origin")
+	return f
+}
+
+func (f *fixture) run(dir, name string, args ...string) string {
+	f.t.Helper()
+	r := local{}.run(dir, name, args...)
+	if r.err != nil || r.code != 0 {
+		f.t.Fatalf("%s %s in %s: code %d err %v: %s", name, strings.Join(args, " "), dir, r.code, r.err, r.stderr)
+	}
+	return strings.TrimSpace(r.stdout)
+}
+
+func (f *fixture) git(args ...string) string {
+	f.t.Helper()
+	return f.run(f.dir, "git", args...)
+}
+
+func (f *fixture) write(rel, body string) {
+	f.t.Helper()
+	p := filepath.Join(f.dir, rel)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		f.t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		f.t.Fatal(err)
+	}
+}
+
+// commitOn adds one commit to a branch, creating it from main if needed, and
+// returns the new tip.
+func (f *fixture) commitOn(branch, rel, body, subject string) string {
+	f.t.Helper()
+	if !f.hasBranch(branch) {
+		f.git("branch", branch, "main")
+	}
+	// Written through a temporary worktree so the main working tree stays on
+	// main and stays clean, which is what the real repository looks like.
+	tmp := filepath.Join(f.t.TempDir(), "edit-"+strings.ReplaceAll(branch, "/", "-"))
+	f.git("worktree", "add", "--quiet", tmp, branch)
+	p := filepath.Join(tmp, rel)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		f.t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		f.t.Fatal(err)
+	}
+	f.run(tmp, "git", "add", "-A")
+	f.run(tmp, "git", "commit", "--quiet", "-m", subject)
+	tip := f.run(tmp, "git", "rev-parse", "HEAD")
+	f.git("worktree", "remove", "--force", tmp)
+	return tip
+}
+
+func (f *fixture) hasBranch(name string) bool {
+	f.t.Helper()
+	return local{}.run(f.dir, "git", "rev-parse", "--verify", "refs/heads/"+name).code == 0
+}
+
+func (f *fixture) sha(rev string) string {
+	f.t.Helper()
+	return f.git("rev-parse", rev)
+}
+
+// squashOntoMain writes one commit on main carrying the branch's content, which
+// is what `just merge` leaves behind, and pushes it. It returns the squash
+// commit, which is the pull request's merge commit.
+func (f *fixture) squashOntoMain(branch, subject string) string {
+	f.t.Helper()
+	f.git("merge", "--quiet", "--squash", branch)
+	f.git("commit", "--quiet", "-m", subject)
+	f.git("push", "--quiet", "origin", "main")
+	f.git("fetch", "--quiet", "origin")
+	return f.sha("main")
+}
+
+// addWorktree checks a branch out into its own directory and returns the path.
+func (f *fixture) addWorktree(name, branch string) string {
+	f.t.Helper()
+	p := filepath.Join(f.t.TempDir(), name)
+	f.git("worktree", "add", "--quiet", p, branch)
+	return p
+}
+
+// setPulls hands the fake the JSON `gh` really returns, so the decoder under
+// test is the production one.
+func (f *fixture) setPulls(ps ...pull) {
+	f.t.Helper()
+	body, err := json.Marshal(ps)
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	f.gh.pulls = string(body)
+}
+
+func mergedPull(number int, branch, headOid, mergeOid string) pull {
+	p := pull{Number: number, State: "MERGED", HeadRefName: branch, HeadRefOid: headOid}
+	p.MergeCommit = &struct {
+		Oid string `json:"oid"`
+	}{Oid: mergeOid}
+	return p
+}
+
+// act runs the command and returns its exit code and everything it printed. The
+// recency signal is off here, because every fixture file was written a second
+// ago and the signal would keep everything; the two tests that are about it
+// switch it on.
+func (f *fixture) act(apply bool) (int, string) {
+	f.t.Helper()
+	return f.actWith(options{mainRef: "origin/main", act: apply})
+}
+
+func (f *fixture) actWith(o options) (int, string) {
+	f.t.Helper()
+	var out bytes.Buffer
+	code := run(f.repo, o, &out)
+	return code, out.String()
+}
+
+// exclude adds a pattern to the repository's own exclude file, which is where
+// this repository's lanes keep their handover and scratch out of git.
+func (f *fixture) exclude(pattern string) {
+	f.t.Helper()
+	p := filepath.Join(f.dir, ".git", "info", "exclude")
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		f.t.Fatal(err)
+	}
+	fh, err := os.OpenFile(p, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	defer fh.Close()
+	if _, err := fh.WriteString(pattern + "\n"); err != nil {
+		f.t.Fatal(err)
+	}
+}
+
+// section returns one labelled block of the report, so a test can say a path was
+// named as NOT CHECKED rather than merely mentioned somewhere.
+//
+// Headers are matched at the start of a line and followed by a comma, because
+// the summary line above them carries the same words ("1 NOT CHECKED") and the
+// first version of this helper read the summary as the section.
+func section(report, label string) string {
+	i := strings.Index("\n"+report, "\n"+label+",")
+	if i < 0 {
+		return ""
+	}
+	rest := report[i+len(label):]
+	for _, next := range []string{"\nREMOVABLE,", "\nKEPT,", "\nNOT CHECKED,", "\nOUT OF SCOPE,", "\nDry run", "\nDone."} {
+		if j := strings.Index(rest, next); j >= 0 {
+			rest = rest[:j]
+		}
+	}
+	return rest
+}
+
+func (f *fixture) assertBranch(branch string, want bool) {
+	f.t.Helper()
+	if got := f.hasBranch(branch); got != want {
+		if want {
+			f.t.Fatalf("the branch %s was deleted and it holds work that is not in main", branch)
+		}
+		f.t.Fatalf("the branch %s still exists and it was proven disposable", branch)
+	}
+}
+
+func (f *fixture) assertDir(path string, want bool) {
+	f.t.Helper()
+	_, err := os.Stat(path)
+	if (err == nil) != want {
+		if want {
+			f.t.Fatalf("the worktree %s was removed", path)
+		}
+		f.t.Fatalf("the worktree %s still exists", path)
+	}
+}
+
+// landedBranch is the ordinary case: a branch whose pull request squashed and
+// which carries nothing after the merge. It returns the branch name, its
+// worktree path and the pull request GitHub would report.
+func (f *fixture) landedBranch(branch, dirName string) (string, pull) {
+	f.t.Helper()
+	f.commitOn(branch, branch+"/one.txt", "one\n", "first")
+	tip := f.commitOn(branch, branch+"/two.txt", "two\n", "second")
+	squash := f.squashOntoMain(branch, "landed "+branch)
+	f.addWorktree(dirName, branch)
+	return tip, mergedPull(300, branch, tip, squash)
+}
+
+// ---------------------------------------------------------------------------
+// The defect this program exists for.
+// ---------------------------------------------------------------------------
+
+// TestABranchWithCommitsAfterItsMergedPullRequestIsRefused is the exact case
+// that produced this file. On 2026-09-11 w-runtime-aca, w-detect-clouds-datastores
+// and w-engine-red were each in this state with a clean worktree, so a predicate
+// made of a merged pull request plus a clean tree called them disposable.
+func TestABranchWithCommitsAfterItsMergedPullRequestIsRefused(t *testing.T) {
+	f := newFixture(t)
+	f.commitOn("w-runtime-aca", "aca/one.txt", "one\n", "first")
+	merged := f.commitOn("w-runtime-aca", "aca/two.txt", "two\n", "second")
+	squash := f.squashOntoMain("w-runtime-aca", "runtime aca (#316)")
+	// The nine commits w-runtime-aca really carried, one is enough to prove it.
+	after := f.commitOn("w-runtime-aca", "aca/three.txt", "three\n", "work after the merge")
+	if after == merged {
+		t.Fatal("the fixture did not advance the branch, so it proves nothing")
+	}
+	wt := f.addWorktree("aca", "w-runtime-aca")
+	f.setPulls(mergedPull(316, "w-runtime-aca", merged, squash))
+
+	code, report := f.act(true)
+
+	f.assertBranch("w-runtime-aca", true)
+	f.assertDir(wt, true)
+	if code != 0 {
+		t.Logf("exit %d, which is fine here: the refusal is the point", code)
+	}
+	if !strings.Contains(section(report, "KEPT"), wt) {
+		t.Fatalf("the worktree was not reported as kept:\n%s", report)
+	}
+	if !strings.Contains(report, "written after the merge") {
+		t.Fatalf("the refusal does not say why:\n%s", report)
+	}
+	if strings.Contains(section(report, "REMOVABLE"), wt) {
+		t.Fatalf("the worktree was called removable:\n%s", report)
+	}
+}
+
+// TestABranchIdenticalToTheCommitItsPullRequestSquashedIsRemoved is the other
+// half. The signal has to be able to say yes, or the tool is useless and the
+// next person reaches for `git branch -D` by hand, which is what this replaces.
+func TestABranchIdenticalToTheCommitItsPullRequestSquashedIsRemoved(t *testing.T) {
+	f := newFixture(t)
+	f.commitOn("w-landed", "landed/one.txt", "one\n", "first")
+	tip := f.commitOn("w-landed", "landed/two.txt", "two\n", "second")
+	squash := f.squashOntoMain("w-landed", "landed (#300)")
+	wt := f.addWorktree("landed", "w-landed")
+	f.setPulls(mergedPull(300, "w-landed", tip, squash))
+
+	// The branch really does hold commits main cannot reach, which is what
+	// makes this route distinct from the ancestry one.
+	if n, err := f.repo.countUnreachable(tip, "origin/main"); err != nil || n == 0 {
+		t.Fatalf("the fixture is not a squash merge: %d unreachable, %v", n, err)
+	}
+
+	code, report := f.act(true)
+
+	f.assertBranch("w-landed", false)
+	f.assertDir(wt, false)
+	if code != 0 {
+		t.Fatalf("exit %d on a clean removal:\n%s", code, report)
+	}
+	if !strings.Contains(report, "the exact commit it squashed") {
+		t.Fatalf("the proof does not name the third signal:\n%s", report)
+	}
+}
+
+// TestABranchWithNoCommitsMainCannotReachIsRemoved is the second shape of the
+// third signal, and the only one where deleting the ref orphans no object at all.
+func TestABranchWithNoCommitsMainCannotReachIsRemoved(t *testing.T) {
+	f := newFixture(t)
+	f.git("branch", "w-rebased", "origin/main")
+	wt := f.addWorktree("rebased", "w-rebased")
+	// No pull request at all. The ancestry route does not need one.
+	f.setPulls()
+
+	code, report := f.act(true)
+
+	f.assertBranch("w-rebased", false)
+	f.assertDir(wt, false)
+	if code != 0 {
+		t.Fatalf("exit %d on a clean removal:\n%s", code, report)
+	}
+	if !strings.Contains(report, "cannot orphan a commit") {
+		t.Fatalf("the proof does not name the ancestry route:\n%s", report)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The signals that say no.
+// ---------------------------------------------------------------------------
+
+func TestADirtyWorktreeIsKept(t *testing.T) {
+	f := newFixture(t)
+	_, p := f.landedBranch("w-dirty", "dirty")
+	f.setPulls(p)
+	path := f.worktreeOf("w-dirty")
+	if err := os.WriteFile(filepath.Join(path, "w-dirty", "one.txt"), []byte("an edit nobody committed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, report := f.act(true)
+
+	f.assertBranch("w-dirty", true)
+	f.assertDir(path, true)
+	if !strings.Contains(section(report, "KEPT"), "UNCOMMITTED CHANGES") {
+		t.Fatalf("the uncommitted edit was not the reason given:\n%s", report)
+	}
+}
+
+func TestAnAbsentWorktreeDirectoryIsNotCheckedRatherThanSkipped(t *testing.T) {
+	f := newFixture(t)
+	_, p := f.landedBranch("w-gone", "gone")
+	f.setPulls(p)
+	path := f.worktreeOf("w-gone")
+	if err := os.RemoveAll(path); err != nil {
+		t.Fatal(err)
+	}
+
+	code, report := f.act(false)
+
+	if !strings.Contains(section(report, "NOT CHECKED"), path) {
+		t.Fatalf("a worktree whose directory is gone was not reported as unchecked:\n%s", report)
+	}
+	if code == 0 {
+		t.Fatalf("the run passed with something unchecked:\n%s", report)
+	}
+	f.assertBranch("w-gone", true)
+}
+
+func TestABranchWithNoMergedPullRequestIsKept(t *testing.T) {
+	f := newFixture(t)
+	f.commitOn("w-in-progress", "wip/one.txt", "one\n", "work nobody merged")
+	path := f.addWorktree("wip", "w-in-progress")
+	f.setPulls()
+
+	_, report := f.act(true)
+
+	f.assertBranch("w-in-progress", true)
+	f.assertDir(path, true)
+	if !strings.Contains(section(report, "KEPT"), "no merged pull request") {
+		t.Fatalf("the absent pull request was not the reason given:\n%s", report)
+	}
+}
+
+func TestAProtectedBranchIsNeverRemoved(t *testing.T) {
+	f := newFixture(t)
+	// status-data is ahead of main by design and a merged pull request from a
+	// branch of the same name would be the worst possible coincidence.
+	f.commitOn("status-data", "status/one.txt", "one\n", "five minutes of history")
+	path := f.addWorktree("statusdata", "status-data")
+	f.setPulls(mergedPull(1, "status-data", f.sha("status-data"), f.sha("origin/main")))
+
+	_, report := f.act(true)
+
+	f.assertBranch("status-data", true)
+	f.assertDir(path, true)
+	if !strings.Contains(section(report, "KEPT"), "protected") {
+		t.Fatalf("the protection was not the reason given:\n%s", report)
+	}
+}
+
+// TestADetachedWorktreeIsKeptWithWhatItsHeadHolds. A detached worktree has no
+// branch to delete, so this program keeps it, and it can still establish what
+// removing it would cost: here, one commit that nothing else points at.
+//
+// The first version filed every detached worktree as NOT CHECKED. On this
+// machine that was thirteen of them, so every run exited nonzero for a reason
+// that never changed, which teaches the operator that the exit code means
+// nothing. That is the habit the exit code exists to prevent.
+func TestADetachedWorktreeIsKeptWithWhatItsHeadHolds(t *testing.T) {
+	f := newFixture(t)
+	tip := f.commitOn("w-temp", "temp/one.txt", "one\n", "a commit reachable from nothing else")
+	path := filepath.Join(t.TempDir(), "detached")
+	f.git("worktree", "add", "--quiet", "--detach", path, tip)
+	f.git("branch", "-D", "w-temp")
+	path = f.worktreeAt(path)
+
+	code, report := f.act(true)
+
+	kept := section(report, "KEPT")
+	if !strings.Contains(kept, path) || !strings.Contains(kept, "reachable from nothing else") {
+		t.Fatalf("a detached worktree holding an unreachable commit was not kept with that reason:\n%s", report)
+	}
+	f.assertDir(path, true)
+	if code != 0 {
+		t.Fatalf("exit %d for a machine where every worktree was judged:\n%s", code, report)
+	}
+}
+
+func TestAMergeCommitThatIsNotAnAncestorOfMainIsRefused(t *testing.T) {
+	f := newFixture(t)
+	f.commitOn("w-elsewhere", "elsewhere/one.txt", "one\n", "first")
+	tip := f.commitOn("w-elsewhere", "elsewhere/two.txt", "two\n", "second")
+	// A merge commit on a branch that is not main, which is what a pull
+	// request merged into a release line or a stale origin/main looks like.
+	other := f.commitOn("w-release", "release/one.txt", "one\n", "merged somewhere else")
+	path := f.addWorktree("elsewhere", "w-elsewhere")
+	f.setPulls(mergedPull(400, "w-elsewhere", tip, other))
+
+	_, report := f.act(true)
+
+	f.assertBranch("w-elsewhere", true)
+	f.assertDir(path, true)
+	if !strings.Contains(report, "did not land here") {
+		t.Fatalf("the refusal does not say the merge commit is not in main:\n%s", report)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The instrument's own failures, which must read as refusals rather than as
+// clean runs.
+// ---------------------------------------------------------------------------
+
+func TestAFailingGhRefusesEverything(t *testing.T) {
+	f := newFixture(t)
+	_, p := f.landedBranch("w-landed", "landed")
+	f.setPulls(p)
+	path := f.worktreeOf("w-landed")
+	f.gh.ghCode = 1
+
+	code, report := f.act(true)
+
+	if code == 0 {
+		t.Fatalf("a failed gh passed:\n%s", report)
+	}
+	f.assertBranch("w-landed", true)
+	f.assertDir(path, true)
+	if f.gh.did("git", "branch", "-D") {
+		t.Fatalf("a branch was deleted after gh failed: %v", f.gh.calls)
+	}
+}
+
+func TestAMissingGhBinaryRefusesRatherThanCrashing(t *testing.T) {
+	f := newFixture(t)
+	_, p := f.landedBranch("w-landed", "landed")
+	f.setPulls(p)
+	f.gh.ghErr = fmt.Errorf("gh: executable file not found in $PATH")
+
+	code, report := f.act(true)
+
+	if code == 0 {
+		t.Fatalf("an absent gh passed:\n%s", report)
+	}
+	f.assertBranch("w-landed", true)
+}
+
+func TestAFailedFetchBlocksApply(t *testing.T) {
+	f := newFixture(t)
+	_, p := f.landedBranch("w-landed", "landed")
+	f.setPulls(p)
+	path := f.worktreeOf("w-landed")
+	f.gh.fetchFails = true
+
+	var out bytes.Buffer
+	code := run(f.repo, options{mainRef: "origin/main", fetch: true, act: true}, &out)
+
+	if code == 0 {
+		t.Fatalf("a failed fetch let an apply through:\n%s", out.String())
+	}
+	f.assertBranch("w-landed", true)
+	f.assertDir(path, true)
+	if f.gh.did("git", "worktree", "remove") {
+		t.Fatalf("a worktree was removed after the fetch failed: %v", f.gh.calls)
+	}
+}
+
+func TestAnUnresolvableMainRefRefusesEverything(t *testing.T) {
+	f := newFixture(t)
+	_, p := f.landedBranch("w-landed", "landed")
+	f.setPulls(p)
+
+	var out bytes.Buffer
+	code := run(f.repo, options{mainRef: "origin/a-branch-that-does-not-exist", act: true}, &out)
+
+	if code == 0 {
+		t.Fatalf("an unresolvable main passed:\n%s", out.String())
+	}
+	f.assertBranch("w-landed", true)
+	// Every later git call would also fail against a ref that does not exist,
+	// so the two assertions above hold even without the early refusal. What
+	// the early refusal owns is that nothing else is asked at all, and the
+	// operator is told the one fact that matters rather than a wall of
+	// per-worktree errors.
+	if f.gh.did("gh", "pr", "list") {
+		t.Fatalf("GitHub was asked about pull requests after main failed to resolve: %v", f.gh.calls)
+	}
+	if !strings.Contains(out.String(), "could not be resolved") {
+		t.Fatalf("the refusal does not say main could not be resolved:\n%s", out.String())
+	}
+}
+
+// TestAMalformedPorcelainRecordIsNotCheckedRatherThanSkipped is the second thing
+// the brief asked for: a worktree the tool could not parse must be named, not
+// passed over. The listing is constructed here because git will not emit a
+// broken one on demand, and the run above proves the parse feeds the report.
+func TestAMalformedPorcelainRecordIsNotCheckedRatherThanSkipped(t *testing.T) {
+	// The /b record names a branch, so the only rule that can refuse it is the
+	// one about the line nobody recognised. Its first version named no branch
+	// either, and a second rule caught it, which hid whether the unknown line
+	// was noticed at all: the mutation that stopped reading unknown lines left
+	// this test passing.
+	listing := "worktree /a\nHEAD " + strings.Repeat("a", 40) + "\nbranch refs/heads/main\n\n" +
+		"worktree /b\nHEAD " + strings.Repeat("b", 40) + "\nbranch refs/heads/w-future\nsomething-new-in-git\n\n" +
+		"worktree /c\nbranch refs/heads/w-no-head\n\n"
+	got := parseWorktrees(listing)
+	if len(got) != 3 {
+		t.Fatalf("parsed %d records, want 3: %+v", len(got), got)
+	}
+	if got[0].malformed != "" {
+		t.Errorf("a good record was called malformed: %q", got[0].malformed)
+	}
+	if got[1].malformed == "" {
+		t.Error("a record carrying an unknown line was accepted, so a future git could be silently misread")
+	}
+	if got[2].malformed == "" {
+		t.Error("a record carrying no HEAD was accepted")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The orderings.
+// ---------------------------------------------------------------------------
+
+// TestABranchTipThatMovedBetweenTheScanAndTheDeletionIsRefused is the ordering
+// the previous script could not see. Five other lanes work on this machine at
+// once, so a commit landing on a branch between the moment it was judged and the
+// moment it is deleted is an ordinary Tuesday, not a theoretical race.
+func TestABranchTipThatMovedBetweenTheScanAndTheDeletionIsRefused(t *testing.T) {
+	f := newFixture(t)
+	f.commitOn("w-moving", "moving/one.txt", "one\n", "first")
+	tip := f.commitOn("w-moving", "moving/two.txt", "two\n", "second")
+	squash := f.squashOntoMain("w-moving", "moving (#401)")
+	path := f.addWorktree("moving", "w-moving")
+	f.setPulls(mergedPull(401, "w-moving", tip, squash))
+
+	merged, _, err := f.repo.mergedPulls()
+	if err != nil {
+		t.Fatal(err)
+	}
+	e := env{mainRef: "origin/main", merged: merged, now: time.Now()}
+	js, err := scan(f.repo, e)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var judged bool
+	for _, j := range js {
+		if j.wt.branch == "w-moving" && j.removable {
+			judged = true
+		}
+	}
+	if !judged {
+		t.Fatal("the fixture was not judged removable, so the ordering is not the thing under test")
+	}
+
+	// Another lane commits into the worktree that is about to be removed.
+	if err := os.WriteFile(filepath.Join(path, "moving", "three.txt"), []byte("three\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	f.run(path, "git", "add", "-A")
+	f.run(path, "git", "commit", "--quiet", "-m", "a lane commits between the scan and the apply")
+
+	var out bytes.Buffer
+	removed, refused := apply(f.repo, js, e, &out)
+
+	if removed != 0 {
+		t.Fatalf("a branch that moved after being judged was still deleted:\n%s", out.String())
+	}
+	if refused != 1 {
+		t.Fatalf("refused %d, want 1:\n%s", refused, out.String())
+	}
+	f.assertBranch("w-moving", true)
+	f.assertDir(path, true)
+	if !strings.Contains(out.String(), "stopped being disposable") {
+		t.Fatalf("the refusal does not say the branch changed:\n%s", out.String())
+	}
+}
+
+// TestABackupRefHoldsEveryDeletedTip is the net under the whole program. The
+// third signal can only be as good as the reasoning behind it, and a ref costs
+// nothing and makes every deletion reversible.
+func TestABackupRefHoldsEveryDeletedTip(t *testing.T) {
+	f := newFixture(t)
+	f.commitOn("w-landed", "landed/one.txt", "one\n", "first")
+	tip := f.commitOn("w-landed", "landed/two.txt", "two\n", "second")
+	squash := f.squashOntoMain("w-landed", "landed (#300)")
+	f.addWorktree("landed", "w-landed")
+	f.setPulls(mergedPull(300, "w-landed", tip, squash))
+
+	code, report := f.act(true)
+	if code != 0 {
+		t.Fatalf("exit %d:\n%s", code, report)
+	}
+	f.assertBranch("w-landed", false)
+
+	got := f.git("rev-parse", "--verify", backupRefPrefix+"w-landed")
+	if got != tip {
+		t.Fatalf("the backup ref is %s, want the deleted tip %s", got, tip)
+	}
+	// And the commits really are restorable, which is the claim the report makes.
+	f.git("branch", "w-landed", backupRefPrefix+"w-landed")
+	if f.sha("w-landed") != tip {
+		t.Fatal("the restore named in the report does not bring the tip back")
+	}
+}
+
+// TestTheReportStatesWhatIsOutOfScope is the third thing the brief asked for.
+// A branch with no worktree is never judged here, and a reader who is not told
+// that will read the removable list as the whole answer.
+func TestTheReportStatesWhatIsOutOfScope(t *testing.T) {
+	f := newFixture(t)
+	f.commitOn("w-no-worktree", "nowt/one.txt", "one\n", "landed long ago")
+	f.squashOntoMain("w-no-worktree", "landed (#402)")
+
+	_, report := f.act(false)
+
+	out := section(report, "OUT OF SCOPE")
+	if !strings.Contains(out, "w-no-worktree") {
+		t.Fatalf("a branch with no worktree was not named as out of scope:\n%s", report)
+	}
+	if !strings.Contains(out, "never judged") {
+		t.Fatalf("the report does not say a branch with no worktree is not judged:\n%s", report)
+	}
+}
+
+// TestTheMainWorkingTreeIsNeverRemoved because git refuses it anyway and a tool
+// that lets the refusal happen at the end has already told the operator it
+// planned to.
+//
+// The primary checkout here sits on an ordinary lane branch rather than on main,
+// and on 2026-09-11 that branch was one commit ahead and otherwise landed. So the
+// fixture puts the main working tree on a branch the ancestry route would call
+// disposable, because a main working tree on `main` is kept by the protected
+// branch rule and would hide whether this guard exists at all.
+func TestTheMainWorkingTreeIsNeverRemoved(t *testing.T) {
+	f := newFixture(t)
+	f.git("checkout", "--quiet", "-b", "w-primary", "origin/main")
+	f.setPulls()
+
+	_, report := f.act(true)
+
+	if !strings.Contains(section(report, "KEPT"), f.dir) {
+		t.Fatalf("the main working tree was not reported as kept:\n%s", report)
+	}
+	if strings.Contains(section(report, "REMOVABLE"), f.dir) {
+		t.Fatalf("the main working tree was called removable:\n%s", report)
+	}
+	f.assertDir(f.dir, true)
+	f.assertBranch("w-primary", true)
+}
+
+// worktreeOf finds where a branch is checked out, which the fixture helpers
+// create under directories the test does not otherwise hold.
+func (f *fixture) worktreeOf(branch string) string {
+	f.t.Helper()
+	for _, wt := range parseWorktrees(f.git("worktree", "list", "--porcelain")) {
+		if wt.branch == branch {
+			return wt.path
+		}
+	}
+	f.t.Fatalf("no worktree holds %s", branch)
+	return ""
+}
+
+// worktreeAt returns the spelling git uses for a worktree it holds, which on
+// macOS resolves the /var symlink that t.TempDir hands out.
+func (f *fixture) worktreeAt(given string) string {
+	f.t.Helper()
+	want, err := filepath.EvalSymlinks(given)
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	for _, wt := range parseWorktrees(f.git("worktree", "list", "--porcelain")) {
+		if got, err := filepath.EvalSymlinks(wt.path); err == nil && got == want {
+			return wt.path
+		}
+	}
+	f.t.Fatalf("git holds no worktree at %s", given)
+	return ""
+}
+
+// ---------------------------------------------------------------------------
+// The signals that say somebody is working here, which the first run against
+// the real machine proved were missing: it called seven live lanes removable.
+// ---------------------------------------------------------------------------
+
+// TestIgnoredScratchThatNoBuildWritesKeepsTheWorktree is the case that makes a
+// clean tree a lie. A lane's handover lives in PROGRESS.md and its scratch under
+// .lane/, both excluded through .git/info/exclude, so `git status` reports the
+// tree clean and `git worktree remove` deletes both without a prompt.
+func TestIgnoredScratchThatNoBuildWritesKeepsTheWorktree(t *testing.T) {
+	f := newFixture(t)
+	_, p := f.landedBranch("w-lane", "lane")
+	f.setPulls(p)
+	path := f.worktreeOf("w-lane")
+	f.exclude("PROGRESS.md")
+	if err := os.WriteFile(filepath.Join(path, "PROGRESS.md"), []byte("the only copy of a handover\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if st := f.run(path, "git", "status", "--porcelain"); st != "" {
+		t.Fatalf("the fixture is not clean to git, so it is not the case under test: %q", st)
+	}
+
+	_, report := f.act(true)
+
+	f.assertBranch("w-lane", true)
+	if _, err := os.Stat(filepath.Join(path, "PROGRESS.md")); err != nil {
+		t.Fatalf("the ignored handover was deleted: %v\n%s", err, report)
+	}
+	if !strings.Contains(section(report, "KEPT"), "PROGRESS.md") {
+		t.Fatalf("the ignored scratch was not named as the reason:\n%s", report)
+	}
+}
+
+// TestBuildOutputAloneDoesNotKeepAWorktree is the other half. node_modules is
+// most of the disk this program exists to free, and a signal that kept every
+// worktree with dependencies installed would keep all of them.
+func TestBuildOutputAloneDoesNotKeepAWorktree(t *testing.T) {
+	f := newFixture(t)
+	_, p := f.landedBranch("w-built", "built")
+	f.setPulls(p)
+	path := f.worktreeOf("w-built")
+	f.exclude("node_modules/")
+	f.exclude(".next/")
+	for _, rel := range []string{"node_modules/pkg/index.js", "www/.next/cache/x"} {
+		full := filepath.Join(path, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte("built\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	code, report := f.act(true)
+
+	if code != 0 {
+		t.Fatalf("exit %d:\n%s", code, report)
+	}
+	f.assertBranch("w-built", false)
+	f.assertDir(path, false)
+}
+
+func TestAProcessWorkingInsideTheWorktreeKeepsIt(t *testing.T) {
+	f := newFixture(t)
+	_, p := f.landedBranch("w-busy", "busy")
+	f.setPulls(p)
+	path := f.worktreeOf("w-busy")
+	wd, _ := os.Getwd()
+	f.gh.lsof = "p" + strconv.Itoa(os.Getpid()) + "\nfcwd\nn" + wd + "\n" +
+		"p424242\nfcwd\nn" + filepath.Join(path, "engine") + "\n"
+
+	_, report := f.act(true)
+
+	f.assertBranch("w-busy", true)
+	f.assertDir(path, true)
+	if !strings.Contains(section(report, "KEPT"), "process 424242 is working in it") {
+		t.Fatalf("the process was not named as the reason:\n%s", report)
+	}
+}
+
+func TestALsofThatCannotRunIsNotCheckedRatherThanSkipped(t *testing.T) {
+	f := newFixture(t)
+	_, p := f.landedBranch("w-landed", "landed")
+	f.setPulls(p)
+	path := f.worktreeOf("w-landed")
+	f.gh.lsofErr = fmt.Errorf("lsof: executable file not found in $PATH")
+
+	code, report := f.act(true)
+
+	f.assertBranch("w-landed", true)
+	f.assertDir(path, true)
+	if !strings.Contains(section(report, "NOT CHECKED"), path) {
+		t.Fatalf("a worktree nobody could check for processes was not reported as unchecked:\n%s", report)
+	}
+	if code == 0 {
+		t.Fatalf("the run passed with something unchecked:\n%s", report)
+	}
+}
+
+// TestALsofListingWithoutThisProcessIsNotTrusted because lsof exits zero on a
+// listing it could only partly read, and a listing that cannot see the one
+// process known to exist has not shown that no lane is working anywhere.
+func TestALsofListingWithoutThisProcessIsNotTrusted(t *testing.T) {
+	f := newFixture(t)
+	_, p := f.landedBranch("w-landed", "landed")
+	f.setPulls(p)
+	f.gh.lsof = "p1\nfcwd\nn/\n"
+
+	code, report := f.act(true)
+
+	f.assertBranch("w-landed", true)
+	if !strings.Contains(section(report, "NOT CHECKED"), "cannot be trusted") {
+		t.Fatalf("a listing without this process was trusted:\n%s", report)
+	}
+	if code == 0 {
+		t.Fatalf("the run passed on a listing it could not trust:\n%s", report)
+	}
+}
+
+// TestARecentlyWrittenWorktreeIsKept is the signal that caught the live lanes.
+// An agent's shell leaves the worktree between commands, so most of the time no
+// process is working in it, and a lane that has not yet written scratch has
+// nothing ignored. What it always has is a checkout from tonight.
+func TestARecentlyWrittenWorktreeIsKept(t *testing.T) {
+	f := newFixture(t)
+	_, p := f.landedBranch("w-fresh", "fresh")
+	f.setPulls(p)
+	path := f.worktreeOf("w-fresh")
+
+	_, report := f.actWith(options{mainRef: "origin/main", act: true, idle: time.Hour})
+
+	f.assertBranch("w-fresh", true)
+	f.assertDir(path, true)
+	if !strings.Contains(section(report, "KEPT"), "idle window") {
+		t.Fatalf("the recent write was not named as the reason:\n%s", report)
+	}
+}
+
+func TestAWorktreeIdleLongerThanTheWindowIsRemoved(t *testing.T) {
+	f := newFixture(t)
+	_, p := f.landedBranch("w-stale", "stale")
+	f.setPulls(p)
+	path := f.worktreeOf("w-stale")
+	old := time.Now().Add(-48 * time.Hour)
+	filepath.WalkDir(path, func(q string, d os.DirEntry, err error) error {
+		if err == nil {
+			os.Chtimes(q, old, old)
+		}
+		return nil
+	})
+
+	code, report := f.actWith(options{mainRef: "origin/main", act: true, idle: 24 * time.Hour})
+
+	if code != 0 {
+		t.Fatalf("exit %d:\n%s", code, report)
+	}
+	f.assertBranch("w-stale", false)
+	f.assertDir(path, false)
+}
+
+// TestTheRealLsofListsThisProcess reads the real command's real output through
+// the production parser, because every other test here hands the parser a
+// listing written by hand, and a parser only ever fed its author's idea of the
+// format is the shape of decoder this repository keeps finding wrong.
+func TestTheRealLsofListsThisProcess(t *testing.T) {
+	if _, err := exec.LookPath("lsof"); err != nil {
+		t.Skip("lsof is not on PATH here, so there is no real listing to read")
+	}
+	procs, err := repo{runner: local{}, dir: "."}.processCwds()
+	if err != nil {
+		t.Fatalf("the real listing was refused: %v", err)
+	}
+	wd, _ := os.Getwd()
+	self := strconv.Itoa(os.Getpid())
+	for _, p := range procs {
+		if p.pid == self {
+			a, _ := filepath.EvalSymlinks(p.cwd)
+			b, _ := filepath.EvalSymlinks(wd)
+			if a != b {
+				t.Fatalf("this process is listed at %s and is working in %s", p.cwd, wd)
+			}
+			return
+		}
+	}
+	t.Fatalf("this process is not in its own listing of %d", len(procs))
+}


### PR DESCRIPTION
## The defect

`worktree-gc` decided a branch was disposable from two signals when it needed
three. It matched the branch NAME against GitHub's merged pull request list and
checked that the working tree was clean. Both of those are true of a branch that
landed. Both are also true of a branch that landed and then carried on.

They are true because `just merge` squashes. The squash is a new commit on main,
the branch is left behind pointing at its own history, and a commit written after
the merge is invisible to a name match. On 2026-09-11 six branches here were in
that state. Three had clean worktrees, so the collector called them disposable
and an applying run would have called `git worktree remove` and `git branch -D`
over work that is in no other place.

| Branch | Would have lost | Pull request it had already merged |
| --- | --- | --- |
| `w-runtime-aca` | 9 commits | 316 |
| `w-detect-clouds-datastores` | 7 commits | 308 |
| `w-engine-red` | 1 commit | 333 |

## The third signal

Either the branch holds zero commits main cannot already reach, so deleting the
ref cannot orphan a commit at all, or the branch tip is byte identical to the
exact commit its merged pull request squashed, so the branch holds nothing
written after the merge and every commit under it is in main as that squash.

Content diffing is not a substitute and is deliberately not used. A squash
followed by further evolution of the same files on main makes even a branch
merged hours ago report conflicts, so diffing would have refused most of the 81
branches that really had landed.

## What the first real run found, and why this change is larger than one comparison

A lane that has just branched from main holds no commits of its own, so the first
shape above proves it disposable. The dry run called SEVEN LIVE LANES removable,
one of them a session that was writing files that minute.

A clean tree is not an idle one. The scratch a lane keeps is ignored on purpose,
through `.git/info/exclude`, so `git status` cannot see `PROGRESS.md` or `.lane/`
and `git worktree remove` deletes both without asking. Three more signals now
stand between a proof and a removal:

- nothing ignored may be anything but build output,
- no process may be working inside the worktree, read with `lsof`,
- nothing in it may have been written inside the idle window, a day by default.

Each worktree is judged AGAIN immediately before it is touched, against a fresh
process list and a fresh clock, and the branch is deleted by compare and swap
against the tip that was proven, so a lane committing in the last millisecond
fails the deletion rather than losing the commit.

## Saying no, and saying what it could not check

It prints what it could NOT establish, by worktree and by missing signal, and
exits nonzero while that list is not empty, because a collector that silently
passes over a worktree it could not read looks exactly like one that found
nothing wrong. A prunable worktree, a `git status` that would not run, an `lsof`
that could not run, a porcelain record carrying a line it does not recognise, and
an `lsof` listing that does not include this very process are all refusals rather
than skips. The report also states what is out of scope: branches with no
worktree, the directory names treated as build output, and that another user's
process is not visible.

Before deleting a branch it writes the tip to a ref under `refs/worktree-gc/`, so
the objects stay reachable and each deletion is undone with one command.

## Where it lives, and why there is no new CI gate

It was an untracked file in one checkout, excluded through `.git/info/exclude`,
which is how a program that runs `git branch -D` had no history, no review and no
test for as long as it existed. It is now `tools/worktreegc`.

There is deliberately no new gate. It reads this machine's worktrees, its local
branches and GitHub, none of which exist in CI, so a gate would report green
having checked nothing. Its logic is tested instead, and `cd tools && go test
./...` already runs those tests inside the `engine` context, which
`just test-tools` matches, so `tools/gatecheck` has nothing new to compare. This
was confirmed by running `go run ./tools/gatecheck .`, which exits 0.

## Verification

26 tests, all passing, every one against a REAL git repository built in a
temporary directory. Only `gh` and `lsof` are replaced, so ancestry, the commit
counts, the worktree listing, each working tree's status, the branch deletion and
the backup ref are done by git. Nothing asserts that the source contains a word.

A dry run against this machine reports 0 removable, 39 kept, 0 not checked, and
refuses all three branches above by name with their commit counts quoted back,
for example `w-detect-clouds-datastores`: "pull request 308 squashed d4d433074
but the branch is at a52378add, which is 7 commit(s) later, so the branch holds
work written after the merge".

Both zeros are worth reading, because each is a signal working rather than a
run that did nothing.

- **0 removable** is the in use signals. Every worktree the commit proof alone
  would have released is one a lane wrote to today, keeps ignored scratch in, or
  has a process sitting in. With `-idle 0`, which switches recency off entirely,
  it is still 0, so this is not one blunt clock keeping everything.
- **0 not checked** is what changed about detached worktrees. The first run filed
  all 13 of them as unreadable, which made every run on this machine exit
  nonzero for a reason that never changed, and an exit code that never changes is
  one the operator stops reading. A detached worktree is now judged on ancestry
  and kept with the count it would orphan, for example "detached at 852d5d9a3,
  which holds 3 commit(s) origin/main cannot reach and no branch names, so
  removing it would leave them reachable from nothing else". The unchecked list
  is now reserved for signals that genuinely could not be established: a prunable
  worktree, a `git status` that would not run, an `lsof` that would not run, an
  `lsof` listing missing this very process, and a porcelain record carrying a
  line the parser does not recognise. Each of those is exercised by a test and
  killed by a mutation cell.

### Proof it can still say yes

A collector that can never remove anything is safe and useless, and the rule cuts
both ways: a check that cannot say no is worse than none, and a check that cannot
say yes is a tool nobody runs. Four of the 26 tests are the yes, and each ends
with the worktree gone from disk and the branch gone from git, not with a message.

- `TestAWorktreeIdleLongerThanTheWindowIsRemoved` is the full set of conditions
  at once: a branch whose tip is byte identical to its merged squash, a clean
  tree, nothing ignored, no process inside it, and every file stamped 48 hours
  old against a one day window. The tool removes it and exits 0.
- `TestABranchIdenticalToTheCommitItsPullRequestSquashedIsRemoved` is the squash
  route on its own, on a branch that really does hold commits main cannot reach.
- `TestABranchWithNoCommitsMainCannotReachIsRemoved` is the ancestry route.
- `TestBuildOutputAloneDoesNotKeepAWorktree` proves the ignored file signal does
  not veto a worktree whose only ignored paths are `node_modules` and `.next`,
  which is most of the disk this exists to free.

Those yeses are load bearing rather than incidental: mutation cells 2, 3, 20 and
25 each make the tool refuse a worktree it should release, and every one of those
cells is killed by the test above it. A change that quietly turned this into a
collector that always says no would fail four tests.

So the zero on this machine is a fact about the machine, not about the tool.
Every worktree here is a live lane, or was written to today, or carries ignored
scratch that no build writes. Tonight zero is the correct answer, and the report
names which of those three reasons applies to each of the 39.

32 mutation cells, 32 killed, each restored to green afterwards, one break per
assertion.

| Cell | Test | Production line broken | Mutant | Restored |
| --- | --- | --- | --- | --- |
| 1 | `ABranchWithCommitsAfterItsMergedPullRequestIsRefused` | drop the tip equals squashed head comparison | killed | pass |
| 2 | `ABranchIdenticalToTheCommitItsPullRequestSquashedIsRemoved` | refuse every merge commit as not landed | killed | pass |
| 3 | `ABranchWithNoCommitsMainCannotReachIsRemoved` | never take the zero unreachable commits route | killed | pass |
| 4a | `ADirtyWorktreeIsKept` | ignore tracked changes | killed | pass |
| 4b | `ADirtyWorktreeIsKept` | ignore tracked changes and force the removal | killed | pass |
| 5a | `AnAbsentWorktreeDirectoryIsNotCheckedRatherThanSkipped` | file a prunable worktree as kept | killed | pass |
| 5b | `AnAbsentWorktreeDirectoryIsNotCheckedRatherThanSkipped` | let a dry run with unchecked worktrees exit zero | killed | pass |
| 6 | `ABranchWithNoMergedPullRequestIsKept` | accept unreachable commits with no pull request | killed | pass |
| 7 | `AProtectedBranchIsNeverRemoved` | remove `status-data` from the protected set | killed | pass |
| 8 | `ADetachedWorktreeIsKeptWithWhatItsHeadHolds` | stop recognising a detached worktree | killed | pass |
| 9 | `AMergeCommitThatIsNotAnAncestorOfMainIsRefused` | accept a merge commit that is not in main | killed | pass |
| 10 | `AFailingGhRefusesEverything` | read gh output after a nonzero exit | killed | pass |
| 11 | `AMissingGhBinaryRefusesRatherThanCrashing` | ignore a gh that could not start | killed | pass |
| 12 | `AFailedFetchBlocksApply` | let an applying run proceed after a failed fetch | killed | pass |
| 13 | `AnUnresolvableMainRefRefusesEverything` | carry on when the main ref does not resolve | killed | pass |
| 14a | `AMalformedPorcelainRecordIsNotCheckedRatherThanSkipped` | accept an unrecognised porcelain line | killed | pass |
| 14b | `AMalformedPorcelainRecordIsNotCheckedRatherThanSkipped` | accept a record with no HEAD line | killed | pass |
| 14c | `AMalformedPorcelainRecordIsNotCheckedRatherThanSkipped` | stop recognising the HEAD line | killed | pass |
| 15 | `ABranchTipThatMovedBetweenTheScanAndTheDeletionIsRefused` | ignore the judgment taken just before deleting | killed | pass |
| 16a | `ABackupRefHoldsEveryDeletedTip` | write no backup ref | killed | pass |
| 16b | `ABackupRefHoldsEveryDeletedTip` | write no backup ref and skip the read back | killed | pass |
| 17a | `TheReportStatesWhatIsOutOfScope` | list no branch as out of scope | killed | pass |
| 17b | `TheReportStatesWhatIsOutOfScope` | stop saying such a branch is not judged | killed | pass |
| 18 | `TheMainWorkingTreeIsNeverRemoved` | drop the main working tree guard | killed | pass |
| 19 | `IgnoredScratchThatNoBuildWritesKeepsTheWorktree` | stop counting ignored files as work | killed | pass |
| 20 | `BuildOutputAloneDoesNotKeepAWorktree` | treat build output directories as work | killed | pass |
| 21 | `AProcessWorkingInsideTheWorktreeKeepsIt` | ignore a process working inside it | killed | pass |
| 22 | `ALsofThatCannotRunIsNotCheckedRatherThanSkipped` | carry on when the process list failed | killed | pass |
| 23 | `ALsofListingWithoutThisProcessIsNotTrusted` | trust a listing without this process | killed | pass |
| 24 | `ARecentlyWrittenWorktreeIsKept` | never call a write recent | killed | pass |
| 25 | `AWorktreeIdleLongerThanTheWindowIsRemoved` | call every write recent | killed | pass |
| 26 | `TheRealLsofListsThisProcess` | stop reading pid lines from the real listing | killed | pass |

Five cells needed a second pass, and the reason is worth recording.

Four of my mutations left a variable with no remaining use, so the package did
not compile. The harness reports that as a broken cell rather than as a kill,
because a package that stopped compiling exits nonzero, and a harness reading
exit status alone would have recorded every one of them as a caught mutation. A
mutation table can therefore be entirely fabricated by breaks that never built,
which is why this harness requires the NAMED TEST to fail rather than the
process to exit nonzero.

The fifth genuinely SURVIVED, and it is the most useful finding in this branch:
it was A CHECK THAT COULD NOT SAY NO, MASKED BY A SECOND CHECK THAT COULD. The
porcelain record carrying an unrecognised line also named no branch, so the rule
about a missing branch refused it, and the rule about the unrecognised line was
never exercised at all. Removing that rule left the test passing. The fixture now
names a branch on that record, so only the rule under test can refuse it, and the
cell kills. That is the defect class this repository keeps finding in its own
instruments, and it is the strongest evidence that the other 31 cells measure
something.

Also run on this branch: `gatecheck` exit 0, `prosecheck` 1004 files clean,
`changecheck` exit 0, `go vet` clean, and the full `cd tools && go test ./...`.

## Limits, stated rather than left to be found

- The compare and swap deletion closes the window between the second judgment and
  the deletion, and there is no test for that window, because it cannot be opened
  from outside the process. The window between the FIRST judgment and the second
  is tested.
- `lsof` runs as this user, so a process of another user working in a worktree is
  not seen. The report says so.
- The recency window is a heuristic, not a proof. It is what catches a lane that
  has branched, has written no scratch yet, and has no process in the directory
  between commands. It defaults to a day and `-idle 0` switches it off, which the
  report also says.
- `gh pr list` is asked for 500 merged pull requests. If that is ever truncated
  the report says so, and the effect is only that a removable branch is kept.
- Branches with no worktree are out of scope and are never deleted here, however
  landed they are.

## One thing this branch nearly shipped about itself

`git commit --amend -F` does not stage the working tree. The first amended commit
therefore carried the corrected message and none of the lint fix, which would
have been a commit whose message described work it did not contain. It was caught
by checking the committed blob rather than the working tree before pushing.

## The loose script

The untracked `worktree-gc` in the primary checkout is replaced by a shim that
runs this tool where it exists and refuses where it does not, which is what any
checkout predating this commit gets. Its original is kept outside the repository,
so nothing about the old predicate was silently discarded.
